### PR TITLE
libkbfs: Protect staller block ops delegate by a lock in tests

### DIFF
--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -384,7 +384,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 				unstall: writeUnstallCh,
 			},
 		},
-		delegate: config2.BlockOps(),
+		internalDelegate: config2.BlockOps(),
 	})
 
 	// Start the sync and wait for it to stall twice only.

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1378,7 +1378,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 				unstall: syncUnstallCh,
 			},
 		},
-		delegate: config2.BlockOps(),
+		internalDelegate: config2.BlockOps(),
 	})
 
 	// User 2 writes some data
@@ -1430,7 +1430,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// the failed sync get cleaned up.
 
 	// Now succeed with different data so CR can happen.
-	config2.SetBlockOps(config2.BlockOps().(*stallingBlockOps).delegate)
+	config2.SetBlockOps(config2.BlockOps().(*stallingBlockOps).delegate())
 	for i := int64(0); i < blockSize*fileBlocks; i++ {
 		data[i] = byte(i + 10)
 	}

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -486,7 +486,7 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 				unstall: writeUnstallCh,
 			},
 		},
-		delegate: config.BlockOps(),
+		internalDelegate: config.BlockOps(),
 	})
 
 	var wg sync.WaitGroup
@@ -633,7 +633,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 				unstall: syncUnstallCh,
 			},
 		},
-		delegate: config.BlockOps(),
+		internalDelegate: config.BlockOps(),
 	})
 
 	var wg sync.WaitGroup
@@ -738,7 +738,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 				unstall: syncUnstallCh,
 			},
 		},
-		delegate: config.BlockOps(),
+		internalDelegate: config.BlockOps(),
 	})
 
 	var wg sync.WaitGroup
@@ -1245,7 +1245,7 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 				unstall: syncUnstallCh,
 			},
 		},
-		delegate: config.BlockOps(),
+		internalDelegate: config.BlockOps(),
 	})
 
 	// create and write to a file
@@ -1461,7 +1461,7 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 				unstall: syncUnstallCh,
 			},
 		},
-		delegate: config.BlockOps(),
+		internalDelegate: config.BlockOps(),
 	})
 
 	// create and write to a file
@@ -1569,7 +1569,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 				unstall: syncUnstallCh,
 			},
 		},
-		delegate: realBlockOps,
+		internalDelegate: realBlockOps,
 	}
 
 	config.SetBlockOps(staller)
@@ -1592,8 +1592,8 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 		t.Errorf("Couldn't write file: %v", err)
 	}
 
-	booq := &blockOpsOverQuota{BlockOps: staller.delegate}
-	staller.delegate = booq
+	booq := &blockOpsOverQuota{BlockOps: staller.delegate()}
+	staller.setDelegate(booq)
 
 	// Block the Sync
 	// Sync the initial two data blocks


### PR DESCRIPTION
Spotted on https://travis-ci.org/keybase/kbfs/jobs/138941150

Fixes a data race in testing code.