### PR TITLE
folder_block_ops: make a deCache entry even for overwritten files

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1315,8 +1315,12 @@ func (fbo *folderBlockOps) writeDataLocked(
 			de.EncodedSize = 0
 			// update the file info
 			de.Size += uint64(len(block.Contents) - oldLen)
-			fbo.deCache[file.tailPointer().ref()] = de
 		}
+		// Put it in the `deCache` even if the size didn't change,
+		// since the `deCache` is used to determine whether there are
+		// any dirty files.  TODO: combine `deCache` with `dirtyFiles`
+		// and `unrefCache`.
+		fbo.deCache[file.tailPointer().ref()] = de
 
 		// Calculate the amount of bytes we've newly-dirtied as part
 		// of this write.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5176,6 +5176,31 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 
 	// Make sure we get the notification
 	<-c
+
+	// Since in the mock test all MDs get the same MD ID, manually
+	// alter head's md ID so it doesn't look the same as the next MD
+	// (which would cause setHeadRevision to skip it).
+	newRmd.mdIDLock.Lock()
+	newRmd.mdID = fakeMdID(fakeTlfIDByte(id) + 100)
+	newRmd.mdIDLock.Unlock()
+
+	// Make sure we get a sync even if we overwrite (not extend) the file
+	data[1] = 0
+	config.mockBsplit.EXPECT().CopyUntilSplit(
+		gomock.Any(), gomock.Any(), data, int64(0)).
+		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
+			block.Contents = data
+		}).Return(int64(len(data)))
+	// expect another sync to happen in the background
+	var newRmd2 *RootMetadata
+	blocks = make([]BlockID, 2)
+	expectSyncBlock(t, config, nil, uid, id, "", p, rmd, false, 0, 0, 0,
+		&newRmd2, blocks)
+
+	if err := config.KBFSOps().Write(ctx, n, data, 0); err != nil {
+		t.Errorf("Got error on write: %v", err)
+	}
+	<-c
 }
 
 func TestKBFSOpsWriteRenameStat(t *testing.T) {


### PR DESCRIPTION
Otherwise the file is not marked as dirty, and background syncs won't
happen.

Split out from #134.
