### PR TITLE
cr: fix block accounting for unmerged-setattr, merged-rename files

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2101,6 +2101,14 @@ func (cr *ConflictResolver) makeRevertedOps(ctx context.Context,
 				}
 			} else {
 				op = chains.copyOpAndRevertUnrefsToOriginals(op)
+				// The dir of renamed setAttrOps must be reverted to
+				// the new parent's original pointer.
+				if sao, ok := op.(*setAttrOp); ok {
+					if newDir, _, ok :=
+						otherChains.renamedParentAndName(sao.File); ok {
+						sao.Dir.Unref = newDir
+					}
+				}
 			}
 
 			ops = append(ops, op)

--- a/test/cr_simple_test.go
+++ b/test/cr_simple_test.go
@@ -159,6 +159,38 @@ func TestCrUnmergedSetMtime(t *testing.T) {
 	)
 }
 
+// bob sets the mtime on a moved file while unstaged
+func TestCrUnmergedSetMtimeOnMovedFile(t *testing.T) {
+	targetMtime := time.Now().Add(1 * time.Minute)
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			mkfile("a/b", "hello"),
+			mkdir("b"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			rename("a/b", "b/a"),
+		),
+		as(bob, noSync(),
+			setmtime("a/b", targetMtime),
+			reenableUpdates(),
+			lsdir("", m{"a": "DIR", "b": "DIR"}),
+			lsdir("a", m{}),
+			lsdir("b", m{"a": "FILE"}),
+			mtime("b/a", targetMtime),
+		),
+		as(alice,
+			lsdir("", m{"a": "DIR", "b": "DIR"}),
+			lsdir("a", m{}),
+			lsdir("b", m{"a": "FILE"}),
+			mtime("b/a", targetMtime),
+		),
+	)
+}
+
 // bob deletes a non-conflicting file while unstaged
 func TestCrUnmergedRmfile(t *testing.T) {
 	test(t,


### PR DESCRIPTION
* Fix the ptr update map for chains that were updated in both branches, even for directories that aren't changed in the resolution.
    
* Don't reference bytes for useless same-pointer updates.  If it was really a new block, there will have been a proper update or ref in an earlier op.

* Fix up parent of renamed setattr operations

Issue: KBFS-1178

