### PR TITLE
folder_branch_ops: don't block folder status on CR

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -304,7 +304,13 @@ func (cr *ConflictResolver) makeChains(ctx context.Context,
 		return nil, nil, err
 	}
 
-	cr.fbo.status.setCRChains(unmergedChains, mergedChains)
+	// Make the chain summaries.  Identify using the unmerged chains,
+	// since those are most likely to be able to identify a node in
+	// the cache.
+	unmergedSummary := unmergedChains.summary(unmergedChains, cr.fbo.nodeCache)
+	mergedSummary := mergedChains.summary(unmergedChains, cr.fbo.nodeCache)
+
+	cr.fbo.status.setCRSummary(unmergedSummary, mergedSummary)
 	return unmergedChains, mergedChains, nil
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -487,7 +487,7 @@ func (fbo *folderBranchOps) setBranchIDLocked(lState *lockState, bid BranchID) {
 
 	fbo.bid = bid
 	if bid == NullBranchID {
-		fbo.status.setCRChains(nil, nil)
+		fbo.status.setCRSummary(nil, nil)
 	}
 }
 
@@ -3150,9 +3150,6 @@ func (fbo *folderBranchOps) FolderStatus(
 		return FolderBranchStatus{}, nil,
 			WrongOpsError{fbo.folderBranch, folderBranch}
 	}
-
-	// Wait for conflict resolution to settle down, if necessary.
-	fbo.cr.Wait(ctx)
 
 	return fbo.status.getStatus(ctx)
 }

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"reflect"
 	"sync"
 
 	"github.com/keybase/client/go/libkb"
@@ -56,8 +57,8 @@ type folderBranchStatusKeeper struct {
 
 	md         ImmutableRootMetadata
 	dirtyNodes map[NodeID]Node
-	unmerged   *crChains
-	merged     *crChains
+	unmerged   []*crChainSummary
+	merged     []*crChainSummary
 	dataMutex  sync.Mutex
 
 	updateChan  chan StatusUpdate
@@ -94,11 +95,12 @@ func (fbsk *folderBranchStatusKeeper) setRootMetadata(md ImmutableRootMetadata) 
 	fbsk.signalChangeLocked()
 }
 
-func (fbsk *folderBranchStatusKeeper) setCRChains(unmerged *crChains,
-	merged *crChains) {
+func (fbsk *folderBranchStatusKeeper) setCRSummary(unmerged []*crChainSummary,
+	merged []*crChainSummary) {
 	fbsk.dataMutex.Lock()
 	defer fbsk.dataMutex.Unlock()
-	if unmerged == fbsk.unmerged && merged == fbsk.merged {
+	if reflect.DeepEqual(unmerged, fbsk.unmerged) &&
+		reflect.DeepEqual(merged, fbsk.merged) {
 		return
 	}
 	fbsk.unmerged = unmerged
@@ -174,15 +176,7 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context) (
 
 	fbs.DirtyPaths = fbsk.convertNodesToPathsLocked(fbsk.dirtyNodes)
 
-	// Make the chain summaries.  Identify using the unmerged chains,
-	// since those are most likely to be able to identify a node in
-	// the cache.
-	if fbsk.unmerged != nil {
-		fbs.Unmerged = fbsk.unmerged.summary(fbsk.unmerged, fbsk.nodeCache)
-		if fbsk.merged != nil {
-			fbs.Merged = fbsk.merged.summary(fbsk.unmerged, fbsk.nodeCache)
-		}
-	}
-
+	fbs.Unmerged = fbsk.unmerged
+	fbs.Merged = fbsk.merged
 	return fbs, fbsk.updateChan, nil
 }


### PR DESCRIPTION
If CR is stuck, we don't want to block the only way for users to
figure out if they're running CR.

However, we don't want to open ourselves up to races on the crChains
object, which could change after `setCRChains` is called.  So instead
just save the summary in the status object, instead of the full chain.
This doesn't cost us anything extra, since the summaries are already
being logged as part of every CR run.

Issue: KBFS-1315