### PR TITLE
CR: fix data loss and block state issue when resolutions are canceled

### DIFF
--- a/libdokan/updates_file.go
+++ b/libdokan/updates_file.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
 )
 
 // UpdatesFile represents a write-only file where any write of at
@@ -38,8 +39,8 @@ func (f *UpdatesFile) WriteFile(fi *dokan.FileInfo, bs []byte, offset int64) (n 
 		if f.folder.updateChan == nil {
 			return 0, errors.New("Updates are already enabled")
 		}
-		err = libkbfs.RestartCRForTesting(f.folder.fs.config,
-			f.folder.getFolderBranch())
+		err = libkbfs.RestartCRForTesting(context.Background(),
+			f.folder.fs.config, f.folder.getFolderBranch())
 		if err != nil {
 			return 0, err
 		}

--- a/libfuse/updates_file.go
+++ b/libfuse/updates_file.go
@@ -50,8 +50,8 @@ func (f *UpdatesFile) Write(ctx context.Context, req *fuse.WriteRequest,
 		if f.folder.updateChan == nil {
 			return errors.New("Updates are already enabled")
 		}
-		err = libkbfs.RestartCRForTesting(f.folder.fs.config,
-			f.folder.getFolderBranch())
+		err = libkbfs.RestartCRForTesting(context.Background(),
+			f.folder.fs.config, f.folder.getFolderBranch())
 		if err != nil {
 			return err
 		}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -220,12 +220,28 @@ func (cr *ConflictResolver) getMDs(ctx context.Context, lState *lockState) (
 	if err != nil {
 		return nil, nil, err
 	}
+	// Deep copy because CR may change them.
+	for i, md := range unmerged {
+		mdCopy, err := md.deepCopy(cr.config.Codec(), true)
+		if err != nil {
+			return nil, nil, err
+		}
+		unmerged[i] = mdCopy
+	}
 
 	// now get all the merged MDs, starting from after the branch point
 	merged, err = getMergedMDUpdates(ctx, cr.fbo.config, cr.fbo.id(),
 		branchPoint+1)
 	if err != nil {
 		return nil, nil, err
+	}
+	// Deep copy because CR may change them.
+	for i, md := range merged {
+		mdCopy, err := md.deepCopy(cr.config.Codec(), true)
+		if err != nil {
+			return nil, nil, err
+		}
+		merged[i] = mdCopy
 	}
 
 	// re-embed all the block changes

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3225,6 +3225,11 @@ func (fbo *folderBranchOps) getAndApplyMDUpdates(ctx context.Context,
 	return nil
 }
 
+// getUnmergedMDUpdates returns a slice of the unmerged MDs for this
+// TLF's current unmerged branch and unmerged branch, between the
+// merge point for the branch and the current head.  The returned MDs
+// are the same instances that are stored in the MD cache, so they
+// should be modified with care.
 func (fbo *folderBranchOps) getUnmergedMDUpdates(
 	ctx context.Context, lState *lockState) (
 	MetadataRevision, []*RootMetadata, error) {

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -474,7 +474,8 @@ func TestBasicCRNoConflict(t *testing.T) {
 
 	// re-enable updates, and wait for CR to complete
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -592,7 +593,8 @@ func TestBasicCRFileConflict(t *testing.T) {
 
 	// re-enable updates, and wait for CR to complete
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -704,7 +706,8 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 
 	// re-enable updates, and wait for CR to complete
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -851,7 +854,8 @@ func TestCRDouble(t *testing.T) {
 
 	// Do one CR.
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -906,7 +910,8 @@ func TestCRDouble(t *testing.T) {
 
 	// Do a second CR.
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -1048,7 +1053,8 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// re-enable updates, and wait for CR to complete.
 	// this should also cause a rekey of the folder.
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -1216,7 +1222,8 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// re-enable updates, and wait for CR to complete.
 	// this should also cause a rekey of the folder.
 	c <- struct{}{}
-	err = RestartCRForTesting(config1, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config1,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -1437,7 +1444,8 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	}
 
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}
@@ -1537,9 +1545,8 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 		c <- struct{}{}
 		// Make sure the CR gets done with a context we can use for
 		// stalling.
-		err = RestartCRForTestingWithCtxMaker(config2,
-			rootNode2.GetFolderBranch(),
-			func() context.Context { return putCtx })
+		err = RestartCRForTesting(putCtx, config2,
+			rootNode2.GetFolderBranch())
 		if err != nil {
 			t.Fatalf("Couldn't disable updates: %v", err)
 		}
@@ -1570,7 +1577,8 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 	c <- struct{}{}
-	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	err = RestartCRForTesting(context.Background(), config2,
+		rootNode2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't disable updates: %v", err)
 	}

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1446,3 +1446,157 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
 }
+
+// Test that a resolution can be canceled right before the Put due to
+// another operation, and then the second resolution includes both
+// unmerged operations.  Regression test for KBFS-1133.
+func TestCRCanceledAfterNewOperation(t *testing.T) {
+	// simulate two users
+	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CheckConfigAndShutdown(t, config1)
+	config1.MDServer().DisableRekeyUpdatesForTesting()
+
+	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	defer CheckConfigAndShutdown(t, config2)
+	_, _, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	config2.MDServer().DisableRekeyUpdatesForTesting()
+
+	clock, now := newTestClockAndTimeNow()
+	config2.SetClock(clock)
+	name := userName1.String() + "," + userName2.String()
+
+	// create and write to a file
+	rootNode := GetRootNodeOrBust(t, config1, name, false)
+	kbfsOps1 := config1.KBFSOps()
+	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %v", err)
+	}
+	data := []byte{1, 2, 3, 4, 5}
+	err = kbfsOps1.Write(ctx, aNode1, data, 0)
+	if err != nil {
+		t.Fatalf("Couldn't write file: %v", err)
+	}
+	err = kbfsOps1.Sync(ctx, aNode1)
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %v", err)
+	}
+
+	// look it up on user2
+	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+
+	kbfsOps2 := config2.KBFSOps()
+	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
+	if err != nil {
+		t.Fatalf("Couldn't lookup dir: %v", err)
+	}
+	// disable updates and CR on user 2
+	c, err := DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't disable updates: %v", err)
+	}
+	err = DisableCRForTesting(config2, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't disable updates: %v", err)
+	}
+
+	// User 1 truncates file a.
+	err = kbfsOps1.Truncate(ctx, aNode1, 0)
+	if err != nil {
+		t.Fatalf("Couldn't truncate file: %v", err)
+	}
+	err = kbfsOps1.Sync(ctx, aNode1)
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %v", err)
+	}
+
+	// User 2 writes to the file, creating a conflict.
+	data2 := []byte{5, 4, 3, 2, 1}
+	err = kbfsOps2.Write(ctx, aNode2, data2, 0)
+	if err != nil {
+		t.Fatalf("Couldn't write file: %v", err)
+	}
+	err = kbfsOps2.Sync(ctx, aNode2)
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %v", err)
+	}
+
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config2, false)
+
+	var wg sync.WaitGroup
+	putCtx, cancel := context.WithCancel(putCtx)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		c <- struct{}{}
+		// Make sure the CR gets done with a context we can use for
+		// stalling.
+		err = RestartCRForTestingWithCtxMaker(config2,
+			rootNode2.GetFolderBranch(),
+			func() context.Context { return putCtx })
+		if err != nil {
+			t.Fatalf("Couldn't disable updates: %v", err)
+		}
+		err = kbfsOps2.SyncFromServerForTesting(putCtx,
+			rootNode2.GetFolderBranch())
+		if err == nil {
+			t.Fatalf("Unexpected successful sync/CR: %v", err)
+		}
+	}()
+	<-onPutStalledCh
+	cancel()
+	close(putUnstallCh)
+	wg.Wait()
+
+	// Disable again
+	c, err = DisableUpdatesForTesting(config2, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't disable updates: %v", err)
+	}
+	err = DisableCRForTesting(config2, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't disable updates: %v", err)
+	}
+
+	// Do a second operation and complete the resolution.
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %v", err)
+	}
+	c <- struct{}{}
+	err = RestartCRForTesting(config2, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't disable updates: %v", err)
+	}
+	err = kbfsOps2.SyncFromServerForTesting(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't finish resolution: %v", err)
+	}
+
+	// Now there should be a conflict file containing data2.
+	cre := WriterDeviceDateConflictRenamer{}
+	// Make sure they both see the same set of children
+	expectedChildren := []string{
+		"a",
+		cre.ConflictRenameHelper(now, "u2", "dev1", "a"),
+		"b",
+	}
+	children2, err := kbfsOps2.GetDirChildren(ctx, rootNode2)
+	if err != nil {
+		t.Fatalf("Couldn't get children: %v", err)
+	}
+	if g, e := len(children2), len(expectedChildren); g != e {
+		t.Errorf("Wrong number of children: %d vs %d", g, e)
+	}
+	for _, child := range expectedChildren {
+		if _, ok := children2[child]; !ok {
+			t.Errorf("Couldn't find child %s", child)
+		}
+	}
+}

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -111,16 +111,21 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	}
 }
 
-func setStallingMDOpsForPut(ctx context.Context, config Config) (
+func setStallingMDOpsForPut(ctx context.Context, config Config,
+	stallAfterPut bool) (
 	<-chan struct{}, chan<- struct{}, context.Context) {
 	onPutStalledCh := make(chan struct{}, 1)
 	putUnstallCh := make(chan struct{})
 
 	stallKey := "requestName"
 	putValue := "put"
+	opName := "Put"
+	if stallAfterPut {
+		opName = "AfterPut"
+	}
 
 	config.SetMDOps(&stallingMDOps{
-		stallOpName: "Put",
+		stallOpName: opName,
 		stallKey:    stallKey,
 		stallMap: map[interface{}]staller{
 			putValue: staller{
@@ -140,7 +145,8 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
 	defer CheckConfigAndShutdown(t, config)
 
-	onPutStalledCh, putUnstallCh, putCtx := setStallingMDOpsForPut(ctx, config)
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config, true)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -189,7 +195,8 @@ func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
 	defer CheckConfigAndShutdown(t, config)
 
-	onPutStalledCh, putUnstallCh, putCtx := setStallingMDOpsForPut(ctx, config)
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config, true)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -323,7 +330,8 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
 	defer CheckConfigAndShutdown(t, config)
 
-	onPutStalledCh, putUnstallCh, putCtx := setStallingMDOpsForPut(ctx, config)
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config, true)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -893,7 +901,8 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
 	defer CheckConfigAndShutdown(t, config)
 
-	onPutStalledCh, putUnstallCh, putCtx := setStallingMDOpsForPut(ctx, config)
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config, true)
 
 	// make blocks small
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = 5
@@ -1337,7 +1346,8 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
 	defer CheckConfigAndShutdown(t, config)
 
-	onPutStalledCh, putUnstallCh, putCtx := setStallingMDOpsForPut(ctx, config)
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config, true)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1396,7 +1396,8 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	RevokeDeviceForLocalUserOrBust(t, config2Dev2, uid2, 0)
 
 	// Stall user 1's rekey, to ensure a conflict.
-	onPutStalledCh, putUnstallCh, putCtx := setStallingMDOpsForPut(ctx, config1)
+	onPutStalledCh, putUnstallCh, putCtx :=
+		setStallingMDOpsForPut(ctx, config1, false)
 
 	// Have user 1 also try to rekey but fail due to conflict
 	errChan := make(chan error)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -103,6 +103,13 @@ func getMDRange(ctx context.Context, config Config, id TlfID, bid BranchID,
 	return rmds, nil
 }
 
+// getMergedMDUpdates returns a slice of all the merged MDs for a TLF,
+// starting from the given startRev.  The returned MDs are the same
+// instances that are stored in the MD cache, so they should be
+// modified with care.
+//
+// TODO: Accept a parameter to express that we want copies of the MDs
+// instead of the cached versions.
 func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 	startRev MetadataRevision) (mergedRmds []*RootMetadata, err error) {
 	// We don't yet know about any revisions yet, so there's no range
@@ -148,6 +155,13 @@ func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 	return mergedRmds, nil
 }
 
+// getUnmergedMDUpdates returns a slice of the unmerged MDs for a TLF
+// and unmerged branch, between the merge point for that branch and
+// startRev (inclusive).  The returned MDs are the same instances that
+// are stored in the MD cache, so they should be modified with care.
+//
+// TODO: Accept a parameter to express that we want copies of the MDs
+// instead of the cached versions.
 func getUnmergedMDUpdates(ctx context.Context, config Config, id TlfID,
 	bid BranchID, startRev MetadataRevision) (
 	currHead MetadataRevision, unmergedRmds []*RootMetadata, err error) {

--- a/libkbfs/stallers_test.go
+++ b/libkbfs/stallers_test.go
@@ -157,7 +157,13 @@ func (m *stallingMDOps) GetUnmergedRange(ctx context.Context, id TlfID,
 
 func (m *stallingMDOps) Put(ctx context.Context, md *RootMetadata) error {
 	m.maybeStall(ctx, "Put")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 	err := m.delegate.Put(ctx, md)
+	m.maybeStall(ctx, "AfterPut")
 	// If the Put was canceled, return the cancel error.  This
 	// emulates the Put being canceled while the RPC is outstanding.
 	select {

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -445,17 +445,17 @@ func DisableCRForTesting(config Config, folderBranch FolderBranch) error {
 	return nil
 }
 
-// RestartCRForTestingWithCtxMaker re-enables conflict resolution for
+// RestartCRForTesting re-enables conflict resolution for
 // the given folder.
-func RestartCRForTestingWithCtxMaker(config Config, folderBranch FolderBranch,
-	ctxMaker func() context.Context) error {
+func RestartCRForTesting(baseCtx context.Context, config Config,
+	folderBranch FolderBranch) error {
 	kbfsOps, ok := config.KBFSOps().(*KBFSOpsStandard)
 	if !ok {
 		return errors.New("Unexpected KBFSOps type")
 	}
 
 	ops := kbfsOps.getOpsNoAdd(folderBranch)
-	ops.cr.Restart(ctxMaker)
+	ops.cr.Restart(baseCtx)
 	// Start a resolution for anything we've missed.
 	if ops.staged {
 		lState := makeFBOLockState()
@@ -463,12 +463,6 @@ func RestartCRForTestingWithCtxMaker(config Config, folderBranch FolderBranch,
 			MetadataRevisionUninitialized)
 	}
 	return nil
-}
-
-// RestartCRForTesting re-enables conflict resolution for the given
-// folder.
-func RestartCRForTesting(config Config, folderBranch FolderBranch) error {
-	return RestartCRForTestingWithCtxMaker(config, folderBranch, nil)
 }
 
 // ForceQuotaReclamationForTesting kicks off quota reclamation under

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -347,7 +347,8 @@ func (k *LibKBFS) ReenableUpdates(u User, tlfName string, isPublic bool) error {
 		return fmt.Errorf("Couldn't re-enable updates for %s (public=%t)", tlfName, isPublic)
 	}
 
-	err = libkbfs.RestartCRForTesting(config, dir.GetFolderBranch())
+	err = libkbfs.RestartCRForTesting(context.Background(), config,
+		dir.GetFolderBranch())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I hit a CR data loss problem in the wild (description in JIRA).  The problem was that we were modifying our only copies of unmerged MD updates, and when the resolution was canceled, we were re-using those modified copies (which contained operations with modified block pointers) and weren't able to completely resolve everything, leading to data loss.

This also uncovered the fact that we don't clean up blocks after a failure, which was being tracked in a different issue.

Issue: KBFS-1133
Issue: KBFS-921