### PR TITLE
Clean up CryptoCommon constructors

### DIFF
--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -109,7 +109,7 @@ type blockMemEntry struct {
 // BlockServerMemory implements the BlockServer interface by just
 // storing blocks in memory.
 type BlockServerMemory struct {
-	crypto Crypto
+	crypto cryptoPure
 	log    logger.Logger
 
 	lock sync.RWMutex
@@ -164,7 +164,7 @@ func (b *BlockServerMemory) Get(ctx context.Context, id BlockID, tlfID TlfID,
 }
 
 func validateBlockServerPut(
-	crypto Crypto, id BlockID, context BlockContext, buf []byte) error {
+	crypto cryptoPure, id BlockID, context BlockContext, buf []byte) error {
 	if context.GetCreator() != context.GetWriter() {
 		return fmt.Errorf("Can't Put() a block with creator=%s != writer=%s",
 			context.GetCreator(), context.GetWriter())

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -181,7 +181,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	codec := NewCodecMsgpack()
 	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"user1", "user2"})
 	currentUID := localUsers[0].UID
-	crypto := &CryptoLocal{CryptoCommon: MakeCryptoCommonNoConfig()}
+	crypto := &CryptoLocal{CryptoCommon: makeTestCryptoCommon(t)}
 	config := &ConfigLocal{codec: codec, crypto: crypto}
 	setTestLogger(config, t)
 	fc := NewFakeBServerClient(config, nil, nil, nil)
@@ -249,7 +249,7 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 	codec := NewCodecMsgpack()
 	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"testuser"})
 	currentUID := localUsers[0].UID
-	crypto := &CryptoLocal{CryptoCommon: MakeCryptoCommonNoConfig()}
+	crypto := &CryptoLocal{CryptoCommon: makeTestCryptoCommon(t)}
 	config := &ConfigLocal{codec: codec, crypto: crypto}
 	setTestLogger(config, t)
 

--- a/libkbfs/bserver_tlf_storage.go
+++ b/libkbfs/bserver_tlf_storage.go
@@ -42,7 +42,7 @@ import (
 // dir/01ff/f...ff/refs/ffffffffffffffff
 type bserverTlfStorage struct {
 	codec  Codec
-	crypto Crypto
+	crypto cryptoPure
 	dir    string
 
 	// Protects any IO operations in dir or any of its children,
@@ -52,7 +52,7 @@ type bserverTlfStorage struct {
 }
 
 func makeBserverTlfStorage(
-	codec Codec, crypto Crypto, dir string) *bserverTlfStorage {
+	codec Codec, crypto cryptoPure, dir string) *bserverTlfStorage {
 	return &bserverTlfStorage{codec: codec, crypto: crypto, dir: dir}
 }
 

--- a/libkbfs/bsplitter_simple_test.go
+++ b/libkbfs/bsplitter_simple_test.go
@@ -155,7 +155,7 @@ func TestBsplitterOverhead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Encoding block failed: %v", err)
 	}
-	crypto := MakeCryptoCommonNoConfig()
+	crypto := makeTestCryptoCommon(t)
 	paddedBlock, err := crypto.padBlock(encodedBlock)
 	if err != nil {
 		t.Fatalf("Padding block failed: %v", err)

--- a/libkbfs/crypto_client.go
+++ b/libkbfs/crypto_client.go
@@ -33,8 +33,9 @@ var _ rpc.ConnectionHandler = (*CryptoClient)(nil)
 
 // NewCryptoClient constructs a new CryptoClient.
 func NewCryptoClient(config Config, kbCtx *libkb.GlobalContext) *CryptoClient {
+	log := config.MakeLogger("")
 	c := &CryptoClient{
-		CryptoCommon: MakeCryptoCommon(config),
+		CryptoCommon: MakeCryptoCommon(config.Codec(), log),
 		config:       config,
 	}
 	conn := NewSharedKeybaseConnection(kbCtx, config, c)
@@ -45,8 +46,9 @@ func NewCryptoClient(config Config, kbCtx *libkb.GlobalContext) *CryptoClient {
 
 // newCryptoClientWithClient should only be used for testing.
 func newCryptoClientWithClient(config Config, client rpc.GenericClient) *CryptoClient {
+	log := config.MakeLogger("")
 	return &CryptoClient{
-		CryptoCommon: MakeCryptoCommon(config),
+		CryptoCommon: MakeCryptoCommon(config.Codec(), log),
 		client:       keybase1.CryptoClient{Cli: client},
 	}
 }

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -42,17 +42,8 @@ type CryptoCommon struct {
 var _ cryptoPure = (*CryptoCommon)(nil)
 
 // MakeCryptoCommon returns a default CryptoCommon object.
-func MakeCryptoCommon(config Config) CryptoCommon {
-	log := config.MakeLogger("")
-	return CryptoCommon{config.Codec(), log, log.CloneWithAddedDepth(1)}
-}
-
-// MakeCryptoCommonNoConfig returns a default CryptoCommon
-// object. This is meant to be used for code that doesn't use Config
-// (like server code).
-func MakeCryptoCommonNoConfig() CryptoCommon {
-	log := logger.NewNull()
-	return CryptoCommon{NewCodecMsgpack(), log, log.CloneWithAddedDepth(1)}
+func MakeCryptoCommon(codec Codec, log logger.Logger) CryptoCommon {
+	return CryptoCommon{codec, log, log.CloneWithAddedDepth(1)}
 }
 
 // MakeRandomTlfID implements the Crypto interface for CryptoCommon.

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -47,7 +47,7 @@ func MakeCryptoCommon(codec Codec, log logger.Logger) CryptoCommon {
 }
 
 // MakeRandomTlfID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeRandomTlfID(isPublic bool) (TlfID, error) {
+func (c CryptoCommon) MakeRandomTlfID(isPublic bool) (TlfID, error) {
 	var id TlfID
 	err := cryptoRandRead(id.id[:])
 	if err != nil {
@@ -62,7 +62,7 @@ func (c *CryptoCommon) MakeRandomTlfID(isPublic bool) (TlfID, error) {
 }
 
 // MakeRandomBranchID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeRandomBranchID() (BranchID, error) {
+func (c CryptoCommon) MakeRandomBranchID() (BranchID, error) {
 	var id BranchID
 	err := cryptoRandRead(id.id[:])
 	if err != nil {
@@ -72,7 +72,7 @@ func (c *CryptoCommon) MakeRandomBranchID() (BranchID, error) {
 }
 
 // MakeMdID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeMdID(md *RootMetadata) (MdID, error) {
+func (c CryptoCommon) MakeMdID(md *RootMetadata) (MdID, error) {
 	// Make sure that the serialized metadata is set; otherwise we
 	// won't get the right MdID.
 	if md.SerializedPrivateMetadata == nil {
@@ -92,7 +92,7 @@ func (c *CryptoCommon) MakeMdID(md *RootMetadata) (MdID, error) {
 }
 
 // MakeMerkleHash implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeMerkleHash(md *RootMetadataSigned) (MerkleHash, error) {
+func (c CryptoCommon) MakeMerkleHash(md *RootMetadataSigned) (MerkleHash, error) {
 	buf, err := c.codec.Encode(md)
 	if err != nil {
 		return MerkleHash{}, err
@@ -105,7 +105,7 @@ func (c *CryptoCommon) MakeMerkleHash(md *RootMetadataSigned) (MerkleHash, error
 }
 
 // MakeTemporaryBlockID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeTemporaryBlockID() (BlockID, error) {
+func (c CryptoCommon) MakeTemporaryBlockID() (BlockID, error) {
 	var dh RawDefaultHash
 	err := cryptoRandRead(dh[:])
 	if err != nil {
@@ -119,7 +119,7 @@ func (c *CryptoCommon) MakeTemporaryBlockID() (BlockID, error) {
 }
 
 // MakePermanentBlockID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakePermanentBlockID(encodedEncryptedData []byte) (BlockID, error) {
+func (c CryptoCommon) MakePermanentBlockID(encodedEncryptedData []byte) (BlockID, error) {
 	h, err := DefaultHash(encodedEncryptedData)
 	if err != nil {
 		return BlockID{}, nil
@@ -128,18 +128,18 @@ func (c *CryptoCommon) MakePermanentBlockID(encodedEncryptedData []byte) (BlockI
 }
 
 // VerifyBlockID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) VerifyBlockID(encodedEncryptedData []byte, id BlockID) error {
+func (c CryptoCommon) VerifyBlockID(encodedEncryptedData []byte, id BlockID) error {
 	return id.h.Verify(encodedEncryptedData)
 }
 
 // MakeBlockRefNonce implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeBlockRefNonce() (nonce BlockRefNonce, err error) {
+func (c CryptoCommon) MakeBlockRefNonce() (nonce BlockRefNonce, err error) {
 	err = cryptoRandRead(nonce[:])
 	return
 }
 
 // MakeRandomTLFKeys implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MakeRandomTLFKeys() (
+func (c CryptoCommon) MakeRandomTLFKeys() (
 	tlfPublicKey TLFPublicKey,
 	tlfPrivateKey TLFPrivateKey,
 	tlfEphemeralPublicKey TLFEphemeralPublicKey,
@@ -182,7 +182,7 @@ func (c *CryptoCommon) MakeRandomTLFKeys() (
 
 // MakeRandomTLFCryptKeyServerHalf implements the Crypto interface for
 // CryptoCommon.
-func (c *CryptoCommon) MakeRandomTLFCryptKeyServerHalf() (serverHalf TLFCryptKeyServerHalf, err error) {
+func (c CryptoCommon) MakeRandomTLFCryptKeyServerHalf() (serverHalf TLFCryptKeyServerHalf, err error) {
 	err = cryptoRandRead(serverHalf.data[:])
 	if err != nil {
 		serverHalf = TLFCryptKeyServerHalf{}
@@ -193,7 +193,7 @@ func (c *CryptoCommon) MakeRandomTLFCryptKeyServerHalf() (serverHalf TLFCryptKey
 
 // MakeRandomBlockCryptKeyServerHalf implements the Crypto interface
 // for CryptoCommon.
-func (c *CryptoCommon) MakeRandomBlockCryptKeyServerHalf() (serverHalf BlockCryptKeyServerHalf, err error) {
+func (c CryptoCommon) MakeRandomBlockCryptKeyServerHalf() (serverHalf BlockCryptKeyServerHalf, err error) {
 	err = cryptoRandRead(serverHalf.data[:])
 	if err != nil {
 		serverHalf = BlockCryptKeyServerHalf{}
@@ -211,25 +211,25 @@ func xorKeys(x, y [32]byte) [32]byte {
 }
 
 // MaskTLFCryptKey implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) MaskTLFCryptKey(serverHalf TLFCryptKeyServerHalf, key TLFCryptKey) (clientHalf TLFCryptKeyClientHalf, err error) {
+func (c CryptoCommon) MaskTLFCryptKey(serverHalf TLFCryptKeyServerHalf, key TLFCryptKey) (clientHalf TLFCryptKeyClientHalf, err error) {
 	clientHalf.data = xorKeys(serverHalf.data, key.data)
 	return
 }
 
 // UnmaskTLFCryptKey implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) UnmaskTLFCryptKey(serverHalf TLFCryptKeyServerHalf, clientHalf TLFCryptKeyClientHalf) (key TLFCryptKey, err error) {
+func (c CryptoCommon) UnmaskTLFCryptKey(serverHalf TLFCryptKeyServerHalf, clientHalf TLFCryptKeyClientHalf) (key TLFCryptKey, err error) {
 	key.data = xorKeys(serverHalf.data, clientHalf.data)
 	return
 }
 
 // UnmaskBlockCryptKey implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) UnmaskBlockCryptKey(serverHalf BlockCryptKeyServerHalf, tlfCryptKey TLFCryptKey) (key BlockCryptKey, error error) {
+func (c CryptoCommon) UnmaskBlockCryptKey(serverHalf BlockCryptKeyServerHalf, tlfCryptKey TLFCryptKey) (key BlockCryptKey, error error) {
 	key.data = xorKeys(serverHalf.data, tlfCryptKey.data)
 	return
 }
 
 // Verify implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) Verify(msg []byte, sigInfo SignatureInfo) (err error) {
+func (c CryptoCommon) Verify(msg []byte, sigInfo SignatureInfo) (err error) {
 	defer func() {
 		c.deferLog.Debug(
 			"Verify result for %d-byte message with %s: %v",
@@ -264,7 +264,7 @@ func (c *CryptoCommon) Verify(msg []byte, sigInfo SignatureInfo) (err error) {
 
 // EncryptTLFCryptKeyClientHalf implements the Crypto interface for
 // CryptoCommon.
-func (c *CryptoCommon) EncryptTLFCryptKeyClientHalf(privateKey TLFEphemeralPrivateKey, publicKey CryptPublicKey, clientHalf TLFCryptKeyClientHalf) (encryptedClientHalf EncryptedTLFCryptKeyClientHalf, err error) {
+func (c CryptoCommon) EncryptTLFCryptKeyClientHalf(privateKey TLFEphemeralPrivateKey, publicKey CryptPublicKey, clientHalf TLFCryptKeyClientHalf) (encryptedClientHalf EncryptedTLFCryptKeyClientHalf, err error) {
 	var nonce [24]byte
 	err = cryptoRandRead(nonce[:])
 	if err != nil {
@@ -292,7 +292,7 @@ func (c *CryptoCommon) EncryptTLFCryptKeyClientHalf(privateKey TLFEphemeralPriva
 	return
 }
 
-func (c *CryptoCommon) encryptData(data []byte, key [32]byte) (encryptedData, error) {
+func (c CryptoCommon) encryptData(data []byte, key [32]byte) (encryptedData, error) {
 	var nonce [24]byte
 	err := cryptoRandRead(nonce[:])
 	if err != nil {
@@ -309,7 +309,7 @@ func (c *CryptoCommon) encryptData(data []byte, key [32]byte) (encryptedData, er
 }
 
 // EncryptPrivateMetadata implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) EncryptPrivateMetadata(pmd *PrivateMetadata, key TLFCryptKey) (encryptedPmd EncryptedPrivateMetadata, err error) {
+func (c CryptoCommon) EncryptPrivateMetadata(pmd *PrivateMetadata, key TLFCryptKey) (encryptedPmd EncryptedPrivateMetadata, err error) {
 	encodedPmd, err := c.codec.Encode(pmd)
 	if err != nil {
 		return
@@ -324,7 +324,7 @@ func (c *CryptoCommon) EncryptPrivateMetadata(pmd *PrivateMetadata, key TLFCrypt
 	return
 }
 
-func (c *CryptoCommon) decryptData(encryptedData encryptedData, key [32]byte) ([]byte, error) {
+func (c CryptoCommon) decryptData(encryptedData encryptedData, key [32]byte) ([]byte, error) {
 	if encryptedData.Version != EncryptionSecretbox {
 		return nil, UnknownEncryptionVer{encryptedData.Version}
 	}
@@ -344,7 +344,7 @@ func (c *CryptoCommon) decryptData(encryptedData encryptedData, key [32]byte) ([
 }
 
 // DecryptPrivateMetadata implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) DecryptPrivateMetadata(encryptedPmd EncryptedPrivateMetadata, key TLFCryptKey) (*PrivateMetadata, error) {
+func (c CryptoCommon) DecryptPrivateMetadata(encryptedPmd EncryptedPrivateMetadata, key TLFCryptKey) (*PrivateMetadata, error) {
 	encodedPmd, err := c.decryptData(encryptedData(encryptedPmd), key.data)
 	if err != nil {
 		return nil, err
@@ -386,7 +386,7 @@ func nextPowerOfTwo(n uint32) uint32 {
 const padPrefixSize = 4
 
 // padBlock adds random padding to an encoded block.
-func (c *CryptoCommon) padBlock(block []byte) ([]byte, error) {
+func (c CryptoCommon) padBlock(block []byte) ([]byte, error) {
 	blockLen := uint32(len(block))
 	overallLen := nextPowerOfTwo(blockLen)
 	padLen := int64(overallLen - blockLen)
@@ -414,7 +414,7 @@ func (c *CryptoCommon) padBlock(block []byte) ([]byte, error) {
 }
 
 // depadBlock extracts the actual block data from a padded block.
-func (c *CryptoCommon) depadBlock(paddedBlock []byte) ([]byte, error) {
+func (c CryptoCommon) depadBlock(paddedBlock []byte) ([]byte, error) {
 	buf := bytes.NewBuffer(paddedBlock)
 
 	var blockLen uint32
@@ -430,7 +430,7 @@ func (c *CryptoCommon) depadBlock(paddedBlock []byte) ([]byte, error) {
 }
 
 // EncryptBlock implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) EncryptBlock(block Block, key BlockCryptKey) (plainSize int, encryptedBlock EncryptedBlock, err error) {
+func (c CryptoCommon) EncryptBlock(block Block, key BlockCryptKey) (plainSize int, encryptedBlock EncryptedBlock, err error) {
 	encodedBlock, err := c.codec.Encode(block)
 	if err != nil {
 		return
@@ -452,7 +452,7 @@ func (c *CryptoCommon) EncryptBlock(block Block, key BlockCryptKey) (plainSize i
 }
 
 // DecryptBlock implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) DecryptBlock(encryptedBlock EncryptedBlock, key BlockCryptKey, block Block) error {
+func (c CryptoCommon) DecryptBlock(encryptedBlock EncryptedBlock, key BlockCryptKey, block Block) error {
 	paddedBlock, err := c.decryptData(encryptedData(encryptedBlock), key.data)
 	if err != nil {
 		return err
@@ -467,7 +467,7 @@ func (c *CryptoCommon) DecryptBlock(encryptedBlock EncryptedBlock, key BlockCryp
 }
 
 // GetTLFCryptKeyServerHalfID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) GetTLFCryptKeyServerHalfID(
+func (c CryptoCommon) GetTLFCryptKeyServerHalfID(
 	user keybase1.UID, deviceKID keybase1.KID,
 	serverHalf TLFCryptKeyServerHalf) (TLFCryptKeyServerHalfID, error) {
 	key := serverHalf.data[:]
@@ -482,7 +482,7 @@ func (c *CryptoCommon) GetTLFCryptKeyServerHalfID(
 }
 
 // VerifyTLFCryptKeyServerHalfID implements the Crypto interface for CryptoCommon.
-func (c *CryptoCommon) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID,
+func (c CryptoCommon) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID,
 	user keybase1.UID, deviceKID keybase1.KID, serverHalf TLFCryptKeyServerHalf) error {
 	key := serverHalf.data[:]
 	data := append(user.ToBytes(), deviceKID.ToBytes()...)
@@ -490,7 +490,7 @@ func (c *CryptoCommon) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeySer
 }
 
 // EncryptMerkleLeaf encrypts a Merkle leaf node with the TLFPublicKey.
-func (c *CryptoCommon) EncryptMerkleLeaf(leaf MerkleLeaf, pubKey TLFPublicKey,
+func (c CryptoCommon) EncryptMerkleLeaf(leaf MerkleLeaf, pubKey TLFPublicKey,
 	nonce *[24]byte, ePrivKey TLFEphemeralPrivateKey) (EncryptedMerkleLeaf, error) {
 	// encode the clear-text leaf
 	leafBytes, err := c.codec.Encode(leaf)
@@ -506,7 +506,7 @@ func (c *CryptoCommon) EncryptMerkleLeaf(leaf MerkleLeaf, pubKey TLFPublicKey,
 }
 
 // DecryptMerkleLeaf decrypts a Merkle leaf node with the TLFPrivateKey.
-func (c *CryptoCommon) DecryptMerkleLeaf(encryptedLeaf EncryptedMerkleLeaf, privKey TLFPrivateKey,
+func (c CryptoCommon) DecryptMerkleLeaf(encryptedLeaf EncryptedMerkleLeaf, privKey TLFPrivateKey,
 	nonce *[24]byte, ePubKey TLFEphemeralPublicKey) (*MerkleLeaf, error) {
 	if encryptedLeaf.Version != EncryptionSecretbox {
 		return nil, UnknownEncryptionVer{encryptedLeaf.Version}

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -39,6 +39,8 @@ type CryptoCommon struct {
 	deferLog logger.Logger
 }
 
+var _ cryptoPure = (*CryptoCommon)(nil)
+
 // MakeCryptoCommon returns a default CryptoCommon object.
 func MakeCryptoCommon(config Config) CryptoCommon {
 	log := config.MakeLogger("")

--- a/libkbfs/crypto_local.go
+++ b/libkbfs/crypto_local.go
@@ -87,7 +87,8 @@ var _ Crypto = (*CryptoLocal)(nil)
 // NewCryptoLocal constructs a new CryptoLocal instance with the given
 // signing key.
 func NewCryptoLocal(config Config, signingKey SigningKey, cryptPrivateKey CryptPrivateKey) *CryptoLocal {
-	return &CryptoLocal{MakeCryptoCommon(config),
+	log := config.MakeLogger("")
+	return &CryptoLocal{MakeCryptoCommon(config.Codec(), log),
 		signingKey, cryptPrivateKey}
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -82,55 +82,14 @@ func (_mr *_MockBlockRecorder) SetEncodedSize(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetEncodedSize", arg0)
 }
 
-// Mock of BlockContext interface
-type MockBlockContext struct {
-	ctrl     *gomock.Controller
-	recorder *_MockBlockContextRecorder
-}
-
-// Recorder for MockBlockContext (not exported)
-type _MockBlockContextRecorder struct {
-	mock *MockBlockContext
-}
-
-func NewMockBlockContext(ctrl *gomock.Controller) *MockBlockContext {
-	mock := &MockBlockContext{ctrl: ctrl}
-	mock.recorder = &_MockBlockContextRecorder{mock}
-	return mock
-}
-
-func (_m *MockBlockContext) EXPECT() *_MockBlockContextRecorder {
-	return _m.recorder
-}
-
-func (_m *MockBlockContext) GetCreator() protocol.UID {
-	ret := _m.ctrl.Call(_m, "GetCreator")
-	ret0, _ := ret[0].(protocol.UID)
+func (_m *MockBlock) DataVersion() DataVer {
+	ret := _m.ctrl.Call(_m, "DataVersion")
+	ret0, _ := ret[0].(DataVer)
 	return ret0
 }
 
-func (_mr *_MockBlockContextRecorder) GetCreator() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCreator")
-}
-
-func (_m *MockBlockContext) GetWriter() protocol.UID {
-	ret := _m.ctrl.Call(_m, "GetWriter")
-	ret0, _ := ret[0].(protocol.UID)
-	return ret0
-}
-
-func (_mr *_MockBlockContextRecorder) GetWriter() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriter")
-}
-
-func (_m *MockBlockContext) GetRefNonce() BlockRefNonce {
-	ret := _m.ctrl.Call(_m, "GetRefNonce")
-	ret0, _ := ret[0].(BlockRefNonce)
-	return ret0
-}
-
-func (_mr *_MockBlockContextRecorder) GetRefNonce() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRefNonce")
+func (_mr *_MockBlockRecorder) DataVersion() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DataVersion")
 }
 
 // Mock of NodeID interface
@@ -1262,6 +1221,292 @@ func (_mr *_MockDirtyBlockCacheRecorder) DirtyBytesEstimate() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DirtyBytesEstimate")
 }
 
+// Mock of cryptoPure interface
+type MockcryptoPure struct {
+	ctrl     *gomock.Controller
+	recorder *_MockcryptoPureRecorder
+}
+
+// Recorder for MockcryptoPure (not exported)
+type _MockcryptoPureRecorder struct {
+	mock *MockcryptoPure
+}
+
+func NewMockcryptoPure(ctrl *gomock.Controller) *MockcryptoPure {
+	mock := &MockcryptoPure{ctrl: ctrl}
+	mock.recorder = &_MockcryptoPureRecorder{mock}
+	return mock
+}
+
+func (_m *MockcryptoPure) EXPECT() *_MockcryptoPureRecorder {
+	return _m.recorder
+}
+
+func (_m *MockcryptoPure) MakeRandomTlfID(isPublic bool) (TlfID, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomTlfID", isPublic)
+	ret0, _ := ret[0].(TlfID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeRandomTlfID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomTlfID", arg0)
+}
+
+func (_m *MockcryptoPure) MakeRandomBranchID() (BranchID, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomBranchID")
+	ret0, _ := ret[0].(BranchID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeRandomBranchID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomBranchID")
+}
+
+func (_m *MockcryptoPure) MakeMdID(md *RootMetadata) (MdID, error) {
+	ret := _m.ctrl.Call(_m, "MakeMdID", md)
+	ret0, _ := ret[0].(MdID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeMdID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeMdID", arg0)
+}
+
+func (_m *MockcryptoPure) MakeMerkleHash(md *RootMetadataSigned) (MerkleHash, error) {
+	ret := _m.ctrl.Call(_m, "MakeMerkleHash", md)
+	ret0, _ := ret[0].(MerkleHash)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeMerkleHash(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeMerkleHash", arg0)
+}
+
+func (_m *MockcryptoPure) MakeTemporaryBlockID() (BlockID, error) {
+	ret := _m.ctrl.Call(_m, "MakeTemporaryBlockID")
+	ret0, _ := ret[0].(BlockID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeTemporaryBlockID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTemporaryBlockID")
+}
+
+func (_m *MockcryptoPure) MakePermanentBlockID(encodedEncryptedData []byte) (BlockID, error) {
+	ret := _m.ctrl.Call(_m, "MakePermanentBlockID", encodedEncryptedData)
+	ret0, _ := ret[0].(BlockID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakePermanentBlockID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakePermanentBlockID", arg0)
+}
+
+func (_m *MockcryptoPure) VerifyBlockID(encodedEncryptedData []byte, id BlockID) error {
+	ret := _m.ctrl.Call(_m, "VerifyBlockID", encodedEncryptedData, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockcryptoPureRecorder) VerifyBlockID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyBlockID", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) MakeBlockRefNonce() (BlockRefNonce, error) {
+	ret := _m.ctrl.Call(_m, "MakeBlockRefNonce")
+	ret0, _ := ret[0].(BlockRefNonce)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeBlockRefNonce() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBlockRefNonce")
+}
+
+func (_m *MockcryptoPure) MakeRandomTLFKeys() (TLFPublicKey, TLFPrivateKey, TLFEphemeralPublicKey, TLFEphemeralPrivateKey, TLFCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomTLFKeys")
+	ret0, _ := ret[0].(TLFPublicKey)
+	ret1, _ := ret[1].(TLFPrivateKey)
+	ret2, _ := ret[2].(TLFEphemeralPublicKey)
+	ret3, _ := ret[3].(TLFEphemeralPrivateKey)
+	ret4, _ := ret[4].(TLFCryptKey)
+	ret5, _ := ret[5].(error)
+	return ret0, ret1, ret2, ret3, ret4, ret5
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeRandomTLFKeys() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomTLFKeys")
+}
+
+func (_m *MockcryptoPure) MakeRandomTLFCryptKeyServerHalf() (TLFCryptKeyServerHalf, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomTLFCryptKeyServerHalf")
+	ret0, _ := ret[0].(TLFCryptKeyServerHalf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeRandomTLFCryptKeyServerHalf() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomTLFCryptKeyServerHalf")
+}
+
+func (_m *MockcryptoPure) MakeRandomBlockCryptKeyServerHalf() (BlockCryptKeyServerHalf, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomBlockCryptKeyServerHalf")
+	ret0, _ := ret[0].(BlockCryptKeyServerHalf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeRandomBlockCryptKeyServerHalf() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomBlockCryptKeyServerHalf")
+}
+
+func (_m *MockcryptoPure) MaskTLFCryptKey(serverHalf TLFCryptKeyServerHalf, key TLFCryptKey) (TLFCryptKeyClientHalf, error) {
+	ret := _m.ctrl.Call(_m, "MaskTLFCryptKey", serverHalf, key)
+	ret0, _ := ret[0].(TLFCryptKeyClientHalf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MaskTLFCryptKey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaskTLFCryptKey", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) UnmaskTLFCryptKey(serverHalf TLFCryptKeyServerHalf, clientHalf TLFCryptKeyClientHalf) (TLFCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "UnmaskTLFCryptKey", serverHalf, clientHalf)
+	ret0, _ := ret[0].(TLFCryptKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) UnmaskTLFCryptKey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmaskTLFCryptKey", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) UnmaskBlockCryptKey(serverHalf BlockCryptKeyServerHalf, tlfCryptKey TLFCryptKey) (BlockCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "UnmaskBlockCryptKey", serverHalf, tlfCryptKey)
+	ret0, _ := ret[0].(BlockCryptKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) UnmaskBlockCryptKey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmaskBlockCryptKey", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) Verify(msg []byte, sigInfo SignatureInfo) error {
+	ret := _m.ctrl.Call(_m, "Verify", msg, sigInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockcryptoPureRecorder) Verify(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Verify", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) EncryptTLFCryptKeyClientHalf(privateKey TLFEphemeralPrivateKey, publicKey CryptPublicKey, clientHalf TLFCryptKeyClientHalf) (EncryptedTLFCryptKeyClientHalf, error) {
+	ret := _m.ctrl.Call(_m, "EncryptTLFCryptKeyClientHalf", privateKey, publicKey, clientHalf)
+	ret0, _ := ret[0].(EncryptedTLFCryptKeyClientHalf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) EncryptTLFCryptKeyClientHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptTLFCryptKeyClientHalf", arg0, arg1, arg2)
+}
+
+func (_m *MockcryptoPure) EncryptPrivateMetadata(pmd *PrivateMetadata, key TLFCryptKey) (EncryptedPrivateMetadata, error) {
+	ret := _m.ctrl.Call(_m, "EncryptPrivateMetadata", pmd, key)
+	ret0, _ := ret[0].(EncryptedPrivateMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) EncryptPrivateMetadata(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptPrivateMetadata", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key TLFCryptKey) (*PrivateMetadata, error) {
+	ret := _m.ctrl.Call(_m, "DecryptPrivateMetadata", encryptedPMD, key)
+	ret0, _ := ret[0].(*PrivateMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) DecryptPrivateMetadata(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptPrivateMetadata", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) EncryptBlock(block Block, key BlockCryptKey) (int, EncryptedBlock, error) {
+	ret := _m.ctrl.Call(_m, "EncryptBlock", block, key)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(EncryptedBlock)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockcryptoPureRecorder) EncryptBlock(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptBlock", arg0, arg1)
+}
+
+func (_m *MockcryptoPure) DecryptBlock(encryptedBlock EncryptedBlock, key BlockCryptKey, block Block) error {
+	ret := _m.ctrl.Call(_m, "DecryptBlock", encryptedBlock, key, block)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockcryptoPureRecorder) DecryptBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptBlock", arg0, arg1, arg2)
+}
+
+func (_m *MockcryptoPure) GetTLFCryptKeyServerHalfID(user protocol.UID, deviceKID protocol.KID, serverHalf TLFCryptKeyServerHalf) (TLFCryptKeyServerHalfID, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyServerHalfID", user, deviceKID, serverHalf)
+	ret0, _ := ret[0].(TLFCryptKeyServerHalfID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) GetTLFCryptKeyServerHalfID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyServerHalfID", arg0, arg1, arg2)
+}
+
+func (_m *MockcryptoPure) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user protocol.UID, deviceKID protocol.KID, serverHalf TLFCryptKeyServerHalf) error {
+	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, deviceKID, serverHalf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockcryptoPureRecorder) VerifyTLFCryptKeyServerHalfID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyTLFCryptKeyServerHalfID", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockcryptoPure) EncryptMerkleLeaf(leaf MerkleLeaf, pubKey TLFPublicKey, nonce *[24]byte, ePrivKey TLFEphemeralPrivateKey) (EncryptedMerkleLeaf, error) {
+	ret := _m.ctrl.Call(_m, "EncryptMerkleLeaf", leaf, pubKey, nonce, ePrivKey)
+	ret0, _ := ret[0].(EncryptedMerkleLeaf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) EncryptMerkleLeaf(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptMerkleLeaf", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockcryptoPure) DecryptMerkleLeaf(encryptedLeaf EncryptedMerkleLeaf, privKey TLFPrivateKey, nonce *[24]byte, ePubKey TLFEphemeralPublicKey) (*MerkleLeaf, error) {
+	ret := _m.ctrl.Call(_m, "DecryptMerkleLeaf", encryptedLeaf, privKey, nonce, ePubKey)
+	ret0, _ := ret[0].(*MerkleLeaf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) DecryptMerkleLeaf(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptMerkleLeaf", arg0, arg1, arg2, arg3)
+}
+
 // Mock of Crypto interface
 type MockCrypto struct {
 	ctrl     *gomock.Controller
@@ -1440,28 +1685,6 @@ func (_mr *_MockCryptoRecorder) UnmaskBlockCryptKey(arg0, arg1 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnmaskBlockCryptKey", arg0, arg1)
 }
 
-func (_m *MockCrypto) Sign(ctx context.Context, msg []byte) (SignatureInfo, error) {
-	ret := _m.ctrl.Call(_m, "Sign", ctx, msg)
-	ret0, _ := ret[0].(SignatureInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockCryptoRecorder) Sign(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Sign", arg0, arg1)
-}
-
-func (_m *MockCrypto) SignToString(ctx context.Context, msg []byte) (string, error) {
-	ret := _m.ctrl.Call(_m, "SignToString", ctx, msg)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockCryptoRecorder) SignToString(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignToString", arg0, arg1)
-}
-
 func (_m *MockCrypto) Verify(msg []byte, sigInfo SignatureInfo) error {
 	ret := _m.ctrl.Call(_m, "Verify", msg, sigInfo)
 	ret0, _ := ret[0].(error)
@@ -1481,50 +1704,6 @@ func (_m *MockCrypto) EncryptTLFCryptKeyClientHalf(privateKey TLFEphemeralPrivat
 
 func (_mr *_MockCryptoRecorder) EncryptTLFCryptKeyClientHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptTLFCryptKeyClientHalf", arg0, arg1, arg2)
-}
-
-func (_m *MockCrypto) DecryptTLFCryptKeyClientHalf(ctx context.Context, publicKey TLFEphemeralPublicKey, encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (TLFCryptKeyClientHalf, error) {
-	ret := _m.ctrl.Call(_m, "DecryptTLFCryptKeyClientHalf", ctx, publicKey, encryptedClientHalf)
-	ret0, _ := ret[0].(TLFCryptKeyClientHalf)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockCryptoRecorder) DecryptTLFCryptKeyClientHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptTLFCryptKeyClientHalf", arg0, arg1, arg2)
-}
-
-func (_m *MockCrypto) DecryptTLFCryptKeyClientHalfAny(ctx context.Context, keys []EncryptedTLFCryptKeyClientAndEphemeral, promptPaper bool) (TLFCryptKeyClientHalf, int, error) {
-	ret := _m.ctrl.Call(_m, "DecryptTLFCryptKeyClientHalfAny", ctx, keys, promptPaper)
-	ret0, _ := ret[0].(TLFCryptKeyClientHalf)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockCryptoRecorder) DecryptTLFCryptKeyClientHalfAny(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptTLFCryptKeyClientHalfAny", arg0, arg1, arg2)
-}
-
-func (_m *MockCrypto) GetTLFCryptKeyServerHalfID(user protocol.UID, deviceKID protocol.KID, serverHalf TLFCryptKeyServerHalf) (TLFCryptKeyServerHalfID, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyServerHalfID", user, deviceKID, serverHalf)
-	ret0, _ := ret[0].(TLFCryptKeyServerHalfID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockCryptoRecorder) GetTLFCryptKeyServerHalfID(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyServerHalfID", arg0, arg1, arg2)
-}
-
-func (_m *MockCrypto) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user protocol.UID, deviceKID protocol.KID, serverHalf TLFCryptKeyServerHalf) error {
-	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, deviceKID, serverHalf)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockCryptoRecorder) VerifyTLFCryptKeyServerHalfID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyTLFCryptKeyServerHalfID", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockCrypto) EncryptPrivateMetadata(pmd *PrivateMetadata, key TLFCryptKey) (EncryptedPrivateMetadata, error) {
@@ -1571,6 +1750,27 @@ func (_mr *_MockCryptoRecorder) DecryptBlock(arg0, arg1, arg2 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptBlock", arg0, arg1, arg2)
 }
 
+func (_m *MockCrypto) GetTLFCryptKeyServerHalfID(user protocol.UID, deviceKID protocol.KID, serverHalf TLFCryptKeyServerHalf) (TLFCryptKeyServerHalfID, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyServerHalfID", user, deviceKID, serverHalf)
+	ret0, _ := ret[0].(TLFCryptKeyServerHalfID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCryptoRecorder) GetTLFCryptKeyServerHalfID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyServerHalfID", arg0, arg1, arg2)
+}
+
+func (_m *MockCrypto) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user protocol.UID, deviceKID protocol.KID, serverHalf TLFCryptKeyServerHalf) error {
+	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, deviceKID, serverHalf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockCryptoRecorder) VerifyTLFCryptKeyServerHalfID(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyTLFCryptKeyServerHalfID", arg0, arg1, arg2, arg3)
+}
+
 func (_m *MockCrypto) EncryptMerkleLeaf(leaf MerkleLeaf, pubKey TLFPublicKey, nonce *[24]byte, ePrivKey TLFEphemeralPrivateKey) (EncryptedMerkleLeaf, error) {
 	ret := _m.ctrl.Call(_m, "EncryptMerkleLeaf", leaf, pubKey, nonce, ePrivKey)
 	ret0, _ := ret[0].(EncryptedMerkleLeaf)
@@ -1591,6 +1791,51 @@ func (_m *MockCrypto) DecryptMerkleLeaf(encryptedLeaf EncryptedMerkleLeaf, privK
 
 func (_mr *_MockCryptoRecorder) DecryptMerkleLeaf(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptMerkleLeaf", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockCrypto) Sign(ctx context.Context, msg []byte) (SignatureInfo, error) {
+	ret := _m.ctrl.Call(_m, "Sign", ctx, msg)
+	ret0, _ := ret[0].(SignatureInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCryptoRecorder) Sign(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Sign", arg0, arg1)
+}
+
+func (_m *MockCrypto) SignToString(ctx context.Context, msg []byte) (string, error) {
+	ret := _m.ctrl.Call(_m, "SignToString", ctx, msg)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCryptoRecorder) SignToString(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignToString", arg0, arg1)
+}
+
+func (_m *MockCrypto) DecryptTLFCryptKeyClientHalf(ctx context.Context, publicKey TLFEphemeralPublicKey, encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (TLFCryptKeyClientHalf, error) {
+	ret := _m.ctrl.Call(_m, "DecryptTLFCryptKeyClientHalf", ctx, publicKey, encryptedClientHalf)
+	ret0, _ := ret[0].(TLFCryptKeyClientHalf)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCryptoRecorder) DecryptTLFCryptKeyClientHalf(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptTLFCryptKeyClientHalf", arg0, arg1, arg2)
+}
+
+func (_m *MockCrypto) DecryptTLFCryptKeyClientHalfAny(ctx context.Context, keys []EncryptedTLFCryptKeyClientAndEphemeral, promptPaper bool) (TLFCryptKeyClientHalf, int, error) {
+	ret := _m.ctrl.Call(_m, "DecryptTLFCryptKeyClientHalfAny", ctx, keys, promptPaper)
+	ret0, _ := ret[0].(TLFCryptKeyClientHalf)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockCryptoRecorder) DecryptTLFCryptKeyClientHalfAny(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptTLFCryptKeyClientHalfAny", arg0, arg1, arg2)
 }
 
 func (_m *MockCrypto) Shutdown() {
@@ -2166,6 +2411,118 @@ func (_m *MockBlockServer) GetUserQuotaInfo(ctx context.Context) (*UserQuotaInfo
 
 func (_mr *_MockBlockServerRecorder) GetUserQuotaInfo(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserQuotaInfo", arg0)
+}
+
+// Mock of blockServerLocal interface
+type MockblockServerLocal struct {
+	ctrl     *gomock.Controller
+	recorder *_MockblockServerLocalRecorder
+}
+
+// Recorder for MockblockServerLocal (not exported)
+type _MockblockServerLocalRecorder struct {
+	mock *MockblockServerLocal
+}
+
+func NewMockblockServerLocal(ctrl *gomock.Controller) *MockblockServerLocal {
+	mock := &MockblockServerLocal{ctrl: ctrl}
+	mock.recorder = &_MockblockServerLocalRecorder{mock}
+	return mock
+}
+
+func (_m *MockblockServerLocal) EXPECT() *_MockblockServerLocalRecorder {
+	return _m.recorder
+}
+
+func (_m *MockblockServerLocal) RefreshAuthToken(_param0 context.Context) {
+	_m.ctrl.Call(_m, "RefreshAuthToken", _param0)
+}
+
+func (_mr *_MockblockServerLocalRecorder) RefreshAuthToken(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RefreshAuthToken", arg0)
+}
+
+func (_m *MockblockServerLocal) Get(ctx context.Context, id BlockID, tlfID TlfID, context BlockContext) ([]byte, BlockCryptKeyServerHalf, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, id, tlfID, context)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(BlockCryptKeyServerHalf)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockblockServerLocalRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockblockServerLocal) Put(ctx context.Context, id BlockID, tlfID TlfID, context BlockContext, buf []byte, serverHalf BlockCryptKeyServerHalf) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, id, tlfID, context, buf, serverHalf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockblockServerLocalRecorder) Put(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+func (_m *MockblockServerLocal) AddBlockReference(ctx context.Context, id BlockID, tlfID TlfID, context BlockContext) error {
+	ret := _m.ctrl.Call(_m, "AddBlockReference", ctx, id, tlfID, context)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockblockServerLocalRecorder) AddBlockReference(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddBlockReference", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockblockServerLocal) RemoveBlockReference(ctx context.Context, tlfID TlfID, contexts map[BlockID][]BlockContext) (map[BlockID]int, error) {
+	ret := _m.ctrl.Call(_m, "RemoveBlockReference", ctx, tlfID, contexts)
+	ret0, _ := ret[0].(map[BlockID]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockblockServerLocalRecorder) RemoveBlockReference(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RemoveBlockReference", arg0, arg1, arg2)
+}
+
+func (_m *MockblockServerLocal) ArchiveBlockReferences(ctx context.Context, tlfID TlfID, contexts map[BlockID][]BlockContext) error {
+	ret := _m.ctrl.Call(_m, "ArchiveBlockReferences", ctx, tlfID, contexts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockblockServerLocalRecorder) ArchiveBlockReferences(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ArchiveBlockReferences", arg0, arg1, arg2)
+}
+
+func (_m *MockblockServerLocal) Shutdown() {
+	_m.ctrl.Call(_m, "Shutdown")
+}
+
+func (_mr *_MockblockServerLocalRecorder) Shutdown() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
+}
+
+func (_m *MockblockServerLocal) GetUserQuotaInfo(ctx context.Context) (*UserQuotaInfo, error) {
+	ret := _m.ctrl.Call(_m, "GetUserQuotaInfo", ctx)
+	ret0, _ := ret[0].(*UserQuotaInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockblockServerLocalRecorder) GetUserQuotaInfo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserQuotaInfo", arg0)
+}
+
+func (_m *MockblockServerLocal) getAll(tlfID TlfID) (map[BlockID]map[BlockRefNonce]blockRefLocalStatus, error) {
+	ret := _m.ctrl.Call(_m, "getAll", tlfID)
+	ret0, _ := ret[0].(map[BlockID]map[BlockRefNonce]blockRefLocalStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockblockServerLocalRecorder) getAll(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "getAll", arg0)
 }
 
 // Mock of BlockSplitter interface


### PR DESCRIPTION
Also move out pure crypto functions into
cryptoPure interface, which is embedded
by Crypto.

This makes testing some stuff easier, as
now you don't have to build a full Crypto
object for some tests.