### PR TITLE
keybase_daemon_rpc: use KeyFamilyChanged instead of UserChanged

### DIFF
--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -52,7 +52,7 @@ type KeybaseDaemonRPC struct {
 
 var _ keybase1.NotifySessionInterface = (*KeybaseDaemonRPC)(nil)
 
-var _ keybase1.NotifyUsersInterface = (*KeybaseDaemonRPC)(nil)
+var _ keybase1.NotifyKeyfamilyInterface = (*KeybaseDaemonRPC)(nil)
 
 var _ keybase1.NotifyPaperKeyInterface = (*KeybaseDaemonRPC)(nil)
 
@@ -260,9 +260,10 @@ func (k *KeybaseDaemonRPC) LoggedOut(ctx context.Context) error {
 	return nil
 }
 
-// UserChanged implements keybase1.NotifyUsersInterface.
-func (k *KeybaseDaemonRPC) UserChanged(ctx context.Context, uid keybase1.UID) error {
-	k.log.CDebugf(ctx, "User %s changed", uid)
+// KeyfamilyChanged implements keybase1.NotifyKeyfamilyInterface.
+func (k *KeybaseDaemonRPC) KeyfamilyChanged(ctx context.Context,
+	uid keybase1.UID) error {
+	k.log.CDebugf(ctx, "Key family for user %s changed", uid)
 	k.setCachedUserInfo(uid, UserInfo{})
 	k.clearCachedUnverifiedKeys(uid)
 
@@ -436,7 +437,7 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 		keybase1.LogUiProtocol(daemonLogUI{k.daemonLog}),
 		keybase1.IdentifyUiProtocol(daemonIdentifyUI{k.daemonLog}),
 		keybase1.NotifySessionProtocol(k),
-		keybase1.NotifyUsersProtocol(k),
+		keybase1.NotifyKeyfamilyProtocol(k),
 		keybase1.NotifyPaperKeyProtocol(k),
 	}
 

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -276,7 +276,7 @@ func TestKeybaseDaemonUserCache(t *testing.T) {
 	testLoadUnverifiedKeys(t, client, c, uid2, name2, expectCached)
 
 	// Should invalidate cache for uid1.
-	err := c.UserChanged(context.Background(), uid1)
+	err := c.KeyfamilyChanged(context.Background(), uid1)
 	require.NoError(t, err)
 
 	// Should fill cache again.
@@ -298,7 +298,7 @@ func TestKeybaseDaemonUserCache(t *testing.T) {
 	testLoadUnverifiedKeys(t, client, c, uid2, name2, expectCached)
 
 	// Should invalidate cache for uid2.
-	err = c.UserChanged(context.Background(), uid2)
+	err = c.KeyfamilyChanged(context.Background(), uid2)
 	require.NoError(t, err)
 
 	// Should fill cache again.
@@ -341,9 +341,9 @@ func TestKeybaseDaemonUserCache(t *testing.T) {
 		func(ctx context.Context) {
 			errChan <- nil
 		}).Return(errChan)
-	err = c.UserChanged(context.Background(), uid1)
+	err = c.KeyfamilyChanged(context.Background(), uid1)
 	<-errChan
 	// This one shouldn't trigger CheckForRekeys; if it does, the mock
 	// controller will catch it during Finish.
-	err = c.UserChanged(context.Background(), uid2)
+	err = c.KeyfamilyChanged(context.Background(), uid2)
 }


### PR DESCRIPTION
Issue: KBFS-1238