### PR TITLE
cr: mark setattr file actions moved, so they don't get moved again

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1729,6 +1729,14 @@ func collapseActions(unmergedChains *crChains, unmergedPaths []path,
 			} else {
 				delete(actionMap, p.tailPointer())
 			}
+		} else {
+			// Mark the copyUnmergedAttrActions as moved, so they
+			// don't get moved again by the parent.
+			for _, action := range fileActions {
+				if realAction, ok := action.(*copyUnmergedAttrAction); ok {
+					realAction.moved = true
+				}
+			}
 		}
 
 		parentPath := *p.parentPath()

--- a/test/cr_complex_test.go
+++ b/test/cr_complex_test.go
@@ -740,7 +740,6 @@ func TestCrUnmergedSetMtimeOfRemovedDir(t *testing.T) {
 	)
 }
 
-/* TODO: Investigate and enable this.
 // bob moves and sets the mtime of a file that was written by alice
 func TestCrConflictMoveAndSetMtimeWrittenFile(t *testing.T) {
 	targetMtime := time.Now().Add(1 * time.Minute)
@@ -771,4 +770,3 @@ func TestCrConflictMoveAndSetMtimeWrittenFile(t *testing.T) {
 		),
 	)
 }
-*/


### PR DESCRIPTION
Issue: KBFS-1196