### PR TITLE
libdokan: raise timeout to 29 seconds

### DIFF
--- a/libdokan/common.go
+++ b/libdokan/common.go
@@ -48,7 +48,7 @@ func NewContextWithOpID(fs *FS, debugMessage string) (
 		return fs.context, func() {}
 	}
 	ctx = context.WithValue(fs.context, CtxIDKey, id)
-	return context.WithTimeout(ctx, 19*time.Second)
+	return context.WithTimeout(ctx, 29*time.Second)
 }
 
 // eiToStat converts from a libkbfs.EntryInfo and error to a *dokan.Stat and error.


### PR DESCRIPTION
More leeway to avoid context deadline exceeded errors.