### PR TITLE
TestCRFileConflictWithMoreUpdatesFromOneUser: sync every time a write happens

### DIFF
--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -618,14 +618,14 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Couldn't write file: %v", err)
 		}
+
+		err = kbfsOps2.Sync(ctx, fileB2)
+		if err != nil {
+			t.Fatalf("Couldn't sync file: %v", err)
+		}
 	}
 
 	chForEnablingUpdates <- struct{}{}
-
-	err = kbfsOps2.Sync(ctx, fileB2)
-	if err != nil {
-		t.Fatalf("Couldn't sync file: %v", err)
-	}
 
 	equal := false
 


### PR DESCRIPTION
This properly tests https://github.com/keybase/kbfs/pull/98