### PR TITLE
root_metadata: track the local timestamp of every immutable MD

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/libkb"
@@ -66,7 +67,7 @@ func TestCRInput(t *testing.T) {
 			Revision: unmergedHead,
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, fakeMdID(1))
+	}, fakeMdID(1), time.Time{})
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -81,7 +82,7 @@ func TestCRInput(t *testing.T) {
 					Revision: i,
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i))), nil)
+			}, fakeMdID(byte(i)), time.Time{}), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
@@ -100,7 +101,7 @@ func TestCRInput(t *testing.T) {
 					Revision: i,
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i))), nil)
+			}, fakeMdID(byte(i)), time.Time{}), nil)
 	}
 	for i := mergedHead + 1; i <= branchPoint+2*maxMDsAtATime; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
@@ -150,7 +151,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 			Revision: unmergedHead,
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, fakeMdID(1))
+	}, fakeMdID(1), time.Time{})
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -165,7 +166,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 					},
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i))), nil)
+			}, fakeMdID(byte(i)), time.Time{}), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
@@ -189,7 +190,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 						Revision: i,
 					},
 					tlfHandle: &TlfHandle{name: "fake"},
-				}, fakeMdID(byte(i))), nil)
+				}, fakeMdID(byte(i)), time.Time{}), nil)
 		} else {
 			config.mockMdcache.EXPECT().Get(cr.fbo.id(), i,
 				NullBranchID).Return(
@@ -206,7 +207,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 				Revision: skipCacheRevision,
 			},
 			tlfHandle: &TlfHandle{name: "fake"},
-		}, fakeMdID(byte(skipCacheRevision)))}, nil)
+		}, fakeMdID(byte(skipCacheRevision)), time.Time{})}, nil)
 	for i := mergedHead + 1; i <= branchPoint+2*maxMDsAtATime; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
 			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), i, NullBranchID})

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -67,7 +67,7 @@ func TestCRInput(t *testing.T) {
 			Revision: unmergedHead,
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, fakeMdID(1), time.Time{})
+	}, fakeMdID(1), time.Now())
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -82,7 +82,7 @@ func TestCRInput(t *testing.T) {
 					Revision: i,
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i)), time.Time{}), nil)
+			}, fakeMdID(byte(i)), time.Now()), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
@@ -101,7 +101,7 @@ func TestCRInput(t *testing.T) {
 					Revision: i,
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i)), time.Time{}), nil)
+			}, fakeMdID(byte(i)), time.Now()), nil)
 	}
 	for i := mergedHead + 1; i <= branchPoint+2*maxMDsAtATime; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
@@ -151,7 +151,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 			Revision: unmergedHead,
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, fakeMdID(1), time.Time{})
+	}, fakeMdID(1), time.Now())
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -166,7 +166,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 					},
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i)), time.Time{}), nil)
+			}, fakeMdID(byte(i)), time.Now()), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
@@ -190,7 +190,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 						Revision: i,
 					},
 					tlfHandle: &TlfHandle{name: "fake"},
-				}, fakeMdID(byte(i)), time.Time{}), nil)
+				}, fakeMdID(byte(i)), time.Now()), nil)
 		} else {
 			config.mockMdcache.EXPECT().Get(cr.fbo.id(), i,
 				NullBranchID).Return(
@@ -207,7 +207,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 				Revision: skipCacheRevision,
 			},
 			tlfHandle: &TlfHandle{name: "fake"},
-		}, fakeMdID(byte(skipCacheRevision)), time.Time{})}, nil)
+		}, fakeMdID(byte(skipCacheRevision)), time.Now())}, nil)
 	for i := mergedHead + 1; i <= branchPoint+2*maxMDsAtATime; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
 			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), i, NullBranchID})

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1025,7 +1025,8 @@ func (fbo *folderBranchOps) initMDLocked(
 			"%v: Unexpected MD ID during new MD initialization: %v",
 			md.ID, fbo.head.mdID)
 	}
-	fbo.setNewInitialHeadLocked(ctx, lState, MakeImmutableRootMetadata(md, mdID))
+	fbo.setNewInitialHeadLocked(ctx, lState,
+		MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now()))
 	if err != nil {
 		return err
 	}
@@ -1966,7 +1967,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	irmd := MakeImmutableRootMetadata(md, mdID)
+	irmd := MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now())
 	err = fbo.setHeadSuccessorLocked(ctx, lState, irmd, rebased)
 	if err != nil {
 		return err
@@ -2013,7 +2014,8 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	return fbo.setHeadSuccessorLocked(ctx, lState, MakeImmutableRootMetadata(md, mdID), rebased)
+	return fbo.setHeadSuccessorLocked(ctx, lState,
+		MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now()), rebased)
 }
 
 func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *gcOp) (
@@ -2088,7 +2090,7 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *gcOp) (
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	irmd := MakeImmutableRootMetadata(md, mdID)
+	irmd := MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now())
 	err = fbo.setHeadSuccessorLocked(ctx, lState, irmd, rebased)
 	if err != nil {
 		return err
@@ -4378,7 +4380,7 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	// Set the head to the new MD.
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	irmd := MakeImmutableRootMetadata(md, mdID)
+	irmd := MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now())
 	err = fbo.setHeadConflictResolvedLocked(ctx, lState, irmd)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't set local MD head after a "+

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -117,7 +117,7 @@ func TestFBStatusAllFields(t *testing.T) {
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
 	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, fakeMdID(1),
-		time.Time{}))
+		time.Now()))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"golang.org/x/net/context"
@@ -115,7 +116,8 @@ func TestFBStatusAllFields(t *testing.T) {
 	p2 := path{path: []pathNode{{Name: "a2"}, {Name: "b2"}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
-	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, fakeMdID(1)))
+	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, fakeMdID(1),
+		time.Time{}))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -117,7 +117,8 @@ func (j journalMDOps) getHeadFromJournal(
 		return ImmutableRootMetadata{}, err
 	}
 
-	return MakeImmutableRootMetadata(&rmd, head.mdID), nil
+	return MakeImmutableRootMetadata(&rmd, head.mdID,
+		head.localTimestamp), nil
 }
 
 func (j journalMDOps) getRangeFromJournal(
@@ -182,7 +183,8 @@ func (j journalMDOps) getRangeFromJournal(
 			return nil, err
 		}
 
-		irmd := MakeImmutableRootMetadata(&rmd, ibrmd.mdID)
+		irmd := MakeImmutableRootMetadata(&rmd, ibrmd.mdID,
+			ibrmd.localTimestamp)
 		irmds = append(irmds, irmd)
 	}
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -247,7 +247,7 @@ func injectNewRMD(t *testing.T, config *ConfigMock) (
 
 	ops := getOps(config, id)
 	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(fakeTlfIDByte(id)),
-		time.Time{})
+		time.Now())
 	rmd.SerializedPrivateMetadata = make([]byte, 1)
 	config.Notifier().RegisterForChanges(
 		[]FolderBranch{{id, MasterBranch}}, config.observer)
@@ -433,7 +433,7 @@ func testKBFSOpsGetRootNodeCreateNewSuccess(t *testing.T, public bool) {
 	// create a new MD
 	config.mockMdops.EXPECT().GetUnmergedForTLF(
 		gomock.Any(), id, gomock.Any()).Return(ImmutableRootMetadata{}, nil)
-	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 	config.mockMdops.EXPECT().GetForTLF(gomock.Any(), id).Return(irmd, nil)
 	config.mockMdcache.EXPECT().Put(irmd).Return(nil)
 
@@ -482,11 +482,11 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, Unmerged).Return(
 		TlfID{}, ImmutableRootMetadata{}, nil)
 	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, Merged).Return(
-		TlfID{}, MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{}), nil)
+		TlfID{}, MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now()), nil)
 	ops := getOps(config, id)
 	assert.False(t, fboIdentityDone(ops))
 
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(2), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(2), time.Now())
 	n, ei, err :=
 		config.KBFSOps().GetOrCreateRootNode(ctx, h, MasterBranch)
 	require.NoError(t, err)
@@ -659,7 +659,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	// won't even try getting the block if the user isn't a reader
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 	expectedErr := ReadAccessError{"alice", h.GetCanonicalName(), false}
 	if _, err := config.KBFSOps().GetDirChildren(ctx, n); err == nil {
 		t.Errorf("Got no expected error on getdir")
@@ -700,7 +700,7 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 
@@ -740,7 +740,7 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 
@@ -783,7 +783,7 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -821,7 +821,7 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -856,7 +856,7 @@ func TestKBFSOpsLookupNewDataVersionFail(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -897,7 +897,7 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -5013,7 +5013,7 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -5033,7 +5033,7 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -78,6 +78,8 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	c := make(chan error, 1)
 	config.mockMdserv.EXPECT().RegisterForUpdate(gomock.Any(),
 		gomock.Any(), gomock.Any()).AnyTimes().Return(c, nil)
+	config.mockMdserv.EXPECT().OffsetFromServerTime().
+		Return(time.Duration(0), true).AnyTimes()
 
 	// None of these tests depend on time
 	config.mockClock.EXPECT().Now().AnyTimes().Return(time.Now())
@@ -244,7 +246,8 @@ func injectNewRMD(t *testing.T, config *ConfigMock) (
 	FakeInitialRekey(&rmd.BareRootMetadata, h.ToBareHandleOrBust())
 
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(fakeTlfIDByte(id)))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(fakeTlfIDByte(id)),
+		time.Time{})
 	rmd.SerializedPrivateMetadata = make([]byte, 1)
 	config.Notifier().RegisterForChanges(
 		[]FolderBranch{{id, MasterBranch}}, config.observer)
@@ -430,7 +433,7 @@ func testKBFSOpsGetRootNodeCreateNewSuccess(t *testing.T, public bool) {
 	// create a new MD
 	config.mockMdops.EXPECT().GetUnmergedForTLF(
 		gomock.Any(), id, gomock.Any()).Return(ImmutableRootMetadata{}, nil)
-	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 	config.mockMdops.EXPECT().GetForTLF(gomock.Any(), id).Return(irmd, nil)
 	config.mockMdcache.EXPECT().Put(irmd).Return(nil)
 
@@ -479,11 +482,11 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, Unmerged).Return(
 		TlfID{}, ImmutableRootMetadata{}, nil)
 	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, Merged).Return(
-		TlfID{}, MakeImmutableRootMetadata(rmd, fakeMdID(1)), nil)
+		TlfID{}, MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{}), nil)
 	ops := getOps(config, id)
 	assert.False(t, fboIdentityDone(ops))
 
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(2))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(2), time.Time{})
 	n, ei, err :=
 		config.KBFSOps().GetOrCreateRootNode(ctx, h, MasterBranch)
 	require.NoError(t, err)
@@ -656,7 +659,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	// won't even try getting the block if the user isn't a reader
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 	expectedErr := ReadAccessError{"alice", h.GetCanonicalName(), false}
 	if _, err := config.KBFSOps().GetDirChildren(ctx, n); err == nil {
 		t.Errorf("Got no expected error on getdir")
@@ -697,7 +700,7 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 
@@ -737,7 +740,7 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 
@@ -780,7 +783,7 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -818,7 +821,7 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -853,7 +856,7 @@ func TestKBFSOpsLookupNewDataVersionFail(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -894,7 +897,7 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -5010,7 +5013,7 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)
@@ -5030,7 +5033,7 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 	ops := getOps(config, id)
-	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 
 	u := h.FirstResolvedWriter()
 	rootID := fakeBlockID(42)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -197,7 +197,12 @@ func (md *MDOpsStandard) processMetadata(
 		return ImmutableRootMetadata{}, err
 	}
 
-	return MakeImmutableRootMetadata(&rmd, mdID), nil
+	localTimestamp := rmds.untrustedServerTimestamp
+	if offset, ok := md.config.MDServer().OffsetFromServerTime(); ok {
+		localTimestamp = localTimestamp.Add(offset)
+	}
+
+	return MakeImmutableRootMetadata(&rmd, mdID, localTimestamp), nil
 }
 
 // GetForHandle implements the MDOps interface for MDOpsStandard.

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -90,6 +90,7 @@ func addFakeRMDSData(rmds *RootMetadataSigned, h *TlfHandle) {
 		Signature:    []byte{42},
 		VerifyingKey: MakeFakeVerifyingKeyOrBust("fake key"),
 	}
+	rmds.untrustedServerTimestamp = time.Now()
 
 	if !h.IsPublic() {
 		FakeInitialRekey(&rmds.MD, h.ToBareHandleOrBust())

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/libkb"
@@ -39,6 +40,8 @@ func mdOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config = NewConfigMock(mockCtrl, ctr)
 	mdops := NewMDOpsStandard(config)
 	config.SetMDOps(mdops)
+	config.mockMdserv.EXPECT().OffsetFromServerTime().
+		Return(time.Duration(0), true).AnyTimes()
 	injectShimCrypto(config)
 	interposeDaemonKBPKI(config, "alice", "bob", "charlie")
 	ctx = context.Background()

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -211,7 +211,8 @@ func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 				return nil, err
 			}
 			// Overwrite the cached copy with the new copy
-			irmdCopy := MakeImmutableRootMetadata(rmdCopy, rmd.mdID)
+			irmdCopy := MakeImmutableRootMetadata(rmdCopy, rmd.mdID,
+				rmd.localTimestamp)
 			if err := config.MDCache().Put(irmdCopy); err != nil {
 				return nil, err
 			}

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	keybase1 "github.com/keybase/client/go/protocol"
@@ -46,7 +47,7 @@ func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	}
 
 	// put the md
-	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1))
+	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
 	if err := config.MDCache().Put(irmd); err != nil {
 		t.Errorf("Got error on put on md %v: %v", tlf, err)
 	}

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -47,7 +47,7 @@ func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	}
 
 	// put the md
-	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Time{})
+	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 	if err := config.MDCache().Put(irmd); err != nil {
 		t.Errorf("Got error on put on md %v: %v", tlf, err)
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -228,6 +228,7 @@ func (md *MDServerMemory) getHeadForTLF(ctx context.Context, id TlfID,
 	if err != nil {
 		return nil, err
 	}
+	rmds.untrustedServerTimestamp = blocks[len(blocks)-1].timestamp
 	return &rmds, nil
 }
 
@@ -305,6 +306,7 @@ func (md *MDServerMemory) GetRange(ctx context.Context, id TlfID,
 		if err != nil {
 			return nil, MDServerError{err}
 		}
+		rmds.untrustedServerTimestamp = blocks[i].timestamp
 		expectedRevision := blockList.initialRevision + MetadataRevision(i)
 		if expectedRevision != rmds.MD.Revision {
 			panic(fmt.Errorf("expected revision %v, got %v",

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -316,17 +316,19 @@ func (md *RootMetadata) ReadOnly() ReadOnlyRootMetadata {
 // can be assumed to never alias a (modifiable) *RootMetadata.
 type ImmutableRootMetadata struct {
 	ReadOnlyRootMetadata
-	mdID MdID
+	mdID           MdID
+	localTimestamp time.Time
 }
 
 // MakeImmutableRootMetadata makes a new ImmutableRootMetadata from
 // the given RMD and its corresponding MdID.
 func MakeImmutableRootMetadata(
-	rmd *RootMetadata, mdID MdID) ImmutableRootMetadata {
+	rmd *RootMetadata, mdID MdID,
+	localTimestamp time.Time) ImmutableRootMetadata {
 	if mdID == (MdID{}) {
 		panic("zero mdID passed to MakeImmutableRootMetadata")
 	}
-	return ImmutableRootMetadata{rmd.ReadOnly(), mdID}
+	return ImmutableRootMetadata{rmd.ReadOnly(), mdID, localTimestamp}
 }
 
 // RootMetadataSigned is the top-level MD object stored in MD server

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -316,7 +316,16 @@ func (md *RootMetadata) ReadOnly() ReadOnlyRootMetadata {
 // can be assumed to never alias a (modifiable) *RootMetadata.
 type ImmutableRootMetadata struct {
 	ReadOnlyRootMetadata
-	mdID           MdID
+	mdID MdID
+	// localTimestamp represents the time at which the MD update was
+	// applied at the server, adjusted for the local clock.  So for
+	// example, it can be used to show how long ago a particular
+	// update happened (e.g., "5 hours ago").  Note that the update
+	// time supplied by the server is technically untrusted (i.e., not
+	// signed by a writer of the TLF, only provided by the server).
+	// If this ImmutableRootMetadata was generated locally and still
+	// persists in the journal or in the cache, localTimestamp comes
+	// directly from the local clock.
 	localTimestamp time.Time
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -337,6 +337,9 @@ func MakeImmutableRootMetadata(
 	if mdID == (MdID{}) {
 		panic("zero mdID passed to MakeImmutableRootMetadata")
 	}
+	if localTimestamp == (time.Time{}) {
+		panic("zero localTimestamp passed to MakeImmutableRootMetadata")
+	}
 	return ImmutableRootMetadata{rmd.ReadOnly(), mdID, localTimestamp}
 }
 


### PR DESCRIPTION
We'll need this to determine how old a given change is, first for the
TLF edit history.  It should also be useful for quota reclamation.

Issue: KBFS-1301