### PR TITLE
Fixes for favorite removal

### DIFF
--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -701,6 +701,12 @@ func (tlf *TLF) getStoredDir() *Dir {
 	return tlf.dir
 }
 
+func (tlf *TLF) clearStoredDir() {
+	tlf.dirLock.Lock()
+	defer tlf.dirLock.Unlock()
+	tlf.dir = nil
+}
+
 func (tlf *TLF) loadDirHelper(ctx context.Context, filterErr bool) (
 	dir *Dir, exitEarly bool, err error) {
 	dir = tlf.getStoredDir()

--- a/libkbfs/favorites.go
+++ b/libkbfs/favorites.go
@@ -120,15 +120,6 @@ func (f *Favorites) handleReq(req *favReq) (err error) {
 		if err != nil {
 			return err
 		}
-		if !folder.Private {
-			// Public folders may be stored under a different name,
-			// pending CORE-2695.  TODO: remove me!
-			folder.Name = folder.Name + ReaderSep + "public"
-			err := kbpki.FavoriteDelete(req.ctx, folder)
-			if err != nil {
-				return err
-			}
-		}
 		delete(f.cache, fav)
 	}
 

--- a/libkbfs/favorites_test.go
+++ b/libkbfs/favorites_test.go
@@ -82,11 +82,6 @@ func TestFavoritesAddRemoveAdd(t *testing.T) {
 		Times(2).Return(nil)
 	config.mockKbpki.EXPECT().FavoriteDelete(gomock.Any(), folder1).
 		Return(nil)
-	// 2nd delete (temporary)
-	folder1WithSuffix := folder1
-	folder1WithSuffix.Name += "#public"
-	config.mockKbpki.EXPECT().FavoriteDelete(gomock.Any(), folder1WithSuffix).
-		Return(nil)
 	if err := f.Add(ctx, fav1); err != nil {
 		t.Fatalf("Couldn't add favorite: %v", err)
 	}


### PR DESCRIPTION
On OS X, the OS helpfully issues a `stat` call after the `rmdir`.  If you've already opened the TLF, this will cause the favorite to be re-added, because it doesn't fake out the attribute, to gets the real one via KBFSOps.  Instead, clear out the stored TLF Dir object on favorite removal, which will make it go back to faking out the attribute until the TLF is deliberately opened again.

Also, the API server now rejects public TLFs with readers, so we can no longer delete the old-style "#public" favorite names.  We'll have to do it manually in the DB if there are any left.

Issue: KBFS-1045
Issue: keybase/keybase-issues#2282
