### PR TITLE
[KBFS-1185] Use per-TLF storage for MDServerDisk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ script:
   # Run libkbfs tests with an in-memory bserver and mdserver, and run all other
   # tests with the tempdir bserver and mdserver.
   - cd libkbfs && go test -i && go test -race -c && ./libkbfs.test -test.timeout 2m
-  - env KEYBASE_TEST_BSERVER_ADDR=tempdir ./libkbfs.test -test.timeout 2m
   - cd ../libfuse && go test -i && go test -c && env KEYBASE_TEST_BSERVER_ADDR=tempdir KEYBASE_TEST_MDSERVER_ADDR=tempdir ./libfuse.test -test.timeout 2m
   - cd ../test
   - go test -i -tags fuse && go test -race -c && env KEYBASE_TEST_BSERVER_ADDR=tempdir KEYBASE_TEST_MDSERVER_ADDR=tempdir ./test.test -test.timeout 7m

--- a/libkbfs/bserver_tlf_journal.go
+++ b/libkbfs/bserver_tlf_journal.go
@@ -369,11 +369,6 @@ var errBserverTlfJournalShutdown = errors.New("bserverTlfJournal is shutdown")
 // and returns it.
 func (j *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
 	[]byte, BlockCryptKeyServerHalf, error) {
-	if j.isShutdown {
-		return nil, BlockCryptKeyServerHalf{},
-			errBserverTlfJournalShutdown
-	}
-
 	// Check arguments.
 
 	refEntry, err := j.getRefEntryLocked(id, context.GetRefNonce())
@@ -461,6 +456,12 @@ func (j *bserverTlfJournal) getData(id BlockID, context BlockContext) (
 	[]byte, BlockCryptKeyServerHalf, error) {
 	j.lock.RLock()
 	defer j.lock.RUnlock()
+
+	if j.isShutdown {
+		return nil, BlockCryptKeyServerHalf{},
+			errBserverTlfJournalShutdown
+	}
+
 	return j.getDataLocked(id, context)
 }
 

--- a/libkbfs/bserver_tlf_journal.go
+++ b/libkbfs/bserver_tlf_journal.go
@@ -363,8 +363,6 @@ func (j *bserverTlfJournal) getRefEntryLocked(
 	return e, nil
 }
 
-var errBserverTlfJournalShutdown = errors.New("bserverTlfJournal is shutdown")
-
 // getDataLocked verifies the block data for the given ID and context
 // and returns it.
 func (j *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
@@ -451,6 +449,8 @@ func (j *bserverTlfJournal) putRefEntryLocked(
 }
 
 // All functions below are public functions.
+
+var errBserverTlfJournalShutdown = errors.New("bserverTlfJournal is shutdown")
 
 func (j *bserverTlfJournal) getData(id BlockID, context BlockContext) (
 	[]byte, BlockCryptKeyServerHalf, error) {

--- a/libkbfs/bserver_tlf_journal.go
+++ b/libkbfs/bserver_tlf_journal.go
@@ -75,7 +75,7 @@ type bserverTlfJournal struct {
 // directory. Any existing journal entries are read.
 func makeBserverTlfJournal(codec Codec, crypto cryptoPure, dir string) (
 	*bserverTlfJournal, error) {
-	bserver := &bserverTlfJournal{
+	journal := &bserverTlfJournal{
 		codec:  codec,
 		crypto: crypto,
 		dir:    dir,
@@ -83,15 +83,15 @@ func makeBserverTlfJournal(codec Codec, crypto cryptoPure, dir string) (
 
 	// Locking here is not strictly necessary, but do it anyway
 	// for consistency.
-	bserver.lock.Lock()
-	defer bserver.lock.Unlock()
-	refs, err := bserver.readJournalLocked()
+	journal.lock.Lock()
+	defer journal.lock.Unlock()
+	refs, err := journal.readJournalLocked()
 	if err != nil {
 		return nil, err
 	}
 
-	bserver.refs = refs
-	return bserver, nil
+	journal.refs = refs
+	return journal, nil
 }
 
 // journalOrdinal is the ordinal used for naming journal entries.
@@ -116,43 +116,43 @@ func (o journalOrdinal) String() string {
 
 // The functions below are for building various paths for the journal.
 
-func (s *bserverTlfJournal) journalPath() string {
-	return filepath.Join(s.dir, "journal")
+func (j *bserverTlfJournal) journalPath() string {
+	return filepath.Join(j.dir, "journal")
 }
 
-func (s *bserverTlfJournal) earliestPath() string {
-	return filepath.Join(s.journalPath(), "EARLIEST")
+func (j *bserverTlfJournal) earliestPath() string {
+	return filepath.Join(j.journalPath(), "EARLIEST")
 }
 
-func (s *bserverTlfJournal) latestPath() string {
-	return filepath.Join(s.journalPath(), "LATEST")
+func (j *bserverTlfJournal) latestPath() string {
+	return filepath.Join(j.journalPath(), "LATEST")
 }
 
-func (s *bserverTlfJournal) journalEntryPath(o journalOrdinal) string {
-	return filepath.Join(s.journalPath(), o.String())
+func (j *bserverTlfJournal) journalEntryPath(o journalOrdinal) string {
+	return filepath.Join(j.journalPath(), o.String())
 }
 
-func (s *bserverTlfJournal) blocksPath() string {
-	return filepath.Join(s.dir, "blocks")
+func (j *bserverTlfJournal) blocksPath() string {
+	return filepath.Join(j.dir, "blocks")
 }
 
-func (s *bserverTlfJournal) blockPath(id BlockID) string {
+func (j *bserverTlfJournal) blockPath(id BlockID) string {
 	idStr := id.String()
-	return filepath.Join(s.blocksPath(), idStr[:4], idStr[4:])
+	return filepath.Join(j.blocksPath(), idStr[:4], idStr[4:])
 }
 
-func (s *bserverTlfJournal) blockDataPath(id BlockID) string {
-	return filepath.Join(s.blockPath(id), "data")
+func (j *bserverTlfJournal) blockDataPath(id BlockID) string {
+	return filepath.Join(j.blockPath(id), "data")
 }
 
-func (s *bserverTlfJournal) keyServerHalfPath(id BlockID) string {
-	return filepath.Join(s.blockPath(id), "key_server_half")
+func (j *bserverTlfJournal) keyServerHalfPath(id BlockID) string {
+	return filepath.Join(j.blockPath(id), "key_server_half")
 }
 
 // The functions below are for getting and setting the earliest and
 // latest ordinals.
 
-func (s *bserverTlfJournal) readOrdinalLocked(path string) (
+func (j *bserverTlfJournal) readOrdinalLocked(path string) (
 	journalOrdinal, error) {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -161,26 +161,26 @@ func (s *bserverTlfJournal) readOrdinalLocked(path string) (
 	return makeJournalOrdinal(string(buf))
 }
 
-func (s *bserverTlfJournal) writeOrdinalLocked(
+func (j *bserverTlfJournal) writeOrdinalLocked(
 	path string, o journalOrdinal) error {
 	return ioutil.WriteFile(path, []byte(o.String()), 0600)
 }
 
-func (s *bserverTlfJournal) readEarliestOrdinalLocked() (
+func (j *bserverTlfJournal) readEarliestOrdinalLocked() (
 	journalOrdinal, error) {
-	return s.readOrdinalLocked(s.earliestPath())
+	return j.readOrdinalLocked(j.earliestPath())
 }
 
-func (s *bserverTlfJournal) writeEarliestOrdinalLocked(o journalOrdinal) error {
-	return s.writeOrdinalLocked(s.earliestPath(), o)
+func (j *bserverTlfJournal) writeEarliestOrdinalLocked(o journalOrdinal) error {
+	return j.writeOrdinalLocked(j.earliestPath(), o)
 }
 
-func (s *bserverTlfJournal) readLatestOrdinalLocked() (journalOrdinal, error) {
-	return s.readOrdinalLocked(s.latestPath())
+func (j *bserverTlfJournal) readLatestOrdinalLocked() (journalOrdinal, error) {
+	return j.readOrdinalLocked(j.latestPath())
 }
 
-func (s *bserverTlfJournal) writeLatestOrdinalLocked(o journalOrdinal) error {
-	return s.writeOrdinalLocked(s.latestPath(), o)
+func (j *bserverTlfJournal) writeLatestOrdinalLocked(o journalOrdinal) error {
+	return j.writeOrdinalLocked(j.latestPath(), o)
 }
 
 type bserverOpName string
@@ -205,16 +205,16 @@ type bserverJournalEntry struct {
 
 // The functions below are for reading and writing journal entries.
 
-func (s *bserverTlfJournal) readJournalEntryLocked(o journalOrdinal) (
+func (j *bserverTlfJournal) readJournalEntryLocked(o journalOrdinal) (
 	bserverJournalEntry, error) {
-	p := s.journalEntryPath(o)
+	p := j.journalEntryPath(o)
 	buf, err := ioutil.ReadFile(p)
 	if err != nil {
 		return bserverJournalEntry{}, err
 	}
 
 	var e bserverJournalEntry
-	err = s.codec.Decode(buf, &e)
+	err = j.codec.Decode(buf, &e)
 	if err != nil {
 		return bserverJournalEntry{}, err
 	}
@@ -224,23 +224,23 @@ func (s *bserverTlfJournal) readJournalEntryLocked(o journalOrdinal) (
 
 // readJournalLocked reads the journal and returns a map of all the
 // block references in the journal.
-func (s *bserverTlfJournal) readJournalLocked() (
+func (j *bserverTlfJournal) readJournalLocked() (
 	map[BlockID]blockRefMap, error) {
 	refs := make(map[BlockID]blockRefMap)
 
-	first, err := s.readEarliestOrdinalLocked()
+	first, err := j.readEarliestOrdinalLocked()
 	if os.IsNotExist(err) {
 		return refs, nil
 	} else if err != nil {
 		return nil, err
 	}
-	last, err := s.readLatestOrdinalLocked()
+	last, err := j.readLatestOrdinalLocked()
 	if err != nil {
 		return nil, err
 	}
 
 	for i := first; i <= last; i++ {
-		e, err := s.readJournalEntryLocked(i)
+		e, err := j.readJournalEntryLocked(i)
 		if err != nil {
 			return nil, err
 		}
@@ -278,16 +278,16 @@ func (s *bserverTlfJournal) readJournalLocked() (
 	return refs, nil
 }
 
-func (s *bserverTlfJournal) writeJournalEntryLocked(
+func (j *bserverTlfJournal) writeJournalEntryLocked(
 	o journalOrdinal, e bserverJournalEntry) error {
-	err := os.MkdirAll(s.journalPath(), 0700)
+	err := os.MkdirAll(j.journalPath(), 0700)
 	if err != nil {
 		return err
 	}
 
-	p := s.journalEntryPath(o)
+	p := j.journalEntryPath(o)
 
-	buf, err := s.codec.Encode(e)
+	buf, err := j.codec.Encode(e)
 	if err != nil {
 		return err
 	}
@@ -295,12 +295,12 @@ func (s *bserverTlfJournal) writeJournalEntryLocked(
 	return ioutil.WriteFile(p, buf, 0600)
 }
 
-func (s *bserverTlfJournal) appendJournalEntryLocked(
+func (j *bserverTlfJournal) appendJournalEntryLocked(
 	op bserverOpName, id BlockID, contexts []BlockContext) error {
 	// TODO: Consider caching the latest ordinal in memory instead
 	// of reading it from disk every time.
 	var next journalOrdinal
-	o, err := s.readLatestOrdinalLocked()
+	o, err := j.readLatestOrdinalLocked()
 	if os.IsNotExist(err) {
 		next = 0
 	} else if err != nil {
@@ -314,7 +314,7 @@ func (s *bserverTlfJournal) appendJournalEntryLocked(
 		}
 	}
 
-	err = s.writeJournalEntryLocked(next, bserverJournalEntry{
+	err = j.writeJournalEntryLocked(next, bserverJournalEntry{
 		Op:       op,
 		ID:       id,
 		Contexts: contexts,
@@ -323,34 +323,34 @@ func (s *bserverTlfJournal) appendJournalEntryLocked(
 		return err
 	}
 
-	_, err = s.readEarliestOrdinalLocked()
+	_, err = j.readEarliestOrdinalLocked()
 	if os.IsNotExist(err) {
-		s.writeEarliestOrdinalLocked(next)
+		j.writeEarliestOrdinalLocked(next)
 	} else if err != nil {
 		return err
 	}
-	return s.writeLatestOrdinalLocked(next)
+	return j.writeLatestOrdinalLocked(next)
 }
 
-func (s *bserverTlfJournal) journalLength() (uint64, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	first, err := s.readEarliestOrdinalLocked()
+func (j *bserverTlfJournal) journalLength() (uint64, error) {
+	j.lock.RLock()
+	defer j.lock.RUnlock()
+	first, err := j.readEarliestOrdinalLocked()
 	if os.IsNotExist(err) {
 		return 0, nil
 	} else if err != nil {
 		return 0, err
 	}
-	last, err := s.readLatestOrdinalLocked()
+	last, err := j.readLatestOrdinalLocked()
 	if err != nil {
 		return 0, err
 	}
 	return uint64(last - first + 1), nil
 }
 
-func (s *bserverTlfJournal) getRefEntryLocked(
+func (j *bserverTlfJournal) getRefEntryLocked(
 	id BlockID, refNonce BlockRefNonce) (blockRefEntry, error) {
-	refs := s.refs[id]
+	refs := j.refs[id]
 	if refs == nil {
 		return blockRefEntry{}, BServerErrorBlockNonExistent{}
 	}
@@ -367,16 +367,16 @@ var errBserverTlfJournalShutdown = errors.New("bserverTlfJournal is shutdown")
 
 // getDataLocked verifies the block data for the given ID and context
 // and returns it.
-func (s *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
+func (j *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
 	[]byte, BlockCryptKeyServerHalf, error) {
-	if s.isShutdown {
+	if j.isShutdown {
 		return nil, BlockCryptKeyServerHalf{},
 			errBserverTlfJournalShutdown
 	}
 
 	// Check arguments.
 
-	refEntry, err := s.getRefEntryLocked(id, context.GetRefNonce())
+	refEntry, err := j.getRefEntryLocked(id, context.GetRefNonce())
 	if err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
@@ -388,7 +388,7 @@ func (s *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
 
 	// Read files.
 
-	data, err := ioutil.ReadFile(s.blockDataPath(id))
+	data, err := ioutil.ReadFile(j.blockDataPath(id))
 	if os.IsNotExist(err) {
 		return nil, BlockCryptKeyServerHalf{},
 			BServerErrorBlockNonExistent{}
@@ -396,7 +396,7 @@ func (s *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
 
-	keyServerHalfPath := s.keyServerHalfPath(id)
+	keyServerHalfPath := j.keyServerHalfPath(id)
 	buf, err := ioutil.ReadFile(keyServerHalfPath)
 	if os.IsNotExist(err) {
 		return nil, BlockCryptKeyServerHalf{},
@@ -407,7 +407,7 @@ func (s *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
 
 	// Check integrity.
 
-	dataID, err := s.crypto.MakePermanentBlockID(data)
+	dataID, err := j.crypto.MakePermanentBlockID(data)
 	if err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
@@ -426,9 +426,9 @@ func (s *bserverTlfJournal) getDataLocked(id BlockID, context BlockContext) (
 	return data, serverHalf, nil
 }
 
-func (s *bserverTlfJournal) putRefEntryLocked(
+func (j *bserverTlfJournal) putRefEntryLocked(
 	id BlockID, refEntry blockRefEntry) error {
-	existingRefEntry, err := s.getRefEntryLocked(
+	existingRefEntry, err := j.getRefEntryLocked(
 		id, refEntry.Context.GetRefNonce())
 	var exists bool
 	switch err.(type) {
@@ -447,35 +447,35 @@ func (s *bserverTlfJournal) putRefEntryLocked(
 		}
 	}
 
-	if s.refs[id] == nil {
-		s.refs[id] = make(blockRefMap)
+	if j.refs[id] == nil {
+		j.refs[id] = make(blockRefMap)
 	}
 
-	s.refs[id].put(refEntry.Context, refEntry.Status)
+	j.refs[id].put(refEntry.Context, refEntry.Status)
 	return nil
 }
 
 // All functions below are public functions.
 
-func (s *bserverTlfJournal) getData(id BlockID, context BlockContext) (
+func (j *bserverTlfJournal) getData(id BlockID, context BlockContext) (
 	[]byte, BlockCryptKeyServerHalf, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.getDataLocked(id, context)
+	j.lock.RLock()
+	defer j.lock.RUnlock()
+	return j.getDataLocked(id, context)
 }
 
-func (s *bserverTlfJournal) getAll() (
+func (j *bserverTlfJournal) getAll() (
 	map[BlockID]map[BlockRefNonce]blockRefLocalStatus, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
+	j.lock.RLock()
+	defer j.lock.RUnlock()
 
-	if s.isShutdown {
+	if j.isShutdown {
 		return nil, errBserverTlfJournalShutdown
 	}
 
 	res := make(map[BlockID]map[BlockRefNonce]blockRefLocalStatus)
 
-	for id, refs := range s.refs {
+	for id, refs := range j.refs {
 		if len(refs) == 0 {
 			continue
 		}
@@ -489,22 +489,22 @@ func (s *bserverTlfJournal) getAll() (
 	return res, nil
 }
 
-func (s *bserverTlfJournal) putData(
+func (j *bserverTlfJournal) putData(
 	id BlockID, context BlockContext, buf []byte,
 	serverHalf BlockCryptKeyServerHalf) error {
-	err := validateBlockServerPut(s.crypto, id, context, buf)
+	err := validateBlockServerPut(j.crypto, id, context, buf)
 	if err != nil {
 		return err
 	}
 
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	j.lock.Lock()
+	defer j.lock.Unlock()
 
-	if s.isShutdown {
+	if j.isShutdown {
 		return errBserverTlfJournalShutdown
 	}
 
-	_, existingServerHalf, err := s.getDataLocked(id, context)
+	_, existingServerHalf, err := j.getDataLocked(id, context)
 	var exists bool
 	switch err.(type) {
 	case BServerErrorBlockNonExistent:
@@ -530,12 +530,12 @@ func (s *bserverTlfJournal) putData(
 		}
 	}
 
-	err = os.MkdirAll(s.blockPath(id), 0700)
+	err = os.MkdirAll(j.blockPath(id), 0700)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(s.blockDataPath(id), buf, 0600)
+	err = ioutil.WriteFile(j.blockDataPath(id), buf, 0600)
 	if err != nil {
 		return err
 	}
@@ -543,12 +543,12 @@ func (s *bserverTlfJournal) putData(
 	// TODO: Add integrity-checking for key server half?
 
 	err = ioutil.WriteFile(
-		s.keyServerHalfPath(id), serverHalf.data[:], 0600)
+		j.keyServerHalfPath(id), serverHalf.data[:], 0600)
 	if err != nil {
 		return err
 	}
 
-	err = s.putRefEntryLocked(id, blockRefEntry{
+	err = j.putRefEntryLocked(id, blockRefEntry{
 		Status:  liveBlockRef,
 		Context: context,
 	})
@@ -556,19 +556,19 @@ func (s *bserverTlfJournal) putData(
 		return err
 	}
 
-	return s.appendJournalEntryLocked(
+	return j.appendJournalEntryLocked(
 		blockPutOp, id, []BlockContext{context})
 }
 
-func (s *bserverTlfJournal) addReference(id BlockID, context BlockContext) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+func (j *bserverTlfJournal) addReference(id BlockID, context BlockContext) error {
+	j.lock.Lock()
+	defer j.lock.Unlock()
 
-	if s.isShutdown {
+	if j.isShutdown {
 		return errBserverTlfJournalShutdown
 	}
 
-	refs := s.refs[id]
+	refs := j.refs[id]
 	if refs == nil {
 		return BServerErrorBlockNonExistent{fmt.Sprintf("Block ID %s "+
 			"doesn't exist and cannot be referenced.", id)}
@@ -593,7 +593,7 @@ func (s *bserverTlfJournal) addReference(id BlockID, context BlockContext) error
 	// no references at all. Also figure out what to do with an
 	// addReference without a preceding Put.
 
-	err := s.putRefEntryLocked(id, blockRefEntry{
+	err := j.putRefEntryLocked(id, blockRefEntry{
 		Status:  liveBlockRef,
 		Context: context,
 	})
@@ -601,20 +601,20 @@ func (s *bserverTlfJournal) addReference(id BlockID, context BlockContext) error
 		return err
 	}
 
-	return s.appendJournalEntryLocked(
+	return j.appendJournalEntryLocked(
 		addRefOp, id, []BlockContext{context})
 }
 
-func (s *bserverTlfJournal) removeReferences(
+func (j *bserverTlfJournal) removeReferences(
 	id BlockID, contexts []BlockContext) (int, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	j.lock.Lock()
+	defer j.lock.Unlock()
 
-	if s.isShutdown {
+	if j.isShutdown {
 		return 0, errBserverTlfJournalShutdown
 	}
 
-	refs := s.refs[id]
+	refs := j.refs[id]
 	if refs == nil {
 		// This block is already gone; no error.
 		return 0, nil
@@ -636,7 +636,7 @@ func (s *bserverTlfJournal) removeReferences(
 
 	count := len(refs)
 	if count == 0 {
-		err := os.RemoveAll(s.blockPath(id))
+		err := os.RemoveAll(j.blockPath(id))
 		if err != nil {
 			return 0, err
 		}
@@ -645,7 +645,7 @@ func (s *bserverTlfJournal) removeReferences(
 	// TODO: Figure out what to do with live count when we have a
 	// real block server backend.
 
-	err := s.appendJournalEntryLocked(removeRefsOp, id, contexts)
+	err := j.appendJournalEntryLocked(removeRefsOp, id, contexts)
 	if err != nil {
 		return 0, err
 	}
@@ -653,18 +653,18 @@ func (s *bserverTlfJournal) removeReferences(
 	return count, nil
 }
 
-func (s *bserverTlfJournal) archiveReferences(
+func (j *bserverTlfJournal) archiveReferences(
 	id BlockID, contexts []BlockContext) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	j.lock.Lock()
+	defer j.lock.Unlock()
 
-	if s.isShutdown {
+	if j.isShutdown {
 		return errBserverTlfJournalShutdown
 	}
 
 	for _, context := range contexts {
 		refNonce := context.GetRefNonce()
-		refEntry, err := s.getRefEntryLocked(id, refNonce)
+		refEntry, err := j.getRefEntryLocked(id, refNonce)
 		switch err.(type) {
 		case BServerErrorBlockNonExistent:
 			return BServerErrorBlockNonExistent{
@@ -686,27 +686,27 @@ func (s *bserverTlfJournal) archiveReferences(
 		}
 
 		refEntry.Status = archivedBlockRef
-		err = s.putRefEntryLocked(id, refEntry)
+		err = j.putRefEntryLocked(id, refEntry)
 		if err != nil {
 			return err
 		}
 	}
 
-	return s.appendJournalEntryLocked(archiveRefsOp, id, contexts)
+	return j.appendJournalEntryLocked(archiveRefsOp, id, contexts)
 }
 
-func (s *bserverTlfJournal) shutdown() {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	s.isShutdown = true
+func (j *bserverTlfJournal) shutdown() {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	j.isShutdown = true
 
 	// Double-check the on-disk journal with the in-memory one.
-	refs, err := s.readJournalLocked()
+	refs, err := j.readJournalLocked()
 	if err != nil {
 		panic(err)
 	}
 
-	if !reflect.DeepEqual(refs, s.refs) {
-		panic(fmt.Sprintf("refs = %v != s.refs = %v", refs, s.refs))
+	if !reflect.DeepEqual(refs, j.refs) {
+		panic(fmt.Sprintf("refs = %v != j.refs = %v", refs, j.refs))
 	}
 }

--- a/libkbfs/bserver_tlf_journal_test.go
+++ b/libkbfs/bserver_tlf_journal_test.go
@@ -23,7 +23,7 @@ func TestBserverTlfJournalBasic(t *testing.T) {
 	codec := NewCodecMsgpack()
 	crypto := makeTestCryptoCommon(t)
 
-	tempdir, err := ioutil.TempDir(os.TempDir(), "bserver_tlf_storage")
+	tempdir, err := ioutil.TempDir(os.TempDir(), "bserver_tlf_journal")
 	require.NoError(t, err)
 	defer func() {
 		err := os.RemoveAll(tempdir)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -512,12 +512,12 @@ func (fbo *folderBranchOps) setHeadLocked(
 	if !isFirstHead {
 		wasReadable = fbo.head.IsReadable()
 
-		mdID, err := md.MetadataID(fbo.config)
+		mdID, err := md.MetadataID(fbo.config.Crypto())
 		if err != nil {
 			return err
 		}
 
-		headID, err := fbo.head.MetadataID(fbo.config)
+		headID, err := fbo.head.MetadataID(fbo.config.Crypto())
 		if err != nil {
 			return err
 		}
@@ -619,7 +619,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 		return fbo.setInitialHeadTrustedLocked(ctx, lState, md)
 	}
 
-	err := fbo.head.CheckValidSuccessor(fbo.config, md)
+	err := fbo.head.CheckValidSuccessor(fbo.config.Crypto(), md)
 	if err != nil {
 		return err
 	}
@@ -689,7 +689,7 @@ func (fbo *folderBranchOps) setHeadPredecessorLocked(ctx context.Context,
 		return errors.New("Unexpected merged head in setHeadPredecessorLocked")
 	}
 
-	err := md.CheckValidSuccessor(fbo.config, fbo.head)
+	err := md.CheckValidSuccessor(fbo.config.Crypto(), fbo.head)
 	if err != nil {
 		return err
 	}
@@ -999,7 +999,7 @@ func (fbo *folderBranchOps) initMDLocked(
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
 	if fbo.head != nil {
-		headID, _ := fbo.head.MetadataID(fbo.config)
+		headID, _ := fbo.head.MetadataID(fbo.config.Crypto())
 		return fmt.Errorf(
 			"%v: Unexpected MD ID during new MD initialization: %v",
 			md.ID, headID)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -366,7 +366,8 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 		}
 
 		if prevMD != nil {
-			err := prevMD.CheckValidSuccessor(md.config, &r.MD)
+			err := prevMD.CheckValidSuccessor(
+				md.config.Crypto(), &r.MD)
 			if err != nil {
 				return nil, MDMismatchError{
 					handle.GetCanonicalPath(),

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -137,8 +137,7 @@ func (md *MDServerDisk) getStorage(tlfID TlfID) (*mdServerTlfStorage, error) {
 	}
 
 	path := filepath.Join(md.dirPath, tlfID.String())
-	storage, err = makeMDServerTlfStorage(
-		md.codec, md.clock, md.crypto, path)
+	storage, err = makeMDServerTlfStorage(md.codec, md.crypto, path)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -41,7 +41,7 @@ type mdServerDiskShared struct {
 type MDServerDisk struct {
 	codec  Codec
 	clock  Clock
-	crypto Crypto
+	crypto cryptoPure
 	kbpki  KBPKI
 	log    logger.Logger
 

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -440,7 +440,8 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 
 	// Consistency checks
 	if head != nil {
-		err := head.MD.CheckValidSuccessorForServer(md.config, &rmds.MD)
+		err := head.MD.CheckValidSuccessorForServer(
+			md.config.Crypto(), &rmds.MD)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -294,6 +294,12 @@ func (md *MDServerDisk) TruncateLock(ctx context.Context, id TlfID) (
 		return false, MDServerError{err}
 	}
 
+	md.lock.Lock()
+	defer md.lock.Unlock()
+	if md.truncateLockManager == nil {
+		return false, errMDServerDiskShutdown
+	}
+
 	return md.truncateLockManager.truncateLock(key.kid, id)
 }
 
@@ -303,6 +309,12 @@ func (md *MDServerDisk) TruncateUnlock(ctx context.Context, id TlfID) (
 	key, err := md.kbpki.GetCurrentCryptPublicKey(ctx)
 	if err != nil {
 		return false, MDServerError{err}
+	}
+
+	md.lock.Lock()
+	defer md.lock.Unlock()
+	if md.truncateLockManager == nil {
+		return false, errMDServerDiskShutdown
 	}
 
 	return md.truncateLockManager.truncateUnlock(key.kid, id)

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -5,10 +5,7 @@
 package libkbfs
 
 import (
-	"bytes"
-	"encoding/binary"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -20,7 +17,6 @@ import (
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
-	"github.com/syndtr/goleveldb/leveldb/util"
 	"golang.org/x/net/context"
 )
 
@@ -28,14 +24,16 @@ import (
 
 // MDServerDisk just stores blocks in local leveldb instances.
 type MDServerDisk struct {
-	config   Config
-	handleDb *leveldb.DB // folder handle                  -> folderId
-	mdDb     *leveldb.DB // folderId+[branchId]+[revision] -> mdBlockLocal
-	branchDb *leveldb.DB // folderId+deviceKID             -> branchId
+	codec    Codec
+	clock    Clock
+	crypto   Crypto
+	kbpki    KBPKI
+	handleDb *leveldb.DB // folder handle -> folderId
 	log      logger.Logger
+	dirPath  string
 
-	locksMutex *sync.Mutex
-	locksDb    *leveldb.DB // folderId -> deviceKID
+	tlfStorageLock *sync.RWMutex
+	tlfStorage     map[TlfID]*mdServerTlfStorage
 
 	updateManager *mdServerLocalUpdateManager
 
@@ -54,47 +52,21 @@ type mdBlockLocal struct {
 func newMDServerDisk(config Config, dirPath string,
 	shutdownFunc func(logger.Logger)) (*MDServerDisk, error) {
 	handlePath := filepath.Join(dirPath, "handles")
-	mdPath := filepath.Join(dirPath, "md")
-	branchPath := filepath.Join(dirPath, "branches")
 
 	handleStorage, err := storage.OpenFile(handlePath)
 	if err != nil {
 		return nil, err
 	}
 
-	mdStorage, err := storage.OpenFile(mdPath)
-	if err != nil {
-		return nil, err
-	}
-
-	branchStorage, err := storage.OpenFile(branchPath)
-	if err != nil {
-		return nil, err
-	}
-
-	// Always use memory for the lock storage, so it gets wiped after
-	// a restart.
-	lockStorage := storage.NewMemStorage()
-
 	handleDb, err := leveldb.Open(handleStorage, leveldbOptions)
 	if err != nil {
 		return nil, err
 	}
-	mdDb, err := leveldb.Open(mdStorage, leveldbOptions)
-	if err != nil {
-		return nil, err
-	}
-	branchDb, err := leveldb.Open(branchStorage, leveldbOptions)
-	if err != nil {
-		return nil, err
-	}
-	locksDb, err := leveldb.Open(lockStorage, leveldbOptions)
-	if err != nil {
-		return nil, err
-	}
 	log := config.MakeLogger("")
-	mdserv := &MDServerDisk{config, handleDb, mdDb, branchDb, log,
-		&sync.Mutex{}, locksDb, newMDServerLocalUpdateManager(),
+	mdserv := &MDServerDisk{config.Codec(), config.Clock(),
+		config.Crypto(), config.KBPKI(), handleDb, log, dirPath,
+		&sync.RWMutex{}, make(map[TlfID]*mdServerTlfStorage),
+		newMDServerLocalUpdateManager(),
 		&sync.RWMutex{}, new(bool), shutdownFunc}
 	return mdserv, nil
 }
@@ -120,6 +92,48 @@ func NewMDServerTempDir(config Config) (*MDServerDisk, error) {
 	})
 }
 
+var errMDServerDiskShutdown = errors.New("MDServerDisk is shutdown")
+
+func (md *MDServerDisk) getStorage(tlfID TlfID) (*mdServerTlfStorage, error) {
+	storage, err := func() (*mdServerTlfStorage, error) {
+		md.tlfStorageLock.RLock()
+		defer md.tlfStorageLock.RUnlock()
+		if md.tlfStorage == nil {
+			return nil, errMDServerDiskShutdown
+		}
+		return md.tlfStorage[tlfID], nil
+	}()
+
+	if err != nil {
+		return nil, err
+	}
+
+	if storage != nil {
+		return storage, nil
+	}
+
+	md.tlfStorageLock.Lock()
+	defer md.tlfStorageLock.Unlock()
+	if md.tlfStorage == nil {
+		return nil, errMDServerDiskShutdown
+	}
+
+	storage = md.tlfStorage[tlfID]
+	if storage != nil {
+		return storage, nil
+	}
+
+	path := filepath.Join(md.dirPath, tlfID.String())
+	storage, err = makeMDServerTlfStorage(
+		md.codec, md.clock, md.crypto, path)
+	if err != nil {
+		return nil, err
+	}
+
+	md.tlfStorage[tlfID] = storage
+	return storage, nil
+}
+
 // GetForHandle implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForHandle(ctx context.Context, handle BareTlfHandle,
 	mStatus MergeStatus) (TlfID, *RootMetadataSigned, error) {
@@ -130,7 +144,7 @@ func (md *MDServerDisk) GetForHandle(ctx context.Context, handle BareTlfHandle,
 		return id, nil, errors.New("MD server already shut down")
 	}
 
-	handleBytes, err := md.config.Codec().Encode(handle)
+	handleBytes, err := md.codec.Encode(handle)
 	if err != nil {
 		return id, nil, err
 	}
@@ -150,7 +164,7 @@ func (md *MDServerDisk) GetForHandle(ctx context.Context, handle BareTlfHandle,
 	}
 
 	// Non-readers shouldn't be able to create the dir.
-	_, uid, err := md.config.KBPKI().GetCurrentUserInfo(ctx)
+	_, uid, err := md.kbpki.GetCurrentUserInfo(ctx)
 	if err != nil {
 		return id, nil, err
 	}
@@ -159,7 +173,7 @@ func (md *MDServerDisk) GetForHandle(ctx context.Context, handle BareTlfHandle,
 	}
 
 	// Allocate a new random ID.
-	id, err = md.config.Crypto().MakeRandomTlfID(handle.IsPublic())
+	id, err = md.crypto.MakeRandomTlfID(handle.IsPublic())
 	if err != nil {
 		return id, nil, MDServerError{err}
 	}
@@ -174,138 +188,12 @@ func (md *MDServerDisk) GetForHandle(ctx context.Context, handle BareTlfHandle,
 // GetForTLF implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForTLF(ctx context.Context, id TlfID,
 	bid BranchID, mStatus MergeStatus) (*RootMetadataSigned, error) {
-	md.shutdownLock.RLock()
-	defer md.shutdownLock.RUnlock()
-	if *md.shutdown {
-		return nil, errors.New("MD server already shut down")
-	}
-
-	if mStatus == Merged && bid != NullBranchID {
-		return nil, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
-
-	mergedMasterHead, err :=
-		md.getHeadForTLF(ctx, id, NullBranchID, Merged)
-	if err != nil {
-		return nil, MDServerError{err}
-	}
-
-	// Check permissions
-	ok, err := isReader(
-		ctx, md.config.Codec(), md.config.KBPKI(), mergedMasterHead)
-	if err != nil {
-		return nil, MDServerError{err}
-	}
-	if !ok {
-		return nil, MDServerErrorUnauthorized{}
-	}
-
-	// Lookup the branch ID if not supplied
-	if mStatus == Unmerged && bid == NullBranchID {
-		bid, err = md.getBranchID(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		if bid == NullBranchID {
-			return nil, nil
-		}
-	}
-
-	rmds, err := md.getHeadForTLF(ctx, id, bid, mStatus)
-	if err != nil {
-		return nil, MDServerError{err}
-	}
-	return rmds, nil
-}
-
-func (md *MDServerDisk) rmdsFromBlockBytes(buf []byte) (
-	*RootMetadataSigned, error) {
-	block := new(mdBlockLocal)
-	err := md.config.Codec().Decode(buf, block)
+	tlfStorage, err := md.getStorage(id)
 	if err != nil {
 		return nil, err
 	}
-	block.MD.untrustedServerTimestamp = block.Timestamp
-	return block.MD, nil
-}
 
-func (md *MDServerDisk) getHeadForTLF(ctx context.Context, id TlfID,
-	bid BranchID, mStatus MergeStatus) (rmds *RootMetadataSigned, err error) {
-	key, err := md.getMDKey(id, 0, bid, mStatus)
-	if err != nil {
-		return
-	}
-	buf, err := md.mdDb.Get(key[:], nil)
-	if err != nil {
-		if err == leveldb.ErrNotFound {
-			rmds, err = nil, nil
-			return
-		}
-		return
-	}
-	return md.rmdsFromBlockBytes(buf)
-}
-
-func (md *MDServerDisk) getMDKey(id TlfID, revision MetadataRevision,
-	bid BranchID, mStatus MergeStatus) ([]byte, error) {
-	// short-cut
-	if revision == MetadataRevisionUninitialized && mStatus == Merged {
-		return id.Bytes(), nil
-	}
-	buf := &bytes.Buffer{}
-
-	// add folder id
-	_, err := buf.Write(id.Bytes())
-	if err != nil {
-		return []byte{}, err
-	}
-
-	// this order is signifcant for range fetches.
-	// we want increments in revision number to only affect
-	// the least significant bits of the key.
-	if mStatus == Unmerged {
-		// add branch ID
-		_, err = buf.Write(bid.Bytes())
-		if err != nil {
-			return []byte{}, err
-		}
-	}
-
-	if revision >= MetadataRevisionInitial {
-		// add revision
-		err = binary.Write(buf, binary.BigEndian, revision.Number())
-		if err != nil {
-			return []byte{}, err
-		}
-	}
-	return buf.Bytes(), nil
-}
-
-func (md *MDServerDisk) getBranchKey(ctx context.Context, id TlfID) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	// add folder id
-	_, err := buf.Write(id.Bytes())
-	if err != nil {
-		return []byte{}, err
-	}
-	// add device KID
-	deviceKID, err := md.getCurrentDeviceKID(ctx)
-	if err != nil {
-		return []byte{}, err
-	}
-	_, err = buf.Write(deviceKID.ToBytes())
-	if err != nil {
-		return []byte{}, err
-	}
-	return buf.Bytes(), nil
-}
-
-func (md *MDServerDisk) getCurrentDeviceKID(ctx context.Context) (keybase1.KID, error) {
-	key, err := md.config.KBPKI().GetCurrentCryptPublicKey(ctx)
-	if err != nil {
-		return keybase1.KID(""), err
-	}
-	return key.kid, nil
+	return tlfStorage.getForTLF(ctx, md.kbpki, bid, mStatus)
 }
 
 // GetRange implements the MDServer interface for MDServerDisk.
@@ -313,191 +201,33 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id TlfID,
 	bid BranchID, mStatus MergeStatus, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
-	md.shutdownLock.RLock()
-	defer md.shutdownLock.RUnlock()
-	if *md.shutdown {
-		return nil, errors.New("MD server already shut down")
-	}
 
-	if mStatus == Merged && bid != NullBranchID {
-		return nil, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
-
-	mergedMasterHead, err :=
-		md.getHeadForTLF(ctx, id, NullBranchID, Merged)
+	tlfStorage, err := md.getStorage(id)
 	if err != nil {
-		return nil, MDServerError{err}
+		return nil, err
 	}
 
-	// Check permissions
-	ok, err := isReader(
-		ctx, md.config.Codec(), md.config.KBPKI(), mergedMasterHead)
-	if err != nil {
-		return nil, MDServerError{err}
-	}
-	if !ok {
-		return nil, MDServerErrorUnauthorized{}
-	}
-
-	// Lookup the branch ID if not supplied
-	if mStatus == Unmerged && bid == NullBranchID {
-		bid, err = md.getBranchID(ctx, id)
-		if err != nil {
-			return nil, err
-		}
-		if bid == NullBranchID {
-			return nil, nil
-		}
-	}
-
-	var rmdses []*RootMetadataSigned
-	startKey, err := md.getMDKey(id, start, bid, mStatus)
-	if err != nil {
-		return rmdses, MDServerError{err}
-	}
-	stopKey, err := md.getMDKey(id, stop+1, bid, mStatus)
-	if err != nil {
-		return rmdses, MDServerError{err}
-	}
-
-	iter := md.mdDb.NewIterator(&util.Range{Start: startKey, Limit: stopKey}, nil)
-	defer iter.Release()
-	for iter.Next() {
-		buf := iter.Value()
-		rmds, err := md.rmdsFromBlockBytes(buf)
-		if err != nil {
-			return rmdses, MDServerError{err}
-		}
-		rmdses = append(rmdses, rmds)
-	}
-	if err := iter.Error(); err != nil {
-		return rmdses, MDServerError{err}
-	}
-
-	return rmdses, nil
+	return tlfStorage.getRange(ctx, md.kbpki, bid, mStatus, start, stop)
 }
 
 // Put implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error {
-	md.shutdownLock.RLock()
-	defer md.shutdownLock.RUnlock()
-	if *md.shutdown {
-		return errors.New("MD server already shut down")
+	tlfStorage, err := md.getStorage(rmds.MD.ID)
+	if err != nil {
+		return err
+	}
+
+	err = tlfStorage.put(ctx, md.kbpki, rmds)
+	if err != nil {
+		return err
 	}
 
 	mStatus := rmds.MD.MergedStatus()
-	bid := rmds.MD.BID
-
-	if mStatus == Merged {
-		if bid != NullBranchID {
-			return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-		}
-	} else if bid == NullBranchID {
-		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
-
-	id := rmds.MD.ID
-
-	mergedMasterHead, err :=
-		md.getHeadForTLF(ctx, id, NullBranchID, Merged)
-	if err != nil {
-		return MDServerError{err}
-	}
-
-	// Check permissions
-	ok, err := isWriterOrValidRekey(
-		ctx, md.config.Codec(), md.config.KBPKI(),
-		mergedMasterHead, rmds)
-	if err != nil {
-		return MDServerError{err}
-	}
-	if !ok {
-		return MDServerErrorUnauthorized{}
-	}
-
-	head, err := md.getHeadForTLF(ctx, id, bid, mStatus)
-	if err != nil {
-		return MDServerError{err}
-	}
-
-	var recordBranchID bool
-
-	if mStatus == Unmerged && head == nil {
-		// currHead for unmerged history might be on the main branch
-		prevRev := rmds.MD.Revision - 1
-		rmdses, err := md.GetRange(ctx, id, NullBranchID, Merged, prevRev, prevRev)
-		if err != nil {
-			return MDServerError{err}
-		}
-		if len(rmdses) != 1 {
-			return MDServerError{
-				Err: fmt.Errorf("Expected 1 MD block got %d", len(rmdses)),
-			}
-		}
-		head = rmdses[0]
-		recordBranchID = true
-	}
-
-	// Consistency checks
-	if head != nil {
-		err := head.MD.CheckValidSuccessorForServer(
-			md.config.Crypto(), &rmds.MD)
-		if err != nil {
-			return err
-		}
-	}
-
-	// Record branch ID
-	if recordBranchID {
-		buf, err := md.config.Codec().Encode(bid)
-		if err != nil {
-			return MDServerError{err}
-		}
-		branchKey, err := md.getBranchKey(ctx, id)
-		if err != nil {
-			return MDServerError{err}
-		}
-		err = md.branchDb.Put(branchKey, buf, nil)
-		if err != nil {
-			return MDServerError{err}
-		}
-	}
-
-	block := &mdBlockLocal{rmds, md.config.Clock().Now()}
-	buf, err := md.config.Codec().Encode(block)
-	if err != nil {
-		return MDServerError{err}
-	}
-
-	// Wrap writes in a batch
-	batch := new(leveldb.Batch)
-
-	// Add an entry with the revision key.
-	revKey, err := md.getMDKey(id, rmds.MD.Revision, bid, mStatus)
-	if err != nil {
-		return MDServerError{err}
-	}
-	batch.Put(revKey, buf)
-
-	// Add an entry with the head key.
-	headKey, err := md.getMDKey(id, MetadataRevisionUninitialized,
-		bid, mStatus)
-	if err != nil {
-		return MDServerError{err}
-	}
-	batch.Put(headKey, buf)
-
-	// Write the batch.
-	err = md.mdDb.Write(batch, nil)
-	if err != nil {
-		return MDServerError{err}
-	}
-
 	if mStatus == Merged &&
 		// Don't send notifies if it's just a rekey (the real mdserver
 		// sends a "folder needs rekey" notification in this case).
 		!(rmds.MD.IsRekeySet() && rmds.MD.IsWriterMetadataCopiedSet()) {
-		md.updateManager.setHead(id, md)
+		md.updateManager.setHead(rmds.MD.ID, md)
 	}
 
 	return nil
@@ -505,61 +235,22 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 
 // PruneBranch implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) PruneBranch(ctx context.Context, id TlfID, bid BranchID) error {
-	md.shutdownLock.RLock()
-	defer md.shutdownLock.RUnlock()
-	if *md.shutdown {
-		return errors.New("MD server already shut down")
-	}
-	if bid == NullBranchID {
-		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
-
-	currBID, err := md.getBranchID(ctx, id)
+	tlfStorage, err := md.getStorage(id)
 	if err != nil {
 		return err
 	}
-	if currBID == NullBranchID || bid != currBID {
-		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
 
-	// Don't actually delete unmerged history. This is intentional to be consistent
-	// with the mdserver behavior-- it garbage collects discarded branches in the
-	// background.
-	branchKey, err := md.getBranchKey(ctx, id)
-	if err != nil {
-		return MDServerError{err}
-	}
-	err = md.branchDb.Delete(branchKey, nil)
-	if err != nil {
-		return MDServerError{err}
-	}
-
-	return nil
-}
-
-func (md *MDServerDisk) getBranchID(ctx context.Context, id TlfID) (BranchID, error) {
-	branchKey, err := md.getBranchKey(ctx, id)
-	if err != nil {
-		return NullBranchID, MDServerError{err}
-	}
-	buf, err := md.branchDb.Get(branchKey, nil)
-	if err == leveldb.ErrNotFound {
-		return NullBranchID, nil
-	}
-	if err != nil {
-		return NullBranchID, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
-	var bid BranchID
-	err = md.config.Codec().Decode(buf, &bid)
-	if err != nil {
-		return NullBranchID, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-	}
-	return bid, nil
+	return tlfStorage.pruneBranch(ctx, md.kbpki, bid)
 }
 
 func (md *MDServerDisk) getCurrentMergedHeadRevision(
 	ctx context.Context, id TlfID) (rev MetadataRevision, err error) {
-	head, err := md.getHeadForTLF(ctx, id, NullBranchID, Merged)
+	tlfStorage, err := md.getStorage(id)
+	if err != nil {
+		return 0, err
+	}
+
+	head, err := tlfStorage.getHeadForTLF(ctx, NullBranchID, Merged)
 	if err != nil {
 		return 0, err
 	}
@@ -572,12 +263,6 @@ func (md *MDServerDisk) getCurrentMergedHeadRevision(
 // RegisterForUpdate implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id TlfID,
 	currHead MetadataRevision) (<-chan error, error) {
-	md.shutdownLock.RLock()
-	defer md.shutdownLock.RUnlock()
-	if *md.shutdown {
-		return nil, errors.New("MD server already shut down")
-	}
-
 	// are we already past this revision?  If so, fire observer
 	// immediately
 	currMergedHeadRev, err := md.getCurrentMergedHeadRevision(ctx, id)
@@ -589,94 +274,26 @@ func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id TlfID,
 	return c, nil
 }
 
-func (md *MDServerDisk) getCurrentDeviceKIDBytes(ctx context.Context) (
-	[]byte, error) {
-	buf := &bytes.Buffer{}
-	deviceKID, err := md.getCurrentDeviceKID(ctx)
-	if err != nil {
-		return []byte{}, err
-	}
-	_, err = buf.Write(deviceKID.ToBytes())
-	if err != nil {
-		return []byte{}, err
-	}
-	return buf.Bytes(), nil
-}
-
-func getTruncateLockKey(id TlfID) ([]byte, error) {
-	buf := &bytes.Buffer{}
-	// add folder id
-	_, err := buf.Write(id.Bytes())
-	if err != nil {
-		return []byte{}, err
-	}
-	return buf.Bytes(), nil
-}
-
 // TruncateLock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateLock(ctx context.Context, id TlfID) (
 	bool, error) {
-	md.locksMutex.Lock()
-	defer md.locksMutex.Unlock()
-
-	key, err := getTruncateLockKey(id)
+	tlfStorage, err := md.getStorage(id)
 	if err != nil {
 		return false, err
 	}
 
-	myKID, err := md.getCurrentDeviceKIDBytes(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	lockBytes, err := md.locksDb.Get(key, nil)
-	if err == leveldb.ErrNotFound {
-		if err := md.locksDb.Put(key, myKID, nil); err != nil {
-			return false, err
-		}
-		return true, nil
-	} else if err != nil {
-		return false, err
-	} else if bytes.Equal(lockBytes, myKID) {
-		// idempotent
-		return true, nil
-	}
-
-	// Locked by someone else.
-	return false, MDServerErrorLocked{}
+	return tlfStorage.truncateLock(ctx, md.kbpki)
 }
 
 // TruncateUnlock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateUnlock(ctx context.Context, id TlfID) (
 	bool, error) {
-	md.locksMutex.Lock()
-	defer md.locksMutex.Unlock()
-
-	key, err := getTruncateLockKey(id)
+	tlfStorage, err := md.getStorage(id)
 	if err != nil {
 		return false, err
 	}
 
-	myKID, err := md.getCurrentDeviceKIDBytes(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	lockBytes, err := md.locksDb.Get(key, nil)
-	if err == leveldb.ErrNotFound {
-		// Already unlocked
-		return true, nil
-	} else if err != nil {
-		return false, err
-	} else if bytes.Equal(lockBytes, myKID) {
-		if err := md.locksDb.Delete(key, nil); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
-	// Locked by someone else.
-	return false, MDServerErrorLocked{}
+	return tlfStorage.truncateUnlock(ctx, md.kbpki)
 }
 
 // Shutdown implements the MDServer interface for MDServerDisk.
@@ -688,17 +305,21 @@ func (md *MDServerDisk) Shutdown() {
 	}
 	*md.shutdown = true
 
+	tlfStorage := func() map[TlfID]*mdServerTlfStorage {
+		md.tlfStorageLock.Lock()
+		defer md.tlfStorageLock.Unlock()
+		// Make further accesses error out.
+		tlfStorage := md.tlfStorage
+		md.tlfStorage = nil
+		return tlfStorage
+	}()
+
+	for _, s := range tlfStorage {
+		s.shutdown()
+	}
+
 	if md.handleDb != nil {
 		md.handleDb.Close()
-	}
-	if md.mdDb != nil {
-		md.mdDb.Close()
-	}
-	if md.branchDb != nil {
-		md.branchDb.Close()
-	}
-	if md.locksDb != nil {
-		md.locksDb.Close()
 	}
 
 	if md.shutdownFunc != nil {
@@ -720,8 +341,9 @@ func (md *MDServerDisk) copy(config Config) mdServerLocal {
 	// purpose, so that the MD server that gets a Put will notify all
 	// observers correctly no matter where they got on the list.
 	log := config.MakeLogger("")
-	return &MDServerDisk{config, md.handleDb, md.mdDb, md.branchDb, log,
-		md.locksMutex, md.locksDb, md.updateManager,
+	return &MDServerDisk{md.codec, md.clock, md.crypto, config.KBPKI(),
+		md.handleDb, log, md.dirPath, md.tlfStorageLock,
+		md.tlfStorage, md.updateManager,
 		md.shutdownLock, md.shutdown, md.shutdownFunc}
 }
 
@@ -761,7 +383,7 @@ func (md *MDServerDisk) addNewAssertionForTest(uid keybase1.UID,
 	for iter.Next() {
 		handleBytes := iter.Key()
 		var handle BareTlfHandle
-		err := md.config.Codec().Decode(handleBytes, &handle)
+		err := md.codec.Decode(handleBytes, &handle)
 		if err != nil {
 			return err
 		}
@@ -772,7 +394,7 @@ func (md *MDServerDisk) addNewAssertionForTest(uid keybase1.UID,
 		if reflect.DeepEqual(handle, newHandle) {
 			continue
 		}
-		newHandleBytes, err := md.config.Codec().Encode(newHandle)
+		newHandleBytes, err := md.codec.Encode(newHandle)
 		if err != nil {
 			return err
 		}
@@ -802,7 +424,7 @@ func (md *MDServerDisk) GetLatestHandleForTLF(_ context.Context, id TlfID) (
 		}
 		handleBytes := iter.Key()
 		handle = BareTlfHandle{}
-		err = md.config.Codec().Decode(handleBytes, &handle)
+		err = md.codec.Decode(handleBytes, &handle)
 		if err != nil {
 			return BareTlfHandle{}, err
 		}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -67,12 +67,17 @@ func newMDServerDisk(config Config, dirPath string,
 	}
 	log := config.MakeLogger("")
 	truncateLockManager := newMDServerLocalTruncatedLockManager()
-	mdserv := &MDServerDisk{config.Codec(),
-		config.Crypto(), config.KBPKI(), log, &mdServerDiskShared{
-			dirPath, sync.RWMutex{}, handleDb, branchDb,
-			make(map[TlfID]*mdServerTlfStorage),
-			&truncateLockManager,
-			newMDServerLocalUpdateManager(), shutdownFunc}}
+	shared := mdServerDiskShared{
+		dirPath:             dirPath,
+		handleDb:            handleDb,
+		branchDb:            branchDb,
+		tlfStorage:          make(map[TlfID]*mdServerTlfStorage),
+		truncateLockManager: &truncateLockManager,
+		updateManager:       newMDServerLocalUpdateManager(),
+		shutdownFunc:        shutdownFunc,
+	}
+	mdserv := &MDServerDisk{
+		config.Codec(), config.Crypto(), config.KBPKI(), log, &shared}
 	return mdserv, nil
 }
 

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -273,7 +273,7 @@ func (md *MDServerDisk) GetForTLF(ctx context.Context, id TlfID,
 		return nil, err
 	}
 
-	return tlfStorage.getForTLF(ctx, md.kbpki, bid, mStatus)
+	return tlfStorage.getForTLF(ctx, md.kbpki, bid)
 }
 
 // GetRange implements the MDServer interface for MDServerDisk.
@@ -299,7 +299,7 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id TlfID,
 		return nil, err
 	}
 
-	return tlfStorage.getRange(ctx, md.kbpki, bid, mStatus, start, stop)
+	return tlfStorage.getRange(ctx, md.kbpki, bid, start, stop)
 }
 
 // Put implements the MDServer interface for MDServerDisk.

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -239,12 +239,7 @@ func (md *MDServerDisk) PruneBranch(ctx context.Context, id TlfID, bid BranchID)
 
 func (md *MDServerDisk) getCurrentMergedHeadRevision(
 	ctx context.Context, id TlfID) (rev MetadataRevision, err error) {
-	tlfStorage, err := md.getStorage(id)
-	if err != nil {
-		return 0, err
-	}
-
-	head, err := tlfStorage.getHeadForTLF(ctx, NullBranchID, Merged)
+	head, err := md.GetForTLF(ctx, id, NullBranchID, Merged)
 	if err != nil {
 		return 0, err
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -19,8 +19,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TODO: Convert this to use flat files and a journal.
-
 // MDServerDisk just stores blocks in local leveldb instances.
 type MDServerDisk struct {
 	codec    Codec

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -43,7 +43,6 @@ type mdServerDiskShared struct {
 // MDServerDisk stores all info on disk.
 type MDServerDisk struct {
 	codec  Codec
-	clock  Clock
 	crypto cryptoPure
 	kbpki  KBPKI
 	log    logger.Logger
@@ -68,7 +67,7 @@ func newMDServerDisk(config Config, dirPath string,
 	}
 	log := config.MakeLogger("")
 	truncateLockManager := newMDServerLocalTruncatedLockManager()
-	mdserv := &MDServerDisk{config.Codec(), config.Clock(),
+	mdserv := &MDServerDisk{config.Codec(),
 		config.Crypto(), config.KBPKI(), log, &mdServerDiskShared{
 			dirPath, sync.RWMutex{}, handleDb, branchDb,
 			make(map[TlfID]*mdServerTlfStorage),
@@ -499,7 +498,7 @@ func (md *MDServerDisk) copy(config Config) mdServerLocal {
 	// purpose, so that the MD server that gets a Put will notify all
 	// observers correctly no matter where they got on the list.
 	log := config.MakeLogger("")
-	return &MDServerDisk{md.codec, md.clock, md.crypto, config.KBPKI(),
+	return &MDServerDisk{md.codec, md.crypto, config.KBPKI(),
 		log, md.mdServerDiskShared}
 }
 

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sync"
-	"time"
 
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -43,11 +42,6 @@ type MDServerDisk struct {
 }
 
 var _ mdServerLocal = (*MDServerDisk)(nil)
-
-type mdBlockLocal struct {
-	MD        *RootMetadataSigned
-	Timestamp time.Time
-}
 
 func newMDServerDisk(config Config, dirPath string,
 	shutdownFunc func(logger.Logger)) (*MDServerDisk, error) {

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 
+	keybase1 "github.com/keybase/client/go/protocol"
+
 	"golang.org/x/net/context"
 )
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -308,11 +308,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 	mStatus := rmds.MD.MergedStatus()
 	bid := rmds.MD.BID
 
-	if mStatus == Merged {
-		if bid != NullBranchID {
-			return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
-		}
-	} else if bid == NullBranchID {
+	if (mStatus == Merged) != (bid == NullBranchID) {
 		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
 	}
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -654,7 +654,7 @@ func (md *MDServerMemory) addNewAssertionForTest(uid keybase1.UID,
 
 func (md *MDServerMemory) getCurrentMergedHeadRevision(
 	ctx context.Context, id TlfID) (rev MetadataRevision, err error) {
-	head, err := md.getHeadForTLF(ctx, id, NullBranchID, Merged)
+	head, err := md.GetForTLF(ctx, id, NullBranchID, Merged)
 	if err != nil {
 		return 0, err
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -370,7 +370,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 
 	// Consistency checks
 	if head != nil {
-		err := head.MD.CheckValidSuccessorForServer(md.config, &rmds.MD)
+		err := head.MD.CheckValidSuccessorForServer(
+			md.config.Crypto(), &rmds.MD)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -78,10 +78,15 @@ func NewMDServerMemory(config Config) (*MDServerMemory, error) {
 	branchDb := make(map[mdBranchKey]BranchID)
 	log := config.MakeLogger("")
 	truncateLockManager := newMDServerLocalTruncatedLockManager()
-	mdserv := &MDServerMemory{config, log, &mdServerMemShared{
-		sync.RWMutex{}, handleDb, latestHandleDb, mdDb, branchDb,
-		&truncateLockManager,
-		newMDServerLocalUpdateManager()}}
+	shared := mdServerMemShared{
+		handleDb:            handleDb,
+		latestHandleDb:      latestHandleDb,
+		mdDb:                mdDb,
+		branchDb:            branchDb,
+		truncateLockManager: &truncateLockManager,
+		updateManager:       newMDServerLocalUpdateManager(),
+	}
+	mdserv := &MDServerMemory{config, log, &shared}
 	return mdserv, nil
 }
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -42,8 +42,9 @@ type mdBlockMemList struct {
 }
 
 type mdServerMemShared struct {
-	// Protects all *db variables. After Shutdown() is called, all
-	// *db variables and truncateLockManager are nil.
+	// Protects all *db variables and truncateLockManager. After
+	// Shutdown() is called, all *db variables and
+	// truncateLockManager are nil.
 	lock sync.RWMutex
 	// Bare TLF handle -> TLF ID
 	handleDb map[mdHandleKey]TlfID
@@ -52,10 +53,10 @@ type mdServerMemShared struct {
 	// (TLF ID, branch ID) -> list of MDs
 	mdDb map[mdBlockKey]mdBlockMemList
 	// (TLF ID, device KID) -> branch ID
-	branchDb map[mdBranchKey]BranchID
-
+	branchDb            map[mdBranchKey]BranchID
 	truncateLockManager *mdServerLocalTruncateLockManager
-	updateManager       *mdServerLocalUpdateManager
+
+	updateManager *mdServerLocalUpdateManager
 }
 
 // MDServerMemory just stores metadata objects in memory.

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -64,7 +64,7 @@ func TestMDServerBasics(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		prevRoot, err = rmds.MD.MetadataID(config)
+		prevRoot, err = rmds.MD.MetadataID(config.Crypto())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -112,7 +112,7 @@ func TestMDServerBasics(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		prevRoot, err = rmds.MD.MetadataID(config)
+		prevRoot, err = rmds.MD.MetadataID(config.Crypto())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -1,0 +1,72 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+type mdServerTlfStorage struct {
+	codec Codec
+	dir   string
+
+	// Protects any IO operations in dir or any of its children,
+	// as well all the DBs and isShutdown.
+	//
+	// TODO: Consider using https://github.com/pkg/singlefile
+	// instead.
+	lock sync.RWMutex
+
+	mdDb     *leveldb.DB // [branchId]+[revision] -> mdBlockLocal
+	branchDb *leveldb.DB // deviceKID             -> branchId
+
+	locksDb *leveldb.DB // folderId -> deviceKID
+
+	isShutdown bool
+}
+
+func makeMDServerTlfStorage(
+	codec Codec, dir string) (*mdServerTlfStorage, error) {
+	mdPath := filepath.Join(dir, "md")
+	branchPath := filepath.Join(dir, "branches")
+
+	mdStorage, err := storage.OpenFile(mdPath)
+	if err != nil {
+		return nil, err
+	}
+
+	branchStorage, err := storage.OpenFile(branchPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Always use memory for the lock storage, so it gets wiped after
+	// a restart.
+	lockStorage := storage.NewMemStorage()
+
+	mdDb, err := leveldb.Open(mdStorage, leveldbOptions)
+	if err != nil {
+		return nil, err
+	}
+	branchDb, err := leveldb.Open(branchStorage, leveldbOptions)
+	if err != nil {
+		return nil, err
+	}
+	locksDb, err := leveldb.Open(lockStorage, leveldbOptions)
+	if err != nil {
+		return nil, err
+	}
+	return &mdServerTlfStorage{
+		codec:    codec,
+		dir:      dir,
+		mdDb:     mdDb,
+		branchDb: branchDb,
+		locksDb:  locksDb,
+	}, nil
+}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -132,6 +133,11 @@ func (md *mdServerTlfStorage) getMDKey(revision MetadataRevision,
 		}
 	}
 	return buf.Bytes(), nil
+}
+
+type mdBlockLocal struct {
+	MD        *RootMetadataSigned
+	Timestamp time.Time
 }
 
 func (md *mdServerTlfStorage) rmdsFromBlockBytes(buf []byte) (

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -5,9 +5,15 @@
 package libkbfs
 
 import (
+	"bytes"
+	"encoding/binary"
+	"errors"
 	"path/filepath"
 	"sync"
 
+	"golang.org/x/net/context"
+
+	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 )
@@ -17,7 +23,7 @@ type mdServerTlfStorage struct {
 	dir   string
 
 	// Protects any IO operations in dir or any of its children,
-	// as well all the DBs and isShutdown.
+	// as well all the DBs, truncateLockHolder, and isShutdown.
 	//
 	// TODO: Consider using https://github.com/pkg/singlefile
 	// instead.
@@ -26,7 +32,9 @@ type mdServerTlfStorage struct {
 	mdDb     *leveldb.DB // [branchId]+[revision] -> mdBlockLocal
 	branchDb *leveldb.DB // deviceKID             -> branchId
 
-	locksDb *leveldb.DB // folderId -> deviceKID
+	// Store the truncate lock holder just in memory, so it gets
+	// wiped after a restart.
+	truncateLockHolder *keybase1.KID
 
 	isShutdown bool
 }
@@ -46,10 +54,6 @@ func makeMDServerTlfStorage(
 		return nil, err
 	}
 
-	// Always use memory for the lock storage, so it gets wiped after
-	// a restart.
-	lockStorage := storage.NewMemStorage()
-
 	mdDb, err := leveldb.Open(mdStorage, leveldbOptions)
 	if err != nil {
 		return nil, err
@@ -58,15 +62,141 @@ func makeMDServerTlfStorage(
 	if err != nil {
 		return nil, err
 	}
-	locksDb, err := leveldb.Open(lockStorage, leveldbOptions)
-	if err != nil {
-		return nil, err
-	}
 	return &mdServerTlfStorage{
 		codec:    codec,
 		dir:      dir,
 		mdDb:     mdDb,
 		branchDb: branchDb,
-		locksDb:  locksDb,
 	}, nil
+}
+
+func (md *mdServerTlfStorage) getBranchKey(ctx context.Context, kbpki KBPKI) ([]byte, error) {
+	key, err := kbpki.GetCurrentCryptPublicKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return key.kid.ToBytes(), nil
+}
+
+func (md *mdServerTlfStorage) getBranchID(ctx context.Context, kbpki KBPKI) (BranchID, error) {
+	branchKey, err := md.getBranchKey(ctx, kbpki)
+	if err != nil {
+		return NullBranchID, MDServerError{err}
+	}
+	buf, err := md.branchDb.Get(branchKey, nil)
+	if err == leveldb.ErrNotFound {
+		return NullBranchID, nil
+	}
+	if err != nil {
+		return NullBranchID, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
+	}
+	var bid BranchID
+	err = md.codec.Decode(buf, &bid)
+	if err != nil {
+		return NullBranchID, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
+	}
+	return bid, nil
+}
+
+func (md *mdServerTlfStorage) getMDKey(revision MetadataRevision,
+	bid BranchID, mStatus MergeStatus) ([]byte, error) {
+	// short-cut
+	if revision == MetadataRevisionUninitialized && mStatus == Merged {
+		return nil, nil
+	}
+	buf := &bytes.Buffer{}
+
+	// this order is signifcant for range fetches.
+	// we want increments in revision number to only affect
+	// the least significant bits of the key.
+	if mStatus == Unmerged {
+		// add branch ID
+		_, err := buf.Write(bid.Bytes())
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if revision >= MetadataRevisionInitial {
+		// add revision
+		err := binary.Write(buf, binary.BigEndian, revision.Number())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (md *mdServerTlfStorage) rmdsFromBlockBytes(buf []byte) (
+	*RootMetadataSigned, error) {
+	block := new(mdBlockLocal)
+	err := md.codec.Decode(buf, block)
+	if err != nil {
+		return nil, err
+	}
+	block.MD.untrustedServerTimestamp = block.Timestamp
+	return block.MD, nil
+}
+
+func (md *mdServerTlfStorage) getHeadForTLF(ctx context.Context,
+	bid BranchID, mStatus MergeStatus) (rmds *RootMetadataSigned, err error) {
+	key, err := md.getMDKey(0, bid, mStatus)
+	if err != nil {
+		return
+	}
+	buf, err := md.mdDb.Get(key[:], nil)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			rmds, err = nil, nil
+			return
+		}
+		return
+	}
+	return md.rmdsFromBlockBytes(buf)
+}
+
+func (md *mdServerTlfStorage) getForTLF(ctx context.Context,
+	kbpki KBPKI, bid BranchID, mStatus MergeStatus) (
+	*RootMetadataSigned, error) {
+	md.lock.RLock()
+	defer md.lock.RUnlock()
+
+	if md.isShutdown {
+		return nil, errors.New("MD server already shut down")
+	}
+
+	if mStatus == Merged && bid != NullBranchID {
+		return nil, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
+	}
+
+	mergedMasterHead, err := md.getHeadForTLF(ctx, NullBranchID, Merged)
+	if err != nil {
+		return nil, MDServerError{err}
+	}
+
+	// Check permissions
+	ok, err := isReader(ctx, md.codec, kbpki, mergedMasterHead)
+	if err != nil {
+		return nil, MDServerError{err}
+	}
+	if !ok {
+		return nil, MDServerErrorUnauthorized{}
+	}
+
+	// Lookup the branch ID if not supplied
+	if mStatus == Unmerged && bid == NullBranchID {
+		bid, err = md.getBranchID(ctx, kbpki)
+		if err != nil {
+			return nil, err
+		}
+		if bid == NullBranchID {
+			return nil, nil
+		}
+	}
+
+	rmds, err := md.getHeadForTLF(ctx, bid, mStatus)
+	if err != nil {
+		return nil, MDServerError{err}
+	}
+	return rmds, nil
 }

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -510,9 +510,9 @@ func (s *mdServerTlfStorage) pruneBranch(
 		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
 	}
 
-	// Don't actually delete unmerged history. This is intentional to be consistent
-	// with the mdserver behavior-- it garbage collects discarded branches in the
-	// background.
+	// Don't actually delete unmerged history. This is intentional
+	// to be consistent with the mdserver behavior-- it garbage
+	// collects discarded branches in the background.
 	branchKey, err := s.getBranchKey(ctx, kbpki)
 	if err != nil {
 		return MDServerError{err}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -88,13 +88,7 @@ func (s *mdServerTlfStorage) mdPath(id MdID) string {
 	return filepath.Join(s.mdsPath(), idStr[:4], idStr[4:])
 }
 
-var errMDServerTlfStorageShutdown = errors.New("mdServerTlfStorage is shutdown")
-
 func (s *mdServerTlfStorage) getMDLocked(id MdID) (*RootMetadataSigned, error) {
-	if s.isShutdown {
-		return nil, errMDServerTlfStorageShutdown
-	}
-
 	// Read file.
 
 	path := s.mdPath(id)
@@ -134,10 +128,6 @@ func (s *mdServerTlfStorage) getMDLocked(id MdID) (*RootMetadataSigned, error) {
 }
 
 func (s *mdServerTlfStorage) putMDLocked(rmds *RootMetadataSigned) error {
-	if s.isShutdown {
-		return errMDServerTlfStorageShutdown
-	}
-
 	id, err := rmds.MD.MetadataID(s.crypto)
 	if err != nil {
 		return err
@@ -326,6 +316,8 @@ func (s *mdServerTlfStorage) getRangeLocked(ctx context.Context,
 }
 
 // All functions below are public functions.
+
+var errMDServerTlfStorageShutdown = errors.New("mdServerTlfStorage is shutdown")
 
 func (s *mdServerTlfStorage) getForTLF(ctx context.Context,
 	kbpki KBPKI, bid BranchID, mStatus MergeStatus) (

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -35,6 +35,8 @@ type mdServerTlfStorage struct {
 	// instead.
 	lock sync.RWMutex
 
+	// TODO: Replace the DBs below with a journal.
+
 	mdDb     *leveldb.DB // [branchId]+[revision] -> MdID
 	branchDb *leveldb.DB // deviceKID             -> branchId
 
@@ -88,6 +90,10 @@ func (s *mdServerTlfStorage) mdPath(id MdID) string {
 	return filepath.Join(s.mdsPath(), idStr[:4], idStr[4:])
 }
 
+// getDataLocked verifies the MD data (but not the signature) for the
+// given ID and returns it.
+//
+// TODO: Verify signature?
 func (s *mdServerTlfStorage) getMDLocked(id MdID) (*RootMetadataSigned, error) {
 	// Read file.
 
@@ -121,8 +127,6 @@ func (s *mdServerTlfStorage) getMDLocked(id MdID) (*RootMetadataSigned, error) {
 	}
 
 	rmds.untrustedServerTimestamp = fileInfo.ModTime()
-
-	// TODO: Verify signature?
 
 	return &rmds, nil
 }

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -286,7 +286,7 @@ func (s *mdServerTlfStorage) getRange(ctx context.Context,
 	return s.getRangeLocked(ctx, kbpki, bid, start, stop)
 }
 
-func (s *mdServerTlfStorage) put(ctx context.Context, kbpki KBPKI, rmds *RootMetadataSigned) (bool, error) {
+func (s *mdServerTlfStorage) put(ctx context.Context, kbpki KBPKI, rmds *RootMetadataSigned) (recordBranchID bool, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -320,8 +320,6 @@ func (s *mdServerTlfStorage) put(ctx context.Context, kbpki KBPKI, rmds *RootMet
 	if err != nil {
 		return false, MDServerError{err}
 	}
-
-	var recordBranchID bool
 
 	if mStatus == Unmerged && head == nil {
 		// currHead for unmerged history might be on the main branch

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -23,7 +23,6 @@ import (
 
 type mdServerTlfStorage struct {
 	codec  Codec
-	clock  Clock
 	crypto cryptoPure
 	dir    string
 
@@ -41,8 +40,7 @@ type mdServerTlfStorage struct {
 	isShutdown bool
 }
 
-func makeMDServerTlfStorage(
-	codec Codec, clock Clock, crypto cryptoPure, dir string) (
+func makeMDServerTlfStorage(codec Codec, crypto cryptoPure, dir string) (
 	*mdServerTlfStorage, error) {
 	mdPath := filepath.Join(dir, "md")
 
@@ -57,7 +55,6 @@ func makeMDServerTlfStorage(
 	}
 	return &mdServerTlfStorage{
 		codec:  codec,
-		clock:  clock,
 		crypto: crypto,
 		dir:    dir,
 		mdDb:   mdDb,

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -147,9 +147,9 @@ func (s *mdServerTlfStorage) getMDKey(revision MetadataRevision,
 	}
 	buf := &bytes.Buffer{}
 
-	// this order is signifcant for range fetches.
-	// we want increments in revision number to only affect
-	// the least significant bits of the key.
+	// this order is significant for range fetches.  we want
+	// increments in revision number to only affect the least
+	// significant bits of the key.
 	if bid != NullBranchID {
 		// add branch ID
 		_, err := buf.Write(bid.Bytes())

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -495,3 +495,20 @@ func (md *mdServerTlfStorage) truncateUnlock(ctx context.Context, kbpki KBPKI) (
 	md.truncateLockHolder = nil
 	return true, nil
 }
+
+func (md *mdServerTlfStorage) shutdown() {
+	md.lock.Lock()
+	defer md.lock.Unlock()
+
+	if md.isShutdown {
+		return
+	}
+	md.isShutdown = true
+
+	if md.mdDb != nil {
+		md.mdDb.Close()
+	}
+	if md.branchDb != nil {
+		md.branchDb.Close()
+	}
+}

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -394,7 +394,7 @@ func (md *RootMetadata) MakeSuccessor(config Config, isWriter bool) (*RootMetada
 		newMd.Flags |= MetadataFlagWriterMetadataCopied
 	}
 
-	newMd.PrevRoot, err = md.MetadataID(config)
+	newMd.PrevRoot, err = md.MetadataID(config.Crypto())
 	if err != nil {
 		return nil, err
 	}
@@ -409,7 +409,7 @@ func (md *RootMetadata) MakeSuccessor(config Config, isWriter bool) (*RootMetada
 // CheckValidSuccessor makes sure the given RootMetadata is a valid
 // successor to the current one, and returns an error otherwise.
 func (md *RootMetadata) CheckValidSuccessor(
-	config Config, nextMd *RootMetadata) error {
+	crypto cryptoPure, nextMd *RootMetadata) error {
 	// (1) Verify current metadata is non-final.
 	if md.IsFinal() {
 		return MetadataIsFinalError{}
@@ -432,7 +432,7 @@ func (md *RootMetadata) CheckValidSuccessor(
 	}
 
 	// (3) Check PrevRoot pointer.
-	currRoot, err := md.MetadataID(config)
+	currRoot, err := md.MetadataID(crypto)
 	if err != nil {
 		return err
 	}
@@ -463,8 +463,8 @@ func (md *RootMetadata) CheckValidSuccessor(
 // CheckValidSuccessorForServer is like CheckValidSuccessor but with
 // server-specific error messages.
 func (md *RootMetadata) CheckValidSuccessorForServer(
-	config Config, nextMd *RootMetadata) error {
-	err := md.CheckValidSuccessor(config, nextMd)
+	crypto cryptoPure, nextMd *RootMetadata) error {
+	err := md.CheckValidSuccessor(crypto, nextMd)
 	switch err := err.(type) {
 	case nil:
 		break
@@ -663,7 +663,7 @@ func (md *RootMetadata) IsInitialized() bool {
 }
 
 // MetadataID computes and caches the MdID for this RootMetadata
-func (md *RootMetadata) MetadataID(config Config) (MdID, error) {
+func (md *RootMetadata) MetadataID(crypto cryptoPure) (MdID, error) {
 	mdID := func() MdID {
 		md.mdIDLock.RLock()
 		defer md.mdIDLock.RUnlock()
@@ -673,7 +673,7 @@ func (md *RootMetadata) MetadataID(config Config) (MdID, error) {
 		return mdID, nil
 	}
 
-	mdID, err := config.Crypto().MakeMdID(md)
+	mdID, err := crypto.MakeMdID(md)
 	if err != nil {
 		return MdID{}, err
 	}


### PR DESCRIPTION
Split up MDServerDisk into per-TLF objects (mdServerTlfStorage).
Make those objects store RootMetadataSigned objects in flat files.
They will eventually store the rest of the data (currently in
levelDBs) in a journal.

Fix up naming in bserver_disk.go and bserver_tlf_journal.go.

Also check for shutdown only in public BServer/MDServer
methods.

Make md.MetadataID() take only a crypto object.

Make MDServer.GetForHandle serialize TLF ID creation.