### PR TITLE
libkbfs: avoid rekey loops on incomplete rekeys

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3461,10 +3461,17 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 		md.clearLastRevision()
 
 	case RekeyIncompleteError:
+		if !rekeyDone && rekeyWasSet {
+			// The rekey bit was already set, and there's nothing else
+			// we can to do, so don't put any new revisions.
+			fbo.log.CDebugf(ctx, "No further rekey possible by this user.")
+			return nil
+		}
+
+		// Rekey incomplete, fallthrough without early exit, to ensure
+		// we write the metadata with any potential changes
 		fbo.log.CDebugf(ctx,
 			"Rekeyed reader devices, but still need writer rekey")
-	// Rekey incomplete, fallthrough without early exit, to ensure we write
-	// the metadata with any potential changes
 
 	case NeedOtherRekeyError:
 		stillNeedsRekey = true

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -508,6 +508,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// Figure out if we need to add or remove any keys.
 	// If we're already incrementing the key generation then we don't need to
 	// figure out the key delta.
+	addNewReaderDeviceForSelf := false
 	if !incKeyGen {
 		// See if there is at least one new device in relation to the
 		// current key bundle
@@ -526,6 +527,10 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		incKeyGen = len(wRemoved) > 0 || len(rRemoved) > 0
 
 		promotedReaders = make(map[keybase1.UID]bool, len(rRemoved))
+
+		// Before we add the removed devices, check if we are adding a
+		// new reader device for ourselves.
+		_, addNewReaderDeviceForSelf = newReaderUsers[uid]
 
 		for u := range rRemoved {
 			// FIXME (potential): this could cause a reader to attempt to rekey
@@ -568,7 +573,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		} else {
 			// No new reader device for our user, so the reader can't do
 			// anything
-			return false, nil, NewReadAccessError(resolvedHandle, username)
+			return false, nil, RekeyIncompleteError{}
 		}
 	}
 
@@ -640,8 +645,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		if len(newReaderUsers) > 0 || addNewWriterDevice || incKeyGen {
 			// If we're a reader but we haven't completed all the work, return
 			// RekeyIncompleteError.
-			rekeyDone := len(newReaderUsers) > 0
-			return rekeyDone, nil, RekeyIncompleteError{}
+			return addNewReaderDeviceForSelf, nil, RekeyIncompleteError{}
 		}
 		// Otherwise, there's nothing left to do!
 		return true, nil, nil

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -639,8 +639,9 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	if !isWriter {
 		if len(newReaderUsers) > 0 || addNewWriterDevice || incKeyGen {
 			// If we're a reader but we haven't completed all the work, return
-			// RekeyIncompleteError
-			return false, nil, RekeyIncompleteError{}
+			// RekeyIncompleteError.
+			rekeyDone := len(newReaderUsers) > 0
+			return rekeyDone, nil, RekeyIncompleteError{}
 		}
 		// Otherwise, there's nothing left to do!
 		return true, nil, nil


### PR DESCRIPTION
If a reader handled a rekey request by setting the rekey bit, but
there was work it couldn't do on behalf of itself (like incrementing
the key generation due to a revoked device), it could enter into a
loop of continuous Put/SendRekeyNeeded messages back and forth with
the server.

Instead, detect if the rekeyer made any useful revisions, and if not,
don't bother putting a new revision.

Issue: KBFS-1119