### PR TITLE
delete blocks in a constantly running goroutine; also use a `chan` instead of a `map` for blocks to be deleted

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -704,8 +704,7 @@ func (c *ConfigLocal) Shutdown() error {
 				continue
 			}
 			for _, fbo := range kbfsOps.ops {
-				err := fbo.fbm.waitForArchives(context.Background())
-				if err != nil {
+				if err := fbo.fbm.waitForArchives(context.Background()); err != nil {
 					return err
 				}
 			}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3809,6 +3809,9 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 	if err := fbo.fbm.waitForArchives(ctx); err != nil {
 		return err
 	}
+	if err := fbo.fbm.waitForDeletingBlocks(ctx); err != nil {
+		return err
+	}
 	return fbo.fbm.waitForQuotaReclamations(ctx)
 }
 

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1010,6 +1010,7 @@ func TestCRDouble(t *testing.T) {
 	// Wait for the processor to try to delete the failed revision
 	// (which pulls the unmerged MD ops back into the cache).
 	ops.fbm.waitForArchives(ctx)
+	ops.fbm.waitForDeletingBlocks(ctx)
 
 	// Sync user 1, then start another round of CR.
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode2.GetFolderBranch())


### PR DESCRIPTION
![selfie-0](http://i.imgur.com/4mDM6nT.png)
[_GitHub Selfies_](https://github.com/thieman/github-selfies/)
