### PR TITLE
TLF reset bug fixes

### DIFF
--- a/libkbfs/bare_tlf_handle.go
+++ b/libkbfs/bare_tlf_handle.go
@@ -269,3 +269,8 @@ func (h BareTlfHandle) Extensions() (extensions []TlfHandleExtension) {
 func (h BareTlfHandle) IsFinal() bool {
 	return h.FinalizedInfo != nil
 }
+
+// IsConflict returns true if the handle is a conflict handle.
+func (h BareTlfHandle) IsConflict() bool {
+	return h.ConflictInfo != nil
+}

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -94,8 +94,7 @@ type LocalUser struct {
 	// Index into UserInfo.VerifyingKeys.
 	CurrentVerifyingKeyIndex int
 	// Unverified keys.
-	UnverifiedVerifyingKeys   []VerifyingKey
-	UnverifiedCryptPublicKeys []CryptPublicKey
+	UnverifiedKeys []keybase1.PublicKey
 }
 
 // GetCurrentCryptPublicKey returns this LocalUser's public encryption key.

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1131,3 +1131,13 @@ type OpsCantHandleFavorite struct {
 func (e OpsCantHandleFavorite) Error() string {
 	return fmt.Sprintf("Couldn't handle the favorite operation: %s", e.Msg)
 }
+
+// TlfHandleFinalizedError is returned when something attempts to modify
+// a finalized TLF handle.
+type TlfHandleFinalizedError struct {
+}
+
+// Error implements the error interface for TlfHandleFinalizedError.
+func (e TlfHandleFinalizedError) Error() string {
+	return "Attempt to modify finalized TLF handle"
+}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -636,7 +636,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	resolvesTo, partialResolvedOldHandle, err :=
 		oldHandle.ResolvesTo(
 			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
-			newHandle)
+			*newHandle)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -290,7 +290,7 @@ type KeybaseDaemon interface {
 	// of all known public keys associated with the account and the currently verified
 	// keys currently part of the user's sigchain.
 	LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
-		[]VerifyingKey, []CryptPublicKey, error)
+		[]keybase1.PublicKey, error)
 
 	// CurrentSession returns a SessionInfo struct with all the
 	// information for the current session, or an error otherwise.

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -131,13 +131,13 @@ func (k *KBPKIClient) hasVerifyingKey(ctx context.Context, uid keybase1.UID,
 
 func (k *KBPKIClient) hasUnverifiedVerifyingKey(ctx context.Context, uid keybase1.UID,
 	verifyingKey VerifyingKey) (bool, error) {
-	verifyingKeys, _, err := k.loadUnverifiedKeys(ctx, uid)
+	keys, err := k.loadUnverifiedKeys(ctx, uid)
 	if err != nil {
 		return false, err
 	}
 
-	for _, key := range verifyingKeys {
-		if !verifyingKey.kid.Equal(key.kid) {
+	for _, key := range keys {
+		if !verifyingKey.kid.Equal(key.KID) {
 			continue
 		}
 		k.log.CDebugf(ctx, "Trusting potentially unverified key %s for user %s",
@@ -237,6 +237,6 @@ func (k *KBPKIClient) Notify(ctx context.Context, notification *keybase1.FSNotif
 }
 
 func (k *KBPKIClient) loadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
-	[]VerifyingKey, []CryptPublicKey, error) {
+	[]keybase1.PublicKey, error) {
 	return k.config.KeybaseDaemon().LoadUnverifiedKeys(ctx, uid)
 }

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -193,7 +193,8 @@ func makeTestKBPKIClientWithUnverifiedKey(t *testing.T) (
 		index := 99
 		keySalt := keySaltForUserDevice(user.Name, index)
 		newVerifyingKey := MakeLocalUserVerifyingKeyOrBust(keySalt)
-		user.UnverifiedVerifyingKeys = []VerifyingKey{newVerifyingKey}
+		key := keybase1.PublicKey{KID: newVerifyingKey.kid}
+		user.UnverifiedKeys = []keybase1.PublicKey{key}
 		users[i] = user
 	}
 	codec := NewCodecMsgpack()
@@ -207,8 +208,8 @@ func TestKBPKIClientHasUnverifiedVerifyingKey(t *testing.T) {
 	c, _, localUsers := makeTestKBPKIClientWithUnverifiedKey(t)
 
 	var unverifiedKey VerifyingKey
-	for _, k := range localUsers[0].UnverifiedVerifyingKeys {
-		unverifiedKey = k
+	for _, k := range localUsers[0].UnverifiedKeys {
+		unverifiedKey.kid = k.KID
 		break
 	}
 

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -216,14 +216,14 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context, uid keybase1.
 
 // LoadUnverifiedKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
-	[]VerifyingKey, []CryptPublicKey, error) {
+	[]keybase1.PublicKey, error) {
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	u, err := k.localUsers.getLocalUser(uid)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return u.UnverifiedVerifyingKeys, u.UnverifiedCryptPublicKeys, nil
+	return u.UnverifiedKeys, nil
 }
 
 // CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.

--- a/libkbfs/keybase_daemon_measured.go
+++ b/libkbfs/keybase_daemon_measured.go
@@ -83,11 +83,11 @@ func (k KeybaseDaemonMeasured) LoadUserPlusKeys(ctx context.Context, uid keybase
 
 // LoadUnverifiedKeys implements the KeybaseDaemon interface for KeybaseDaemonMeasured.
 func (k KeybaseDaemonMeasured) LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
-	verifyingKeys []VerifyingKey, cryptKeys []CryptPublicKey, err error) {
+	keys []keybase1.PublicKey, err error) {
 	k.loadUnverifiedKeysTimer.Time(func() {
-		verifyingKeys, cryptKeys, err = k.delegate.LoadUnverifiedKeys(ctx, uid)
+		keys, err = k.delegate.LoadUnverifiedKeys(ctx, uid)
 	})
-	return verifyingKeys, cryptKeys, err
+	return keys, err
 }
 
 // CurrentSession implements the KeybaseDaemon interface for

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -118,13 +118,9 @@ func (c *fakeKeybaseClient) Call(ctx context.Context, s string, args interface{}
 
 	case "keybase.1.user.loadAllPublicKeysUnverified":
 		pk := keybase1.PublicKey{
-			KID:      MakeFakeVerifyingKeyOrBust("foo").KID(),
-			IsSibkey: true,
+			KID: MakeFakeVerifyingKeyOrBust("foo").KID(),
 		}
-		ck := keybase1.PublicKey{
-			KID: MakeFakeCryptPublicKeyOrBust("bar").KID(),
-		}
-		*res.(*[]keybase1.PublicKey) = []keybase1.PublicKey{pk, ck}
+		*res.(*[]keybase1.PublicKey) = []keybase1.PublicKey{pk}
 
 		c.loadAllPublicKeysUnverified = true
 		return nil
@@ -216,13 +212,11 @@ func testLoadUnverifiedKeys(
 	client.loadAllPublicKeysUnverified = false
 
 	ctx := context.Background()
-	verifyingKeys, cryptKeys, err := c.LoadUnverifiedKeys(ctx, uid)
+	keys, err := c.LoadUnverifiedKeys(ctx, uid)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, len(verifyingKeys))
-	assert.Equal(t, verifyingKeys[0].KID(), MakeFakeVerifyingKeyOrBust("foo").KID())
-	assert.Equal(t, 1, len(cryptKeys))
-	assert.Equal(t, cryptKeys[0].KID(), MakeFakeCryptPublicKeyOrBust("bar").KID())
+	assert.Equal(t, 1, len(keys))
+	assert.Equal(t, keys[0].KID, MakeFakeVerifyingKeyOrBust("foo").KID())
 	assert.Equal(t, expectedCalled, client.loadAllPublicKeysUnverified)
 }
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -231,7 +231,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 
 	handleResolvesToMdHandle, partialResolvedHandle, err :=
 		handle.ResolvesTo(
-			ctx, md.config.Codec(), md.config.KBPKI(), mdHandle)
+			ctx, md.config.Codec(), md.config.KBPKI(), *mdHandle)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 	// TODO: If handle has conflict info, mdHandle should, too.
 	mdHandleResolvesToHandle, partialResolvedMdHandle, err :=
 		mdHandle.ResolvesTo(
-			ctx, md.config.Codec(), md.config.KBPKI(), handle)
+			ctx, md.config.Codec(), md.config.KBPKI(), *handle)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -719,7 +719,7 @@ func TestMDOpsGetRangeFailFinal(t *testing.T) {
 
 	rmds2.MD.Revision = 201
 	rmds2.MD.mdID = fakeMdID(41)
-	rmds2.MD.PrevRoot = rmds3.MD.mdID
+	rmds2.MD.PrevRoot = rmds3.MD.PrevRoot
 	rmds2.MD.Flags |= MetadataFlagFinal
 
 	rmds1.MD.Revision = 202

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4,15 +4,14 @@
 package libkbfs
 
 import (
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
 	protocol "github.com/keybase/client/go/protocol"
 	go_metrics "github.com/rcrowley/go-metrics"
 	context "golang.org/x/net/context"
+	reflect "reflect"
+	time "time"
 )
 
 // Mock of AuthTokenRefreshHandler interface
@@ -545,12 +544,11 @@ func (_mr *_MockKeybaseDaemonRecorder) LoadUserPlusKeys(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadUserPlusKeys", arg0, arg1)
 }
 
-func (_m *MockKeybaseDaemon) LoadUnverifiedKeys(ctx context.Context, uid protocol.UID) ([]VerifyingKey, []CryptPublicKey, error) {
+func (_m *MockKeybaseDaemon) LoadUnverifiedKeys(ctx context.Context, uid protocol.UID) ([]protocol.PublicKey, error) {
 	ret := _m.ctrl.Call(_m, "LoadUnverifiedKeys", ctx, uid)
-	ret0, _ := ret[0].([]VerifyingKey)
-	ret1, _ := ret[1].([]CryptPublicKey)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].([]protocol.PublicKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockKeybaseDaemonRecorder) LoadUnverifiedKeys(arg0, arg1 interface{}) *gomock.Call {
@@ -3567,6 +3565,14 @@ func (_m *MockConfig) DoBackgroundFlushes() bool {
 
 func (_mr *_MockConfigRecorder) DoBackgroundFlushes() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DoBackgroundFlushes")
+}
+
+func (_m *MockConfig) SetDoBackgroundFlushes(_param0 bool) {
+	_m.ctrl.Call(_m, "SetDoBackgroundFlushes", _param0)
+}
+
+func (_mr *_MockConfigRecorder) SetDoBackgroundFlushes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDoBackgroundFlushes", arg0)
 }
 
 func (_m *MockConfig) RekeyWithPromptWaitTime() time.Duration {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -442,9 +442,17 @@ func (md *RootMetadata) CheckValidSuccessor(
 	}
 
 	// (3) Check PrevRoot pointer.
-	currRoot, err := md.MetadataID(crypto)
-	if err != nil {
-		return err
+	var currRoot MdID
+	if !nextMd.IsFinal() {
+		var err error
+		currRoot, err = md.MetadataID(crypto)
+		if err != nil {
+			return err
+		}
+	} else {
+		// For finalized metadata the previous head's
+		// PrevRoot is expected.
+		currRoot = md.PrevRoot
 	}
 	if nextMd.PrevRoot != currRoot {
 		return MDPrevRootMismatch{

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -637,19 +637,19 @@ func (h TlfHandle) ResolvesTo(
 
 	// Check the conflict extension.
 	var conflictAdded, finalizedAdded bool
-	if h.conflictInfo == nil && other.conflictInfo != nil {
+	if !h.IsConflict() && other.IsConflict() {
 		conflictAdded = true
 		// Ignore the added extension for resolution comparison purposes.
 		other.conflictInfo = nil
 	}
 
 	// Check the finalized extension.
-	if h.finalizedInfo != nil {
+	if h.IsFinal() {
 		if conflictAdded {
 			// Can't add conflict info to a finalized handle.
 			return false, nil, TlfHandleFinalizedError{}
 		}
-	} else if other.finalizedInfo != nil {
+	} else if other.IsFinal() {
 		finalizedAdded = true
 		// Ignore the added extension for resolution comparison purposes.
 		other.finalizedInfo = nil
@@ -941,4 +941,10 @@ func CheckTlfHandleOffline(
 // top-level folder.
 func (h TlfHandle) IsFinal() bool {
 	return h.finalizedInfo != nil
+}
+
+// IsConflict returns whether or not this TlfHandle represents a conflicted
+// top-level folder.
+func (h TlfHandle) IsConflict() bool {
+	return h.conflictInfo != nil
 }

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -207,8 +207,8 @@ func init() {
 	}
 }
 
-// Equals returns whether h and other contain the same info.
-func (h TlfHandle) Equals(codec Codec, other TlfHandle) (bool, error) {
+// EqualsIgnoreName returns whether h and other contain the same info ignoring the name.
+func (h TlfHandle) EqualsIgnoreName(codec Codec, other TlfHandle) (bool, error) {
 	if h.public != other.public {
 		return false, nil
 	}
@@ -241,16 +241,22 @@ func (h TlfHandle) Equals(codec Codec, other TlfHandle) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if !eq {
-		return false, nil
+	return eq, nil
+}
+
+// Equals returns whether h and other contain the same info.
+func (h TlfHandle) Equals(codec Codec, other TlfHandle) (bool, error) {
+	eq, err := h.EqualsIgnoreName(codec, other)
+	if err != nil {
+		return false, err
 	}
 
-	if h.name != other.name {
+	if eq && h.name != other.name {
 		panic(fmt.Errorf(
 			"%+v equals %+v in everything but name", h, other))
 	}
 
-	return true, nil
+	return eq, nil
 }
 
 // ToBareHandle returns a BareTlfHandle corresponding to this handle.
@@ -626,8 +632,29 @@ func (pr partialResolver) Resolve(ctx context.Context, assertion string) (
 // resolved except for unresolved assertions in other; this should
 // equal other if and only if true is returned.
 func (h TlfHandle) ResolvesTo(
-	ctx context.Context, codec Codec, resolver resolver, other *TlfHandle) (
+	ctx context.Context, codec Codec, resolver resolver, other TlfHandle) (
 	resolvesTo bool, partialResolvedH *TlfHandle, err error) {
+
+	// Check the conflict extension.
+	var conflictAdded, finalizedAdded bool
+	if h.conflictInfo == nil && other.conflictInfo != nil {
+		conflictAdded = true
+		// Ignore the added extension for resolution comparison purposes.
+		other.conflictInfo = nil
+	}
+
+	// Check the finalized extension.
+	if h.finalizedInfo != nil {
+		if conflictAdded {
+			// Can't add conflict info to a finalized handle.
+			return false, nil, TlfHandleFinalizedError{}
+		}
+	} else if other.finalizedInfo != nil {
+		finalizedAdded = true
+		// Ignore the added extension for resolution comparison purposes.
+		other.finalizedInfo = nil
+	}
+
 	unresolvedAssertions := make(map[string]bool)
 	for _, uw := range other.unresolvedWriters {
 		unresolvedAssertions[uw.String()] = true
@@ -645,11 +672,11 @@ func (h TlfHandle) ResolvesTo(
 		return false, nil, err
 	}
 
-	// TODO: If h doesn't have conflict info and other does, and
-	// everything else is equal, we should still return true.
-	//
-	// TODO: The same for finalized info?
-	resolvesTo, err = partialResolvedH.Equals(codec, *other)
+	if conflictAdded || finalizedAdded {
+		resolvesTo, err = partialResolvedH.EqualsIgnoreName(codec, other)
+	} else {
+		resolvesTo, err = partialResolvedH.Equals(codec, other)
+	}
 	if err != nil {
 		return false, nil, err
 	}


### PR DESCRIPTION
This along with https://github.com/keybase/kbfs-server/pull/64 fixes issues seen when integration testing in the staging environment.

Note: It's not obvious from the diff but when the API server returns unverified keys they aren't tagged as sibling or subkeys so I needed to stop filtering them as such (they all ended up as subkeys w/filtering.)