### PR TITLE
Remove deviceKID arg from mdServerTlfStorage

### DIFF
--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -317,17 +317,12 @@ func (md *MDServerDisk) GetForTLF(ctx context.Context, id TlfID,
 		return nil, MDServerError{err}
 	}
 
-	key, err := md.config.KBPKI().GetCurrentCryptPublicKey(ctx)
-	if err != nil {
-		return nil, MDServerError{err}
-	}
-
 	tlfStorage, err := md.getStorage(id)
 	if err != nil {
 		return nil, err
 	}
 
-	return tlfStorage.getForTLF(currentUID, key.kid, bid)
+	return tlfStorage.getForTLF(currentUID, bid)
 }
 
 // GetRange implements the MDServer interface for MDServerDisk.
@@ -353,17 +348,12 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id TlfID,
 		return nil, MDServerError{err}
 	}
 
-	key, err := md.config.KBPKI().GetCurrentCryptPublicKey(ctx)
-	if err != nil {
-		return nil, MDServerError{err}
-	}
-
 	tlfStorage, err := md.getStorage(id)
 	if err != nil {
 		return nil, err
 	}
 
-	return tlfStorage.getRange(currentUID, key.kid, bid, start, stop)
+	return tlfStorage.getRange(currentUID, bid, start, stop)
 }
 
 // Put implements the MDServer interface for MDServerDisk.
@@ -373,17 +363,12 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 		return MDServerError{err}
 	}
 
-	key, err := md.config.KBPKI().GetCurrentCryptPublicKey(ctx)
-	if err != nil {
-		return MDServerError{err}
-	}
-
 	tlfStorage, err := md.getStorage(rmds.MD.ID)
 	if err != nil {
 		return err
 	}
 
-	recordBranchID, err := tlfStorage.put(currentUID, key.kid, rmds)
+	recordBranchID, err := tlfStorage.put(currentUID, rmds)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -195,7 +195,7 @@ func (s *mdServerTlfStorage) getHeadForTLFReadLocked(bid BranchID) (
 }
 
 func (s *mdServerTlfStorage) checkGetParamsReadLocked(
-	currentUID keybase1.UID, deviceKID keybase1.KID, bid BranchID) error {
+	currentUID keybase1.UID, bid BranchID) error {
 	mergedMasterHead, err := s.getHeadForTLFReadLocked(NullBranchID)
 	if err != nil {
 		return MDServerError{err}
@@ -213,10 +213,9 @@ func (s *mdServerTlfStorage) checkGetParamsReadLocked(
 }
 
 func (s *mdServerTlfStorage) getRangeReadLocked(
-	currentUID keybase1.UID, deviceKID keybase1.KID,
-	bid BranchID, start, stop MetadataRevision) (
+	currentUID keybase1.UID, bid BranchID, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
-	err := s.checkGetParamsReadLocked(currentUID, deviceKID, bid)
+	err := s.checkGetParamsReadLocked(currentUID, bid)
 	if err != nil {
 		return nil, err
 	}
@@ -272,8 +271,7 @@ func (s *mdServerTlfStorage) journalLength(bid BranchID) (uint64, error) {
 }
 
 func (s *mdServerTlfStorage) getForTLF(
-	currentUID keybase1.UID, deviceKID keybase1.KID,
-	bid BranchID) (*RootMetadataSigned, error) {
+	currentUID keybase1.UID, bid BranchID) (*RootMetadataSigned, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -281,7 +279,7 @@ func (s *mdServerTlfStorage) getForTLF(
 		return nil, errMDServerTlfStorageShutdown
 	}
 
-	err := s.checkGetParamsReadLocked(currentUID, deviceKID, bid)
+	err := s.checkGetParamsReadLocked(currentUID, bid)
 	if err != nil {
 		return nil, err
 	}
@@ -294,8 +292,7 @@ func (s *mdServerTlfStorage) getForTLF(
 }
 
 func (s *mdServerTlfStorage) getRange(
-	currentUID keybase1.UID, deviceKID keybase1.KID,
-	bid BranchID, start, stop MetadataRevision) (
+	currentUID keybase1.UID, bid BranchID, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -304,12 +301,12 @@ func (s *mdServerTlfStorage) getRange(
 		return nil, errMDServerTlfStorageShutdown
 	}
 
-	return s.getRangeReadLocked(currentUID, deviceKID, bid, start, stop)
+	return s.getRangeReadLocked(currentUID, bid, start, stop)
 }
 
 func (s *mdServerTlfStorage) put(
-	currentUID keybase1.UID, deviceKID keybase1.KID,
-	rmds *RootMetadataSigned) (recordBranchID bool, err error) {
+	currentUID keybase1.UID, rmds *RootMetadataSigned) (
+	recordBranchID bool, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -349,7 +346,7 @@ func (s *mdServerTlfStorage) put(
 		// currHead for unmerged history might be on the main branch
 		prevRev := rmds.MD.Revision - 1
 		rmdses, err := s.getRangeReadLocked(
-			currentUID, deviceKID, NullBranchID, prevRev, prevRev)
+			currentUID, NullBranchID, prevRev, prevRev)
 		if err != nil {
 			return false, MDServerError{err}
 		}


### PR DESCRIPTION
This is redundant, since the branch ID is already passed
in. I just forgot to remove it.