### PR TITLE
stop devices from continuously registering and fetching merged updates

### DIFF
--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -332,7 +332,7 @@ func (d *DirtyBlockCacheStandard) RequestPermissionToDirty(
 	d.shutdownLock.RLock()
 	defer d.shutdownLock.RUnlock()
 	if d.isShutdown {
-		return nil, errShutdownHappened
+		return nil, ShutdownHappenedError{}
 	}
 
 	if estimatedDirtyBytes < 0 {

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1068,3 +1068,21 @@ func (e IncompatibleHandleError) Error() string {
 		"old head %q resolves to %q instead of new head %q",
 		e.oldName, e.partiallyResolvedOldName, e.newName)
 }
+
+// ShutdownHappenedError indicates that shutdown has happened.
+type ShutdownHappenedError struct {
+}
+
+// Error implements the error interface for ShutdownHappenedError.
+func (e ShutdownHappenedError) Error() string {
+	return "Shutdown happened"
+}
+
+// UnmergedError indicates that fbo is on an unmerged local revision
+type UnmergedError struct {
+}
+
+// Error implements the error interface for UnmergedError.
+func (e UnmergedError) Error() string {
+	return "fbo is on an unmerged local revision"
+}

--- a/libkbfs/favorites.go
+++ b/libkbfs/favorites.go
@@ -224,7 +224,7 @@ func (f *Favorites) startOrJoinAddReq(
 // Add adds a favorite to your favorites list.
 func (f *Favorites) Add(ctx context.Context, fav favToAdd) error {
 	if f.hasShutdown() {
-		return errShutdownHappened
+		return ShutdownHappenedError{}
 	}
 	doAdd := true
 	var err error
@@ -266,7 +266,7 @@ func (f *Favorites) AddAsync(ctx context.Context, fav favToAdd) {
 // idempotent.
 func (f *Favorites) Delete(ctx context.Context, fav Favorite) error {
 	if f.hasShutdown() {
-		return errShutdownHappened
+		return ShutdownHappenedError{}
 	}
 	return f.sendReq(ctx, &favReq{
 		ctx:   ctx,
@@ -298,7 +298,7 @@ func (f *Favorites) RefreshCache(ctx context.Context) {
 // doesn't use the cache.
 func (f *Favorites) Get(ctx context.Context) ([]Favorite, error) {
 	if f.hasShutdown() {
-		return nil, errShutdownHappened
+		return nil, ShutdownHappenedError{}
 	}
 	favChan := make(chan []Favorite, 1)
 	req := &favReq{

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -542,6 +542,10 @@ func (fbo *folderBranchOps) setHeadLocked(
 		// Use uninitialized for the merged branch; the unmerged
 		// revision is enough to trigger conflict resolution.
 		fbo.cr.Resolve(md.Revision, MetadataRevisionUninitialized)
+	} else if md.MergedStatus() == Merged {
+		// if we are already merged through this write, the revision would be the
+		// latestMergedRevision on server
+		fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision)
 	}
 
 	fbo.head = md

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -543,8 +543,8 @@ func (fbo *folderBranchOps) setHeadLocked(
 		// revision is enough to trigger conflict resolution.
 		fbo.cr.Resolve(md.Revision, MetadataRevisionUninitialized)
 	} else if md.MergedStatus() == Merged {
-		// if we are already merged through this write, the revision would be the
-		// latestMergedRevision on server
+		// If we are already merged through this write, the revision would be the
+		// latestMergedRevision on server.
 		fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision)
 	}
 
@@ -3275,8 +3275,6 @@ func (fbo *folderBranchOps) reembedForFBM(ctx context.Context,
 
 type applyMDUpdatesFunc func(context.Context, *lockState, []*RootMetadata) error
 
-var errUnmerged = errors.New("fbo is on an unmerged local revision")
-
 func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 	lState *lockState, rmds []*RootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -3298,7 +3296,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			}
 			fbo.cr.Resolve(unmergedRev, rmds[len(rmds)-1].Revision)
 		}
-		return errUnmerged
+		return UnmergedError{}
 	}
 
 	// Don't allow updates while we're in the dirty state; the next
@@ -3406,7 +3404,7 @@ func (fbo *folderBranchOps) setLatestMergedRevisionLocked(ctx context.Context, l
 	fbo.headLock.AssertLocked(lState)
 
 	fbo.latestMergedRevision = rev
-	fbo.log.CDebugf(ctx, "updated latestMergedRevision to %d", rev)
+	fbo.log.CDebugf(ctx, "Updated latestMergedRevision to %d.", rev)
 }
 
 // Assumes all necessary locking is either already done by caller, or
@@ -3856,8 +3854,6 @@ func (fbo *folderBranchOps) ctxWithFBOID(ctx context.Context) context.Context {
 	return ctxWithRandomID(ctx, CtxFBOIDKey, CtxFBOOpID, fbo.log)
 }
 
-var errShutdownHappened = errors.New("Shutdown happened")
-
 // Run the passed function with a context that's canceled on shutdown.
 func (fbo *folderBranchOps) runUnlessShutdown(fn func(ctx context.Context) error) error {
 	ctx := fbo.ctxWithFBOID(context.Background())
@@ -3872,7 +3868,7 @@ func (fbo *folderBranchOps) runUnlessShutdown(fn func(ctx context.Context) error
 	case err := <-errChan:
 		return err
 	case <-fbo.shutdownChan:
-		return errShutdownHappened
+		return ShutdownHappenedError{}
 	}
 }
 
@@ -3904,7 +3900,7 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 					}
 				}
 				err = fbo.waitForAndProcessUpdates(newCtx, updateChan)
-				if err == errUnmerged {
+				if _, ok := err.(UnmergedError); ok {
 					// skip the back-off timer and continue directly to next
 					// registerForUpdates
 					return nil


### PR DESCRIPTION
(by letting devices track latest merged revision on server)b