### PR TITLE
Bump vendored bazil.org/fuse to support OSXFUSE 3.3+

### DIFF
--- a/vendor/bazil.org/fuse/fuse.go
+++ b/vendor/bazil.org/fuse/fuse.go
@@ -1326,7 +1326,7 @@ type Attr struct {
 	Ctime     time.Time   // time of last inode change
 	Crtime    time.Time   // time of creation (OS X only)
 	Mode      os.FileMode // file mode
-	Nlink     uint32      // number of links
+	Nlink     uint32      // number of links (usually 1)
 	Uid       uint32      // owner uid
 	Gid       uint32      // group gid
 	Rdev      uint32      // device numbers

--- a/vendor/bazil.org/fuse/mount_darwin.go
+++ b/vendor/bazil.org/fuse/mount_darwin.go
@@ -113,7 +113,10 @@ func callMount(bin string, daemonVar string, dir string, conf *mountConfig, f *o
 	)
 	cmd.ExtraFiles = []*os.File{f}
 	cmd.Env = os.Environ()
+	// OSXFUSE <3.3.0
 	cmd.Env = append(cmd.Env, "MOUNT_FUSEFS_CALL_BY_LIB=")
+	// OSXFUSE >=3.3.0
+	cmd.Env = append(cmd.Env, "MOUNT_OSXFUSE_CALL_BY_LIB=")
 
 	daemon := os.Args[0]
 	if daemonVar != "" {

--- a/vendor/bazil.org/fuse/options.go
+++ b/vendor/bazil.org/fuse/options.go
@@ -83,6 +83,37 @@ func VolumeName(name string) MountOption {
 	return volumeName(name)
 }
 
+// NoAppleDouble makes OSXFUSE disallow files with names used by OS X
+// to store extended attributes on file systems that do not support
+// them natively.
+//
+// Such file names are:
+//
+//     ._*
+//     .DS_Store
+//
+// OS X only.  Others ignore this option.
+func NoAppleDouble() MountOption {
+	return noAppleDouble
+}
+
+// NoAppleXattr makes OSXFUSE disallow extended attributes with the
+// prefix "com.apple.". This disables persistent Finder state and
+// other such information.
+//
+// OS X only.  Others ignore this option.
+func NoAppleXattr() MountOption {
+	return noAppleXattr
+}
+
+// DaemonTimeout sets the time in seconds between a request and a reply before
+// the FUSE mount is declared dead.
+//
+// OS X and FreeBSD only. Others ignore this option.
+func DaemonTimeout(name string) MountOption {
+	return daemonTimeout(name)
+}
+
 var ErrCannotCombineAllowOtherAndAllowRoot = errors.New("cannot combine AllowOther and AllowRoot")
 
 // AllowOther allows other users to access the file system.
@@ -109,6 +140,24 @@ func AllowRoot() MountOption {
 			return ErrCannotCombineAllowOtherAndAllowRoot
 		}
 		conf.options["allow_root"] = ""
+		return nil
+	}
+}
+
+// AllowDev enables interpreting character or block special devices on the
+// filesystem.
+func AllowDev() MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["dev"] = ""
+		return nil
+	}
+}
+
+// AllowSUID allows set-user-identifier or set-group-identifier bits to take
+// effect.
+func AllowSUID() MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["suid"] = ""
 		return nil
 	}
 }

--- a/vendor/bazil.org/fuse/options_darwin.go
+++ b/vendor/bazil.org/fuse/options_darwin.go
@@ -11,3 +11,20 @@ func volumeName(name string) MountOption {
 		return nil
 	}
 }
+
+func daemonTimeout(name string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["daemon_timeout"] = name
+		return nil
+	}
+}
+
+func noAppleXattr(conf *mountConfig) error {
+	conf.options["noapplexattr"] = ""
+	return nil
+}
+
+func noAppleDouble(conf *mountConfig) error {
+	conf.options["noappledouble"] = ""
+	return nil
+}

--- a/vendor/bazil.org/fuse/options_freebsd.go
+++ b/vendor/bazil.org/fuse/options_freebsd.go
@@ -7,3 +7,18 @@ func localVolume(conf *mountConfig) error {
 func volumeName(name string) MountOption {
 	return dummyOption
 }
+
+func daemonTimeout(name string) MountOption {
+	return func(conf *mountConfig) error {
+		conf.options["timeout"] = name
+		return nil
+	}
+}
+
+func noAppleXattr(conf *mountConfig) error {
+	return nil
+}
+
+func noAppleDouble(conf *mountConfig) error {
+	return nil
+}

--- a/vendor/bazil.org/fuse/options_linux.go
+++ b/vendor/bazil.org/fuse/options_linux.go
@@ -7,3 +7,15 @@ func localVolume(conf *mountConfig) error {
 func volumeName(name string) MountOption {
 	return dummyOption
 }
+
+func daemonTimeout(name string) MountOption {
+	return dummyOption
+}
+
+func noAppleXattr(conf *mountConfig) error {
+	return nil
+}
+
+func noAppleDouble(conf *mountConfig) error {
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test appengine appenginevm",
 	"package": [
 		{
-			"checksumSHA1": "II2RjEFgX9EzV4fJSgV/oZrB7aE=",
+			"checksumSHA1": "xCAVewAtJpNeqReS0fRzarfwfjA=",
 			"path": "bazil.org/fuse",
-			"revision": "5d02b06737b3b3c2e6a44e03348b6f2b44aa6835",
-			"revisionTime": "2016-04-22T03:27:55Z"
+			"revision": "0dfaa72ce1313ab5a43f1cb501fd87e2f367283f",
+			"revisionTime": "2015-11-25T17:25:30Z"
 		},
 		{
 			"checksumSHA1": "rtIltwN9oB5n/tvuHCHw8enNGzA=",


### PR DESCRIPTION
This patch bumps vendors basil.org/fuse to support the new library-use-only flag provided by OSXFUSE 3.3+. This was first reported in https://github.com/keybase/keybase-issues/issues/2281.