### PR TITLE
folder_branch_ops: gracefully handle set attrs on unlinked files

### DIFF
--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -1120,9 +1120,19 @@ func TestRemoveFileWhileOpenSetEx(t *testing.T) {
 	}
 
 	// this must not resurrect a deleted file
-	if err := f.Chmod(0777); err != nil {
+	if err := f.Chmod(0755); err != nil {
 		t.Fatalf("cannot setex: %v", err)
 	}
+
+	// Make sure the mode sticks around even though the file was unlinked.
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g, e := fi.Mode().String(), `-rwxr-xr-x`; g != e {
+		t.Errorf("wrong mode: %q != %q", g, e)
+	}
+
 	if err := f.Close(); err != nil {
 		t.Fatalf("error on close: %v", err)
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2623,13 +2623,16 @@ func (fbo *folderBlockOps) getUndirtiedEntry(
 
 func (fbo *folderBlockOps) setCachedAttr(
 	ctx context.Context, lState *lockState,
-	ref blockRef, op *setAttrOp, realEntry *DirEntry) {
+	ref blockRef, op *setAttrOp, realEntry *DirEntry, doCreate bool) {
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
 
 	fileEntry, ok := fbo.deCache[ref]
 	if !ok {
-		return
+		if !doCreate {
+			return
+		}
+		fileEntry = *realEntry
 	}
 
 	switch op.Attr {
@@ -2638,6 +2641,7 @@ func (fbo *folderBlockOps) setCachedAttr(
 	case mtimeAttr:
 		fileEntry.Mtime = realEntry.Mtime
 	}
+	fileEntry.Ctime = realEntry.Ctime
 	fbo.deCache[ref] = fileEntry
 }
 
@@ -2673,10 +2677,22 @@ func (fbo *folderBlockOps) UpdateCachedEntryAttributes(
 	}
 
 	if cleanEntry != nil {
-		fbo.setCachedAttr(ctx, lState, de.ref(), op, cleanEntry)
+		fbo.setCachedAttr(ctx, lState, de.ref(), op, cleanEntry, false)
 	}
 
 	return childNode, nil
+}
+
+// UpdateCachedEntryAttributesOnRemovedFile updates any cached entry
+// for the given path of an unlinked file, according to the given op,
+// and it makes a new dirty cache entry if one doesn't exist yet.  We
+// assume Sync will be called eventually on the corresponding open
+// file handle, which will clear out the entry.
+func (fbo *folderBlockOps) UpdateCachedEntryAttributesOnRemovedFile(
+	ctx context.Context, lState *lockState, md *RootMetadata,
+	file path, op *setAttrOp, de DirEntry) error {
+	fbo.setCachedAttr(ctx, lState, de.ref(), op, &de, true)
+	return nil
 }
 
 func (fbo *folderBlockOps) getDeferredWriteCountForTest(lState *lockState) int {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2689,10 +2689,8 @@ func (fbo *folderBlockOps) UpdateCachedEntryAttributes(
 // assume Sync will be called eventually on the corresponding open
 // file handle, which will clear out the entry.
 func (fbo *folderBlockOps) UpdateCachedEntryAttributesOnRemovedFile(
-	ctx context.Context, lState *lockState, md *RootMetadata,
-	file path, op *setAttrOp, de DirEntry) error {
+	ctx context.Context, lState *lockState, op *setAttrOp, de DirEntry) {
 	fbo.setCachedAttr(ctx, lState, de.ref(), op, &de, true)
-	return nil
 }
 
 func (fbo *folderBlockOps) getDeferredWriteCountForTest(lState *lockState) int {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2808,8 +2808,9 @@ func (fbo *folderBranchOps) setExLocked(
 	if md.data.Dir.BlockPointer != file.path[0].BlockPointer {
 		fbo.log.CDebugf(ctx, "Skipping setex for a removed file %v",
 			file.tailPointer())
-		return fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
-			ctx, lState, md, file, sao, de)
+		fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
+			ctx, lState, sao, de)
+		return nil
 	}
 
 	md.AddOp(sao)
@@ -2876,8 +2877,9 @@ func (fbo *folderBranchOps) setMtimeLocked(
 	if md.data.Dir.BlockPointer != file.path[0].BlockPointer {
 		fbo.log.CDebugf(ctx, "Skipping setmtime for a removed file %v",
 			file.tailPointer())
-		return fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
-			ctx, lState, md, file, sao, de)
+		fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
+			ctx, lState, sao, de)
+		return nil
 	}
 
 	md.AddOp(sao)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -4019,6 +4019,7 @@ func TestSetExFailNoSuchName(t *testing.T) {
 	u, id, rmd := injectNewRMD(t, config)
 
 	rootID := fakeBlockID(42)
+	rmd.data.Dir.ID = rootID
 	aID := fakeBlockID(43)
 	rootBlock := NewDirBlock().(*DirBlock)
 	node := pathNode{makeBP(rootID, rmd, config, u), "p"}
@@ -4147,6 +4148,7 @@ func TestMtimeFailNoSuchName(t *testing.T) {
 	u, id, rmd := injectNewRMD(t, config)
 
 	rootID := fakeBlockID(42)
+	rmd.data.Dir.ID = rootID
 	aID := fakeBlockID(43)
 	rootBlock := NewDirBlock().(*DirBlock)
 	node := pathNode{makeBP(rootID, rmd, config, u), "p"}
@@ -5080,7 +5082,8 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
-	node := pathNode{makeBP(rootID, rmd, config, u), "p"}
+	rmd.data.Dir.BlockPointer = makeBP(rootID, rmd, config, u)
+	node := pathNode{rmd.data.Dir.BlockPointer, "p"}
 	p := path{FolderBranch{Tlf: id}, []pathNode{node}}
 	n := nodeFromPath(t, ops, p)
 


### PR DESCRIPTION
This should solve the issue with null BlockPointers in `setAttrOp`s.

Issue: KBFS-1114