### PR TITLE
rpc connection handler callbacks now passes in context

### DIFF
--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -129,8 +129,8 @@ func (b *BlockServerRemote) RefreshAuthToken(ctx context.Context) {
 }
 
 // OnConnectError implements the ConnectionHandler interface.
-func (b *BlockServerRemote) OnConnectError(err error, wait time.Duration) {
-	b.log.Warning("connection error: %v; retrying in %s",
+func (b *BlockServerRemote) OnConnectError(ctx context.Context, err error, wait time.Duration) {
+	b.deferLog.CWarningf(ctx, "connection error: %v; retrying in %s",
 		err, wait)
 	if b.authToken != nil {
 		b.authToken.Shutdown()
@@ -140,8 +140,8 @@ func (b *BlockServerRemote) OnConnectError(err error, wait time.Duration) {
 }
 
 // OnDoCommandError implements the ConnectionHandler interface.
-func (b *BlockServerRemote) OnDoCommandError(err error, wait time.Duration) {
-	b.log.Warning("DoCommand error: %v; retrying in %s",
+func (b *BlockServerRemote) OnDoCommandError(ctx context.Context, err error, wait time.Duration) {
+	b.deferLog.CWarningf(ctx, "DoCommand error: %v; retrying in %s",
 		err, wait)
 }
 
@@ -157,7 +157,7 @@ func (b *BlockServerRemote) OnDisconnected(ctx context.Context,
 }
 
 // ShouldRetry implements the ConnectionHandler interface.
-func (b *BlockServerRemote) ShouldRetry(rpcName string, err error) bool {
+func (b *BlockServerRemote) ShouldRetry(_ context.Context, rpcName string, err error) bool {
 	//do not let connection.go's DoCommand retry any batch rpcs automatically
 	//because i will manually retry them without successfully completed references
 	switch rpcName {
@@ -178,7 +178,7 @@ func (b *BlockServerRemote) ShouldRetry(rpcName string, err error) bool {
 }
 
 // ShouldRetryOnConnect implements the ConnectionHandler interface.
-func (b *BlockServerRemote) ShouldRetryOnConnect(err error) bool {
+func (b *BlockServerRemote) ShouldRetryOnConnect(_ context.Context, err error) bool {
 	_, inputCanceled := err.(libkb.InputCanceledError)
 	return !inputCanceled
 }

--- a/libkbfs/crypto_client.go
+++ b/libkbfs/crypto_client.go
@@ -66,15 +66,15 @@ func (c *CryptoClient) OnConnect(ctx context.Context, conn *rpc.Connection,
 }
 
 // OnConnectError implements the ConnectionHandler interface.
-func (c *CryptoClient) OnConnectError(err error, wait time.Duration) {
-	c.log.Warning("CryptoClient: connection error: %q; retrying in %s",
+func (c *CryptoClient) OnConnectError(ctx context.Context, err error, wait time.Duration) {
+	c.log.CWarningf(ctx, "CryptoClient: connection error: %q; retrying in %s",
 		err, wait)
 	c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, err)
 }
 
 // OnDoCommandError implements the ConnectionHandler interface.
-func (c *CryptoClient) OnDoCommandError(err error, wait time.Duration) {
-	c.log.Warning("CryptoClient: docommand error: %q; retrying in %s",
+func (c *CryptoClient) OnDoCommandError(ctx context.Context, err error, wait time.Duration) {
+	c.log.CWarningf(ctx, "CryptoClient: docommand error: %q; retrying in %s",
 		err, wait)
 	c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, err)
 }
@@ -89,12 +89,12 @@ func (c *CryptoClient) OnDisconnected(_ context.Context,
 }
 
 // ShouldRetry implements the ConnectionHandler interface.
-func (c *CryptoClient) ShouldRetry(rpcName string, err error) bool {
+func (c *CryptoClient) ShouldRetry(_ context.Context, rpcName string, err error) bool {
 	return false
 }
 
 // ShouldRetryOnConnect implements the ConnectionHandler interface.
-func (c *CryptoClient) ShouldRetryOnConnect(err error) bool {
+func (c *CryptoClient) ShouldRetryOnConnect(_ context.Context, err error) bool {
 	_, inputCanceled := err.(libkb.InputCanceledError)
 	return !inputCanceled
 }

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -482,14 +482,14 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 }
 
 // OnConnectError implements the ConnectionHandler interface.
-func (k *KeybaseDaemonRPC) OnConnectError(err error, wait time.Duration) {
-	k.log.Warning("KeybaseDaemonRPC: connection error: %q; retrying in %s",
+func (k *KeybaseDaemonRPC) OnConnectError(ctx context.Context, err error, wait time.Duration) {
+	k.log.CWarningf(ctx, "KeybaseDaemonRPC: connection error: %q; retrying in %s",
 		err, wait)
 }
 
 // OnDoCommandError implements the ConnectionHandler interface.
-func (k *KeybaseDaemonRPC) OnDoCommandError(err error, wait time.Duration) {
-	k.log.Warning("KeybaseDaemonRPC: docommand error: %q; retrying in %s",
+func (k *KeybaseDaemonRPC) OnDoCommandError(ctx context.Context, err error, wait time.Duration) {
+	k.log.CWarningf(ctx, "KeybaseDaemonRPC: docommand error: %q; retrying in %s",
 		err, wait)
 }
 
@@ -504,12 +504,12 @@ func (k *KeybaseDaemonRPC) OnDisconnected(_ context.Context,
 }
 
 // ShouldRetry implements the ConnectionHandler interface.
-func (k *KeybaseDaemonRPC) ShouldRetry(rpcName string, err error) bool {
+func (k *KeybaseDaemonRPC) ShouldRetry(_ context.Context, rpcName string, err error) bool {
 	return false
 }
 
 // ShouldRetryOnConnect implements the ConnectionHandler interface.
-func (k *KeybaseDaemonRPC) ShouldRetryOnConnect(err error) bool {
+func (k *KeybaseDaemonRPC) ShouldRetryOnConnect(_ context.Context, err error) bool {
 	_, inputCanceled := err.(libkb.InputCanceledError)
 	return !inputCanceled
 }

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -256,8 +256,8 @@ func (md *MDServerRemote) resetPingTicker(intervalSeconds int) {
 }
 
 // OnConnectError implements the ConnectionHandler interface.
-func (md *MDServerRemote) OnConnectError(err error, wait time.Duration) {
-	md.log.Warning("MDServerRemote: connection error: %q; retrying in %s",
+func (md *MDServerRemote) OnConnectError(ctx context.Context, err error, wait time.Duration) {
+	md.log.CWarningf(ctx, "MDServerRemote: connection error: %q; retrying in %s",
 		err, wait)
 	// TODO: it might make sense to show something to the user if this is
 	// due to authentication, for example.
@@ -271,8 +271,8 @@ func (md *MDServerRemote) OnConnectError(err error, wait time.Duration) {
 }
 
 // OnDoCommandError implements the ConnectionHandler interface.
-func (md *MDServerRemote) OnDoCommandError(err error, wait time.Duration) {
-	md.log.Warning("MDServerRemote: DoCommand error: %q; retrying in %s",
+func (md *MDServerRemote) OnDoCommandError(ctx context.Context, err error, wait time.Duration) {
+	md.log.CWarningf(ctx, "MDServerRemote: DoCommand error: %q; retrying in %s",
 		err, wait)
 	md.config.KBFSOps().PushConnectionStatusChange(MDServiceName, err)
 }
@@ -280,7 +280,7 @@ func (md *MDServerRemote) OnDoCommandError(err error, wait time.Duration) {
 // OnDisconnected implements the ConnectionHandler interface.
 func (md *MDServerRemote) OnDisconnected(ctx context.Context,
 	status rpc.DisconnectStatus) {
-	md.log.Warning("MDServerRemote is disconnected: %v", status)
+	md.log.CWarningf(ctx, "MDServerRemote is disconnected: %v", status)
 	md.config.Reporter().Notify(ctx,
 		connectionNotification(connectionStatusDisconnected))
 	md.cancelObservers()
@@ -297,13 +297,13 @@ func (md *MDServerRemote) OnDisconnected(ctx context.Context,
 }
 
 // ShouldRetry implements the ConnectionHandler interface.
-func (md *MDServerRemote) ShouldRetry(name string, err error) bool {
+func (md *MDServerRemote) ShouldRetry(_ context.Context, name string, err error) bool {
 	_, shouldThrottle := err.(MDServerErrorThrottle)
 	return shouldThrottle
 }
 
 // ShouldRetryOnConnect implements the ConnectionHandler interface.
-func (md *MDServerRemote) ShouldRetryOnConnect(err error) bool {
+func (md *MDServerRemote) ShouldRetryOnConnect(_ context.Context, err error) bool {
 	_, inputCanceled := err.(libkb.InputCanceledError)
 	return !inputCanceled
 }

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/connection_test_util.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/connection_test_util.go
@@ -18,20 +18,20 @@ func (testConnectionHandler) OnConnect(context.Context, *Connection, GenericClie
 	return nil
 }
 
-func (testConnectionHandler) OnConnectError(err error, reconnectThrottleDuration time.Duration) {
+func (testConnectionHandler) OnConnectError(ctx context.Context, err error, reconnectThrottleDuration time.Duration) {
 }
 
-func (testConnectionHandler) OnDoCommandError(err error, nextTime time.Duration) {
+func (testConnectionHandler) OnDoCommandError(ctx context.Context, err error, nextTime time.Duration) {
 }
 
 func (testConnectionHandler) OnDisconnected(ctx context.Context, status DisconnectStatus) {
 }
 
-func (testConnectionHandler) ShouldRetry(name string, err error) bool {
+func (testConnectionHandler) ShouldRetry(ctx context.Context, name string, err error) bool {
 	return false
 }
 
-func (testConnectionHandler) ShouldRetryOnConnect(err error) bool {
+func (testConnectionHandler) ShouldRetryOnConnect(ctx context.Context, err error) bool {
 	return false
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -207,10 +207,10 @@
 			"revisionTime": "2016-03-16T16:25:20-04:00"
 		},
 		{
-			"checksumSHA1": "Ao/ZFbwpEQ2kdtaim/5borAcVKE=",
+			"checksumSHA1": "1ccp9ziBK9qn9myFVRCz2vdX5CI=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc",
-			"revision": "090895b12240aa18b8d6a759a2638f0c1065c7d0",
-			"revisionTime": "2016-06-15T10:04:14-04:00"
+			"revision": "653f4395fad769c9475a626ea8c29bf87af46c36",
+			"revisionTime": "2016-06-06T15:02:16Z"
 		},
 		{
 			"path": "github.com/keybase/go-jsonw",


### PR DESCRIPTION
related to [this PR](https://github.com/keybase/go-framed-msgpack-rpc/pull/98)
