### PR TITLE
Remove direct use of GlobalContext from package (use an interface)

### DIFF
--- a/env/context.go
+++ b/env/context.go
@@ -10,10 +10,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/go-framed-msgpack-rpc"
-	"github.com/keybase/kbfs/libkbfs"
 )
-
-var _ libkbfs.Context = (*Context)(nil)
 
 // Context is an implementation for libkbfs.Context
 type Context struct {

--- a/env/context.go
+++ b/env/context.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/go-framed-msgpack-rpc"
+	"github.com/keybase/kbfs/libkbfs"
 )
+
+var _ libkbfs.Context = (*Context)(nil)
 
 // Context is an implementation for libkbfs.Context
 type Context struct {

--- a/env/context.go
+++ b/env/context.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 
-package main
+package env
 
 import (
 	"net"
@@ -11,28 +11,36 @@ import (
 	"github.com/keybase/go-framed-msgpack-rpc"
 )
 
-type context struct {
+type Context struct {
 	g *libkb.GlobalContext
 }
 
-func newContext() *context {
+func NewContext() *Context {
 	// TODO: Remove direct use of libkb.G
 	libkb.G.Init()
 	libkb.G.ConfigureConfig()
 	libkb.G.ConfigureLogging()
 	libkb.G.ConfigureCaches()
 	libkb.G.ConfigureMerkleClient()
-	return &context{g: libkb.G}
+	return &Context{g: libkb.G}
 }
 
-func (c context) GetLogDir() string {
+func (c Context) GetLogDir() string {
 	return c.g.Env.GetLogDir()
 }
 
-func (c context) GetRunMode() libkb.RunMode {
+func (c Context) GetRunMode() libkb.RunMode {
 	return c.g.GetRunMode()
 }
 
-func (c context) GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error) {
+func (c Context) GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error) {
 	return c.g.GetSocket(clearError)
+}
+
+func (c Context) ConfigureSocketInfo() error {
+	return c.g.ConfigureSocketInfo()
+}
+
+func (c Context) NewRPCLogFactory() *libkb.RPCLogFactory {
+	return &libkb.RPCLogFactory{Contextified: libkb.NewContextified(c.g)}
 }

--- a/env/context.go
+++ b/env/context.go
@@ -6,41 +6,53 @@ package env
 
 import (
 	"net"
+	"sync"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/go-framed-msgpack-rpc"
 )
 
+// Context is an implementation for libkbfs.Context
 type Context struct {
 	g *libkb.GlobalContext
 }
 
+var libkbOnce sync.Once
+
+// NewContext constructs a context
 func NewContext() *Context {
 	// TODO: Remove direct use of libkb.G
-	libkb.G.Init()
-	libkb.G.ConfigureConfig()
-	libkb.G.ConfigureLogging()
-	libkb.G.ConfigureCaches()
-	libkb.G.ConfigureMerkleClient()
+	libkbOnce.Do(func() {
+		libkb.G.Init()
+		libkb.G.ConfigureConfig()
+		libkb.G.ConfigureLogging()
+		libkb.G.ConfigureCaches()
+		libkb.G.ConfigureMerkleClient()
+	})
 	return &Context{g: libkb.G}
 }
 
+// GetLogDir returns log dir
 func (c Context) GetLogDir() string {
 	return c.g.Env.GetLogDir()
 }
 
+// GetRunMode returns run mode
 func (c Context) GetRunMode() libkb.RunMode {
 	return c.g.GetRunMode()
 }
 
+// GetSocket returns a socket
 func (c Context) GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error) {
 	return c.g.GetSocket(clearError)
 }
 
+// ConfigureSocketInfo configures a socket
 func (c Context) ConfigureSocketInfo() error {
 	return c.g.ConfigureSocketInfo()
 }
 
+// NewRPCLogFactory constructs an RPC logger
 func (c Context) NewRPCLogFactory() *libkb.RPCLogFactory {
 	return &libkb.RPCLogFactory{Contextified: libkb.NewContextified(c.g)}
 }

--- a/kbfs/main.go
+++ b/kbfs/main.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libkbfs"
 )
 
@@ -38,12 +39,12 @@ The possible commands are:
 
 `
 
-func getUsageStr() string {
-	defaultBServer := libkbfs.GetDefaultBServer()
+func getUsageStr(kbCtx libkbfs.Context) string {
+	defaultBServer := libkbfs.GetDefaultBServer(kbCtx)
 	if len(defaultBServer) == 0 {
 		defaultBServer = "host:port"
 	}
-	defaultMDServer := libkbfs.GetDefaultMDServer()
+	defaultMDServer := libkbfs.GetDefaultMDServer(kbCtx)
 	if len(defaultMDServer) == 0 {
 		defaultMDServer = "host:port"
 	}
@@ -52,7 +53,8 @@ func getUsageStr() string {
 
 // Define this so deferred functions get executed before exit.
 func realMain() (exitStatus int) {
-	kbfsParams := libkbfs.AddFlags(flag.CommandLine)
+	kbCtx := env.NewContext()
+	kbfsParams := libkbfs.AddFlags(flag.CommandLine, kbCtx)
 
 	flag.Parse()
 
@@ -62,13 +64,13 @@ func realMain() (exitStatus int) {
 	}
 
 	if len(flag.Args()) < 1 {
-		fmt.Print(getUsageStr())
+		fmt.Print(getUsageStr(kbCtx))
 		return 1
 	}
 
 	log := logger.NewWithCallDepth("", 1)
 
-	config, err := libkbfs.Init(*kbfsParams, nil, log)
+	config, err := libkbfs.Init(kbCtx, *kbfsParams, nil, log)
 	if err != nil {
 		printError("kbfs", err)
 		return 1

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libdokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -42,12 +42,12 @@ To run in a local testing environment:
 
 `
 
-func getUsageStr() string {
-	defaultBServer := libkbfs.GetDefaultBServer()
+func getUsageStr(ctx libkbfs.Context) string {
+	defaultBServer := libkbfs.GetDefaultBServer(ctx)
 	if len(defaultBServer) == 0 {
 		defaultBServer = "host:port"
 	}
-	defaultMDServer := libkbfs.GetDefaultMDServer()
+	defaultMDServer := libkbfs.GetDefaultMDServer(ctx)
 	if len(defaultMDServer) == 0 {
 		defaultMDServer = "host:port"
 	}
@@ -55,7 +55,8 @@ func getUsageStr() string {
 }
 
 func start() *libfs.Error {
-	kbfsParams := libkbfs.AddFlags(flag.CommandLine)
+	ctx := newContext()
+	kbfsParams := libkbfs.AddFlags(flag.CommandLine, ctx)
 
 	flag.Parse()
 
@@ -65,12 +66,12 @@ func start() *libfs.Error {
 	}
 
 	if len(flag.Args()) < 1 {
-		fmt.Print(getUsageStr())
+		fmt.Print(getUsageStr(ctx))
 		return libfs.InitError("no mount specified")
 	}
 
 	if len(flag.Args()) > 1 {
-		fmt.Print(getUsageStr())
+		fmt.Print(getUsageStr(ctx))
 		return libfs.InitError("extra arguments specified (flags go before the first argument)")
 	}
 
@@ -88,7 +89,7 @@ func start() *libfs.Error {
 		Label:      *label,
 	}
 
-	return libdokan.Start(mounter, options)
+	return libdokan.Start(mounter, options, ctx)
 }
 
 func main() {

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -55,7 +55,7 @@ func getUsageStr(ctx libkbfs.Context) string {
 }
 
 func start() *libfs.Error {
-	ctx := newContext()
+	ctx := env.NewContext()
 	kbfsParams := libkbfs.AddFlags(flag.CommandLine, ctx)
 
 	flag.Parse()

--- a/kbfsfuse/context.go
+++ b/kbfsfuse/context.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/go-framed-msgpack-rpc"
+)
+
+type context struct {
+	g *libkb.GlobalContext
+}
+
+func newContext() *context {
+	// TODO: Remove direct use of libkb.G
+	libkb.G.Init()
+	libkb.G.ConfigureConfig()
+	libkb.G.ConfigureLogging()
+	libkb.G.ConfigureCaches()
+	libkb.G.ConfigureMerkleClient()
+	return &context{g: libkb.G}
+}
+
+func (c context) GetLogDir() string {
+	return c.g.Env.GetLogDir()
+}
+
+func (c context) GetRunMode() libkb.RunMode {
+	return c.g.GetRunMode()
+}
+
+func (c context) GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error) {
+	return c.g.GetSocket(clearError)
+}

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -14,6 +14,7 @@ import (
 	"bazil.org/fuse"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libfuse"
 	"github.com/keybase/kbfs/libkbfs"
@@ -59,7 +60,7 @@ func getUsageStr(ctx libkbfs.Context) string {
 }
 
 func start() *libfs.Error {
-	ctx := newContext()
+	ctx := env.NewContext()
 
 	kbfsParams := libkbfs.AddFlags(flag.CommandLine, ctx)
 	platformParams := libfuse.AddPlatformFlags(flag.CommandLine)

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -43,12 +43,12 @@ To run in a local testing environment:
 
 `
 
-func getUsageStr() string {
-	defaultBServer := libkbfs.GetDefaultBServer()
+func getUsageStr(ctx libkbfs.Context) string {
+	defaultBServer := libkbfs.GetDefaultBServer(ctx)
 	if len(defaultBServer) == 0 {
 		defaultBServer = "host:port"
 	}
-	defaultMDServer := libkbfs.GetDefaultMDServer()
+	defaultMDServer := libkbfs.GetDefaultMDServer(ctx)
 	if len(defaultMDServer) == 0 {
 		defaultMDServer = "host:port"
 	}
@@ -59,7 +59,9 @@ func getUsageStr() string {
 }
 
 func start() *libfs.Error {
-	kbfsParams := libkbfs.AddFlags(flag.CommandLine)
+	ctx := newContext()
+
+	kbfsParams := libkbfs.AddFlags(flag.CommandLine, ctx)
 	platformParams := libfuse.AddPlatformFlags(flag.CommandLine)
 
 	flag.Parse()
@@ -70,12 +72,12 @@ func start() *libfs.Error {
 	}
 
 	if len(flag.Args()) < 1 {
-		fmt.Print(getUsageStr())
+		fmt.Print(getUsageStr(ctx))
 		return libfs.InitError("no mount specified")
 	}
 
 	if len(flag.Args()) > 1 {
-		fmt.Print(getUsageStr())
+		fmt.Print(getUsageStr(ctx))
 		return libfs.InitError("extra arguments specified (flags go before the first argument)")
 	}
 
@@ -101,7 +103,7 @@ func start() *libfs.Error {
 		Label:      *label,
 	}
 
-	return libfuse.Start(mounter, options)
+	return libfuse.Start(mounter, options, ctx)
 }
 
 func main() {

--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -32,7 +32,7 @@ func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.
 		mounter.Unmount()
 	}
 
-	config, err := libkbfs.Init(options.KbfsParams, onInterruptFn, log)
+	config, err := libkbfs.Init(kbCtx, options.KbfsParams, onInterruptFn, log)
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}

--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -24,9 +24,9 @@ type StartOptions struct {
 }
 
 // Start the filesystem
-func Start(mounter Mounter, options StartOptions) *libfs.Error {
+func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// InitLog errors are non-fatal and are ignored.
-	log, _ := libkbfs.InitLog(options.KbfsParams)
+	log, _ := libkbfs.InitLog(options.KbfsParams, kbCtx)
 
 	onInterruptFn := func() {
 		mounter.Unmount()

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -22,9 +22,9 @@ type StartOptions struct {
 }
 
 // Start the filesystem
-func Start(mounter Mounter, options StartOptions) *libfs.Error {
+func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// InitLog errors are non-fatal and are ignored.
-	log, _ := libkbfs.InitLog(options.KbfsParams)
+	log, _ := libkbfs.InitLog(options.KbfsParams, kbCtx)
 
 	if options.RuntimeDir != "" {
 		info := libkb.NewServiceInfo(libkbfs.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
@@ -60,7 +60,8 @@ func Start(mounter Mounter, options StartOptions) *libfs.Error {
 	}
 
 	log.Debug("Initializing")
-	config, err := libkbfs.Init(options.KbfsParams, onInterruptFn, log)
+
+	config, err := libkbfs.Init(kbCtx, options.KbfsParams, onInterruptFn, log)
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -42,7 +42,7 @@ var _ AuthTokenRefreshHandler = (*BlockServerRemote)(nil)
 
 // NewBlockServerRemote constructs a new BlockServerRemote for the
 // given address.
-func NewBlockServerRemote(config Config, blkSrvAddr string) *BlockServerRemote {
+func NewBlockServerRemote(config Config, blkSrvAddr string, ctx Context) *BlockServerRemote {
 	log := config.MakeLogger("BSR")
 	deferLog := log.CloneWithAddedDepth(1)
 	bs := &BlockServerRemote{
@@ -57,7 +57,7 @@ func NewBlockServerRemote(config Config, blkSrvAddr string) *BlockServerRemote {
 		"libkbfs_bserver_remote", bs)
 	// This will connect only on-demand due to the last argument.
 	conn := rpc.NewTLSConnection(blkSrvAddr, GetRootCerts(blkSrvAddr),
-		bServerErrorUnwrapper{}, bs, false, libkb.NewRPCLogFactory(libkb.G),
+		bServerErrorUnwrapper{}, bs, false, ctx.NewRPCLogFactory(),
 		libkb.WrapError, config.MakeLogger(""), LogTagsFromContext)
 	bs.client = keybase1.BlockClient{Cli: conn.GetClient()}
 	bs.shutdownFn = conn.Shutdown

--- a/libkbfs/context.go
+++ b/libkbfs/context.go
@@ -15,5 +15,7 @@ import (
 type Context interface {
 	GetRunMode() libkb.RunMode
 	GetLogDir() string
+	ConfigureSocketInfo() (err error)
 	GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
+	NewRPCLogFactory() *libkb.RPCLogFactory
 }

--- a/libkbfs/context.go
+++ b/libkbfs/context.go
@@ -1,0 +1,19 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"net"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/go-framed-msgpack-rpc"
+)
+
+// Context defines the environment for this package
+type Context interface {
+	GetRunMode() libkb.RunMode
+	GetLogDir() string
+	GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
+}

--- a/libkbfs/crypto_client.go
+++ b/libkbfs/crypto_client.go
@@ -32,7 +32,7 @@ var _ Crypto = (*CryptoClient)(nil)
 var _ rpc.ConnectionHandler = (*CryptoClient)(nil)
 
 // NewCryptoClient constructs a new CryptoClient.
-func NewCryptoClient(config Config, kbCtx *libkb.GlobalContext) *CryptoClient {
+func NewCryptoClient(config Config, kbCtx Context) *CryptoClient {
 	log := config.MakeLogger("")
 	c := &CryptoClient{
 		CryptoCommon: MakeCryptoCommon(config.Codec(), log),

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -12,7 +12,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime/pprof"
-	"sync"
 	"time"
 
 	"github.com/keybase/client/go/libkb"
@@ -55,27 +54,9 @@ type InitParams struct {
 	LogFileConfig logger.LogFileConfig
 }
 
-var libkbOnce sync.Once
-
-func initLibkb() {
-	libkbOnce.Do(func() {
-		libkb.G.Init()
-		libkb.G.ConfigureConfig()
-		libkb.G.ConfigureLogging()
-		libkb.G.ConfigureCaches()
-		libkb.G.ConfigureMerkleClient()
-	})
-}
-
-func getRunMode() libkb.RunMode {
-	// Initialize libkb.G.Env.
-	initLibkb()
-	return libkb.G.Env.GetRunMode()
-}
-
 // GetDefaultBServer returns the default value for the -bserver flag.
-func GetDefaultBServer() string {
-	switch getRunMode() {
+func GetDefaultBServer(ctx Context) string {
+	switch ctx.GetRunMode() {
 	case libkb.StagingRunMode:
 		return "bserver.dev.keybase.io:443"
 	case libkb.ProductionRunMode:
@@ -86,8 +67,8 @@ func GetDefaultBServer() string {
 }
 
 // GetDefaultMDServer returns the default value for the -mdserver flag.
-func GetDefaultMDServer() string {
-	switch getRunMode() {
+func GetDefaultMDServer(ctx Context) string {
+	switch ctx.GetRunMode() {
 	case libkb.StagingRunMode:
 		return "mdserver.dev.keybase.io:443"
 	case libkb.ProductionRunMode:
@@ -97,26 +78,26 @@ func GetDefaultMDServer() string {
 	}
 }
 
-func defaultLogPath() string {
+func defaultLogPath(ctx Context) string {
 	// TODO is there a better way to get G here?
-	return filepath.Join(libkb.G.Env.GetLogDir(), libkb.KBFSLogFileName)
+	return filepath.Join(ctx.GetLogDir(), libkb.KBFSLogFileName)
 }
 
 // AddFlags adds libkbfs flags to the given FlagSet. Returns an
 // InitParams that will be filled in once the given FlagSet is parsed.
-func AddFlags(flags *flag.FlagSet) *InitParams {
+func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	var params InitParams
 	flags.BoolVar(&params.Debug, "debug", BoolForString(os.Getenv("KBFS_DEBUG")), "Print debug messages")
 	flags.StringVar(&params.CPUProfile, "cpuprofile", "", "write cpu profile to file")
 
-	flags.StringVar(&params.BServerAddr, "bserver", GetDefaultBServer(), "host:port of the block server")
-	flags.StringVar(&params.MDServerAddr, "mdserver", GetDefaultMDServer(), "host:port of the metadata server")
+	flags.StringVar(&params.BServerAddr, "bserver", GetDefaultBServer(ctx), "host:port of the block server")
+	flags.StringVar(&params.MDServerAddr, "mdserver", GetDefaultMDServer(ctx), "host:port of the metadata server")
 
 	flags.BoolVar(&params.ServerInMemory, "server-in-memory", false, "use in-memory server (and ignore -bserver, -mdserver, and -server-root)")
 	flags.StringVar(&params.ServerRootDir, "server-root", "", "directory to put local server files (and ignore -bserver and -mdserver)")
 	flags.StringVar(&params.LocalUser, "localuser", "", "fake local user (used only with -server-in-memory or -server-root)")
 	flags.DurationVar(&params.TLFValidDuration, "tlf-valid", tlfValidDurationDefault, "time tlfs are valid before redoing identification")
-	flags.BoolVar(&params.LogToFile, "log-to-file", false, fmt.Sprintf("Log to default file: %s", defaultLogPath()))
+	flags.BoolVar(&params.LogToFile, "log-to-file", false, fmt.Sprintf("Log to default file: %s", defaultLogPath(ctx)))
 	flags.StringVar(&params.LogFileConfig.Path, "log-file", "", "Path to log file")
 	flags.DurationVar(&params.LogFileConfig.MaxAge, "log-file-max-age", 30*24*time.Hour, "Maximum age of a log file before rotation")
 	params.LogFileConfig.MaxSize = 128 * 1024 * 1024
@@ -198,10 +179,10 @@ func makeBlockServer(config Config, serverInMemory bool, serverRootDir, bserverA
 	return NewBlockServerRemote(config, bserverAddr), nil
 }
 
-func makeKeybaseDaemon(config Config, serverInMemory bool, serverRootDir string, localUser libkb.NormalizedUsername, codec Codec, log logger.Logger, debug bool) (KeybaseDaemon, error) {
+func makeKeybaseDaemon(config Config, serverInMemory bool, serverRootDir string, localUser libkb.NormalizedUsername, codec Codec, ctx Context, log logger.Logger, debug bool) (KeybaseDaemon, error) {
 	if len(localUser) == 0 {
 		libkb.G.ConfigureSocketInfo()
-		return NewKeybaseDaemonRPC(config, libkb.G, log, debug), nil
+		return NewKeybaseDaemonRPC(config, ctx, log, debug), nil
 	}
 
 	users := []libkb.NormalizedUsername{"strib", "max", "chris", "fred"}
@@ -242,7 +223,7 @@ func makeKeybaseDaemon(config Config, serverInMemory bool, serverRootDir string,
 // Returns a valid logger even on error, which are non-fatal, thus
 // errors from this function may be ignored.
 // Possible errors are logged to the logger returned.
-func InitLog(params InitParams) (logger.Logger, error) {
+func InitLog(params InitParams, ctx Context) (logger.Logger, error) {
 	var err error
 	log := logger.NewWithCallDepth("kbfs", 1)
 
@@ -251,7 +232,7 @@ func InitLog(params InitParams) (logger.Logger, error) {
 		if params.LogFileConfig.Path != "" {
 			return nil, fmt.Errorf("log-to-file and log-file flags can't be specified together")
 		}
-		params.LogFileConfig.Path = defaultLogPath()
+		params.LogFileConfig.Path = defaultLogPath(ctx)
 	}
 
 	if params.LogFileConfig.Path != "" {
@@ -276,9 +257,7 @@ func InitLog(params InitParams) (logger.Logger, error) {
 // Init should be called at the beginning of main. Shutdown (see
 // below) should then be called at the end of main (usually via
 // defer).
-func Init(params InitParams, onInterruptFn func(), log logger.Logger) (Config, error) {
-	initLibkb()
-
+func Init(ctx Context, params InitParams, onInterruptFn func(), log logger.Logger) (Config, error) {
 	localUser := libkb.NewNormalizedUsername(params.LocalUser)
 
 	if params.CPUProfile != "" {
@@ -376,7 +355,7 @@ func Init(params InitParams, onInterruptFn func(), log logger.Logger) (Config, e
 
 	config.SetKeyServer(keyServer)
 
-	daemon, err := makeKeybaseDaemon(config, params.ServerInMemory, params.ServerRootDir, localUser, config.Codec(), config.MakeLogger(""), params.Debug)
+	daemon, err := makeKeybaseDaemon(config, params.ServerInMemory, params.ServerRootDir, localUser, config.Codec(), ctx, config.MakeLogger(""), params.Debug)
 	if err != nil {
 		return nil, fmt.Errorf("problem creating daemon: %s", err)
 	}
@@ -393,7 +372,7 @@ func Init(params InitParams, onInterruptFn func(), log logger.Logger) (Config, e
 	config.SetReporter(NewReporterKBPKI(config, 10, 1000))
 
 	if localUser == "" {
-		c := NewCryptoClient(config, libkb.G)
+		c := NewCryptoClient(config, ctx)
 		config.SetCrypto(c)
 	} else {
 		signingKey := MakeLocalUserSigningKeyOrBust(localUser)

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -19,7 +19,7 @@ import (
 // KeybaseDaemonRPC implements the KeybaseDaemon interface using RPC
 // calls.
 type KeybaseDaemonRPC struct {
-	libkb.Contextified
+	context        Context
 	identifyClient keybase1.IdentifyInterface
 	userClient     keybase1.UserInterface
 	sessionClient  keybase1.SessionInterface
@@ -56,7 +56,7 @@ var _ KeybaseDaemon = (*KeybaseDaemonRPC)(nil)
 
 // NewKeybaseDaemonRPC makes a new KeybaseDaemonRPC that makes RPC
 // calls using the socket of the given Keybase context.
-func NewKeybaseDaemonRPC(config Config, kbCtx *libkb.GlobalContext, log logger.Logger, debug bool) *KeybaseDaemonRPC {
+func NewKeybaseDaemonRPC(config Config, kbCtx Context, log logger.Logger, debug bool) *KeybaseDaemonRPC {
 	k := newKeybaseDaemonRPC(kbCtx, log)
 	k.config = config
 	conn := NewSharedKeybaseConnection(kbCtx, config, k)
@@ -70,18 +70,18 @@ func NewKeybaseDaemonRPC(config Config, kbCtx *libkb.GlobalContext, log logger.L
 }
 
 // For testing.
-func newKeybaseDaemonRPCWithClient(kbCtx *libkb.GlobalContext, client rpc.GenericClient,
+func newKeybaseDaemonRPCWithClient(kbCtx Context, client rpc.GenericClient,
 	log logger.Logger) *KeybaseDaemonRPC {
 	k := newKeybaseDaemonRPC(kbCtx, log)
 	k.fillClients(client)
 	return k
 }
 
-func newKeybaseDaemonRPC(kbCtx *libkb.GlobalContext, log logger.Logger) *KeybaseDaemonRPC {
+func newKeybaseDaemonRPC(kbCtx Context, log logger.Logger) *KeybaseDaemonRPC {
 	k := KeybaseDaemonRPC{
-		Contextified: libkb.NewContextified(kbCtx),
-		log:          log,
-		userCache:    make(map[keybase1.UID]UserInfo),
+		context:   kbCtx,
+		log:       log,
+		userCache: make(map[keybase1.UID]UserInfo),
 	}
 	return &k
 }

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -65,7 +65,7 @@ var _ AuthTokenRefreshHandler = (*MDServerRemote)(nil)
 var _ rpc.ConnectionHandler = (*MDServerRemote)(nil)
 
 // NewMDServerRemote returns a new instance of MDServerRemote.
-func NewMDServerRemote(config Config, srvAddr string) *MDServerRemote {
+func NewMDServerRemote(config Config, srvAddr string, ctx Context) *MDServerRemote {
 	mdServer := &MDServerRemote{
 		config:     config,
 		observers:  make(map[TlfID]chan<- error),
@@ -77,7 +77,7 @@ func NewMDServerRemote(config Config, srvAddr string) *MDServerRemote {
 		"libkbfs_mdserver_remote", mdServer)
 	conn := rpc.NewTLSConnection(srvAddr, GetRootCerts(srvAddr),
 		MDServerErrorUnwrapper{}, mdServer, true,
-		libkb.NewRPCLogFactory(libkb.G), libkb.WrapError,
+		ctx.NewRPCLogFactory(), libkb.WrapError,
 		config.MakeLogger(""), LogTagsFromContext)
 	mdServer.conn = conn
 	mdServer.client = keybase1.MetadataClient{Cli: conn.GetClient()}

--- a/libkbfs/shared_keybase_transport.go
+++ b/libkbfs/shared_keybase_transport.go
@@ -14,7 +14,7 @@ import (
 
 // NewSharedKeybaseConnection returns a connection that tries to
 // connect to the local keybase daemon.
-func NewSharedKeybaseConnection(kbCtx *libkb.GlobalContext, config Config,
+func NewSharedKeybaseConnection(kbCtx Context, config Config,
 	handler rpc.ConnectionHandler) *rpc.Connection {
 	transport := &SharedKeybaseTransport{kbCtx: kbCtx}
 	return rpc.NewConnectionWithTransport(handler, transport,
@@ -25,7 +25,7 @@ func NewSharedKeybaseConnection(kbCtx *libkb.GlobalContext, config Config,
 // SharedKeybaseTransport is a ConnectionTransport implementation that
 // uses a shared local socket to a keybase daemon.
 type SharedKeybaseTransport struct {
-	kbCtx *libkb.GlobalContext
+	kbCtx Context
 
 	// Protects everything below.
 	mutex           sync.Mutex

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/keybase/kbfs/env"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -104,7 +105,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 		}
 
 	case len(bserverAddr) != 0:
-		blockServer = NewBlockServerRemote(config, bserverAddr)
+		blockServer = NewBlockServerRemote(config, bserverAddr, env.NewContext())
 
 	default:
 		blockServer = NewBlockServerMemory(config)
@@ -132,7 +133,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 		libkb.G.ConfigureLogging()
 
 		// connect to server
-		mdServer = NewMDServerRemote(config, mdServerAddr)
+		mdServer = NewMDServerRemote(config, mdServerAddr, env.NewContext())
 		// for now the MD server acts as the key server in production
 		keyServer = mdServer.(*MDServerRemote)
 	} else {
@@ -197,7 +198,7 @@ func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *C
 	c.SetCrypto(crypto)
 
 	if s, ok := config.BlockServer().(*BlockServerRemote); ok {
-		blockServer := NewBlockServerRemote(c, s.RemoteAddress())
+		blockServer := NewBlockServerRemote(c, s.RemoteAddress(), env.NewContext())
 		c.SetBlockServer(blockServer)
 	} else {
 		c.SetBlockServer(config.BlockServer())
@@ -210,7 +211,7 @@ func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *C
 	var keyServer KeyServer
 	if len(mdServerAddr) != 0 {
 		// connect to server
-		mdServer = NewMDServerRemote(c, mdServerAddr)
+		mdServer = NewMDServerRemote(c, mdServerAddr, env.NewContext())
 		// for now the MD server also acts as the key server.
 		keyServer = mdServer.(*MDServerRemote)
 	} else {


### PR DESCRIPTION
Removes a direct dependency on GlobalContext for libkbfs package.

This is important for mobile which has issues with the libkb.G global and GlobalContext.

- Replaces libkb.GlobalContext with libkbfs.Context interface
- Replaces access of libkb.G with passed in var (context interface)
- Move construction of context (from GlobalContext) to alternate package (env), since it's used in kbfsfuse, kbfsdokan main packages (and test)
- The impl wraps GlobalContext (implementation hiding) for easy refactoring in the future

In general, we should be using interfaces for library packages like this rather than direct dependencies on something like GlobalContext which itself has a ton of dependencies.

In general we should be deprecating direct use of GlobalContext.

@strib 

cc @maxtaco 