### PR TITLE
[KBFS-1326] Make a KeyMetadata interface and use it

### DIFF
--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -140,14 +140,13 @@ type BareRootMetadata struct {
 	codec.UnknownFieldSetHandler
 }
 
-// TlfID returns the ID of the TLF for which this object holds key
-// info.
+// TlfID returns the ID of the TLF this BareRootMetadata is for.
 func (md *BareRootMetadata) TlfID() TlfID {
 	return md.ID
 }
 
-// LatestKeyGeneration returns the most recent key generation with key
-// data in this object, or PublicKeyGen if this TLF is public.
+// LatestKeyGeneration returns the most recent key generation in this
+// BareRootMetadata, or PublicKeyGen if this TLF is public.
 func (md *BareRootMetadata) LatestKeyGeneration() KeyGen {
 	if md.ID.IsPublic() {
 		return PublicKeyGen

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -531,24 +531,6 @@ func (md *BareRootMetadata) GetTLFCryptKeyInfo(keyGen KeyGen, user keybase1.UID,
 	return TLFCryptKeyInfo{}, false, nil
 }
 
-// GetTLFCryptPublicKeys returns the public crypt keys for the given user
-// at the given key generation.
-func (md *BareRootMetadata) GetTLFCryptPublicKeys(
-	keyGen KeyGen, user keybase1.UID) (
-	[]keybase1.KID, bool) {
-	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
-	if err != nil {
-		return nil, false
-	}
-
-	if u, ok1 := wkb.WKeys[user]; ok1 {
-		return u.GetKIDs(), true
-	} else if u, ok1 = rkb.RKeys[user]; ok1 {
-		return u.GetKIDs(), true
-	}
-	return nil, false
-}
-
 // GetTLFEphemeralPublicKey returns the ephemeral public key used for
 // the TLFCryptKeyInfo for the given user and device.
 func (md *BareRootMetadata) GetTLFEphemeralPublicKey(

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -529,11 +529,11 @@ func (md *RootMetadata) HasKeyForUser(
 	return (len(wkb.WKeys[user]) > 0) || (len(rkb.RKeys[user]) > 0)
 }
 
-// GetTLFCryptKeyInfo returns all the necessary info to construct the
-// TLF crypt key for the given key generation, user, and device
+// GetTLFCryptKeyParams returns all the necessary info to construct
+// the TLF crypt key for the given key generation, user, and device
 // (identified by its crypt public key), or false if not found. This
 // returns an error if the TLF is public.
-func (md *BareRootMetadata) GetTLFCryptKeyInfo(
+func (md *BareRootMetadata) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 	TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
 	TLFCryptKeyServerHalfID, bool, error) {

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -140,12 +140,14 @@ type BareRootMetadata struct {
 	codec.UnknownFieldSetHandler
 }
 
-// TlfID implements KeyMetadata.
+// TlfID returns the ID of the TLF for which this object holds key
+// info.
 func (md *BareRootMetadata) TlfID() TlfID {
 	return md.ID
 }
 
-// LatestKeyGeneration implements KeyMetadata.
+// LatestKeyGeneration returns the most recent key generation with key
+// data in this object, or PublicKeyGen if this TLF is public.
 func (md *BareRootMetadata) LatestKeyGeneration() KeyGen {
 	if md.ID.IsPublic() {
 		return PublicKeyGen
@@ -530,7 +532,8 @@ func (md *RootMetadata) HasKeyForUser(
 
 // GetTLFCryptKeyInfo returns all the necessary info to construct the
 // TLF crypt key for the given key generation, user, and device
-// (identified by its crypt public key), or false if not found.
+// (identified by its crypt public key), or false if not found. This
+// returns an error if the TLF is public.
 func (md *BareRootMetadata) GetTLFCryptKeyInfo(
 	keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 	TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -560,31 +560,27 @@ func (md *BareRootMetadata) GetTLFCryptKeyParams(
 			TLFCryptKeyServerHalfID{}, false, nil
 	}
 
-	if info.EPubKeyIndex < 0 {
-		index := -1 - info.EPubKeyIndex
-		keyCount := len(rkb.TLFReaderEphemeralPublicKeys)
-		if index >= keyCount {
-			return TLFEphemeralPublicKey{},
-				EncryptedTLFCryptKeyClientHalf{},
-				TLFCryptKeyServerHalfID{}, false,
-				fmt.Errorf("Invalid reader key index %d >= %d",
-					index, keyCount)
-		}
-		return rkb.TLFReaderEphemeralPublicKeys[index],
-			info.ClientHalf, info.ServerHalfID, true, nil
+	var index int
+	var publicKeys TLFEphemeralPublicKeys
+	var keyType string
+	if info.EPubKeyIndex >= 0 {
+		index = info.EPubKeyIndex
+		publicKeys = wkb.TLFEphemeralPublicKeys
+		keyType = "writer"
+	} else {
+		index = -1 - info.EPubKeyIndex
+		publicKeys = rkb.TLFReaderEphemeralPublicKeys
+		keyType = "reader"
 	}
-
-	index := info.EPubKeyIndex
-	keyCount := len(wkb.TLFEphemeralPublicKeys)
+	keyCount := len(publicKeys)
 	if index >= keyCount {
 		return TLFEphemeralPublicKey{},
 			EncryptedTLFCryptKeyClientHalf{},
 			TLFCryptKeyServerHalfID{}, false,
-			fmt.Errorf("Invalid writer key index %d >= %d",
-				index, keyCount)
+			fmt.Errorf("Invalid %s key index %d >= %d",
+				keyType, index, keyCount)
 	}
-	return wkb.TLFEphemeralPublicKeys[index], info.ClientHalf,
-		info.ServerHalfID, true, nil
+	return publicKeys[index], info.ClientHalf, info.ServerHalfID, true, nil
 }
 
 // DeepCopyForServerTest returns a complete copy of this BareRootMetadata

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -497,7 +497,7 @@ func (md *BareRootMetadata) TlfHandleExtensions() (
 func (md *BareRootMetadata) getTLFKeyBundles(keyGen KeyGen) (
 	*TLFWriterKeyBundle, *TLFReaderKeyBundle, error) {
 	if md.ID.IsPublic() {
-		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundle"}
+		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles"}
 	}
 
 	if keyGen < FirstValidKeyGen {

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -158,22 +158,22 @@ func (b *BlockOpsStandard) Put(ctx context.Context, kmd KeyMetadata,
 }
 
 // Delete implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Delete(ctx context.Context, kmd KeyMetadata,
+func (b *BlockOpsStandard) Delete(ctx context.Context, tlfID TlfID,
 	ptrs []BlockPointer) (liveCounts map[BlockID]int, err error) {
 	contexts := make(map[BlockID][]BlockContext)
 	for _, ptr := range ptrs {
 		contexts[ptr.ID] = append(contexts[ptr.ID], ptr.BlockContext)
 	}
-	return b.config.BlockServer().RemoveBlockReference(ctx, kmd.TlfID(), contexts)
+	return b.config.BlockServer().RemoveBlockReference(ctx, tlfID, contexts)
 }
 
 // Archive implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Archive(ctx context.Context, kmd KeyMetadata,
+func (b *BlockOpsStandard) Archive(ctx context.Context, tlfID TlfID,
 	ptrs []BlockPointer) error {
 	contexts := make(map[BlockID][]BlockContext)
 	for _, ptr := range ptrs {
 		contexts[ptr.ID] = append(contexts[ptr.ID], ptr.BlockContext)
 	}
 
-	return b.config.BlockServer().ArchiveBlockReferences(ctx, kmd.TlfID(), contexts)
+	return b.config.BlockServer().ArchiveBlockReferences(ctx, tlfID, contexts)
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -135,24 +135,18 @@ func (b *BlockOpsStandard) Ready(ctx context.Context, kmd KeyMetadata,
 }
 
 // Put implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Put(ctx context.Context, kmd KeyMetadata,
+func (b *BlockOpsStandard) Put(ctx context.Context, tlfID TlfID,
 	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
 	bserv := b.config.BlockServer()
 	var err error
 	if blockPtr.RefNonce == zeroBlockRefNonce {
-		err = bserv.Put(ctx, blockPtr.ID, kmd.TlfID(), blockPtr.BlockContext,
+		err = bserv.Put(ctx, blockPtr.ID, tlfID, blockPtr.BlockContext,
 			readyBlockData.buf, readyBlockData.serverHalf)
 	} else {
 		// non-zero block refnonce means this is a new reference to an
 		// existing block.
-		err = bserv.AddBlockReference(ctx, blockPtr.ID, kmd.TlfID(),
+		err = bserv.AddBlockReference(ctx, blockPtr.ID, tlfID,
 			blockPtr.BlockContext)
-	}
-	if qe, ok := err.(BServerErrorOverQuota); ok && !qe.Throttled {
-		name := kmd.GetTlfHandle().GetCanonicalName()
-		b.config.Reporter().ReportErr(ctx, name, kmd.TlfID().IsPublic(),
-			WriteMode, OverQuotaWarning{qe.Usage, qe.Limit})
-		return nil
 	}
 	return err
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -19,10 +19,10 @@ type BlockOpsStandard struct {
 var _ BlockOps = (*BlockOpsStandard)(nil)
 
 // Get implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Get(ctx context.Context, md ReadOnlyRootMetadata,
+func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 	blockPtr BlockPointer, block Block) error {
 	bserv := b.config.BlockServer()
-	buf, blockServerHalf, err := bserv.Get(ctx, blockPtr.ID, md.ID, blockPtr.BlockContext)
+	buf, blockServerHalf, err := bserv.Get(ctx, blockPtr.ID, kmd.TlfID(), blockPtr.BlockContext)
 	if err != nil {
 		// Temporary code to track down bad block
 		// requests. Remove when not needed anymore.
@@ -40,7 +40,7 @@ func (b *BlockOpsStandard) Get(ctx context.Context, md ReadOnlyRootMetadata,
 	}
 
 	tlfCryptKey, err := b.config.KeyManager().
-		GetTLFCryptKeyForBlockDecryption(ctx, md, blockPtr)
+		GetTLFCryptKeyForBlockDecryption(ctx, kmd, blockPtr)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (b *BlockOpsStandard) Get(ctx context.Context, md ReadOnlyRootMetadata,
 }
 
 // Ready implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Ready(ctx context.Context, md ReadOnlyRootMetadata,
+func (b *BlockOpsStandard) Ready(ctx context.Context, kmd KeyMetadata,
 	block Block) (id BlockID, plainSize int, readyBlockData ReadyBlockData,
 	err error) {
 	defer func() {
@@ -83,7 +83,7 @@ func (b *BlockOpsStandard) Ready(ctx context.Context, md ReadOnlyRootMetadata,
 	crypto := b.config.Crypto()
 
 	tlfCryptKey, err := b.config.KeyManager().
-		GetTLFCryptKeyForEncryption(ctx, md)
+		GetTLFCryptKeyForEncryption(ctx, kmd)
 	if err != nil {
 		return
 	}
@@ -135,22 +135,22 @@ func (b *BlockOpsStandard) Ready(ctx context.Context, md ReadOnlyRootMetadata,
 }
 
 // Put implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Put(ctx context.Context, md ReadOnlyRootMetadata,
+func (b *BlockOpsStandard) Put(ctx context.Context, kmd KeyMetadata,
 	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
 	bserv := b.config.BlockServer()
 	var err error
 	if blockPtr.RefNonce == zeroBlockRefNonce {
-		err = bserv.Put(ctx, blockPtr.ID, md.ID, blockPtr.BlockContext,
+		err = bserv.Put(ctx, blockPtr.ID, kmd.TlfID(), blockPtr.BlockContext,
 			readyBlockData.buf, readyBlockData.serverHalf)
 	} else {
 		// non-zero block refnonce means this is a new reference to an
 		// existing block.
-		err = bserv.AddBlockReference(ctx, blockPtr.ID, md.ID,
+		err = bserv.AddBlockReference(ctx, blockPtr.ID, kmd.TlfID(),
 			blockPtr.BlockContext)
 	}
 	if qe, ok := err.(BServerErrorOverQuota); ok && !qe.Throttled {
-		name := md.GetTlfHandle().GetCanonicalName()
-		b.config.Reporter().ReportErr(ctx, name, md.ID.IsPublic(),
+		name := kmd.GetTlfHandle().GetCanonicalName()
+		b.config.Reporter().ReportErr(ctx, name, kmd.TlfID().IsPublic(),
 			WriteMode, OverQuotaWarning{qe.Usage, qe.Limit})
 		return nil
 	}
@@ -158,22 +158,22 @@ func (b *BlockOpsStandard) Put(ctx context.Context, md ReadOnlyRootMetadata,
 }
 
 // Delete implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Delete(ctx context.Context, md ReadOnlyRootMetadata,
+func (b *BlockOpsStandard) Delete(ctx context.Context, kmd KeyMetadata,
 	ptrs []BlockPointer) (liveCounts map[BlockID]int, err error) {
 	contexts := make(map[BlockID][]BlockContext)
 	for _, ptr := range ptrs {
 		contexts[ptr.ID] = append(contexts[ptr.ID], ptr.BlockContext)
 	}
-	return b.config.BlockServer().RemoveBlockReference(ctx, md.ID, contexts)
+	return b.config.BlockServer().RemoveBlockReference(ctx, kmd.TlfID(), contexts)
 }
 
 // Archive implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) Archive(ctx context.Context, md ReadOnlyRootMetadata,
+func (b *BlockOpsStandard) Archive(ctx context.Context, kmd KeyMetadata,
 	ptrs []BlockPointer) error {
 	contexts := make(map[BlockID][]BlockContext)
 	for _, ptr := range ptrs {
 		contexts[ptr.ID] = append(contexts[ptr.ID], ptr.BlockContext)
 	}
 
-	return b.config.BlockServer().ArchiveBlockReferences(ctx, md.ID, contexts)
+	return b.config.BlockServer().ArchiveBlockReferences(ctx, kmd.TlfID(), contexts)
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -22,7 +22,8 @@ var _ BlockOps = (*BlockOpsStandard)(nil)
 func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 	blockPtr BlockPointer, block Block) error {
 	bserv := b.config.BlockServer()
-	buf, blockServerHalf, err := bserv.Get(ctx, blockPtr.ID, kmd.TlfID(), blockPtr.BlockContext)
+	buf, blockServerHalf, err := bserv.Get(
+		ctx, blockPtr.ID, kmd.TlfID(), blockPtr.BlockContext)
 	if err != nil {
 		// Temporary code to track down bad block
 		// requests. Remove when not needed anymore.

--- a/libkbfs/block_ops_constrained.go
+++ b/libkbfs/block_ops_constrained.go
@@ -20,6 +20,8 @@ type BlockOpsConstrained struct {
 	lock   sync.Mutex
 }
 
+var _ BlockOps = (*BlockOpsConstrained)(nil)
+
 // NewBlockOpsConstrained constructs a new BlockOpsConstrained.
 func NewBlockOpsConstrained(delegate BlockOps, bwKBps int) *BlockOpsConstrained {
 	return &BlockOpsConstrained{
@@ -46,10 +48,10 @@ func (b *BlockOpsConstrained) delay(ctx context.Context, size int) error {
 }
 
 // Put implements the BlockOps interface for BlockOpsConstrained.
-func (b *BlockOpsConstrained) Put(ctx context.Context, md ReadOnlyRootMetadata,
+func (b *BlockOpsConstrained) Put(ctx context.Context, kmd KeyMetadata,
 	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
 	if err := b.delay(ctx, len(readyBlockData.buf)); err != nil {
 		return err
 	}
-	return b.BlockOps.Put(ctx, md, blockPtr, readyBlockData)
+	return b.BlockOps.Put(ctx, kmd, blockPtr, readyBlockData)
 }

--- a/libkbfs/block_ops_constrained.go
+++ b/libkbfs/block_ops_constrained.go
@@ -48,10 +48,10 @@ func (b *BlockOpsConstrained) delay(ctx context.Context, size int) error {
 }
 
 // Put implements the BlockOps interface for BlockOpsConstrained.
-func (b *BlockOpsConstrained) Put(ctx context.Context, kmd KeyMetadata,
+func (b *BlockOpsConstrained) Put(ctx context.Context, tlfID TlfID,
 	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
 	if err := b.delay(ctx, len(readyBlockData.buf)); err != nil {
 		return err
 	}
-	return b.BlockOps.Put(ctx, kmd, blockPtr, readyBlockData)
+	return b.BlockOps.Put(ctx, tlfID, blockPtr, readyBlockData)
 }

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -139,7 +139,7 @@ func (kmd emptyKeyMetadata) HasKeyForUser(
 	return false
 }
 
-func (kmd emptyKeyMetadata) GetTLFCryptKeyInfo(
+func (kmd emptyKeyMetadata) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 	TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
 	TLFCryptKeyServerHalfID, bool, error) {

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -126,6 +126,9 @@ func (kmd emptyKeyMetadata) TlfID() TlfID {
 	return kmd.tlfID
 }
 
+// GetTlfHandle just returns nil. This contradicts the requirements
+// for KeyMetadata, but emptyKeyMetadata shouldn't be used in contexts
+// that actually use GetTlfHandle().
 func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
 	return nil
 }

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -407,7 +407,7 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 		Return(liveCounts, nil)
 
 	if _, err := config.BlockOps().Delete(
-		ctx, rmd.ReadOnly(), blockPtrs); err != nil {
+		ctx, rmd.ID, blockPtrs); err != nil {
 		t.Errorf("Got error on delete: %v", err)
 	}
 }
@@ -431,7 +431,7 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 		Return(liveCounts, err)
 
 	if _, err2 := config.BlockOps().Delete(
-		ctx, rmd.ReadOnly(), blockPtrs); err2 != err {
+		ctx, rmd.ID, blockPtrs); err2 != err {
 		t.Errorf("Got bad error on delete: %v", err2)
 	}
 }

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -83,8 +83,8 @@ func blockOpsShutdown(mockCtrl *gomock.Controller, config *ConfigMock) {
 	mockCtrl.Finish()
 }
 
-func expectBlockEncrypt(config *ConfigMock, rmd *RootMetadata, decData Block, plainSize int, encData []byte, err error) {
-	expectGetTLFCryptKeyForEncryption(config, rmd)
+func expectBlockEncrypt(config *ConfigMock, kmd KeyMetadata, decData Block, plainSize int, encData []byte, err error) {
+	expectGetTLFCryptKeyForEncryption(config, kmd)
 	config.mockCrypto.EXPECT().MakeRandomBlockCryptKeyServerHalf().
 		Return(BlockCryptKeyServerHalf{}, nil)
 	config.mockCrypto.EXPECT().UnmaskBlockCryptKey(
@@ -99,9 +99,9 @@ func expectBlockEncrypt(config *ConfigMock, rmd *RootMetadata, decData Block, pl
 	}
 }
 
-func expectBlockDecrypt(config *ConfigMock, rmd *RootMetadata, blockPtr BlockPointer, encData []byte, block TestBlock, err error) {
+func expectBlockDecrypt(config *ConfigMock, kmd KeyMetadata, blockPtr BlockPointer, encData []byte, block TestBlock, err error) {
 	config.mockCrypto.EXPECT().VerifyBlockID(encData, blockPtr.ID).Return(nil)
-	expectGetTLFCryptKeyForBlockDecryption(config, rmd, blockPtr)
+	expectGetTLFCryptKeyForBlockDecryption(config, kmd, blockPtr)
 	config.mockCrypto.EXPECT().UnmaskBlockCryptKey(gomock.Any(), gomock.Any()).
 		Return(BlockCryptKey{}, nil)
 	config.mockCodec.EXPECT().Decode(encData, gomock.Any()).Return(nil)

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -328,7 +328,7 @@ func TestBlockOpsPutNewBlockSuccess(t *testing.T) {
 		readyBlockData.buf, readyBlockData.serverHalf).Return(nil)
 
 	if err := config.BlockOps().Put(
-		ctx, rmd.ReadOnly(), blockPtr, readyBlockData); err != nil {
+		ctx, rmd.ID, blockPtr, readyBlockData); err != nil {
 		t.Errorf("Got error on put: %v", err)
 	}
 }
@@ -358,7 +358,7 @@ func TestBlockOpsPutIncRefSuccess(t *testing.T) {
 		Return(nil)
 
 	if err := config.BlockOps().Put(
-		ctx, rmd.ReadOnly(), blockPtr, readyBlockData); err != nil {
+		ctx, rmd.ID, blockPtr, readyBlockData); err != nil {
 		t.Errorf("Got error on put: %v", err)
 	}
 }
@@ -384,7 +384,7 @@ func TestBlockOpsPutFail(t *testing.T) {
 		readyBlockData.buf, readyBlockData.serverHalf).Return(err)
 
 	if err2 := config.BlockOps().Put(
-		ctx, rmd.ReadOnly(), blockPtr, readyBlockData); err2 != err {
+		ctx, rmd.ID, blockPtr, readyBlockData); err2 != err {
 		t.Errorf("Got bad error on put: %v", err2)
 	}
 }

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -318,17 +318,17 @@ func TestBlockOpsPutNewBlockSuccess(t *testing.T) {
 	encData := []byte{1, 2, 3, 4}
 	blockPtr := BlockPointer{ID: id}
 
-	rmd := makeRMD()
+	tlfID := FakeTlfID(1, false)
 
 	readyBlockData := ReadyBlockData{
 		buf: encData,
 	}
 
-	config.mockBserv.EXPECT().Put(ctx, id, rmd.ID, blockPtr.BlockContext,
+	config.mockBserv.EXPECT().Put(ctx, id, tlfID, blockPtr.BlockContext,
 		readyBlockData.buf, readyBlockData.serverHalf).Return(nil)
 
 	if err := config.BlockOps().Put(
-		ctx, rmd.ID, blockPtr, readyBlockData); err != nil {
+		ctx, tlfID, blockPtr, readyBlockData); err != nil {
 		t.Errorf("Got error on put: %v", err)
 	}
 }
@@ -374,17 +374,17 @@ func TestBlockOpsPutFail(t *testing.T) {
 
 	err := errors.New("Fake fail")
 
-	rmd := makeRMD()
+	tlfID := FakeTlfID(1, false)
 
 	readyBlockData := ReadyBlockData{
 		buf: encData,
 	}
 
-	config.mockBserv.EXPECT().Put(ctx, id, rmd.ID, blockPtr.BlockContext,
+	config.mockBserv.EXPECT().Put(ctx, id, tlfID, blockPtr.BlockContext,
 		readyBlockData.buf, readyBlockData.serverHalf).Return(err)
 
 	if err2 := config.BlockOps().Put(
-		ctx, rmd.ID, blockPtr, readyBlockData); err2 != err {
+		ctx, tlfID, blockPtr, readyBlockData); err2 != err {
 		t.Errorf("Got bad error on put: %v", err2)
 	}
 }
@@ -394,7 +394,6 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 	defer blockOpsShutdown(mockCtrl, config)
 
 	// expect one call to delete several blocks
-	rmd := makeRMD()
 
 	contexts := make(map[BlockID][]BlockContext)
 	b1 := BlockPointer{ID: fakeBlockID(1)}
@@ -403,11 +402,12 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 	contexts[b2.ID] = []BlockContext{b2.BlockContext}
 	blockPtrs := []BlockPointer{b1, b2}
 	var liveCounts map[BlockID]int
-	config.mockBserv.EXPECT().RemoveBlockReference(ctx, rmd.ID, contexts).
+	tlfID := FakeTlfID(1, false)
+	config.mockBserv.EXPECT().RemoveBlockReference(ctx, tlfID, contexts).
 		Return(liveCounts, nil)
 
 	if _, err := config.BlockOps().Delete(
-		ctx, rmd.ID, blockPtrs); err != nil {
+		ctx, tlfID, blockPtrs); err != nil {
 		t.Errorf("Got error on delete: %v", err)
 	}
 }
@@ -417,7 +417,6 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 	defer blockOpsShutdown(mockCtrl, config)
 
 	// fail the delete call
-	rmd := makeRMD()
 
 	contexts := make(map[BlockID][]BlockContext)
 	b1 := BlockPointer{ID: fakeBlockID(1)}
@@ -427,11 +426,12 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 	blockPtrs := []BlockPointer{b1, b2}
 	err := errors.New("Fake fail")
 	var liveCounts map[BlockID]int
-	config.mockBserv.EXPECT().RemoveBlockReference(ctx, rmd.ID, contexts).
+	tlfID := FakeTlfID(1, false)
+	config.mockBserv.EXPECT().RemoveBlockReference(ctx, tlfID, contexts).
 		Return(liveCounts, err)
 
 	if _, err2 := config.BlockOps().Delete(
-		ctx, rmd.ID, blockPtrs); err2 != err {
+		ctx, tlfID, blockPtrs); err2 != err {
 		t.Errorf("Got bad error on delete: %v", err2)
 	}
 }

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3270,7 +3270,8 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	}()
 
 	// Put all the blocks.  TODO: deal with recoverable block errors?
-	_, err = cr.fbo.doBlockPuts(ctx, md.ReadOnly(), *bps)
+	_, err = cr.fbo.doBlockPuts(
+		ctx, md.ID, md.GetTlfHandle().GetCanonicalName(), *bps)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1866,7 +1866,7 @@ func (cr *ConflictResolver) computeActions(ctx context.Context,
 }
 
 func (cr *ConflictResolver) fetchDirBlockCopy(ctx context.Context,
-	lState *lockState, md ReadOnlyRootMetadata, dir path, lbc localBcache) (
+	lState *lockState, kmd KeyMetadata, dir path, lbc localBcache) (
 	*DirBlock, error) {
 	ptr := dir.tailPointer()
 	// TODO: lock lbc if we parallelize
@@ -1874,7 +1874,7 @@ func (cr *ConflictResolver) fetchDirBlockCopy(ctx context.Context,
 		return block, nil
 	}
 	dblock, err := cr.fbo.blocks.GetDirBlockForReading(
-		ctx, lState, md, ptr, dir.Branch, dir)
+		ctx, lState, kmd, ptr, dir.Branch, dir)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -302,7 +302,7 @@ func (c BlockContext) String() string {
 // considering how old clients will handle them.
 type BlockPointer struct {
 	ID      BlockID `codec:"i"`
-	KeyGen  KeyGen  `codec:"k"` // if valid, which generation of the TLFKeyBundle to use.
+	KeyGen  KeyGen  `codec:"k"` // if valid, which generation of the TLF{Writer,Reader}KeyBundle to use.
 	DataVer DataVer `codec:"d"` // if valid, which version of the KBFS data structures is pointed to
 	BlockContext
 }

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -514,19 +514,6 @@ func (e UnknownSigVer) Error() string {
 	return fmt.Sprintf("Unknown signature version %d", int(e.sigVer))
 }
 
-// TLFEphemeralPublicKeyNotFoundError indicates that an ephemeral
-// public key matching the user and device KID couldn't be found.
-type TLFEphemeralPublicKeyNotFoundError struct {
-	uid keybase1.UID
-	kid keybase1.KID
-}
-
-// Error implements the error interface for TLFEphemeralPublicKeyNotFoundError.
-func (e TLFEphemeralPublicKeyNotFoundError) Error() string {
-	return fmt.Sprintf("Could not find ephemeral public key for "+
-		"user %s, device KID %v", e.uid, e.kid)
-}
-
 // KeyNotFoundError indicates that a key matching the given KID
 // couldn't be found.
 type KeyNotFoundError struct {

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -879,7 +879,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	head, err := fbm.helper.getMDForFBM(ctx)
 	if err != nil {
 		return err
-	} else if err := isReadableOrError(ctx, fbm.config, head); err != nil {
+	} else if err := isReadableOrError(ctx, fbm.config, head.ReadOnly()); err != nil {
 		return err
 	} else if head.MergedStatus() != Merged {
 		return errors.New("Skipping quota reclamation while unstaged")

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -338,7 +338,7 @@ func (fbm *folderBlockManager) forceQuotaReclamation() {
 // block server for the given block pointers.  For deletes, it returns
 // a list of block IDs that no longer have any references.
 func (fbm *folderBlockManager) doChunkedDowngrades(ctx context.Context,
-	md ReadOnlyRootMetadata, ptrs []BlockPointer, archive bool) (
+	tlfID TlfID, ptrs []BlockPointer, archive bool) (
 	[]BlockID, error) {
 	fbm.log.CDebugf(ctx, "Downgrading %d pointers (archive=%t)",
 		len(ptrs), archive)
@@ -371,10 +371,10 @@ func (fbm *folderBlockManager) doChunkedDowngrades(ctx context.Context,
 			var res workerResult
 			fbm.log.CDebugf(ctx, "Downgrading chunk of %d pointers", len(chunk))
 			if archive {
-				res.err = bops.Archive(ctx, md, chunk)
+				res.err = bops.Archive(ctx, tlfID, chunk)
 			} else {
 				var liveCounts map[BlockID]int
-				liveCounts, res.err = bops.Delete(ctx, md, chunk)
+				liveCounts, res.err = bops.Delete(ctx, tlfID, chunk)
 				if res.err == nil {
 					for id, count := range liveCounts {
 						if count == 0 {
@@ -422,8 +422,8 @@ func (fbm *folderBlockManager) doChunkedDowngrades(ctx context.Context,
 // for the given block pointers.  It returns a list of block IDs that
 // no longer have any references.
 func (fbm *folderBlockManager) deleteBlockRefs(ctx context.Context,
-	md ReadOnlyRootMetadata, ptrs []BlockPointer) ([]BlockID, error) {
-	return fbm.doChunkedDowngrades(ctx, md, ptrs, false)
+	tlfID TlfID, ptrs []BlockPointer) ([]BlockID, error) {
+	return fbm.doChunkedDowngrades(ctx, tlfID, ptrs, false)
 }
 
 func (fbm *folderBlockManager) processBlocksToDelete(ctx context.Context, toDelete blocksToDelete) error {
@@ -484,7 +484,7 @@ func (fbm *folderBlockManager) processBlocksToDelete(ctx context.Context, toDele
 			toDelete.md.Revision)
 	}
 
-	_, err := fbm.deleteBlockRefs(ctx, toDelete.md, toDelete.blocks)
+	_, err := fbm.deleteBlockRefs(ctx, toDelete.md.ID, toDelete.blocks)
 	// Ignore permanent errors
 	_, isPermErr := err.(BServerError)
 	_, isNonceNonExistentErr := err.(BServerErrorNonceNonExistent)
@@ -539,8 +539,8 @@ func (fbm *folderBlockManager) runUnlessShutdown(
 }
 
 func (fbm *folderBlockManager) archiveBlockRefs(ctx context.Context,
-	md ReadOnlyRootMetadata, ptrs []BlockPointer) error {
-	_, err := fbm.doChunkedDowngrades(ctx, md, ptrs, true)
+	tlfID TlfID, ptrs []BlockPointer) error {
+	_, err := fbm.doChunkedDowngrades(ctx, tlfID, ptrs, true)
 	return err
 }
 
@@ -580,7 +580,7 @@ func (fbm *folderBlockManager) archiveBlocksInBackground() {
 
 				fbm.log.CDebugf(ctx, "Archiving %d block pointers as a result "+
 					"of revision %d", len(ptrs), md.Revision)
-				err = fbm.archiveBlockRefs(ctx, md, ptrs)
+				err = fbm.archiveBlockRefs(ctx, md.ID, ptrs)
 				if err != nil {
 					fbm.log.CWarningf(ctx, "Couldn't archive blocks: %v", err)
 					return err
@@ -971,7 +971,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		return nil
 	}
 
-	zeroRefCounts, err := fbm.deleteBlockRefs(ctx, head.ReadOnly(), ptrs)
+	zeroRefCounts, err := fbm.deleteBlockRefs(ctx, head.ID, ptrs)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -879,7 +879,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	head, err := fbm.helper.getMDForFBM(ctx)
 	if err != nil {
 		return err
-	} else if err := head.isReadableOrError(ctx, fbm.config); err != nil {
+	} else if err := isReadableOrError(ctx, fbm.config, head); err != nil {
 		return err
 	} else if head.MergedStatus() != Merged {
 		return errors.New("Skipping quota reclamation while unstaged")

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2652,8 +2652,7 @@ func (fbo *folderBranchOps) renameLocked(
 	}
 
 	oldPBlock, newPBlock, newDe, lbc, err := fbo.blocks.PrepRename(
-		ctx, lState, md.ReadOnly(),
-		oldParent, oldName, newParent, newName)
+		ctx, lState, md, oldParent, oldName, newParent, newName)
 
 	if err != nil {
 		return err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1207,7 +1207,7 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	}
 
 	// we may be an unkeyed client
-	if err := isReadableOrError(ctx, fbo.config, md); err != nil {
+	if err := isReadableOrError(ctx, fbo.config, md.ReadOnly()); err != nil {
 		return nil, EntryInfo{}, nil, err
 	}
 
@@ -3511,7 +3511,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			// Already caught up!
 			continue
 		}
-		if err := isReadableOrError(ctx, fbo.config, rmd); err != nil {
+		if err := isReadableOrError(ctx, fbo.config, rmd.ReadOnly()); err != nil {
 			return err
 		}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1451,10 +1451,10 @@ func (bps *blockPutState) DeepCopy() *blockPutState {
 }
 
 func (fbo *folderBranchOps) readyBlockMultiple(ctx context.Context,
-	md ReadOnlyRootMetadata, currBlock Block, uid keybase1.UID,
+	kmd KeyMetadata, currBlock Block, uid keybase1.UID,
 	bps *blockPutState) (info BlockInfo, plainSize int, err error) {
 	info, plainSize, readyBlockData, err :=
-		fbo.blocks.ReadyBlock(ctx, md, currBlock, uid)
+		fbo.blocks.ReadyBlock(ctx, kmd, currBlock, uid)
 	if err != nil {
 		return
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1207,7 +1207,7 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	}
 
 	// we may be an unkeyed client
-	if err := md.isReadableOrError(ctx, fbo.config); err != nil {
+	if err := isReadableOrError(ctx, fbo.config, md); err != nil {
 		return nil, EntryInfo{}, nil, err
 	}
 
@@ -3511,7 +3511,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			// Already caught up!
 			continue
 		}
-		if err := rmd.isReadableOrError(ctx, fbo.config); err != nil {
+		if err := isReadableOrError(ctx, fbo.config, rmd); err != nil {
 			return err
 		}
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -438,12 +438,12 @@ type KeyMetadata interface {
 	// given key generation is invalid.
 	HasKeyForUser(keyGen KeyGen, user keybase1.UID) bool
 
-	// GetTLFCryptKeyInfo returns all the necessary info to
+	// GetTLFCryptKeyParams returns all the necessary info to
 	// construct the TLF crypt key for the given key generation,
 	// user, and device (identified by its crypt public key), or
 	// false if not found. This returns an error if the TLF is
 	// public.
-	GetTLFCryptKeyInfo(
+	GetTLFCryptKeyParams(
 		keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 		TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
 		TLFCryptKeyServerHalfID, bool, error)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -425,7 +425,8 @@ type KeyMetadata interface {
 	// is public.
 	LatestKeyGeneration() KeyGen
 
-	// GetTlfHandle returns the handle for the TLF.
+	// GetTlfHandle returns the handle for the TLF. It must not
+	// return nil.
 	//
 	// TODO: Remove the need for this function in this interface,
 	// so that BareRootMetadata can implement this interface

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -888,14 +888,14 @@ type BlockOps interface {
 	// Delete instructs the server to delete the given block references.
 	// It returns the number of not-yet deleted references to
 	// each block reference
-	Delete(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) (
+	Delete(ctx context.Context, tlfID TlfID, ptrs []BlockPointer) (
 		liveCounts map[BlockID]int, err error)
 
 	// Archive instructs the server to mark the given block references
 	// as "archived"; that is, they are not being used in the current
 	// view of the folder, and shouldn't be served to anyone other
 	// than folder writers.
-	Archive(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) error
+	Archive(ctx context.Context, tlfID TlfID, ptrs []BlockPointer) error
 }
 
 // MDServer gets and puts metadata for each top-level directory.  The

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -428,7 +428,7 @@ type encryptionKeyGetter interface {
 	// GetTLFCryptKeyForEncryption gets the crypt key to use for
 	// encryption (i.e., with the latest key generation) for the
 	// TLF with the given metadata.
-	GetTLFCryptKeyForEncryption(ctx context.Context, md ReadOnlyRootMetadata) (
+	GetTLFCryptKeyForEncryption(ctx context.Context, kmd KeyMetadata) (
 		TLFCryptKey, error)
 }
 
@@ -443,12 +443,12 @@ type KeyManager interface {
 	// (which in most cases is the same as mdToDecrypt) if it's not
 	// already cached.
 	GetTLFCryptKeyForMDDecryption(ctx context.Context,
-		mdToDecrypt, mdWithKeys ReadOnlyRootMetadata) (TLFCryptKey, error)
+		kmdToDecrypt, kmdWithKeys KeyMetadata) (TLFCryptKey, error)
 
 	// GetTLFCryptKeyForBlockDecryption gets the crypt key to use
 	// for the TLF with the given metadata to decrypt the block
 	// pointed to by the given pointer.
-	GetTLFCryptKeyForBlockDecryption(ctx context.Context, md ReadOnlyRootMetadata,
+	GetTLFCryptKeyForBlockDecryption(ctx context.Context, kmd KeyMetadata,
 		blockPtr BlockPointer) (TLFCryptKey, error)
 
 	// Rekey checks the given MD object, if it is a private TLF,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -413,6 +413,17 @@ type KBPKI interface {
 	Notify(ctx context.Context, notification *keybase1.FSNotification) error
 }
 
+type KeyMetadata interface {
+	TlfID() TlfID
+	GetTlfHandle() *TlfHandle
+	LatestKeyGeneration() KeyGen
+	HasKeyForUser(keyGen KeyGen, user keybase1.UID) bool
+	GetTLFCryptKeyInfo(
+		keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
+		TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
+		TLFCryptKeyServerHalfID, bool, error)
+}
+
 type encryptionKeyGetter interface {
 	// GetTLFCryptKeyForEncryption gets the crypt key to use for
 	// encryption (i.e., with the latest key generation) for the

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -413,6 +413,8 @@ type KBPKI interface {
 	Notify(ctx context.Context, notification *keybase1.FSNotification) error
 }
 
+// KeyMetadata is an interface for something that holds key
+// information. This is usually implemented by RootMetadata.
 type KeyMetadata interface {
 	TlfID() TlfID
 	GetTlfHandle() *TlfHandle

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -416,10 +416,31 @@ type KBPKI interface {
 // KeyMetadata is an interface for something that holds key
 // information. This is usually implemented by RootMetadata.
 type KeyMetadata interface {
+	// TlfID returns the ID of the TLF for which this object holds
+	// key info.
 	TlfID() TlfID
-	GetTlfHandle() *TlfHandle
+
+	// LatestKeyGeneration returns the most recent key generation
+	// with key data in this object, or PublicKeyGen if this TLF
+	// is public.
 	LatestKeyGeneration() KeyGen
+
+	// GetTlfHandle returns the handle for the TLF.
+	//
+	// TODO: Remove the need for this function in this interface.
+	GetTlfHandle() *TlfHandle
+
+	// HasKeyForUser returns whether or not the given user has
+	// keys for at least one device at the given key
+	// generation. Returns false if the TLF is public, or if the
+	// given key generation is invalid.
 	HasKeyForUser(keyGen KeyGen, user keybase1.UID) bool
+
+	// GetTLFCryptKeyInfo returns all the necessary info to
+	// construct the TLF crypt key for the given key generation,
+	// user, and device (identified by its crypt public key), or
+	// false if not found. This returns an error if the TLF is
+	// public.
 	GetTLFCryptKeyInfo(
 		keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 		TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -427,7 +427,9 @@ type KeyMetadata interface {
 
 	// GetTlfHandle returns the handle for the TLF.
 	//
-	// TODO: Remove the need for this function in this interface.
+	// TODO: Remove the need for this function in this interface,
+	// so that BareRootMetadata can implement this interface
+	// fully.
 	GetTlfHandle() *TlfHandle
 
 	// HasKeyForUser returns whether or not the given user has

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -889,7 +889,7 @@ type KeyOps interface {
 // the necessary crypto operations on each block.
 type BlockOps interface {
 	// Get gets the block associated with the given block pointer
-	// (which belongs to the TLF with the given metadata),
+	// (which belongs to the TLF with the given key metadata),
 	// decrypts it if necessary, and fills in the provided block
 	// object with its contents, if the logged-in user has read
 	// permission for that block.
@@ -897,16 +897,16 @@ type BlockOps interface {
 		block Block) error
 
 	// Ready turns the given block (which belongs to the TLF with
-	// the given metadata) into encoded (and encrypted) data, and
-	// calculates its ID and size, so that we can do a bunch of
-	// block puts in parallel for every write. Ready() must
+	// the given key metadata) into encoded (and encrypted) data,
+	// and calculates its ID and size, so that we can do a bunch
+	// of block puts in parallel for every write. Ready() must
 	// guarantee that plainSize <= readyBlockData.QuotaSize().
 	Ready(ctx context.Context, kmd KeyMetadata, block Block) (
 		id BlockID, plainSize int, readyBlockData ReadyBlockData, err error)
 
 	// Put stores the readied block data under the given block
-	// pointer (which belongs to the TLF with the given metadata)
-	// on the server.
+	// pointer (which belongs to the TLF with the given ID) on the
+	// server.
 	Put(ctx context.Context, tlfID TlfID, blockPtr BlockPointer,
 		readyBlockData ReadyBlockData) error
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -882,7 +882,7 @@ type BlockOps interface {
 	// Put stores the readied block data under the given block
 	// pointer (which belongs to the TLF with the given metadata)
 	// on the server.
-	Put(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
+	Put(ctx context.Context, tlfID TlfID, blockPtr BlockPointer,
 		readyBlockData ReadyBlockData) error
 
 	// Delete instructs the server to delete the given block references.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -868,7 +868,7 @@ type BlockOps interface {
 	// decrypts it if necessary, and fills in the provided block
 	// object with its contents, if the logged-in user has read
 	// permission for that block.
-	Get(ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer,
+	Get(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
 		block Block) error
 
 	// Ready turns the given block (which belongs to the TLF with
@@ -876,26 +876,26 @@ type BlockOps interface {
 	// calculates its ID and size, so that we can do a bunch of
 	// block puts in parallel for every write. Ready() must
 	// guarantee that plainSize <= readyBlockData.QuotaSize().
-	Ready(ctx context.Context, md ReadOnlyRootMetadata, block Block) (
+	Ready(ctx context.Context, kmd KeyMetadata, block Block) (
 		id BlockID, plainSize int, readyBlockData ReadyBlockData, err error)
 
 	// Put stores the readied block data under the given block
 	// pointer (which belongs to the TLF with the given metadata)
 	// on the server.
-	Put(ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer,
+	Put(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
 		readyBlockData ReadyBlockData) error
 
 	// Delete instructs the server to delete the given block references.
 	// It returns the number of not-yet deleted references to
 	// each block reference
-	Delete(ctx context.Context, md ReadOnlyRootMetadata, ptrs []BlockPointer) (
+	Delete(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) (
 		liveCounts map[BlockID]int, err error)
 
 	// Archive instructs the server to mark the given block references
 	// as "archived"; that is, they are not being used in the current
 	// view of the folder, and shouldn't be served to anyone other
 	// than folder writers.
-	Archive(ctx context.Context, md ReadOnlyRootMetadata, ptrs []BlockPointer) error
+	Archive(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) error
 }
 
 // MDServer gets and puts metadata for each top-level directory.  The

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -293,7 +293,7 @@ func (fs *KBFSOpsStandard) GetOrCreateRootNode(
 
 	// we might not be able to read the metadata if we aren't in the
 	// key group yet.
-	if err := isReadableOrError(ctx, fs.config, md); err != nil {
+	if err := isReadableOrError(ctx, fs.config, md.ReadOnly()); err != nil {
 		fs.opsLock.Lock()
 		defer fs.opsLock.Unlock()
 		// If we already have an FBO for this ID, trigger a rekey

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -293,7 +293,7 @@ func (fs *KBFSOpsStandard) GetOrCreateRootNode(
 
 	// we might not be able to read the metadata if we aren't in the
 	// key group yet.
-	if err := md.isReadableOrError(ctx, fs.config); err != nil {
+	if err := isReadableOrError(ctx, fs.config, md); err != nil {
 		fs.opsLock.Lock()
 		defer fs.opsLock.Unlock()
 		// If we already have an FBO for this ID, trigger a rekey

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -464,7 +464,7 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	}
 }
 
-// mdRecordingKeyManager records the last *RootMetadata argument seen
+// mdRecordingKeyManager records the last KeyMetadata argument seen
 // in its KeyManager methods.
 type mdRecordingKeyManager struct {
 	lastKMDMu sync.RWMutex
@@ -594,10 +594,8 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 
 	lastKMD := km.getLastKMD()
 
-	if md != lastKMD &&
-		md.ReadOnlyRootMetadata != lastKMD &&
-		md.RootMetadata != lastKMD {
-		t.Errorf("Last MD seen by key manager != head")
+	if md.ReadOnlyRootMetadata != lastKMD {
+		t.Error("Last MD seen by key manager != head")
 	}
 }
 
@@ -683,7 +681,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 
 	lastKMD := km.getLastKMD()
 
-	if md != lastKMD && md.ReadOnlyRootMetadata != lastKMD && md.RootMetadata != lastKMD {
+	if md.ReadOnlyRootMetadata != lastKMD {
 		t.Error("Last MD seen by key manager != head")
 	}
 }

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -478,10 +478,10 @@ func (km *mdRecordingKeyManager) getLastKMD() KeyMetadata {
 	return km.lastKMD
 }
 
-func (km *mdRecordingKeyManager) setLastKMD(md KeyMetadata) {
+func (km *mdRecordingKeyManager) setLastKMD(kmd KeyMetadata) {
 	km.lastKMDMu.Lock()
 	defer km.lastKMDMu.Unlock()
-	km.lastKMD = md
+	km.lastKMD = kmd
 }
 
 func (km *mdRecordingKeyManager) GetTLFCryptKeyForEncryption(
@@ -594,7 +594,9 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 
 	lastKMD := km.getLastKMD()
 
-	if md != lastKMD && md.ReadOnlyRootMetadata != lastKMD && md.RootMetadata != lastKMD {
+	if md != lastKMD &&
+		md.ReadOnlyRootMetadata != lastKMD &&
+		md.RootMetadata != lastKMD {
 		t.Errorf("Last MD seen by key manager != head")
 	}
 }

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1395,7 +1395,7 @@ type blockOpsOverQuota struct {
 	BlockOps
 }
 
-func (booq *blockOpsOverQuota) Put(ctx context.Context, md ReadOnlyRootMetadata,
+func (booq *blockOpsOverQuota) Put(ctx context.Context, kmd KeyMetadata,
 	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
 	return BServerErrorOverQuota{
 		Throttled: true,

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1395,7 +1395,7 @@ type blockOpsOverQuota struct {
 	BlockOps
 }
 
-func (booq *blockOpsOverQuota) Put(ctx context.Context, kmd KeyMetadata,
+func (booq *blockOpsOverQuota) Put(ctx context.Context, tlfID TlfID,
 	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
 	return BServerErrorOverQuota{
 		Throttled: true,

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -511,11 +511,11 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 // the helper functions below, but all the callers would have to go
 // md.ReadOnly(), which doesn't buy us much in tests.
 
-func makeBP(id BlockID, rmd *RootMetadata, config Config,
+func makeBP(id BlockID, kmd KeyMetadata, config Config,
 	u keybase1.UID) BlockPointer {
 	return BlockPointer{
 		ID:      id,
-		KeyGen:  rmd.LatestKeyGeneration(),
+		KeyGen:  kmd.LatestKeyGeneration(),
 		DataVer: DefaultNewBlockDataVersion(config, false),
 		BlockContext: BlockContext{
 			Creator: u,
@@ -525,19 +525,19 @@ func makeBP(id BlockID, rmd *RootMetadata, config Config,
 	}
 }
 
-func makeBI(id BlockID, rmd *RootMetadata, config Config,
+func makeBI(id BlockID, kmd KeyMetadata, config Config,
 	u keybase1.UID, encodedSize uint32) BlockInfo {
 	return BlockInfo{
-		BlockPointer: makeBP(id, rmd, config, u),
+		BlockPointer: makeBP(id, kmd, config, u),
 		EncodedSize:  encodedSize,
 	}
 }
 
-func makeIFP(id BlockID, rmd *RootMetadata, config Config,
+func makeIFP(id BlockID, kmd KeyMetadata, config Config,
 	u keybase1.UID, encodedSize uint32, off int64) IndirectFilePtr {
 	return IndirectFilePtr{
 		BlockInfo{
-			BlockPointer: makeBP(id, rmd, config, u),
+			BlockPointer: makeBP(id, kmd, config, u),
 			EncodedSize:  encodedSize,
 		},
 		off,
@@ -1025,19 +1025,19 @@ func expectSyncBlockHelper(
 
 func expectSyncBlock(
 	t *testing.T, config *ConfigMock, lastCall *gomock.Call,
-	uid keybase1.UID, id TlfID, name string, p path, rmd *RootMetadata,
+	uid keybase1.UID, id TlfID, name string, p path, kmd KeyMetadata,
 	newEntry bool, skipSync int, refBytes uint64, unrefBytes uint64,
 	newRmd *ImmutableRootMetadata, newBlockIDs []BlockID) (path, *gomock.Call) {
-	return expectSyncBlockHelper(t, config, lastCall, uid, id, name, p, rmd,
+	return expectSyncBlockHelper(t, config, lastCall, uid, id, name, p, kmd,
 		newEntry, skipSync, refBytes, unrefBytes, newRmd, newBlockIDs, false)
 }
 
 func expectSyncBlockUnmerged(
 	t *testing.T, config *ConfigMock, lastCall *gomock.Call,
-	uid keybase1.UID, id TlfID, name string, p path, rmd *RootMetadata,
+	uid keybase1.UID, id TlfID, name string, p path, kmd KeyMetadata,
 	newEntry bool, skipSync int, refBytes uint64, unrefBytes uint64,
 	newRmd *ImmutableRootMetadata, newBlockIDs []BlockID) (path, *gomock.Call) {
-	return expectSyncBlockHelper(t, config, lastCall, uid, id, name, p, rmd,
+	return expectSyncBlockHelper(t, config, lastCall, uid, id, name, p, kmd,
 		newEntry, skipSync, refBytes, unrefBytes, newRmd, newBlockIDs, true)
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -991,7 +991,7 @@ func expectSyncBlockHelper(
 		lastCall = call
 		newPath.path[i].ID = newID
 		newBlockIDs[i] = newID
-		config.mockBops.EXPECT().Put(gomock.Any(), rmdMatcher{rmd},
+		config.mockBops.EXPECT().Put(gomock.Any(), rmd.ID,
 			ptrMatcher{newPath.path[i].BlockPointer}, readyBlockData).
 			Return(nil)
 	}
@@ -4298,7 +4298,7 @@ func expectSyncDirtyBlock(config *ConfigMock, rmd *RootMetadata,
 		// removed.
 	}
 
-	config.mockBops.EXPECT().Put(gomock.Any(), rmdMatcher{rmd},
+	config.mockBops.EXPECT().Put(gomock.Any(), rmd.ID,
 		ptrMatcher{newPtr}, gomock.Any()).Return(nil)
 	return c2
 }
@@ -4493,7 +4493,7 @@ func TestSyncDirtyDupBlockSuccess(t *testing.T) {
 	// manually add b
 	expectedPath.path = append(expectedPath.path,
 		pathNode{BlockPointer{ID: aID, BlockContext: BlockContext{RefNonce: refNonce}}, "b"})
-	config.mockBops.EXPECT().Put(gomock.Any(), rmdMatcher{rmd},
+	config.mockBops.EXPECT().Put(gomock.Any(), rmd.ID,
 		ptrMatcher{expectedPath.path[1].BlockPointer}, readyBlockData).
 		Return(nil)
 
@@ -4986,7 +4986,7 @@ func TestSyncDirtyWithBlockChangePointerSuccess(t *testing.T) {
 	lastCall = config.mockBops.EXPECT().Ready(gomock.Any(), rmdMatcher{rmd},
 		gomock.Any()).Return(changeBlockID, changePlainSize,
 		changeReadyBlockData, nil).After(lastCall)
-	config.mockBops.EXPECT().Put(gomock.Any(), rmdMatcher{rmd},
+	config.mockBops.EXPECT().Put(gomock.Any(), rmd.ID,
 		ptrMatcher{BlockPointer{ID: changeBlockID}}, changeReadyBlockData).
 		Return(nil)
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -22,42 +22,22 @@ import (
 )
 
 type CheckBlockOps struct {
-	delegate BlockOps
-	tr       gomock.TestReporter
+	BlockOps
+	tr gomock.TestReporter
 }
 
 var _ BlockOps = (*CheckBlockOps)(nil)
 
-func (cbo *CheckBlockOps) Get(ctx context.Context, md ReadOnlyRootMetadata,
-	blockPtr BlockPointer, block Block) error {
-	return cbo.delegate.Get(ctx, md, blockPtr, block)
-}
-
-func (cbo *CheckBlockOps) Ready(ctx context.Context, md ReadOnlyRootMetadata,
+func (cbo *CheckBlockOps) Ready(ctx context.Context, kmd KeyMetadata,
 	block Block) (id BlockID, plainSize int, readyBlockData ReadyBlockData,
 	err error) {
-	id, plainSize, readyBlockData, err = cbo.delegate.Ready(ctx, md, block)
+	id, plainSize, readyBlockData, err = cbo.BlockOps.Ready(ctx, kmd, block)
 	encodedSize := readyBlockData.GetEncodedSize()
 	if plainSize > encodedSize {
 		cbo.tr.Errorf("expected plainSize <= encodedSize, got plainSize = %d, "+
 			"encodedSize = %d", plainSize, encodedSize)
 	}
 	return
-}
-
-func (cbo *CheckBlockOps) Put(ctx context.Context, md ReadOnlyRootMetadata,
-	blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
-	return cbo.delegate.Put(ctx, md, blockPtr, readyBlockData)
-}
-
-func (cbo *CheckBlockOps) Delete(ctx context.Context, md ReadOnlyRootMetadata,
-	ptrs []BlockPointer) (map[BlockID]int, error) {
-	return cbo.delegate.Delete(ctx, md, ptrs)
-}
-
-func (cbo *CheckBlockOps) Archive(ctx context.Context, md ReadOnlyRootMetadata,
-	ptrs []BlockPointer) error {
-	return cbo.delegate.Archive(ctx, md, ptrs)
 }
 
 var tCtxID = "kbfs-ops-test-id"

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -12,9 +12,6 @@ import (
 // All section references below are to https://keybase.io/blog/kbfs-crypto
 // (version 1.3).
 
-// TODO once TLFKeyBundle is removed, ensure that methods take
-// value receivers unless they mutate the receiver.
-
 // TLFCryptKeyServerHalfID is the identifier type for a server-side key half.
 type TLFCryptKeyServerHalfID struct {
 	ID HMAC // Exported for serialization.

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -102,15 +102,6 @@ func (kim DeviceKeyInfoMap) fillInDeviceInfo(crypto Crypto,
 	return serverMap, nil
 }
 
-// GetKIDs returns the KIDs for the given bundle.
-func (kim DeviceKeyInfoMap) GetKIDs() []keybase1.KID {
-	var keys []keybase1.KID
-	for k := range kim {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // UserDeviceKeyInfoMap maps a user's keybase UID to their DeviceKeyInfoMap
 type UserDeviceKeyInfoMap map[keybase1.UID]DeviceKeyInfoMap
 

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -118,8 +118,8 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 				h.GetCanonicalPath(), err)
 			resolvedHandle = h
 		}
-		return md.makeRekeyReadError(
-			resolvedHandle, keyGen, uid, username)
+		return makeRekeyReadError(
+			md, resolvedHandle, keyGen, uid, username)
 	}
 
 	var clientHalf TLFCryptKeyClientHalf

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -499,15 +499,13 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 			return false, nil, err
 		}
 
-		romd := md.ReadOnly()
-
-		newWriterUsers = km.usersWithNewDevices(ctx, romd.ID, wkb.WKeys, wKeys)
-		newReaderUsers = km.usersWithNewDevices(ctx, romd.ID, rkb.RKeys, rKeys)
+		newWriterUsers = km.usersWithNewDevices(ctx, md.ID, wkb.WKeys, wKeys)
+		newReaderUsers = km.usersWithNewDevices(ctx, md.ID, rkb.RKeys, rKeys)
 		addNewWriterDevice = len(newWriterUsers) > 0
 		addNewReaderDevice = len(newReaderUsers) > 0
 
-		wRemoved := km.usersWithRemovedDevices(ctx, romd.ID, wkb.WKeys, wKeys)
-		rRemoved := km.usersWithRemovedDevices(ctx, romd.ID, rkb.RKeys, rKeys)
+		wRemoved := km.usersWithRemovedDevices(ctx, md.ID, wkb.WKeys, wKeys)
+		rRemoved := km.usersWithRemovedDevices(ctx, md.ID, rkb.RKeys, rKeys)
 		incKeyGen = len(wRemoved) > 0 || len(rRemoved) > 0
 
 		promotedReaders = make(map[keybase1.UID]bool, len(rRemoved))
@@ -533,7 +531,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 			newWriterUsers[u] = true
 		}
 
-		if err := km.identifyUIDSets(ctx, romd.ID, newWriterUsers, newReaderUsers); err != nil {
+		if err := km.identifyUIDSets(ctx, md.ID, newWriterUsers, newReaderUsers); err != nil {
 			return false, nil, err
 		}
 	}

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -109,17 +109,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 	}
 
 	localMakeRekeyReadError := func() error {
-		h := md.GetTlfHandle()
-		resolvedHandle, err := h.ResolveAgain(ctx, km.config.KBPKI())
-		if err != nil {
-			// Ignore error and pretend h is already fully
-			// resolved.
-			km.log.CWarningf(ctx, "ResolveAgain for %v error: %v",
-				h.GetCanonicalPath(), err)
-			resolvedHandle = h
-		}
-		return makeRekeyReadError(
-			md, resolvedHandle, keyGen, uid, username)
+		return makeRekeyReadError(ctx, km.config, md, keyGen, uid, username)
 	}
 
 	var clientHalf TLFCryptKeyClientHalf

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -141,7 +141,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		for i, k := range publicKeys {
 			info, ok, _ := md.GetTLFCryptKeyInfo(keyGen, uid, k)
 			if ok {
-				ePublicKey, err := md.GetTLFEphemeralPublicKey(keyGen, uid, k)
+				ePublicKey, _, err := md.GetTLFEphemeralPublicKey(keyGen, uid, k)
 				if err != nil {
 					continue
 				}
@@ -186,7 +186,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 			return TLFCryptKey{}, localMakeRekeyReadError()
 		}
 
-		ePublicKey, err := md.GetTLFEphemeralPublicKey(keyGen, uid,
+		ePublicKey, _, err := md.GetTLFEphemeralPublicKey(keyGen, uid,
 			cryptPublicKey)
 		if err != nil {
 			return TLFCryptKey{}, err

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -136,6 +136,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 				continue
 			}
 			if !found {
+				km.log.CDebugf(ctx, "Could not find key info for(%d, %v, %v); skipping", keyGen, uid, k)
 				continue
 			}
 

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -130,9 +130,9 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		publicKeyLookup := make([]int, 0, len(publicKeys))
 
 		for i, k := range publicKeys {
-			ePublicKey, encryptedClientHalf, serverHalfID, found, err := kmd.GetTLFCryptKeyInfo(keyGen, uid, k)
+			ePublicKey, encryptedClientHalf, serverHalfID, found, err := kmd.GetTLFCryptKeyParams(keyGen, uid, k)
 			if err != nil {
-				km.log.CDebugf(ctx, "Got error for GetTLFCryptKeyInfo(%d, %v, %v); skipping: %v", keyGen, uid, k, err)
+				km.log.CDebugf(ctx, "Got error for GetTLFCryptKeyParams(%d, %v, %v); skipping: %v", keyGen, uid, k, err)
 				continue
 			}
 			if !found {
@@ -171,7 +171,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		}
 
 		ePublicKey, encryptedClientHalf, foundServerHalfID, found, err :=
-			kmd.GetTLFCryptKeyInfo(keyGen, uid, cryptPublicKey)
+			kmd.GetTLFCryptKeyParams(keyGen, uid, cryptPublicKey)
 		if err != nil {
 			return TLFCryptKey{}, err
 		} else if !found {

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -206,6 +206,8 @@ func makeDirRKeyBundle(uid keybase1.UID, cryptPublicKey CryptPublicKey) TLFReade
 	}
 }
 
+// TODO: Can change the tests below to use a fake KeyMetadata object.
+
 func TestKeyManagerUncachedSecretKeyForEncryptionSuccess(t *testing.T) {
 	mockCtrl, config, ctx := keyManagerInit(t)
 	defer keyManagerShutdown(mockCtrl, config)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -21,7 +21,7 @@ type singleEncryptionKeyGetter struct {
 }
 
 func (g singleEncryptionKeyGetter) GetTLFCryptKeyForEncryption(
-	ctx context.Context, md KeyMetadata) (TLFCryptKey, error) {
+	ctx context.Context, kmd KeyMetadata) (TLFCryptKey, error) {
 	return g.k, nil
 }
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -21,7 +21,7 @@ type singleEncryptionKeyGetter struct {
 }
 
 func (g singleEncryptionKeyGetter) GetTLFCryptKeyForEncryption(
-	ctx context.Context, md ReadOnlyRootMetadata) (TLFCryptKey, error) {
+	ctx context.Context, md KeyMetadata) (TLFCryptKey, error) {
 	return g.k, nil
 }
 

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -360,7 +360,7 @@ func signMD(
 }
 
 func decryptMDPrivateData(ctx context.Context, config Config,
-	rmdToDecrypt *RootMetadata, rmdWithKeys ReadOnlyRootMetadata) error {
+	rmdToDecrypt *RootMetadata, rmdWithKeys KeyMetadata) error {
 	handle := rmdToDecrypt.GetTlfHandle()
 	crypto := config.Crypto()
 	codec := config.Codec()

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -20,7 +20,7 @@ type mdRange struct {
 }
 
 func makeRekeyReadErrorHelper(
-	md ReadOnlyRootMetadata, resolvedHandle *TlfHandle, keyGen KeyGen,
+	kmd KeyMetadata, resolvedHandle *TlfHandle, keyGen KeyGen,
 	uid keybase1.UID, username libkb.NormalizedUsername) error {
 	if resolvedHandle.IsPublic() {
 		panic("makeRekeyReadError called on public folder")
@@ -33,16 +33,16 @@ func makeRekeyReadErrorHelper(
 
 	// Otherwise, this folder needs to be rekeyed for this device.
 	tlfName := resolvedHandle.GetCanonicalName()
-	if hasKeys := md.HasKeyForUser(keyGen, uid); hasKeys {
+	if hasKeys := kmd.HasKeyForUser(keyGen, uid); hasKeys {
 		return NeedSelfRekeyError{tlfName}
 	}
 	return NeedOtherRekeyError{tlfName}
 }
 
 func makeRekeyReadError(
-	ctx context.Context, config Config, md ReadOnlyRootMetadata, keyGen KeyGen,
+	ctx context.Context, config Config, kmd KeyMetadata, keyGen KeyGen,
 	uid keybase1.UID, username libkb.NormalizedUsername) error {
-	h := md.GetTlfHandle()
+	h := kmd.GetTlfHandle()
 	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI())
 	if err != nil {
 		// Ignore error and pretend h is already fully
@@ -50,7 +50,7 @@ func makeRekeyReadError(
 		resolvedHandle = h
 	}
 	return makeRekeyReadErrorHelper(
-		md, resolvedHandle, keyGen, uid, username)
+		kmd, resolvedHandle, keyGen, uid, username)
 }
 
 // Helper which returns nil if the md block is uninitialized or readable by

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -33,7 +33,7 @@ func makeRekeyReadErrorHelper(
 
 	// Otherwise, this folder needs to be rekeyed for this device.
 	tlfName := resolvedHandle.GetCanonicalName()
-	if hasKeys := md.hasKeyForUser(keyGen, uid); hasKeys {
+	if hasKeys := md.HasKeyForUser(keyGen, uid); hasKeys {
 		return NeedSelfRekeyError{tlfName}
 	}
 	return NeedOtherRekeyError{tlfName}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2362,8 +2362,8 @@ func (_mr *_MockBlockOpsRecorder) Ready(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Ready", arg0, arg1, arg2)
 }
 
-func (_m *MockBlockOps) Put(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, kmd, blockPtr, readyBlockData)
+func (_m *MockBlockOps) Put(ctx context.Context, tlfID TlfID, blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, tlfID, blockPtr, readyBlockData)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2339,8 +2339,8 @@ func (_m *MockBlockOps) EXPECT() *_MockBlockOpsRecorder {
 	return _m.recorder
 }
 
-func (_m *MockBlockOps) Get(ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer, block Block) error {
-	ret := _m.ctrl.Call(_m, "Get", ctx, md, blockPtr, block)
+func (_m *MockBlockOps) Get(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer, block Block) error {
+	ret := _m.ctrl.Call(_m, "Get", ctx, kmd, blockPtr, block)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2349,8 +2349,8 @@ func (_mr *_MockBlockOpsRecorder) Get(arg0, arg1, arg2, arg3 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBlockOps) Ready(ctx context.Context, md ReadOnlyRootMetadata, block Block) (BlockID, int, ReadyBlockData, error) {
-	ret := _m.ctrl.Call(_m, "Ready", ctx, md, block)
+func (_m *MockBlockOps) Ready(ctx context.Context, kmd KeyMetadata, block Block) (BlockID, int, ReadyBlockData, error) {
+	ret := _m.ctrl.Call(_m, "Ready", ctx, kmd, block)
 	ret0, _ := ret[0].(BlockID)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(ReadyBlockData)
@@ -2362,8 +2362,8 @@ func (_mr *_MockBlockOpsRecorder) Ready(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Ready", arg0, arg1, arg2)
 }
 
-func (_m *MockBlockOps) Put(ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, md, blockPtr, readyBlockData)
+func (_m *MockBlockOps) Put(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer, readyBlockData ReadyBlockData) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, kmd, blockPtr, readyBlockData)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2372,8 +2372,8 @@ func (_mr *_MockBlockOpsRecorder) Put(arg0, arg1, arg2, arg3 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBlockOps) Delete(ctx context.Context, md ReadOnlyRootMetadata, ptrs []BlockPointer) (map[BlockID]int, error) {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, md, ptrs)
+func (_m *MockBlockOps) Delete(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) (map[BlockID]int, error) {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, kmd, ptrs)
 	ret0, _ := ret[0].(map[BlockID]int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2383,8 +2383,8 @@ func (_mr *_MockBlockOpsRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockBlockOps) Archive(ctx context.Context, md ReadOnlyRootMetadata, ptrs []BlockPointer) error {
-	ret := _m.ctrl.Call(_m, "Archive", ctx, md, ptrs)
+func (_m *MockBlockOps) Archive(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) error {
+	ret := _m.ctrl.Call(_m, "Archive", ctx, kmd, ptrs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2372,8 +2372,8 @@ func (_mr *_MockBlockOpsRecorder) Put(arg0, arg1, arg2, arg3 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBlockOps) Delete(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) (map[BlockID]int, error) {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, kmd, ptrs)
+func (_m *MockBlockOps) Delete(ctx context.Context, tlfID TlfID, ptrs []BlockPointer) (map[BlockID]int, error) {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, tlfID, ptrs)
 	ret0, _ := ret[0].(map[BlockID]int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2383,8 +2383,8 @@ func (_mr *_MockBlockOpsRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockBlockOps) Archive(ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) error {
-	ret := _m.ctrl.Call(_m, "Archive", ctx, kmd, ptrs)
+func (_m *MockBlockOps) Archive(ctx context.Context, tlfID TlfID, ptrs []BlockPointer) error {
+	ret := _m.ctrl.Call(_m, "Archive", ctx, tlfID, ptrs)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -900,6 +900,81 @@ func (_mr *_MockKBPKIRecorder) Notify(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Notify", arg0, arg1)
 }
 
+// Mock of KeyMetadata interface
+type MockKeyMetadata struct {
+	ctrl     *gomock.Controller
+	recorder *_MockKeyMetadataRecorder
+}
+
+// Recorder for MockKeyMetadata (not exported)
+type _MockKeyMetadataRecorder struct {
+	mock *MockKeyMetadata
+}
+
+func NewMockKeyMetadata(ctrl *gomock.Controller) *MockKeyMetadata {
+	mock := &MockKeyMetadata{ctrl: ctrl}
+	mock.recorder = &_MockKeyMetadataRecorder{mock}
+	return mock
+}
+
+func (_m *MockKeyMetadata) EXPECT() *_MockKeyMetadataRecorder {
+	return _m.recorder
+}
+
+func (_m *MockKeyMetadata) TlfID() TlfID {
+	ret := _m.ctrl.Call(_m, "TlfID")
+	ret0, _ := ret[0].(TlfID)
+	return ret0
+}
+
+func (_mr *_MockKeyMetadataRecorder) TlfID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfID")
+}
+
+func (_m *MockKeyMetadata) GetTlfHandle() *TlfHandle {
+	ret := _m.ctrl.Call(_m, "GetTlfHandle")
+	ret0, _ := ret[0].(*TlfHandle)
+	return ret0
+}
+
+func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
+}
+
+func (_m *MockKeyMetadata) LatestKeyGeneration() KeyGen {
+	ret := _m.ctrl.Call(_m, "LatestKeyGeneration")
+	ret0, _ := ret[0].(KeyGen)
+	return ret0
+}
+
+func (_mr *_MockKeyMetadataRecorder) LatestKeyGeneration() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestKeyGeneration")
+}
+
+func (_m *MockKeyMetadata) HasKeyForUser(keyGen KeyGen, user protocol.UID) bool {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockKeyMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
+}
+
+func (_m *MockKeyMetadata) GetTLFCryptKeyInfo(keyGen KeyGen, user protocol.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyInfo", keyGen, user, key)
+	ret0, _ := ret[0].(TLFEphemeralPublicKey)
+	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
+	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
+	ret3, _ := ret[3].(bool)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+func (_mr *_MockKeyMetadataRecorder) GetTLFCryptKeyInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyInfo", arg0, arg1, arg2)
+}
+
 // Mock of encryptionKeyGetter interface
 type MockencryptionKeyGetter struct {
 	ctrl     *gomock.Controller
@@ -921,8 +996,8 @@ func (_m *MockencryptionKeyGetter) EXPECT() *_MockencryptionKeyGetterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockencryptionKeyGetter) GetTLFCryptKeyForEncryption(ctx context.Context, md ReadOnlyRootMetadata) (TLFCryptKey, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForEncryption", ctx, md)
+func (_m *MockencryptionKeyGetter) GetTLFCryptKeyForEncryption(ctx context.Context, kmd KeyMetadata) (TLFCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForEncryption", ctx, kmd)
 	ret0, _ := ret[0].(TLFCryptKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -953,8 +1028,8 @@ func (_m *MockKeyManager) EXPECT() *_MockKeyManagerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKeyManager) GetTLFCryptKeyForEncryption(ctx context.Context, md ReadOnlyRootMetadata) (TLFCryptKey, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForEncryption", ctx, md)
+func (_m *MockKeyManager) GetTLFCryptKeyForEncryption(ctx context.Context, kmd KeyMetadata) (TLFCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForEncryption", ctx, kmd)
 	ret0, _ := ret[0].(TLFCryptKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -964,8 +1039,8 @@ func (_mr *_MockKeyManagerRecorder) GetTLFCryptKeyForEncryption(arg0, arg1 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyForEncryption", arg0, arg1)
 }
 
-func (_m *MockKeyManager) GetTLFCryptKeyForMDDecryption(ctx context.Context, mdToDecrypt ReadOnlyRootMetadata, mdWithKeys ReadOnlyRootMetadata) (TLFCryptKey, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForMDDecryption", ctx, mdToDecrypt, mdWithKeys)
+func (_m *MockKeyManager) GetTLFCryptKeyForMDDecryption(ctx context.Context, kmdToDecrypt KeyMetadata, kmdWithKeys KeyMetadata) (TLFCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForMDDecryption", ctx, kmdToDecrypt, kmdWithKeys)
 	ret0, _ := ret[0].(TLFCryptKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -975,8 +1050,8 @@ func (_mr *_MockKeyManagerRecorder) GetTLFCryptKeyForMDDecryption(arg0, arg1, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyForMDDecryption", arg0, arg1, arg2)
 }
 
-func (_m *MockKeyManager) GetTLFCryptKeyForBlockDecryption(ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer) (TLFCryptKey, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForBlockDecryption", ctx, md, blockPtr)
+func (_m *MockKeyManager) GetTLFCryptKeyForBlockDecryption(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer) (TLFCryptKey, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyForBlockDecryption", ctx, kmd, blockPtr)
 	ret0, _ := ret[0].(TLFCryptKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -1661,6 +1736,17 @@ func (_m *MockcryptoSigner) Sign(ctx context.Context, msg []byte) (SignatureInfo
 
 func (_mr *_MockcryptoSignerRecorder) Sign(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Sign", arg0, arg1)
+}
+
+func (_m *MockcryptoSigner) SignToString(ctx context.Context, msg []byte) (string, error) {
+	ret := _m.ctrl.Call(_m, "SignToString", ctx, msg)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoSignerRecorder) SignToString(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignToString", arg0, arg1)
 }
 
 // Mock of Crypto interface

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -931,16 +931,6 @@ func (_mr *_MockKeyMetadataRecorder) TlfID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfID")
 }
 
-func (_m *MockKeyMetadata) GetTlfHandle() *TlfHandle {
-	ret := _m.ctrl.Call(_m, "GetTlfHandle")
-	ret0, _ := ret[0].(*TlfHandle)
-	return ret0
-}
-
-func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
-}
-
 func (_m *MockKeyMetadata) LatestKeyGeneration() KeyGen {
 	ret := _m.ctrl.Call(_m, "LatestKeyGeneration")
 	ret0, _ := ret[0].(KeyGen)
@@ -949,6 +939,16 @@ func (_m *MockKeyMetadata) LatestKeyGeneration() KeyGen {
 
 func (_mr *_MockKeyMetadataRecorder) LatestKeyGeneration() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestKeyGeneration")
+}
+
+func (_m *MockKeyMetadata) GetTlfHandle() *TlfHandle {
+	ret := _m.ctrl.Call(_m, "GetTlfHandle")
+	ret0, _ := ret[0].(*TlfHandle)
+	return ret0
+}
+
+func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
 }
 
 func (_m *MockKeyMetadata) HasKeyForUser(keyGen KeyGen, user protocol.UID) bool {
@@ -961,8 +961,8 @@ func (_mr *_MockKeyMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
 }
 
-func (_m *MockKeyMetadata) GetTLFCryptKeyInfo(keyGen KeyGen, user protocol.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyInfo", keyGen, user, key)
+func (_m *MockKeyMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user protocol.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key)
 	ret0, _ := ret[0].(TLFEphemeralPublicKey)
 	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
 	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
@@ -971,8 +971,8 @@ func (_m *MockKeyMetadata) GetTLFCryptKeyInfo(keyGen KeyGen, user protocol.UID, 
 	return ret0, ret1, ret2, ret3, ret4
 }
 
-func (_mr *_MockKeyMetadataRecorder) GetTLFCryptKeyInfo(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyInfo", arg0, arg1, arg2)
+func (_mr *_MockKeyMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
 }
 
 // Mock of encryptionKeyGetter interface

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -13,7 +13,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/go-codec/codec"
-	"golang.org/x/net/context"
 )
 
 // PrivateMetadata contains the portion of metadata that's secret for private
@@ -224,27 +223,6 @@ func (md *RootMetadata) ClearBlockChanges() {
 	md.data.Changes.sizeEstimate = 0
 	md.data.Changes.Info = BlockInfo{}
 	md.data.Changes.Ops = nil
-}
-
-// Helper which returns nil if the md block is uninitialized or readable by
-// the current user. Otherwise an appropriate read access error is returned.
-func (md *RootMetadata) isReadableOrError(ctx context.Context, config Config) error {
-	if !md.IsInitialized() || md.IsReadable() {
-		return nil
-	}
-	// this should only be the case if we're a new device not yet
-	// added to the set of reader/writer keys.
-	username, uid, err := config.KBPKI().GetCurrentUserInfo(ctx)
-	if err != nil {
-		return err
-	}
-	h := md.GetTlfHandle()
-	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI())
-	if err != nil {
-		return err
-	}
-	return md.makeRekeyReadError(resolvedHandle, md.LatestKeyGeneration(),
-		uid, username)
 }
 
 // hasKeyForUser returns whether or not the given user has keys for at

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -140,7 +140,7 @@ func (md *RootMetadata) MakeSuccessor(
 }
 
 // AddNewKeys makes a new key generation for this RootMetadata using the
-// given TLFKeyBundles.
+// given TLF key bundles.
 func (md *RootMetadata) AddNewKeys(
 	wkb TLFWriterKeyBundle, rkb TLFReaderKeyBundle) error {
 	if md.ID.IsPublic() {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -63,6 +63,7 @@ type RootMetadata struct {
 
 var _ KeyMetadata = (*RootMetadata)(nil)
 
+// TlfID returns the ID of the TLF this RootMetadata is for.
 func (md *RootMetadata) TlfID() TlfID {
 	return md.ID
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -63,11 +63,6 @@ type RootMetadata struct {
 
 var _ KeyMetadata = (*RootMetadata)(nil)
 
-// TlfID returns the ID of the TLF this RootMetadata is for.
-func (md *RootMetadata) TlfID() TlfID {
-	return md.ID
-}
-
 // Data returns the private metadata of this RootMetadata.
 func (md *RootMetadata) Data() *PrivateMetadata {
 	return &md.data
@@ -229,19 +224,6 @@ func (md *RootMetadata) ClearBlockChanges() {
 	md.data.Changes.sizeEstimate = 0
 	md.data.Changes.Info = BlockInfo{}
 	md.data.Changes.Ops = nil
-}
-
-// HasKeyForUser returns whether or not the given user has keys for at
-// least one device at the given key generation. Returns false if the
-// TLF is public, or if the given key generation is invalid.
-func (md *RootMetadata) HasKeyForUser(
-	keyGen KeyGen, user keybase1.UID) bool {
-	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
-	if err != nil {
-		return false
-	}
-
-	return (len(wkb.WKeys[user]) > 0) || (len(rkb.RKeys[user]) > 0)
 }
 
 // updateFromTlfHandle updates the current RootMetadata's fields to

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -61,6 +61,12 @@ type RootMetadata struct {
 	tlfHandle *TlfHandle
 }
 
+var _ KeyMetadata = (*RootMetadata)(nil)
+
+func (md *RootMetadata) TlfID() TlfID {
+	return md.ID
+}
+
 // Data returns the private metadata of this RootMetadata.
 func (md *RootMetadata) Data() *PrivateMetadata {
 	return &md.data
@@ -224,10 +230,10 @@ func (md *RootMetadata) ClearBlockChanges() {
 	md.data.Changes.Ops = nil
 }
 
-// hasKeyForUser returns whether or not the given user has keys for at
+// HasKeyForUser returns whether or not the given user has keys for at
 // least one device at the given key generation. Returns false if the
 // TLF is public, or if the given key generation is invalid.
-func (md *RootMetadata) hasKeyForUser(
+func (md *RootMetadata) HasKeyForUser(
 	keyGen KeyGen, user keybase1.UID) bool {
 	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
 	if err != nil {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol"
 	"github.com/keybase/go-codec/codec"
 )
@@ -236,26 +235,6 @@ func (md *RootMetadata) hasKeyForUser(
 	}
 
 	return (len(wkb.WKeys[user]) > 0) || (len(rkb.RKeys[user]) > 0)
-}
-
-func (md *RootMetadata) makeRekeyReadError(
-	resolvedHandle *TlfHandle, keyGen KeyGen,
-	uid keybase1.UID, username libkb.NormalizedUsername) error {
-	if resolvedHandle.IsPublic() {
-		panic("makeRekeyReadError called on public folder")
-	}
-	// If the user is not a legitimate reader of the folder, this is a
-	// normal read access error.
-	if !resolvedHandle.IsReader(uid) {
-		return NewReadAccessError(resolvedHandle, username)
-	}
-
-	// Otherwise, this folder needs to be rekeyed for this device.
-	tlfName := resolvedHandle.GetCanonicalName()
-	if hasKeys := md.hasKeyForUser(keyGen, uid); hasKeys {
-		return NeedSelfRekeyError{tlfName}
-	}
-	return NeedOtherRekeyError{tlfName}
 }
 
 // updateFromTlfHandle updates the current RootMetadata's fields to

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -579,13 +579,13 @@ func TestMakeRekeyReadError(t *testing.T) {
 	u, uid, err := config.KBPKI().Resolve(context.Background(), "bob")
 	require.NoError(t, err)
 
-	err = rmd.makeRekeyReadError(h, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
 	require.Equal(t, NewReadAccessError(h, u), err)
 
-	err = rmd.makeRekeyReadError(h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
+	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedSelfRekeyError{"alice"}, err)
 
-	err = rmd.makeRekeyReadError(h, FirstValidKeyGen+1, h.FirstResolvedWriter(), "alice")
+	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen+1, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedOtherRekeyError{"alice"}, err)
 }
 
@@ -604,7 +604,7 @@ func TestMakeRekeyReadErrorResolvedHandle(t *testing.T) {
 	u, uid, err := config.KBPKI().Resolve(ctx, "bob")
 	require.NoError(t, err)
 
-	err = rmd.makeRekeyReadError(h, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
 	require.Equal(t, NewReadAccessError(h, u), err)
 
 	config.KeybaseDaemon().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
@@ -613,7 +613,7 @@ func TestMakeRekeyReadErrorResolvedHandle(t *testing.T) {
 	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI())
 	require.NoError(t, err)
 
-	err = rmd.makeRekeyReadError(resolvedHandle, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadError(rmd.ReadOnly(), resolvedHandle, FirstValidKeyGen, uid, u)
 	require.Equal(t, NeedOtherRekeyError{"alice,bob"}, err)
 }
 

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -579,13 +579,13 @@ func TestMakeRekeyReadError(t *testing.T) {
 	u, uid, err := config.KBPKI().Resolve(context.Background(), "bob")
 	require.NoError(t, err)
 
-	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
 	require.Equal(t, NewReadAccessError(h, u), err)
 
-	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
+	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedSelfRekeyError{"alice"}, err)
 
-	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen+1, h.FirstResolvedWriter(), "alice")
+	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen+1, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedOtherRekeyError{"alice"}, err)
 }
 
@@ -604,7 +604,7 @@ func TestMakeRekeyReadErrorResolvedHandle(t *testing.T) {
 	u, uid, err := config.KBPKI().Resolve(ctx, "bob")
 	require.NoError(t, err)
 
-	err = makeRekeyReadError(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
 	require.Equal(t, NewReadAccessError(h, u), err)
 
 	config.KeybaseDaemon().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
@@ -613,7 +613,7 @@ func TestMakeRekeyReadErrorResolvedHandle(t *testing.T) {
 	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI())
 	require.NoError(t, err)
 
-	err = makeRekeyReadError(rmd.ReadOnly(), resolvedHandle, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), resolvedHandle, FirstValidKeyGen, uid, u)
 	require.Equal(t, NeedOtherRekeyError{"alice,bob"}, err)
 }
 

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -359,22 +359,22 @@ func (f *stallingBlockOps) Put(
 }
 
 func (f *stallingBlockOps) Delete(
-	ctx context.Context, kmd KeyMetadata,
+	ctx context.Context, tlfID TlfID,
 	ptrs []BlockPointer) (notDeleted map[BlockID]int, err error) {
 	f.maybeStall(ctx, StallableBlockDelete)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
 		var errDelete error
-		notDeleted, errDelete = f.delegate.Delete(ctx, kmd, ptrs)
+		notDeleted, errDelete = f.delegate.Delete(ctx, tlfID, ptrs)
 		return errDelete
 	})
 	return notDeleted, err
 }
 
 func (f *stallingBlockOps) Archive(
-	ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) error {
+	ctx context.Context, tlfID TlfID, ptrs []BlockPointer) error {
 	f.maybeStall(ctx, StallableBlockArchive)
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return f.delegate.Archive(ctx, kmd, ptrs)
+		return f.delegate.Archive(ctx, tlfID, ptrs)
 	})
 }
 

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -350,11 +350,11 @@ func (f *stallingBlockOps) Ready(
 }
 
 func (f *stallingBlockOps) Put(
-	ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
+	ctx context.Context, tlfID TlfID, blockPtr BlockPointer,
 	readyBlockData ReadyBlockData) error {
 	f.maybeStall(ctx, StallableBlockPut)
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return f.delegate.Put(ctx, kmd, blockPtr, readyBlockData)
+		return f.delegate.Put(ctx, tlfID, blockPtr, readyBlockData)
 	})
 }
 

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -329,52 +329,52 @@ func (f *stallingBlockOps) maybeStall(ctx context.Context, opName StallableBlock
 }
 
 func (f *stallingBlockOps) Get(
-	ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer,
+	ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
 	block Block) error {
 	f.maybeStall(ctx, StallableBlockGet)
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return f.delegate.Get(ctx, md, blockPtr, block)
+		return f.delegate.Get(ctx, kmd, blockPtr, block)
 	})
 }
 
 func (f *stallingBlockOps) Ready(
-	ctx context.Context, md ReadOnlyRootMetadata, block Block) (
+	ctx context.Context, kmd KeyMetadata, block Block) (
 	id BlockID, plainSize int, readyBlockData ReadyBlockData, err error) {
 	f.maybeStall(ctx, StallableBlockReady)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
 		var errReady error
-		id, plainSize, readyBlockData, errReady = f.delegate.Ready(ctx, md, block)
+		id, plainSize, readyBlockData, errReady = f.delegate.Ready(ctx, kmd, block)
 		return errReady
 	})
 	return id, plainSize, readyBlockData, err
 }
 
 func (f *stallingBlockOps) Put(
-	ctx context.Context, md ReadOnlyRootMetadata, blockPtr BlockPointer,
+	ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
 	readyBlockData ReadyBlockData) error {
 	f.maybeStall(ctx, StallableBlockPut)
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return f.delegate.Put(ctx, md, blockPtr, readyBlockData)
+		return f.delegate.Put(ctx, kmd, blockPtr, readyBlockData)
 	})
 }
 
 func (f *stallingBlockOps) Delete(
-	ctx context.Context, md ReadOnlyRootMetadata,
+	ctx context.Context, kmd KeyMetadata,
 	ptrs []BlockPointer) (notDeleted map[BlockID]int, err error) {
 	f.maybeStall(ctx, StallableBlockDelete)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
 		var errDelete error
-		notDeleted, errDelete = f.delegate.Delete(ctx, md, ptrs)
+		notDeleted, errDelete = f.delegate.Delete(ctx, kmd, ptrs)
 		return errDelete
 	})
 	return notDeleted, err
 }
 
 func (f *stallingBlockOps) Archive(
-	ctx context.Context, md ReadOnlyRootMetadata, ptrs []BlockPointer) error {
+	ctx context.Context, kmd KeyMetadata, ptrs []BlockPointer) error {
 	f.maybeStall(ctx, StallableBlockArchive)
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return f.delegate.Archive(ctx, md, ptrs)
+		return f.delegate.Archive(ctx, kmd, ptrs)
 	})
 }
 


### PR DESCRIPTION
This replaces a good chunk of the ReadOnlyRootMetadata
parameters. This is safer, since you can't accidentally
write through the KeyMetadata interface.

Fix one place where we were accidentally writing through
a ReadOnlyRootMetadata object.

Also move the quota error check from BlockOps into
FolderBranchOps.