### PR TITLE
folder_block_ops: when creating indirect block, mark it not dirty

### DIFF
--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -86,6 +86,16 @@ func (df *dirtyFile) setBlockDirty(ptr BlockPointer) (
 	return needsCaching, isSyncing
 }
 
+func (df *dirtyFile) setBlockNotDirty(ptr BlockPointer) (
+	needsCaching bool, isSyncing bool) {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	state := df.fileBlockStates[ptr]
+	state.copy = blockNeedsCopy
+	df.fileBlockStates[ptr] = state
+	return
+}
+
 func (df *dirtyFile) isBlockSyncing(ptr BlockPointer) bool {
 	df.lock.Lock()
 	defer df.lock.Unlock()

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1108,6 +1108,11 @@ func (fbo *folderBlockOps) createIndirectBlockLocked(lState *lockState,
 			},
 		},
 	}
+
+	df := fbo.getOrCreateDirtyFileLocked(lState, file)
+	// Mark the old block ID as not dirty, so that we will treat the
+	// old block ID as newly dirtied in cacheBlockIfNotYetDirtyLocked.
+	df.setBlockNotDirty(file.tailPointer())
 	err = fbo.cacheBlockIfNotYetDirtyLocked(lState, file.tailPointer(), file,
 		fblock)
 	if err != nil {


### PR DESCRIPTION
Previously, we put the new block directly into the dirty cache.
However, with the new dirtyFile organization, we first check if it was
dirty before caching it, and the dirtyFile thought it was still marked
as dirty and so didn't re-cache the new indirect block.  As a result,
the sync got the old, direct block out of the cache and sync'd that.
The file size in the direct entry was roughly correct though, so any
reader would see zeroes when they read past the end of that block.

Issue: KBFS-1138