### PR TITLE
cr: count blocks belonging to file created+renamed while unmerged

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2155,9 +2155,11 @@ func (cr *ConflictResolver) makeRevertedOps(ctx context.Context,
 						chain.original, cop.NewName)
 				}
 
-				if otherChains.isDeleted(renameOriginal) {
-					// If we are re-instating a deleted node, just use
-					// the create op.
+				if otherChains.isDeleted(renameOriginal) ||
+					chains.isCreated(renameOriginal) {
+					// If we are re-instating a deleted node, or
+					// dealing with a node that was created entirely
+					// in this branch, just use the create op.
 					op = chains.copyOpAndRevertUnrefsToOriginals(cop)
 					if cop.Type != Dir {
 						err := cr.addChildBlocksIfIndirectFile(ctx, lState,

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -261,7 +261,8 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 		// created by any sync ops (and not unreferenced by future
 		// ones).
 		for _, op := range targetChain.ops {
-			if _, ok := op.(*syncOp); !ok {
+			syncOp, ok := op.(*syncOp)
+			if !ok {
 				continue
 			}
 			for _, ref := range op.Refs() {
@@ -271,6 +272,12 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 			}
 			for _, unref := range op.Unrefs() {
 				unrefs = append(unrefs, unref)
+			}
+			// Account for the file ptr too, if it's the most recent.
+			filePtr := syncOp.File.Ref
+			_, isMostRecent := unmergedChains.byMostRecent[filePtr]
+			if isMostRecent && !unmergedChains.isDeleted(filePtr) {
+				refs = append(refs, filePtr)
 			}
 		}
 	}

--- a/test/cr_simple_test.go
+++ b/test/cr_simple_test.go
@@ -466,6 +466,37 @@ func TestCrUnmergedRenameInDir(t *testing.T) {
 	)
 }
 
+// bob creates and renames a non-conflicting file while unstaged
+func TestCrUnmergedCreateAndRenameInDir(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			mkfile("a/b", "hello"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			write("a/c", "world"),
+		),
+		as(bob, noSync(),
+			write("a/b2", "hellohello"),
+			rename("a/b2", "a/d"),
+			reenableUpdates(),
+			lsdir("a/", m{"b": "FILE", "c": "FILE", "d": "FILE"}),
+			read("a/b", "hello"),
+			read("a/c", "world"),
+			read("a/d", "hellohello"),
+		),
+		as(alice,
+			lsdir("a/", m{"b": "FILE", "c": "FILE", "d": "FILE"}),
+			read("a/b", "hello"),
+			read("a/c", "world"),
+			read("a/d", "hellohello"),
+		),
+	)
+}
+
 // bob renames a non-conflicting symlink(while unstaged),
 func TestCrUnmergedRenameSymlinkInDir(t *testing.T) {
 	test(t,


### PR DESCRIPTION
Without this, we can delete the top-level block of a file that was
created, and then renamed, while the client is unmerged.

Issue: KBFS-1319