### PR TITLE
Mobile needs a few methods from KeybaseDaemonRPC to be made available

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -891,3 +891,55 @@ const (
 	// WriteMode indicates that an error happened while trying to write.
 	WriteMode
 )
+
+// UserInfoFromProtocol returns UserInfo from UserPlusKeys
+func UserInfoFromProtocol(upk keybase1.UserPlusKeys) (UserInfo, error) {
+	verifyingKeys, cryptPublicKeys, kidNames, err := filterKeys(upk.DeviceKeys)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	revokedVerifyingKeys, revokedCryptPublicKeys, revokedKidNames, err :=
+		filterRevokedKeys(upk.RevokedDeviceKeys)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	if len(revokedKidNames) > 0 {
+		for k, v := range revokedKidNames {
+			kidNames[k] = v
+		}
+	}
+
+	return UserInfo{
+		Name:                   libkb.NewNormalizedUsername(upk.Username),
+		UID:                    upk.Uid,
+		VerifyingKeys:          verifyingKeys,
+		CryptPublicKeys:        cryptPublicKeys,
+		KIDNames:               kidNames,
+		RevokedVerifyingKeys:   revokedVerifyingKeys,
+		RevokedCryptPublicKeys: revokedCryptPublicKeys,
+	}, nil
+}
+
+// SessionInfoFromProtocol returns SessionInfo from Session
+func SessionInfoFromProtocol(session keybase1.Session) (SessionInfo, error) {
+	// Import the KIDs to validate them.
+	deviceSubkey, err := libkb.ImportKeypairFromKID(session.DeviceSubkeyKid)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	deviceSibkey, err := libkb.ImportKeypairFromKID(session.DeviceSibkeyKid)
+	if err != nil {
+		return SessionInfo{}, err
+	}
+	cryptPublicKey := MakeCryptPublicKey(deviceSubkey.GetKID())
+	verifyingKey := MakeVerifyingKey(deviceSibkey.GetKID())
+	return SessionInfo{
+		Name:           libkb.NewNormalizedUsername(session.Username),
+		UID:            keybase1.UID(session.Uid),
+		Token:          session.Token,
+		CryptPublicKey: cryptPublicKey,
+		VerifyingKey:   verifyingKey,
+	}, nil
+}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -899,16 +899,13 @@ func UserInfoFromProtocol(upk keybase1.UserPlusKeys) (UserInfo, error) {
 		return UserInfo{}, err
 	}
 
-	revokedVerifyingKeys, revokedCryptPublicKeys, revokedKidNames, err :=
-		filterRevokedKeys(upk.RevokedDeviceKeys)
+	revokedVerifyingKeys, revokedCryptPublicKeys, revokedKidNames, err := filterRevokedKeys(upk.RevokedDeviceKeys)
 	if err != nil {
 		return UserInfo{}, err
 	}
 
-	if len(revokedKidNames) > 0 {
-		for k, v := range revokedKidNames {
-			kidNames[k] = v
-		}
+	for k, v := range revokedKidNames {
+		kidNames[k] = v
 	}
 
 	return UserInfo{


### PR DESCRIPTION
- `SessionInfoFromProtocol` method to convert protocol `Session` to `libkbfs.SessionInfo` (put in `data_types.go`)
- `UserInfoFromProtocol` method to convert protocol `UserPlusKeys` to `libkbfs.UserInfo` (put in `data_types.go`)
- Make ConvertIdentifyError public