### PR TITLE
Handle block get errors gracefully in file/dir removal

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -434,7 +434,11 @@ func (fbo *folderBlockOps) getFileLocked(ctx context.Context,
 }
 
 // GetIndirectFileBlockInfos returns a list of BlockInfos for all
-// indirect blocks of the given file.
+// indirect blocks of the given file. If the returned error is a
+// recoverable one (as determined by isRecoverableBlockError), the
+// returned list may still be non-empty, and holds all the BlockInfos
+// for all found indirect blocks. (This will be relevant when we
+// handle multiple levels of indirection.)
 func (fbo *folderBlockOps) GetIndirectFileBlockInfos(ctx context.Context,
 	lState *lockState, md *RootMetadata, file path) ([]BlockInfo, error) {
 	// TODO: handle multiple levels of indirection.

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -439,6 +439,9 @@ func (fbo *folderBlockOps) getFileLocked(ctx context.Context,
 // returned list may still be non-empty, and holds all the BlockInfos
 // for all found indirect blocks. (This will be relevant when we
 // handle multiple levels of indirection.)
+//
+// TODO: Consider other errors recoverable, e.g. ones that arise from
+// present but corrupted blocks?
 func (fbo *folderBlockOps) GetIndirectFileBlockInfos(ctx context.Context,
 	lState *lockState, md *RootMetadata, file path) ([]BlockInfo, error) {
 	// TODO: handle multiple levels of indirection.

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -435,13 +435,11 @@ func (fbo *folderBlockOps) getFileLocked(ctx context.Context,
 
 // GetIndirectFileBlockInfos returns a list of BlockInfos for all
 // indirect blocks of the given file. If the returned error is a
-// recoverable one (as determined by isRecoverableBlockError), the
-// returned list may still be non-empty, and holds all the BlockInfos
-// for all found indirect blocks. (This will be relevant when we
-// handle multiple levels of indirection.)
-//
-// TODO: Consider other errors recoverable, e.g. ones that arise from
-// present but corrupted blocks?
+// recoverable one (as determined by
+// isRecoverableBlockErrorForRemoval), the returned list may still be
+// non-empty, and holds all the BlockInfos for all found indirect
+// blocks. (This will be relevant when we handle multiple levels of
+// indirection.)
 func (fbo *folderBlockOps) GetIndirectFileBlockInfos(ctx context.Context,
 	lState *lockState, md *RootMetadata, file path) ([]BlockInfo, error) {
 	// TODO: handle multiple levels of indirection.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2405,11 +2405,11 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 
 	childBlock, err := fbo.blocks.GetDir(
 		ctx, lState, md, childPath, blockRead)
-	if err != nil {
+	if isRecoverableBlockError(err) {
+		fbo.log.CWarningf(ctx, "Recoverable block error encountered in removeDirLocked(%v); continuing", childPath)
+	} else if err != nil {
 		return err
-	}
-
-	if len(childBlock.Children) > 0 {
+	} else if len(childBlock.Children) > 0 {
 		return DirNotEmptyError{dirName}
 	}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2405,6 +2405,9 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 
 	childBlock, err := fbo.blocks.GetDir(
 		ctx, lState, md, childPath, blockRead)
+	// TODO: Like folderBlockOps.GetIndirectFileBlockInfos,
+	// consider other errors recoverable, e.g. ones that arise
+	// from present but corrupted blocks?
 	if isRecoverableBlockError(err) {
 		fbo.log.CWarningf(ctx, "Recoverable block error encountered in removeDirLocked(%v); continuing", childPath)
 	} else if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2339,7 +2339,9 @@ func (fbo *folderBranchOps) unrefEntry(ctx context.Context,
 		blockInfos, err := fbo.blocks.GetIndirectFileBlockInfos(
 			ctx, lState, md, childPath)
 		if isRecoverableBlockErrorForRemoval(err) {
-			fbo.log.CWarningf(ctx, "Recoverable block error encountered in unrefEntry(%v, %v, %v); continuing", dir, de, name)
+			msg := fmt.Sprintf("Recoverable block error encountered for unrefEntry(%v); continuing", childPath)
+			fbo.log.CWarningf(ctx, "%s", msg)
+			fbo.log.CDebugf(ctx, "%s (err=%v)", msg, err)
 		} else if err != nil {
 			return err
 		}
@@ -2415,7 +2417,9 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 	childBlock, err := fbo.blocks.GetDir(
 		ctx, lState, md, childPath, blockRead)
 	if isRecoverableBlockErrorForRemoval(err) {
-		fbo.log.CWarningf(ctx, "Recoverable block error encountered in removeDirLocked(%v); continuing", childPath)
+		msg := fmt.Sprintf("Recoverable block error encountered for removeDirLocked(%v); continuing", childPath)
+		fbo.log.CWarningf(ctx, "%s", msg)
+		fbo.log.CDebugf(ctx, "%s (err=%v)", msg, err)
 	} else if err != nil {
 		return err
 	} else if len(childBlock.Children) > 0 {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2332,7 +2332,7 @@ func (fbo *folderBranchOps) unrefEntry(ctx context.Context,
 		if isRecoverableBlockError(err) {
 			fbo.log.CWarningf(ctx, "Recoverable block error encountered in unrefEntry(%v, %v, %v); continuing", dir, de, name)
 		} else if err != nil {
-			return NoSuchBlockError{de.ID}
+			return err
 		}
 		for _, blockInfo := range blockInfos {
 			md.AddUnrefBlock(blockInfo)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2329,7 +2329,9 @@ func (fbo *folderBranchOps) unrefEntry(ctx context.Context,
 	if de.Type == File || de.Type == Exec {
 		blockInfos, err := fbo.blocks.GetIndirectFileBlockInfos(
 			ctx, lState, md, childPath)
-		if err != nil {
+		if isRecoverableBlockError(err) {
+			fbo.log.CWarningf(ctx, "Recoverable block error encountered in unrefEntry(%v, %v, %v); continuing", dir, de, name)
+		} else if err != nil {
 			return NoSuchBlockError{de.ID}
 		}
 		for _, blockInfo := range blockInfos {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -2055,7 +2055,7 @@ func TestKBFSOpsRemoveFileMissingBlock(t *testing.T) {
 	if _, ok := b1.Children[entryName]; ok {
 		t.Errorf("entry for %s is still around after removal", entryName)
 	}
-	for _, n := range p.path {
+	for _, n := range dirPath.path {
 		blockIDs = append(blockIDs, n.ID)
 	}
 	checkBlockCache(t, config, blockIDs, nil)
@@ -2113,7 +2113,7 @@ func TestKBFSOpsRemoveDirMissingBlock(t *testing.T) {
 	if _, ok := b1.Children[entryName]; ok {
 		t.Errorf("entry for %s is still around after removal", entryName)
 	}
-	for _, n := range p.path {
+	for _, n := range dirPath.path {
 		blockIDs = append(blockIDs, n.ID)
 	}
 	checkBlockCache(t, config, blockIDs, nil)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1714,8 +1714,8 @@ func testKBFSOpsRemoveFileSuccess(t *testing.T, et EntryType) {
 
 	err := config.KBFSOps().RemoveEntry(ctx, n, entryName)
 	require.NoError(t, err)
-	newDirPath := ops.nodeCache.PathFromNode(n)
 
+	newDirPath := ops.nodeCache.PathFromNode(n)
 	checkNewPath(t, ctx, config, newDirPath, expectedPath, newRmd,
 		blockIDs, et, "", false)
 	newParentDirBlock := getDirBlockFromCache(
@@ -1772,8 +1772,8 @@ func TestKBFSOpsRemoveDirSuccess(t *testing.T) {
 
 	err := config.KBFSOps().RemoveDir(ctx, n, entryName)
 	require.NoError(t, err)
-	newDirPath := ops.nodeCache.PathFromNode(n)
 
+	newDirPath := ops.nodeCache.PathFromNode(n)
 	checkNewPath(t, ctx, config, newDirPath, expectedPath, newRmd,
 		blockIDs, Dir, "", false)
 	newParentBlock := getDirBlockFromCache(
@@ -1824,8 +1824,8 @@ func TestKBFSOpsRemoveSymSuccess(t *testing.T) {
 
 	err := config.KBFSOps().RemoveEntry(ctx, n, entryName)
 	require.NoError(t, err)
-	newDirPath := ops.nodeCache.PathFromNode(n)
 
+	newDirPath := ops.nodeCache.PathFromNode(n)
 	checkNewPath(t, ctx, config, newDirPath, expectedPath, newRmd,
 		blockIDs, Sym, "", false)
 	newParentDirBlock := getDirBlockFromCache(
@@ -1847,7 +1847,8 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 
 	uid, id, rmd := injectNewRMD(t, config)
 
-	rootEntry, dirPath, dirBlocks := makeDirTree(id, uid, "a", "b", "c", "d")
+	rootEntry, dirPath, dirBlocks :=
+		makeDirTree(id, uid, "a", "b", "c", "d")
 	rmd.data.Dir = rootEntry
 
 	// Prime cache with all dir blocks.
@@ -1858,7 +1859,7 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 
 	parentDirBlock := dirBlocks[len(dirBlocks)-1]
 
-	entryName := "e"
+	entryName := "multiBlockFile"
 	lastBID := dirPath.tailPointer().ID
 	fileBID := fakeBlockIDAdd(lastBID, 1)
 	fileBI := makeBIFromID(fileBID, dirPath.tailPointer().Creator)
@@ -1897,7 +1898,6 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 
 	// let the top block be uncached, so we have to fetch it from BlockOps.
 	expectBlock(config, rmd, fileBP, fileBlock, nil)
-
 	testPutBlockInCache(t, config, fileBlock.IPtrs[0].BlockPointer, id, block1)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[2].BlockPointer, id, block3)
@@ -1911,17 +1911,16 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 		dirPath, rmd, false, 0, 0, unrefBytes, &newRmd, blockIDs)
 
 	err := config.KBFSOps().RemoveEntry(ctx, n, entryName)
+	require.NoError(t, err)
+
 	newDirPath := ops.nodeCache.PathFromNode(n)
-	if err != nil {
-		t.Errorf("Got error on removal: %v", err)
-	}
 	checkNewPath(t, ctx, config, newDirPath, expectedPath, newRmd, blockIDs,
 		File, "", false)
-	b0 :=
-		getDirBlockFromCache(t, config, newDirPath.tailPointer(), newDirPath.Branch)
-	if _, ok := b0.Children[entryName]; ok {
-		t.Errorf("entry for %s is still around after removal", entryName)
-	}
+	newParentDirBlock := getDirBlockFromCache(
+		t, config, newDirPath.tailPointer(), newDirPath.Branch)
+	_, ok := newParentDirBlock.Children[entryName]
+	require.False(t, ok)
+
 	for _, n := range p.path {
 		blockIDs = append(blockIDs, n.ID)
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1885,6 +1885,84 @@ func TestKBFSOpsRemoveFileMissingBlock(t *testing.T) {
 	}
 }
 
+func TestKBFSOpsRemoveDirMissingBlock(t *testing.T) {
+	mockCtrl, config, ctx := kbfsOpsInit(t, true)
+	defer kbfsTestShutdown(mockCtrl, config)
+
+	uid, id, rmd := injectNewRMD(t, config)
+
+	rootID := fakeBlockID(41)
+	rmd.data.Dir.ID = rootID
+	aID := fakeBlockID(42)
+	bID := fakeBlockID(43)
+	rootBlock := NewDirBlock().(*DirBlock)
+	rootBlock.Children["a"] = DirEntry{
+		BlockInfo: makeBIFromID(aID, uid),
+		EntryInfo: EntryInfo{
+			Type: Dir,
+		},
+	}
+	aBlock := NewDirBlock().(*DirBlock)
+	aBlock.Children["b"] = DirEntry{
+		BlockInfo: makeBIFromID(bID, uid),
+		EntryInfo: EntryInfo{
+			Type: Dir,
+		},
+	}
+	node := pathNode{makeBP(rootID, rmd, config, uid), "p"}
+	aNode := pathNode{makeBP(aID, rmd, config, uid), "a"}
+	bNode := pathNode{makeBP(bID, rmd, config, uid), "b"}
+	p := path{FolderBranch{Tlf: id}, []pathNode{node, aNode}}
+	ops := getOps(config, id)
+	n := nodeFromPath(t, ops, p)
+
+	// deleting "a/b"
+	testPutBlockInCache(t, config, aNode.BlockPointer, id, aBlock)
+	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
+	config.mockBops.EXPECT().Get(
+		gomock.Any(), gomock.Any(), bNode.BlockPointer,
+		gomock.Any()).Return(BServerErrorBlockNonExistent{})
+	// sync block
+	var newRmd *RootMetadata
+	blocks := make([]BlockID, 2)
+	unrefBytes := uint64(1) // a block of size 1 is being unreferenced
+	expectedPath, _ := expectSyncBlock(t, config, nil, uid, id, "",
+		p, rmd, false, 0, 0, unrefBytes, &newRmd, blocks)
+
+	err := config.KBFSOps().RemoveDir(ctx, n, "b")
+	if err != nil {
+		t.Fatalf("Got error on removal: %v", err)
+	}
+	newP := ops.nodeCache.PathFromNode(n)
+
+	checkNewPath(t, ctx, config, newP, expectedPath, newRmd, blocks,
+		Dir, "", false)
+	b1 :=
+		getDirBlockFromCache(t, config, newP.path[1].BlockPointer, newP.Branch)
+	if _, ok := b1.Children["b"]; ok {
+		t.Errorf("entry for b is still around after removal")
+	}
+	checkBlockCache(t, config, append(blocks, rootID, aID), nil)
+
+	// make sure the rmOp is correct
+	ro, ok := newRmd.data.Changes.Ops[0].(*rmOp)
+	if !ok {
+		t.Errorf("Couldn't find the rmOp")
+	}
+	unrefBlocks := []BlockPointer{bNode.BlockPointer}
+	updates := []blockUpdate{
+		{rmd.data.Dir.BlockPointer, newP.path[0].BlockPointer},
+	}
+	checkOp(t, ro.OpCommon, nil, unrefBlocks, updates)
+	dirUpdate := blockUpdate{rootBlock.Children["a"].BlockPointer,
+		newP.path[1].BlockPointer}
+	if ro.Dir != dirUpdate {
+		t.Errorf("Incorrect dir update in op: %v vs. %v", ro.Dir, dirUpdate)
+	} else if ro.OldName != "b" {
+		t.Errorf("Incorrect name in op: %v", ro.OldName)
+	}
+}
+
 func TestRemoveDirFailNoSuchName(t *testing.T) {
 	mockCtrl, config, ctx := kbfsOpsInit(t, false)
 	defer kbfsTestShutdown(mockCtrl, config)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1967,8 +1967,6 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et EntryType) {
 		panic(fmt.Sprintf("Unexpected type %s", et))
 	}
 
-	t.Skip()
-
 	mockCtrl, config, ctx := kbfsOpsInit(t, true)
 	defer kbfsTestShutdown(mockCtrl, config)
 
@@ -2036,7 +2034,6 @@ func TestKBFSOpsRemoveExecMissingBlockSuccess(t *testing.T) {
 }
 
 func TestKBFSOpsRemoveDirMissingBlock(t *testing.T) {
-	t.Skip()
 	mockCtrl, config, ctx := kbfsOpsInit(t, true)
 	defer kbfsTestShutdown(mockCtrl, config)
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1818,7 +1818,7 @@ func TestKBFSOpsRemoveSymSuccess(t *testing.T) {
 	var newRmd *RootMetadata
 	blockIDs := make([]BlockID, len(dirPath.path))
 	// No block is being referenced.
-	var unrefBytes uint64 = 0
+	var unrefBytes uint64
 	expectedPath, _ := expectSyncBlock(t, config, nil, uid, id, "",
 		dirPath, rmd, false, 0, 0, unrefBytes, &newRmd, blockIDs)
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1611,7 +1611,7 @@ func testRemoveEntrySuccess(t *testing.T, entryType EntryType) {
 		err = config.KBFSOps().RemoveEntry(ctx, n, "b")
 	}
 	if err != nil {
-		t.Errorf("Got error on removal: %v", err)
+		t.Fatalf("Got error on removal: %v", err)
 	}
 	newP := ops.nodeCache.PathFromNode(n)
 
@@ -1804,6 +1804,84 @@ func TestRemoveDirFailNonEmpty(t *testing.T) {
 		t.Errorf("Got no expected error on removal")
 	} else if err != expectedErr {
 		t.Errorf("Got unexpected error on removal: %v", err)
+	}
+}
+
+func TestKBFSOpsRemoveFileMissingBlock(t *testing.T) {
+	mockCtrl, config, ctx := kbfsOpsInit(t, true)
+	defer kbfsTestShutdown(mockCtrl, config)
+
+	uid, id, rmd := injectNewRMD(t, config)
+
+	rootID := fakeBlockID(41)
+	rmd.data.Dir.ID = rootID
+	aID := fakeBlockID(42)
+	bID := fakeBlockID(43)
+	rootBlock := NewDirBlock().(*DirBlock)
+	rootBlock.Children["a"] = DirEntry{
+		BlockInfo: makeBIFromID(aID, uid),
+		EntryInfo: EntryInfo{
+			Type: Dir,
+		},
+	}
+	aBlock := NewDirBlock().(*DirBlock)
+	aBlock.Children["b"] = DirEntry{
+		BlockInfo: makeBIFromID(bID, uid),
+		EntryInfo: EntryInfo{
+			Type: File,
+		},
+	}
+	node := pathNode{makeBP(rootID, rmd, config, uid), "p"}
+	aNode := pathNode{makeBP(aID, rmd, config, uid), "a"}
+	bNode := pathNode{makeBP(bID, rmd, config, uid), "b"}
+	p := path{FolderBranch{Tlf: id}, []pathNode{node, aNode}}
+	ops := getOps(config, id)
+	n := nodeFromPath(t, ops, p)
+
+	// deleting "a/b"
+	testPutBlockInCache(t, config, aNode.BlockPointer, id, aBlock)
+	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
+	config.mockBops.EXPECT().Get(
+		gomock.Any(), gomock.Any(), bNode.BlockPointer,
+		gomock.Any()).Return(BServerErrorBlockNonExistent{})
+	// sync block
+	var newRmd *RootMetadata
+	blocks := make([]BlockID, 2)
+	unrefBytes := uint64(1) // a block of size 1 is being unreferenced
+	expectedPath, _ := expectSyncBlock(t, config, nil, uid, id, "",
+		p, rmd, false, 0, 0, unrefBytes, &newRmd, blocks)
+
+	err := config.KBFSOps().RemoveEntry(ctx, n, "b")
+	if err != nil {
+		t.Fatalf("Got error on removal: %v", err)
+	}
+	newP := ops.nodeCache.PathFromNode(n)
+
+	checkNewPath(t, ctx, config, newP, expectedPath, newRmd, blocks,
+		File, "", false)
+	b1 :=
+		getDirBlockFromCache(t, config, newP.path[1].BlockPointer, newP.Branch)
+	if _, ok := b1.Children["b"]; ok {
+		t.Errorf("entry for b is still around after removal")
+	}
+	checkBlockCache(t, config, append(blocks, rootID, aID), nil)
+
+	// make sure the rmOp is correct
+	ro, ok := newRmd.data.Changes.Ops[0].(*rmOp)
+	if !ok {
+		t.Errorf("Couldn't find the rmOp")
+	}
+	unrefBlocks := []BlockPointer{bNode.BlockPointer}
+	updates := []blockUpdate{
+		{rmd.data.Dir.BlockPointer, newP.path[0].BlockPointer},
+	}
+	checkOp(t, ro.OpCommon, nil, unrefBlocks, updates)
+	dirUpdate := blockUpdate{rootBlock.Children["a"].BlockPointer,
+		newP.path[1].BlockPointer}
+	if ro.Dir != dirUpdate {
+		t.Errorf("Incorrect dir update in op: %v vs. %v", ro.Dir, dirUpdate)
+	} else if ro.OldName != "b" {
+		t.Errorf("Incorrect name in op: %v", ro.OldName)
 	}
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -2126,32 +2126,23 @@ func TestRemoveDirFailNoSuchName(t *testing.T) {
 	mockCtrl, config, ctx := kbfsOpsInit(t, false)
 	defer kbfsTestShutdown(mockCtrl, config)
 
-	u, id, rmd := injectNewRMD(t, config)
+	uid, id, _ := injectNewRMD(t, config)
 
-	rootID := fakeBlockID(41)
-	aID := fakeBlockID(42)
-	bID := fakeBlockID(43)
-	rootBlock := NewDirBlock().(*DirBlock)
-	rootBlock.Children["a"] = DirEntry{
-		BlockInfo: makeBIFromID(aID, u),
-		EntryInfo: EntryInfo{
-			Type: Dir,
-		},
+	_, dirPath, dirBlocks := makeDirTree(id, uid, "a", "b", "c", "d", "e")
+	// Don't actually set rmd.data.Dir. Stuff should work anyway.
+
+	// Prime cache with all dir blocks.
+	for i, dirBlock := range dirBlocks {
+		testPutBlockInCache(
+			t, config, dirPath.path[i].BlockPointer, id, dirBlock)
 	}
-	aBlock := NewDirBlock().(*DirBlock)
-	bBlock := NewDirBlock().(*DirBlock)
-	node := pathNode{makeBP(rootID, rmd, config, u), "p"}
-	aNode := pathNode{makeBP(aID, rmd, config, u), "a"}
-	bNode := pathNode{makeBP(bID, rmd, config, u), "b"}
-	p := path{FolderBranch{Tlf: id}, []pathNode{node, aNode}}
+
 	ops := getOps(config, id)
-	n := nodeFromPath(t, ops, p)
+	n := nodeFromPath(t, ops, dirPath)
 
-	testPutBlockInCache(t, config, bNode.BlockPointer, id, bBlock)
-	testPutBlockInCache(t, config, aNode.BlockPointer, id, aBlock)
-	expectedErr := NoSuchNameError{bNode.Name}
+	expectedErr := NoSuchNameError{"nonexistent"}
 
-	if err := config.KBFSOps().RemoveDir(ctx, n, "b"); err == nil {
+	if err := config.KBFSOps().RemoveDir(ctx, n, "nonexistent"); err == nil {
 		t.Errorf("Got no expected error on removal")
 	} else if err != expectedErr {
 		t.Errorf("Got unexpected error on removal: %v", err)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -2071,77 +2071,55 @@ func TestKBFSOpsRemoveDirMissingBlock(t *testing.T) {
 
 	uid, id, rmd := injectNewRMD(t, config)
 
-	rootID := fakeBlockID(41)
-	rmd.data.Dir.ID = rootID
-	aID := fakeBlockID(42)
-	bID := fakeBlockID(43)
-	rootBlock := NewDirBlock().(*DirBlock)
-	rootBlock.Children["a"] = DirEntry{
-		BlockInfo: makeBIFromID(aID, uid),
-		EntryInfo: EntryInfo{
-			Type: Dir,
-		},
-	}
-	aBlock := NewDirBlock().(*DirBlock)
-	aBlock.Children["b"] = DirEntry{
-		BlockInfo: makeBIFromID(bID, uid),
-		EntryInfo: EntryInfo{
-			Type: Dir,
-		},
-	}
-	node := pathNode{makeBP(rootID, rmd, config, uid), "p"}
-	aNode := pathNode{makeBP(aID, rmd, config, uid), "a"}
-	bNode := pathNode{makeBP(bID, rmd, config, uid), "b"}
-	p := path{FolderBranch{Tlf: id}, []pathNode{node, aNode}}
-	ops := getOps(config, id)
-	n := nodeFromPath(t, ops, p)
+	rootEntry, dirPath, dirBlocks := makeDirTree(id, uid, "a", "b", "c", "d")
+	rmd.data.Dir = rootEntry
 
-	// deleting "a/b"
-	testPutBlockInCache(t, config, aNode.BlockPointer, id, aBlock)
-	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
+	// Prime cache with all dir blocks.
+	for i, dirBlock := range dirBlocks {
+		testPutBlockInCache(
+			t, config, dirPath.path[i].BlockPointer, id, dirBlock)
+	}
+
+	parentDirBlock := dirBlocks[len(dirBlocks)-1]
+
+	ops := getOps(config, id)
+	n := nodeFromPath(t, ops, dirPath)
+
+	entryName := "e"
+	p, _ := makeDir(dirPath, parentDirBlock, entryName)
 	// The operation might be retried several times.
 	config.mockBops.EXPECT().Get(
-		gomock.Any(), gomock.Any(), bNode.BlockPointer,
+		gomock.Any(), gomock.Any(), p.tailPointer(),
 		gomock.Any()).Return(BServerErrorBlockNonExistent{}).MinTimes(1)
+
 	// sync block
 	var newRmd *RootMetadata
-	blocks := make([]BlockID, 2)
-	unrefBytes := uint64(1) // a block of size 1 is being unreferenced
+	blockIDs := make([]BlockID, len(dirPath.path))
+	// a block of size 1 is being unreferenced
+	var unrefBytes uint64 = 1
 	expectedPath, _ := expectSyncBlock(t, config, nil, uid, id, "",
-		p, rmd, false, 0, 0, unrefBytes, &newRmd, blocks)
+		dirPath, rmd, false, 0, 0, unrefBytes, &newRmd, blockIDs)
 
-	err := config.KBFSOps().RemoveDir(ctx, n, "b")
+	err := config.KBFSOps().RemoveDir(ctx, n, entryName)
 	if err != nil {
 		t.Fatalf("Got error on removal: %v", err)
 	}
-	newP := ops.nodeCache.PathFromNode(n)
+	newDirPath := ops.nodeCache.PathFromNode(n)
 
-	checkNewPath(t, ctx, config, newP, expectedPath, newRmd, blocks,
-		Dir, "", false)
-	b1 :=
-		getDirBlockFromCache(t, config, newP.path[1].BlockPointer, newP.Branch)
-	if _, ok := b1.Children["b"]; ok {
-		t.Errorf("entry for b is still around after removal")
+	checkNewPath(t, ctx, config, newDirPath, expectedPath, newRmd,
+		blockIDs, Dir, "", false)
+	b1 := getDirBlockFromCache(
+		t, config, newDirPath.tailPointer(), newDirPath.Branch)
+	if _, ok := b1.Children[entryName]; ok {
+		t.Errorf("entry for %s is still around after removal", entryName)
 	}
-	checkBlockCache(t, config, append(blocks, rootID, aID), nil)
+	for _, n := range p.path {
+		blockIDs = append(blockIDs, n.ID)
+	}
+	checkBlockCache(t, config, blockIDs, nil)
 
-	// make sure the rmOp is correct
-	ro, ok := newRmd.data.Changes.Ops[0].(*rmOp)
-	if !ok {
-		t.Errorf("Couldn't find the rmOp")
-	}
-	unrefBlocks := []BlockPointer{bNode.BlockPointer}
-	updates := []blockUpdate{
-		{rmd.data.Dir.BlockPointer, newP.path[0].BlockPointer},
-	}
-	checkOp(t, ro.OpCommon, nil, unrefBlocks, updates)
-	dirUpdate := blockUpdate{rootBlock.Children["a"].BlockPointer,
-		newP.path[1].BlockPointer}
-	if ro.Dir != dirUpdate {
-		t.Errorf("Incorrect dir update in op: %v vs. %v", ro.Dir, dirUpdate)
-	} else if ro.OldName != "b" {
-		t.Errorf("Incorrect name in op: %v", ro.OldName)
-	}
+	unrefBlocks := []BlockPointer{p.tailPointer()}
+	checkRmOp(t, entryName, newRmd, dirPath, newDirPath, unrefBlocks)
 }
 
 func TestRemoveDirFailNoSuchName(t *testing.T) {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1841,9 +1841,10 @@ func TestKBFSOpsRemoveFileMissingBlock(t *testing.T) {
 	// deleting "a/b"
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, aBlock)
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
+	// The operation might be retried several times.
 	config.mockBops.EXPECT().Get(
 		gomock.Any(), gomock.Any(), bNode.BlockPointer,
-		gomock.Any()).Return(BServerErrorBlockNonExistent{})
+		gomock.Any()).Return(BServerErrorBlockNonExistent{}).MinTimes(1)
 	// sync block
 	var newRmd *RootMetadata
 	blocks := make([]BlockID, 2)
@@ -1919,9 +1920,10 @@ func TestKBFSOpsRemoveDirMissingBlock(t *testing.T) {
 	// deleting "a/b"
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, aBlock)
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
+	// The operation might be retried several times.
 	config.mockBops.EXPECT().Get(
 		gomock.Any(), gomock.Any(), bNode.BlockPointer,
-		gomock.Any()).Return(BServerErrorBlockNonExistent{})
+		gomock.Any()).Return(BServerErrorBlockNonExistent{}).MinTimes(1)
 	// sync block
 	var newRmd *RootMetadata
 	blocks := make([]BlockID, 2)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1563,7 +1563,7 @@ func TestCreateLinkFailKBFSPrefix(t *testing.T) {
 // blocks. If n components are given, then the path will have n+1
 // nodes (one extra for the root node).
 func makeDir(uid keybase1.UID, id TlfID, rmd *RootMetadata,
-	components ...string) (path, []Block) {
+	components ...string) (path, []*DirBlock) {
 	var idCounter byte = 41
 	makeBlockID := func() BlockID {
 		id := fakeBlockID(idCounter)
@@ -1583,7 +1583,7 @@ func makeDir(uid keybase1.UID, id TlfID, rmd *RootMetadata,
 	}
 	nodes := []pathNode{{bi.BlockPointer, "{root}"}}
 	rootBlock := NewDirBlock().(*DirBlock)
-	blocks := []Block{rootBlock}
+	blocks := []*DirBlock{rootBlock}
 
 	// Handle the rest.
 
@@ -1619,9 +1619,13 @@ func makePath(uid keybase1.UID, id TlfID, rmd *RootMetadata, et EntryType,
 	dirComponents := components[:len(components)-1]
 	entryComponent := components[len(components)-1]
 
-	dirPath, blocks := makeDir(uid, id, rmd, dirComponents...)
+	dirPath, dirBlocks := makeDir(uid, id, rmd, dirComponents...)
 
-	parentDirBlock := blocks[len(blocks)-1].(*DirBlock)
+	parentDirBlock := dirBlocks[len(dirBlocks)-1]
+	blocks := make([]Block, len(dirBlocks))
+	for i, dirBlock := range dirBlocks {
+		blocks[i] = dirBlock
+	}
 	bid := fakeBlockID(105)
 	bi := makeBIFromID(bid, uid)
 	if et == Sym {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1648,11 +1648,19 @@ func checkRmOp(t *testing.T, entryName string, newRmd *RootMetadata,
 	if et != Sym {
 		unrefBlocks = []BlockPointer{p.tailPointer()}
 	}
-	parentPath := *p.parentPath()
-	updates := []blockUpdate{{
-		parentPath.path[0].BlockPointer,
-		newParentPath.path[0].BlockPointer,
-	}}
+	var parentPath path
+	if et == Sym {
+		parentPath = p
+	} else {
+		parentPath = *p.parentPath()
+	}
+	var updates []blockUpdate
+	for i := 0; i < len(parentPath.path)-1; i++ {
+		updates = append(updates, blockUpdate{
+			parentPath.path[i].BlockPointer,
+			newParentPath.path[i].BlockPointer,
+		})
+	}
 	checkOp(t, ro.OpCommon, nil, unrefBlocks, updates)
 	dirUpdate := blockUpdate{
 		parentPath.tailPointer(), newParentPath.tailPointer(),

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1871,6 +1871,8 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 		},
 	}
 
+	// TODO: Write a helper function for making a file with
+	// indirect blocks and use it in other tests.
 	bid1 := fakeBlockIDAdd(lastBID, 2)
 	bid2 := fakeBlockIDAdd(lastBID, 3)
 	bid3 := fakeBlockIDAdd(lastBID, 4)

--- a/vendor/github.com/golang/mock/LICENSE
+++ b/vendor/github.com/golang/mock/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/golang/mock/gomock/call.go
+++ b/vendor/github.com/golang/mock/gomock/call.go
@@ -41,8 +41,29 @@ type Call struct {
 	setArgs map[int]reflect.Value
 }
 
+// AnyTimes allows the expectation to be called 0 or more times
 func (c *Call) AnyTimes() *Call {
 	c.minCalls, c.maxCalls = 0, 1e8 // close enough to infinity
+	return c
+}
+
+// MinTimes requires the call to occur at least n times. If AnyTimes or MaxTimes have not been called, MinTimes also
+// sets the maximum number of calls to infinity.
+func (c *Call) MinTimes(n int) *Call {
+	c.minCalls = n
+	if c.maxCalls == 1 {
+		c.maxCalls = 1e8
+	}
+	return c
+}
+
+// MaxTimes limits the number of calls to n times. If AnyTimes or MinTimes have not been called, MaxTimes also
+// sets the minimum number of calls to 0.
+func (c *Call) MaxTimes(n int) *Call {
+	c.maxCalls = n
+	if c.minCalls == 1 {
+		c.minCalls = 0
+	}
 	return c
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -93,9 +93,10 @@
 			"tree": true
 		},
 		{
+			"checksumSHA1": "JSHl8b3nI8EWvzm+uyrIqj2Hiu4=",
 			"path": "github.com/golang/mock/gomock",
-			"revision": "58a501f87109a45c68afc54e6b1368398678d386",
-			"revisionTime": "2015-12-12T20:20:50-08:00"
+			"revision": "bd3c8e81be01eef76d4b503f5e687d2d1354d2d9",
+			"revisionTime": "2016-01-21T18:51:14Z"
 		},
 		{
 			"path": "github.com/google/go-snappy/snappy",


### PR DESCRIPTION
When removing a file, we need to retrieve its top block
in order to account for any other indirect blocks. Also,
when removing a dir, we need to retrieve it in order to
make sure it is empty. In either case, if the block doesn't
exist, go ahead with the removal.

We should still figure out what's causing these bad
pointers, but we shouldn't prevent people from removing
those bad files/dirs.