### PR TITLE
travis: fix osxfuse tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
     else
       cd $GOPATH/src/github.com/keybase &&
       echo "Cloning client" &&
-      git clone git@github.com:keybase/client.git &&
+      git clone https://github.com/keybase/client.git &&
       cd client/osx/Fuse &&
       echo "Installing OSXFuse" &&
       ./install.sh &&


### PR DESCRIPTION
Use https for client repo, since travis is doing public builds now.