### PR TITLE
qr_test: add workaround to TestQRLargePointerSet for osxfuse bug

### DIFF
--- a/test/qr_test.go
+++ b/test/qr_test.go
@@ -7,6 +7,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -30,7 +31,8 @@ func TestQRLargePointerSet(t *testing.T) {
 	var busyWork []fileOp
 	iters := 100
 	for i := 0; i < iters; i++ {
-		busyWork = append(busyWork, mkfile("a", "hello"), rm("a"))
+		name := fmt.Sprintf("a%d", i)
+		busyWork = append(busyWork, mkfile(name, "hello"), rm(name))
 	}
 	// 5 unreferenced pointers per iteration -- 3 updates to the root
 	// block, one empty file written to, and one non-empty file


### PR DESCRIPTION
If a Lookup gets issued from outside the test (by Finder?)
concurrently with the Remove, it could end up adding the file name
back into the osxfuse lookup cache, and a subsequent lookup by the
test can succeed incorrectly when it hits the cache.

This PR works around that by simply using a unique name for each
iteration, while looking into the osxfuse issue separately.

Issue: KBFS-1253