### PR TITLE
[KBFS-1265] Port metadata validator from server

### DIFF
--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -585,7 +585,7 @@ func (md *BareRootMetadata) DeepCopyForServerTest(codec Codec) (
 // problem was found.
 func (md *BareRootMetadata) IsValidAndSigned(
 	codec Codec, crypto cryptoPure,
-	currentUID keybase1.UID, currentKID keybase1.KID) error {
+	currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error {
 	if md.Revision < MetadataRevisionInitial {
 		return errors.New("Invalid revision")
 	}
@@ -625,9 +625,8 @@ func (md *BareRootMetadata) IsValidAndSigned(
 		if writer != currentUID {
 			return errors.New("Last writer and current user mismatch")
 		}
-		kid := md.WriterMetadataSigInfo.VerifyingKey.KID()
-		if kid != currentKID {
-			return errors.New("Last writer key and current device mismatch")
+		if md.WriterMetadataSigInfo.VerifyingKey != currentVerifyingKey {
+			return errors.New("Last writer verifying key and current verifying key mismatch")
 		}
 	}
 

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -111,7 +111,6 @@ type BareRootMetadata struct {
 
 	// The signature for the writer metadata, to prove
 	// that it's only been changed by writers.
-
 	WriterMetadataSigInfo SignatureInfo
 
 	// The last KB user who modified this BareRootMetadata

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -579,11 +579,19 @@ func (md *BareRootMetadata) DeepCopyForServerTest(codec Codec) (
 }
 
 // IsValidAndSigned verifies the BareRootMetadata given the current
-// user and device, checks the writer signature, and returns an error
-// if a problem was found.
+// user and device (identified by the KID of the device verifying
+// key), checks the writer signature, and returns an error if a
+// problem was found.
 func (md *BareRootMetadata) IsValidAndSigned(
 	codec Codec, crypto cryptoPure,
 	currentUID keybase1.UID, currentKID keybase1.KID) error {
+	mStatus := md.MergedStatus()
+	bid := md.BID
+
+	if (mStatus == Merged) != (bid == NullBranchID) {
+		return errors.New("Branch ID doesn't match merged status")
+	}
+
 	handle, err := md.MakeBareTlfHandle()
 	if err != nil {
 		return err

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -181,7 +181,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	codec := NewCodecMsgpack()
 	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"user1", "user2"})
 	currentUID := localUsers[0].UID
-	crypto := &CryptoLocal{CryptoCommon: makeTestCryptoCommon(t)}
+	crypto := &CryptoLocal{CryptoCommon: MakeCryptoCommon(codec)}
 	config := &ConfigLocal{codec: codec, crypto: crypto}
 	setTestLogger(config, t)
 	fc := NewFakeBServerClient(config, nil, nil, nil)
@@ -252,7 +252,7 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 	codec := NewCodecMsgpack()
 	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"testuser"})
 	currentUID := localUsers[0].UID
-	crypto := &CryptoLocal{CryptoCommon: makeTestCryptoCommon(t)}
+	crypto := &CryptoLocal{CryptoCommon: MakeCryptoCommon(codec)}
 	config := &ConfigLocal{codec: codec, crypto: crypto}
 	setTestLogger(config, t)
 

--- a/libkbfs/bserver_tlf_journal_test.go
+++ b/libkbfs/bserver_tlf_journal_test.go
@@ -21,7 +21,7 @@ func getBlockJournalLength(t *testing.T, j *bserverTlfJournal) int {
 
 func TestBserverTlfJournalBasic(t *testing.T) {
 	codec := NewCodecMsgpack()
-	crypto := makeTestCryptoCommon(t)
+	crypto := MakeCryptoCommon(codec)
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "bserver_tlf_journal")
 	require.NoError(t, err)
@@ -95,7 +95,7 @@ func TestBserverTlfJournalBasic(t *testing.T) {
 
 func TestBserverTlfJournalRemoveReferences(t *testing.T) {
 	codec := NewCodecMsgpack()
-	crypto := makeTestCryptoCommon(t)
+	crypto := MakeCryptoCommon(codec)
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "bserver_tlf_storage")
 	require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestBserverTlfJournalRemoveReferences(t *testing.T) {
 
 func TestBserverTlfJournalArchiveReferences(t *testing.T) {
 	codec := NewCodecMsgpack()
-	crypto := makeTestCryptoCommon(t)
+	crypto := MakeCryptoCommon(codec)
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "bserver_tlf_storage")
 	require.NoError(t, err)

--- a/libkbfs/bsplitter_simple_test.go
+++ b/libkbfs/bsplitter_simple_test.go
@@ -155,7 +155,7 @@ func TestBsplitterOverhead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Encoding block failed: %v", err)
 	}
-	crypto := makeTestCryptoCommon(t)
+	crypto := MakeCryptoCommon(codec)
 	paddedBlock, err := crypto.padBlock(encodedBlock)
 	if err != nil {
 		t.Fatalf("Padding block failed: %v", err)

--- a/libkbfs/crypto_client.go
+++ b/libkbfs/crypto_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
 	rpc "github.com/keybase/go-framed-msgpack-rpc"
 	"golang.org/x/net/context"
@@ -18,6 +19,8 @@ import (
 // signing key.
 type CryptoClient struct {
 	CryptoCommon
+	log        logger.Logger
+	deferLog   logger.Logger
 	client     keybase1.CryptoClient
 	shutdownFn func()
 	config     Config
@@ -34,8 +37,11 @@ var _ rpc.ConnectionHandler = (*CryptoClient)(nil)
 // NewCryptoClient constructs a new CryptoClient.
 func NewCryptoClient(config Config, kbCtx Context) *CryptoClient {
 	log := config.MakeLogger("")
+	deferLog := log.CloneWithAddedDepth(1)
 	c := &CryptoClient{
-		CryptoCommon: MakeCryptoCommon(config.Codec(), log),
+		CryptoCommon: MakeCryptoCommon(config.Codec()),
+		log:          log,
+		deferLog:     deferLog,
 		config:       config,
 	}
 	conn := NewSharedKeybaseConnection(kbCtx, config, c)
@@ -47,8 +53,11 @@ func NewCryptoClient(config Config, kbCtx Context) *CryptoClient {
 // newCryptoClientWithClient should only be used for testing.
 func newCryptoClientWithClient(config Config, client rpc.GenericClient) *CryptoClient {
 	log := config.MakeLogger("")
+	deferLog := log.CloneWithAddedDepth(1)
 	return &CryptoClient{
-		CryptoCommon: MakeCryptoCommon(config.Codec(), log),
+		CryptoCommon: MakeCryptoCommon(config.Codec()),
+		log:          log,
+		deferLog:     deferLog,
 		client:       keybase1.CryptoClient{Cli: client},
 	}
 }

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type FakeCryptoClient struct {
-	Local     *CryptoLocal
+	Local     CryptoLocal
 	readyChan chan<- struct{}
 	goChan    <-chan struct{}
 }

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -11,7 +11,6 @@ import (
 	"io"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -34,16 +33,14 @@ func cryptoRandRead(buf []byte) error {
 // CryptoCommon contains many of the function implementations need for
 // the Crypto interface, which can be reused by other implementations.
 type CryptoCommon struct {
-	codec    Codec
-	log      logger.Logger
-	deferLog logger.Logger
+	codec Codec
 }
 
 var _ cryptoPure = (*CryptoCommon)(nil)
 
 // MakeCryptoCommon returns a default CryptoCommon object.
-func MakeCryptoCommon(codec Codec, log logger.Logger) CryptoCommon {
-	return CryptoCommon{codec, log, log.CloneWithAddedDepth(1)}
+func MakeCryptoCommon(codec Codec) CryptoCommon {
+	return CryptoCommon{codec}
 }
 
 // MakeRandomTlfID implements the Crypto interface for CryptoCommon.

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -230,12 +230,6 @@ func (c CryptoCommon) UnmaskBlockCryptKey(serverHalf BlockCryptKeyServerHalf, tl
 
 // Verify implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) Verify(msg []byte, sigInfo SignatureInfo) (err error) {
-	defer func() {
-		c.deferLog.Debug(
-			"Verify result for %d-byte message with %s: %v",
-			len(msg), sigInfo, err)
-	}()
-
 	if sigInfo.Version != SigED25519 {
 		err = UnknownSigVer{sigInfo.Version}
 		return

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -13,17 +13,12 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 )
-
-func makeTestCryptoCommon(t logger.TestLogBackend) CryptoCommon {
-	return MakeCryptoCommon(NewCodecMsgpack(), logger.NewTestLogger(t))
-}
 
 // Test (very superficially) that MakeTemporaryBlockID() returns non-zero
 // values that aren't equal.
 func TestCryptoCommonRandomBlockID(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	b1, err := c.MakeTemporaryBlockID()
 	if err != nil {
@@ -51,7 +46,7 @@ func TestCryptoCommonRandomBlockID(t *testing.T) {
 // Test (very superficially) that MakeRandomTLFKeys() returns non-zero
 // values that aren't equal.
 func TestCryptoCommonRandomTLFKeys(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	a1, a2, a3, a4, a5, err := c.MakeRandomTLFKeys()
 	if err != nil {
@@ -127,7 +122,7 @@ func TestCryptoCommonRandomTLFKeys(t *testing.T) {
 // Test (very superficially) that MakeRandomTLFCryptKeyServerHalf()
 // returns non-zero values that aren't equal.
 func TestCryptoCommonRandomTLFCryptKeyServerHalf(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	k1, err := c.MakeRandomTLFCryptKeyServerHalf()
 	if err != nil {
@@ -155,7 +150,7 @@ func TestCryptoCommonRandomTLFCryptKeyServerHalf(t *testing.T) {
 // Test (very superficially) that MakeRandomBlockCryptKeyServerHalf()
 // returns non-zero values that aren't equal.
 func TestCryptoCommonRandomBlockCryptKeyServerHalf(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	k1, err := c.MakeRandomBlockCryptKeyServerHalf()
 	if err != nil {
@@ -184,7 +179,7 @@ func TestCryptoCommonRandomBlockCryptKeyServerHalf(t *testing.T) {
 // the server half and the key, and that UnmaskTLFCryptKey() undoes
 // the masking properly.
 func TestCryptoCommonMaskUnmaskTLFCryptKey(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	serverHalf, err := c.MakeRandomTLFCryptKeyServerHalf()
 	if err != nil {
@@ -222,7 +217,7 @@ func TestCryptoCommonMaskUnmaskTLFCryptKey(t *testing.T) {
 // Test that UnmaskBlockCryptKey() returns bytes that are different from
 // the server half and the key.
 func TestCryptoCommonUnmaskTLFCryptKey(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	serverHalf, err := c.MakeRandomBlockCryptKeyServerHalf()
 	if err != nil {
@@ -249,7 +244,7 @@ func TestCryptoCommonUnmaskTLFCryptKey(t *testing.T) {
 }
 
 func TestCryptoCommonEncryptDecryptBlock(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	block := TestBlock{42}
 	key := BlockCryptKey{}
@@ -281,7 +276,7 @@ func TestCryptoCommonVerifyFailures(t *testing.T) {
 		VerifyingKey: signingKey.GetVerifyingKey(),
 	}
 
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	var expectedErr, err error
 
@@ -356,7 +351,7 @@ func TestCryptoCommonVerifyFailures(t *testing.T) {
 // Test that crypto.EncryptTLFCryptKeyClientHalf() encrypts its
 // passed-in client half properly.
 func TestCryptoCommonEncryptTLFCryptKeyClientHalf(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	_, _, ephPublicKey, ephPrivateKey, cryptKey, err := c.MakeRandomTLFKeys()
 	if err != nil {
@@ -442,7 +437,7 @@ func checkSecretboxOpen(t *testing.T, encryptedData encryptedData, key [32]byte)
 // Test that crypto.EncryptPrivateMetadata() encrypts its passed-in
 // PrivateMetadata object properly.
 func TestEncryptPrivateMetadata(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	_, tlfPrivateKey, _, _, cryptKey, err := c.MakeRandomTLFKeys()
 	if err != nil {
@@ -498,7 +493,7 @@ func secretboxSealEncoded(t *testing.T, c *CryptoCommon, encodedData []byte, key
 // PrivateMetadata object encrypted with the default method (current
 // nacl/secretbox).
 func TestDecryptPrivateMetadataSecretboxSeal(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	_, tlfPrivateKey, _, _, cryptKey, err := c.MakeRandomTLFKeys()
 	if err != nil {
@@ -530,7 +525,7 @@ func TestDecryptPrivateMetadataSecretboxSeal(t *testing.T) {
 // PrivateMetadata object encrypted with the default method (current
 // nacl/secretbox).
 func TestDecryptEncryptedPrivateMetadata(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	_, tlfPrivateKey, _, _, cryptKey, err := c.MakeRandomTLFKeys()
 	if err != nil {
@@ -609,7 +604,7 @@ func checkDecryptionFailures(
 
 // Test various failure cases for crypto.DecryptPrivateMetadata().
 func TestDecryptPrivateMetadataFailures(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	_, tlfPrivateKey, _, _, cryptKey, err := c.MakeRandomTLFKeys()
 	if err != nil {
@@ -650,7 +645,7 @@ func makeFakeBlockCryptKey(t *testing.T) BlockCryptKey {
 // Test that crypto.EncryptBlock() encrypts its passed-in Block object
 // properly.
 func TestEncryptBlock(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	cryptKey := makeFakeBlockCryptKey(t)
 
@@ -683,7 +678,7 @@ func TestEncryptBlock(t *testing.T) {
 // Test that crypto.DecryptBlock() decrypts a Block object encrypted
 // with the default method (current nacl/secretbox).
 func TestDecryptBlockSecretboxSeal(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	cryptKey := makeFakeBlockCryptKey(t)
 
@@ -715,7 +710,7 @@ func TestDecryptBlockSecretboxSeal(t *testing.T) {
 // Test that crypto.DecryptBlock() decrypts a Block object encrypted
 // with the default method (current nacl/secretbox).
 func TestDecryptEncryptedBlock(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	cryptKey := makeFakeBlockCryptKey(t)
 
@@ -739,7 +734,7 @@ func TestDecryptEncryptedBlock(t *testing.T) {
 
 // Test various failure cases for crypto.DecryptBlock().
 func TestDecryptBlockFailures(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	cryptKey := makeFakeBlockCryptKey(t)
 
@@ -838,7 +833,7 @@ func TestBlockPadMinimum(t *testing.T) {
 // Test that secretbox encrypted data length is a deterministic
 // function of the input data length.
 func TestSecretboxEncryptedLen(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 
 	const startSize = 100
 	const endSize = 100000
@@ -885,7 +880,7 @@ func (testBlockArray) DataVersion() DataVer { return FirstValidDataVer }
 // Test that block encrypted data length is the same for data
 // length within same power of 2.
 func TestBlockEncryptedLen(t *testing.T) {
-	c := makeTestCryptoCommon(t)
+	c := MakeCryptoCommon(NewCodecMsgpack())
 	cryptKey := makeFakeBlockCryptKey(t)
 
 	const startSize = 1025

--- a/libkbfs/crypto_local.go
+++ b/libkbfs/crypto_local.go
@@ -107,9 +107,8 @@ var _ Crypto = CryptoLocal{}
 // NewCryptoLocal constructs a new CryptoLocal instance with the given
 // signing key.
 func NewCryptoLocal(config Config, signingKey SigningKey, cryptPrivateKey CryptPrivateKey) CryptoLocal {
-	log := config.MakeLogger("")
 	return CryptoLocal{
-		MakeCryptoCommon(config.Codec(), log),
+		MakeCryptoCommon(config.Codec()),
 		cryptoSignerLocal{signingKey},
 		cryptPrivateKey,
 	}

--- a/libkbfs/crypto_local.go
+++ b/libkbfs/crypto_local.go
@@ -74,26 +74,11 @@ func (k CryptPrivateKey) getPublicKey() CryptPublicKey {
 	return MakeCryptPublicKey(k.kp.Public.GetKID())
 }
 
-// CryptoLocal implements the Crypto interface by using a local
-// signing key and a local crypt private key.
-type CryptoLocal struct {
-	CryptoCommon
-	signingKey      SigningKey
-	cryptPrivateKey CryptPrivateKey
+type cryptoSignerLocal struct {
+	signingKey SigningKey
 }
 
-var _ Crypto = (*CryptoLocal)(nil)
-
-// NewCryptoLocal constructs a new CryptoLocal instance with the given
-// signing key.
-func NewCryptoLocal(config Config, signingKey SigningKey, cryptPrivateKey CryptPrivateKey) *CryptoLocal {
-	log := config.MakeLogger("")
-	return &CryptoLocal{MakeCryptoCommon(config.Codec(), log),
-		signingKey, cryptPrivateKey}
-}
-
-// Sign implements the Crypto interface for CryptoLocal.
-func (c *CryptoLocal) Sign(ctx context.Context, msg []byte) (
+func (c cryptoSignerLocal) Sign(ctx context.Context, msg []byte) (
 	sigInfo SignatureInfo, err error) {
 	sigInfo = SignatureInfo{
 		Version:      SigED25519,
@@ -103,14 +88,34 @@ func (c *CryptoLocal) Sign(ctx context.Context, msg []byte) (
 	return
 }
 
-// SignToString implements the Crypto interface for CryptoLocal.
-func (c *CryptoLocal) SignToString(ctx context.Context, msg []byte) (
+func (c cryptoSignerLocal) SignToString(ctx context.Context, msg []byte) (
 	signature string, err error) {
 	signature, _, err = c.signingKey.kp.SignToString(msg)
 	return
 }
 
-func (c *CryptoLocal) prepareTLFCryptKeyClientHalf(encryptedClientHalf EncryptedTLFCryptKeyClientHalf,
+// CryptoLocal implements the Crypto interface by using a local
+// signing key and a local crypt private key.
+type CryptoLocal struct {
+	CryptoCommon
+	cryptoSignerLocal
+	cryptPrivateKey CryptPrivateKey
+}
+
+var _ Crypto = CryptoLocal{}
+
+// NewCryptoLocal constructs a new CryptoLocal instance with the given
+// signing key.
+func NewCryptoLocal(config Config, signingKey SigningKey, cryptPrivateKey CryptPrivateKey) CryptoLocal {
+	log := config.MakeLogger("")
+	return CryptoLocal{
+		MakeCryptoCommon(config.Codec(), log),
+		cryptoSignerLocal{signingKey},
+		cryptPrivateKey,
+	}
+}
+
+func (c CryptoLocal) prepareTLFCryptKeyClientHalf(encryptedClientHalf EncryptedTLFCryptKeyClientHalf,
 	clientHalf TLFCryptKeyClientHalf) (
 	nonce [24]byte, err error) {
 	if encryptedClientHalf.Version != EncryptionSecretbox {
@@ -135,7 +140,7 @@ func (c *CryptoLocal) prepareTLFCryptKeyClientHalf(encryptedClientHalf Encrypted
 
 // DecryptTLFCryptKeyClientHalf implements the Crypto interface for
 // CryptoLocal.
-func (c *CryptoLocal) DecryptTLFCryptKeyClientHalf(ctx context.Context,
+func (c CryptoLocal) DecryptTLFCryptKeyClientHalf(ctx context.Context,
 	publicKey TLFEphemeralPublicKey,
 	encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (
 	clientHalf TLFCryptKeyClientHalf, err error) {
@@ -161,7 +166,7 @@ func (c *CryptoLocal) DecryptTLFCryptKeyClientHalf(ctx context.Context,
 
 // DecryptTLFCryptKeyClientHalfAny implements the Crypto interface for
 // CryptoLocal.
-func (c *CryptoLocal) DecryptTLFCryptKeyClientHalfAny(ctx context.Context,
+func (c CryptoLocal) DecryptTLFCryptKeyClientHalfAny(ctx context.Context,
 	keys []EncryptedTLFCryptKeyClientAndEphemeral, _ bool) (
 	clientHalf TLFCryptKeyClientHalf, index int, err error) {
 	if len(keys) == 0 {
@@ -183,4 +188,4 @@ func (c *CryptoLocal) DecryptTLFCryptKeyClientHalfAny(ctx context.Context,
 }
 
 // Shutdown implements the Crypto interface for CryptoLocal.
-func (c *CryptoLocal) Shutdown() {}
+func (c CryptoLocal) Shutdown() {}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -715,15 +715,19 @@ type cryptoPure interface {
 		nonce *[24]byte, ePubKey TLFEphemeralPublicKey) (*MerkleLeaf, error)
 }
 
-// Crypto signs, verifies, encrypts, and decrypts stuff.
-type Crypto interface {
-	cryptoPure
-
+type cryptoSigner interface {
 	// Sign signs the msg with the current device's private key.
 	Sign(ctx context.Context, msg []byte) (sigInfo SignatureInfo, err error)
 	// Sign signs the msg with the current device's private key and output
 	// the full serialized NaclSigInfo.
 	SignToString(ctx context.Context, msg []byte) (signature string, err error)
+}
+
+// Crypto signs, verifies, encrypts, and decrypts stuff.
+type Crypto interface {
+	cryptoPure
+	cryptoSigner
+
 	// DecryptTLFCryptKeyClientHalf decrypts a TLFCryptKeyClientHalf
 	// using the current device's private key and the TLF's ephemeral
 	// public key.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5091,7 +5091,7 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 
 	// Make sure all MDs get different MD IDs, as otherwise
 	// setHeadLocked will panic).
-	injectShimCrypto(t, config)
+	injectShimCrypto(config)
 
 	rootID := fakeBlockID(42)
 	rmd.data.Dir.ID = rootID

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -25,10 +24,10 @@ func (c shimCrypto) MakeMdID(md *BareRootMetadata) (MdID, error) {
 	return c.pure.MakeMdID(md)
 }
 
-func injectShimCrypto(t *testing.T, config Config) {
+func injectShimCrypto(config Config) {
 	crypto := shimCrypto{
 		config.Crypto(),
-		MakeCryptoCommon(NewCodecMsgpack(), logger.NewTestLogger(t)),
+		MakeCryptoCommon(NewCodecMsgpack()),
 	}
 	config.SetCrypto(crypto)
 }
@@ -40,7 +39,7 @@ func mdOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config = NewConfigMock(mockCtrl, ctr)
 	mdops := NewMDOpsStandard(config)
 	config.SetMDOps(mdops)
-	injectShimCrypto(t, config)
+	injectShimCrypto(config)
 	interposeDaemonKBPKI(config, "alice", "bob", "charlie")
 	ctx = context.Background()
 	return

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -364,12 +364,17 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 		return MDServerError{err}
 	}
 
+	key, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return MDServerError{err}
+	}
+
 	tlfStorage, err := md.getStorage(rmds.MD.ID)
 	if err != nil {
 		return err
 	}
 
-	recordBranchID, err := tlfStorage.put(currentUID, rmds)
+	recordBranchID, err := tlfStorage.put(currentUID, key.KID(), rmds)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -364,7 +364,7 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 		return MDServerError{err}
 	}
 
-	key, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	currentVerifyingKey, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
 	if err != nil {
 		return MDServerError{err}
 	}
@@ -374,7 +374,8 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 		return err
 	}
 
-	recordBranchID, err := tlfStorage.put(currentUID, key.KID(), rmds)
+	recordBranchID, err := tlfStorage.put(
+		currentUID, currentVerifyingKey, rmds)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -320,13 +320,14 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 		return MDServerError{err}
 	}
 
-	key, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	currentVerifyingKey, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
 	if err != nil {
 		return MDServerError{err}
 	}
 
 	err = rmds.IsValidAndSigned(
-		md.config.Codec(), md.config.Crypto(), currentUID, key.KID())
+		md.config.Codec(), md.config.Crypto(),
+		currentUID, currentVerifyingKey)
 	if err != nil {
 		return MDServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -315,21 +315,25 @@ func (md *MDServerMemory) GetRange(ctx context.Context, id TlfID,
 
 // Put implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) error {
-	mStatus := rmds.MD.MergedStatus()
-	bid := rmds.MD.BID
+	_, currentUID, err := md.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return MDServerError{err}
+	}
 
-	if (mStatus == Merged) != (bid == NullBranchID) {
-		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
+	key, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return MDServerError{err}
+	}
+
+	err = rmds.IsValidAndSigned(
+		md.config.Codec(), md.config.Crypto(), currentUID, key.KID())
+	if err != nil {
+		return MDServerErrorBadRequest{Reason: err.Error()}
 	}
 
 	id := rmds.MD.ID
 
 	// Check permissions
-
-	_, currentUID, err := md.config.KBPKI().GetCurrentUserInfo(ctx)
-	if err != nil {
-		return MDServerError{err}
-	}
 
 	mergedMasterHead, err :=
 		md.getHeadForTLF(ctx, id, NullBranchID, Merged)
@@ -345,6 +349,9 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 	if !ok {
 		return MDServerErrorUnauthorized{}
 	}
+
+	bid := rmds.MD.BID
+	mStatus := rmds.MD.MergedStatus()
 
 	head, err := md.getHeadForTLF(ctx, id, bid, mStatus)
 	if err != nil {

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -13,6 +13,43 @@ import (
 	"golang.org/x/net/context"
 )
 
+func makeRMDSForTest(t *testing.T, id TlfID, h BareTlfHandle,
+	revision MetadataRevision, uid keybase1.UID,
+	prevRoot MdID) *RootMetadataSigned {
+	rmds, err := NewRootMetadataSignedForTest(id, h)
+	require.NoError(t, err)
+	rmds.MD.SerializedPrivateMetadata = []byte{0x1}
+	rmds.MD.Revision = revision
+	rmds.MD.LastModifyingWriter = uid
+	rmds.MD.LastModifyingUser = uid
+	FakeInitialRekey(&rmds.MD, h)
+	rmds.MD.PrevRoot = prevRoot
+	return rmds
+}
+
+func signRMDSForTest(t *testing.T, config Config, rmds *RootMetadataSigned) {
+	codec := config.Codec()
+	crypto := config.Crypto()
+
+	ctx := context.Background()
+
+	// Encode and sign writer metadata.
+	buf, err := codec.Encode(rmds.MD.WriterMetadata)
+	require.NoError(t, err)
+
+	sigInfo, err := crypto.Sign(ctx, buf)
+	require.NoError(t, err)
+	rmds.MD.WriterMetadataSigInfo = sigInfo
+
+	// Encode and sign root metadata.
+	buf, err = codec.Encode(rmds.MD)
+	require.NoError(t, err)
+
+	sigInfo, err = crypto.Sign(ctx, buf)
+	require.NoError(t, err)
+	rmds.SigInfo = sigInfo
+}
+
 // This should pass for both local and remote servers.
 func TestMDServerBasics(t *testing.T) {
 	// setup
@@ -36,17 +73,8 @@ func TestMDServerBasics(t *testing.T) {
 	prevRoot := MdID{}
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
-		rmds, err := NewRootMetadataSignedForTest(id, h)
-		require.NoError(t, err)
-		rmds.MD.SerializedPrivateMetadata = make([]byte, 1)
-		rmds.MD.SerializedPrivateMetadata[0] = 0x1
-		rmds.MD.Revision = MetadataRevision(i)
-		rmds.MD.LastModifyingWriter = uid
-		rmds.MD.LastModifyingUser = uid
-		FakeInitialRekey(&rmds.MD, h)
-		if i > 1 {
-			rmds.MD.PrevRoot = prevRoot
-		}
+		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
+		signRMDSForTest(t, config, rmds)
 		err = mdServer.Put(ctx, rmds)
 		require.NoError(t, err)
 		prevRoot, err = config.Crypto().MakeMdID(&rmds.MD)
@@ -57,13 +85,7 @@ func TestMDServerBasics(t *testing.T) {
 	}
 
 	// (3) trigger a conflict
-	rmds, err = NewRootMetadataSignedForTest(id, h)
-	require.NoError(t, err)
-	rmds.MD.Revision = MetadataRevision(10)
-	rmds.MD.SerializedPrivateMetadata = make([]byte, 1)
-	rmds.MD.SerializedPrivateMetadata[0] = 0x1
-	FakeInitialRekey(&rmds.MD, h)
-	rmds.MD.PrevRoot = prevRoot
+	rmds = makeRMDSForTest(t, id, h, 10, uid, prevRoot)
 	err = mdServer.Put(ctx, rmds)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 
@@ -73,15 +95,10 @@ func TestMDServerBasics(t *testing.T) {
 	bid, err := config.Crypto().MakeRandomBranchID()
 	require.NoError(t, err)
 	for i := MetadataRevision(6); i < 41; i++ {
-		rmds, err := NewRootMetadataSignedForTest(id, h)
-		require.NoError(t, err)
-		rmds.MD.Revision = MetadataRevision(i)
-		rmds.MD.SerializedPrivateMetadata = make([]byte, 1)
-		rmds.MD.SerializedPrivateMetadata[0] = 0x1
-		rmds.MD.PrevRoot = prevRoot
-		FakeInitialRekey(&rmds.MD, h)
+		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
 		rmds.MD.WFlags |= MetadataFlagUnmerged
 		rmds.MD.BID = bid
+		signRMDSForTest(t, config, rmds)
 		err = mdServer.Put(ctx, rmds)
 		require.NoError(t, err)
 		prevRoot, err = config.Crypto().MakeMdID(&rmds.MD)

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -41,6 +41,8 @@ func TestMDServerBasics(t *testing.T) {
 		rmds.MD.SerializedPrivateMetadata = make([]byte, 1)
 		rmds.MD.SerializedPrivateMetadata[0] = 0x1
 		rmds.MD.Revision = MetadataRevision(i)
+		rmds.MD.LastModifyingWriter = uid
+		rmds.MD.LastModifyingUser = uid
 		FakeInitialRekey(&rmds.MD, h)
 		if i > 1 {
 			rmds.MD.PrevRoot = prevRoot

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -86,6 +86,7 @@ func TestMDServerBasics(t *testing.T) {
 
 	// (3) trigger a conflict
 	rmds = makeRMDSForTest(t, id, h, 10, uid, prevRoot)
+	signRMDSForTest(t, config, rmds)
 	err = mdServer.Put(ctx, rmds)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -310,7 +310,8 @@ func (s *mdServerTlfStorage) getRange(
 }
 
 func (s *mdServerTlfStorage) put(
-	currentUID keybase1.UID, rmds *RootMetadataSigned) (
+	currentUID keybase1.UID, currentKID keybase1.KID,
+	rmds *RootMetadataSigned) (
 	recordBranchID bool, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -319,11 +320,10 @@ func (s *mdServerTlfStorage) put(
 		return false, errMDServerTlfStorageShutdown
 	}
 
-	mStatus := rmds.MD.MergedStatus()
-	bid := rmds.MD.BID
-
-	if (mStatus == Merged) != (bid == NullBranchID) {
-		return false, MDServerErrorBadRequest{Reason: "Invalid branch ID"}
+	err = rmds.IsValidAndSigned(
+		s.codec, s.crypto, currentUID, currentKID)
+	if err != nil {
+		return false, MDServerErrorBadRequest{Reason: err.Error()}
 	}
 
 	// Check permissions
@@ -341,6 +341,9 @@ func (s *mdServerTlfStorage) put(
 	if !ok {
 		return false, MDServerErrorUnauthorized{}
 	}
+
+	bid := rmds.MD.BID
+	mStatus := rmds.MD.MergedStatus()
 
 	head, err := s.getHeadForTLFReadLocked(bid)
 	if err != nil {

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -310,7 +310,7 @@ func (s *mdServerTlfStorage) getRange(
 }
 
 func (s *mdServerTlfStorage) put(
-	currentUID keybase1.UID, currentKID keybase1.KID,
+	currentUID keybase1.UID, currentVerifyingKey VerifyingKey,
 	rmds *RootMetadataSigned) (
 	recordBranchID bool, err error) {
 	s.lock.Lock()
@@ -321,7 +321,7 @@ func (s *mdServerTlfStorage) put(
 	}
 
 	err = rmds.IsValidAndSigned(
-		s.codec, s.crypto, currentUID, currentKID)
+		s.codec, s.crypto, currentUID, currentVerifyingKey)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -58,7 +58,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
 		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
-		recordBranchID, err := s.put(uid, key.KID(), rmds)
+		recordBranchID, err := s.put(uid, key, rmds)
 		require.NoError(t, err)
 		require.False(t, recordBranchID)
 		prevRoot, err = crypto.MakeMdID(&rmds.MD)
@@ -73,7 +73,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	// (3) Trigger a conflict.
 
 	rmds := makeRMDSForTest(t, id, h, 10, uid, prevRoot)
-	_, err = s.put(uid, key.KID(), rmds)
+	_, err = s.put(uid, key, rmds)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 
 	require.Equal(t, 10, getMDJournalLength(t, s, NullBranchID))
@@ -87,7 +87,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
 		rmds.MD.WFlags |= MetadataFlagUnmerged
 		rmds.MD.BID = bid
-		recordBranchID, err := s.put(uid, key.KID(), rmds)
+		recordBranchID, err := s.put(uid, key, rmds)
 		require.NoError(t, err)
 		require.Equal(t, i == MetadataRevision(6), recordBranchID)
 		prevRoot, err = crypto.MakeMdID(&rmds.MD)

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -23,7 +23,7 @@ func getMDJournalLength(t *testing.T, s *mdServerTlfStorage, bid BranchID) int {
 // single mdServerTlfStorage.
 func TestMDServerTlfStorageBasic(t *testing.T) {
 	codec := NewCodecMsgpack()
-	crypto := makeTestCryptoCommon(t)
+	crypto := MakeCryptoCommon(codec)
 	signingKey := MakeFakeSigningKeyOrBust("test key")
 	verifyingKey := MakeFakeVerifyingKeyOrBust("test key")
 	signer := cryptoSignerLocal{signingKey}

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -57,15 +57,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot := MdID{}
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
-		rmds, err := NewRootMetadataSignedForTest(id, h)
-		require.NoError(t, err)
-
-		rmds.MD.SerializedPrivateMetadata = []byte{0x1}
-		rmds.MD.Revision = MetadataRevision(i)
-		FakeInitialRekey(&rmds.MD, h)
-		if i > 1 {
-			rmds.MD.PrevRoot = prevRoot
-		}
+		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
 		recordBranchID, err := s.put(uid, key.KID(), rmds)
 		require.NoError(t, err)
 		require.False(t, recordBranchID)
@@ -80,13 +72,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 
 	// (3) Trigger a conflict.
 
-	rmds, err := NewRootMetadataSignedForTest(id, h)
-	require.NoError(t, err)
-	rmds.MD.Revision = MetadataRevision(10)
-	rmds.MD.SerializedPrivateMetadata = make([]byte, 1)
-	rmds.MD.SerializedPrivateMetadata[0] = 0x1
-	FakeInitialRekey(&rmds.MD, h)
-	rmds.MD.PrevRoot = prevRoot
+	rmds := makeRMDSForTest(t, id, h, 10, uid, prevRoot)
 	_, err = s.put(uid, key.KID(), rmds)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 
@@ -98,12 +84,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot = middleRoot
 	bid := FakeBranchID(1)
 	for i := MetadataRevision(6); i < 41; i++ {
-		rmds, err := NewRootMetadataSignedForTest(id, h)
-		require.NoError(t, err)
-		rmds.MD.Revision = MetadataRevision(i)
-		rmds.MD.SerializedPrivateMetadata = []byte{0x1}
-		rmds.MD.PrevRoot = prevRoot
-		FakeInitialRekey(&rmds.MD, h)
+		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
 		rmds.MD.WFlags |= MetadataFlagUnmerged
 		rmds.MD.BID = bid
 		recordBranchID, err := s.put(uid, key.KID(), rmds)

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -42,6 +42,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	h, err := MakeBareTlfHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
+	key := MakeFakeVerifyingKeyOrBust("test key")
+
 	// (1) Validate merged branch is empty.
 
 	head, err := s.getForTLF(uid, NullBranchID)
@@ -64,7 +66,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		if i > 1 {
 			rmds.MD.PrevRoot = prevRoot
 		}
-		recordBranchID, err := s.put(uid, rmds)
+		recordBranchID, err := s.put(uid, key.KID(), rmds)
 		require.NoError(t, err)
 		require.False(t, recordBranchID)
 		prevRoot, err = crypto.MakeMdID(&rmds.MD)
@@ -85,7 +87,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	rmds.MD.SerializedPrivateMetadata[0] = 0x1
 	FakeInitialRekey(&rmds.MD, h)
 	rmds.MD.PrevRoot = prevRoot
-	_, err = s.put(uid, rmds)
+	_, err = s.put(uid, key.KID(), rmds)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 
 	require.Equal(t, 10, getMDJournalLength(t, s, NullBranchID))
@@ -104,7 +106,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		FakeInitialRekey(&rmds.MD, h)
 		rmds.MD.WFlags |= MetadataFlagUnmerged
 		rmds.MD.BID = bid
-		recordBranchID, err := s.put(uid, rmds)
+		recordBranchID, err := s.put(uid, key.KID(), rmds)
 		require.NoError(t, err)
 		require.Equal(t, i == MetadataRevision(6), recordBranchID)
 		prevRoot, err = crypto.MakeMdID(&rmds.MD)

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -390,7 +390,8 @@ func (rmds *RootMetadataSigned) IsInitialized() bool {
 
 // VerifyRootMetadata verifies rmd's MD against rmd's SigInfo,
 // assuming the verifying key there is valid.
-func (rmds *RootMetadataSigned) VerifyRootMetadata(codec Codec, crypto Crypto) error {
+func (rmds *RootMetadataSigned) VerifyRootMetadata(
+	codec Codec, crypto cryptoPure) error {
 	md := &rmds.MD
 	if rmds.MD.IsFinal() {
 		// Since we're just working with the immediate fields
@@ -468,4 +469,27 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(config Config) (
 	// the head revision - 1.
 	newRmds.MD.Revision = rmds.MD.Revision + 1
 	return &newRmds, nil
+}
+
+// IsValidAndSigned verifies the RootMetadataSigned given the current
+// user and device, checks the writer signature, and returns an error
+// if a problem was found.
+func (rmds *RootMetadataSigned) IsValidAndSigned(
+	codec Codec, crypto cryptoPure,
+	currentUID keybase1.UID, currentKID keybase1.KID) error {
+	err := rmds.MD.IsValidAndSigned(codec, crypto, currentUID, currentKID)
+	if err != nil {
+		return err
+	}
+
+	if rmds.SigInfo.VerifyingKey.KID() != currentKID {
+		return errors.New("Last modifier key and current device mismatch")
+	}
+
+	err = rmds.VerifyRootMetadata(codec, crypto)
+	if err != nil {
+		return fmt.Errorf("Could not verify root metadata: %v", err)
+	}
+
+	return nil
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -476,14 +476,15 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(config Config) (
 // if a problem was found.
 func (rmds *RootMetadataSigned) IsValidAndSigned(
 	codec Codec, crypto cryptoPure,
-	currentUID keybase1.UID, currentKID keybase1.KID) error {
-	err := rmds.MD.IsValidAndSigned(codec, crypto, currentUID, currentKID)
+	currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error {
+	err := rmds.MD.IsValidAndSigned(
+		codec, crypto, currentUID, currentVerifyingKey)
 	if err != nil {
 		return err
 	}
 
-	if rmds.SigInfo.VerifyingKey.KID() != currentKID {
-		return errors.New("Last modifier key and current device mismatch")
+	if rmds.SigInfo.VerifyingKey != currentVerifyingKey {
+		return errors.New("Last modifier verifying key and current verifying key mismatch")
 	}
 
 	err = rmds.VerifyRootMetadata(codec, crypto)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -359,7 +359,7 @@ func SwitchDeviceForLocalUserOrBust(t logger.TestLogBackend, config Config, inde
 		t.Fatal(err.Error())
 	}
 
-	if _, ok := config.Crypto().(*CryptoLocal); !ok {
+	if _, ok := config.Crypto().(CryptoLocal); !ok {
 		t.Fatal("Bad crypto")
 	}
 


### PR DESCRIPTION
Add IsValidAndSigned() function to BareRootMetadata
and RootMetadataSigned, which is a port of the existing
server-side validation code. But also add some other
simple checks to it.

Clean up Crypto interfaces and implementations a bit.
In particular, stop logging verify.