### PR TITLE
cr: track refs/unrefs resulting from syncOps on newly-created, unmerged files

### DIFF
--- a/test/cr_multi_blocks_test.go
+++ b/test/cr_multi_blocks_test.go
@@ -21,7 +21,7 @@ func TestCrUnmergedWriteMultiblockFile(t *testing.T) {
 		as(alice,
 			write("a/foo", "hello"),
 		),
-		as(bob,
+		as(bob, noSync(),
 			write("a/b", ntimesString(15, "0123456789")),
 			reenableUpdates(),
 			lsdir("a/", m{"b": "FILE", "foo": "FILE"}),
@@ -174,4 +174,31 @@ func TestCrConflictMoveRemovedMultiblockFile(t *testing.T) {
 	)
 }
 
-// TODO: test md.RefBytes, md.UnrefBytes, and md.DiskUsage as well!
+// bob writes a multi-block file while unmerged and the block change
+// size is small, no conflicts
+func TestCrUnmergedWriteMultiblockFileWithSmallBlockChangeSize(t *testing.T) {
+	test(t,
+		blockSize(20), blockChangeSize(5), users("alice", "bob"),
+		as(alice,
+			mkdir("a"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			write("a/foo", "hello"),
+		),
+		as(bob,
+			write("a/b", ntimesString(15, "0123456789")),
+			reenableUpdates(),
+			lsdir("a/", m{"b": "FILE", "foo": "FILE"}),
+			read("a/b", ntimesString(15, "0123456789")),
+			read("a/foo", "hello"),
+		),
+		as(alice,
+			lsdir("a/", m{"b": "FILE", "foo": "FILE"}),
+			read("a/b", ntimesString(15, "0123456789")),
+			read("a/foo", "hello"),
+		),
+	)
+}

--- a/test/cr_multi_blocks_test.go
+++ b/test/cr_multi_blocks_test.go
@@ -22,6 +22,8 @@ func TestCrUnmergedWriteMultiblockFile(t *testing.T) {
 			write("a/foo", "hello"),
 		),
 		as(bob, noSync(),
+			write("a/b", ntimesString(5, "0123456789")),
+			write("a/b", ntimesString(10, "0123456789")),
 			write("a/b", ntimesString(15, "0123456789")),
 			reenableUpdates(),
 			lsdir("a/", m{"b": "FILE", "foo": "FILE"}),


### PR DESCRIPTION
It turns out our test for CR for indirect block files had a bug, and so it wasn't being tested (and was broken of course).

Issue: KBFS-1193