### PR TITLE
Always lock before calling setLatestMergedRevisionLocked

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -797,9 +797,14 @@ func (fbo *folderBranchOps) getMDLocked(
 		// There are no unmerged MDs for this device, so just use the current head.
 		md = mergedMD
 	} else {
-		// We don't need to do this for merged head because the setHeadLocked()
-		// already does that anyway.
-		fbo.setLatestMergedRevisionLocked(ctx, lState, mergedMD.Revision, false)
+		func() {
+			fbo.headLock.Lock(lState)
+			defer fbo.headLock.Unlock(lState)
+			// We don't need to do this for merged head
+			// because the setHeadLocked() already does
+			// that anyway.
+			fbo.setLatestMergedRevisionLocked(ctx, lState, mergedMD.Revision, false)
+		}
 	}
 
 	if md.data.Dir.Type != Dir && (!md.IsInitialized() || md.IsReadable()) {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3467,8 +3467,12 @@ func (fbo *folderBranchOps) undoUnmergedMDUpdatesLocked(
 	err = func() error {
 		fbo.headLock.Lock(lState)
 		defer fbo.headLock.Unlock(lState)
+		err := fbo.setHeadPredecessorLocked(ctx, lState, rmds[0])
+		if err != nil {
+			return err
+		}
 		fbo.setLatestMergedRevisionLocked(ctx, lState, rmds[0].Revision, true)
-		return fbo.setHeadPredecessorLocked(ctx, lState, rmds[0])
+		return nil
 	}()
 	if err != nil {
 		return nil, err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -777,6 +777,13 @@ func (fbo *folderBranchOps) getMDLocked(
 		return nil, MDWriteNeededInRequest{}
 	}
 
+	// We go down this code path either due to a rekey
+	// notification for an unseen TLF, or in some tests.
+	//
+	// TODO: Make tests not take this code path, and keep track of
+	// the fact that MDs coming from rekey notifications are
+	// untrusted.
+
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	// Not in cache, fetch from server and add to cache.  First, see
@@ -814,12 +821,6 @@ func (fbo *folderBranchOps) getMDLocked(
 			return nil, err
 		}
 	} else {
-		// We go down this code path either due to a rekey
-		// notification for an unseen TLF, or in some tests.
-		//
-		// TODO: Make tests not take this code path, and keep
-		// track of the fact that MDs coming from rekey
-		// notifications are untrusted.
 		fbo.headLock.Lock(lState)
 		defer fbo.headLock.Unlock(lState)
 		err = fbo.setInitialHeadUntrustedLocked(ctx, lState, md)


### PR DESCRIPTION
Also only call it after the head is properly set in
one case.

Put headLock-protected variables together.