### PR TITLE
tlf_handle_extension: more descriptive suffix string

### DIFF
--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -684,7 +684,7 @@ func TestRootMetadataFinalVerify(t *testing.T) {
 	}
 
 	// add the extension
-	rmds2.MD.FinalizedInfo, err = NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionFinalized, 1)
+	rmds2.MD.FinalizedInfo, err = NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionFinalized, 1, "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/tlf_handle_extension_test.go
+++ b/libkbfs/tlf_handle_extension_test.go
@@ -28,7 +28,7 @@ func TestTlfHandleExtension(t *testing.T) {
 		if len(exts) != 1 {
 			t.Fatalf("Expected 1 extension, got: %d", len(exts))
 		}
-		// check that extensons can be encoded/decoded
+		// check that extensions can be encoded/decoded
 		buf, err := codec.Encode(exts[0])
 		if err != nil {
 			t.Fatal(err)
@@ -48,6 +48,9 @@ func TestTlfHandleExtension(t *testing.T) {
 			t.Fatalf("Expected %s, got: %s", e, e2)
 		}
 		if e.Type == TlfHandleExtensionConflict {
+			if e2.Username != "" {
+				t.Fatalf("Expected empty username got: %s", e2.Username)
+			}
 			continue
 		}
 		if e2.Username != e.Username {

--- a/libkbfs/tlf_handle_extension_test.go
+++ b/libkbfs/tlf_handle_extension_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 func TestTlfHandleExtension(t *testing.T) {
+	codec := NewCodecMsgpack()
 	for _, et := range []TlfHandleExtensionType{
 		TlfHandleExtensionConflict,
 		TlfHandleExtensionFinalized,
 	} {
-		e, err := NewTlfHandleExtension(et, 1)
+		e, err := NewTlfHandleExtension(et, 1, "alice")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,7 +28,16 @@ func TestTlfHandleExtension(t *testing.T) {
 		if len(exts) != 1 {
 			t.Fatalf("Expected 1 extension, got: %d", len(exts))
 		}
-		e2 := exts[0]
+		// check that extensons can be encoded/decoded
+		buf, err := codec.Encode(exts[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+		var e2 TlfHandleExtension
+		err = codec.Decode(buf, &e2)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if e2.Number != e.Number {
 			t.Fatalf("Expected %d, got: %d", e.Number, e2.Number)
 		}
@@ -36,6 +46,12 @@ func TestTlfHandleExtension(t *testing.T) {
 		}
 		if e2.String() != e.String() {
 			t.Fatalf("Expected %s, got: %s", e, e2)
+		}
+		if e.Type == TlfHandleExtensionConflict {
+			continue
+		}
+		if e2.Username != e.Username {
+			t.Fatalf("Expected %s, got: %s", e.Username, e2.Username)
 		}
 	}
 }
@@ -45,7 +61,7 @@ func TestTlfHandleExtensionNumber(t *testing.T) {
 		TlfHandleExtensionConflict,
 		TlfHandleExtensionFinalized,
 	} {
-		e, err := NewTlfHandleExtension(et, 2)
+		e, err := NewTlfHandleExtension(et, 2, "bob")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,16 +82,23 @@ func TestTlfHandleExtensionNumber(t *testing.T) {
 		if e2.String() != e.String() {
 			t.Fatalf("Expected %s, got: %s", e, e2)
 		}
+		if e.Type == TlfHandleExtensionConflict {
+			continue
+		}
+		if e2.Username != e.Username {
+			t.Fatalf("Expected %s, got: %s", e.Username, e2.Username)
+		}
 	}
 }
 
 func TestTlfHandleExtensionKnownTime(t *testing.T) {
 	e := &TlfHandleExtension{
-		Date:   1462838400,
-		Number: 1,
-		Type:   TlfHandleExtensionFinalized,
+		Date:     1462838400,
+		Number:   1,
+		Type:     TlfHandleExtensionFinalized,
+		Username: "alice",
 	}
-	expect := "(finalized 2016-05-10)"
+	expect := "(files before alice account reset 2016-05-10)"
 	if e.String() != expect {
 		t.Fatalf("Expected %s, got: %s", expect, e)
 	}
@@ -88,10 +111,19 @@ func TestTlfHandleExtensionKnownTime(t *testing.T) {
 	if e2.String() != expect {
 		t.Fatalf("Expected %s, got: %s", expect, e2)
 	}
+	e3 := &TlfHandleExtension{
+		Date:   1462838400,
+		Number: 2,
+		Type:   TlfHandleExtensionFinalized,
+	}
+	expect = "(files before account reset 2016-05-10 #2)"
+	if e3.String() != expect {
+		t.Fatalf("Expected %s, got: %s", expect, e3)
+	}
 }
 
 func TestTlfHandleExtensionErrors(t *testing.T) {
-	_, err := NewTlfHandleExtension(TlfHandleExtensionConflict, 0)
+	_, err := NewTlfHandleExtension(TlfHandleExtensionConflict, 0, "")
 	if err != ErrTlfHandleExtensionInvalidNumber {
 		t.Fatalf("Expected ErrTlfHandleExtensionInvalidNumber, got: %v", err)
 	}
@@ -133,6 +165,7 @@ func TestTlfHandleExtensionUnknownFields(t *testing.T) {
 				time.Now().UTC().Unix(),
 				2,
 				TlfHandleExtensionFinalized,
+				"",
 				codec.UnknownFieldSetHandler{},
 			},
 			makeExtraOrBust("TlfHandleExtension", t),
@@ -140,17 +173,17 @@ func TestTlfHandleExtensionUnknownFields(t *testing.T) {
 }
 
 func TestTlfHandleExtensionMultiple(t *testing.T) {
-	e, err := NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionConflict, 1)
+	e, err := NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionConflict, 1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	e2, err := NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionFinalized, 2)
+	e2, err := NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionFinalized, 2, "charlie")
 	if err != nil {
 		t.Fatal(err)
 	}
 	exts := []TlfHandleExtension{*e, *e2}
 	suffix := NewTlfHandleExtensionSuffix(exts)
-	expectSuffix := " (conflicted copy 2016-03-14) (finalized 2016-03-14 #2)"
+	expectSuffix := " (conflicted copy 2016-03-14) (files before charlie account reset 2016-03-14 #2)"
 	if suffix != expectSuffix {
 		t.Fatalf("Expected suffix '%s', got: '%s'", expectSuffix, suffix)
 	}
@@ -167,6 +200,47 @@ func TestTlfHandleExtensionMultiple(t *testing.T) {
 		}
 		if ext.Date != exts[i].Date {
 			t.Fatalf("Expected %d, got: %d", exts[i].Date, ext.Date)
+		}
+		if ext.Username != exts[i].Username {
+			t.Fatalf("Expected %s, got: %s", exts[i].Username, ext.Username)
+		}
+		if ext.String() != exts[i].String() {
+			t.Fatalf("Expected %s, got: %s", ext, exts[i])
+		}
+	}
+}
+
+func TestTlfHandleExtensionMultipleSingleUser(t *testing.T) {
+	e, err := NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionConflict, 2, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2, err := NewTestTlfHandleExtensionStaticTime(TlfHandleExtensionFinalized, 1, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	exts := []TlfHandleExtension{*e, *e2}
+	suffix := NewTlfHandleExtensionSuffix(exts)
+	expectSuffix := " (conflicted copy 2016-03-14 #2) (files before account reset 2016-03-14)"
+	if suffix != expectSuffix {
+		t.Fatalf("Expected suffix '%s', got: '%s'", expectSuffix, suffix)
+	}
+	exts2, err := ParseTlfHandleExtensionSuffix(suffix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exts2) != 2 {
+		t.Fatalf("Expected 2 extensions, got: %d", len(exts2))
+	}
+	for i, ext := range exts2 {
+		if ext.Number != exts[i].Number {
+			t.Fatalf("Expected %d, got: %d", exts[i].Number, ext.Number)
+		}
+		if ext.Date != exts[i].Date {
+			t.Fatalf("Expected %d, got: %d", exts[i].Date, ext.Date)
+		}
+		if ext.Username != exts[i].Username {
+			t.Fatalf("Expected %s, got: %s", exts[i].Username, ext.Username)
 		}
 		if ext.String() != exts[i].String() {
 			t.Fatalf("Expected %s, got: %s", ext, exts[i])

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -639,7 +639,7 @@ func TestResolveAgainConflict(t *testing.T) {
 	assert.Equal(t, CanonicalTlfName(name), h.GetCanonicalName())
 
 	daemon.addNewAssertionForTestOrBust("u3", "u3@twitter")
-	ext, err := NewTlfHandleExtension(TlfHandleExtensionConflict, 1)
+	ext, err := NewTlfHandleExtension(TlfHandleExtensionConflict, 1, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -780,7 +780,7 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 		daemon: daemon,
 	}
 
-	name := "u1,u2#u3 (conflicted copy 2016-03-14 #3) (finalized 2016-03-14 #2)"
+	name := "u1,u2#u3 (conflicted copy 2016-03-14 #3) (files before u2 account reset 2016-03-14 #2)"
 	h, err := ParseTlfHandle(ctx, kbpki, name, false)
 	require.Nil(t, err)
 	assert.Equal(t, TlfHandleExtension{
@@ -789,12 +789,13 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 		Number: 3,
 	}, *h.ConflictInfo())
 	assert.Equal(t, TlfHandleExtension{
-		Type:   TlfHandleExtensionFinalized,
-		Date:   TlfHandleExtensionStaticTestDate,
-		Number: 2,
+		Type:     TlfHandleExtensionFinalized,
+		Date:     TlfHandleExtensionStaticTestDate,
+		Number:   2,
+		Username: "u2",
 	}, *h.FinalizedInfo())
 
-	nonCanonicalName := "u1,u2#u3 (finalized 2016-03-14 #2) (conflicted copy 2016-03-14 #3)"
+	nonCanonicalName := "u1,u2#u3 (files before u2 account reset 2016-03-14 #2) (conflicted copy 2016-03-14 #3)"
 	_, err = ParseTlfHandle(ctx, kbpki, nonCanonicalName, false)
 	assert.Equal(t, TlfNameNotCanonical{nonCanonicalName, name}, err)
 }


### PR DESCRIPTION
This changes the format of finalized handle extensions from `alice,bob#charlie (finalized 2016-03-14 #2)` to `alice,bob#charlie (files before bob account reset 2016-03-14 #2)` or in the case of a single participant `bob (files before account reset 2016-03-14)`

