### PR TITLE
folder_branch_ops: allow a rename over an empty directory

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -252,6 +252,17 @@ func (e NotFileError) Error() string {
 	return fmt.Sprintf("%s is not a file (folder %s)", e.path, e.path.Tlf)
 }
 
+// NotDirError indicates that the user tried to perform a
+// dir-specific operation on something that isn't a directory.
+type NotDirError struct {
+	path path
+}
+
+// Error implements the error interface for NotDirError
+func (e NotDirError) Error() string {
+	return fmt.Sprintf("%s is not a directory (folder %s)", e.path, e.path.Tlf)
+}
+
 // BlockDecodeError indicates that a block couldn't be decoded as
 // expected; probably it is the wrong type.
 type BlockDecodeError struct {

--- a/test/cr_simple_test.go
+++ b/test/cr_simple_test.go
@@ -541,14 +541,13 @@ func TestCrUnmergedRenameFileOverFile(t *testing.T) {
 	)
 }
 
-// bob renames a directory over an existing file
-func TestCrUnmergedRenameDirOverFile(t *testing.T) {
+// bob renames a dir over an existing empty dir
+func TestCrUnmergedRenameDirOverEmptyDir(t *testing.T) {
 	test(t,
-		skip("fuse", "Renaming directories over files not supported on linux fuse (ENOTDIR)"),
 		users("alice", "bob"),
 		as(alice,
-			mkfile("a/b", "hello"),
-			mkfile("a/c/d", "world"),
+			mkdir("a/b"),
+			mkfile("a/c/d", "hello"),
 		),
 		as(bob,
 			disableUpdates(),
@@ -560,12 +559,14 @@ func TestCrUnmergedRenameDirOverFile(t *testing.T) {
 			rename("a/c", "a/b"),
 			reenableUpdates(),
 			lsdir("a/", m{"b": "DIR", "e": "FILE"}),
-			read("a/b/d", "world"),
+			lsdir("a/b", m{"d": "FILE"}),
+			read("a/b/d", "hello"),
 			read("a/e", "just another file"),
 		),
 		as(alice,
 			lsdir("a/", m{"b": "DIR", "e": "FILE"}),
-			read("a/b/d", "world"),
+			lsdir("a/b", m{"d": "FILE"}),
+			read("a/b/d", "hello"),
 			read("a/e", "just another file"),
 		),
 	)

--- a/test/simple_test.go
+++ b/test/simple_test.go
@@ -14,7 +14,7 @@ import (
 // Check that renaming over a file correctly cleans up state
 func TestRenameFileOverFile(t *testing.T) {
 	test(t,
-		users("alice", "bob"),
+		users("alice"),
 		as(alice,
 			mkfile("a/b", "hello"),
 			mkfile("a/c", "world"),
@@ -25,17 +25,21 @@ func TestRenameFileOverFile(t *testing.T) {
 	)
 }
 
-// Check that renaming a directory over a file correctly cleans up state
-func TestRenameDirOverFile(t *testing.T) {
+func TestRenameDirOverDir(t *testing.T) {
 	test(t,
-		skip("fuse", "Renaming directories over files not supported on linux fuse (ENOTDIR)"),
-		users("alice", "bob"),
+		users("alice"),
 		as(alice,
-			mkfile("a/b", "hello"),
-			mkfile("a/c/d", "world"),
+			mkdir("a/b"),
+			mkfile("a/c/d", "hello"),
 			rename("a/c", "a/b"),
 			lsdir("a/", m{"b": "DIR"}),
-			read("a/b/d", "world"),
+			lsdir("a/b", m{"d": "FILE"}),
+			read("a/b/d", "hello"),
+
+			// Rename over a non-empty dir should fail
+			mkfile("a/c/e", "world"),
+			expectError(rename("a/c", "a/b"),
+				"Directory b is not empty and can't be removed"),
 		),
 	)
 }


### PR DESCRIPTION
Also, remove support for renaming over files of different types, that
seems silly and isn't supported by the higher FS levels anyway.

Issue: KBFS-1176