### PR TITLE
dirty_bcache: track unsynced and total dirty bytes, system-wide

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -1055,7 +1055,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 		t.Fatalf("Couldn't re-make file: %v", err)
 	}
 
-	// user2 updates the file attribute and writes to
+	// user2 updates the file attribute and writes too.
 	err = config2.KBFSOps().SetEx(ctx, file2, true)
 	if err != nil {
 		t.Fatalf("Couldn't set ex: %v", err)
@@ -1063,6 +1063,10 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	err = config2.KBFSOps().Write(ctx, file2, []byte{1, 2, 3}, 0)
 	if err != nil {
 		t.Fatalf("Couldn't write: %v", err)
+	}
+	err = config2.KBFSOps().Sync(ctx, file2)
+	if err != nil {
+		t.Fatalf("Couldn't sync: %v", err)
 	}
 
 	// Now step through conflict resolution manually for user 2

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -20,17 +21,42 @@ type dirtyBlockID struct {
 // block may be forked and modified on different branches and under
 // different references simultaneously.
 type DirtyBlockCacheStandard struct {
-	dirtyLock          sync.Mutex
-	dirty              map[dirtyBlockID]Block
-	dirtyBytesEstimate uint64
+	// requestsChan is a queue for channels that should be closed when
+	// permission is granted to dirty new data.
+	requestsChan chan chan<- struct{}
+	// bytesDecreasedChan is signalled when syncs have finished or dirty
+	// blocks have been deleted.
+	bytesDecreasedChan chan struct{}
+	// shutdownChan is closed when Shutdown is called.
+	shutdownChan chan struct{}
+
+	// When the number of un-synced dirty bytes exceeds this level,
+	// block new writes.
+	maxSyncBufferSize int64
+	// When the number of total dirty bytes exceeds this level, block
+	// new writes.
+	maxDirtyBufferSize int64
+
+	lock               sync.Mutex
+	cache              map[dirtyBlockID]Block
+	unsyncedDirtyBytes int64
+	totalDirtyBytes    int64
 }
 
 // NewDirtyBlockCacheStandard constructs a new BlockCacheStandard
 // instance.
-func NewDirtyBlockCacheStandard() *DirtyBlockCacheStandard {
-	return &DirtyBlockCacheStandard{
-		dirty: make(map[dirtyBlockID]Block),
+func NewDirtyBlockCacheStandard(maxSyncBufferSize int64,
+	maxDirtyBufferSize int64) *DirtyBlockCacheStandard {
+	d := &DirtyBlockCacheStandard{
+		requestsChan:       make(chan chan<- struct{}, 1000),
+		bytesDecreasedChan: make(chan struct{}, 10),
+		shutdownChan:       make(chan struct{}),
+		cache:              make(map[dirtyBlockID]Block),
+		maxSyncBufferSize:  maxSyncBufferSize,
+		maxDirtyBufferSize: maxDirtyBufferSize,
 	}
+	go d.processPermission()
+	return d
 }
 
 // Get implements the DirtyBlockCache interface for
@@ -43,9 +69,9 @@ func (d *DirtyBlockCacheStandard) Get(ptr BlockPointer, branch BranchName) (
 			refNonce: ptr.RefNonce,
 			branch:   branch,
 		}
-		d.dirtyLock.Lock()
-		defer d.dirtyLock.Unlock()
-		return d.dirty[dirtyID]
+		d.lock.Lock()
+		defer d.lock.Unlock()
+		return d.cache[dirtyID]
 	}()
 	if block != nil {
 		return block, nil
@@ -64,10 +90,9 @@ func (d *DirtyBlockCacheStandard) Put(ptr BlockPointer, branch BranchName,
 		branch:   branch,
 	}
 
-	d.dirtyLock.Lock()
-	defer d.dirtyLock.Unlock()
-	d.dirty[dirtyID] = block
-	d.dirtyBytesEstimate = 0
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.cache[dirtyID] = block
 	return nil
 }
 
@@ -81,10 +106,9 @@ func (d *DirtyBlockCacheStandard) Delete(ptr BlockPointer,
 		branch:   branch,
 	}
 
-	d.dirtyLock.Lock()
-	defer d.dirtyLock.Unlock()
-	delete(d.dirty, dirtyID)
-	d.dirtyBytesEstimate = 0
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	delete(d.cache, dirtyID)
 	return nil
 }
 
@@ -98,25 +122,101 @@ func (d *DirtyBlockCacheStandard) IsDirty(
 		branch:   branch,
 	}
 
-	d.dirtyLock.Lock()
-	defer d.dirtyLock.Unlock()
-	_, isDirty = d.dirty[dirtyID]
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	_, isDirty = d.cache[dirtyID]
 	return
 }
 
-// DirtyBytesEstimate implements the DirtyBlockCache interface for
-// DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) DirtyBytesEstimate() uint64 {
-	d.dirtyLock.Lock()
-	defer d.dirtyLock.Unlock()
-	if d.dirtyBytesEstimate == 0 {
-		// Users of this cache can update dirty blocks at will, so
-		// it's not possible to return the exact sizes of the blocks.
-		// Just cache what we have until we know for sure that it's
-		// changed (because a new block is added, for example).
-		for _, block := range d.dirty {
-			d.dirtyBytesEstimate += uint64(getCachedBlockSize(block))
+func (d *DirtyBlockCacheStandard) canAcceptNewWrite() bool {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	return d.unsyncedDirtyBytes < d.maxSyncBufferSize &&
+		d.totalDirtyBytes < d.maxDirtyBufferSize
+}
+
+func (d *DirtyBlockCacheStandard) processPermission() {
+	var currentReq chan<- struct{}
+	for {
+		reqChan := d.requestsChan
+		if currentReq != nil {
+			// We are already waiting on a request
+			reqChan = nil
+		}
+
+		select {
+		case <-d.shutdownChan:
+			return
+		case <-d.bytesDecreasedChan:
+		case c := <-reqChan:
+			currentReq = c
+		}
+
+		if currentReq != nil && d.canAcceptNewWrite() {
+			close(currentReq)
+			currentReq = nil
 		}
 	}
-	return d.dirtyBytesEstimate
+}
+
+// RequestPermissionToDirty implements the DirtyBlockCache interface
+// for DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) RequestPermissionToDirty() DirtyPermChan {
+	c := make(chan struct{})
+	d.requestsChan <- c
+	return c
+}
+
+// UpdateUnsyncedBytes implements the DirtyBlockCache interface for
+// DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) UpdateUnsyncedBytes(newUnsyncedBytes int64) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.unsyncedDirtyBytes += newUnsyncedBytes
+	d.totalDirtyBytes += newUnsyncedBytes
+	if d.unsyncedDirtyBytes < 0 {
+		d.bytesDecreasedChan <- struct{}{}
+	}
+}
+
+// BlockSyncFinished implements the DirtyBlockCache interface for
+// DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) BlockSyncFinished(size int64) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.unsyncedDirtyBytes -= size
+	if size > 0 {
+		d.bytesDecreasedChan <- struct{}{}
+	}
+}
+
+// SyncFinished implements the DirtyBlockCache interface for
+// DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) SyncFinished(size int64) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	if size <= 0 {
+		return
+	}
+	d.totalDirtyBytes -= size
+	d.bytesDecreasedChan <- struct{}{}
+}
+
+// ShouldForceSync implements the DirtyBlockCache interface for
+// DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) ShouldForceSync() bool {
+	return !d.canAcceptNewWrite()
+}
+
+// Shutdown implements the DirtyBlockCache interface for
+// DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) Shutdown() error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	close(d.shutdownChan)
+	if d.unsyncedDirtyBytes != 0 || d.totalDirtyBytes != 0 {
+		return fmt.Errorf("Unexpected dirty bytes leftover on shutdown: "+
+			"unsynced=%d, total=%d", d.unsyncedDirtyBytes, d.totalDirtyBytes)
+	}
+	return nil
 }

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -187,7 +187,7 @@ func (d *DirtyBlockCacheStandard) processPermission() {
 func (d *DirtyBlockCacheStandard) RequestPermissionToDirty(
 	estimatedDirtyBytes int64) DirtyPermChan {
 	if estimatedDirtyBytes < 0 {
-		panic("Must request permission for a positive number of bytes.")
+		panic("Must request permission for a non-negative number of bytes.")
 	}
 	c := make(chan struct{})
 	d.requestsChan <- dirtyReq{c, estimatedDirtyBytes}

--- a/libkbfs/dirty_bcache_test.go
+++ b/libkbfs/dirty_bcache_test.go
@@ -41,12 +41,12 @@ func testExpectedMissingDirty(t *testing.T, id BlockID,
 }
 
 func TestDirtyBcachePut(t *testing.T) {
-	dirtyBcache := NewDirtyBlockCacheStandard()
+	dirtyBcache := NewDirtyBlockCacheStandard(5<<20, 10<<20)
 	testDirtyBcachePut(t, fakeBlockID(1), dirtyBcache)
 }
 
 func TestDirtyBcachePutDuplicate(t *testing.T) {
-	dirtyBcache := NewDirtyBlockCacheStandard()
+	dirtyBcache := NewDirtyBlockCacheStandard(5<<20, 10<<20)
 	id1 := fakeBlockID(1)
 
 	// Dirty a specific reference nonce, and make sure the
@@ -89,7 +89,7 @@ func TestDirtyBcachePutDuplicate(t *testing.T) {
 }
 
 func TestDirtyBcacheDelete(t *testing.T) {
-	dirtyBcache := NewDirtyBlockCacheStandard()
+	dirtyBcache := NewDirtyBlockCacheStandard(5<<20, 10<<20)
 
 	id1 := fakeBlockID(1)
 	testDirtyBcachePut(t, id1, dirtyBcache)

--- a/libkbfs/dirty_bcache_test.go
+++ b/libkbfs/dirty_bcache_test.go
@@ -42,11 +42,13 @@ func testExpectedMissingDirty(t *testing.T, id BlockID,
 
 func TestDirtyBcachePut(t *testing.T) {
 	dirtyBcache := NewDirtyBlockCacheStandard(5<<20, 10<<20)
+	defer dirtyBcache.Shutdown()
 	testDirtyBcachePut(t, fakeBlockID(1), dirtyBcache)
 }
 
 func TestDirtyBcachePutDuplicate(t *testing.T) {
 	dirtyBcache := NewDirtyBlockCacheStandard(5<<20, 10<<20)
+	defer dirtyBcache.Shutdown()
 	id1 := fakeBlockID(1)
 
 	// Dirty a specific reference nonce, and make sure the
@@ -90,6 +92,7 @@ func TestDirtyBcachePutDuplicate(t *testing.T) {
 
 func TestDirtyBcacheDelete(t *testing.T) {
 	dirtyBcache := NewDirtyBlockCacheStandard(5<<20, 10<<20)
+	defer dirtyBcache.Shutdown()
 
 	id1 := fakeBlockID(1)
 	testDirtyBcachePut(t, id1, dirtyBcache)
@@ -105,4 +108,73 @@ func TestDirtyBcacheDelete(t *testing.T) {
 	if !dirtyBcache.IsDirty(BlockPointer{ID: id1}, newBranch) {
 		t.Errorf("New branch block is now unexpectedly clean")
 	}
+}
+
+func TestDirtyBcacheRequestPermission(t *testing.T) {
+	bufSize := int64(5)
+	dirtyBcache := NewDirtyBlockCacheStandard(bufSize, bufSize*2)
+	defer dirtyBcache.Shutdown()
+	blockedChan := make(chan int64)
+	dirtyBcache.blockedChanForTesting = blockedChan
+
+	// The first write should get immediate permission.
+	c1 := dirtyBcache.RequestPermissionToDirty(bufSize)
+	<-c1
+	// Now the unsynced buffer is full
+	if !dirtyBcache.ShouldForceSync() {
+		t.Fatalf("Unsynced not full after a request")
+	}
+	// Not blocked
+	if blockedSize := <-blockedChan; blockedSize != -1 {
+		t.Fatalf("Wrong blocked size: %d", blockedSize)
+	}
+
+	// The next request should block
+	c2 := dirtyBcache.RequestPermissionToDirty(bufSize)
+	if blockedSize := <-blockedChan; blockedSize != bufSize {
+		t.Fatalf("Wrong blocked size: %d", blockedSize)
+	}
+	select {
+	case <-c2:
+		t.Fatalf("Request should be blocked")
+	default:
+	}
+
+	// Let's say the actual number of unsynced bytes for c1 was double
+	dirtyBcache.UpdateUnsyncedBytes(2 * bufSize)
+	// Now release the previous bytes
+	dirtyBcache.UpdateUnsyncedBytes(-bufSize)
+
+	// Request 2 should still be blocked.  (This check isn't
+	// fool-proof, since it doesn't necessarily give time for the
+	// background thread to run.)
+	select {
+	case <-c2:
+		t.Fatalf("Request should be blocked")
+	default:
+	}
+
+	// Finish syncing full size, but c2 is still blocked because we
+	// haven't finished the sync yet.
+	dirtyBcache.BlockSyncFinished(bufSize)
+	dirtyBcache.BlockSyncFinished(bufSize)
+	if !dirtyBcache.ShouldForceSync() {
+		t.Fatalf("Total not full before sync finishes")
+	}
+	select {
+	case <-c2:
+		t.Fatalf("Request should be blocked")
+	default:
+	}
+
+	// Finally, finish off the sync, which should unblock c2
+	dirtyBcache.SyncFinished(2 * bufSize)
+	if dirtyBcache.ShouldForceSync() {
+		t.Fatalf("Buffers still full after sync finished")
+	}
+
+	if blockedSize := <-blockedChan; blockedSize != -1 {
+		t.Fatalf("Wrong blocked size: %d", blockedSize)
+	}
+	<-c2
 }

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -32,16 +32,22 @@ const (
 )
 
 type dirtyBlockState struct {
-	sync dirtyBlockSyncState
-	copy dirtyBlockCopyState
+	sync     dirtyBlockSyncState
+	copy     dirtyBlockCopyState
+	syncSize int64
+	// An "orphaned" block is one that is now referred to in an
+	// indirect file block under its new, permanent block ID.  Once a
+	// block is orphaned, it is no longer re-dirtiable.
+	orphaned bool
 }
 
 // dirtyFile represents a particular file that's been written to, but
 // has not yet completed syncing its dirty blocks to the server.
 type dirtyFile struct {
-	path path
+	path        path
+	dirtyBcache DirtyBlockCache
 
-	// Protects access to fileBlockStates.  Most, but not all,
+	// Protects access to the fields below.  Most, but not all,
 	// accesses to dirtyFile is already protected by
 	// folderBlockOps.blockLock, so this lock should always be taken
 	// just in case.
@@ -54,11 +60,29 @@ type dirtyFile struct {
 	// blockSyncing and blockAlreadyCopied, then just defer the
 	// writes.
 	fileBlockStates map[BlockPointer]dirtyBlockState
+	// totalSyncBytes is the total number of outstanding dirty bytes
+	// for this file, including those blocks that have already
+	// finished syncing.
+	totalSyncBytes int64
+	// deferredNewBytes is the number of bytes that have been
+	// deferred, and will be rewritten after the current sync
+	// finishes.  It counts only new bytes that extended the file as
+	// part of the deferred write.  This is useful in the case where
+	// the current sync gets retried due to a recoverable error, and
+	// those bytes get sucked into the retry and need to be accounted
+	// for.
+	deferredNewBytes int64
+	// If there are too many deferred bytes outstanding, writes should
+	// add themselves to this list.  They will be able to receive on
+	// the channel on an outstanding Sync() completes.  If they
+	// receive an error, they should fail the write.
+	errListeners []chan<- error
 }
 
-func newDirtyFile(file path) *dirtyFile {
+func newDirtyFile(file path, dirtyBcache DirtyBlockCache) *dirtyFile {
 	return &dirtyFile{
 		path:            file,
+		dirtyBcache:     dirtyBcache,
 		fileBlockStates: make(map[BlockPointer]dirtyBlockState),
 	}
 }
@@ -117,6 +141,16 @@ func (df *dirtyFile) setBlockSyncing(ptr BlockPointer) error {
 	}
 	state.copy = blockNeedsCopy
 	state.sync = blockSyncing
+	block, err := df.dirtyBcache.Get(ptr, df.path.Branch)
+	if err != nil {
+		panic(err)
+	}
+	fblock, ok := block.(*FileBlock)
+	if !ok {
+		panic("Dirty file syncing a non-file block")
+	}
+	state.syncSize = int64(len(fblock.Contents))
+	df.totalSyncBytes += state.syncSize
 	df.fileBlockStates[ptr] = state
 	return nil
 }
@@ -126,26 +160,50 @@ func (df *dirtyFile) resetSyncingBlocksToDirty() {
 	defer df.lock.Unlock()
 	// Reset all syncing blocks to just be dirty again
 	for ptr, state := range df.fileBlockStates {
+		if state.orphaned {
+			// This block will never be sync'd again, so clear any
+			// bytes from the buffer.
+			if state.sync == blockSyncing {
+				df.dirtyBcache.UpdateUnsyncedBytes(-state.syncSize)
+			} else if state.sync == blockSynced {
+				df.dirtyBcache.SyncFinished(state.syncSize)
+			}
+			state.syncSize = 0
+			delete(df.fileBlockStates, ptr)
+			continue
+		}
+		if state.sync == blockSynced {
+			// Re-dirty the unsynced bytes (but don't touch the total
+			// bytes).
+			df.dirtyBcache.BlockSyncFinished(-state.syncSize)
+		}
 		if state.sync != blockNotSyncing {
 			state.copy = blockAlreadyCopied
 			state.sync = blockNotSyncing
+			state.syncSize = 0
 			df.fileBlockStates[ptr] = state
 		}
 	}
+	df.totalSyncBytes = 0 // all the blocks need to be re-synced.
 }
 
 func (df *dirtyFile) setBlockSyncedLocked(ptr BlockPointer) error {
-	state := df.fileBlockStates[ptr]
-	if state.copy == blockAlreadyCopied && state.sync == blockNotSyncing {
-		// We've likely already had an resetSyncingBlocksToDirty call; ignore.
+	state, ok := df.fileBlockStates[ptr]
+	if !ok || (state.copy == blockAlreadyCopied &&
+		state.sync == blockNotSyncing) {
+		// We've likely already had an resetSyncingBlocksToDirty; ignore.
 		return nil
 	}
 
-	if state.sync != blockSyncing {
+	if state.sync != blockSyncing && !state.orphaned {
 		return fmt.Errorf("Trying to finish a block sync that wasn't in "+
-			"progress: %v (%d)", ptr, df.fileBlockStates[ptr])
+			"progress: %v (%v)", ptr, df.fileBlockStates[ptr])
 	}
 	state.sync = blockSynced
+	df.dirtyBcache.BlockSyncFinished(state.syncSize)
+	//state.syncSize = 0
+	// Keep syncSize set in case the block needs to be re-dirtied due
+	// to an error.
 	df.fileBlockStates[ptr] = state
 	// TODO: Eventually we'll need to free up space in the buffer
 	// taken up by these sync'd blocks, so new writes can proceed.
@@ -169,12 +227,15 @@ func (df *dirtyFile) finishSync() error {
 	// only be one, equal to the original top block).
 	found := false
 	for ptr, state := range df.fileBlockStates {
+		if state.orphaned {
+			continue
+		}
 		if state.sync == blockSyncing {
 			if found {
 				return fmt.Errorf("Unexpected syncing block %v", ptr)
 			}
 			if ptr != df.path.tailPointer() {
-				return fmt.Errorf("Unexoected syncing block %v; expected %v",
+				return fmt.Errorf("Unexpected syncing block %v; expected %v",
 					ptr, df.path.tailPointer())
 			}
 			found = true
@@ -184,5 +245,54 @@ func (df *dirtyFile) finishSync() error {
 			}
 		}
 	}
+	df.dirtyBcache.SyncFinished(df.totalSyncBytes)
+	df.totalSyncBytes = 0
+	df.deferredNewBytes = 0
 	return nil
+}
+
+func (df *dirtyFile) addErrListener(listener chan<- error) {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	df.errListeners = append(df.errListeners, listener)
+}
+
+func (df *dirtyFile) notifyErrListeners(err error) {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	listeners := df.errListeners
+	df.errListeners = nil
+	if err == nil {
+		return
+	}
+	for _, listener := range listeners {
+		listener <- err
+	}
+}
+
+func (df *dirtyFile) setBlockOrphaned(ptr BlockPointer, orphaned bool) {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	state, ok := df.fileBlockStates[ptr]
+	if !ok {
+		return
+	}
+	state.orphaned = orphaned
+	df.fileBlockStates[ptr] = state
+}
+
+func (df *dirtyFile) addDeferredNewBytes(bytes int64) {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	df.deferredNewBytes += bytes
+}
+
+func (df *dirtyFile) assimilateDeferredNewBytes() {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	if df.deferredNewBytes == 0 {
+		return
+	}
+	df.dirtyBcache.UpdateUnsyncedBytes(df.deferredNewBytes)
+	df.deferredNewBytes = 0
 }

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -212,12 +212,9 @@ func (df *dirtyFile) setBlockSyncedLocked(ptr BlockPointer) error {
 	}
 	state.sync = blockSynced
 	df.dirtyBcache.BlockSyncFinished(state.syncSize)
-	//state.syncSize = 0
 	// Keep syncSize set in case the block needs to be re-dirtied due
 	// to an error.
 	df.fileBlockStates[ptr] = state
-	// TODO: Eventually we'll need to free up space in the buffer
-	// taken up by these sync'd blocks, so new writes can proceed.
 	return nil
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -108,7 +108,7 @@ func (si *syncInfo) DeepCopy(codec Codec) (*syncInfo, error) {
 //     creates a new copy of those blocks, and the whole size of that block
 //     (not just the newly-dirtied bytes) count for the total.  However,
 //     when the write gets replayed, folderBlockOps first subtracts those bytes
-//     from the system-wide numbers, since they are about the be replayed.
+//     from the system-wide numbers, since they are about to be replayed.
 //   * When a Sync is retried after a recoverable failure, dirtyFile adds
 //     the newly-dirtied deferred bytes to the system-wide numbers, since they
 //     are now being assimilated into this Sync.

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -67,6 +67,57 @@ func (si *syncInfo) DeepCopy(codec Codec) (*syncInfo, error) {
 // blockLock. It will eventually also contain all the methods that
 // must be synchronized by blockLock, so that folderBranchOps will
 // have no knowledge of blockLock.
+//
+// -- And now, a primer on tracking dirty bytes --
+//
+// The DirtyBlockCache tracks the number of bytes that are dirtied
+// system-wide, as the number of bytes that haven't yet been synced
+// ("unsynced"), and a number of bytes that haven't yet been resolved
+// yet because the overall file Sync hasn't finished yet ("total").
+// This data helps us decide when we need to block incoming Writes, in
+// order to keep memory usage from exploding.
+//
+// It's the responsibility of folderBlockOps (and its helper struct
+// dirtyFile) to update these totals in DirtyBlockCache for the
+// individual files within this TLF.  This is complicated by a few things:
+//   * New writes to a file are "deferred" while a Sync is happening, and
+//     are replayed after the Sync finishes.
+//   * Syncs can be canceled or error out halfway through syncing the blocks,
+//     leaving the file in a dirty state until the next Sync.
+//   * Syncs can fail with a /recoverable/ error, in which case they get
+//     retried automatically by folderBranchOps.  In that case, the retried
+//     Sync also sucks in any outstanding deferred writes.
+//
+// With all that in mind, here is the rough breakdown of how this
+// bytes-tracking is implemented:
+//   * On a Write/Truncate to a block, folderBranchOps counts all the
+//     newly-dirtied bytes in a file as "unsynced".  That is, if the block was
+//     already in the dirty cache (and not already being synced), only
+//     extensions to the block count as "unsynced" bytes.
+//   * When a Sync starts, dirtyFile remembers the total of bytes being synced,
+//     and the size of each block being synced.
+//   * When each block put finishes successfully, dirtyFile subtracts the size
+//     of that block from "unsynced".
+//   * When a Sync finishes successfully, the total sum of bytes in that sync
+//     are subtracted from the "total" dirty bytes outstanding.
+//   * If a Sync fails, but some blocks were put successfully, those blocks
+//     are "re-dirtied", which means they count as unsynced bytes again.
+//     dirtyFile handles this.
+//   * When a Write/Truncate is deferred due to an ongoing Sync, its bytes
+//     still count towards the "unsynced" total.  In fact, this essentially
+//     creates a new copy of those blocks, and the whole size of that block
+//     (not just the newly-dirtied bytes) count for the total.  However,
+//     when the write gets replayed, folderBlockOps first subtracts those bytes
+//     from the system-wide numbers, since they are about the be replayed.
+//   * When a Sync is retried after a recoverable failure, dirtyFile adds
+//     the newly-dirtied deferred bytes to the system-wide numbers, since they
+//     are now being assimilated into this Sync.
+//   * dirtyFile also exposes a concept of "orphaned" blocks.  These are child
+//     blocks being synced that are now referenced via a new, permanent block
+//     ID from the parent indirect block.  This matters for when hard failures
+//     occur during a Sync -- the blocks will no longer be accessible under
+//     their previous old pointers, and so dirtyFile needs to know their old
+//     bytes can be cleaned up now.
 type folderBlockOps struct {
 	config       Config
 	log          logger.Logger
@@ -100,12 +151,6 @@ type folderBlockOps struct {
 	// Blocks that need to be deleted from the dirty cache before any
 	// deferred writes are replayed.
 	deferredDirtyDeletes []BlockPointer
-	// If there are too many deferred bytes outstanding, writes should
-	// add themselves to this list (while holding blockLock).  They
-	// will be able to receive on the channel on an outstanding Sync()
-	// completes.  If they receive an error, they should fail the
-	// write.
-	syncListeners []chan error
 
 	// set to true if this write or truncate should be deferred
 	doDeferWrite bool
@@ -681,7 +726,7 @@ func (fbo *folderBlockOps) getOrCreateDirtyFileLocked(lState *lockState,
 	ptr := file.tailPointer()
 	df := fbo.dirtyFiles[ptr]
 	if df == nil {
-		df = newDirtyFile(file)
+		df = newDirtyFile(file, fbo.config.DirtyBlockCache())
 		fbo.dirtyFiles[ptr] = df
 	}
 	return df
@@ -808,6 +853,14 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableError(
 	// redirty all the sync'd blocks under their new IDs, so that
 	// future syncs will know they failed.
 	df := fbo.dirtyFiles[file.tailPointer()]
+	if df != nil {
+		// Un-orphan old blocks, since we are reverting back to the
+		// previous state.
+		for _, oldPtr := range redirtyOnRecoverableError {
+			fbo.log.CDebugf(ctx, "Un-orphaning %v", oldPtr)
+			df.setBlockOrphaned(oldPtr, false)
+		}
+	}
 	if df == nil || !df.isBlockDirty(file.tailPointer()) ||
 		!df.isBlockSyncing(file.tailPointer()) {
 		return
@@ -986,62 +1039,52 @@ func (fbo *folderBlockOps) Read(
 }
 
 func (fbo *folderBlockOps) maybeWaitOnDeferredWrites(
-	ctx context.Context, lState *lockState) error {
+	ctx context.Context, lState *lockState, file Node) error {
 	// If there is too much unflushed data, we should wait until some
 	// of it gets flush so our memory usage doesn't grow without
 	// bound.
-	dirtyBcache := fbo.config.DirtyBlockCache()
-	var syncBlockingCh chan error
-	for {
-		overThreshold := func() bool {
-			fbo.blockLock.Lock(lState)
-			defer fbo.blockLock.Unlock(lState)
-			dirtyBytes := dirtyBcache.DirtyBytesEstimate()
-			if dirtyBytes < dirtyBytesThreshold {
-				return false
-			}
-			fbo.log.CDebugf(ctx, "Blocking a write because of %d dirty bytes",
-				dirtyBytes)
-			if syncBlockingCh == nil {
-				syncBlockingCh = make(chan error, 1)
-				fbo.syncListeners =
-					append(fbo.syncListeners, syncBlockingCh)
-			}
-			return true
-		}()
-		if !overThreshold {
-			break
-		}
+	c := fbo.config.DirtyBlockCache().RequestPermissionToDirty()
 
-		select {
-		// If we can't send on the channel, that means a sync is
-		// already in progress
-		case fbo.forceSyncChan <- struct{}{}:
-		default:
+	var errListener chan error
+	err := func() error {
+		fbo.blockLock.Lock(lState)
+		defer fbo.blockLock.Unlock(lState)
+		filePath, err := fbo.pathFromNodeForBlockWriteLocked(lState, file)
+		if err != nil {
+			return err
 		}
-
-		// Check again periodically, in case some other TLF is hogging
-		// all the dirty bytes.
-		t := time.NewTimer(100 * time.Millisecond)
-		select {
-		case err := <-syncBlockingCh:
-			syncBlockingCh = nil
-			if err != nil {
-				// XXX: should we ignore non-fatal errors (like
-				// context.Canceled), or errors that are specific only
-				// to some other file being sync'd (e.g.,
-				// "recoverable" block errors from which we couldn't
-				// recover)?
-				return err
-			}
-		case <-t.C:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-
-		fbo.log.CDebugf(ctx, "Write unblocked")
+		df := fbo.getOrCreateDirtyFileLocked(lState, filePath)
+		errListener = make(chan error, 1)
+		df.addErrListener(errListener)
+		return nil
+	}()
+	if err != nil {
+		return err
 	}
-	return nil
+
+	logTimer := time.After(100 * time.Millisecond)
+	for {
+		select {
+		case <-c:
+			// Make sure there aren't any queued errors.
+			select {
+			case err := <-errListener:
+				return err
+			default:
+			}
+			return nil
+		case <-logTimer:
+			// Print a log message once if it's taking too long.
+			fbo.log.CDebugf(ctx,
+				"Blocking a write because of a full dirty buffer")
+		case err := <-errListener:
+			// XXX: should we ignore non-fatal errors (like
+			// context.Canceled), or errors that are specific only to
+			// some other file being sync'd (e.g., "recoverable" block
+			// errors from which we couldn't recover)?
+			return err
+		}
+	}
 }
 
 func (fbo *folderBlockOps) pathFromNodeForBlockWriteLocked(
@@ -1125,39 +1168,59 @@ func (fbo *folderBlockOps) createIndirectBlockLocked(lState *lockState,
 // to be cleaned up if the write is deferred.
 func (fbo *folderBlockOps) writeDataLocked(
 	ctx context.Context, lState *lockState, md *RootMetadata, file path,
-	data []byte, off int64) (WriteRange, []BlockPointer, error) {
+	data []byte, off int64) (latestWrite WriteRange, dirtyPtrs []BlockPointer,
+	newlyDirtiedChildBytes int64, err error) {
 	if sz := off + int64(len(data)); uint64(sz) > fbo.config.MaxFileBytes() {
-		return WriteRange{}, nil, FileTooBigError{file, sz, fbo.config.MaxFileBytes()}
+		return WriteRange{}, nil, 0,
+			FileTooBigError{file, sz, fbo.config.MaxFileBytes()}
 	}
 
 	fblock, uid, err := fbo.writeGetFileLocked(ctx, lState, md, file)
 	if err != nil {
-		return WriteRange{}, nil, err
+		return WriteRange{}, nil, 0, err
 	}
 
 	dirtyBcache := fbo.config.DirtyBlockCache()
 	bsplit := fbo.config.BlockSplitter()
 	n := int64(len(data))
 	nCopied := int64(0)
+	defer func() {
+		// Always update unsynced bytes and potentially force a sync,
+		// even on an error, since the previously-dirty bytes stay in
+		// the cache.
+		dirtyBcache.UpdateUnsyncedBytes(newlyDirtiedChildBytes)
+		if dirtyBcache.ShouldForceSync() {
+			fbo.log.CDebugf(ctx, "Forcing a sync due to full buffer")
+			select {
+			// If we can't send on the channel, that means a sync is
+			// already in progress
+			case fbo.forceSyncChan <- struct{}{}:
+			default:
+			}
+		}
+	}()
 
 	de, err := fbo.getDirtyEntryLocked(ctx, lState, md, file)
 	if err != nil {
-		return WriteRange{}, nil, err
+		return WriteRange{}, nil, 0, err
 	}
+	oldSize := de.Size
 
 	si := fbo.getOrCreateSyncInfoLocked(lState, de)
-	var dirtyPtrs []BlockPointer
 	for nCopied < n {
 		ptr, parentBlock, indexInParent, block, nextBlockOff, startOff, err :=
 			fbo.getFileBlockAtOffsetLocked(
 				ctx, lState, md, file, fblock,
 				off+nCopied, blockWrite)
 		if err != nil {
-			return WriteRange{}, nil, err
+			return WriteRange{}, nil, newlyDirtiedChildBytes, err
 		}
 
 		oldLen := len(block.Contents)
-		// Take care not to write past the beginning of the next block by using max.
+		wasDirty := dirtyBcache.IsDirty(ptr, file.Branch)
+
+		// Take care not to write past the beginning of the next block
+		// by using max.
 		max := len(data)
 		if nextBlockOff > 0 {
 			if room := int(nextBlockOff - off); room < max {
@@ -1178,7 +1241,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 				fblock, err = fbo.createIndirectBlockLocked(lState, md, file,
 					uid, DefaultNewBlockDataVersion(fbo.config, false))
 				if err != nil {
-					return WriteRange{}, nil, err
+					return WriteRange{}, nil, newlyDirtiedChildBytes, err
 				}
 				ptr = fblock.IPtrs[0].BlockPointer
 			}
@@ -1188,14 +1251,14 @@ func (fbo *folderBlockOps) writeDataLocked(
 			err = fbo.newRightBlockLocked(ctx, lState, file.tailPointer(),
 				file, fblock, startOff+int64(len(block.Contents)), md)
 			if err != nil {
-				return WriteRange{}, nil, err
+				return WriteRange{}, nil, newlyDirtiedChildBytes, err
 			}
 		} else if nCopied < n && off+nCopied < nextBlockOff {
 			// We need a new block to be inserted here
 			err = fbo.newRightBlockLocked(ctx, lState, file.tailPointer(),
 				file, fblock, startOff+int64(len(block.Contents)), md)
 			if err != nil {
-				return WriteRange{}, nil, err
+				return WriteRange{}, nil, newlyDirtiedChildBytes, err
 			}
 			// And push the indirect pointers to right
 			newb := fblock.IPtrs[len(fblock.IPtrs)-1]
@@ -1211,6 +1274,13 @@ func (fbo *folderBlockOps) writeDataLocked(
 			fbo.deCache[file.tailPointer().ref()] = de
 		}
 
+		// Calculate the amount of bytes we've newly-dirtied as part
+		// of this write.
+		newlyDirtiedChildBytes += int64(len(block.Contents))
+		if wasDirty {
+			newlyDirtiedChildBytes -= int64(oldLen)
+		}
+
 		if parentBlock != nil {
 			// remember how many bytes it was
 			si.unrefs = append(si.unrefs,
@@ -1220,7 +1290,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 		// keep the old block ID while it's dirty
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState, ptr, file,
 			block); err != nil {
-			return WriteRange{}, nil, err
+			return WriteRange{}, nil, newlyDirtiedChildBytes, err
 		}
 		dirtyPtrs = append(dirtyPtrs, ptr)
 	}
@@ -1234,32 +1304,28 @@ func (fbo *folderBlockOps) writeDataLocked(
 		// the dirtyFiles map.
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
 			file.tailPointer(), file, fblock); err != nil {
-			return WriteRange{}, nil, err
+			return WriteRange{}, nil, newlyDirtiedChildBytes, err
 		}
 		dirtyPtrs = append(dirtyPtrs, file.tailPointer())
-	}
-	latestWrite := si.op.addWrite(uint64(off), uint64(len(data)))
 
-	if d := dirtyBcache.DirtyBytesEstimate(); d > dirtyBytesThreshold {
-		fbo.log.CDebugf(ctx, "Forcing a sync due to %d dirty bytes", d)
-		select {
-		// If we can't send on the channel, that means a sync is
-		// already in progress
-		case fbo.forceSyncChan <- struct{}{}:
-		default:
+		if fbo.doDeferWrite && de.Size > oldSize {
+			df := fbo.getOrCreateDirtyFileLocked(lState, file)
+			df.addDeferredNewBytes(int64(de.Size - oldSize))
 		}
 	}
+	latestWrite = si.op.addWrite(uint64(off), uint64(len(data)))
 
-	return latestWrite, dirtyPtrs, nil
+	return latestWrite, dirtyPtrs, newlyDirtiedChildBytes, nil
 }
 
 // Write writes the given data to the given file. May block if there
 // is too much unflushed data; in that case, it will be unblocked by a
-// future sync (as controlled by NotifyBlockedWrites).
+// future sync.
 func (fbo *folderBlockOps) Write(
 	ctx context.Context, lState *lockState, md *RootMetadata,
 	file Node, data []byte, off int64) error {
-	if err := fbo.maybeWaitOnDeferredWrites(ctx, lState); err != nil {
+	err := fbo.maybeWaitOnDeferredWrites(ctx, lState, file)
+	if err != nil {
 		return err
 	}
 
@@ -1275,7 +1341,7 @@ func (fbo *folderBlockOps) Write(
 		fbo.doDeferWrite = false
 	}()
 
-	latestWrite, dirtyPtrs, err := fbo.writeDataLocked(
+	latestWrite, dirtyPtrs, newlyDirtiedChildBytes, err := fbo.writeDataLocked(
 		ctx, lState, md, filePath, data, off)
 	if err != nil {
 		return err
@@ -1300,9 +1366,13 @@ func (fbo *folderBlockOps) Write(
 			dirtyPtrs...)
 		fbo.deferredWrites = append(fbo.deferredWrites,
 			func(ctx context.Context, lState *lockState, rmd *RootMetadata, f path) error {
+				// We are about to re-dirty these bytes.
+				fbo.config.DirtyBlockCache().
+					UpdateUnsyncedBytes(-newlyDirtiedChildBytes)
+
 				// Write the data again.  We know this won't be
 				// deferred, so no need to check the new ptrs.
-				_, _, err = fbo.writeDataLocked(
+				_, _, _, err = fbo.writeDataLocked(
 					ctx, lState, rmd, f, dataCopy, off)
 				return err
 			})
@@ -1391,9 +1461,8 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	dirtyPtrs = append(dirtyPtrs, file.tailPointer())
 	latestWrite := si.op.addTruncate(size)
 
-	dirtyBcache := fbo.config.DirtyBlockCache()
-	if d := dirtyBcache.DirtyBytesEstimate(); d > dirtyBytesThreshold {
-		fbo.log.CDebugf(ctx, "Forcing a sync due to %d dirty bytes", d)
+	if fbo.config.DirtyBlockCache().ShouldForceSync() {
+		fbo.log.CDebugf(ctx, "Forcing a sync due to full buffer")
 		select {
 		// If we can't send on the channel, that means a sync is
 		// already in progress
@@ -1414,10 +1483,10 @@ const truncateExtendCutoffPoint = 128 * 1024
 // that might need to be cleaned up if the truncate is deferred.
 func (fbo *folderBlockOps) truncateLocked(
 	ctx context.Context, lState *lockState, md *RootMetadata,
-	file path, size uint64) (*WriteRange, []BlockPointer, error) {
+	file path, size uint64) (*WriteRange, []BlockPointer, int64, error) {
 	fblock, _, err := fbo.writeGetFileLocked(ctx, lState, md, file)
 	if err != nil {
-		return &WriteRange{}, nil, err
+		return &WriteRange{}, nil, 0, err
 	}
 
 	// find the block where the file should now end
@@ -1431,31 +1500,41 @@ func (fbo *folderBlockOps) truncateLocked(
 		latestWrite, dirtyPtrs, err := fbo.truncateExtendLocked(
 			ctx, lState, md, file, uint64(iSize))
 		if err != nil {
-			return &latestWrite, dirtyPtrs, err
+			return &latestWrite, dirtyPtrs, 0, err
 		}
-		return &latestWrite, dirtyPtrs, err
+		return &latestWrite, dirtyPtrs, 0, err
 	} else if currLen < iSize {
 		moreNeeded := iSize - currLen
-		latestWrite, dirtyPtrs, err := fbo.writeDataLocked(
-			ctx, lState, md, file,
-			make([]byte, moreNeeded, moreNeeded), currLen)
+		latestWrite, dirtyPtrs, newlyDirtiedChildBytes, err :=
+			fbo.writeDataLocked(ctx, lState, md, file,
+				make([]byte, moreNeeded, moreNeeded), currLen)
 		if err != nil {
-			return &latestWrite, dirtyPtrs, err
+			return &latestWrite, dirtyPtrs, newlyDirtiedChildBytes, err
 		}
-		return &latestWrite, dirtyPtrs, err
+		return &latestWrite, dirtyPtrs, newlyDirtiedChildBytes, err
 	} else if currLen == iSize && nextBlockOff < 0 {
 		// same size!
-		return nil, nil, nil
+		return nil, nil, 0, nil
 	}
 
 	// update the local entry size
 	de, err := fbo.getDirtyEntryLocked(ctx, lState, md, file)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
+
+	oldLen := len(block.Contents)
+	dirtyBcache := fbo.config.DirtyBlockCache()
+	wasDirty := dirtyBcache.IsDirty(ptr, file.Branch)
 
 	// otherwise, we need to delete some data (and possibly entire blocks)
 	block.Contents = append([]byte(nil), block.Contents[:iSize-startOff]...)
+
+	newlyDirtiedChildBytes := int64(len(block.Contents))
+	if wasDirty {
+		newlyDirtiedChildBytes -= int64(oldLen) // negative
+	}
+	dirtyBcache.UpdateUnsyncedBytes(newlyDirtiedChildBytes)
 
 	si := fbo.getOrCreateSyncInfoLocked(lState, de)
 	if nextBlockOff > 0 {
@@ -1467,7 +1546,7 @@ func (fbo *folderBlockOps) truncateLocked(
 		// always make the parent block dirty, so we will sync it
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
 			file.tailPointer(), file, parentBlock); err != nil {
-			return nil, nil, err
+			return nil, nil, newlyDirtiedChildBytes, err
 		}
 	}
 
@@ -1480,7 +1559,7 @@ func (fbo *folderBlockOps) truncateLocked(
 		// the dirtyFiles map.
 		if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
 			file.tailPointer(), file, fblock); err != nil {
-			return nil, nil, err
+			return nil, nil, newlyDirtiedChildBytes, err
 		}
 	}
 
@@ -1502,20 +1581,20 @@ func (fbo *folderBlockOps) truncateLocked(
 	// Keep the old block ID while it's dirty.
 	if err = fbo.cacheBlockIfNotYetDirtyLocked(lState,
 		ptr, file, block); err != nil {
-		return nil, nil, err
+		return nil, nil, newlyDirtiedChildBytes, err
 	}
 
-	return &latestWrite, nil, nil
+	return &latestWrite, nil, newlyDirtiedChildBytes, nil
 }
 
 // Truncate truncates or extends the given file to the given size.
 // May block if there is too much unflushed data; in that case, it
-// will be unblocked by a future sync (as controlled by
-// NotifyBlockedWrites).
+// will be unblocked by a future sync.
 func (fbo *folderBlockOps) Truncate(
 	ctx context.Context, lState *lockState, md *RootMetadata,
 	file Node, size uint64) error {
-	if err := fbo.maybeWaitOnDeferredWrites(ctx, lState); err != nil {
+	err := fbo.maybeWaitOnDeferredWrites(ctx, lState, file)
+	if err != nil {
 		return err
 	}
 
@@ -1531,7 +1610,7 @@ func (fbo *folderBlockOps) Truncate(
 		fbo.doDeferWrite = false
 	}()
 
-	latestWrite, dirtyPtrs, err := fbo.truncateLocked(
+	latestWrite, dirtyPtrs, newlyDirtiedChildBytes, err := fbo.truncateLocked(
 		ctx, lState, md, filePath, size)
 	if err != nil {
 		return err
@@ -1552,9 +1631,13 @@ func (fbo *folderBlockOps) Truncate(
 			dirtyPtrs...)
 		fbo.deferredWrites = append(fbo.deferredWrites,
 			func(ctx context.Context, lState *lockState, rmd *RootMetadata, f path) error {
+				// We are about to re-dirty these bytes.
+				fbo.config.DirtyBlockCache().
+					UpdateUnsyncedBytes(-newlyDirtiedChildBytes)
+
 				// Truncate the file again.  We know this won't be
 				// deferred, so no need to check the new ptrs.
-				_, _, err := fbo.truncateLocked(
+				_, _, _, err := fbo.truncateLocked(
 					ctx, lState, rmd, f, size)
 				return err
 			})
@@ -1759,6 +1842,11 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 	bcache := fbo.config.BlockCache()
 	dirtyBcache := fbo.config.DirtyBlockCache()
 	df := fbo.getOrCreateDirtyFileLocked(lState, file)
+	// If there were any deferred writes from before we started this
+	// sync, it implies that we are retrying a previous sync, and will
+	// be assimilating those bytes into this sync.
+	// TODO: clear the deferred writes slice in that case?
+	df.assimilateDeferredNewBytes()
 
 	// Note: below we add possibly updated file blocks as "unref" and
 	// "ref" blocks.  This is fine, since conflict resolution or
@@ -1894,6 +1982,7 @@ func (fbo *folderBlockOps) startSyncWriteLocked(ctx context.Context,
 				if err != nil {
 					return nil, nil, syncState, err
 				}
+				df.setBlockOrphaned(ptr.BlockPointer, true)
 
 				// Defer the DirtyBlockCache.Delete until after the
 				// new path is ready, in case anyone tries to read the
@@ -2003,6 +2092,10 @@ func (fbo *folderBlockOps) CleanupSyncState(
 		return
 	}
 
+	// Notify error listeners before we reset the dirty blocks and
+	// permissions to be granted.
+	fbo.notifyErrListeners(lState, file.tailPointer(), err)
+
 	// If there was an error, we need to back out any changes that
 	// might have been filled into the sync op, because it could
 	// get reused again in a later Sync call.
@@ -2028,7 +2121,6 @@ func (fbo *folderBlockOps) CleanupSyncState(
 	defer fbo.blockLock.Unlock(lState)
 	// Old syncing blocks are now just dirty
 	if df := fbo.dirtyFiles[file.tailPointer()]; df != nil {
-		fbo.log.CDebugf(nil, "Calling error on sync")
 		df.resetSyncingBlocksToDirty()
 	}
 
@@ -2108,16 +2200,15 @@ func (fbo *folderBlockOps) FinishSync(
 	return stillDirty, nil
 }
 
-// NotifyBlockedWrites notifies any write operations that are blocked
-// so that they can check if they can be unblocked. Should be called
-// after a sync.
-func (fbo *folderBlockOps) NotifyBlockedWrites(lState *lockState, err error) {
+// notifyErrListeners notifies any write operations that are blocked
+// on a file so that they can learn about a sync error.
+func (fbo *folderBlockOps) notifyErrListeners(lState *lockState,
+	ptr BlockPointer, err error) {
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
-	listeners := fbo.syncListeners
-	fbo.syncListeners = nil
-	for _, listener := range listeners {
-		listener <- err
+	df := fbo.dirtyFiles[ptr]
+	if df != nil {
+		df.notifyErrListeners(err)
 	}
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1194,7 +1194,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 		if dirtyBcache.ShouldForceSync() {
 			select {
 			// If we can't send on the channel, that means a sync is
-			// already in progress
+			// already in progress.
 			case fbo.forceSyncChan <- struct{}{}:
 				fbo.log.CDebugf(ctx, "Forcing a sync due to full buffer")
 			default:

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1328,10 +1328,13 @@ func (fbo *folderBlockOps) Write(
 	// If there is too much unflushed data, we should wait until some
 	// of it gets flush so our memory usage doesn't grow without
 	// bound.
-	c := fbo.config.DirtyBlockCache().RequestPermissionToDirty(
+	c, err := fbo.config.DirtyBlockCache().RequestPermissionToDirty(ctx,
 		int64(len(data)))
+	if err != nil {
+		return err
+	}
 	defer fbo.config.DirtyBlockCache().UpdateUnsyncedBytes(-int64(len(data)))
-	err := fbo.maybeWaitOnDeferredWrites(ctx, lState, file, c)
+	err = fbo.maybeWaitOnDeferredWrites(ctx, lState, file, c)
 	if err != nil {
 		return err
 	}
@@ -1609,10 +1612,13 @@ func (fbo *folderBlockOps) Truncate(
 	// Assume the whole remaining file will be dirty after this
 	// truncate.  TODO: try to figure out how many bytes actually will
 	// be dirtied ahead of time?
-	c := fbo.config.DirtyBlockCache().RequestPermissionToDirty(
+	c, err := fbo.config.DirtyBlockCache().RequestPermissionToDirty(ctx,
 		int64(size))
+	if err != nil {
+		return err
+	}
 	defer fbo.config.DirtyBlockCache().UpdateUnsyncedBytes(-int64(size))
-	err := fbo.maybeWaitOnDeferredWrites(ctx, lState, file, c)
+	err = fbo.maybeWaitOnDeferredWrites(ctx, lState, file, c)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2671,8 +2671,7 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 		// stat calls accurately if the user still has an open
 		// handle to this file. TODO: Hook this in with the
 		// node cache GC logic to be perfectly accurate.
-		fbo.blocks.ClearCacheInfo(lState, file)
-		return true, nil
+		return true, fbo.blocks.ClearCacheInfo(lState, file)
 	}
 
 	_, uid, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -54,8 +54,6 @@ const (
 	secondsBetweenBackgroundFlushes = 10
 	// Cap the number of times we retry after a recoverable error
 	maxRetriesOnRecoverableErrors = 10
-	// When the number of dirty bytes exceeds this level, force a sync.
-	dirtyBytesThreshold = maxParallelBlockPuts * (512 << 10)
 	// The timeout for any background task.
 	backgroundTaskTimeout = 1 * time.Minute
 )
@@ -2746,10 +2744,6 @@ func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
 	if err != nil {
 		return
 	}
-	defer func() {
-		lState := makeFBOLockState()
-		fbo.blocks.NotifyBlockedWrites(lState, err)
-	}()
 
 	var stillDirty bool
 	err = fbo.doMDWriteWithRetryUnlessCanceled(ctx,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -550,7 +550,8 @@ type DirtyBlockCache interface {
 	// `UpdateUnsyncedBytes(-estimatedDirtyBytes)` once it has
 	// completed its write and called `UpdateUnsyncedBytes` for all
 	// the exact dirty block sizes.
-	RequestPermissionToDirty(estimatedDirtyBytes int64) DirtyPermChan
+	RequestPermissionToDirty(ctx context.Context,
+		estimatedDirtyBytes int64) (DirtyPermChan, error)
 	// UpdateUnsyncedBytes is called by a user, who has already been
 	// granted permission to write, with the delta in block sizes that
 	// were dirtied as part of the write.  So for example, if a

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -512,6 +512,12 @@ type BlockCache interface {
 	DeleteKnownPtr(tlf TlfID, block *FileBlock) error
 }
 
+// DirtyPermChan is a channel that gets closed when the holder has
+// permission to write.  We are forced to define it as a type due to a
+// bug in mockgen that can't handle return values with a chan
+// struct{}.
+type DirtyPermChan <-chan struct{}
+
 // DirtyBlockCache gets and puts plaintext dir blocks and file blocks
 // into a cache, which have been modified by the application and not
 // yet committed on the KBFS servers.  They are identified by a
@@ -533,11 +539,44 @@ type DirtyBlockCache interface {
 	// IsDirty states whether or not the block associated with the
 	// given block pointer and branch name is dirty in this cache.
 	IsDirty(ptr BlockPointer, branch BranchName) bool
-	// DirtyBytesEstimate counts the number of outstanding bytes held
-	// in dirty blocks.  It's an estimate because callers can be
-	// modifying the size of the dirty blocks outside of the cache
-	// while this is being called.
-	DirtyBytesEstimate() uint64
+	// RequestPermissionToDirty is called whenever a user wants to
+	// write data to a file.  It returns a channel that blocks until
+	// the cache is ready to receive more dirty data, at which point
+	// the channel is closed.  The user must call AddDirtyDelta once
+	// it has completed its write.
+	//
+	// TODO: Send along an estimate of the bytes it expects to dirty?
+	// DIfficult without first fetching blocks and determining the
+	// block size.
+	RequestPermissionToDirty() DirtyPermChan
+	// UpdateUnsyncedBytes is called by a user, who has already been
+	// granted permission to write, with the delta in block sizes that
+	// were dirtied as part of the write.  So for example, if a
+	// newly-dirtied block of 20 bytes was extended by 5 bytes, they
+	// should send 25.  If on the next write (before any syncs), bytes
+	// 10-15 of that same block were overwritten, they should send 0
+	// over the channel because there were no new bytes.  If an
+	// already-dirtied block is truncated, or if previously requested
+	// bytes have now been updated more accurately in previous
+	// requests, newUnsyncedBytes may be negative.
+	UpdateUnsyncedBytes(newUnsyncedBytes int64)
+	// BlockSyncFinished is called when a particular block has
+	// finished syncing, though the overall sync might not yet be
+	// complete.  This lets the cache know it might be able to grant
+	// more permission to writers.
+	BlockSyncFinished(size int64)
+	// SyncFinished is called when a complete sync has completed and
+	// its dirty blocks have been removed from the cache.  This lets
+	// the cache know it might be able to grant more permission to
+	// writers.
+	SyncFinished(size int64)
+	// ShouldForceSync returns true if the sync buffer is full enough
+	// to force all callers to sync their data immediately.
+	ShouldForceSync() bool
+
+	// Shutdown frees any resources associated with this instance.  It
+	// returns an error if there are any unsynced blocks.
+	Shutdown() error
 }
 
 // cryptoPure contains all methods of Crypto that don't depend on

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -78,7 +78,7 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	// Each test is expected to check the cache for correctness at the
 	// end of the test.
 	config.SetBlockCache(NewBlockCacheStandard(config, 100, 1<<30))
-	config.SetDirtyBlockCache(NewDirtyBlockCacheStandard())
+	config.SetDirtyBlockCache(NewDirtyBlockCacheStandard(5<<20, 10<<20))
 	config.mockBcache = nil
 	config.mockDirtyBcache = nil
 
@@ -173,7 +173,7 @@ func checkBlockCache(t *testing.T, config *ConfigMock,
 				"the end of the test: err %v", ptr, branch, err)
 		}
 	}
-	if len(dirtyBcache.dirty) != len(expectedDirtyBlocks) {
+	if len(dirtyBcache.cache) != len(expectedDirtyBlocks) {
 		t.Errorf("BlockCache has extra dirty blocks at end of test")
 	}
 }
@@ -4330,6 +4330,8 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 	config.SetBlockCache(config.mockBcache)
 	config.mockDirtyBcache = NewMockDirtyBlockCache(mockCtrl)
 	config.SetDirtyBlockCache(config.mockDirtyBcache)
+	config.mockDirtyBcache.EXPECT().BlockSyncFinished(gomock.Any()).AnyTimes()
+	config.mockDirtyBcache.EXPECT().SyncFinished(gomock.Any())
 
 	uid, id, rmd := injectNewRMD(t, config)
 
@@ -4525,6 +4527,8 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 	config.SetBlockCache(config.mockBcache)
 	config.mockDirtyBcache = NewMockDirtyBlockCache(mockCtrl)
 	config.SetDirtyBlockCache(config.mockDirtyBcache)
+	config.mockDirtyBcache.EXPECT().BlockSyncFinished(gomock.Any()).AnyTimes()
+	config.mockDirtyBcache.EXPECT().SyncFinished(gomock.Any())
 
 	uid, id, rmd := injectNewRMD(t, config)
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1211,14 +1211,58 @@ func (_mr *_MockDirtyBlockCacheRecorder) IsDirty(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsDirty", arg0, arg1)
 }
 
-func (_m *MockDirtyBlockCache) DirtyBytesEstimate() uint64 {
-	ret := _m.ctrl.Call(_m, "DirtyBytesEstimate")
-	ret0, _ := ret[0].(uint64)
+func (_m *MockDirtyBlockCache) RequestPermissionToDirty() DirtyPermChan {
+	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty")
+	ret0, _ := ret[0].(DirtyPermChan)
 	return ret0
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) DirtyBytesEstimate() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DirtyBytesEstimate")
+func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty")
+}
+
+func (_m *MockDirtyBlockCache) UpdateUnsyncedBytes(newUnsyncedBytes int64) {
+	_m.ctrl.Call(_m, "UpdateUnsyncedBytes", newUnsyncedBytes)
+}
+
+func (_mr *_MockDirtyBlockCacheRecorder) UpdateUnsyncedBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUnsyncedBytes", arg0)
+}
+
+func (_m *MockDirtyBlockCache) BlockSyncFinished(size int64) {
+	_m.ctrl.Call(_m, "BlockSyncFinished", size)
+}
+
+func (_mr *_MockDirtyBlockCacheRecorder) BlockSyncFinished(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockSyncFinished", arg0)
+}
+
+func (_m *MockDirtyBlockCache) SyncFinished(size int64) {
+	_m.ctrl.Call(_m, "SyncFinished", size)
+}
+
+func (_mr *_MockDirtyBlockCacheRecorder) SyncFinished(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncFinished", arg0)
+}
+
+func (_m *MockDirtyBlockCache) ShouldForceSync() bool {
+	ret := _m.ctrl.Call(_m, "ShouldForceSync")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockDirtyBlockCacheRecorder) ShouldForceSync() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShouldForceSync")
+}
+
+func (_m *MockDirtyBlockCache) Shutdown() error {
+	ret := _m.ctrl.Call(_m, "Shutdown")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDirtyBlockCacheRecorder) Shutdown() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
 }
 
 // Mock of cryptoPure interface

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1211,14 +1211,14 @@ func (_mr *_MockDirtyBlockCacheRecorder) IsDirty(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsDirty", arg0, arg1)
 }
 
-func (_m *MockDirtyBlockCache) RequestPermissionToDirty() DirtyPermChan {
-	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty")
+func (_m *MockDirtyBlockCache) RequestPermissionToDirty(estimatedDirtyBytes int64) DirtyPermChan {
+	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty", estimatedDirtyBytes)
 	ret0, _ := ret[0].(DirtyPermChan)
 	return ret0
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty")
+func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty", arg0)
 }
 
 func (_m *MockDirtyBlockCache) UpdateUnsyncedBytes(newUnsyncedBytes int64) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1211,14 +1211,15 @@ func (_mr *_MockDirtyBlockCacheRecorder) IsDirty(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsDirty", arg0, arg1)
 }
 
-func (_m *MockDirtyBlockCache) RequestPermissionToDirty(estimatedDirtyBytes int64) DirtyPermChan {
-	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty", estimatedDirtyBytes)
+func (_m *MockDirtyBlockCache) RequestPermissionToDirty(ctx context.Context, estimatedDirtyBytes int64) (DirtyPermChan, error) {
+	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty", ctx, estimatedDirtyBytes)
 	ret0, _ := ret[0].(DirtyPermChan)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty", arg0)
+func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty", arg0, arg1)
 }
 
 func (_m *MockDirtyBlockCache) UpdateUnsyncedBytes(newUnsyncedBytes int64) {


### PR DESCRIPTION
And use these counts to control when writes are allowed to proceed.

I did my best to explain what's going on in the new comment above `folderBlockOps`, but please let me know if you need more clarification!

Issue: KBFS-1105
Issue: KBFS-1106
Issue: KBFS-1107