### PR TITLE
cr: block md writes if the state to resolve gets too large

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -283,7 +283,7 @@ func testCRCheckPathsAndActions(t *testing.T, cr *ConflictResolver,
 
 	// Step 1 -- check the chains and paths
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, _, err := cr.buildChainsAndPaths(ctx, lState)
+		recreateOps, _, _, err := cr.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1169,7 +1169,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState)
+		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1285,7 +1285,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState)
+		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}


### PR DESCRIPTION
This is meant to be a nuclear option.  In the future, maybe we should
consider throttling unmerged writes a little more nicely, proportional
to how far past the branch point we are.

Issue: KBFS-1310