### PR TITLE
cr_chains: take ImmutableRootMetadatas when making chains

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2533,7 +2533,11 @@ func (cr *ConflictResolver) makePostResolutionPaths(ctx context.Context,
 	md *RootMetadata, unmergedChains *crChains, mergedChains *crChains,
 	mergedPaths map[BlockPointer]path) (map[BlockPointer]path, error) {
 	// No need to run any identifies on these chains, since we have
-	// already finished all actions.
+	// already finished all actions.  It is an ugly hack that we fake
+	// out the metadata ID here, but we can't calculate the true ID
+	// yet since the private metadata isn't yet set.  newCRChains
+	// doesn't use it; it only inspects the MD itself and the
+	// timestamp.
 	resolvedChains, err := newCRChains(ctx, cr.config,
 		[]ImmutableRootMetadata{MakeImmutableRootMetadata(md, fakeMdID(1),
 			cr.config.Clock().Now())},

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -637,13 +637,14 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 			ccs.blockChangePointers[ptr] = true
 		}
 
-		// Copy the rmd since CR will change the ops.
-		rmdCopy, err := rmd.deepCopy(cfg.Codec(), false)
+		// Copy the ops since CR will change them.
+		ops := make(opsList, len(rmd.data.Changes.Ops))
+		err = CodecUpdate(cfg.Codec(), &ops, rmd.data.Changes.Ops)
 		if err != nil {
 			return nil, err
 		}
 
-		for _, op := range rmdCopy.data.Changes.Ops {
+		for _, op := range ops {
 			op.setWriterInfo(winfo)
 			err := ccs.makeChainForOp(op)
 			if err != nil {
@@ -654,7 +655,7 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 		if !ccs.originalRoot.IsInitialized() {
 			// Find the original pointer for the root directory
 			if rootChain, ok :=
-				ccs.byMostRecent[rmdCopy.data.Dir.BlockPointer]; ok {
+				ccs.byMostRecent[rmd.data.Dir.BlockPointer]; ok {
 				ccs.originalRoot = rootChain.original
 			}
 		}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -153,7 +153,7 @@ func (cc *crChain) isFile() bool {
 // state, but setAttr(mtime) can apply to either type; in that case,
 // we need to fetch the block to figure out the type.
 func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
-	md *RootMetadata, chains *crChains) error {
+	md ImmutableRootMetadata, chains *crChains) error {
 	if len(cc.ops) == 0 {
 		return nil
 	}
@@ -280,7 +280,7 @@ type crChains struct {
 
 	// Also keep a reference to the most recent MD that's part of this
 	// chain.
-	mostRecentMD *RootMetadata
+	mostRecentMD ImmutableRootMetadata
 
 	// We need to be able to track ANY BlockPointer, at any point in
 	// the chain, back to its original.
@@ -613,7 +613,7 @@ func newCRChainsEmpty() *crChains {
 	}
 }
 
-func newCRChains(ctx context.Context, cfg Config, rmds []*RootMetadata,
+func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 	fbo *folderBlockOps, identifyTypes bool) (
 	ccs *crChains, err error) {
 	ccs = newCRChainsEmpty()
@@ -627,7 +627,8 @@ func newCRChains(ctx context.Context, cfg Config, rmds []*RootMetadata,
 			continue
 		}
 
-		winfo, err := newWriterInfo(ctx, cfg, rmd.LastModifyingWriter, rmd.writerKID())
+		winfo, err := newWriterInfo(ctx, cfg, rmd.LastModifyingWriter,
+			rmd.writerKID())
 		if err != nil {
 			return nil, err
 		}
@@ -636,7 +637,13 @@ func newCRChains(ctx context.Context, cfg Config, rmds []*RootMetadata,
 			ccs.blockChangePointers[ptr] = true
 		}
 
-		for _, op := range rmd.data.Changes.Ops {
+		// Copy the rmd since CR will change the ops.
+		rmdCopy, err := rmd.deepCopy(cfg.Codec(), false)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, op := range rmdCopy.data.Changes.Ops {
 			op.setWriterInfo(winfo)
 			err := ccs.makeChainForOp(op)
 			if err != nil {
@@ -647,7 +654,7 @@ func newCRChains(ctx context.Context, cfg Config, rmds []*RootMetadata,
 		if !ccs.originalRoot.IsInitialized() {
 			// Find the original pointer for the root directory
 			if rootChain, ok :=
-				ccs.byMostRecent[rmd.data.Dir.BlockPointer]; ok {
+				ccs.byMostRecent[rmdCopy.data.Dir.BlockPointer]; ok {
 				ccs.originalRoot = rootChain.original
 			}
 		}


### PR DESCRIPTION
A future PR will need to access the local timestamp of the
RootMetadata, which will only be available in the
ImmutableRootMetadata (see #204).  It would be nicer if it was a
ReadOnlyRootMetadata, since in one place we pass a non-final MD into
newCRChains, but the timestamp will only be available in
ImmutableRootMetadata, so in that place we have to fake out the MD ID.

Issue: KBFS-1301