### PR TITLE
[KBFS-1099] Add scaffolding for write journals

### DIFF
--- a/libdokan/journal_control_file.go
+++ b/libdokan/journal_control_file.go
@@ -35,9 +35,13 @@ func (f *JournalControlFile) WriteFile(
 
 	jServer, err := libkbfs.GetJournalServer(f.folder.fs.config)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	err = f.action.Execute(jServer, f.folder.getFolderBranch().Tlf)
-	return len(bs), err
+	if err != nil {
+		return 0, err
+	}
+
+	return len(bs), nil
 }

--- a/libdokan/journal_control_file.go
+++ b/libdokan/journal_control_file.go
@@ -29,37 +29,9 @@ func (f *JournalControlFile) WriteFile(
 		f.folder.fs,
 		fmt.Sprintf("JournalQuotaFile (action=%s) Write", action))
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err, cancel) }()
-	if len(req.Data) == 0 {
-		return nil
+	if len(bs) == 0 {
+		return 0, nil
 	}
-
-	jServer, err := libkbfs.GetJournalServer(f.folder.fs.config)
-	if err != nil {
-		return 0, err
-	}
-
-	switch f.action {
-	case libfs.JournalEnable:
-		err := jServer.Enable(f.folder.getFolderBranch().Tlf)
-		if err != nil {
-			return 0, err
-		}
-
-	case libfs.JournalFlush:
-		err := jServer.Flush(f.folder.getFolderBranch().Tlf)
-		if err != nil {
-			return 0, err
-		}
-
-	case libfs.JournalDisable:
-		err := jServer.Disable(f.folder.getFolderBranch().Tlf)
-		if err != nil {
-			return 0, err
-		}
-
-	default:
-		return 0, fmt.Errorf("Unknown action %s", f.action)
-	}
-
+	err = f.action.Execute(jServer, f.folder.getFolderBranch().Tlf)
 	return len(bs), err
 }

--- a/libdokan/journal_control_file.go
+++ b/libdokan/journal_control_file.go
@@ -1,0 +1,65 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package libdokan
+
+import (
+	"fmt"
+
+	"github.com/keybase/kbfs/dokan"
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+)
+
+// JournalControlFile is a special file used to control journal
+// settings.
+type JournalControlFile struct {
+	specialWriteFile
+	folder *Folder
+	action libfs.JournalAction
+}
+
+// Write implements writes for dokan.
+func (f *JournalControlFile) WriteFile(
+	fi *dokan.FileInfo, bs []byte, offset int64) (n int, err error) {
+	ctx, cancel := NewContextWithOpID(
+		f.folder.fs,
+		fmt.Sprintf("JournalQuotaFile (action=%s) Write", action))
+	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err, cancel) }()
+	if len(req.Data) == 0 {
+		return nil
+	}
+
+	jServer, err := libkbfs.GetJournalServer(f.folder.fs.config)
+	if err != nil {
+		return 0, err
+	}
+
+	switch f.action {
+	case libfs.JournalEnable:
+		err := jServer.Enable(f.folder.getFolderBranch().Tlf)
+		if err != nil {
+			return 0, err
+		}
+
+	case libfs.JournalFlush:
+		err := jServer.Flush(f.folder.getFolderBranch().Tlf)
+		if err != nil {
+			return 0, err
+		}
+
+	case libfs.JournalDisable:
+		err := jServer.Disable(f.folder.getFolderBranch().Tlf)
+		if err != nil {
+			return 0, err
+		}
+
+	default:
+		return 0, fmt.Errorf("Unknown action %s", f.action)
+	}
+
+	return len(bs), err
+}

--- a/libdokan/journal_control_file.go
+++ b/libdokan/journal_control_file.go
@@ -27,11 +27,17 @@ func (f *JournalControlFile) WriteFile(
 	fi *dokan.FileInfo, bs []byte, offset int64) (n int, err error) {
 	ctx, cancel := NewContextWithOpID(
 		f.folder.fs,
-		fmt.Sprintf("JournalQuotaFile (action=%s) Write", action))
+		fmt.Sprintf("JournalQuotaFile (action=%s) Write", f.action))
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err, cancel) }()
 	if len(bs) == 0 {
 		return 0, nil
 	}
+
+	jServer, err := libkbfs.GetJournalServer(f.folder.fs.config)
+	if err != nil {
+		return err
+	}
+
 	err = f.action.Execute(jServer, f.folder.getFolderBranch().Tlf)
 	return len(bs), err
 }

--- a/libdokan/journal_control_file.go
+++ b/libdokan/journal_control_file.go
@@ -27,7 +27,7 @@ func (f *JournalControlFile) WriteFile(
 	fi *dokan.FileInfo, bs []byte, offset int64) (n int, err error) {
 	ctx, cancel := NewContextWithOpID(
 		f.folder.fs,
-		fmt.Sprintf("JournalQuotaFile (action=%s) Write", f.action))
+		fmt.Sprintf("JournalQuotaFile (f.action=%s) Write", f.action))
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err, cancel) }()
 	if len(bs) == 0 {
 		return 0, nil

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -38,3 +38,15 @@ const EnableUpdatesFileName = ".kbfs_enable_updates"
 
 // ResetCachesFileName is the name of the KBFS unstaging file.
 const ResetCachesFileName = ".kbfs_reset_caches"
+
+// EnableJournalFileName is the name of the journal-enabling file. It
+// can be reached anywhere within a top-level folder.
+const EnableJournalFileName = ".kbfs_enable_journal"
+
+// FlushJournalFileName is the name of the journal-flushing file. It
+// can be reached anywhere within a top-level folder.
+const FlushJournalFileName = ".kbfs_flush_journal"
+
+// DisableJournalFileName is the name of the journal-disabling
+// file. It can be reached anywhere within a top-level folder.
+const DisableJournalFileName = ".kbfs_disable_journal"

--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -17,9 +17,9 @@ type JournalAction int
 const (
 	// JournalEnable is to turn the journal on.
 	JournalEnable JournalAction = iota
-	// JournalEnable is to flush the journal.
+	// JournalFlush is to flush the journal.
 	JournalFlush
-	// JournalEnable is to disable the journal.
+	// JournalDisable is to disable the journal.
 	JournalDisable
 )
 

--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -4,7 +4,11 @@
 
 package libfs
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/keybase/kbfs/libkbfs"
+)
 
 type JournalAction int
 
@@ -24,4 +28,32 @@ func (a JournalAction) String() string {
 		return "Disable journal"
 	}
 	return fmt.Sprintf("JournalAction(%d)", int(a))
+}
+
+func (a JournalAction) Execute(
+	jServer *libkbfs.JournalServer, tlf libkbfs.TlfID) error {
+	switch a {
+	case JournalEnable:
+		err := jServer.Enable(tlf)
+		if err != nil {
+			return err
+		}
+
+	case JournalFlush:
+		err := jServer.Flush(tlf)
+		if err != nil {
+			return err
+		}
+
+	case JournalDisable:
+		err := jServer.Disable(tlf)
+		if err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("Unknown action %s", a)
+	}
+
+	return nil
 }

--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -10,11 +10,16 @@ import (
 	"github.com/keybase/kbfs/libkbfs"
 )
 
+// JournalAction enumerates all the possible actions to take on a
+// TLF's journal.
 type JournalAction int
 
 const (
+	// JournalEnable is to turn the journal on.
 	JournalEnable JournalAction = iota
+	// JournalEnable is to flush the journal.
 	JournalFlush
+	// JournalEnable is to disable the journal.
 	JournalDisable
 )
 
@@ -30,6 +35,8 @@ func (a JournalAction) String() string {
 	return fmt.Sprintf("JournalAction(%d)", int(a))
 }
 
+// Execute performs the action on the given JournalServer for the
+// given TLF.
 func (a JournalAction) Execute(
 	jServer *libkbfs.JournalServer, tlf libkbfs.TlfID) error {
 	switch a {

--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import "fmt"
+
+type JournalAction int
+
+const (
+	JournalEnable JournalAction = iota
+	JournalFlush
+	JournalDisable
+)
+
+func (a JournalAction) String() string {
+	switch a {
+	case JournalEnable:
+		return "Enable journal"
+	case JournalFlush:
+		return "Flush journal"
+	case JournalDisable:
+		return "Disable journal"
+	}
+	return fmt.Sprintf("JournalAction(%d)", int(a))
+}

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -402,6 +402,27 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 			folder: d.folder,
 		}
 		return child, nil
+
+	case libfs.EnableJournalFileName:
+		child := &JournalControlFile{
+			folder: d.folder,
+			action: libfs.JournalEnable,
+		}
+		return child, nil
+
+	case libfs.FlushJournalFileName:
+		child := &JournalControlFile{
+			folder: d.folder,
+			action: libfs.JournalFlush,
+		}
+		return child, nil
+
+	case libfs.DisableJournalFileName:
+		child := &JournalControlFile{
+			folder: d.folder,
+			action: libfs.JournalDisable,
+		}
+		return child, nil
 	}
 
 	newNode, de, err := d.folder.fs.config.KBFSOps().Lookup(ctx, d.node, req.Name)

--- a/libfuse/journal_control_file.go
+++ b/libfuse/journal_control_file.go
@@ -9,35 +9,16 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
+	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
-
-type journalAction int
-
-const (
-	journalEnable journalAction = iota
-	journalFlush
-	journalDisable
-)
-
-func (a journalAction) String() string {
-	switch a {
-	case journalEnable:
-		return "Enable journal"
-	case journalFlush:
-		return "Flush journal"
-	case journalDisable:
-		return "Disable journal"
-	}
-	return fmt.Sprintf("journalAction(%d)", int(a))
-}
 
 // JournalControlFile is a special file used to control journal
 // settings.
 type JournalControlFile struct {
 	folder *Folder
-	action journalAction
+	action libfs.JournalAction
 }
 
 var _ fs.Node = (*JournalControlFile)(nil)
@@ -69,20 +50,20 @@ func (f *JournalControlFile) Write(ctx context.Context, req *fuse.WriteRequest,
 	}
 
 	switch f.action {
-	case journalEnable:
+	case libfs.JournalEnable:
 		err := jServer.Enable(f.folder.getFolderBranch().Tlf)
 		if err != nil {
 			return err
 		}
 
-	case journalFlush:
-		jServer.Flush(f.folder.getFolderBranch().Tlf)
+	case libfs.JournalFlush:
+		err := jServer.Flush(f.folder.getFolderBranch().Tlf)
 		if err != nil {
 			return err
 		}
 
-	case journalDisable:
-		jServer.Flush(f.folder.getFolderBranch().Tlf)
+	case libfs.JournalDisable:
+		err := jServer.Disable(f.folder.getFolderBranch().Tlf)
 		if err != nil {
 			return err
 		}

--- a/libfuse/journal_control_file.go
+++ b/libfuse/journal_control_file.go
@@ -5,8 +5,6 @@
 package libfuse
 
 import (
-	"fmt"
-
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/keybase/kbfs/libfs"
@@ -49,27 +47,9 @@ func (f *JournalControlFile) Write(ctx context.Context, req *fuse.WriteRequest,
 		return err
 	}
 
-	switch f.action {
-	case libfs.JournalEnable:
-		err := jServer.Enable(f.folder.getFolderBranch().Tlf)
-		if err != nil {
-			return err
-		}
-
-	case libfs.JournalFlush:
-		err := jServer.Flush(f.folder.getFolderBranch().Tlf)
-		if err != nil {
-			return err
-		}
-
-	case libfs.JournalDisable:
-		err := jServer.Disable(f.folder.getFolderBranch().Tlf)
-		if err != nil {
-			return err
-		}
-
-	default:
-		return fmt.Errorf("Unknown action %s", f.action)
+	err = f.action.Execute(jServer, f.folder.getFolderBranch().Tlf)
+	if err != nil {
+		return err
 	}
 
 	resp.Size = len(req.Data)

--- a/libfuse/journal_control_file.go
+++ b/libfuse/journal_control_file.go
@@ -1,0 +1,96 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"fmt"
+
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+type journalAction int
+
+const (
+	journalEnable journalAction = iota
+	journalFlush
+	journalDisable
+)
+
+func (a journalAction) String() string {
+	switch a {
+	case journalEnable:
+		return "Enable journal"
+	case journalFlush:
+		return "Flush journal"
+	case journalDisable:
+		return "Disable journal"
+	}
+	return fmt.Sprintf("journalAction(%d)", int(a))
+}
+
+// JournalControlFile is a special file used to control journal
+// settings.
+type JournalControlFile struct {
+	folder *Folder
+	action journalAction
+}
+
+var _ fs.Node = (*JournalControlFile)(nil)
+
+// Attr implements the fs.Node interface for JournalControlFile.
+func (f *JournalControlFile) Attr(ctx context.Context, a *fuse.Attr) error {
+	a.Size = 0
+	a.Mode = 0222
+	return nil
+}
+
+var _ fs.Handle = (*JournalControlFile)(nil)
+
+var _ fs.HandleWriter = (*JournalControlFile)(nil)
+
+// Write implements the fs.HandleWriter interface for JournalControlFile.
+func (f *JournalControlFile) Write(ctx context.Context, req *fuse.WriteRequest,
+	resp *fuse.WriteResponse) (err error) {
+	f.folder.fs.log.CDebugf(ctx, "JournalControlFile (action=%s) Write",
+		f.action)
+	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
+	if len(req.Data) == 0 {
+		return nil
+	}
+
+	jServer, err := libkbfs.GetJournalServer(f.folder.fs.config)
+	if err != nil {
+		return err
+	}
+
+	switch f.action {
+	case journalEnable:
+		err := jServer.Enable(f.folder.getFolderBranch().Tlf)
+		if err != nil {
+			return err
+		}
+
+	case journalFlush:
+		jServer.Flush(f.folder.getFolderBranch().Tlf)
+		if err != nil {
+			return err
+		}
+
+	case journalDisable:
+		jServer.Flush(f.folder.getFolderBranch().Tlf)
+		if err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("Unknown action %s", f.action)
+	}
+
+	resp.Size = len(req.Data)
+	return nil
+}

--- a/libfuse/journal_control_file.go
+++ b/libfuse/journal_control_file.go
@@ -35,7 +35,7 @@ var _ fs.HandleWriter = (*JournalControlFile)(nil)
 // Write implements the fs.HandleWriter interface for JournalControlFile.
 func (f *JournalControlFile) Write(ctx context.Context, req *fuse.WriteRequest,
 	resp *fuse.WriteResponse) (err error) {
-	f.folder.fs.log.CDebugf(ctx, "JournalControlFile (action=%s) Write",
+	f.folder.fs.log.CDebugf(ctx, "JournalControlFile (f.action=%s) Write",
 		f.action)
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 	if len(req.Data) == 0 {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -125,7 +125,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flag.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
 	// The default is to *DELETE* old log files for kbfs.
 	flag.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
-	flags.BoolVar(&params.WriteJournalRoot, "write-journal-root-this-may-lose-data", false, "If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
+	flags.StringVar(&params.WriteJournalRoot, "write-journal-root-this-may-lose-data", "", "If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	return &params
 }
 
@@ -363,7 +363,7 @@ func Init(ctx Context, params InitParams, keybaseDaemonFn KeybaseDaemonFn, onInt
 
 	config.SetBlockServer(bserv)
 
-	if params.WriteJournalRoot {
+	if len(params.WriteJournalRoot) > 0 {
 		// TODO: Sanity-check the root directory, e.g. create
 		// it if it doesn't exist, make sure that it doesn't
 		// point to /keybase itself, etc.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -125,7 +125,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flag.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
 	// The default is to *DELETE* old log files for kbfs.
 	flag.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
-	flags.StringVar(&params.WriteJournalRoot, "write-journal-root-this-may-lose-data", "", "If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
+	flags.StringVar(&params.WriteJournalRoot, "write-journal-root-this-may-lose-data", "", "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	return &params
 }
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -48,8 +48,11 @@ func (j *JournalServer) getBundle(tlfID TlfID) (*tlfJournalBundle, bool) {
 func (j *JournalServer) Enable(tlfID TlfID) (err error) {
 	j.log.Debug("Enabling journal for %s", tlfID)
 	defer func() {
-		j.deferLog.Debug("Error when enabling journal for %s: %v",
-			tlfID, err)
+		if err != nil {
+			j.deferLog.Debug(
+				"Error when enabling journal for %s: %v",
+				tlfID, err)
+		}
 	}()
 
 	j.lock.Lock()
@@ -60,6 +63,8 @@ func (j *JournalServer) Enable(tlfID TlfID) (err error) {
 		return nil
 	}
 
+	j.log.Debug("Enabled journal for %s", tlfID)
+
 	j.tlfBundles[tlfID] = &tlfJournalBundle{}
 	return nil
 }
@@ -67,9 +72,16 @@ func (j *JournalServer) Enable(tlfID TlfID) (err error) {
 // Flush flushes the write journal for the given TLF.
 func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 	j.log.Debug("Flushing journal for %s", tlfID)
+	flushedBlockEntries := 0
+	flushedMDEntries := 0
 	defer func() {
-		j.deferLog.Debug("Error when flushing journal for %s: %v",
-			tlfID, err)
+		if err != nil {
+			j.deferLog.Debug(
+				"Flushed %d block entries and %d MD entries "+
+					"for %s, but got error %v",
+				flushedBlockEntries, flushedMDEntries,
+				tlfID, err)
+		}
 	}()
 	_, ok := j.getBundle(tlfID)
 	if !ok {
@@ -77,11 +89,7 @@ func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 		return nil
 	}
 
-	flushedBlockEntries := 0
-	// TODO: Flush block journal.
-
-	flushedMDEntries := 0
-	// TODO: Flush MD journal.
+	// TODO: Flush block and MD journal.
 
 	j.log.Debug("Flushed %d block entries and %d MD entries for %s",
 		flushedBlockEntries, flushedMDEntries, tlfID)
@@ -93,8 +101,11 @@ func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 func (j *JournalServer) Disable(tlfID TlfID) (err error) {
 	j.log.Debug("Disabling journal for %s", tlfID)
 	defer func() {
-		j.deferLog.Debug("Error when disabling journal for %s: %v",
-			tlfID, err)
+		if err != nil {
+			j.deferLog.Debug(
+				"Error when disabling journal for %s: %v",
+				tlfID, err)
+		}
 	}()
 
 	j.lock.Lock()
@@ -107,6 +118,8 @@ func (j *JournalServer) Disable(tlfID TlfID) (err error) {
 
 	// TODO: Either return an error if there are still entries in
 	// the journal, or flush them.
+
+	j.log.Debug("Disabled journal for %s", tlfID)
 
 	delete(j.tlfBundles, tlfID)
 	return nil

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -16,6 +16,12 @@ type tlfJournalBundle struct {
 	// TODO: Fill in with a block journal and an MD journal.
 }
 
+// JournalServer is the server that handles write journals. It
+// interposes itself between BlockServer and MDOps. It uses MDOps
+// instead of MDServer because it has to potentially modify the
+// RootMetadata passed in, and by the time it hits MDServer it's
+// already too late. However, this assumes that all MD ops go through
+// MDOps.
 type JournalServer struct {
 	config Config
 
@@ -38,6 +44,7 @@ func (j *JournalServer) getBundle(tlfID TlfID) (*tlfJournalBundle, bool) {
 	return bundle, ok
 }
 
+// Enable turns on the write journal for the given TLF.
 func (j *JournalServer) Enable(tlfID TlfID) (err error) {
 	j.log.Debug("Enabling journal for %s", tlfID)
 	defer func() {
@@ -57,6 +64,7 @@ func (j *JournalServer) Enable(tlfID TlfID) (err error) {
 	return nil
 }
 
+// Enable flushes the write journal for the given TLF.
 func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 	j.log.Debug("Flushing journal for %s", tlfID)
 	defer func() {
@@ -81,6 +89,7 @@ func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 	return nil
 }
 
+// Disable turns off the write journal for the given TLF.
 func (j *JournalServer) Disable(tlfID TlfID) (err error) {
 	j.log.Debug("Disabling journal for %s", tlfID)
 	defer func() {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -64,7 +64,7 @@ func (j *JournalServer) Enable(tlfID TlfID) (err error) {
 	return nil
 }
 
-// Enable flushes the write journal for the given TLF.
+// Flush flushes the write journal for the given TLF.
 func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 	j.log.Debug("Flushing journal for %s", tlfID)
 	defer func() {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -81,6 +81,28 @@ func (j *JournalServer) Flush(tlfID TlfID) (err error) {
 	return nil
 }
 
+func (j *JournalServer) Disable(tlfID TlfID) (err error) {
+	j.log.Debug("Disabling journal for %s", tlfID)
+	defer func() {
+		j.deferLog.Debug("Error when disabling journal for %s: %v",
+			tlfID, err)
+	}()
+
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	_, ok := j.tlfBundles[tlfID]
+	if !ok {
+		j.log.Debug("Journal already disabled for %s", tlfID)
+		return nil
+	}
+
+	// TODO: Either return an error if there are still entries in
+	// the journal, or flush them.
+
+	delete(j.tlfBundles, tlfID)
+	return nil
+}
+
 type journalBlockServer struct {
 	jServer *JournalServer
 	BlockServer

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -1,0 +1,183 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"sync"
+
+	"github.com/keybase/client/go/logger"
+
+	"golang.org/x/net/context"
+)
+
+type tlfJournalBundle struct {
+	// TODO: Fill in with a block journal and an MD journal.
+}
+
+type JournalServer struct {
+	config Config
+
+	log      logger.Logger
+	deferLog logger.Logger
+
+	dir string
+
+	delegateBlockServer BlockServer
+	delegateMDOps       MDOps
+
+	lock       sync.RWMutex
+	tlfBundles map[TlfID]*tlfJournalBundle
+}
+
+func (j *JournalServer) getBundle(tlfID TlfID) (*tlfJournalBundle, bool) {
+	j.lock.RLock()
+	defer j.lock.RUnlock()
+	bundle, ok := j.tlfBundles[tlfID]
+	return bundle, ok
+}
+
+func (j *JournalServer) Enable(tlfID TlfID) (err error) {
+	j.log.Debug("Enabling journal for %s", tlfID)
+	defer func() {
+		j.deferLog.Debug("Error when enabling journal for %s: %v",
+			tlfID, err)
+	}()
+
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	_, ok := j.tlfBundles[tlfID]
+	if ok {
+		j.log.Debug("Journal already enabled for %s", tlfID)
+		return nil
+	}
+
+	j.tlfBundles[tlfID] = &tlfJournalBundle{}
+	return nil
+}
+
+func (j *JournalServer) Flush(tlfID TlfID) (err error) {
+	j.log.Debug("Flushing journal for %s", tlfID)
+	defer func() {
+		j.deferLog.Debug("Error when flushing journal for %s: %v",
+			tlfID, err)
+	}()
+	_, ok := j.getBundle(tlfID)
+	if !ok {
+		j.log.Debug("Journal not enabled for %s", tlfID)
+		return nil
+	}
+
+	flushedBlockEntries := 0
+	// TODO: Flush block journal.
+
+	flushedMDEntries := 0
+	// TODO: Flush MD journal.
+
+	j.log.Debug("Flushed %d block entries and %d MD entries for %s",
+		flushedBlockEntries, flushedMDEntries, tlfID)
+
+	return nil
+}
+
+type journalBlockServer struct {
+	jServer *JournalServer
+	BlockServer
+}
+
+var _ BlockServer = journalBlockServer{}
+
+func (j journalBlockServer) Put(
+	ctx context.Context, id BlockID, tlfID TlfID, context BlockContext,
+	buf []byte, serverHalf BlockCryptKeyServerHalf) error {
+	_, ok := j.jServer.getBundle(tlfID)
+	if ok {
+		// TODO: Delegate to bundle's block journal.
+	}
+
+	return j.BlockServer.Put(ctx, id, tlfID, context, buf, serverHalf)
+}
+
+func (j journalBlockServer) AddBlockReference(
+	ctx context.Context, id BlockID, tlfID TlfID,
+	context BlockContext) error {
+	_, ok := j.jServer.getBundle(tlfID)
+	if ok {
+		// TODO: Delegate to bundle's block journal.
+	}
+
+	return j.BlockServer.AddBlockReference(ctx, id, tlfID, context)
+}
+
+func (j journalBlockServer) RemoveBlockReference(
+	ctx context.Context, tlfID TlfID,
+	contexts map[BlockID][]BlockContext) (
+	liveCounts map[BlockID]int, err error) {
+	_, ok := j.jServer.getBundle(tlfID)
+	if ok {
+		// TODO: Delegate to bundle's block journal.
+	}
+
+	return j.BlockServer.RemoveBlockReference(ctx, tlfID, contexts)
+}
+
+func (j journalBlockServer) ArchiveBlockReferences(
+	ctx context.Context, tlfID TlfID,
+	contexts map[BlockID][]BlockContext) error {
+	_, ok := j.jServer.getBundle(tlfID)
+	if ok {
+		// TODO: Delegate to bundle's block journal.
+	}
+
+	return j.BlockServer.ArchiveBlockReferences(ctx, tlfID, contexts)
+}
+
+type journalMDOps struct {
+	jServer *JournalServer
+	MDOps
+}
+
+var _ MDOps = journalMDOps{}
+
+func (j journalMDOps) Put(ctx context.Context, rmd *RootMetadata) error {
+	_, ok := j.jServer.getBundle(rmd.ID)
+	if ok {
+		// TODO: Delegate to bundle's MD journal.
+	}
+
+	return j.MDOps.Put(ctx, rmd)
+}
+
+func (j journalMDOps) PutUnmerged(
+	ctx context.Context, rmd *RootMetadata, bid BranchID) error {
+	_, ok := j.jServer.getBundle(rmd.ID)
+	if ok {
+		// TODO: Delegate to bundle's MD journal.
+	}
+
+	return j.MDOps.PutUnmerged(ctx, rmd, bid)
+}
+
+func (j *JournalServer) blockServer() journalBlockServer {
+	return journalBlockServer{j, j.delegateBlockServer}
+}
+
+func (j *JournalServer) mdOps() journalMDOps {
+	return journalMDOps{j, j.delegateMDOps}
+}
+
+func makeJournalServer(
+	config Config, log logger.Logger,
+	dir string, bserver BlockServer, mdOps MDOps) *JournalServer {
+	jServer := JournalServer{
+		config:              config,
+		log:                 log,
+		deferLog:            log.CloneWithAddedDepth(1),
+		dir:                 dir,
+		delegateBlockServer: bserver,
+		delegateMDOps:       mdOps,
+		tlfBundles:          make(map[TlfID]*tlfJournalBundle),
+	}
+	return &jServer
+}

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -17,7 +17,7 @@ type tlfJournalBundle struct {
 }
 
 // JournalServer is the server that handles write journals. It
-// interposes itself between BlockServer and MDOps. It uses MDOps
+// interposes itself in front of BlockServer and MDOps. It uses MDOps
 // instead of MDServer because it has to potentially modify the
 // RootMetadata passed in, and by the time it hits MDServer it's
 // already too late. However, this assumes that all MD ops go through

--- a/libkbfs/journal_server_util.go
+++ b/libkbfs/journal_server_util.go
@@ -6,11 +6,13 @@ package libkbfs
 
 import "errors"
 
+// GetJournalServer returns the JournalServer tied to a particular
+// config.
 func GetJournalServer(config Config) (*JournalServer, error) {
 	bserver := config.BlockServer()
 	jbserver, ok := bserver.(journalBlockServer)
 	if !ok {
-		return nil, errors.New("Write journaling not enabled")
+		return nil, errors.New("Write journal not enabled")
 	}
 	return jbserver.jServer, nil
 }

--- a/libkbfs/journal_server_util.go
+++ b/libkbfs/journal_server_util.go
@@ -1,0 +1,16 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import "errors"
+
+func GetJournalServer(config Config) (*JournalServer, error) {
+	bserver := config.BlockServer()
+	jbserver, ok := bserver.(journalBlockServer)
+	if !ok {
+		return nil, errors.New("Write journaling not enabled")
+	}
+	return jbserver.jServer, nil
+}


### PR DESCRIPTION
Add a command-line switch to permit per-TLF write
journals.

Add special files to turn on, flush, and disable
write journals.

Add a JournalServer that interposes itself between
BlockServer and MDOps and manages the (currently
empty) per-TLF journals.