### PR TITLE
[KBFS-1293] wait for block deletion in parallel test

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -707,6 +707,10 @@ func (c *ConfigLocal) Shutdown() error {
 				if err := fbo.fbm.waitForArchives(context.Background()); err != nil {
 					return err
 				}
+				if err := fbo.fbm.waitForDeletingBlocks(
+					context.Background()); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This should fix https://ci.appveyor.com/project/keybase/kbfs/build/1.0.4659