### PR TITLE
folder_branch_ops: force a sync after a PutUnmerged rev conflict

### DIFF
--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -325,7 +325,7 @@ func (md *BareRootMetadata) CheckValidSuccessor(
 		}
 	}
 
-	// (2) Check revision.
+	// (3) Check revision.
 	if nextMd.Revision != md.Revision+1 {
 		return MDRevisionMismatch{
 			rev:  nextMd.Revision,
@@ -333,7 +333,7 @@ func (md *BareRootMetadata) CheckValidSuccessor(
 		}
 	}
 
-	// (3) Check PrevRoot pointer.
+	// (4) Check PrevRoot pointer.
 	expectedPrevRoot := currID
 	if nextMd.IsFinal() {
 		expectedPrevRoot = md.PrevRoot
@@ -345,6 +345,15 @@ func (md *BareRootMetadata) CheckValidSuccessor(
 		}
 	}
 
+	// (5) Check branch ID.
+	if md.MergedStatus() == nextMd.MergedStatus() && md.BID != nextMd.BID {
+		return fmt.Errorf("Unexpected branch ID on successor: %s vs. %s",
+			md.BID, nextMd.BID)
+	} else if md.MergedStatus() == Unmerged && nextMd.MergedStatus() == Merged {
+		return errors.New("Merged MD can't follow unmerged MD.")
+	}
+
+	// (6) Check disk usage.
 	expectedUsage := md.DiskUsage
 	if !nextMd.IsWriterMetadataCopiedSet() {
 		expectedUsage += nextMd.RefBytes - nextMd.UnrefBytes

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1163,3 +1163,15 @@ type RekeyConflictError struct {
 func (e RekeyConflictError) Error() string {
 	return fmt.Sprintf("Conflict during a rekey, not retrying: %v", e.Err)
 }
+
+// UnmergedSelfConflictError indicates that we hit a conflict on the
+// unmerged branch, so a previous MD PutUnmerged we thought had
+// failed, had actually succeeded.
+type UnmergedSelfConflictError struct {
+	Err error
+}
+
+// Error implements the error interface for UnmergedSelfConflictError.
+func (e UnmergedSelfConflictError) Error() string {
+	return fmt.Sprintf("Unmerged self conflict: %v", e.Err)
+}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1153,3 +1153,13 @@ func (e NoSigChainError) Error() string {
 	return fmt.Sprintf("%s has not yet installed Keybase and set up the "+
 		"Keybase filesystem. Please ask them to.", e.User)
 }
+
+// RekeyConflictError indicates a conflict happened while trying to rekey.
+type RekeyConflictError struct {
+	Err error
+}
+
+// Error implements the error interface for RekeyConflictError.
+func (e RekeyConflictError) Error() string {
+	return fmt.Sprintf("Conflict during a rekey, not retrying: %v", e.Err)
+}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -537,11 +537,6 @@ func (fbo *folderBranchOps) setHeadLocked(
 		fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision, false)
 	}
 
-	if md.MergedStatus() == Unmerged && md.BID != fbo.bid {
-		return fmt.Errorf("Unexpected branch ID on unmerged branch: %s vs. %s",
-			md.BID, fbo.bid)
-	}
-
 	fbo.head = md
 	fbo.status.setRootMetadata(md)
 	if isFirstHead {
@@ -719,6 +714,7 @@ func (fbo *folderBranchOps) setHeadConflictResolvedLocked(ctx context.Context,
 	if md.MergedStatus() != Merged {
 		return errors.New("Unexpected unmerged update in setHeadConflictResolvedLocked")
 	}
+
 	return fbo.setHeadLocked(ctx, lState, md)
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -537,6 +537,11 @@ func (fbo *folderBranchOps) setHeadLocked(
 		fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision, false)
 	}
 
+	if md.MergedStatus() == Unmerged && md.BID != fbo.bid {
+		return fmt.Errorf("Unexpected branch ID on unmerged branch: %s vs. %s",
+			md.BID, fbo.bid)
+	}
+
 	fbo.head = md
 	fbo.status.setRootMetadata(md)
 	if isFirstHead {
@@ -1725,7 +1730,8 @@ func isRecoverableBlockErrorForRemoval(err error) bool {
 
 func isRetriableError(err error, retries int) bool {
 	_, isExclOnUnmergedError := err.(ExclOnUnmergedError)
-	recoverable := isExclOnUnmergedError || isRecoverableBlockError(err)
+	recoverable := isExclOnUnmergedError || isRevisionConflict(err) ||
+		isRecoverableBlockError(err)
 	return recoverable && retries < maxRetriesOnRecoverableErrors
 }
 
@@ -1850,7 +1856,7 @@ func (fbo *folderBranchOps) finalizeBlocks(bps *blockPutState) error {
 }
 
 // Returns true if the passed error indicates a revision conflict.
-func (fbo *folderBranchOps) isRevisionConflict(err error) bool {
+func isRevisionConflict(err error) bool {
 	if err == nil {
 		return false
 	}
@@ -1878,7 +1884,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 		// only do a normal Put if we're not already staged.
 		err = mdops.Put(ctx, md)
 
-		if doUnmergedPut = fbo.isRevisionConflict(err); doUnmergedPut {
+		if doUnmergedPut = isRevisionConflict(err); doUnmergedPut {
 			fbo.log.CDebugf(ctx, "Conflict: %v", err)
 			mergedRev = md.Revision
 
@@ -1970,7 +1976,7 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 
 	// finally, write out the new metadata
 	err = fbo.config.MDOps().Put(ctx, md)
-	isConflict := fbo.isRevisionConflict(err)
+	isConflict := isRevisionConflict(err)
 	if err != nil && !isConflict {
 		return err
 	}
@@ -1982,7 +1988,7 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 		// be safe as it's idempotent. we don't want any rekeys present
 		// in unmerged history or that will just make a mess.
 		fbo.config.RekeyQueue().Enqueue(md.ID)
-		return err
+		return RekeyConflictError{err}
 	}
 
 	mdID, err := fbo.config.Crypto().MakeMdID(&md.BareRootMetadata)
@@ -2242,6 +2248,31 @@ func (fbo *folderBranchOps) doMDWriteWithRetry(ctx context.Context,
 				if err = fbo.cr.Wait(ctx); err != nil {
 					return err
 				}
+			} else if isRevisionConflict(err) {
+				// We can only get here if we are already on an
+				// unmerged branch and an errored PutUnmerged did make
+				// it to the mdserver.  Let's force sync, with a fresh
+				// context so the observer doesn't ignore the updates
+				// (but tie the cancels together).
+				newCtx := fbo.ctxWithFBOID(context.Background())
+				newCtx, cancel := context.WithCancel(newCtx)
+				defer cancel()
+				var wg sync.WaitGroup
+				wg.Add(1)
+				go func() {
+					select {
+					case <-ctx.Done():
+						cancel()
+					case <-newCtx.Done():
+					}
+				}()
+				fbo.log.CDebugf(ctx, "Got a revision conflict while unmerged "+
+					"(%v); forcing a sync", err)
+				err = fbo.getAndApplyNewestUnmergedHead(newCtx, lState)
+				if err != nil {
+					return err
+				}
+				cancel()
 			}
 			continue
 		} else if err != nil {
@@ -3591,6 +3622,45 @@ func (fbo *folderBranchOps) getAndApplyMDUpdates(ctx context.Context,
 	return nil
 }
 
+func (fbo *folderBranchOps) getAndApplyNewestUnmergedHead(ctx context.Context,
+	lState *lockState) error {
+	fbo.log.CDebugf(ctx, "Fetching the newest unmerged head")
+	bid := func() BranchID {
+		fbo.mdWriterLock.Lock(lState)
+		defer fbo.mdWriterLock.Unlock(lState)
+		return fbo.bid
+	}()
+
+	// We can only ever be at most one revision behind, so fetch the
+	// latest unmerged revision and apply it as a successor.
+	md, err := fbo.config.MDOps().GetUnmergedForTLF(ctx, fbo.id(), bid)
+	if err != nil {
+		return err
+	}
+
+	if md == (ImmutableRootMetadata{}) {
+		// There is no unmerged revision, oops!
+		return errors.New("Couldn't find an unmerged head")
+	}
+
+	fbo.mdWriterLock.Lock(lState)
+	defer fbo.mdWriterLock.Unlock(lState)
+	if fbo.isMasterBranchLocked(lState) {
+		return errors.New("Can't apply newest unmerged head while on master")
+	}
+
+	fbo.headLock.Lock(lState)
+	defer fbo.headLock.Unlock(lState)
+	if err := fbo.setHeadSuccessorLocked(ctx, lState, md); err != nil {
+		return err
+	}
+	fbo.notifyBatchLocked(ctx, lState, md)
+	if err := fbo.config.MDCache().Put(md); err != nil {
+		return err
+	}
+	return nil
+}
+
 // getUnmergedMDUpdates returns a slice of the unmerged MDs for this
 // TLF's current unmerged branch and unmerged branch, between the
 // merge point for the branch and the current head.  The returned MDs
@@ -4255,7 +4325,7 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	// Put the MD.  If there's a conflict, abort the whole process and
 	// let CR restart itself.
 	err = fbo.config.MDOps().Put(ctx, md)
-	doUnmergedPut := fbo.isRevisionConflict(err)
+	doUnmergedPut := isRevisionConflict(err)
 	if doUnmergedPut {
 		fbo.log.CDebugf(ctx, "Got a conflict after resolution; aborting CR")
 		return err

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1889,7 +1889,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 
 // Test that an umerged put can be canceled, and the next put will
 // force itself into sync with the server on a retry and succeed.
-func TestCRCanceledAfterCanceledUnmergedPut(t *testing.T) {
+func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
@@ -1970,12 +1970,7 @@ func TestCRCanceledAfterCanceledUnmergedPut(t *testing.T) {
 			t.Fatalf("Could create file without error: %v", err)
 		}
 	}()
-	timer := time.After(2 * time.Second)
-	select {
-	case <-onPutStalledCh:
-	case <-timer:
-		t.Fatalf("TIMEOUT")
-	}
+	<-onPutStalledCh
 	cancel()
 	close(putUnstallCh)
 	wg.Wait()

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1416,7 +1416,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	// Make sure user 1's rekey failed.
 	putUnstallCh <- struct{}{}
 	err = <-errChan
-	if _, isConflict := err.(MDServerErrorConflictRevision); !isConflict {
+	if _, isConflict := err.(RekeyConflictError); !isConflict {
 		t.Fatalf("Expected failure due to conflict")
 	}
 

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -37,6 +37,7 @@ const (
 	StallableMDPut                   StallableMDOp = "Put"
 	StallableMDAfterPut              StallableMDOp = "AfterPut"
 	StallableMDPutUnmerged           StallableMDOp = "PutUnmerged"
+	StallableMDAfterPutUnmerged      StallableMDOp = "AfterPutUnmerged"
 )
 
 const stallKeyStallEverything = ""
@@ -495,6 +496,8 @@ func (m *stallingMDOps) PutUnmerged(ctx context.Context, md *RootMetadata,
 	// emulates the PutUnmerged being canceled while the RPC is
 	// outstanding.
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return m.delegate.PutUnmerged(ctx, md, bid)
+		err := m.delegate.PutUnmerged(ctx, md, bid)
+		m.maybeStall(ctx, StallableMDAfterPutUnmerged)
+		return err
 	})
 }


### PR DESCRIPTION
If a PutUnmerged is canceled or errors out in some other ambiguous
way, then the device can be behind the server's view of the branch by
a single commit.  Force a sync up to the real head and retry the
PutUnmerged in that case.

Issue: KBFS-1315