### PR TITLE
Update go-framed-msgpack to match keybase/client/go

### DIFF
--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/server.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/server.go
@@ -15,20 +15,21 @@ func (s *Server) Register(p Protocol) error {
 }
 
 // Run starts processing incoming RPC messages asynchronously, if it
-// hasn't been started already. Returns a channel that's closed when
-// incoming frames have finished processing, either due to an error or
-// the underlying connection being closed. Successive calls to Run()
-// return the same value.
-//
-// If you want to know when said processing is done, and any
-// associated error, use Transport.Done() and Transport.Err().
+// hasn't been started already. Returns the result of Done(), for
+// convenience.
 func (s *Server) Run() <-chan struct{} {
 	return s.xp.receiveFrames()
 }
 
-// Err returns a non-nil error value after the channel returned by Run
-// is closed.  After that channel is closed, successive calls to Err
-// return the same value.
+// Returns a channel that's closed when incoming frames have finished
+// processing, either due to an error or the underlying connection
+// being closed. Successive calls to Done() return the same value.
+func (s *Server) Done() <-chan struct{} {
+	return s.xp.done()
+}
+
+// Err returns a non-nil error value after Done() is closed.  After
+// Done() is closed, successive calls to Err return the same value.
 func (s *Server) Err() error {
 	return s.xp.err()
 }

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/transport.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/transport.go
@@ -24,15 +24,17 @@ type Transporter interface {
 
 	// receiveFrames starts processing incoming frames in a
 	// background goroutine, if it's not already happening.
-	//
+	// Returns the result of done(), for convenience.
+	receiveFrames() <-chan struct{}
+
 	// Returns a channel that's closed when incoming frames have
 	// finished processing, either due to an error or the
 	// underlying connection being closed. Successive calls to
-	// receiveFrames return the same value.
-	receiveFrames() <-chan struct{}
+	// done() return the same value.
+	done() <-chan struct{}
 
-	// err returns a non-nil error value after done is closed.
-	// After done is closed, successive calls to err return the
+	// err returns a non-nil error value after done() is closed.
+	// After done() is closed, successive calls to err return the
 	// same value.
 	err() error
 }
@@ -119,6 +121,10 @@ func (t *transport) receiveFrames() <-chan struct{} {
 		// Subsequent times -- do nothing.
 	}
 
+	return t.stopCh
+}
+
+func (t *transport) done() <-chan struct{} {
 	return t.stopCh
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -203,8 +203,8 @@
 		{
 			"checksumSHA1": "Ao/ZFbwpEQ2kdtaim/5borAcVKE=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc",
-			"revision": "de15ffc288b52dbb017651238e4397242dc21016",
-			"revisionTime": "2016-05-20T19:44:56Z"
+			"revision": "090895b12240aa18b8d6a759a2638f0c1065c7d0",
+			"revisionTime": "2016-06-15T10:04:14-04:00"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
For gomobile bind client+kbfs, need to have compatible vendoring.

`govendor update github.com/keybase/go-framed-msgpack`

@maxtaco or @strib