### PR TITLE
favorites: allow waiting for outstanding requests

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -94,8 +94,10 @@ func (fs *KBFSOpsStandard) markForReIdentifyIfNeeded(now time.Time, maxValid tim
 // been launched by KBFSOpsStandard.
 func (fs *KBFSOpsStandard) Shutdown() error {
 	close(fs.reIdentifyControlChan)
-	fs.favs.Shutdown()
 	var errors []error
+	if err := fs.favs.Shutdown(); err != nil {
+		errors = append(errors, err)
+	}
 	for _, ops := range fs.ops {
 		if err := ops.Shutdown(); err != nil {
 			errors = append(errors, err)


### PR DESCRIPTION
And use that to fix a flaky test.

Issue: KBFS-1298
