### PR TITLE
[KBFS-1262] Ignore invalid ops when unstaging

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2222,8 +2222,11 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 				// skips chains which are newly-created within this
 				// branch.
 				newCreateOp := *cop
-				newCreateOp.Dir.setUnref(chain.mostRecent)
-				newCreateOp.Dir.setRef(chain.mostRecent)
+				newCreateOp.Dir, err = makeBlockUpdate(
+					chain.mostRecent, chain.mostRecent)
+				if err != nil {
+					return nil, err
+				}
 				chain.ops[i] = &newCreateOp
 				if !added {
 					newPaths = append(newPaths, path{
@@ -2363,8 +2366,11 @@ func crFixOpPointers(oldOps []op, updates map[BlockPointer]BlockPointer,
 			// Since the first op does all the heavy lifting of
 			// updating pointers, we can set these to both just be the
 			// new pointer
-			update.setUnref(newPtr)
-			update.setRef(newPtr)
+			var err error
+			*update, err = makeBlockUpdate(newPtr, newPtr)
+			if err != nil {
+				return nil, err
+			}
 		}
 		for _, ptr := range ptrsToFix {
 			newPtr, ok := updates[*ptr]

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2176,7 +2176,7 @@ func (cr *ConflictResolver) makeRevertedOps(ctx context.Context,
 				if sao, ok := op.(*setAttrOp); ok {
 					if newDir, _, ok :=
 						otherChains.renamedParentAndName(sao.File); ok {
-						sao.Dir.Unref = newDir
+						sao.Dir.setUnref(newDir)
 					}
 				}
 			}
@@ -2222,8 +2222,8 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 				// skips chains which are newly-created within this
 				// branch.
 				newCreateOp := *cop
-				newCreateOp.Dir.Unref = chain.mostRecent
-				newCreateOp.Dir.Ref = chain.mostRecent
+				newCreateOp.Dir.setUnref(chain.mostRecent)
+				newCreateOp.Dir.setRef(chain.mostRecent)
 				chain.ops[i] = &newCreateOp
 				if !added {
 					newPaths = append(newPaths, path{
@@ -2363,8 +2363,8 @@ func crFixOpPointers(oldOps []op, updates map[BlockPointer]BlockPointer,
 			// Since the first op does all the heavy lifting of
 			// updating pointers, we can set these to both just be the
 			// new pointer
-			update.Unref = newPtr
-			update.Ref = newPtr
+			update.setUnref(newPtr)
+			update.setRef(newPtr)
 		}
 		for _, ptr := range ptrsToFix {
 			newPtr, ok := updates[*ptr]
@@ -2880,7 +2880,7 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 			cr.log.CDebugf(ctx, "Fixing resOp update from unmerged most "+
 				"recent %v to merged most recent %v",
 				update.Unref, mergedMostRecent)
-			update.Unref = mergedMostRecent
+			update.setUnref(mergedMostRecent)
 			resOp.Updates[i] = update
 			updates[update.Unref] = update.Ref
 		}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1190,13 +1190,19 @@ outer:
 				if err != nil {
 					return err
 				}
-				invertCreate.Dir.setRef(info.originalNewParent)
+				err = invertCreate.Dir.setRef(info.originalNewParent)
+				if err != nil {
+					return err
+				}
 				invertRm, err := newCreateOp(info.oldName,
 					info.originalOldParent, cop.Type)
 				if err != nil {
 					return err
 				}
-				invertRm.Dir.setRef(info.originalOldParent)
+				err = invertRm.Dir.setRef(info.originalOldParent)
+				if err != nil {
+					return err
+				}
 				invertRm.renamed = true
 				invertRm.AddRefBlock(ptr)
 
@@ -1614,7 +1620,10 @@ func (cr *ConflictResolver) addMergedRecreates(ctx context.Context,
 					if err != nil {
 						return err
 					}
-					co.Dir.setRef(chain.original)
+					err = co.Dir.setRef(chain.original)
+					if err != nil {
+						return err
+					}
 					co.AddRefBlock(c.mostRecent)
 					winfo, err := newWriterInfo(ctx, cr.config,
 						mergedChains.mostRecentMD.LastModifyingWriter,

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3171,6 +3171,13 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 		return err
 	}
 
+	// Can only do this after syncBlocks, since syncBlocks calls
+	// crFixOpPointers, and the ops may be invalid until then.
+	err := md.data.checkValid()
+	if err != nil {
+		return err
+	}
+
 	defer func() {
 		if err != nil {
 			cr.fbo.fbm.cleanUpBlockState(md, bps)

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3173,7 +3173,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 
 	// Can only do this after syncBlocks, since syncBlocks calls
 	// crFixOpPointers, and the ops may be invalid until then.
-	err := md.data.checkValid()
+	err = md.data.checkValid()
 	if err != nil {
 		return err
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2176,7 +2176,10 @@ func (cr *ConflictResolver) makeRevertedOps(ctx context.Context,
 				if sao, ok := op.(*setAttrOp); ok {
 					if newDir, _, ok :=
 						otherChains.renamedParentAndName(sao.File); ok {
-						sao.Dir.setUnref(newDir)
+						err := sao.Dir.setUnref(newDir)
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 			}
@@ -2886,7 +2889,10 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 			cr.log.CDebugf(ctx, "Fixing resOp update from unmerged most "+
 				"recent %v to merged most recent %v",
 				update.Unref, mergedMostRecent)
-			update.setUnref(mergedMostRecent)
+			err = update.setUnref(mergedMostRecent)
+			if err != nil {
+				return nil, nil, err
+			}
 			resOp.Updates[i] = update
 			updates[update.Unref] = update.Ref
 		}

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -913,7 +913,8 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 
 	ro, err := newRmOp("dirA", dirRootPtr)
 	require.NoError(t, err)
-	ro.Dir.setRef(unmergedPathRoot.tailPointer())
+	err = ro.Dir.setRef(unmergedPathRoot.tailPointer())
+	require.NoError(t, err)
 	ro.dropThis = true
 	ro.setWriterInfo(writerInfo{name: "u2"})
 	ro.setFinalPath(unmergedPathRoot)

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
@@ -559,8 +560,10 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	})
 	mergedPaths[expectedUnmergedPath.tailPointer()] = mergedPath
 
-	coB := newCreateOp("dirB", dirAPtr, Dir)
-	coC := newCreateOp("dirC", dirBPtr, Dir)
+	coB, err := newCreateOp("dirB", dirAPtr, Dir)
+	require.NoError(t, err)
+	coC, err := newCreateOp("dirC", dirBPtr, Dir)
+	require.NoError(t, err)
 
 	dirAPtr1 := cr1.fbo.nodeCache.PathFromNode(dirA1).tailPointer()
 	expectedActions := map[BlockPointer]crActionList{
@@ -818,7 +821,8 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	mergedPathB := cr1.fbo.nodeCache.PathFromNode(dirB1)
 	mergedPaths[uPathB2.tailPointer()] = mergedPathB
 
-	coF := newCreateOp("dirF", dirEPtr, Dir)
+	coF, err := newCreateOp("dirF", dirEPtr, Dir)
+	require.NoError(t, err)
 
 	mergedPathE := cr1.fbo.nodeCache.PathFromNode(dirE1)
 	expectedActions := map[BlockPointer]crActionList{
@@ -907,8 +911,9 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	mergedPathB := cr1.fbo.nodeCache.PathFromNode(dirB1)
 	mergedPaths[unmergedPathB.tailPointer()] = mergedPathB
 
-	ro := newRmOp("dirA", dirRootPtr)
-	ro.Dir.Ref = unmergedPathRoot.tailPointer()
+	ro, err := newRmOp("dirA", dirRootPtr)
+	require.NoError(t, err)
+	ro.Dir.setRef(unmergedPathRoot.tailPointer())
 	ro.dropThis = true
 	ro.setWriterInfo(writerInfo{name: "u2"})
 	ro.setFinalPath(unmergedPathRoot)
@@ -1081,7 +1086,8 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	})
 	mergedPaths[unmergedPathFile.tailPointer()] = mergedPathFile
 
-	coFile := newCreateOp("file", dirRootPtr, Exec)
+	coFile, err := newCreateOp("file", dirRootPtr, Exec)
+	require.NoError(t, err)
 
 	cre := WriterDeviceDateConflictRenamer{}
 	mergedPathRoot := cr1.fbo.nodeCache.PathFromNode(dirRoot1)

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -220,11 +220,17 @@ func crActionConvertSymlink(unmergedMostRecent BlockPointer,
 	mergedChains *crChains, fromName string, toName string) error {
 	// If this was turned into a symlink, then we have to simulate
 	// rm/create at the beginning of the mergedOps list.
-	ro := newRmOp(fromName, mergedMostRecent)
+	ro, err := newRmOp(fromName, mergedMostRecent)
+	if err != nil {
+		return err
+	}
 	// Add a fake unref so this rm doesn't get mistaken for one
 	// half of a rename operation.
 	ro.AddUnrefBlock(zeroPtr)
-	co := newCreateOp(toName, mergedMostRecent, Sym)
+	co, err := newCreateOp(toName, mergedMostRecent, Sym)
+	if err != nil {
+		return err
+	}
 
 	// If the chain already exists, just append the operations instead
 	// of prepending them.  We don't want to do any rms of nodes that
@@ -540,9 +546,12 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 		return NoSuchNameError{rua.fromName}
 	}
 
-	rop := newRenameOp(rua.fromName, mergedMostRecent, rua.toName,
+	rop, err := newRenameOp(rua.fromName, mergedMostRecent, rua.toName,
 		mergedMostRecent, newMergedEntry.BlockPointer,
 		newMergedEntry.Type)
+	if err != nil {
+		return err
+	}
 	// For local notifications, we need to transform the entry's
 	// pointer into the new (de-dup'd) pointer.  newMergedEntry is
 	// not yet the final pointer (that happens during syncBlock),
@@ -551,8 +560,11 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 		rop.AddUpdate(unmergedEntry.BlockPointer,
 			newMergedEntry.BlockPointer)
 	}
-	err := prependOpsToChain(mergedMostRecent, mergedChains,
-		rop, newCreateOp(rua.fromName, mergedMostRecent, mergedEntry.Type))
+	co, err := newCreateOp(rua.fromName, mergedMostRecent, mergedEntry.Type)
+	if err != nil {
+		return err
+	}
+	err = prependOpsToChain(mergedMostRecent, mergedChains, rop, co)
 	if err != nil {
 		return err
 	}
@@ -560,7 +572,7 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 	// Before merging the unmerged ops, create a file with the new
 	// name, unless the create already exists.
 	found := false
-	var co *createOp
+	co = nil
 	for _, op := range unmergedChain.ops {
 		var ok bool
 		if co, ok = op.(*createOp); ok && co.NewName == rua.toName {
@@ -572,7 +584,10 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 		}
 	}
 	if !found {
-		co = newCreateOp(rua.toName, unmergedMostRecent, mergedEntry.Type)
+		co, err = newCreateOp(rua.toName, unmergedMostRecent, mergedEntry.Type)
+		if err != nil {
+			return err
+		}
 		if rua.symPath == "" {
 			co.AddRefBlock(newMergedEntry.BlockPointer)
 		}
@@ -687,9 +702,12 @@ func (rma *renameMergedAction) updateOps(unmergedMostRecent BlockPointer,
 
 		// Prepend a rename for the merged copy to the unmerged set of
 		// operations.
-		rop := newRenameOp(rma.fromName, unmergedMostRecent, rma.toName,
+		rop, err := newRenameOp(rma.fromName, unmergedMostRecent, rma.toName,
 			unmergedMostRecent, mergedEntry.BlockPointer, mergedEntry.Type)
-		err := prependOpsToChain(unmergedMostRecent, unmergedChains, rop)
+		if err != nil {
+			return err
+		}
+		err = prependOpsToChain(unmergedMostRecent, unmergedChains, rop)
 		if err != nil {
 			return err
 		}
@@ -706,8 +724,11 @@ func (rma *renameMergedAction) updateOps(unmergedMostRecent BlockPointer,
 			}
 		}
 		if !found {
-			err := prependOpsToChain(mergedMostRecent, mergedChains,
-				newCreateOp(rma.toName, mergedMostRecent, mergedEntry.Type))
+			co, err := newCreateOp(rma.toName, mergedMostRecent, mergedEntry.Type)
+			if err != nil {
+				return err
+			}
+			err = prependOpsToChain(mergedMostRecent, mergedChains, co)
 			if err != nil {
 				return err
 			}
@@ -765,8 +786,11 @@ func (dua *dropUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 		return nil
 	}
 
-	invertedOp := invertOpForLocalNotifications(dua.op)
-	err := prependOpsToChain(mergedMostRecent, mergedChains, invertedOp)
+	invertedOp, err := invertOpForLocalNotifications(dua.op)
+	if err != nil {
+		return err
+	}
+	err = prependOpsToChain(mergedMostRecent, mergedChains, invertedOp)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -503,8 +503,13 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 		for _, op := range unmergedChain.ops {
 			switch realOp := op.(type) {
 			case *syncOp:
-				realOp.File.setUnref(newMergedEntry.BlockPointer)
-				realOp.File.setRef(newMergedEntry.BlockPointer)
+				var err error
+				realOp.File, err = makeBlockUpdate(
+					newMergedEntry.BlockPointer,
+					newMergedEntry.BlockPointer)
+				if err != nil {
+					return err
+				}
 				// Nuke the previously referenced blocks, they are no
 				// longer relevant.
 				realOp.RefBlocks = nil

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -503,8 +503,8 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 		for _, op := range unmergedChain.ops {
 			switch realOp := op.(type) {
 			case *syncOp:
-				realOp.File.Unref = newMergedEntry.BlockPointer
-				realOp.File.Ref = newMergedEntry.BlockPointer
+				realOp.File.setUnref(newMergedEntry.BlockPointer)
+				realOp.File.setRef(newMergedEntry.BlockPointer)
 				// Nuke the previously referenced blocks, they are no
 				// longer relevant.
 				realOp.RefBlocks = nil

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -395,7 +395,7 @@ func (ccs *crChains) makeChainForOp(op op) error {
 
 		// ndr may be zero if this is a post-resolution chain,
 		// so set co.Dir.Ref manually.
-		if ndr != (BlockPointer{}) {
+		if ndr != zeroPtr {
 			co.Dir.Ref = ndr
 			err = ccs.addOp(ndr, co)
 			if err != nil {

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -348,7 +348,7 @@ func (ccs *crChains) makeChainForOp(op op) error {
 			return err
 		}
 		ro.setWriterInfo(realOp.getWriterInfo())
-		ro.Dir.Ref = realOp.OldDir.Ref
+		ro.Dir.setRef(realOp.OldDir.Ref)
 		err = ccs.addOp(realOp.OldDir.Ref, ro)
 		if err != nil {
 			return err
@@ -387,7 +387,7 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		}
 		co.setWriterInfo(realOp.getWriterInfo())
 		co.renamed = true
-		co.Dir.Ref = ndr
+		co.Dir.setRef(ndr)
 		err = ccs.addOp(ndr, co)
 		if err != nil {
 			return err
@@ -461,13 +461,12 @@ func (ccs *crChains) makeChainForOp(op op) error {
 
 func (ccs *crChains) makeChainForNewOpWithUpdate(
 	targetPtr BlockPointer, newOp op, update *blockUpdate) error {
-	oldUnref := update.Unref
-	update.Unref = targetPtr
-	update.Ref = update.Unref // so that most recent == original
+	oldUpdate := *update
+	update.setUnref(targetPtr)
+	update.setRef(update.Unref) // so that most recent == original
 	defer func() {
 		// reset the update to its original state before returning.
-		update.Unref = oldUnref
-		update.Ref = BlockPointer{}
+		*update = oldUpdate
 	}()
 	err := ccs.makeChainForOp(newOp)
 	if err != nil {

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -462,13 +462,17 @@ func (ccs *crChains) makeChainForOp(op op) error {
 func (ccs *crChains) makeChainForNewOpWithUpdate(
 	targetPtr BlockPointer, newOp op, update *blockUpdate) error {
 	oldUpdate := *update
-	update.setUnref(targetPtr)
-	update.setRef(update.Unref) // so that most recent == original
+	// so that most recent == original
+	var err error
+	*update, err = makeBlockUpdate(targetPtr, update.Unref)
+	if err != nil {
+		return err
+	}
 	defer func() {
 		// reset the update to its original state before returning.
 		*update = oldUpdate
 	}()
-	err := ccs.makeChainForOp(newOp)
+	err = ccs.makeChainForOp(newOp)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -348,7 +348,10 @@ func (ccs *crChains) makeChainForOp(op op) error {
 			return err
 		}
 		ro.setWriterInfo(realOp.getWriterInfo())
-		ro.Dir.setRef(realOp.OldDir.Ref)
+		err = ro.Dir.setRef(realOp.OldDir.Ref)
+		if err != nil {
+			return err
+		}
 		err = ccs.addOp(realOp.OldDir.Ref, ro)
 		if err != nil {
 			return err
@@ -370,7 +373,10 @@ func (ccs *crChains) makeChainForOp(op op) error {
 				return err
 			}
 			roOverwrite.setWriterInfo(realOp.getWriterInfo())
-			roOverwrite.Dir.setRef(ndr)
+			err = roOverwrite.Dir.setRef(ndr)
+			if err != nil {
+				return err
+			}
 			err = ccs.addOp(ndr, roOverwrite)
 			if err != nil {
 				return err
@@ -387,7 +393,10 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		}
 		co.setWriterInfo(realOp.getWriterInfo())
 		co.renamed = true
-		co.Dir.setRef(ndr)
+		err = co.Dir.setRef(ndr)
+		if err != nil {
+			return err
+		}
 		err = ccs.addOp(ndr, co)
 		if err != nil {
 			return err

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -348,7 +348,7 @@ func (ccs *crChains) makeChainForOp(op op) error {
 			return err
 		}
 		ro.setWriterInfo(realOp.getWriterInfo())
-		// OldDir.Ref may be nil, since realOp may still be
+		// OldDir.Ref may be zero, since realOp may still be
 		// invalid (if we're being called before pointers are
 		// fixed up).
 		if realOp.OldDir.Ref != (BlockPointer{}) {
@@ -396,10 +396,10 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		co.setWriterInfo(realOp.getWriterInfo())
 		co.renamed = true
 
-		// ndr may be nil, since realOp may still be invalid
+		// ndr may be zero, since realOp may still be invalid
 		// (if we're being called before pointers are fixed
 		// up).
-		if ndr != nil {
+		if ndr != (BlockPointer{}) {
 			co.Dir.Ref = ndr
 			err = ccs.addOp(ndr, co)
 			if err != nil {

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -348,15 +348,12 @@ func (ccs *crChains) makeChainForOp(op op) error {
 			return err
 		}
 		ro.setWriterInfo(realOp.getWriterInfo())
-		// OldDir.Ref may be zero, since realOp may still be
-		// invalid (if we're being called before pointers are
-		// fixed up).
-		if realOp.OldDir.Ref != (BlockPointer{}) {
-			ro.Dir.Ref = realOp.OldDir.Ref
-			err = ccs.addOp(realOp.OldDir.Ref, ro)
-			if err != nil {
-				return err
-			}
+		// realOp.OldDir.Ref may be zero if this is a
+		// post-resolution chain, so set ro.Dir.Ref manually.
+		ro.Dir.Ref = realOp.OldDir.Ref
+		err = ccs.addOp(realOp.OldDir.Ref, ro)
+		if err != nil {
+			return err
 		}
 
 		ndu := realOp.NewDir.Unref
@@ -396,9 +393,8 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		co.setWriterInfo(realOp.getWriterInfo())
 		co.renamed = true
 
-		// ndr may be zero, since realOp may still be invalid
-		// (if we're being called before pointers are fixed
-		// up).
+		// ndr may be zero if this is a post-resolution chain,
+		// so set co.Dir.Ref manually.
 		if ndr != (BlockPointer{}) {
 			co.Dir.Ref = ndr
 			err = ccs.addOp(ndr, co)

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -392,15 +392,12 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		}
 		co.setWriterInfo(realOp.getWriterInfo())
 		co.renamed = true
-
 		// ndr may be zero if this is a post-resolution chain,
 		// so set co.Dir.Ref manually.
-		if ndr != zeroPtr {
-			co.Dir.Ref = ndr
-			err = ccs.addOp(ndr, co)
-			if err != nil {
-				return err
-			}
+		co.Dir.Ref = ndr
+		err = ccs.addOp(ndr, co)
+		if err != nil {
+			return err
 		}
 
 		// also keep track of the new parent for the renamed node

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -348,13 +348,15 @@ func (ccs *crChains) makeChainForOp(op op) error {
 			return err
 		}
 		ro.setWriterInfo(realOp.getWriterInfo())
-		err = ro.Dir.setRef(realOp.OldDir.Ref)
-		if err != nil {
-			return err
-		}
-		err = ccs.addOp(realOp.OldDir.Ref, ro)
-		if err != nil {
-			return err
+		// OldDir.Ref may be nil, since realOp may still be
+		// invalid (if we're being called before pointers are
+		// fixed up).
+		if realOp.OldDir.Ref != (BlockPointer{}) {
+			ro.Dir.Ref = realOp.OldDir.Ref
+			err = ccs.addOp(realOp.OldDir.Ref, ro)
+			if err != nil {
+				return err
+			}
 		}
 
 		ndu := realOp.NewDir.Unref
@@ -393,13 +395,16 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		}
 		co.setWriterInfo(realOp.getWriterInfo())
 		co.renamed = true
-		err = co.Dir.setRef(ndr)
-		if err != nil {
-			return err
-		}
-		err = ccs.addOp(ndr, co)
-		if err != nil {
-			return err
+
+		// ndr may be nil, since realOp may still be invalid
+		// (if we're being called before pointers are fixed
+		// up).
+		if ndr != nil {
+			co.Dir.Ref = ndr
+			err = ccs.addOp(ndr, co)
+			if err != nil {
+				return err
+			}
 		}
 
 		// also keep track of the new parent for the renamed node

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3380,7 +3380,12 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 			io, err := invertOpForLocalNotifications(ops[j])
 			if err != nil {
 				fbo.log.CWarningf(ctx,
-					"got error %v when invert op %v; skipping",
+					"got error %v when invert op %v; "+
+						"skipping. Open file handles "+
+						"may now be in an invalid "+
+						"state, which can be fixed by "+
+						"either closing them all or "+
+						"restarting KBFS.",
 					err, ops[j])
 				continue
 			}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -993,7 +993,8 @@ func (fbo *folderBranchOps) initMDLocked(
 			Ctime: now,
 		},
 	}
-	md.AddOp(newCreateOp("", BlockPointer{}, Dir))
+	co := newCreateOpForRootDir()
+	md.AddOp(co)
 	md.AddRefBlock(md.data.Dir.BlockInfo)
 	md.UnrefBytes = 0
 
@@ -2078,7 +2079,11 @@ func (fbo *folderBranchOps) createEntryLocked(
 		return nil, DirEntry{}, err
 	}
 
-	md.AddOp(newCreateOp(name, dirPath.tailPointer(), entryType))
+	co, err := newCreateOp(name, dirPath.tailPointer(), entryType)
+	if err != nil {
+		return nil, DirEntry{}, err
+	}
+	md.AddOp(co)
 	// create new data block
 	var newBlock Block
 	// XXX: for now, put a unique ID in every new block, to make sure it
@@ -2257,7 +2262,11 @@ func (fbo *folderBranchOps) createLinkLocked(
 		return DirEntry{}, err
 	}
 
-	md.AddOp(newCreateOp(fromName, dirPath.tailPointer(), Sym))
+	co, err := newCreateOp(fromName, dirPath.tailPointer(), Sym)
+	if err != nil {
+		return DirEntry{}, err
+	}
+	md.AddOp(co)
 
 	// Create a direntry for the link, and then sync
 	now := fbo.nowUnixNano()
@@ -2345,7 +2354,11 @@ func (fbo *folderBranchOps) removeEntryLocked(ctx context.Context,
 		return NoSuchNameError{name}
 	}
 
-	md.AddOp(newRmOp(name, dir.tailPointer()))
+	ro, err := newRmOp(name, dir.tailPointer())
+	if err != nil {
+		return err
+	}
+	md.AddOp(ro)
 	err = fbo.unrefEntry(ctx, lState, md, dir, de, name)
 	if err != nil {
 		return err
@@ -2749,8 +2762,12 @@ func (fbo *folderBranchOps) setExLocked(
 	}
 
 	parentPath := file.parentPath()
-	md.AddOp(newSetAttrOp(file.tailName(), parentPath.tailPointer(), exAttr,
-		file.tailPointer()))
+	sao, err := newSetAttrOp(file.tailName(), parentPath.tailPointer(), exAttr,
+		file.tailPointer())
+	if err != nil {
+		return err
+	}
+	md.AddOp(sao)
 
 	// If the type isn't File or Exec, there's nothing to do, but
 	// change the ctime anyway (to match ext4 behavior).
@@ -2801,8 +2818,12 @@ func (fbo *folderBranchOps) setMtimeLocked(
 	}
 
 	parentPath := file.parentPath()
-	md.AddOp(newSetAttrOp(file.tailName(), parentPath.tailPointer(), mtimeAttr,
-		file.tailPointer()))
+	sao, err := newSetAttrOp(file.tailName(), parentPath.tailPointer(), mtimeAttr,
+		file.tailPointer())
+	if err != nil {
+		return err
+	}
+	md.AddOp(sao)
 
 	de.Mtime = mtime.UnixNano()
 	// setting the mtime counts as changing the file MD, so must set ctime too
@@ -3356,7 +3377,11 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 		// iterate the ops in reverse and invert each one
 		ops := rmd.data.Changes.Ops
 		for j := len(ops) - 1; j >= 0; j-- {
-			fbo.notifyOneOpLocked(ctx, lState, invertOpForLocalNotifications(ops[j]), rmd)
+			io, err := invertOpForLocalNotifications(ops[j])
+			if err != nil {
+				return err
+			}
+			fbo.notifyOneOpLocked(ctx, lState, io, rmd)
 		}
 	}
 	return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3381,7 +3381,7 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 			if err != nil {
 				fbo.log.CWarningf(ctx,
 					"got error %v when invert op %v; skipping",
-					err, io)
+					err, ops[j])
 				continue
 			}
 			fbo.notifyOneOpLocked(ctx, lState, io, rmd)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1801,6 +1801,11 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState, excl EXCL) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
+	err := md.data.checkValid()
+	if err != nil {
+		return err
+	}
+
 	// finally, write out the new metadata
 	mdops := fbo.config.MDOps()
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1801,7 +1801,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState, excl EXCL) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	err := md.data.checkValid()
+	err = md.data.checkValid()
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3379,7 +3379,10 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 		for j := len(ops) - 1; j >= 0; j-- {
 			io, err := invertOpForLocalNotifications(ops[j])
 			if err != nil {
-				return err
+				fbo.log.CWarningf(ctx,
+					"got error %v when invert op %v; skipping",
+					err, io)
+				continue
 			}
 			fbo.notifyOneOpLocked(ctx, lState, io, rmd)
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1801,11 +1801,6 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState, excl EXCL) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	err = md.data.checkValid()
-	if err != nil {
-		return err
-	}
-
 	// finally, write out the new metadata
 	mdops := fbo.config.MDOps()
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -497,6 +497,11 @@ func (md *MDOpsStandard) readyMD(ctx context.Context, rmd *RootMetadata) (
 }
 
 func (md *MDOpsStandard) put(ctx context.Context, rmd *RootMetadata) error {
+	err := rmd.data.checkValid()
+	if err != nil {
+		return err
+	}
+
 	rmds, err := md.readyMD(ctx, rmd)
 	if err != nil {
 		return err

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -62,15 +62,23 @@ type blockUpdate struct {
 	Ref   BlockPointer `codec:"r,omitempty"`
 }
 
+func makeBlockUpdate(unref, ref BlockPointer) (blockUpdate, error) {
+	bu := blockUpdate{}
+	err := bu.setUnref(unref)
+	if err != nil {
+		return blockUpdate{}, err
+	}
+	bu.setRef(ref)
+	return bu, nil
+}
+
 func (u blockUpdate) isValid() bool {
 	return u.Unref != (BlockPointer{}) && u.Ref != (BlockPointer{})
 }
 
 func (u *blockUpdate) setUnref(ptr BlockPointer) error {
 	if ptr == (BlockPointer{}) {
-		err := fmt.Errorf("setUnref called with nil ptr")
-		panic(err)
-		return err
+		return fmt.Errorf("setUnref called with nil ptr")
 	}
 	u.Unref = ptr
 	return nil

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -254,6 +254,11 @@ func (co *createOp) AllUpdates() []blockUpdate {
 }
 
 func (co *createOp) checkValid() error {
+	if co.NewName == "" {
+		// Must be for root dir.
+		return nil
+	}
+
 	err := co.Dir.checkValid()
 	if err != nil {
 		return fmt.Errorf("createOp.Dir=%v got error: %v", co.Dir, err)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -213,7 +213,7 @@ func newCreateOpForRootDir() *createOp {
 
 func (co *createOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 	if co.Dir == (blockUpdate{}) {
-		panic("AdUpdate called on create op for root dir")
+		panic("AddUpdate called on create op for root dir")
 	}
 	if oldPtr == co.Dir.Unref {
 		err := co.Dir.setRef(newPtr)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -68,7 +68,10 @@ func makeBlockUpdate(unref, ref BlockPointer) (blockUpdate, error) {
 	if err != nil {
 		return blockUpdate{}, err
 	}
-	bu.setRef(ref)
+	err = bu.setRef(ref)
+	if err != nil {
+		return blockUpdate{}, err
+	}
 	return bu, nil
 }
 
@@ -84,11 +87,12 @@ func (u *blockUpdate) setUnref(ptr BlockPointer) error {
 	return nil
 }
 
-func (u *blockUpdate) setRef(ptr BlockPointer) {
+func (u *blockUpdate) setRef(ptr BlockPointer) error {
 	if ptr == (BlockPointer{}) {
-		panic(fmt.Errorf("setUnref called with nil ptr"))
+		return fmt.Errorf("setUnref called with nil ptr")
 	}
 	u.Ref = ptr
+	return nil
 }
 
 // list codes
@@ -212,7 +216,10 @@ func (co *createOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 		panic("AdUpdate called on create op for root dir")
 	}
 	if oldPtr == co.Dir.Unref {
-		co.Dir.setRef(newPtr)
+		err := co.Dir.setRef(newPtr)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 	co.OpCommon.AddUpdate(oldPtr, newPtr)
@@ -324,7 +331,10 @@ func newRmOp(name string, oldDir BlockPointer) (*rmOp, error) {
 
 func (ro *rmOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 	if oldPtr == ro.Dir.Unref {
-		ro.Dir.setRef(newPtr)
+		err := ro.Dir.setRef(newPtr)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 	ro.OpCommon.AddUpdate(oldPtr, newPtr)
@@ -412,11 +422,17 @@ func newRenameOp(oldName string, oldOldDir BlockPointer,
 
 func (ro *renameOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 	if oldPtr == ro.OldDir.Unref {
-		ro.OldDir.setRef(newPtr)
+		err := ro.OldDir.setRef(newPtr)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 	if ro.NewDir != (blockUpdate{}) && oldPtr == ro.NewDir.Unref {
-		ro.NewDir.setRef(newPtr)
+		err := ro.NewDir.setRef(newPtr)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 	ro.OpCommon.AddUpdate(oldPtr, newPtr)
@@ -517,7 +533,10 @@ func (so *syncOp) resetUpdateState() {
 
 func (so *syncOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 	if oldPtr == so.File.Unref {
-		so.File.setRef(newPtr)
+		err := so.File.setRef(newPtr)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 	so.OpCommon.AddUpdate(oldPtr, newPtr)
@@ -747,7 +766,10 @@ func newSetAttrOp(name string, oldDir BlockPointer,
 
 func (sao *setAttrOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 	if oldPtr == sao.Dir.Unref {
-		sao.Dir.setRef(newPtr)
+		err := sao.Dir.setRef(newPtr)
+		if err != nil {
+			panic(err)
+		}
 		return
 	}
 	sao.OpCommon.AddUpdate(oldPtr, newPtr)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -144,10 +144,9 @@ func (oc *OpCommon) AddUnrefBlock(ptr BlockPointer) {
 // AddUpdate adds a mapping from an old block to the new version of
 // that block, for this op.
 func (oc *OpCommon) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
-	bu, err := makeBlockUpdate(oldPtr, newPtr)
-	if err != nil {
-		panic(err)
-	}
+	// Either pointer may be zero, if we're building an op that
+	// will be fixed up later.
+	bu := blockUpdate{oldPtr, newPtr}
 	oc.Updates = append(oc.Updates, bu)
 }
 

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -231,7 +231,8 @@ func newCreateOpForRootDir() *createOp {
 
 func (co *createOp) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
 	if co.Dir == (blockUpdate{}) {
-		panic("AddUpdate called on create op for root dir")
+		panic("AddUpdate called on create op with empty Dir " +
+			"(probably create op for root dir)")
 	}
 	if oldPtr == co.Dir.Unref {
 		err := co.Dir.setRef(newPtr)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -259,8 +259,6 @@ func (co *createOp) checkValid() error {
 	if err != nil {
 		return fmt.Errorf("createOp.Dir=%v got error: %v", co.Dir, err)
 	}
-	return nil
-
 	return co.checkUpdatesValid()
 }
 
@@ -384,8 +382,6 @@ func (ro *rmOp) checkValid() error {
 	if err != nil {
 		return fmt.Errorf("rmOp.Dir=%v got error: %v", ro.Dir, err)
 	}
-	return nil
-
 	return ro.checkUpdatesValid()
 }
 

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -75,10 +75,6 @@ func makeBlockUpdate(unref, ref BlockPointer) (blockUpdate, error) {
 	return bu, nil
 }
 
-func (u blockUpdate) isValid() bool {
-	return u.Unref != (BlockPointer{}) && u.Ref != (BlockPointer{})
-}
-
 func (u *blockUpdate) setUnref(ptr BlockPointer) error {
 	if ptr == (BlockPointer{}) {
 		return fmt.Errorf("setUnref called with nil ptr")
@@ -136,9 +132,9 @@ func (oc *OpCommon) AddUnrefBlock(ptr BlockPointer) {
 // AddUpdate adds a mapping from an old block to the new version of
 // that block, for this op.
 func (oc *OpCommon) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
-	bu := blockUpdate{oldPtr, newPtr}
-	if !bu.isValid() {
-		panic(fmt.Errorf("Invalid update %+v", bu))
+	bu, err := makeBlockUpdate(oldPtr, newPtr)
+	if err != nil {
+		panic(err)
 	}
 	oc.Updates = append(oc.Updates, bu)
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -37,6 +37,16 @@ type PrivateMetadata struct {
 	cachedChanges BlockChanges
 }
 
+func (p PrivateMetadata) checkValid() error {
+	for i, op := range md.data.Changes.Ops {
+		err := op.checkValid()
+		if err != nil {
+			return fmt.Errorf("op[%d]=%v invalid: %v", i, op, err)
+		}
+	}
+	return nil
+}
+
 // MetadataFlags bitfield.
 type MetadataFlags byte
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -38,7 +38,7 @@ type PrivateMetadata struct {
 }
 
 func (p PrivateMetadata) checkValid() error {
-	for i, op := range md.data.Changes.Ops {
+	for i, op := range p.Changes.Ops {
 		err := op.checkValid()
 		if err != nil {
 			return fmt.Errorf("op[%d]=%v invalid: %v", i, op, err)


### PR DESCRIPTION
Also add various functions to check the validity of
ops.

Check ops before pushing an MD to the server.