### PR TITLE
Compare ConflictInfos properly

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -987,15 +987,15 @@ func (e NoSuchTlfHandleError) Error() string {
 // TlfHandleExtensionMismatchError indicates the expected extension
 // doesn't match the server's extension for the given handle.
 type TlfHandleExtensionMismatchError struct {
-	Expected *TlfHandleExtension
+	Expected TlfHandleExtension
 	// Actual may be nil.
 	Actual *TlfHandleExtension
 }
 
 // Error implements the error interface for TlfHandleExtensionMismatchError
 func (e TlfHandleExtensionMismatchError) Error() string {
-	return fmt.Sprint("Folder handle extension mismatch, "+
-		"expected: %s, actual: %v", e.Expected, e.Actual)
+	return fmt.Sprintf("Folder handle extension mismatch, "+
+		"expected: %s, actual: %s", e.Expected, e.Actual)
 }
 
 // MetadataIsFinalError indicates that we tried to make a successor to a

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -988,13 +988,14 @@ func (e NoSuchTlfHandleError) Error() string {
 // doesn't match the server's extension for the given handle.
 type TlfHandleExtensionMismatchError struct {
 	Expected *TlfHandleExtension
-	Actual   *TlfHandleExtension
+	// Actual may be nil.
+	Actual *TlfHandleExtension
 }
 
 // Error implements the error interface for TlfHandleExtensionMismatchError
 func (e TlfHandleExtensionMismatchError) Error() string {
-	return fmt.Sprint("Folder handle extension  mismatch, "+
-		"expected: %s, actual: %s", e.Expected, e.Actual)
+	return fmt.Sprint("Folder handle extension mismatch, "+
+		"expected: %s, actual: %v", e.Expected, e.Actual)
 }
 
 // MetadataIsFinalError indicates that we tried to make a successor to a

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -450,21 +450,41 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 			return false, nil, err
 		}
 		resolvedInfo := resolvedHandle.ConflictInfo()
-		if latestHandle.ConflictInfo != resolvedInfo {
-			km.log.CDebugf(ctx, "handle for %s is conflicted",
-				handle.GetCanonicalPath())
-			if resolvedInfo != nil {
-				// ConflictInfo is inconsistent.
+		if resolvedInfo == nil {
+			if latestHandle.ConflictInfo == nil {
+				// Nothing to do.
+			} else {
+				km.log.CDebugf(
+					ctx, "handle for %s is conflicted",
+					handle.GetCanonicalPath())
+				// Set the conflict info in the resolved handle.
+				// This will get stored in the metadata block.
+				// TODO: We should do some verification of this.
+				resolvedHandle.SetConflictInfo(latestHandle.ConflictInfo)
+			}
+		} else {
+			if latestHandle.ConflictInfo == nil {
+				// Conflict info disappeared?
+				err := TlfHandleExtensionMismatchError{
+					Expected: resolvedInfo,
+					Actual:   nil,
+				}
+				return false, nil, err
+			}
+			// Make sure conflict info is the same.
+			equal, err := CodecEqual(
+				km.config.Codec(), resolvedInfo,
+				latestHandle.ConflictInfo)
+			if err != nil {
+				return false, nil, err
+			}
+			if !equal {
 				err := TlfHandleExtensionMismatchError{
 					Expected: resolvedInfo,
 					Actual:   latestHandle.ConflictInfo,
 				}
 				return false, nil, err
 			}
-			// Set the conflict info in the resolved handle.
-			// This will get stored in the metadata block.
-			// TODO: We should do some verification of this.
-			resolvedHandle.SetConflictInfo(latestHandle.ConflictInfo)
 		}
 	}
 

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -156,7 +156,7 @@ func (h *TlfHandle) UpdateConflictInfo(
 	// a TLF, once set, is immutable and should never change.
 	if info == nil {
 		return TlfHandleExtensionMismatchError{
-			Expected: h.ConflictInfo(),
+			Expected: *h.ConflictInfo(),
 			Actual:   nil,
 		}
 	}
@@ -166,7 +166,7 @@ func (h *TlfHandle) UpdateConflictInfo(
 	}
 	if !equal {
 		return TlfHandleExtensionMismatchError{
-			Expected: h.ConflictInfo(),
+			Expected: *h.ConflictInfo(),
 			Actual:   info,
 		}
 	}

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -152,7 +152,8 @@ func (h *TlfHandle) UpdateConflictInfo(
 		h.conflictInfo = &conflictInfoCopy
 		return nil
 	}
-	// Make sure conflict info is the same.
+	// Make sure conflict info is the same; the conflict info for
+	// a TLF, once set, is immutable and should never change.
 	if info == nil {
 		return TlfHandleExtensionMismatchError{
 			Expected: h.ConflictInfo(),

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -137,15 +137,39 @@ func (h TlfHandle) ConflictInfo() *TlfHandleExtension {
 	return &conflictInfoCopy
 }
 
-// SetConflictInfo sets the handle's conflict info to the given one,
-// which may be nil.
-func (h *TlfHandle) SetConflictInfo(info *TlfHandleExtension) {
-	if info == nil {
-		h.conflictInfo = nil
-		return
+// UpdateConflictInfo sets the handle's conflict info to the given
+// one, if the existing one is nil. (In this case, the given one may
+// also be nil.) Otherwise, the given conflict info must match the
+// existing one.
+func (h *TlfHandle) UpdateConflictInfo(
+	codec Codec, info *TlfHandleExtension) error {
+	if h.conflictInfo == nil {
+		if info == nil {
+			// Nothing to do.
+			return nil
+		}
+		conflictInfoCopy := *info
+		h.conflictInfo = &conflictInfoCopy
+		return nil
 	}
-	conflictInfoCopy := *info
-	h.conflictInfo = &conflictInfoCopy
+	// Make sure conflict info is the same.
+	if info == nil {
+		return TlfHandleExtensionMismatchError{
+			Expected: h.ConflictInfo(),
+			Actual:   nil,
+		}
+	}
+	equal, err := CodecEqual(codec, h.conflictInfo, info)
+	if err != nil {
+		return err
+	}
+	if !equal {
+		return TlfHandleExtensionMismatchError{
+			Expected: h.ConflictInfo(),
+			Actual:   info,
+		}
+	}
+	return nil
 }
 
 // FinalizedInfo returns the handle's finalized info, if any.

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -306,18 +306,24 @@ func TestTlfHandleConflictInfo(t *testing.T) {
 	err = h.UpdateConflictInfo(codec, &info)
 	require.NoError(t, err)
 
-	err = h.UpdateConflictInfo(codec, nil)
-	require.Equal(t, TlfHandleExtensionMismatchError{
-		Expected: h.ConflictInfo(),
+	expectedErr := TlfHandleExtensionMismatchError{
+		Expected: *h.ConflictInfo(),
 		Actual:   nil,
-	}, err)
+	}
+	err = h.UpdateConflictInfo(codec, nil)
+	require.Equal(t, expectedErr, err)
+	require.Equal(t, "Folder handle extension mismatch, expected: (conflicted copy 1970-01-01 #50), actual: <nil>", err.Error())
 
+	expectedErr = TlfHandleExtensionMismatchError{
+		Expected: *h.ConflictInfo(),
+		Actual:   &info,
+	}
 	info.Date = 101
 	err = h.UpdateConflictInfo(codec, &info)
-	require.Equal(t, TlfHandleExtensionMismatchError{
-		Expected: h.ConflictInfo(),
-		Actual:   &info,
-	}, err)
+	require.Equal(t, expectedErr, err)
+	// A strange error message, since the difference doesn't show
+	// up in the strings. Oh, well.
+	require.Equal(t, "Folder handle extension mismatch, expected: (conflicted copy 1970-01-01 #50), actual: (conflicted copy 1970-01-01 #50)", err.Error())
 }
 
 func TestTlfHandleFinalizedInfo(t *testing.T) {


### PR DESCRIPTION
Apparently, I forgot to do this in
an earlier PR where I noticed this.