### PR TITLE
[KBFS-1134] Always use creator in BlockIdCombo

### DIFF
--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -224,7 +224,7 @@ func (b *BlockServerMemory) Put(ctx context.Context, id BlockID, tlfID TlfID,
 
 		if entry.keyServerHalf != serverHalf {
 			return fmt.Errorf(
-				"key server half mismatch: expected %v, got %v",
+				"key server half mismatch: expected %s, got %s",
 				entry.keyServerHalf, serverHalf)
 		}
 

--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -399,6 +399,12 @@ func (b *BlockServerMemory) getAll(tlfID TlfID) (
 	return res, nil
 }
 
+func (b *BlockServerMemory) numBlocks() int {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	return len(b.m)
+}
+
 // Shutdown implements the BlockServer interface for BlockServerMemory.
 func (b *BlockServerMemory) Shutdown() {
 	b.lock.Lock()

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -200,7 +200,7 @@ func (b *BlockServerRemote) Get(ctx context.Context, id BlockID, tlfID TlfID,
 	arg := keybase1.GetBlockArg{
 		Bid: keybase1.BlockIdCombo{
 			BlockHash: id.String(),
-			ChargedTo: context.GetWriter(),
+			ChargedTo: context.GetCreator(),
 		},
 		Folder: tlfID.String(),
 	}
@@ -239,8 +239,8 @@ func (b *BlockServerRemote) Put(ctx context.Context, id BlockID, tlfID TlfID,
 
 	arg := keybase1.PutBlockArg{
 		Bid: keybase1.BlockIdCombo{
-			ChargedTo: context.GetWriter(),
 			BlockHash: id.String(),
+			ChargedTo: context.GetCreator(),
 		},
 		BlockKey: serverHalf.String(),
 		Folder:   tlfID.String(),
@@ -275,8 +275,8 @@ func (b *BlockServerRemote) AddBlockReference(ctx context.Context, id BlockID,
 
 	ref := keybase1.BlockReference{
 		Bid: keybase1.BlockIdCombo{
-			ChargedTo: context.GetCreator(),
 			BlockHash: id.String(),
+			ChargedTo: context.GetCreator(),
 		},
 		ChargedTo: context.GetWriter(), //the actual writer to decrement quota from
 		Nonce:     keybase1.BlockRefNonce(context.GetRefNonce()),
@@ -423,8 +423,8 @@ func (b *BlockServerRemote) getNotDone(all map[BlockID][]BlockContext, doneRefs 
 			}
 			notDone = append(notDone, keybase1.BlockReference{
 				Bid: keybase1.BlockIdCombo{
-					ChargedTo: context.GetCreator(),
 					BlockHash: id.String(),
+					ChargedTo: context.GetCreator(),
 				},
 				ChargedTo: context.GetWriter(),
 				Nonce:     keybase1.BlockRefNonce(context.GetRefNonce()),

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -187,6 +187,8 @@ func makeBlockIDCombo(id BlockID, context BlockContext) keybase1.BlockIdCombo {
 	// used in a BlockReference -- it just refers to the original
 	// creator of the block, i.e. the original user charged for
 	// the block.
+	//
+	// This may all change once we implement groups.
 	return keybase1.BlockIdCombo{
 		BlockHash: id.String(),
 		ChargedTo: context.GetCreator(),
@@ -196,7 +198,7 @@ func makeBlockIDCombo(id BlockID, context BlockContext) keybase1.BlockIdCombo {
 func makeBlockReference(id BlockID, context BlockContext) keybase1.BlockReference {
 	return keybase1.BlockReference{
 		Bid: makeBlockIDCombo(id, context),
-		// The actual writer to decrement quota from.
+		// The actual writer to modify quota for.
 		ChargedTo: context.GetWriter(),
 		Nonce:     keybase1.BlockRefNonce(context.GetRefNonce()),
 	}

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -255,7 +255,9 @@ func (b *BlockServerRemote) Put(ctx context.Context, id BlockID, tlfID TlfID,
 	}()
 
 	arg := keybase1.PutBlockArg{
-		Bid:      makeBlockIDCombo(id, context),
+		Bid: makeBlockIDCombo(id, context),
+		// BlockKey is misnamed -- it contains just the server
+		// half.
 		BlockKey: serverHalf.String(),
 		Folder:   tlfID.String(),
 		Buf:      buf,

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -182,7 +182,7 @@ func (b *BlockServerRemote) ShouldRetryOnConnect(err error) bool {
 	return !inputCanceled
 }
 
-func makeBlockIdCombo(id BlockID, context BlockContext) keybase1.BlockIdCombo {
+func makeBlockIDCombo(id BlockID, context BlockContext) keybase1.BlockIdCombo {
 	// ChargedTo is somewhat confusing when this BlockIdCombo is
 	// used in a BlockReference -- it just refers to the original
 	// creator of the block, i.e. the original user charged for
@@ -195,7 +195,7 @@ func makeBlockIdCombo(id BlockID, context BlockContext) keybase1.BlockIdCombo {
 
 func makeBlockReference(id BlockID, context BlockContext) keybase1.BlockReference {
 	return keybase1.BlockReference{
-		Bid: makeBlockIdCombo(id, context),
+		Bid: makeBlockIDCombo(id, context),
 		// The actual writer to decrement quota from.
 		ChargedTo: context.GetWriter(),
 		Nonce:     keybase1.BlockRefNonce(context.GetRefNonce()),
@@ -218,7 +218,7 @@ func (b *BlockServerRemote) Get(ctx context.Context, id BlockID, tlfID TlfID,
 	}()
 
 	arg := keybase1.GetBlockArg{
-		Bid:    makeBlockIdCombo(id, context),
+		Bid:    makeBlockIDCombo(id, context),
 		Folder: tlfID.String(),
 	}
 
@@ -255,7 +255,7 @@ func (b *BlockServerRemote) Put(ctx context.Context, id BlockID, tlfID TlfID,
 	}()
 
 	arg := keybase1.PutBlockArg{
-		Bid:      makeBlockIdCombo(id, context),
+		Bid:      makeBlockIDCombo(id, context),
 		BlockKey: serverHalf.String(),
 		Folder:   tlfID.String(),
 		Buf:      buf,

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -211,11 +211,13 @@ func (b *BlockServerRemote) Get(ctx context.Context, id BlockID, tlfID TlfID,
 	size := -1
 	defer func() {
 		if err != nil {
-			b.deferLog.CWarningf(ctx, "Get id=%s uid=%s sz=%d err=%v",
-				id, context.GetWriter(), size, err)
+			b.deferLog.CWarningf(
+				ctx, "Get id=%s tlf=%s context=%s sz=%d err=%v",
+				id, tlfID, context, size, err)
 		} else {
-			b.deferLog.CDebugf(ctx, "Get id=%s uid=%s sz=%d",
-				id, context.GetWriter(), size)
+			b.deferLog.CDebugf(
+				ctx, "Get id=%s tlf=%s context=%s sz=%d",
+				id, tlfID, context, size)
 		}
 	}()
 
@@ -248,11 +250,12 @@ func (b *BlockServerRemote) Put(ctx context.Context, id BlockID, tlfID TlfID,
 	defer func() {
 		if err != nil {
 			b.deferLog.CWarningf(
-				ctx, "Put id=%s uid=%s sz=%d err=%v",
-				id, context.GetWriter(), size, err)
+				ctx, "Put id=%s tlf=%s context=%s sz=%d err=%v",
+				id, tlfID, context, size, err)
 		} else {
-			b.deferLog.CDebugf(ctx, "Put id=%s uid=%s sz=%d",
-				id, context.GetWriter(), size)
+			b.deferLog.CDebugf(
+				ctx, "Put id=%s tlf=%s context=%s sz=%d",
+				id, tlfID, context, size)
 		}
 	}()
 
@@ -282,12 +285,12 @@ func (b *BlockServerRemote) AddBlockReference(ctx context.Context, id BlockID,
 	defer func() {
 		if err != nil {
 			b.deferLog.CWarningf(
-				ctx, "AddBlockReference id=%s uid=%s err=%v",
-				id, context.GetWriter(), err)
+				ctx, "AddBlockReference id=%s tlf=%s context=%s err=%v",
+				id, tlfID, context, err)
 		} else {
 			b.deferLog.CDebugf(
-				ctx, "AddBlockReference id=%s uid=%s",
-				id, context.GetWriter())
+				ctx, "AddBlockReference id=%s tlf=%s context=%s",
+				id, tlfID, context)
 		}
 	}()
 

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -6,9 +6,7 @@ package libkbfs
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
@@ -85,16 +83,10 @@ func (fc *FakeBServerClient) PutBlock(ctx context.Context, arg keybase1.PutBlock
 		return err
 	}
 
-	buf, err := hex.DecodeString(arg.BlockKey)
+	serverHalf, err := ParseBlockCryptKeyServerHalf(arg.BlockKey)
 	if err != nil {
-		return fmt.Errorf("Invalid server half %s", arg.BlockKey)
+		return err
 	}
-	var serverHalfData [32]byte
-	if len(buf) != len(serverHalfData) {
-		return fmt.Errorf("Invalid server half %s", arg.BlockKey)
-	}
-	copy(serverHalfData[:], buf)
-	serverHalf := MakeBlockCryptKeyServerHalf(serverHalfData)
 
 	bCtx := BlockContext{
 		RefNonce: zeroBlockRefNonce,

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -80,9 +80,9 @@ func (fc *FakeBServerClient) PutBlock(ctx context.Context, arg keybase1.PutBlock
 		return err
 	}
 
-	tlfID := ParseTlfID(arg.Folder)
-	if tlfID == NullTlfID {
-		return fmt.Errorf("Invalid TLF ID %s", arg.Folder)
+	tlfID, err := ParseTlfID(arg.Folder)
+	if err != nil {
+		return err
 	}
 
 	buf, err := hex.DecodeString(arg.BlockKey)
@@ -115,9 +115,9 @@ func (fc *FakeBServerClient) GetBlock(ctx context.Context, arg keybase1.GetBlock
 		return keybase1.GetBlockRes{}, err
 	}
 
-	tlfID := ParseTlfID(arg.Folder)
-	if tlfID == NullTlfID {
-		return keybase1.GetBlockRes{}, fmt.Errorf("Invalid TLF ID %s", arg.Folder)
+	tlfID, err := ParseTlfID(arg.Folder)
+	if err != nil {
+		return keybase1.GetBlockRes{}, err
 	}
 
 	bCtx := BlockContext{
@@ -141,9 +141,9 @@ func (fc *FakeBServerClient) AddReference(ctx context.Context, arg keybase1.AddR
 		return err
 	}
 
-	tlfID := ParseTlfID(arg.Folder)
-	if tlfID == NullTlfID {
-		return fmt.Errorf("Invalid TLF ID %s", arg.Folder)
+	tlfID, err := ParseTlfID(arg.Folder)
+	if err != nil {
+		return err
 	}
 
 	bCtx := BlockContext{

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -112,8 +112,10 @@ func (fc *FakeBServerClient) GetBlock(ctx context.Context, arg keybase1.GetBlock
 		return keybase1.GetBlockRes{}, err
 	}
 
-	// Always use this block context since the RPC API drops the
-	// real context.
+	// Always use this block context (the one the block was
+	// originally put with) since the RPC API doesn't pass along
+	// all the info from the block context passed into
+	// BlockServer.Get().
 	bCtx := BlockContext{
 		RefNonce: zeroBlockRefNonce,
 		Creator:  arg.Bid.ChargedTo,

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -112,6 +112,8 @@ func (fc *FakeBServerClient) GetBlock(ctx context.Context, arg keybase1.GetBlock
 		return keybase1.GetBlockRes{}, err
 	}
 
+	// Always use this block context since the RPC API drops the
+	// real context.
 	bCtx := BlockContext{
 		RefNonce: zeroBlockRefNonce,
 		Creator:  arg.Bid.ChargedTo,

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -18,8 +18,9 @@ import (
 )
 
 type FakeBServerClient struct {
-	blocks     map[keybase1.GetBlockArg]keybase1.GetBlockRes
 	blocksLock sync.Mutex
+	blocks     map[keybase1.GetBlockArg]keybase1.GetBlockRes
+
 	readyChan  chan<- struct{}
 	goChan     <-chan struct{}
 	finishChan chan<- struct{}

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -129,7 +129,10 @@ func (fc *FakeBServerClient) GetBlock(ctx context.Context, arg keybase1.GetBlock
 	if err != nil {
 		return keybase1.GetBlockRes{}, err
 	}
-	return keybase1.GetBlockRes{serverHalf.String(), data}, nil
+	return keybase1.GetBlockRes{
+		BlockKey: serverHalf.String(),
+		Buf:      data,
+	}, nil
 }
 
 func (fc *FakeBServerClient) AddReference(ctx context.Context, arg keybase1.AddReferenceArg) error {

--- a/libkbfs/bserver_tlf_storage.go
+++ b/libkbfs/bserver_tlf_storage.go
@@ -144,14 +144,12 @@ func (s *bserverTlfStorage) getDataLocked(id BlockID, context BlockContext) (
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
 
-	var serverHalfData [32]byte
-	if len(buf) != len(serverHalfData) {
-		return nil, BlockCryptKeyServerHalf{},
-			fmt.Errorf("Corrupt server half data file %s",
-				keyServerHalfPath)
+	var serverHalf BlockCryptKeyServerHalf
+	err = serverHalf.UnmarshalBinary(buf)
+	if err != nil {
+		return nil, BlockCryptKeyServerHalf{}, err
 	}
-	copy(serverHalfData[:], buf)
-	serverHalf := MakeBlockCryptKeyServerHalf(serverHalfData)
+
 	return data, serverHalf, nil
 }
 

--- a/libkbfs/bserver_tlf_storage.go
+++ b/libkbfs/bserver_tlf_storage.go
@@ -324,7 +324,7 @@ func (s *bserverTlfStorage) putData(
 
 		if existingServerHalf != serverHalf {
 			return fmt.Errorf(
-				"key server half mismatch: expected %v, got %v",
+				"key server half mismatch: expected %s, got %s",
 				existingServerHalf, serverHalf)
 		}
 	}

--- a/libkbfs/crypto_key_types.go
+++ b/libkbfs/crypto_key_types.go
@@ -305,6 +305,21 @@ func MakeBlockCryptKeyServerHalf(data [32]byte) BlockCryptKeyServerHalf {
 	return BlockCryptKeyServerHalf{byte32Container{data}}
 }
 
+// ParseBlockCryptKeyServerHalf returns a BlockCryptKeyServerHalf
+// containing the given hex-encoded data, or an error.
+func ParseBlockCryptKeyServerHalf(s string) (BlockCryptKeyServerHalf, error) {
+	buf, err := hex.DecodeString(s)
+	if err != nil {
+		return BlockCryptKeyServerHalf{}, err
+	}
+	var serverHalf BlockCryptKeyServerHalf
+	err = serverHalf.UnmarshalBinary(buf)
+	if err != nil {
+		return BlockCryptKeyServerHalf{}, err
+	}
+	return serverHalf, nil
+}
+
 // BlockCryptKey is used to encrypt/decrypt block data. (See 4.1.2.)
 type BlockCryptKey struct {
 	// Should only be used by implementations of Crypto.

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -700,6 +700,16 @@ func (e InvalidHashError) Error() string {
 	return fmt.Sprintf("Invalid hash %s", e.H)
 }
 
+// InvalidTlfID indicates whether the TLF ID string is not parseable
+// or invalid.
+type InvalidTlfID struct {
+	id string
+}
+
+func (e InvalidTlfID) Error() string {
+	return fmt.Sprintf("Invalid TLF ID %q", e.id)
+}
+
 // UnknownHashTypeError is returned whenever a hash with an unknown
 // hash type is attempted to be used for verification.
 type UnknownHashTypeError struct {

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -678,17 +678,6 @@ func (e NotDirectFileBlockError) Error() string {
 	return fmt.Sprintf("Unexpected block type; expected a direct file block")
 }
 
-// MDInvalidTlfID indicates whether the folder ID returned from the
-// MD server was not parsable/invalid.
-type MDInvalidTlfID struct {
-	id string
-}
-
-// Error implements the error interface for MDInvalidTlfID.
-func (e MDInvalidTlfID) Error() string {
-	return fmt.Sprintf("Invalid TLF ID returned from server: %s", e.id)
-}
-
 // KeyHalfMismatchError is returned when the key server doesn't return the expected key half.
 type KeyHalfMismatchError struct {
 	Expected TLFCryptKeyServerHalfID

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -997,7 +997,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	defer CheckConfigAndShutdown(t, config)
 
 	// give it a remote block server with a fake client
-	fc := NewFakeBServerClient(nil, nil, nil)
+	fc := NewFakeBServerClient(config, nil, nil, nil)
 	b := newBlockServerRemoteWithClient(config, fc)
 	config.BlockServer().Shutdown()
 	config.SetBlockServer(b)

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -351,9 +351,9 @@ func (md *MDServerRemote) get(ctx context.Context, id TlfID,
 	}
 
 	// response
-	id = ParseTlfID(response.FolderID)
-	if id == NullTlfID {
-		return id, nil, MDInvalidTlfID{response.FolderID}
+	id, err = ParseTlfID(response.FolderID)
+	if err != nil {
+		return id, nil, err
 	}
 
 	// deserialize blocks
@@ -446,9 +446,9 @@ func (md *MDServerRemote) PruneBranch(ctx context.Context, id TlfID, bid BranchI
 
 // MetadataUpdate implements the MetadataUpdateProtocol interface.
 func (md *MDServerRemote) MetadataUpdate(_ context.Context, arg keybase1.MetadataUpdateArg) error {
-	id := ParseTlfID(arg.FolderID)
-	if id == NullTlfID {
-		return MDServerErrorBadRequest{"Invalid folder ID"}
+	id, err := ParseTlfID(arg.FolderID)
+	if err != nil {
+		return err
 	}
 
 	md.observerMu.Lock()
@@ -466,9 +466,9 @@ func (md *MDServerRemote) MetadataUpdate(_ context.Context, arg keybase1.Metadat
 
 // FolderNeedsRekey implements the MetadataUpdateProtocol interface.
 func (md *MDServerRemote) FolderNeedsRekey(_ context.Context, arg keybase1.FolderNeedsRekeyArg) error {
-	id := ParseTlfID(arg.FolderID)
-	if id == NullTlfID {
-		return MDServerErrorBadRequest{"Invalid folder ID"}
+	id, err := ParseTlfID(arg.FolderID)
+	if err != nil {
+		return err
 	}
 	md.log.Debug("MDServerRemote: folder needs rekey: %s", id.String())
 	if md.squelchRekey {

--- a/libkbfs/tlf_id.go
+++ b/libkbfs/tlf_id.go
@@ -7,7 +7,6 @@ package libkbfs
 import (
 	"encoding"
 	"encoding/hex"
-	"fmt"
 )
 
 const (
@@ -41,16 +40,6 @@ func (id TlfID) Bytes() []byte {
 // String implements the fmt.Stringer interface for TlfID.
 func (id TlfID) String() string {
 	return hex.EncodeToString(id.id[:])
-}
-
-// InvalidTlfID indicates whether the folder ID returned from the MD
-// server was not parsable/invalid.
-type InvalidTlfID struct {
-	id string
-}
-
-func (e InvalidTlfID) Error() string {
-	return fmt.Sprintf("Invalid TLF ID %q", e.id)
 }
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface for TlfID.


### PR DESCRIPTION
This fixes a latent bug where getting a dedup-ed block
might fail.

Add regression test.

Clean up some conversions to and from RPC types.