### PR TITLE
folder_block_ops: introduce a dirtyFile type

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2477,7 +2477,8 @@ func (cr *ConflictResolver) syncTree(ctx context.Context, lState *lockState,
 				// For an indirect file block, make sure a new
 				// reference is made for every child block.
 				for _, iptr := range fblock.IPtrs {
-					bps.addNewBlock(iptr.BlockPointer, nil, ReadyBlockData{})
+					bps.addNewBlock(iptr.BlockPointer, nil, ReadyBlockData{},
+						nil)
 					// TODO: add block updates to the op chain for these guys
 					// (need encoded size!)
 					newMD.AddRefBlock(iptr.BlockInfo)

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -1,0 +1,109 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"fmt"
+	"sync"
+)
+
+// syncBlockState represents that state of a block with respect to
+// whether it's dirty or currently being synced.  There can be four states:
+//  1) Not dirty or being synced
+//  2) Dirty and awaiting a sync
+//  3) Being synced and not yet re-dirtied: any write needs to
+//     make a copy of the block before dirtying it.  Also, all writes must be
+//     deferred.
+//  4) Being synced and already re-dirtied: no copies are needed, but all
+//     writes must still be deferred.
+type syncBlockState int
+
+const (
+	blockNotDirty syncBlockState = iota
+	blockDirty
+	blockSyncingNotDirty
+	blockSyncingAndDirty
+)
+
+// dirtyFile represents a particular file that's been written to, but
+// has not yet completed syncing its dirty blocks to the server.
+type dirtyFile struct {
+	lock sync.Mutex
+	// Which blocks are currently being synced, so that writes and
+	// truncates can do copy-on-write to avoid messing up the ongoing
+	// sync.  If it is blockSyncingNotDirty, then any write to the
+	// block should result in a deep copy and those writes should be
+	// deferred; if it is blockSyncingAndDirty, then just defer the
+	// writes.
+	fileBlockStates map[BlockPointer]syncBlockState
+}
+
+func newDirtyFile() *dirtyFile {
+	return &dirtyFile{
+		fileBlockStates: make(map[BlockPointer]syncBlockState),
+	}
+}
+
+func (df *dirtyFile) blockNeedsCopy(ptr BlockPointer) bool {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	return df.fileBlockStates[ptr] == blockSyncingNotDirty
+}
+
+// dirtyBlock transitions a block to a dirty state, and returns
+// whether or not the block needs to be put in the dirty cache
+// (because it isn't yet), and whether or not the block is currently
+// being sync'd.
+func (df *dirtyFile) dirtiedBlock(ptr BlockPointer) (
+	needsCaching bool, isSyncing bool) {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+
+	switch df.fileBlockStates[ptr] {
+	case blockNotDirty:
+		// A clean block became dirty
+		df.fileBlockStates[ptr] = blockDirty
+		return true, false
+	case blockDirty:
+		// Nothing to do, already dirty.
+		return false, false
+	case blockSyncingNotDirty:
+		// Future writes can use this same block.
+		df.fileBlockStates[ptr] = blockSyncingAndDirty
+		return true, true
+	case blockSyncingAndDirty:
+		return false, true
+	default:
+		panic(fmt.Sprintf("Unknown dirty block state: %v",
+			df.fileBlockStates[ptr]))
+	}
+}
+
+func (df *dirtyFile) blockSyncingAndDirty(ptr BlockPointer) bool {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	return df.fileBlockStates[ptr] == blockSyncingAndDirty
+}
+
+func (df *dirtyFile) syncingBlock(ptr BlockPointer) error {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	if df.fileBlockStates[ptr] == blockNotDirty {
+		return fmt.Errorf("Trying to sync a block that isn't dirty: %v", ptr)
+	}
+	df.fileBlockStates[ptr] = blockSyncingNotDirty
+	return nil
+}
+
+func (df *dirtyFile) errorOnSync() {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	// Reset all syncing blocks to just be dirty again
+	for ptr, state := range df.fileBlockStates {
+		if state > blockDirty {
+			df.fileBlockStates[ptr] = blockDirty
+		}
+	}
+}

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -10,7 +10,7 @@ import (
 )
 
 // syncBlockState represents that state of a block with respect to
-// whether it's dirty or currently being synced.  There can be four states:
+// whether it's dirty or currently being synced.  There can be six states:
 //  1) Not dirty or being synced
 //  2) Dirty and awaiting a sync
 //  3) Being synced and not yet re-dirtied: any write needs to
@@ -18,6 +18,10 @@ import (
 //     deferred.
 //  4) Being synced and already re-dirtied: no copies are needed, but all
 //     writes must still be deferred.
+//  5) Finished syncing, and not yet re-dirtied, but the rest of the
+//     sync hasn't finished yet.
+//  5) Finished syncing, and already re-dirtied, but the rest of the
+//     sync hasn't finished yet.
 type syncBlockState int
 
 const (
@@ -25,6 +29,8 @@ const (
 	blockDirty
 	blockSyncingNotDirty
 	blockSyncingAndDirty
+	blockSyncedAndDirty
+	blockSyncedNotDirty
 )
 
 // dirtyFile represents a particular file that's been written to, but
@@ -55,7 +61,7 @@ func (df *dirtyFile) blockNeedsCopy(ptr BlockPointer) bool {
 // dirtyBlock transitions a block to a dirty state, and returns
 // whether or not the block needs to be put in the dirty cache
 // (because it isn't yet), and whether or not the block is currently
-// being sync'd.
+// part of a sync in progress.
 func (df *dirtyFile) dirtiedBlock(ptr BlockPointer) (
 	needsCaching bool, isSyncing bool) {
 	df.lock.Lock()
@@ -74,6 +80,12 @@ func (df *dirtyFile) dirtiedBlock(ptr BlockPointer) (
 		df.fileBlockStates[ptr] = blockSyncingAndDirty
 		return true, true
 	case blockSyncingAndDirty:
+		return false, true
+	case blockSyncedNotDirty:
+		// Future writes can use this same block.
+		df.fileBlockStates[ptr] = blockSyncedAndDirty
+		return true, true
+	case blockSyncedAndDirty:
 		return false, true
 	default:
 		panic(fmt.Sprintf("Unknown dirty block state: %v",
@@ -104,6 +116,46 @@ func (df *dirtyFile) errorOnSync() {
 	for ptr, state := range df.fileBlockStates {
 		if state > blockDirty {
 			df.fileBlockStates[ptr] = blockDirty
+		}
+	}
+}
+
+func (df *dirtyFile) syncedBlockLocked(ptr BlockPointer) error {
+	switch df.fileBlockStates[ptr] {
+	case blockDirty:
+		// We've likely already had an errorOnSync call; ignore
+	case blockSyncingNotDirty:
+		df.fileBlockStates[ptr] = blockSyncedNotDirty
+	case blockSyncingAndDirty:
+		df.fileBlockStates[ptr] = blockSyncedAndDirty
+	default:
+		return fmt.Errorf("Trying to finish a block sync that wasn't in "+
+			"progress: %v (%d)", ptr, df.fileBlockStates[ptr])
+	}
+	// TODO: Eventually we'll need to free up space in the buffer
+	// taken up by these sync'd blocks, so new writes can proceed.
+	return nil
+}
+
+func (df *dirtyFile) syncedBlock(ptr BlockPointer) error {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	return df.syncedBlockLocked(ptr)
+}
+
+func (df *dirtyFile) syncFinished() {
+	// Mark any remaining blocks as finished syncing.  For example,
+	// top-level indirect blocks needs this because they are added to
+	// the blockPutState by folderBranchOps, not folderBlockOps.
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	// Reset all syncing blocks to just be dirty again
+	for ptr, state := range df.fileBlockStates {
+		if state == blockSyncingNotDirty || state == blockSyncingAndDirty {
+			err := df.syncedBlockLocked(ptr)
+			if err != nil {
+				panic(fmt.Sprintf("Unexpected error: %v", err))
+			}
 		}
 	}
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -34,22 +34,6 @@ const (
 	blockWrite
 )
 
-// syncBlockState represents that state of a block with respect to
-// whether it's currently being synced.  There can be three states:
-//  1) Not being synced
-//  2) Being synced and not yet re-dirtied: any write needs to
-//     make a copy of the block before dirtying it.  Also, all writes must be
-//     deferred.
-//  3) Being synced and already re-dirtied: no copies are needed, but all
-//     writes must still be deferred.
-type syncBlockState int
-
-const (
-	blockNotBeingSynced syncBlockState = iota
-	blockSyncingNotDirty
-	blockSyncingAndDirty
-)
-
 type syncInfo struct {
 	oldInfo    BlockInfo
 	op         *syncOp
@@ -97,13 +81,9 @@ type folderBlockOps struct {
 	// below.
 	blockLock blockLock
 
-	// Which blocks are currently being synced, so that writes and
-	// truncates can do copy-on-write to avoid messing up the ongoing
-	// sync.  If it is blockSyncingNotDirty, then any write to the
-	// block should result in a deep copy and those writes should be
-	// deferred; if it is blockSyncingAndDirty, then just defer the
-	// writes.
-	fileBlockStates map[BlockPointer]syncBlockState
+	// Which files are currently dirty and have dirty blocks that are either
+	// currently syncing, or waiting to be sync'd.
+	dirtyFiles map[BlockPointer]*dirtyFile
 
 	// For writes and truncates, track the unsynced to-be-unref'd
 	// block infos, per-path.
@@ -388,8 +368,9 @@ func (fbo *folderBlockOps) getFileBlockLocked(ctx context.Context,
 		// block is not yet dirty or the block is currently
 		// being sync'd and needs a copy even though it's
 		// already dirty.
+		df := fbo.dirtyFiles[file.tailPointer()]
 		if !fbo.config.DirtyBlockCache().IsDirty(ptr, file.Branch) ||
-			fbo.fileBlockStates[ptr] == blockSyncingNotDirty {
+			(df != nil && df.blockNeedsCopy(ptr)) {
 			fblock, err = fblock.DeepCopy(fbo.config.Codec())
 			if err != nil {
 				return nil, err
@@ -694,43 +675,43 @@ func (fbo *folderBlockOps) GetDirtyEntry(
 	return fbo.getDirtyEntryLocked(ctx, lState, md, file)
 }
 
+func (fbo *folderBlockOps) getOrCreateDirtyFileLocked(lState *lockState,
+	file BlockPointer) *dirtyFile {
+	fbo.blockLock.AssertLocked(lState)
+	df := fbo.dirtyFiles[file]
+	if df == nil {
+		df = newDirtyFile()
+		fbo.dirtyFiles[file] = df
+	}
+	return df
+}
+
 // cacheBlockIfNotYetDirtyLocked puts a block into the cache, but only
 // does so if the block isn't already marked as dirty in the cache.
 // This is useful when operating on a dirty copy of a block that may
 // already be in the cache.
 func (fbo *folderBlockOps) cacheBlockIfNotYetDirtyLocked(
-	lState *lockState, ptr BlockPointer, branch BranchName, block Block) error {
+	lState *lockState, ptr BlockPointer, file path, block Block) error {
 	fbo.blockLock.AssertLocked(lState)
+	df := fbo.getOrCreateDirtyFileLocked(lState, file.tailPointer())
+	needsCaching, isSyncing := df.dirtiedBlock(ptr)
 
-	if !fbo.config.DirtyBlockCache().IsDirty(ptr, branch) {
-		return fbo.config.DirtyBlockCache().Put(ptr, branch, block)
-	}
-
-	switch fbo.fileBlockStates[ptr] {
-	case blockNotBeingSynced:
-		// Nothing to do
-	case blockSyncingNotDirty:
-		// Overwrite the dirty block if this is a copy-on-write during
-		// a sync.  Don't worry, the old dirty block is safe in the
-		// sync goroutine (and also probably saved to the cache under
-		// its new ID already).
-		err := fbo.config.DirtyBlockCache().Put(ptr, branch, block)
+	if needsCaching {
+		err := fbo.config.DirtyBlockCache().Put(ptr, file.Branch, block)
 		if err != nil {
 			return err
 		}
-		// Future writes can use this same block.
-		fbo.fileBlockStates[ptr] = blockSyncingAndDirty
-		fbo.doDeferWrite = true
-	case blockSyncingAndDirty:
-		fbo.doDeferWrite = true
 	}
 
+	if isSyncing {
+		fbo.doDeferWrite = true
+	}
 	return nil
 }
 
 func (fbo *folderBlockOps) newRightBlockLocked(
 	ctx context.Context, lState *lockState, ptr BlockPointer,
-	branch BranchName, pblock *FileBlock,
+	file path, pblock *FileBlock,
 	off int64, md *RootMetadata) error {
 	fbo.blockLock.AssertLocked(lState)
 
@@ -760,13 +741,12 @@ func (fbo *folderBlockOps) newRightBlockLocked(
 		Off: off,
 	})
 
-	if err := fbo.config.DirtyBlockCache().Put(
-		newPtr, branch, rblock); err != nil {
+	if err = fbo.cacheBlockIfNotYetDirtyLocked(
+		lState, newPtr, file, rblock); err != nil {
 		return err
 	}
-
 	if err = fbo.cacheBlockIfNotYetDirtyLocked(
-		lState, ptr, branch, pblock); err != nil {
+		lState, ptr, file, pblock); err != nil {
 		return err
 	}
 	return nil
@@ -824,8 +804,8 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableError(
 	// If a copy of the top indirect block was made, we need to
 	// redirty all the sync'd blocks under their new IDs, so that
 	// future syncs will know they failed.
-	state := fbo.fileBlockStates[file.tailPointer()]
-	if state != blockSyncingAndDirty {
+	df := fbo.dirtyFiles[file.tailPointer()]
+	if df == nil || !df.blockSyncingAndDirty(file.tailPointer()) {
 		return
 	}
 
@@ -837,6 +817,7 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableError(
 			"top-block for %v: %v", file.tailPointer(), err)
 		return
 	}
+
 	for newPtr, oldPtr := range redirtyOnRecoverableError {
 		found := false
 		for i, iptr := range fblock.IPtrs {
@@ -851,15 +832,15 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableError(
 
 		fbo.log.CDebugf(ctx, "Re-dirtying %v (and deleting dirty block %v)",
 			newPtr, oldPtr)
-		// These block would have been permanent, so they're
+		// These blocks would have been permanent, so they're
 		// definitely still in the cache.
 		b, err := fbo.config.BlockCache().Get(newPtr)
 		if err != nil {
 			fbo.log.CWarningf(ctx, "Couldn't re-dirty %v: %v", newPtr, err)
 			continue
 		}
-		err = dirtyBcache.Put(newPtr, fbo.branch(), b)
-		if err != nil {
+		if err = fbo.cacheBlockIfNotYetDirtyLocked(
+			lState, newPtr, file, b); err != nil {
 			fbo.log.CWarningf(ctx, "Couldn't re-dirty %v: %v", newPtr, err)
 		}
 		err = dirtyBcache.Delete(oldPtr, fbo.branch())
@@ -1093,8 +1074,9 @@ func (fbo *folderBlockOps) writeGetFileLocked(
 // createIndirectBlockLocked creates a new indirect block and
 // pick a new id for the existing block, and use the existing block's ID for
 // the new indirect block that becomes the parent.
-func (fbo *folderBlockOps) createIndirectBlockLocked(md *RootMetadata,
-	file path, uid keybase1.UID, dver DataVer) (*FileBlock, error) {
+func (fbo *folderBlockOps) createIndirectBlockLocked(lState *lockState,
+	md *RootMetadata, file path, uid keybase1.UID, dver DataVer) (
+	*FileBlock, error) {
 
 	newID, err := fbo.config.Crypto().MakeTemporaryBlockID()
 	if err != nil {
@@ -1120,9 +1102,8 @@ func (fbo *folderBlockOps) createIndirectBlockLocked(md *RootMetadata,
 			},
 		},
 	}
-	dirtyBcache := fbo.config.DirtyBlockCache()
-	err = dirtyBcache.Put(file.tailPointer(), file.Branch, fblock)
-
+	err = fbo.cacheBlockIfNotYetDirtyLocked(lState, file.tailPointer(), file,
+		fblock)
 	if err != nil {
 		return nil, err
 	}
@@ -1183,8 +1164,8 @@ func (fbo *folderBlockOps) writeDataLocked(
 		if nCopied < n && nextBlockOff < 0 {
 			// If the block doesn't already have a parent block, make one.
 			if ptr == file.tailPointer() {
-				fblock, err = fbo.createIndirectBlockLocked(md, file, uid,
-					DefaultNewBlockDataVersion(fbo.config, false))
+				fblock, err = fbo.createIndirectBlockLocked(lState, md, file,
+					uid, DefaultNewBlockDataVersion(fbo.config, false))
 				if err != nil {
 					return WriteRange{}, nil, err
 				}
@@ -1194,14 +1175,14 @@ func (fbo *folderBlockOps) writeDataLocked(
 			// Make a new right block and update the parent's
 			// indirect block list
 			err = fbo.newRightBlockLocked(ctx, lState, file.tailPointer(),
-				file.Branch, fblock, startOff+int64(len(block.Contents)), md)
+				file, fblock, startOff+int64(len(block.Contents)), md)
 			if err != nil {
 				return WriteRange{}, nil, err
 			}
 		} else if nCopied < n && off+nCopied < nextBlockOff {
 			// We need a new block to be inserted here
 			err = fbo.newRightBlockLocked(ctx, lState, file.tailPointer(),
-				file.Branch, fblock, startOff+int64(len(block.Contents)), md)
+				file, fblock, startOff+int64(len(block.Contents)), md)
 			if err != nil {
 				return WriteRange{}, nil, err
 			}
@@ -1226,7 +1207,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 			parentBlock.IPtrs[indexInParent].EncodedSize = 0
 		}
 		// keep the old block ID while it's dirty
-		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState, ptr, file.Branch,
+		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState, ptr, file,
 			block); err != nil {
 			return WriteRange{}, nil, err
 		}
@@ -1239,9 +1220,9 @@ func (fbo *folderBlockOps) writeDataLocked(
 		// that any write to a file while it's being sync'd will be
 		// deferred, even if it's to a block that's not currently
 		// being sync'd, since this top-most block will always be in
-		// the fileBlockStates map.
+		// the dirtyFiles map.
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
-			file.tailPointer(), file.Branch, fblock); err != nil {
+			file.tailPointer(), file, fblock); err != nil {
 			return WriteRange{}, nil, err
 		}
 		dirtyPtrs = append(dirtyPtrs, file.tailPointer())
@@ -1340,13 +1321,14 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	if !fblock.IsInd {
 		fbo.log.CDebugf(ctx, "truncateExtendLocked: making block indirect %v", file.tailPointer())
 		old := fblock
-		fblock, err = fbo.createIndirectBlockLocked(md, file, uid,
+		fblock, err = fbo.createIndirectBlockLocked(lState, md, file, uid,
 			DefaultNewBlockDataVersion(fbo.config, true))
 		if err != nil {
 			return WriteRange{}, nil, err
 		}
 		fblock.IPtrs[0].Holes = true
-		err = fbo.cacheBlockIfNotYetDirtyLocked(lState, fblock.IPtrs[0].BlockPointer, file.Branch, old)
+		err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
+			fblock.IPtrs[0].BlockPointer, file, old)
 		if err != nil {
 			return WriteRange{}, nil, err
 		}
@@ -1359,12 +1341,13 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	// generalize, just annoying
 
 	err = fbo.newRightBlockLocked(ctx, lState, file.tailPointer(),
-		file.Branch, fblock, int64(size), md)
+		file, fblock, int64(size), md)
 	if err != nil {
 		return WriteRange{}, nil, err
 	}
 	dirtyPtrs = append(dirtyPtrs, fblock.IPtrs[len(fblock.IPtrs)-1].BlockPointer)
-	fbo.log.CDebugf(ctx, "truncateExtendLocked: new right data block %v", fblock.IPtrs[len(fblock.IPtrs)-1].BlockPointer)
+	fbo.log.CDebugf(ctx, "truncateExtendLocked: new right data block %v",
+		fblock.IPtrs[len(fblock.IPtrs)-1].BlockPointer)
 
 	de, err := fbo.getDirtyEntryLocked(ctx, lState, md, file)
 	if err != nil {
@@ -1390,7 +1373,7 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	// being sync'd, since this top-most block will always be in
 	// the fileBlockStates map.
 	err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
-		file.tailPointer(), file.Branch, fblock)
+		file.tailPointer(), file, fblock)
 	if err != nil {
 		return WriteRange{}, nil, err
 	}
@@ -1472,7 +1455,7 @@ func (fbo *folderBlockOps) truncateLocked(
 		parentBlock.IPtrs = parentBlock.IPtrs[:indexInParent+1]
 		// always make the parent block dirty, so we will sync it
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
-			file.tailPointer(), file.Branch, parentBlock); err != nil {
+			file.tailPointer(), file, parentBlock); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -1483,9 +1466,9 @@ func (fbo *folderBlockOps) truncateLocked(
 		// that any truncate to a file while it's being sync'd will be
 		// deferred, even if it's to a block that's not currently
 		// being sync'd, since this top-most block will always be in
-		// the fileBlockStates map.
+		// the dirtyFiles map.
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
-			file.tailPointer(), file.Branch, fblock); err != nil {
+			file.tailPointer(), file, fblock); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -1507,7 +1490,7 @@ func (fbo *folderBlockOps) truncateLocked(
 
 	// Keep the old block ID while it's dirty.
 	if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
-		ptr, file.Branch, block); err != nil {
+		ptr, file, block); err != nil {
 		return nil, nil, err
 	}
 
@@ -1762,6 +1745,7 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 
 	bcache := fbo.config.BlockCache()
 	dirtyBcache := fbo.config.DirtyBlockCache()
+	df := fbo.getOrCreateDirtyFileLocked(lState, file.tailPointer())
 
 	// Note: below we add possibly updated file blocks as "unref" and
 	// "ref" blocks.  This is fine, since conflict resolution or
@@ -1809,7 +1793,7 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 					if nextBlockOff < 0 {
 						// need to make a new block
 						if err := fbo.newRightBlockLocked(
-							ctx, lState, file.tailPointer(), file.Branch, fblock,
+							ctx, lState, file.tailPointer(), file, fblock,
 							endOfBlock, md); err != nil {
 							return nil, nil, syncState, err
 						}
@@ -1823,7 +1807,7 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 					}
 					rblock.Contents = append(extraBytes, rblock.Contents...)
 					if err = fbo.cacheBlockIfNotYetDirtyLocked(
-						lState, rPtr, file.Branch, rblock); err != nil {
+						lState, rPtr, file, rblock); err != nil {
 						return nil, nil, syncState, err
 					}
 					fblock.IPtrs[i+1].Off = ptr.Off + int64(len(block.Contents))
@@ -1849,7 +1833,7 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 					rblock.Contents = rblock.Contents[nCopied:]
 					if len(rblock.Contents) > 0 {
 						if err = fbo.cacheBlockIfNotYetDirtyLocked(
-							lState, rPtr, file.Branch, rblock); err != nil {
+							lState, rPtr, file, rblock); err != nil {
 							return nil, nil, syncState, err
 						}
 						fblock.IPtrs[i+1].Off =
@@ -1907,13 +1891,19 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 				fblock.IPtrs[i].BlockInfo = newInfo
 				md.AddRefBlock(newInfo)
 				si.bps.addNewBlock(newInfo.BlockPointer, block, readyBlockData)
-				fbo.fileBlockStates[localPtr] = blockSyncingNotDirty
+				err = df.syncingBlock(localPtr)
+				if err != nil {
+					return nil, nil, syncState, err
+				}
 				syncState.redirtyOnRecoverableError[newInfo.BlockPointer] = localPtr
 			}
 		}
 	}
 
-	fbo.fileBlockStates[file.tailPointer()] = blockSyncingNotDirty
+	err = df.syncingBlock(file.tailPointer())
+	if err != nil {
+		return nil, nil, syncState, err
+	}
 	syncState.oldFileBlockPtrs = append(syncState.oldFileBlockPtrs, file.tailPointer())
 	// TODO: Returning si.bps in this way is racy, since si is a
 	// member of unrefCache.
@@ -2020,7 +2010,10 @@ func (fbo *folderBlockOps) CleanupSyncState(
 	// don't defer any subsequent writes.
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
-	fbo.fileBlockStates = make(map[BlockPointer]syncBlockState)
+	// Old syncing blocks are now just dirty
+	if df := fbo.dirtyFiles[file.tailPointer()]; df != nil {
+		df.errorOnSync()
+	}
 
 	// TODO: Clear deferredWrites and deferredDirtyDeletes?
 }
@@ -2051,7 +2044,7 @@ func (fbo *folderBlockOps) FinishSync(
 		}
 	}
 
-	fbo.fileBlockStates = make(map[BlockPointer]syncBlockState)
+	delete(fbo.dirtyFiles, oldPath.tailPointer())
 	// Redo any writes or truncates that happened to our file while
 	// the sync was happening.
 	deletes := fbo.deferredDirtyDeletes
@@ -2068,11 +2061,11 @@ func (fbo *folderBlockOps) FinishSync(
 		}
 	}
 
-	// Clear cached info for the old path.  We are guaranteed that
-	// any concurrent write to this file was deferred, even if it
-	// was to a block that wasn't currently being sync'd, since
-	// the top-most block is always in fileBlockStates and is
-	// always dirtied during a write/truncate.
+	// Clear cached info for the old path.  We are guaranteed that any
+	// concurrent write to this file was deferred, even if it was to a
+	// block that wasn't currently being sync'd, since the top-most
+	// block is always in dirtyFiles and is always dirtied during a
+	// write/truncate.
 	//
 	// Also, we can get rid of all the sync state that might have
 	// happened during the sync, since we will replay the writes

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -318,9 +318,9 @@ func newFolderBranchOps(config Config, fb FolderBranch,
 			blockLock: blockLock{
 				leveledRWMutex: blockLockMu,
 			},
-			fileBlockStates: make(map[BlockPointer]syncBlockState),
-			unrefCache:      make(map[blockRef]*syncInfo),
-			deCache:         make(map[blockRef]DirEntry),
+			dirtyFiles: make(map[BlockPointer]*dirtyFile),
+			unrefCache: make(map[blockRef]*syncInfo),
+			deCache:    make(map[blockRef]DirEntry),
 			deferredWrites: make(
 				[]func(context.Context, *lockState, *RootMetadata, path) error, 0),
 			nodeCache: nodeCache,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1169,6 +1169,11 @@ func newBlockPutState(length int) *blockPutState {
 	return bps
 }
 
+// addNewBlock tracks a new block that will be put.  If syncedCb is
+// non-nil, it will be called whenever the put for that block is
+// complete (whether or not the put resulted in an error).  Currently
+// it will not be called if the block is never put (due to an earlier
+// error).
 func (bps *blockPutState) addNewBlock(blockPtr BlockPointer, block Block,
 	readyBlockData ReadyBlockData, syncedCb func() error) {
 	bps.blockStates = append(bps.blockStates,

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3893,7 +3893,7 @@ func makeBlockStateDirty(config Config, rmd *RootMetadata, p path,
 	ops.blocks.blockLock.Lock(lState)
 	defer ops.blocks.blockLock.Unlock(lState)
 	df := ops.blocks.getOrCreateDirtyFileLocked(lState, p.tailPointer())
-	df.dirtiedBlock(ptr)
+	df.setBlockDirty(ptr)
 }
 
 // SetMtime failure cases are all the same as any other block sync

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3886,7 +3886,7 @@ func getOrCreateSyncInfo(
 	return ops.blocks.getOrCreateSyncInfoLocked(lState, de)
 }
 
-func dirtyBlockState(config Config, rmd *RootMetadata, p path,
+func makeBlockStateDirty(config Config, rmd *RootMetadata, p path,
 	ptr BlockPointer) {
 	ops := getOps(config, rmd.ID)
 	lState := makeFBOLockState()
@@ -3929,7 +3929,7 @@ func testSyncDirtySuccess(t *testing.T, isUnmerged bool) {
 
 	// fsync a
 	config.DirtyBlockCache().Put(aNode.BlockPointer, p.Branch, aBlock)
-	dirtyBlockState(config, rmd, p, aNode.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, aNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 	// TODO: put a dirty DE entry in the cache, to test that the new
 	// root block has the correct file size.
@@ -4032,7 +4032,7 @@ func expectSyncDirtyBlock(config *ConfigMock, rmd *RootMetadata,
 		config.DirtyBlockCache().Put(ptr, branch, block)
 	}
 	if !opsLockHeld {
-		dirtyBlockState(config, rmd, p, ptr)
+		makeBlockStateDirty(config, rmd, p, ptr)
 	}
 	c1 := config.mockBsplit.EXPECT().CheckSplit(block).Return(splitAt)
 
@@ -4116,7 +4116,7 @@ func TestSyncDirtyMultiBlocksSuccess(t *testing.T) {
 
 	// fsync a, only block 2 is dirty
 	config.DirtyBlockCache().Put(fileNode.BlockPointer, p.Branch, fileBlock)
-	dirtyBlockState(config, rmd, p, fileNode.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, fileNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 
 	// the split is good
@@ -4222,7 +4222,7 @@ func TestSyncDirtyDupBlockSuccess(t *testing.T) {
 	si.op.addWrite(0, 10)
 
 	config.DirtyBlockCache().Put(bNode.BlockPointer, p.Branch, bBlock)
-	dirtyBlockState(config, rmd, p, bNode.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, bNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(config, aNode.BlockPointer, id, aBlock)
 
@@ -4365,7 +4365,7 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 	config.mockDirtyBcache.EXPECT().IsDirty(
 		ptrMatcher{fileBlock.IPtrs[0].BlockPointer},
 		p.Branch).AnyTimes().Return(false)
-	dirtyBlockState(config, rmd, p, fileNode.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, fileNode.BlockPointer)
 	config.mockDirtyBcache.EXPECT().IsDirty(
 		ptrMatcher{fileBlock.IPtrs[2].BlockPointer},
 		p.Branch).Return(false)
@@ -4379,7 +4379,7 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 		p.Branch).AnyTimes().Return(false)
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{node.BlockPointer},
 		p.Branch).AnyTimes().Return(true)
-	dirtyBlockState(config, rmd, p, node.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, node.BlockPointer)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{node.BlockPointer}, p.Branch).
 		AnyTimes().Return(rootBlock, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{fileNode.BlockPointer},
@@ -4559,12 +4559,12 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 	// fsync a, only block 2 is dirty
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{fileNode.BlockPointer},
 		p.Branch).AnyTimes().Return(true)
-	dirtyBlockState(config, rmd, p, fileNode.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, fileNode.BlockPointer)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{fileNode.BlockPointer},
 		p.Branch).AnyTimes().Return(fileBlock, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{node.BlockPointer},
 		p.Branch).AnyTimes().Return(true)
-	dirtyBlockState(config, rmd, p, node.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, node.BlockPointer)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{node.BlockPointer}, p.Branch).
 		AnyTimes().Return(rootBlock, nil)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{fileBlock.IPtrs[1].BlockPointer},
@@ -4712,7 +4712,7 @@ func TestSyncDirtyWithBlockChangePointerSuccess(t *testing.T) {
 
 	// fsync a
 	config.DirtyBlockCache().Put(aNode.BlockPointer, p.Branch, aBlock)
-	dirtyBlockState(config, rmd, p, aNode.BlockPointer)
+	makeBlockStateDirty(config, rmd, p, aNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 
 	// override the AnyTimes expect call done by default in expectSyncBlock()

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3892,7 +3892,7 @@ func makeBlockStateDirty(config Config, rmd *RootMetadata, p path,
 	lState := makeFBOLockState()
 	ops.blocks.blockLock.Lock(lState)
 	defer ops.blocks.blockLock.Unlock(lState)
-	df := ops.blocks.getOrCreateDirtyFileLocked(lState, p.tailPointer())
+	df := ops.blocks.getOrCreateDirtyFileLocked(lState, p)
 	df.setBlockDirty(ptr)
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3886,6 +3886,16 @@ func getOrCreateSyncInfo(
 	return ops.blocks.getOrCreateSyncInfoLocked(lState, de)
 }
 
+func dirtyBlockState(config Config, rmd *RootMetadata, p path,
+	ptr BlockPointer) {
+	ops := getOps(config, rmd.ID)
+	lState := makeFBOLockState()
+	ops.blocks.blockLock.Lock(lState)
+	defer ops.blocks.blockLock.Unlock(lState)
+	df := ops.blocks.getOrCreateDirtyFileLocked(lState, p.tailPointer())
+	df.dirtiedBlock(ptr)
+}
+
 // SetMtime failure cases are all the same as any other block sync
 
 func testSyncDirtySuccess(t *testing.T, isUnmerged bool) {
@@ -3919,6 +3929,7 @@ func testSyncDirtySuccess(t *testing.T, isUnmerged bool) {
 
 	// fsync a
 	config.DirtyBlockCache().Put(aNode.BlockPointer, p.Branch, aBlock)
+	dirtyBlockState(config, rmd, p, aNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 	// TODO: put a dirty DE entry in the cache, to test that the new
 	// root block has the correct file size.
@@ -4009,8 +4020,8 @@ func TestSyncCleanSuccess(t *testing.T) {
 }
 
 func expectSyncDirtyBlock(config *ConfigMock, rmd *RootMetadata,
-	ptr BlockPointer, block *FileBlock, splitAt int64,
-	padSize int) *gomock.Call {
+	p path, ptr BlockPointer, block *FileBlock, splitAt int64,
+	padSize int, opsLockHeld bool) *gomock.Call {
 	branch := MasterBranch
 	if config.mockDirtyBcache != nil {
 		config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{ptr}, branch).
@@ -4019,6 +4030,9 @@ func expectSyncDirtyBlock(config *ConfigMock, rmd *RootMetadata,
 			AnyTimes().Return(block, nil)
 	} else {
 		config.DirtyBlockCache().Put(ptr, branch, block)
+	}
+	if !opsLockHeld {
+		dirtyBlockState(config, rmd, p, ptr)
 	}
 	c1 := config.mockBsplit.EXPECT().CheckSplit(block).Return(splitAt)
 
@@ -4102,15 +4116,16 @@ func TestSyncDirtyMultiBlocksSuccess(t *testing.T) {
 
 	// fsync a, only block 2 is dirty
 	config.DirtyBlockCache().Put(fileNode.BlockPointer, p.Branch, fileBlock)
+	dirtyBlockState(config, rmd, p, fileNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 
 	// the split is good
 	pad2 := 5
 	pad4 := 8
-	expectSyncDirtyBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2,
-		int64(0), pad2)
-	expectSyncDirtyBlock(config, rmd, fileBlock.IPtrs[3].BlockPointer, block4,
-		int64(0), pad4)
+	expectSyncDirtyBlock(config, rmd, p, fileBlock.IPtrs[1].BlockPointer,
+		block2, int64(0), pad2, false)
+	expectSyncDirtyBlock(config, rmd, p, fileBlock.IPtrs[3].BlockPointer,
+		block4, int64(0), pad4, false)
 
 	// sync 2 blocks, plus their pad sizes
 	refBytes := uint64((len(block2.Contents) + pad2) +
@@ -4207,6 +4222,7 @@ func TestSyncDirtyDupBlockSuccess(t *testing.T) {
 	si.op.addWrite(0, 10)
 
 	config.DirtyBlockCache().Put(bNode.BlockPointer, p.Branch, bBlock)
+	dirtyBlockState(config, rmd, p, bNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(config, aNode.BlockPointer, id, aBlock)
 
@@ -4349,9 +4365,10 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 	config.mockDirtyBcache.EXPECT().IsDirty(
 		ptrMatcher{fileBlock.IPtrs[0].BlockPointer},
 		p.Branch).AnyTimes().Return(false)
+	dirtyBlockState(config, rmd, p, fileNode.BlockPointer)
 	config.mockDirtyBcache.EXPECT().IsDirty(
 		ptrMatcher{fileBlock.IPtrs[2].BlockPointer},
-		p.Branch).Times(2).Return(false)
+		p.Branch).Return(false)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{fileBlock.IPtrs[2].BlockPointer},
 		p.Branch).Return(nil,
 		NoSuchBlockError{fileBlock.IPtrs[2].BlockPointer.ID})
@@ -4362,6 +4379,7 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 		p.Branch).AnyTimes().Return(false)
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{node.BlockPointer},
 		p.Branch).AnyTimes().Return(true)
+	dirtyBlockState(config, rmd, p, node.BlockPointer)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{node.BlockPointer}, p.Branch).
 		AnyTimes().Return(rootBlock, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{fileNode.BlockPointer},
@@ -4377,8 +4395,8 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 	pad2 := 0
 	pad3 := 14
 	extraBytesFor3 := 2
-	expectSyncDirtyBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2,
-		int64(len(block2.Contents)-extraBytesFor3), pad2)
+	expectSyncDirtyBlock(config, rmd, p, fileBlock.IPtrs[1].BlockPointer,
+		block2, int64(len(block2.Contents)-extraBytesFor3), pad2, false)
 	// this causes block 3 to be updated
 	var newBlock3 *FileBlock
 	config.mockDirtyBcache.EXPECT().Put(fileBlock.IPtrs[2].BlockPointer,
@@ -4388,14 +4406,15 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 			// id3 syncs just fine
 			config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{ptr}, branch).
 				AnyTimes().Return(true)
-			expectSyncDirtyBlock(config, rmd, ptr, newBlock3, int64(0), pad3)
+			expectSyncDirtyBlock(config, rmd, p, ptr, newBlock3, int64(0), pad3,
+				true)
 		}).Return(nil)
 
 	// id4 is the final block, and the split causes a new block to be made
 	pad4 := 9
 	pad5 := 1
-	c4 := expectSyncDirtyBlock(config, rmd, fileBlock.IPtrs[3].BlockPointer,
-		block4, int64(3), pad4)
+	c4 := expectSyncDirtyBlock(config, rmd, p, fileBlock.IPtrs[3].BlockPointer,
+		block4, int64(3), pad4, false)
 	var newID5 BlockID
 	var newBlock5 *FileBlock
 	id5 := fakeBlockID(48)
@@ -4406,7 +4425,8 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 			newID5 = ptr.ID
 			newBlock5 = block.(*FileBlock)
 			// id5 syncs just fine
-			expectSyncDirtyBlock(config, rmd, ptr, newBlock5, int64(0), pad5)
+			expectSyncDirtyBlock(config, rmd, p, ptr, newBlock5, int64(0), pad5,
+				true)
 			config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{ptr}, branch).
 				AnyTimes().Return(true)
 		}).Return(nil)
@@ -4539,10 +4559,12 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 	// fsync a, only block 2 is dirty
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{fileNode.BlockPointer},
 		p.Branch).AnyTimes().Return(true)
+	dirtyBlockState(config, rmd, p, fileNode.BlockPointer)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{fileNode.BlockPointer},
 		p.Branch).AnyTimes().Return(fileBlock, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{node.BlockPointer},
 		p.Branch).AnyTimes().Return(true)
+	dirtyBlockState(config, rmd, p, node.BlockPointer)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{node.BlockPointer}, p.Branch).
 		AnyTimes().Return(rootBlock, nil)
 	config.mockDirtyBcache.EXPECT().Get(ptrMatcher{fileBlock.IPtrs[1].BlockPointer},
@@ -4560,7 +4582,7 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 		Return(block4, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(
 		ptrMatcher{fileBlock.IPtrs[3].BlockPointer},
-		p.Branch).Times(2).Return(false)
+		p.Branch).Return(false)
 
 	// no matching pointers
 	config.mockBcache.EXPECT().CheckForKnownPtr(gomock.Any(), gomock.Any()).
@@ -4568,8 +4590,8 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 
 	// the split is in the middle
 	pad1 := 14
-	expectSyncDirtyBlock(config, rmd, fileBlock.IPtrs[0].BlockPointer,
-		block1, int64(-1), pad1)
+	expectSyncDirtyBlock(config, rmd, p, fileBlock.IPtrs[0].BlockPointer,
+		block1, int64(-1), pad1, false)
 	// this causes block 2 to be copied from (copy whole block)
 	config.mockBsplit.EXPECT().CopyUntilSplit(
 		gomock.Any(), gomock.Any(), block2.Contents, int64(5)).
@@ -4582,8 +4604,8 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 	pad3 := 10
 	split4At := int64(3)
 	pad4 := 15
-	expectSyncDirtyBlock(config, rmd, fileBlock.IPtrs[2].BlockPointer, block3,
-		int64(-1), pad3)
+	expectSyncDirtyBlock(config, rmd, p, fileBlock.IPtrs[2].BlockPointer,
+		block3, int64(-1), pad3, false)
 	config.mockBsplit.EXPECT().CopyUntilSplit(
 		gomock.Any(), gomock.Any(), block4.Contents, int64(5)).
 		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
@@ -4596,7 +4618,8 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 			newBlock4 = block.(*FileBlock)
 			// now block 4 is dirty, but it's the end of the line,
 			// so nothing else to do
-			expectSyncDirtyBlock(config, rmd, ptr, newBlock4, int64(-1), pad4)
+			expectSyncDirtyBlock(config, rmd, p, ptr, newBlock4, int64(-1),
+				pad4, true)
 			config.mockDirtyBcache.EXPECT().IsDirty(ptrMatcher{ptr}, branch).
 				AnyTimes().Return(false)
 		}).Return(nil)
@@ -4689,6 +4712,7 @@ func TestSyncDirtyWithBlockChangePointerSuccess(t *testing.T) {
 
 	// fsync a
 	config.DirtyBlockCache().Put(aNode.BlockPointer, p.Branch, aBlock)
+	dirtyBlockState(config, rmd, p, aNode.BlockPointer)
 	testPutBlockInCache(config, node.BlockPointer, id, rootBlock)
 
 	// override the AnyTimes expect call done by default in expectSyncBlock()


### PR DESCRIPTION
This tracks the state each block is in for a file that's been written to.  In addition, it notes when a block is done syncing, even if the overall sync isn't finished yet.  In future commits, this will let us new Writes proceed as buffer space gets freed up.

Issue: KBFS-1104