### PR TITLE
[KBFS-1159] Consolidate RootMetadata checks

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -767,7 +767,7 @@ func (e MDTlfIDMismatch) Error() string {
 }
 
 // MDPrevRootMismatch indicates that the PrevRoot field of a successor
-// MD doesn't match the ID of its predecessor.
+// MD doesn't match the metadata ID of its predecessor.
 type MDPrevRootMismatch struct {
 	prevRoot MdID
 	currRoot MdID

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -320,7 +320,7 @@ func (e MDMissingDataError) Error() string {
 // for the given top-level folder.
 type MDMismatchError struct {
 	Dir string
-	Err string
+	Err error
 }
 
 // Error implements the error interface for MDMismatchError

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -778,6 +778,18 @@ func (e MDPrevRootMismatch) Error() string {
 		e.prevRoot, e.currRoot)
 }
 
+// MDDiskUsageMismatch indicates an inconsistency in the DiskUsage
+// field of a RootMetadata object.
+type MDDiskUsageMismatch struct {
+	expectedDiskUsage uint64
+	actualDiskUsage   uint64
+}
+
+func (e MDDiskUsageMismatch) Error() string {
+	return fmt.Sprintf("Disk usage %d doesn't match expected %d",
+		e.actualDiskUsage, e.expectedDiskUsage)
+}
+
 // MDUpdateInvertError indicates that we tried to apply a revision that
 // was not the next in line.
 type MDUpdateInvertError struct {

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -754,16 +754,28 @@ func (e MDUpdateApplyError) Error() string {
 		"current revision %d", e.rev, e.curr)
 }
 
+// MDTlfIDMismatch indicates that the ID field of a successor MD
+// doesn't match the ID field of its predecessor.
+type MDTlfIDMismatch struct {
+	currID TlfID
+	nextID TlfID
+}
+
+func (e MDTlfIDMismatch) Error() string {
+	return fmt.Sprintf("TLF ID %s doesn't match successor TLF ID %s",
+		e.currID, e.nextID)
+}
+
 // MDPrevRootMismatch indicates that the PrevRoot field of a successor
 // MD doesn't match the ID of its predecessor.
 type MDPrevRootMismatch struct {
-	expected MdID
-	actual   MdID
+	prevRoot MdID
+	currRoot MdID
 }
 
 func (e MDPrevRootMismatch) Error() string {
-	return fmt.Sprintf("ID of prev root is %s, expected %s",
-		e.actual, e.expected)
+	return fmt.Sprintf("PrevRoot %s doesn't match current root %s",
+		e.prevRoot, e.currRoot)
 }
 
 // MDUpdateInvertError indicates that we tried to apply a revision that

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -754,6 +754,18 @@ func (e MDUpdateApplyError) Error() string {
 		"current revision %d", e.rev, e.curr)
 }
 
+// MDPrevRootMismatch indicates that the PrevRoot field of a successor
+// MD doesn't match the ID of its predecessor.
+type MDPrevRootMismatch struct {
+	expected MdID
+	actual   MdID
+}
+
+func (e MDPrevRootMismatch) Error() string {
+	return fmt.Sprintf("ID of prev root is %s, expected %s",
+		e.actual, e.expected)
+}
+
 // MDUpdateInvertError indicates that we tried to apply a revision that
 // was not the next in line.
 type MDUpdateInvertError struct {
@@ -998,8 +1010,8 @@ func (e TlfHandleExtensionMismatchError) Error() string {
 		"expected: %s, actual: %s", e.Expected, e.Actual)
 }
 
-// MetadataIsFinalError indicates that we tried to make a successor to a
-// finalized folder.
+// MetadataIsFinalError indicates that we tried to make or set a
+// successor to a finalized folder.
 type MetadataIsFinalError struct {
 }
 

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -741,15 +741,15 @@ func (e MDServerDisconnected) Error() string {
 	return "MDServer is disconnected"
 }
 
-// MDUpdateApplyError indicates that we tried to apply a revision that
+// MDRevisionMismatch indicates that we tried to apply a revision that
 // was not the next in line.
-type MDUpdateApplyError struct {
+type MDRevisionMismatch struct {
 	rev  MetadataRevision
 	curr MetadataRevision
 }
 
-// Error implements the error interface for MDUpdateApplyError.
-func (e MDUpdateApplyError) Error() string {
+// Error implements the error interface for MDRevisionMismatch.
+func (e MDRevisionMismatch) Error() string {
 	return fmt.Sprintf("MD revision %d isn't next in line for our "+
 		"current revision %d", e.rev, e.curr)
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -660,8 +660,9 @@ func (fbo *folderBranchOps) setHeadPredecessorLocked(ctx context.Context,
 	if fbo.head.Revision <= MetadataRevisionInitial {
 		panic(fmt.Sprintf("low rev = %d", fbo.head.Revision))
 	}
-	if md.Revision != fbo.head.Revision-1 {
-		return MDUpdateApplyError{md.Revision, fbo.head.Revision - 1}
+	err := md.CheckValidSuccessor(fbo.config, fbo.head)
+	if err != nil {
+		return err
 	}
 
 	return fbo.setHeadLocked(ctx, lState, md)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -603,16 +603,34 @@ func (fbo *folderBranchOps) setHeadLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) setHeadUntrustedLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata) error {
+	fbo.mdWriterLock.AssertLocked(lState)
+	fbo.headLock.AssertLocked(lState)
+	if fbo.head != nil {
+		panic("Unexpected non-nil head")
+	}
 	return fbo.setHeadLocked(ctx, lState, md)
 }
 
 func (fbo *folderBranchOps) setHeadInitLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata) error {
+	fbo.mdWriterLock.AssertLocked(lState)
+	fbo.headLock.AssertLocked(lState)
+	if fbo.head != nil {
+		panic("Unexpected non-nil head")
+	}
+	if md.Revision != MetadataRevisionInitial {
+		panic(fmt.Sprintf("what %d", md.Revision))
+	}
 	return fbo.setHeadLocked(ctx, lState, md)
 }
 
 func (fbo *folderBranchOps) setHeadTrustedLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata) error {
+	fbo.mdWriterLock.AssertLocked(lState)
+	fbo.headLock.AssertLocked(lState)
+	if fbo.head != nil {
+		panic("Unexpected non-nil head")
+	}
 	return fbo.setHeadLocked(ctx, lState, md)
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3319,11 +3319,6 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			// Already caught up!
 			continue
 		}
-		if rmd.Revision != fbo.getCurrMDRevisionLocked(lState)+1 {
-			return MDRevisionMismatch{rmd.Revision,
-				fbo.getCurrMDRevisionLocked(lState)}
-		}
-
 		if err := rmd.isReadableOrError(ctx, fbo.config); err != nil {
 			return err
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3372,7 +3372,8 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 				fbo.getCurrMDRevisionLocked(lState)}
 		}
 
-		// TODO: Skip if not predecessor.
+		// TODO: Check that the revisions are equal only for
+		// the first iteration.
 		if rmd.Revision < fbo.getCurrMDRevisionLocked(lState) {
 			err := fbo.setHeadPredecessorLocked(ctx, lState, rmd)
 			if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3259,7 +3259,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			continue
 		}
 		if rmd.Revision != fbo.getCurrMDRevisionLocked(lState)+1 {
-			return MDUpdateApplyError{rmd.Revision,
+			return MDRevisionMismatch{rmd.Revision,
 				fbo.getCurrMDRevisionLocked(lState)}
 		}
 
@@ -3547,7 +3547,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 		// rekey bit is set, just a "folder needs rekey" update.
 		if err := fbo.getAndApplyMDUpdates(
 			ctx, lState, fbo.applyMDUpdatesLocked); err != nil {
-			if applyErr, ok := err.(MDUpdateApplyError); !ok ||
+			if applyErr, ok := err.(MDRevisionMismatch); !ok ||
 				applyErr.rev != applyErr.curr {
 				return err
 			}
@@ -3748,7 +3748,7 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 	}
 
 	if err := fbo.getAndApplyMDUpdates(ctx, lState, fbo.applyMDUpdates); err != nil {
-		if applyErr, ok := err.(MDUpdateApplyError); ok {
+		if applyErr, ok := err.(MDRevisionMismatch); ok {
 			if applyErr.rev == applyErr.curr {
 				fbo.log.CDebugf(ctx, "Already up-to-date with server")
 				return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -674,6 +674,11 @@ func (fbo *folderBranchOps) setHeadPredecessorLocked(ctx context.Context,
 	if fbo.head.Revision <= MetadataRevisionInitial {
 		return fmt.Errorf("setHeadPredecessorLocked unexpectedly called with revision %d", fbo.head.Revision)
 	}
+
+	if fbo.head.BID == NullBranchID {
+		return fmt.Errorf("setHeadPredecessorLocked unexpectedly called with null branch ID")
+	}
+
 	err := md.CheckValidSuccessor(fbo.config, fbo.head)
 	if err != nil {
 		return err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -670,12 +670,8 @@ func (fbo *folderBranchOps) setHeadPredecessorLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) setHeadResolvedLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata) error {
-	currRev := fbo.getCurrMDRevisionLocked(lState)
 	if fbo.head.MergedStatus() != Unmerged {
 		panic("Unexpected merge status")
-	}
-	if md.Revision < currRev {
-		return MDUpdateApplyError{md.Revision, currRev}
 	}
 	if md.MergedStatus() != Merged {
 		panic("Unexpected merge status 2")

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -636,6 +636,11 @@ func (fbo *folderBranchOps) setHeadTrustedLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata) error {
+	currRev := fbo.getCurrMDRevisionLocked(lState)
+	if md.Revision != currRev+1 {
+		return MDUpdateApplyError{md.Revision, currRev}
+	}
+
 	return fbo.setHeadLocked(ctx, lState, md)
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3347,6 +3347,10 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 		rmd := rmds[i]
 		// on undo, it's ok to re-apply the current revision since you
 		// need to invert all of its ops.
+		//
+		// This duplicates a check in
+		// fbo.setHeadPredecessorLocked. TODO: Remove this
+		// duplication.
 		if rmd.Revision != fbo.getCurrMDRevisionLocked(lState) &&
 			rmd.Revision != fbo.getCurrMDRevisionLocked(lState)-1 {
 			return MDUpdateInvertError{rmd.Revision,

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5201,6 +5201,5 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	// Simulate the server triggering alice to update.
 	config1.SetKeyCache(NewKeyCacheStandard(1))
 	err = kbfsOps1.SyncFromServerForTesting(ctx, fb1)
-	require.EqualError(t, err,
-		"Could not verify metadata for directory : ")
+	require.IsType(t, MDPrevRootMismatch{}, err)
 }

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5201,5 +5201,8 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	// Simulate the server triggering alice to update.
 	config1.SetKeyCache(NewKeyCacheStandard(1))
 	err = kbfsOps1.SyncFromServerForTesting(ctx, fb1)
+	// TODO: We can actually fake out the PrevRoot pointer, too
+	// and then we'll be caught by the handle check. But when we
+	// have MDOps do the handle check, that'll trigger first.
 	require.IsType(t, MDPrevRootMismatch{}, err)
 }

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5202,5 +5202,5 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	config1.SetKeyCache(NewKeyCacheStandard(1))
 	err = kbfsOps1.SyncFromServerForTesting(ctx, fb1)
 	require.EqualError(t, err,
-		"old head \"alice\" resolves to \"alice\" instead of new head \"alice,mallory\"")
+		"Could not verify metadata for directory : ")
 }

--- a/libkbfs/mdserver_local.go
+++ b/libkbfs/mdserver_local.go
@@ -478,19 +478,14 @@ func (md *MDServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned) erro
 				Actual:   err.prevRoot,
 			}
 
+		case MDDiskUsageMismatch:
+			return MDServerErrorConflictDiskUsage{
+				Expected: err.expectedDiskUsage,
+				Actual:   err.actualDiskUsage,
+			}
+
 		default:
 			return MDServerError{Err: err}
-		}
-
-		expectedUsage := head.MD.DiskUsage
-		if !rmds.MD.IsWriterMetadataCopiedSet() {
-			expectedUsage += rmds.MD.RefBytes - rmds.MD.UnrefBytes
-		}
-		if rmds.MD.DiskUsage != expectedUsage {
-			return MDServerErrorConflictDiskUsage{
-				Expected: expectedUsage,
-				Actual:   rmds.MD.DiskUsage,
-			}
 		}
 	}
 

--- a/libkbfs/mdserver_local.go
+++ b/libkbfs/mdserver_local.go
@@ -466,10 +466,10 @@ func (md *MDServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned) erro
 		case nil:
 			break
 
-		case MDUpdateApplyError:
+		case MDRevisionMismatch:
 			return MDServerErrorConflictRevision{
-				Expected: head.MD.Revision + 1,
-				Actual:   rmds.MD.Revision,
+				Expected: err.curr + 1,
+				Actual:   err.rev,
 			}
 
 		case MDPrevRootMismatch:

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -424,7 +424,10 @@ func (md *RootMetadata) CheckValidSuccessor(
 
 	// (2) Check revision.
 	if nextMd.Revision != md.Revision+1 {
-		return MDUpdateApplyError{nextMd.Revision, md.Revision}
+		return MDRevisionMismatch{
+			rev:  nextMd.Revision,
+			curr: md.Revision,
+		}
 	}
 
 	// (3) Check PrevRoot pointer.

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -439,6 +439,9 @@ func (md *RootMetadata) CheckValidSuccessor(
 		}
 	}
 
+	// TODO: Check that the successor TLF handle is the same or
+	// more resolved.
+
 	return nil
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -409,14 +409,17 @@ func (md *RootMetadata) MakeSuccessor(config Config, isWriter bool) (*RootMetada
 // successor to the current one, and returns an error otherwise.
 func (md *RootMetadata) CheckValidSuccessor(
 	config Config, nextMd *RootMetadata) error {
+	// (1) Verify current metadata is non-final.
 	if md.IsFinal() {
 		return MetadataIsFinalError{}
 	}
 
+	// (2) Check revision.
 	if nextMd.Revision != md.Revision+1 {
 		return MDUpdateApplyError{nextMd.Revision, md.Revision}
 	}
 
+	// (3) Check PrevRoot pointer.
 	currRoot, err := md.MetadataID(config)
 	if err != nil {
 		return err

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -442,6 +442,17 @@ func (md *RootMetadata) CheckValidSuccessor(
 		}
 	}
 
+	expectedUsage := md.DiskUsage
+	if !nextMd.IsWriterMetadataCopiedSet() {
+		expectedUsage += nextMd.RefBytes - nextMd.UnrefBytes
+	}
+	if nextMd.DiskUsage != expectedUsage {
+		return MDDiskUsageMismatch{
+			expectedDiskUsage: expectedUsage,
+			actualDiskUsage:   nextMd.DiskUsage,
+		}
+	}
+
 	// TODO: Check that the successor (bare) TLF handle is the
 	// same or more resolved.
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -439,8 +439,8 @@ func (md *RootMetadata) CheckValidSuccessor(
 		}
 	}
 
-	// TODO: Check that the successor TLF handle is the same or
-	// more resolved.
+	// TODO: Check that the successor (bare) TLF handle is the
+	// same or more resolved.
 
 	return nil
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -405,8 +405,14 @@ func (md *RootMetadata) MakeSuccessor(config Config, isWriter bool) (*RootMetada
 	return newMd, nil
 }
 
+// CheckValidSuccessor makes sure the given RootMetadata is a valid
+// successor to the current one, and returns an error otherwise.
 func (md *RootMetadata) CheckValidSuccessor(
 	config Config, nextMd *RootMetadata) error {
+	if md.IsFinal() {
+		return MetadataIsFinalError{}
+	}
+
 	if nextMd.Revision != md.Revision+1 {
 		return MDUpdateApplyError{nextMd.Revision, md.Revision}
 	}
@@ -416,11 +422,7 @@ func (md *RootMetadata) CheckValidSuccessor(
 		return err
 	}
 	if nextMd.PrevRoot != currRoot {
-		return MDMismatchError{}
-	}
-
-	if md.IsFinal() {
-		return MDMismatchError{}
+		return MDPrevRootMismatch{currRoot, nextMd.PrevRoot}
 	}
 
 	return nil

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -405,6 +405,27 @@ func (md *RootMetadata) MakeSuccessor(config Config, isWriter bool) (*RootMetada
 	return newMd, nil
 }
 
+func (md *RootMetadata) CheckValidSuccessor(
+	config Config, nextMd *RootMetadata) error {
+	if nextMd.Revision != md.Revision+1 {
+		return MDUpdateApplyError{nextMd.Revision, md.Revision}
+	}
+
+	currRoot, err := md.MetadataID(config)
+	if err != nil {
+		return err
+	}
+	if nextMd.PrevRoot != currRoot {
+		return MDMismatchError{}
+	}
+
+	if md.IsFinal() {
+		return MDMismatchError{}
+	}
+
+	return nil
+}
+
 func (md *RootMetadata) getTLFKeyBundles(keyGen KeyGen) (*TLFWriterKeyBundle, *TLFReaderKeyBundle, error) {
 	if md.ID.IsPublic() {
 		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundle"}

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -414,6 +414,14 @@ func (md *RootMetadata) CheckValidSuccessor(
 		return MetadataIsFinalError{}
 	}
 
+	// (2) Check TLF ID.
+	if nextMd.ID != md.ID {
+		return MDTlfIDMismatch{
+			currID: md.ID,
+			nextID: nextMd.ID,
+		}
+	}
+
 	// (2) Check revision.
 	if nextMd.Revision != md.Revision+1 {
 		return MDUpdateApplyError{nextMd.Revision, md.Revision}
@@ -425,7 +433,10 @@ func (md *RootMetadata) CheckValidSuccessor(
 		return err
 	}
 	if nextMd.PrevRoot != currRoot {
-		return MDPrevRootMismatch{currRoot, nextMd.PrevRoot}
+		return MDPrevRootMismatch{
+			prevRoot: nextMd.PrevRoot,
+			currRoot: currRoot,
+		}
 	}
 
 	return nil

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -399,10 +399,9 @@ func (md *RootMetadata) MakeSuccessor(config Config, isWriter bool) (*RootMetada
 	}
 	// bump revision
 	if md.Revision < MetadataRevisionInitial {
-		newMd.Revision = MetadataRevisionInitial
-	} else {
-		newMd.Revision = md.Revision + 1
+		return nil, errors.New("MD with invalid revision")
 	}
+	newMd.Revision = md.Revision + 1
 	return newMd, nil
 }
 


### PR DESCRIPTION
We check RootMetadata validity in a few places, all
slightly differently. Consolidate that into
RootMetadata.CheckValidSuccessor().

Also add helper functions to wrap around
FBO.setHeadLocked().