### PR TITLE
dokan*: Disable timeouts and allow customizing mount options from command line

### DIFF
--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -306,9 +306,6 @@ struct kbfsLibdokanCtx* kbfsLibdokanAllocCtx(ULONG64 slot) {
   ctx->dokan_options.Timeout = 600 * 1000;
   ctx->dokan_options.GlobalContext = slot;
 
-  ctx->dokan_options.Options = DOKAN_OPTION_REMOVABLE |
-                               DOKAN_OPTION_CURRENT_SESSION |
-                               DOKAN_OPTION_MOUNT_MANAGER;
   ctx->dokan_operations.ZwCreateFile = kbfsLibdokanC_CreateFile;
   ctx->dokan_operations.Cleanup = kbfsLibdokanC_Cleanup;
   ctx->dokan_operations.CloseFile = kbfsLibdokanC_CloseFile;

--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -302,8 +302,8 @@ struct kbfsLibdokanCtx* kbfsLibdokanAllocCtx(ULONG64 slot) {
     return ctx;
   memset(ctx, 0, sizeof(struct kbfsLibdokanCtx));
   ctx->dokan_options.Version = DOKAN_VERSION;
-  // Dokan timeout 10 minutes...
-  ctx->dokan_options.Timeout = 600 * 1000;
+  // Dokan timeout 10 minutes... Disables - was related to dokan crashes!
+  //  ctx->dokan_options.Timeout = 600 * 1000;
   ctx->dokan_options.GlobalContext = slot;
 
   ctx->dokan_operations.ZwCreateFile = kbfsLibdokanC_CreateFile;

--- a/dokan/bridge.h
+++ b/dokan/bridge.h
@@ -47,7 +47,11 @@ BOOL kbfsLibdokan_RemoveMountPoint(LPCWSTR MountPoint);
 HANDLE kbfsLibdokan_OpenRequestorToken(PDOKAN_FILE_INFO DokanFileInfo);
 
 enum {
-  kbfsLibdokanDebug = DOKAN_OPTION_DEBUG|DOKAN_OPTION_STDERR,
+  kbfsLibdokanDebug = DOKAN_OPTION_DEBUG,
+  kbfsLibdokanStderr = DOKAN_OPTION_STDERR,
+  kbfsLibdokanRemovable = DOKAN_OPTION_REMOVABLE,
+  kbfsLibdokanMountManager = DOKAN_OPTION_MOUNT_MANAGER,
+  kbfsLibdokanCurrentSession = DOKAN_OPTION_CURRENT_SESSION,
 };
 
 #endif /* windows check */

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -24,8 +24,6 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-type MountFlag uint32
-
 const (
 	CDebug         = MountFlag(C.kbfsLibdokanDebug)
 	CStderr        = MountFlag(C.kbfsLibdokanDebug)

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -504,7 +504,7 @@ func allocCtx(slot uint32) *dokanCtx {
 }
 
 func (ctx *dokanCtx) Run(path string, flags MountFlag) error {
-	ctx.ptr.dokan_options.Options = C.ulong(flags)
+	ctx.ptr.dokan_options.Options = C.ULONG(flags)
 	if isDebug {
 		ctx.ptr.dokan_options.Options |= C.kbfsLibdokanDebug | C.kbfsLibdokanStderr
 	}

--- a/dokan/dokan.go
+++ b/dokan/dokan.go
@@ -19,10 +19,11 @@ type MountHandle struct {
 func Mount(fs FileSystem, path string) (*MountHandle, error) {
 	var ec = make(chan error, 2)
 	var slot = fsTableStore(fs, ec)
+	flags := fs.MountFlags()
 	go func() {
 		ctx := allocCtx(slot)
 		defer ctx.Free()
-		ec <- ctx.Run(path)
+		ec <- ctx.Run(path, flags)
 		close(ec)
 	}()
 	// This gets a send from either

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -22,6 +22,7 @@ type FileSystem interface {
 	MountFlags() MountFlag
 }
 
+// MountFlag is the type for Dokan mount flags.
 type MountFlag uint32
 
 // CreateData contains all the info needed to create a file.

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -18,6 +18,8 @@ type FileSystem interface {
 
 	GetVolumeInformation() (VolumeInformation, error)
 	Mounted() error
+
+	MountFlags() MountFlag
 }
 
 // CreateData contains all the info needed to create a file.

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -22,6 +22,8 @@ type FileSystem interface {
 	MountFlags() MountFlag
 }
 
+type MountFlag uint32
+
 // CreateData contains all the info needed to create a file.
 type CreateData struct {
 	DesiredAccess     uint32

--- a/dokan/testfs_test.go
+++ b/dokan/testfs_test.go
@@ -256,6 +256,7 @@ func (t errorFS) SetEndOfFile(fi *FileInfo, length int64) error                 
 func (t errorFS) SetAllocationSize(fi *FileInfo, length int64) error                       { return t }
 func (t errorFS) MoveFile(source *FileInfo, targetPath string, replaceExisting bool) error { return t }
 func (t errorFS) Mounted() error                                                           { return t }
+func (t errorFS) MountFlags() MountFlag                                                    { return Removable | MountManager | CurrentSession }
 
 var _ FileSystem = emptyFS{}
 
@@ -310,6 +311,7 @@ func (t emptyFS) Mounted() error {
 	debug("emptyFS.Mounted")
 	return nil
 }
+func (t emptyFS) MountFlags() MountFlag { return Removable | MountManager | CurrentSession }
 
 type emptyFile struct{}
 

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libdokan"
 	"github.com/keybase/kbfs/libfs"
@@ -24,6 +25,7 @@ var runtimeDir = flag.String("runtime-dir", os.Getenv("KEYBASE_RUNTIME_DIR"), "r
 var label = flag.String("label", os.Getenv("KEYBASE_LABEL"), "label to help identify if running as a service")
 var mountType = flag.String("mount-type", defaultMountType, "mount type: default, force")
 var version = flag.Bool("version", false, "Print version")
+var mountFlags = flag.Int64("mount-flags", int64(libdokan.DefaultMountFlags), "Dokan mount flags")
 
 const usageFormatStr = `Usage:
   kbfsdokan -version
@@ -94,6 +96,7 @@ func start() *libfs.Error {
 		KbfsParams: *kbfsParams,
 		RuntimeDir: *runtimeDir,
 		Label:      *label,
+		MountFlags: dokan.MountFlag(*mountFlags),
 	}
 
 	return libdokan.Start(mounter, options, ctx)

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -36,7 +36,11 @@ type FS struct {
 
 	// remoteStatus is the current status of remote connections.
 	remoteStatus libfs.RemoteStatus
+
+	mountFlags dokan.MountFlag
 }
+
+const DefaultMountFlags = dokan.Removable | dokan.MountManager | dokan.CurrentSession
 
 // NewFS creates an FS
 func NewFS(ctx context.Context, config libkbfs.Config, log logger.Logger) (*FS, error) {
@@ -73,8 +77,13 @@ func NewFS(ctx context.Context, config libkbfs.Config, log logger.Logger) (*FS, 
 	f.remoteStatus.Init(ctx, f.log, f.config)
 	f.notifications.LaunchProcessor(ctx)
 	go clearFolderListCacheLoop(ctx, f.root)
+	f.mountFlags = DefaultMountFlags
 
 	return f, nil
+}
+
+func (f *FS) MountFlags() dokan.MountFlag {
+	return f.mountFlags
 }
 
 var vinfo = dokan.VolumeInformation{

--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -11,6 +11,7 @@ import (
 	"path"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
@@ -21,6 +22,7 @@ type StartOptions struct {
 	KbfsParams libkbfs.InitParams
 	RuntimeDir string
 	Label      string
+	MountFlags dokan.MountFlag
 }
 
 // Start the filesystem
@@ -57,6 +59,7 @@ func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}
+	fs.mountFlags = options.MountFlags
 
 	if newFolderNameErr != nil {
 		log.CWarningf(fs.context, "Error guessing new folder name: %v", newFolderNameErr)


### PR DESCRIPTION
This disables timeouts on the Dokan level - they are still handled with context.

`-mount-flags` as follows:
0 - nothing
3 - extra debugging
32 - removable
64 - mount manager
128 - only current session

Can be combined: e.g. removable + mount manager + only current session = 224.