### PR TITLE
mdserver: calculate the time offset from the local md server

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -965,6 +965,12 @@ type MDServer interface {
 	// should verify the mapping with a Merkle tree lookup.
 	GetLatestHandleForTLF(ctx context.Context, id TlfID) (
 		BareTlfHandle, error)
+
+	// OffsetFromServerTime is the current estimate for how off our
+	// local clock is from the mdserver clock.  Add this to any
+	// mdserver-provided timestamps to get the "local" time of the
+	// corresponding event.
+	OffsetFromServerTime() time.Duration
 }
 
 type mdServerLocal interface {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -969,8 +969,9 @@ type MDServer interface {
 	// OffsetFromServerTime is the current estimate for how off our
 	// local clock is from the mdserver clock.  Add this to any
 	// mdserver-provided timestamps to get the "local" time of the
-	// corresponding event.
-	OffsetFromServerTime() time.Duration
+	// corresponding event.  If the returned bool is false, then we
+	// don't have a current estimate for the offset.
+	OffsetFromServerTime() (time.Duration, bool)
 }
 
 type mdServerLocal interface {

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -613,6 +613,6 @@ func (md *MDServerDisk) GetLatestHandleForTLF(_ context.Context, id TlfID) (
 
 // OffsetFromServerTime implements the MDServer interface for
 // MDServerDisk.
-func (md *MDServerDisk) OffsetFromServerTime() time.Duration {
-	return 0
+func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
+	return 0, true
 }

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -608,4 +609,10 @@ func (md *MDServerDisk) GetLatestHandleForTLF(_ context.Context, id TlfID) (
 		}
 	}
 	return handle, nil
+}
+
+// OffsetFromServerTime implements the MDServer interface for
+// MDServerDisk.
+func (md *MDServerDisk) OffsetFromServerTime() time.Duration {
+	return 0
 }

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -658,6 +658,6 @@ func (md *MDServerMemory) GetLatestHandleForTLF(_ context.Context, id TlfID) (
 
 // OffsetFromServerTime implements the MDServer interface for
 // MDServerMemory.
-func (md *MDServerMemory) OffsetFromServerTime() time.Duration {
-	return 0
+func (md *MDServerMemory) OffsetFromServerTime() (time.Duration, bool) {
+	return 0, true
 }

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -655,3 +655,9 @@ func (md *MDServerMemory) GetLatestHandleForTLF(_ context.Context, id TlfID) (
 
 	return md.latestHandleDb[id], nil
 }
+
+// OffsetFromServerTime implements the MDServer interface for
+// MDServerMemory.
+func (md *MDServerMemory) OffsetFromServerTime() time.Duration {
+	return 0
+}

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -583,6 +583,12 @@ func (md *MDServerRemote) GetLatestHandleForTLF(ctx context.Context, id TlfID) (
 	return handle, nil
 }
 
+// OffsetFromServerTime implements the MDServer interface for
+// MDServerRemote.
+func (md *MDServerRemote) OffsetFromServerTime() time.Duration {
+	return 0
+}
+
 // CheckForRekeys implements the MDServer interface.
 func (md *MDServerRemote) CheckForRekeys(ctx context.Context) <-chan error {
 	// Wait 5 seconds before asking for rekeys, because the server

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2405,10 +2405,11 @@ func (_mr *_MockMDServerRecorder) GetLatestHandleForTLF(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLatestHandleForTLF", arg0, arg1)
 }
 
-func (_m *MockMDServer) OffsetFromServerTime() time.Duration {
+func (_m *MockMDServer) OffsetFromServerTime() (time.Duration, bool) {
 	ret := _m.ctrl.Call(_m, "OffsetFromServerTime")
 	ret0, _ := ret[0].(time.Duration)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 func (_mr *_MockMDServerRecorder) OffsetFromServerTime() *gomock.Call {
@@ -2578,10 +2579,11 @@ func (_mr *_MockmdServerLocalRecorder) GetLatestHandleForTLF(arg0, arg1 interfac
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLatestHandleForTLF", arg0, arg1)
 }
 
-func (_m *MockmdServerLocal) OffsetFromServerTime() time.Duration {
+func (_m *MockmdServerLocal) OffsetFromServerTime() (time.Duration, bool) {
 	ret := _m.ctrl.Call(_m, "OffsetFromServerTime")
 	ret0, _ := ret[0].(time.Duration)
-	return ret0
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
 }
 
 func (_mr *_MockmdServerLocalRecorder) OffsetFromServerTime() *gomock.Call {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2405,6 +2405,16 @@ func (_mr *_MockMDServerRecorder) GetLatestHandleForTLF(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLatestHandleForTLF", arg0, arg1)
 }
 
+func (_m *MockMDServer) OffsetFromServerTime() time.Duration {
+	ret := _m.ctrl.Call(_m, "OffsetFromServerTime")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+func (_mr *_MockMDServerRecorder) OffsetFromServerTime() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "OffsetFromServerTime")
+}
+
 // Mock of mdServerLocal interface
 type MockmdServerLocal struct {
 	ctrl     *gomock.Controller
@@ -2566,6 +2576,16 @@ func (_m *MockmdServerLocal) GetLatestHandleForTLF(ctx context.Context, id TlfID
 
 func (_mr *_MockmdServerLocalRecorder) GetLatestHandleForTLF(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLatestHandleForTLF", arg0, arg1)
+}
+
+func (_m *MockmdServerLocal) OffsetFromServerTime() time.Duration {
+	ret := _m.ctrl.Call(_m, "OffsetFromServerTime")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+func (_mr *_MockmdServerLocalRecorder) OffsetFromServerTime() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "OffsetFromServerTime")
 }
 
 func (_m *MockmdServerLocal) addNewAssertionForTest(uid protocol.UID, newAssertion protocol.SocialAssertion) error {

--- a/vendor/github.com/keybase/client/go/protocol/metadata.go
+++ b/vendor/github.com/keybase/client/go/protocol/metadata.go
@@ -30,6 +30,10 @@ type MerkleRoot struct {
 	Root    []byte `codec:"root" json:"root"`
 }
 
+type PingResponse struct {
+	Timestamp Time `codec:"timestamp" json:"timestamp"`
+}
+
 type GetChallengeArg struct {
 }
 
@@ -103,6 +107,9 @@ type GetFoldersForRekeyArg struct {
 type PingArg struct {
 }
 
+type Ping2Arg struct {
+}
+
 type GetLatestFolderHandleArg struct {
 	FolderID string `codec:"folderID" json:"folderID"`
 }
@@ -140,6 +147,7 @@ type MetadataInterface interface {
 	GetFolderHandle(context.Context, GetFolderHandleArg) ([]byte, error)
 	GetFoldersForRekey(context.Context, KID) error
 	Ping(context.Context) error
+	Ping2(context.Context) (PingResponse, error)
 	GetLatestFolderHandle(context.Context, string) ([]byte, error)
 	GetMerkleRoot(context.Context, GetMerkleRootArg) (MerkleRoot, error)
 	GetMerkleRootLatest(context.Context, MerkleTreeID) (MerkleRoot, error)
@@ -365,6 +373,17 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"ping2": {
+				MakeArg: func() interface{} {
+					ret := make([]Ping2Arg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					ret, err = i.Ping2(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"getLatestFolderHandle": {
 				MakeArg: func() interface{} {
 					ret := make([]GetLatestFolderHandleArg, 1)
@@ -524,6 +543,11 @@ func (c MetadataClient) GetFoldersForRekey(ctx context.Context, deviceKID KID) (
 
 func (c MetadataClient) Ping(ctx context.Context) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.metadata.ping", []interface{}{PingArg{}}, nil)
+	return
+}
+
+func (c MetadataClient) Ping2(ctx context.Context) (res PingResponse, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.metadata.ping2", []interface{}{Ping2Arg{}}, &res)
 	return
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -156,10 +156,10 @@
 			"revisionTime": "2016-07-11T12:37:48-07:00"
 		},
 		{
-			"checksumSHA1": "YhoblENfkJjVtOd8rJPNVJRohnE=",
+			"checksumSHA1": "lZ4fqdEV+0CrpHWPV04wQ3a5pHI=",
 			"path": "github.com/keybase/client/go/protocol",
-			"revision": "0b3cd7c083d90c805fb034d29004a1dbe1c18143",
-			"revisionTime": "2016-07-21T21:04:37Z"
+			"revision": "23acbd6e479fc939bdb4a5b72b780941f2c93ece",
+			"revisionTime": "2016-07-22T18:23:30Z"
 		},
 		{
 			"path": "github.com/keybase/go-codec/codec",


### PR DESCRIPTION
This will let us figure out how "old" a server-timestamped MD update is.

I expect the docker tests to fail until the corresponding server update is merged.

Depends on keybase/client#3569.

Issue: KBFS-1312