### PR TITLE
libdokan: SetFileTime for TLFs

### DIFF
--- a/libdokan/fso.go
+++ b/libdokan/fso.go
@@ -24,7 +24,7 @@ type FSO struct {
 	emptyFile
 }
 
-// SetFileTime sets mtime for FSOs (File and Dir).
+// SetFileTime sets mtime for FSOs (File and Dir). TLFs have a separate SetFileTime.
 func (f *FSO) SetFileTime(fi *dokan.FileInfo, creation time.Time, lastAccess time.Time, lastWrite time.Time) (err error) {
 	ctx, cancel := NewContextWithOpID(f.folder.fs, "FSO SetFileTime")
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err, cancel) }()

--- a/libdokan/tlf.go
+++ b/libdokan/tlf.go
@@ -9,6 +9,7 @@ package libdokan
 import (
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
@@ -115,6 +116,18 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, info string, filterErr bool) 
 func (tlf *TLF) loadDirAllowNonexistent(ctx context.Context, info string) (
 	*Dir, bool, error) {
 	return tlf.loadDirHelper(ctx, info, true)
+}
+
+// SetFileTime sets mtime for FSOs (File and Dir).
+func (tlf *TLF) SetFileTime(fi *dokan.FileInfo, creation time.Time, lastAccess time.Time, lastWrite time.Time) (err error) {
+	ctx, cancel := NewContextWithOpID(tlf.folder.fs, "TLF SetFileTime")
+	defer cancel()
+
+	dir, _, err := tlf.loadDirHelper(ctx, "TLF SetFileTime", false)
+	if err != nil {
+		return err
+	}
+	return dir.SetFileTime(fi, creation, lastAccess, lastWrite)
 }
 
 // GetFileInformation for dokan.


### PR DESCRIPTION
This adds support for chtimes on TLFs in addition to files/directories inside them.