### PR TITLE
QR: account for gcOp size correctly, to be sure big block changes aren't embedded in the MD

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -334,6 +334,8 @@ func (p BlockPointer) IsFirstRef() bool {
 	return p.RefNonce == zeroBlockRefNonce
 }
 
+var bpSize = uint64(reflect.TypeOf(BlockPointer{}).Size())
+
 // ReadyBlockData is a block that has been encoded (and encrypted).
 type ReadyBlockData struct {
 	// These fields should not be used outside of BlockOps.Put().
@@ -561,7 +563,7 @@ func (bc BlockChanges) Equals(other BlockChanges) bool {
 func (bc *BlockChanges) addBPSize() {
 	// We want an estimate of the codec-encoded size, but the
 	// in-memory size is good enough.
-	bc.sizeEstimate += uint64(reflect.TypeOf(BlockPointer{}).Size())
+	bc.sizeEstimate += bpSize
 }
 
 // AddRefBlock adds the newly-referenced block to this BlockChanges

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1666,15 +1666,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 		}
 	}
 
-	// Swap any cached block changes so that future local accesses to
-	// this MD (from the cache) can directly access the ops without
-	// needing to re-embed the block changes.
-	if md.data.Changes.Ops == nil {
-		md.data.Changes, md.data.cachedChanges =
-			md.data.cachedChanges, md.data.Changes
-		md.data.Changes.Ops[0].
-			AddRefBlock(md.data.cachedChanges.Info.BlockPointer)
-	}
+	md.swapCachedBlockChanges()
 
 	err = fbo.finalizeBlocks(bps)
 	if err != nil {
@@ -1773,6 +1765,7 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *gcOp) (
 	}
 
 	fbo.setStagedLocked(lState, false, NullBranchID)
+	md.swapCachedBlockChanges()
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -800,7 +800,8 @@ func (ro *rekeyOp) GetDefaultAction(mergedPath path) crAction {
 
 // gcOp is an op that represents garbage-collecting the history of a
 // folder (which may involve unreferencing blocks that previously held
-// operation lists.
+// operation lists.  It may contain unref blocks before it is added to
+// the metadata ops list.
 type gcOp struct {
 	OpCommon
 
@@ -820,7 +821,7 @@ func newGCOp(latestRev MetadataRevision) *gcOp {
 }
 
 func (gco *gcOp) SizeExceptUpdates() uint64 {
-	return 0
+	return bpSize * uint64(len(gco.UnrefBlocks))
 }
 
 func (gco *gcOp) AllUpdates() []blockUpdate {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -734,6 +734,18 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
 	return nil
 }
 
+// swapCachedBlockChanges swaps any cached block changes so that
+// future local accesses to this MD (from the cache) can directly
+// access the ops without needing to re-embed the block changes.
+func (md *RootMetadata) swapCachedBlockChanges() {
+	if md.data.Changes.Ops == nil {
+		md.data.Changes, md.data.cachedChanges =
+			md.data.cachedChanges, md.data.Changes
+		md.data.Changes.Ops[0].
+			AddRefBlock(md.data.cachedChanges.Info.BlockPointer)
+	}
+}
+
 // RootMetadataSigned is the top-level MD object stored in MD server
 type RootMetadataSigned struct {
 	// signature over the root metadata by the private signing key


### PR DESCRIPTION
@aalness noticed that one user has been getting constant errors from the MD server when trying to run QR on a change list that is too big to be embedded in the MD block.  Turns out we weren't properly estimating the size of a `gcOp`, so we weren't unembedding the block change list.

This PR fixes that, and another bug it exposes, and adds a test.