### PR TITLE
dokan: Load dokan1.dll dynamically

### DIFF
--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -11,9 +11,10 @@ static HANDLE __stdcall (*kbfsLibdokanPtr_OpenRequestorToken)(PDOKAN_FILE_INFO D
 static int __stdcall (*kbfsLibdokanPtr_Main)(PDOKAN_OPTIONS DokanOptions, PDOKAN_OPERATIONS DokanOperations);
 
 DWORD kbfsLibdokanLoadLibrary(LPCWSTR location) {
+  int i;
   // 0x800 is LOAD_LIBRARY_SEARCH_SYSTEM32 but that is not defined on build machines.
   DWORD flags = 0x800;
-  for(int i=0; location[i]; i++)
+  for(i=0; location[i]; i++)
     if(location[i]== L'/' || location[i]==L'\\') {
       flags = 0;
       break;

--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -11,12 +11,13 @@ static HANDLE __stdcall (*kbfsLibdokanPtr_OpenRequestorToken)(PDOKAN_FILE_INFO D
 static int __stdcall (*kbfsLibdokanPtr_Main)(PDOKAN_OPTIONS DokanOptions, PDOKAN_OPERATIONS DokanOperations);
 
 DWORD kbfsLibdokanLoadLibrary(LPCWSTR location) {
-	DWORD flags = LOAD_LIBRARY_SEARCH_SYSTEM32;
-	for(int i=0; location[i]; i++)
-		if(location[i]== L'/' || location[i]==L'\\') {
-			flags = 0;
-			break;
-		}
+  // 0x800 is LOAD_LIBRARY_SEARCH_SYSTEM32 but that is not defined on build machines.
+  DWORD flags = 0x800;
+  for(int i=0; location[i]; i++)
+    if(location[i]== L'/' || location[i]==L'\\') {
+      flags = 0;
+      break;
+    }
   HMODULE mod = LoadLibraryExW(location, NULL, flags);
   if(mod == NULL)
     return GetLastError();

--- a/dokan/bridge.h
+++ b/dokan/bridge.h
@@ -34,12 +34,17 @@ struct kbfsLibdokanCtx {
   DOKAN_OPTIONS dokan_options;
 };
 
+DWORD kbfsLibdokanLoadLibrary(LPCWSTR location);
+
 struct kbfsLibdokanCtx* kbfsLibdokanAllocCtx(ULONG64 fsslot);
 error_t kbfsLibdokanFree(struct kbfsLibdokanCtx* ctx);
 error_t kbfsLibdokanRun(struct kbfsLibdokanCtx* ctx);
 void kbfsLibdokanSet_path(struct kbfsLibdokanCtx* ctx, void*);
 
 int kbfsLibdokanFill_find(PFillFindData, PWIN32_FIND_DATAW, PDOKAN_FILE_INFO);
+
+BOOL kbfsLibdokan_RemoveMountPoint(LPCWSTR MountPoint);
+HANDLE kbfsLibdokan_OpenRequestorToken(PDOKAN_FILE_INFO DokanFileInfo);
 
 enum {
   kbfsLibdokanDebug = DOKAN_OPTION_DEBUG|DOKAN_OPTION_STDERR,


### PR DESCRIPTION
This allows for more freedom in specifying the location of dokan1.dll