### PR TITLE
favorites: fix a possible hang, and handle deletions better

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1110,3 +1110,14 @@ func (w OverQuotaWarning) Error() string {
 	return fmt.Sprintf("You are using %d bytes, and your plan limits you "+
 		"to %d bytes.  Please delete some data.", w.UsageBytes, w.LimitBytes)
 }
+
+// OpsCantHandleFavorite means that folderBranchOps wasn't able to
+// deal with a favorites request.
+type OpsCantHandleFavorite struct {
+	Msg string
+}
+
+// Error implements the error interface for OpsCantHandleFavorite.
+func (e OpsCantHandleFavorite) Error() string {
+	return fmt.Sprintf("Couldn't handle the favorite operation: %s", e.Msg)
+}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -438,7 +438,7 @@ func (fbo *folderBranchOps) addToFavorites(ctx context.Context,
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
 	if head == nil {
-		return errors.New("Can't add a favorite without a handle")
+		return OpsCantHandleFavorite{"Can't add a favorite without a handle"}
 	}
 
 	h := head.GetTlfHandle()
@@ -456,7 +456,8 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
 	if head == nil {
-		return errors.New("Can't delete a favorite without a handle")
+		// This can happen when identifies fail and the head is never set.
+		return OpsCantHandleFavorite{"Can't delete a favorite without a handle"}
 	}
 
 	h := head.GetTlfHandle()

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -160,7 +160,12 @@ func (fs *KBFSOpsStandard) DeleteFavorite(ctx context.Context,
 		return fs.opsByFav[fav]
 	}()
 	if ops != nil {
-		return ops.deleteFromFavorites(ctx, fs.favs)
+		err := ops.deleteFromFavorites(ctx, fs.favs)
+		if _, ok := err.(OpsCantHandleFavorite); !ok {
+			return err
+		}
+		// If the ops couldn't handle the delete, fall through to
+		// going directly via Favorites.
 	}
 
 	if isLoggedIn {


### PR DESCRIPTION
I hit a KBFS hang when Emacs canceled a context while KBFS was trying to send a favorites request onto the channel, leaving it in the `inFlightAdds` map forever and blocking and future requests for that same folder.  This PR cleans up the map in that case.

Also, a user noticed that they couldn't delete certain favorites.  It turns out that can happen when a `folderBranchOps` is made, but `head` is never set (e.g., due to identify or MD fetch errors)

@songgao: want to try reviewing?

Issue: KBFS-1235
Issue: keybase/client#3263