### PR TITLE
md_util: re-embed block changes in decryptMDPrivateData

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -245,16 +245,6 @@ func (cr *ConflictResolver) getMDs(ctx context.Context, lState *lockState) (
 		merged[i] = mdCopy
 	}
 
-	// re-embed all the block changes
-	err = cr.fbo.reembedBlockChanges(ctx, lState, unmerged)
-	if err != nil {
-		return nil, nil, err
-	}
-	err = cr.fbo.reembedBlockChanges(ctx, lState, merged)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	return unmerged, merged, nil
 }
 

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -16,7 +16,6 @@ import (
 
 type fbmHelper interface {
 	getMDForFBM(ctx context.Context) (*RootMetadata, error)
-	reembedForFBM(ctx context.Context, rmds []*RootMetadata) error
 	finalizeGCOp(ctx context.Context, gco *gcOp) error
 }
 
@@ -545,11 +544,6 @@ func (fbm *folderBlockManager) getMostRecentOldEnoughAndGCRevisions(
 				MetadataRevisionUninitialized, err
 		}
 
-		if err := fbm.helper.reembedForFBM(ctx, rmds); err != nil {
-			return MetadataRevisionUninitialized,
-				MetadataRevisionUninitialized, err
-		}
-
 		numNew := len(rmds)
 		for i := len(rmds) - 1; i >= 0; i-- {
 			rmd := rmds[i]
@@ -631,10 +625,6 @@ outer:
 		rmds, err := getMDRange(ctx, fbm.config, fbm.id, NullBranchID, startRev,
 			currHead, Merged)
 		if err != nil {
-			return nil, MetadataRevisionUninitialized, false, err
-		}
-
-		if err := fbm.helper.reembedForFBM(ctx, rmds); err != nil {
 			return nil, MetadataRevisionUninitialized, false, err
 		}
 

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -130,7 +130,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't get MD: %v", err)
 	}
-	if md.data.Changes.Info.BlockPointer == zeroPtr {
+	if md.data.cachedChanges.Info.BlockPointer == zeroPtr {
 		t.Fatalf("No unembedded changes for ops %v", md.data.Changes.Ops)
 	}
 }

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -145,10 +145,6 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 
 	fb := FolderBranch{tlf, MasterBranch}
 	ops := kbfsOps.getOpsNoAdd(fb)
-	if err := ops.reembedBlockChanges(ctx, lState, rmds); err != nil {
-		return err
-	}
-
 	lastGCRevisionTime := sc.getLastGCRevisionTime(ctx, tlf)
 
 	// Build the expected block list.


### PR DESCRIPTION
This ensures the private metadata won't change once it is initially
decrypted, avoiding possible races.

Suggested by @akalin-keybase.

Issue: KBFS-1207