### PR TITLE
tlf_edit_history: find the last 20 file creates/edits for each writer of a TLF

### DIFF
--- a/libkbfs/conflict_renamer.go
+++ b/libkbfs/conflict_renamer.go
@@ -65,5 +65,10 @@ func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID, kid keybas
 		return writerInfo{}, err
 	}
 
-	return writerInfo{name: ui.Name, kid: kid, deviceName: ui.KIDNames[kid]}, nil
+	return writerInfo{
+		name:       ui.Name,
+		uid:        uid,
+		kid:        kid,
+		deviceName: ui.KIDNames[kid],
+	}, nil
 }

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -341,67 +341,6 @@ func (sp crSortedPaths) Swap(i, j int) {
 	sp[j], sp[i] = sp[i], sp[j]
 }
 
-// getPathsFromChains returns a sorted slice of most recent paths to
-// all the nodes in the given CR chains that were directly modified
-// during a branch, and which existed at both the start and the end of
-// the branch.  This represents the paths that need to be checked for
-// conflicts.  The paths are sorted by descending path length.  It
-// uses the corresponding node cache when looking up paths, which must
-// at least contain the most recent root node of the branch.  Note
-// that if a path cannot be found, the corresponding chain is
-// completely removed from the set of CR chains.
-func (cr *ConflictResolver) getPathsFromChains(ctx context.Context,
-	chains *crChains, nodeCache NodeCache) ([]path, error) {
-	newPtrs := make(map[BlockPointer]bool)
-	var ptrs []BlockPointer
-	for ptr, chain := range chains.byMostRecent {
-		newPtrs[ptr] = true
-		// We only care about the paths for ptrs that are directly
-		// affected by operations and were live through the entire
-		// unmerged branch.
-		if len(chain.ops) > 0 && !chains.isCreated(chain.original) &&
-			!chains.isDeleted(chain.original) {
-			ptrs = append(ptrs, ptr)
-		}
-	}
-
-	nodeMap, err := cr.fbo.blocks.SearchForNodes(
-		ctx, nodeCache, ptrs, newPtrs,
-		chains.mostRecentMD.ReadOnly())
-	if err != nil {
-		return nil, err
-	}
-
-	paths := make([]path, 0, len(nodeMap))
-	for ptr, n := range nodeMap {
-		if n == nil {
-			cr.log.CDebugf(ctx, "Ignoring pointer with no found path: %v", ptr)
-			chains.removeChain(ptr)
-			continue
-		}
-
-		p := cr.fbo.nodeCache.PathFromNode(n)
-		if p.tailPointer() != ptr {
-			return nil, NodeNotFoundError{ptr}
-		}
-		paths = append(paths, p)
-
-		// update the unmerged final paths
-		chain, ok := chains.byMostRecent[ptr]
-		if !ok {
-			cr.log.CErrorf(ctx, "Couldn't find chain for found path: %v", ptr)
-			continue
-		}
-		for _, op := range chain.ops {
-			op.setFinalPath(p)
-		}
-	}
-
-	// Order by descending path length.
-	sort.Sort(crSortedPaths(paths))
-	return paths, nil
-}
-
 func fileWithConflictingWrite(unmergedChains *crChains, mergedChains *crChains,
 	unmergedOriginal BlockPointer, mergedOriginal BlockPointer) bool {
 	mergedChain := mergedChains.byOriginal[mergedOriginal]
@@ -1045,8 +984,8 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	// Get the full path for every most recent unmerged pointer with a
 	// chain of unmerged operations, and which was not created or
 	// deleted within in the unmerged branch.
-	unmergedPaths, err = cr.getPathsFromChains(ctx, unmergedChains,
-		cr.fbo.nodeCache)
+	unmergedPaths, err = unmergedChains.getPaths(ctx, &cr.fbo.blocks,
+		cr.log, cr.fbo.nodeCache, cr.fbo.nodeCache, true)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
@@ -1368,8 +1307,8 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 				newChains.byMostRecent[c.mostRecent] = newChain
 			}
 			newChains.mostRecentMD = unmergedChains.mostRecentMD
-			unmergedPaths, err := cr.getPathsFromChains(ctx, newChains,
-				cr.fbo.nodeCache)
+			unmergedPaths, err := newChains.getPaths(ctx, &cr.fbo.blocks,
+				cr.log, cr.fbo.nodeCache, cr.fbo.nodeCache, true)
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -985,7 +985,7 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	// chain of unmerged operations, and which was not created or
 	// deleted within in the unmerged branch.
 	unmergedPaths, err = unmergedChains.getPaths(ctx, &cr.fbo.blocks,
-		cr.log, cr.fbo.nodeCache, cr.fbo.nodeCache, true)
+		cr.log, cr.fbo.nodeCache, true)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
@@ -1308,7 +1308,7 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 			}
 			newChains.mostRecentMD = unmergedChains.mostRecentMD
 			unmergedPaths, err := newChains.getPaths(ctx, &cr.fbo.blocks,
-				cr.log, cr.fbo.nodeCache, cr.fbo.nodeCache, true)
+				cr.log, cr.fbo.nodeCache, true)
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -985,7 +985,7 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	// chain of unmerged operations, and which was not created or
 	// deleted within in the unmerged branch.
 	unmergedPaths, err = unmergedChains.getPaths(ctx, &cr.fbo.blocks,
-		cr.log, cr.fbo.nodeCache, true)
+		cr.log, cr.fbo.nodeCache, false)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, err
 	}
@@ -1308,7 +1308,7 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 			}
 			newChains.mostRecentMD = unmergedChains.mostRecentMD
 			unmergedPaths, err := newChains.getPaths(ctx, &cr.fbo.blocks,
-				cr.log, cr.fbo.nodeCache, true)
+				cr.log, cr.fbo.nodeCache, false)
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -811,9 +811,10 @@ func (ccs *crChains) changeOriginal(oldOriginal BlockPointer,
 // uses nodeCache when looking up paths, which must at least contain
 // the most recent root node of the branch.  Note that if a path
 // cannot be found, the corresponding chain is completely removed from
-// the set of CR chains.
+// the set of CR chains.  Set includeCreates to true if the returned
+// paths should include the paths of newly-created nodes.
 func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
-	log logger.Logger, nodeCache NodeCache, ignoreCreates bool) (
+	log logger.Logger, nodeCache NodeCache, includeCreates bool) (
 	[]path, error) {
 	newPtrs := make(map[BlockPointer]bool)
 	var ptrs []BlockPointer
@@ -821,9 +822,10 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 		newPtrs[ptr] = true
 		// We only care about the paths for ptrs that are directly
 		// affected by operations and were live through the entire
-		// unmerged branch.
+		// unmerged branch, or, if includeCreates was set, was created
+		// and not deleted in the unmerged branch.
 		if len(chain.ops) > 0 &&
-			(!ignoreCreates || !ccs.isCreated(chain.original)) &&
+			(includeCreates || !ccs.isCreated(chain.original)) &&
 			!ccs.isDeleted(chain.original) {
 			ptrs = append(ptrs, ptr)
 		}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -648,6 +648,7 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 
 		for _, op := range ops {
 			op.setWriterInfo(winfo)
+			op.setLocalTimestamp(rmd.localTimestamp)
 			err := ccs.makeChainForOp(op)
 			if err != nil {
 				return nil, err

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -808,13 +808,12 @@ func (ccs *crChains) changeOriginal(oldOriginal BlockPointer,
 // branch, and which existed at both the start and the end of the
 // branch.  This represents the paths that need to be checked for
 // conflicts.  The paths are sorted by descending path length.  It
-// uses the corresponding node cache when looking up paths, which must
-// at least contain the most recent root node of the branch.  Note
-// that if a path cannot be found, the corresponding chain is
-// completely removed from the set of CR chains.
+// uses nodeCache when looking up paths, which must at least contain
+// the most recent root node of the branch.  Note that if a path
+// cannot be found, the corresponding chain is completely removed from
+// the set of CR chains.
 func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
-	log logger.Logger, nodeCache NodeCache, localNodeCache NodeCache,
-	ignoreCreates bool) (
+	log logger.Logger, nodeCache NodeCache, ignoreCreates bool) (
 	[]path, error) {
 	newPtrs := make(map[BlockPointer]bool)
 	var ptrs []BlockPointer
@@ -844,7 +843,7 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 			continue
 		}
 
-		p := localNodeCache.PathFromNode(n)
+		p := nodeCache.PathFromNode(n)
 		if p.tailPointer() != ptr {
 			return nil, NodeNotFoundError{ptr}
 		}

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -154,7 +154,7 @@ func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
 		rmd.LastModifyingWriter = uid
 		rmd.ID = FakeTlfID(1, false)
 		immutableRmds[i] = MakeImmutableRootMetadata(rmd,
-			fakeMdID(1), time.Now())
+			fakeMdID(1), time.Unix(0, 0))
 	}
 	return config, immutableRmds
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -877,6 +877,7 @@ type TLFUpdateHistory struct {
 // writerInfo is the keybase username and device that generated the operation.
 type writerInfo struct {
 	name       libkb.NormalizedUsername
+	uid        keybase1.UID
 	kid        keybase1.KID
 	deviceName string
 }

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -15,7 +15,7 @@ import (
 )
 
 type fbmHelper interface {
-	getMDForExternalUse(ctx context.Context) (ImmutableRootMetadata, error)
+	getMDForFBM(ctx context.Context) (ImmutableRootMetadata, error)
 	finalizeGCOp(ctx context.Context, gco *gcOp) error
 }
 
@@ -876,7 +876,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	// run indefinitely.
 
 	// First get the current head, and see if we're staged or not.
-	head, err := fbm.helper.getMDForExternalUse(ctx)
+	head, err := fbm.helper.getMDForFBM(ctx)
 	if err != nil {
 		return err
 	} else if err := isReadableOrError(ctx, fbm.config, head.ReadOnly()); err != nil {

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -15,7 +15,7 @@ import (
 )
 
 type fbmHelper interface {
-	getMDForFBM(ctx context.Context) (ImmutableRootMetadata, error)
+	getMDForExternalUse(ctx context.Context) (ImmutableRootMetadata, error)
 	finalizeGCOp(ctx context.Context, gco *gcOp) error
 }
 
@@ -876,7 +876,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	// run indefinitely.
 
 	// First get the current head, and see if we're staged or not.
-	head, err := fbm.helper.getMDForFBM(ctx)
+	head, err := fbm.helper.getMDForExternalUse(ctx)
 	if err != nil {
 		return err
 	} else if err := isReadableOrError(ctx, fbm.config, head.ReadOnly()); err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4512,7 +4512,12 @@ func (fbo *folderBranchOps) GetEditHistory(ctx context.Context,
 		return nil, WrongOpsError{fbo.folderBranch, folderBranch}
 	}
 
-	return fbo.editHistory.GetComplete(ctx)
+	head, err := fbo.getMDForExternalUse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return fbo.editHistory.GetComplete(ctx, head)
 }
 
 // PushConnectionStatusChange pushes human readable connection status changes.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -841,8 +841,9 @@ func (fbo *folderBranchOps) getMDForReadHelper(
 	return md, nil
 }
 
-// getMDForFBM is a helper method for the folderBlockManager only.
-func (fbo *folderBranchOps) getMDForFBM(ctx context.Context) (
+// getMDForExternalUse is a helper method for other structs to get the
+// current head for reading.
+func (fbo *folderBranchOps) getMDForExternalUse(ctx context.Context) (
 	ImmutableRootMetadata, error) {
 	lState := makeFBOLockState()
 	return fbo.getMDForReadHelper(ctx, lState, mdReadNoIdentify)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -848,9 +848,8 @@ func (fbo *folderBranchOps) getMDForReadHelper(
 	return md, nil
 }
 
-// getMDForExternalUse is a helper method for other structs to get the
-// current head for reading.
-func (fbo *folderBranchOps) getMDForExternalUse(ctx context.Context) (
+// getMDForFBM is a helper method for the folderBlockManager only.
+func (fbo *folderBranchOps) getMDForFBM(ctx context.Context) (
 	ImmutableRootMetadata, error) {
 	lState := makeFBOLockState()
 	return fbo.getMDForReadHelper(ctx, lState, mdReadNoIdentify)
@@ -4505,14 +4504,15 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 // GetEditHistory implements the KBFSOps interface for folderBranchOps
 func (fbo *folderBranchOps) GetEditHistory(ctx context.Context,
 	folderBranch FolderBranch) (edits TlfWriterEdits, err error) {
-	fbo.log.CDebugf(ctx, "GetWriterEdits")
+	fbo.log.CDebugf(ctx, "GetEditHistory")
 	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return nil, WrongOpsError{fbo.folderBranch, folderBranch}
 	}
 
-	head, err := fbo.getMDForExternalUse(ctx)
+	lState := makeFBOLockState()
+	head, err := fbo.getMDForReadHelper(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -283,6 +283,8 @@ type folderBranchOps struct {
 	// rekey with a paper key prompt, if enough time has passed.
 	// Protected by mdWriterLock
 	rekeyWithPromptTimer *time.Timer
+
+	editHistory TlfEditHistory
 }
 
 var _ KBFSOps = (*folderBranchOps)(nil)
@@ -344,9 +346,14 @@ func newFolderBranchOps(config Config, fb FolderBranch,
 		shutdownChan:    make(chan struct{}),
 		updatePauseChan: make(chan (<-chan struct{})),
 		forceSyncChan:   forceSyncChan,
+		editHistory: TlfEditHistory{
+			config: config,
+			log:    log,
+		},
 	}
 	fbo.cr = NewConflictResolver(config, fbo)
 	fbo.fbm = newFolderBlockManager(config, fb, fbo)
+	fbo.editHistory.fbo = fbo
 	if config.DoBackgroundFlushes() {
 		go fbo.backgroundFlusher(secondsBetweenBackgroundFlushes * time.Second)
 	}
@@ -4493,6 +4500,19 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 		history.Updates = append(history.Updates, updateSummary)
 	}
 	return history, nil
+}
+
+// GetEditHistory implements the KBFSOps interface for folderBranchOps
+func (fbo *folderBranchOps) GetEditHistory(ctx context.Context,
+	folderBranch FolderBranch) (edits TlfWriterEdits, err error) {
+	fbo.log.CDebugf(ctx, "GetWriterEdits")
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+
+	if folderBranch != fbo.folderBranch {
+		return nil, WrongOpsError{fbo.folderBranch, folderBranch}
+	}
+
+	return fbo.editHistory.GetComplete(ctx)
 }
 
 // PushConnectionStatusChange pushes human readable connection status changes.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -250,6 +250,13 @@ type KBFSOps interface {
 	// outstanding writes from the local device.
 	GetUpdateHistory(ctx context.Context, folderBranch FolderBranch) (
 		history TLFUpdateHistory, err error)
+	// GetEditHistory returns a clustered list of the most recent file
+	// edits by each of the valid writers of the given folder.  users
+	// looking to get updates to this list can register as an observer
+	// for the folder.
+	GetEditHistory(ctx context.Context, folderBranch FolderBranch) (
+		edits TlfWriterEdits, err error)
+
 	// Shutdown is called to clean up any resources associated with
 	// this KBFSOps instance.
 	Shutdown() error

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -510,6 +510,13 @@ func (fs *KBFSOpsStandard) GetUpdateHistory(ctx context.Context,
 	return ops.GetUpdateHistory(ctx, folderBranch)
 }
 
+// GetEditHistory implements the KBFSOps interface for KBFSOpsStandard
+func (fs *KBFSOpsStandard) GetEditHistory(ctx context.Context,
+	folderBranch FolderBranch) (edits TlfWriterEdits, err error) {
+	ops := fs.getOps(ctx, folderBranch)
+	return ops.GetEditHistory(ctx, folderBranch)
+}
+
 // Notifier:
 var _ Notifier = (*KBFSOpsStandard)(nil)
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -471,6 +471,17 @@ func (_mr *_MockKBFSOpsRecorder) GetUpdateHistory(arg0, arg1 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUpdateHistory", arg0, arg1)
 }
 
+func (_m *MockKBFSOps) GetEditHistory(ctx context.Context, folderBranch FolderBranch) (TlfWriterEdits, error) {
+	ret := _m.ctrl.Call(_m, "GetEditHistory", ctx, folderBranch)
+	ret0, _ := ret[0].(TlfWriterEdits)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKBFSOpsRecorder) GetEditHistory(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetEditHistory", arg0, arg1)
+}
+
 func (_m *MockKBFSOps) Shutdown() error {
 	ret := _m.ctrl.Call(_m, "Shutdown")
 	ret0, _ := ret[0].(error)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/keybase/go-codec/codec"
 )
@@ -27,6 +28,8 @@ type op interface {
 	getWriterInfo() writerInfo
 	setFinalPath(p path)
 	getFinalPath() path
+	setLocalTimestamp(t time.Time)
+	getLocalTimestamp() time.Time
 	checkValid() error
 	// CheckConflict compares the function's target op with the given
 	// op, and returns a resolution if one is needed (or nil
@@ -127,6 +130,10 @@ type OpCommon struct {
 	// operation affects in a set of MD updates.  Not exported; only
 	// used during conflict resolution.
 	finalPath path
+	// localTimestamp should be set to the localTimestamp of the
+	// corresponding ImmutableRootMetadata when ops need individual
+	// timestamps.  Not exported; only used locally.
+	localTimestamp time.Time
 }
 
 // AddRefBlock adds this block to the list of newly-referenced blocks
@@ -176,6 +183,14 @@ func (oc *OpCommon) setFinalPath(p path) {
 
 func (oc *OpCommon) getFinalPath() path {
 	return oc.finalPath
+}
+
+func (oc *OpCommon) setLocalTimestamp(t time.Time) {
+	oc.localTimestamp = t
+}
+
+func (oc *OpCommon) getLocalTimestamp() time.Time {
+	return oc.localTimestamp
 }
 
 func (oc *OpCommon) checkUpdatesValid() error {

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/keybase/go-codec/codec"
 	"github.com/stretchr/testify/require"
@@ -224,6 +225,7 @@ func makeFakeOpCommon(t *testing.T, withRefBlocks bool) OpCommon {
 		codec.UnknownFieldSetHandler{},
 		writerInfo{},
 		path{},
+		time.Time{},
 	}
 	return oc
 }

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -236,10 +236,14 @@ outer:
 // history for this TLF.
 func (teh *TlfEditHistory) GetComplete(ctx context.Context) (
 	TlfWriterEdits, error) {
-	currEdits := teh.getEditsCopy()
-	if currEdits != nil {
-		return currEdits, nil
-	}
+	var currEdits TlfWriterEdits
+	/**
+	* Once we update currEdits based on notifications, we can uncomment this.
+		currEdits := teh.getEditsCopy()
+		if currEdits != nil {
+			return currEdits, nil
+		}
+	*/
 
 	// We have no history -- fetch from the server until we have a
 	// complete history.

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -1,0 +1,342 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	keybase1 "github.com/keybase/client/go/protocol"
+	"golang.org/x/net/context"
+)
+
+// TlfEditNotificationType indicates what type of edit happened to a
+// file.
+type TlfEditNotificationType int
+
+const (
+	// FileCreated indicates a new file.
+	FileCreated TlfEditNotificationType = iota
+	// FileModified indicates an existing file that was written to.
+	FileModified
+	// FileDeleted indicates an existing file that was deleted.  It
+	// doesn't appear in the edit history, only in individual edit
+	// updates.
+	FileDeleted
+)
+
+// TlfEdit represents an individual update about a file edit within a
+// TLF.
+type TlfEdit struct {
+	Filepath  string // relative to the TLF root
+	Type      TlfEditNotificationType
+	LocalTime time.Time // reflects difference between server and local clock
+}
+
+const (
+	// How many edits per writer we want to return in the complete history?
+	desiredEditsPerWriter = 20
+
+	// How far back we're willing to go to get the complete history.
+	maxMDsToInspect = 1000
+)
+
+// TlfEditList is a list of edits by a particular user, that can be
+// sort by increasing timestamp.
+type TlfEditList []TlfEdit
+
+// Len implements sort.Interface for TlfEditList
+func (tel TlfEditList) Len() int {
+	return len(tel)
+}
+
+// Less implements sort.Interface for TlfEditList
+func (tel TlfEditList) Less(i, j int) bool {
+	return tel[i].LocalTime.Before(tel[j].LocalTime)
+}
+
+// Swap implements sort.Interface for TlfEditList
+func (tel TlfEditList) Swap(i, j int) {
+	tel[j], tel[i] = tel[i], tel[j]
+}
+
+// TlfWriterEdits is a map of a writer name to the most recent file
+// edits in a given folder by that writer.
+type TlfWriterEdits map[keybase1.UID]TlfEditList
+
+func (we TlfWriterEdits) isComplete() bool {
+	for _, edits := range we {
+		if len(edits) < desiredEditsPerWriter {
+			return false
+		}
+	}
+	return true
+}
+
+type writerEditEstimates map[keybase1.UID]int
+
+func (wee writerEditEstimates) isComplete() bool {
+	for _, count := range wee {
+		if count < desiredEditsPerWriter {
+			return false
+		}
+	}
+	return true
+}
+
+func (wee *writerEditEstimates) update(rmds []ImmutableRootMetadata) {
+	for i := len(rmds) - 1; i >= 0; i-- {
+		rmd := rmds[i]
+		if rmd.IsWriterMetadataCopiedSet() {
+			continue
+		}
+		writer := rmd.LastModifyingWriter
+		for _, op := range rmd.data.Changes.Ops {
+			// Estimate the number of writes just based on operations
+			// (without yet taking into account whether the same file
+			// is being edited more than once).
+			switch realOp := op.(type) {
+			case *createOp:
+				if realOp.Type == Dir || realOp.Type == Sym {
+					continue
+				}
+				(*wee)[writer]++
+			case *syncOp:
+				(*wee)[writer]++
+			}
+		}
+	}
+}
+
+func (wee *writerEditEstimates) reset(edits TlfWriterEdits) {
+	for writer := range *wee {
+		(*wee)[writer] = len(edits[writer])
+	}
+}
+
+// TlfEditHistory allows you to get the update history about a
+// particular TLF.
+type TlfEditHistory struct {
+	config Config
+	fbo    *folderBranchOps
+	log    logger.Logger
+
+	lock  sync.Mutex
+	edits TlfWriterEdits
+}
+
+func (teh *TlfEditHistory) getEditsCopy() TlfWriterEdits {
+	teh.lock.Lock()
+	defer teh.lock.Unlock()
+	if teh.edits == nil {
+		return nil
+	}
+	edits := make(TlfWriterEdits)
+	for user, userEdits := range teh.edits {
+		userEditsCopy := make([]TlfEdit, 0, len(userEdits))
+		copy(userEditsCopy, userEdits)
+		edits[user] = userEditsCopy
+	}
+	return edits
+}
+
+func (teh *TlfEditHistory) updateRmds(rmds []ImmutableRootMetadata,
+	olderRmds []ImmutableRootMetadata) ([]ImmutableRootMetadata, error) {
+	newRmds := make([]ImmutableRootMetadata, len(olderRmds)+len(rmds))
+	copy(newRmds[:len(olderRmds)], olderRmds)
+	copy(newRmds[len(olderRmds):], rmds)
+	return newRmds, nil
+}
+
+func (teh *TlfEditHistory) calculateEditCounts(ctx context.Context,
+	rmds []ImmutableRootMetadata) (TlfWriterEdits, error) {
+	chains, err := newCRChains(ctx, teh.config, rmds, &teh.fbo.blocks, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the paths on all the ops
+	_, err = chains.getPaths(ctx, &teh.fbo.blocks, teh.config.MakeLogger(""),
+		teh.fbo.nodeCache, teh.fbo.nodeCache, false)
+	if err != nil {
+		return nil, err
+	}
+
+	edits := make(TlfWriterEdits)
+	for _, writer := range rmds[len(rmds)-1].GetTlfHandle().ResolvedWriters() {
+		edits[writer] = nil
+	}
+
+outer:
+	for ptr, chain := range chains.byOriginal {
+		if chains.isDeleted(ptr) {
+			continue
+		}
+
+		for _, op := range chain.ops {
+			// Is this a create?
+			switch realOp := op.(type) {
+			case *createOp:
+				if realOp.renamed {
+					// Ignore renames for now.  TODO: notify about renames?
+					continue
+				}
+				if realOp.Type == Dir || realOp.Type == Sym {
+					// Ignore directories and symlinks. Because who
+					// wants notifications for those?
+					continue
+				}
+
+				// The pointer is actually the newly-referenced Block
+				for _, ref := range op.Refs() {
+					ptr = ref
+					break
+				}
+
+				// If a chain exists for the file, ignore this create.
+				if _, ok := chains.byOriginal[ptr]; ok {
+					continue
+				}
+
+				writer := op.getWriterInfo().uid
+				createdPath := op.getFinalPath().ChildPathNoPtr(realOp.NewName)
+				edits[writer] = append(edits[writer], TlfEdit{
+					Filepath: createdPath.String(),
+					Type:     FileCreated,
+				})
+			case *syncOp:
+				// Only the final writer matters.
+				lastOp := chain.ops[len(chain.ops)-1]
+				writer := lastOp.getWriterInfo().uid
+				t := FileModified
+				if chains.isCreated(ptr) {
+					t = FileCreated
+				}
+				edits[writer] = append(edits[writer], TlfEdit{
+					Filepath: lastOp.getFinalPath().String(),
+					Type:     t,
+					// LocalTime: XXX
+				})
+				continue outer
+			default:
+				continue
+			}
+		}
+	}
+
+	return edits, nil
+}
+
+// GetComplete returns the most recently known set of clustered edit
+// history for this TLF.
+func (teh *TlfEditHistory) GetComplete(ctx context.Context) (
+	TlfWriterEdits, error) {
+	currEdits := teh.getEditsCopy()
+	if currEdits != nil {
+		return currEdits, nil
+	}
+
+	// We have no history -- fetch from the server until we have a
+	// complete history.
+
+	// Get current head for this folder.
+	head, err := teh.fbo.getMDForExternalUse(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	estimates := make(writerEditEstimates)
+	for _, writer := range head.GetTlfHandle().ResolvedWriters() {
+		estimates[writer] = 0
+	}
+	rmds := []ImmutableRootMetadata{head}
+	estimates.update(rmds)
+
+	// If unmerged, get all the unmerged updates.
+	if head.MergedStatus() == Unmerged {
+		_, unmergedRmds, err := getUnmergedMDUpdates(ctx, teh.config, head.ID,
+			head.BID, head.Revision-1)
+		if err != nil {
+			return nil, err
+		}
+		estimates.update(unmergedRmds)
+		rmds, err = teh.updateRmds(rmds, unmergedRmds)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for (currEdits == nil || !currEdits.isComplete()) &&
+		len(rmds) < maxMDsToInspect &&
+		rmds[0].Revision > MetadataRevisionInitial {
+		teh.log.CDebugf(ctx, "Edits not complete after %d revisions", len(rmds))
+		if estimates.isComplete() {
+			// Once the estimate hits the threshold for each writer,
+			// calculate the chains using all those MDs, and build the
+			// real edit map (discounting deleted files, etc).
+			currEdits, err = teh.calculateEditCounts(ctx, rmds)
+			if err != nil {
+				return nil, err
+			}
+			if currEdits.isComplete() {
+				break
+			}
+
+			// Set the estimates to their exact known values
+			estimates.reset(currEdits)
+		}
+
+		for !estimates.isComplete() && len(rmds) < maxMDsToInspect &&
+			rmds[0].Revision > MetadataRevisionInitial {
+			// Starting from the head/branchpoint, work backwards
+			// mdMax revisions at a time.
+			endRev := rmds[0].Revision - 1
+			startRev := endRev - maxMDsAtATime + 1
+			if startRev < MetadataRevisionInitial {
+				startRev = MetadataRevisionInitial
+			}
+
+			olderRmds, err := getMDRange(ctx, teh.config, head.ID, NullBranchID,
+				startRev, endRev, Merged)
+			if err != nil {
+				return nil, err
+			}
+
+			// Estimate the number of per-writer file operations by
+			// keeping a count of the createOps and syncOps found.
+			estimates.update(olderRmds)
+			rmds, err = teh.updateRmds(rmds, olderRmds)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if currEdits == nil {
+		// We broke out of the loop early.
+		currEdits, err = teh.calculateEditCounts(ctx, rmds)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sort each of the edit lists by timestamp
+	for w, list := range currEdits {
+		sort.Sort(list)
+		if len(list) > desiredEditsPerWriter {
+			list = list[len(list)-desiredEditsPerWriter:]
+		}
+		currEdits[w] = list
+	}
+	teh.log.CDebugf(ctx, "Edits complete: %d revisions, starting from "+
+		"revision %d", len(rmds), rmds[0].Revision)
+
+	teh.lock.Lock()
+	defer teh.lock.Unlock()
+	teh.edits = currEdits
+	return currEdits, nil
+}

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -205,8 +205,9 @@ outer:
 				writer := op.getWriterInfo().uid
 				createdPath := op.getFinalPath().ChildPathNoPtr(realOp.NewName)
 				edits[writer] = append(edits[writer], TlfEdit{
-					Filepath: createdPath.String(),
-					Type:     FileCreated,
+					Filepath:  createdPath.String(),
+					Type:      FileCreated,
+					LocalTime: op.getLocalTimestamp(),
 				})
 			case *syncOp:
 				// Only the final writer matters.
@@ -217,9 +218,9 @@ outer:
 					t = FileCreated
 				}
 				edits[writer] = append(edits[writer], TlfEdit{
-					Filepath: lastOp.getFinalPath().String(),
-					Type:     t,
-					// LocalTime: XXX
+					Filepath:  lastOp.getFinalPath().String(),
+					Type:      t,
+					LocalTime: op.getLocalTimestamp(),
 				})
 				continue outer
 			default:

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -17,6 +17,9 @@ func TestBasicTlfEditHistory(t *testing.T) {
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
 	defer CheckConfigAndShutdown(t, config1)
 
+	clock, now := newTestClockAndTimeNow()
+	config1.SetClock(clock)
+
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
@@ -53,12 +56,14 @@ func TestBasicTlfEditHistory(t *testing.T) {
 	// Each user should see 1 create edit for each user
 	expectedEdits := make(TlfWriterEdits)
 	expectedEdits[uid1] = TlfEditList{{
-		Filepath: name + "/a",
-		Type:     FileCreated,
+		Filepath:  name + "/a",
+		Type:      FileCreated,
+		LocalTime: now,
 	}}
 	expectedEdits[uid2] = TlfEditList{{
-		Filepath: name + "/b",
-		Type:     FileCreated,
+		Filepath:  name + "/b",
+		Type:      FileCreated,
+		LocalTime: now,
 	}}
 
 	edits1, err := kbfsOps1.GetEditHistory(ctx, rootNode1.GetFolderBranch())

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -1,0 +1,79 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"golang.org/x/net/context"
+)
+
+func TestBasicTlfEditHistory(t *testing.T) {
+	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CheckConfigAndShutdown(t, config1)
+
+	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	defer CheckConfigAndShutdown(t, config2)
+
+	name := userName1.String() + "," + userName2.String()
+
+	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+
+	// user 1 creates a file
+	kbfsOps1 := config1.KBFSOps()
+	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %v", err)
+	}
+
+	kbfsOps2 := config2.KBFSOps()
+	err = kbfsOps2.SyncFromServerForTesting(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %v", err)
+	}
+	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %v", err)
+	}
+
+	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %v", err)
+	}
+
+	_, uid1, err := config1.KBPKI().GetCurrentUserInfo(context.Background())
+	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
+
+	// Each user should see 1 create edit for each user
+	expectedEdits := make(TlfWriterEdits)
+	expectedEdits[uid1] = TlfEditList{{
+		Filepath: name + "/a",
+		Type:     FileCreated,
+	}}
+	expectedEdits[uid2] = TlfEditList{{
+		Filepath: name + "/b",
+		Type:     FileCreated,
+	}}
+
+	edits1, err := kbfsOps1.GetEditHistory(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't get history: %v", err)
+	}
+	edits2, err := kbfsOps2.GetEditHistory(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't get history: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedEdits, edits1) {
+		t.Fatalf("User1 has unexpected edit history: %v", edits1)
+	}
+	if !reflect.DeepEqual(expectedEdits, edits2) {
+		t.Fatalf("User2 has unexpected edit history: %v", edits2)
+	}
+}

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -5,10 +5,13 @@
 package libkbfs
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
+	keybase1 "github.com/keybase/client/go/protocol"
 	"golang.org/x/net/context"
 )
 
@@ -77,6 +80,140 @@ func TestBasicTlfEditHistory(t *testing.T) {
 
 	if !reflect.DeepEqual(expectedEdits, edits1) {
 		t.Fatalf("User1 has unexpected edit history: %v", edits1)
+	}
+	if !reflect.DeepEqual(expectedEdits, edits2) {
+		t.Fatalf("User2 has unexpected edit history: %v", edits2)
+	}
+}
+
+func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
+	kbfsOps KBFSOps, rootNode Node, i int, uid keybase1.UID, now time.Time,
+	createRemainders map[keybase1.UID]int, edits TlfWriterEdits) {
+	err := kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %v", err)
+	}
+
+	// Sometimes mix it up with a different operation.
+	if i%(len(createRemainders)*2) == createRemainders[uid] {
+		_, _, err := kbfsOps.CreateDir(ctx, rootNode, fmt.Sprintf("dir%d", i))
+		if err != nil {
+			t.Fatalf("Couldn't mkdir: %v", err)
+		}
+	}
+
+	if i%len(createRemainders) == createRemainders[uid] {
+		// Creates a new file.
+		fileName := fmt.Sprintf("file%d", i)
+		_, _, err := kbfsOps.CreateFile(ctx, rootNode,
+			fileName, false, NoExcl)
+		if err != nil {
+			t.Fatalf("Couldn't create file: %v", err)
+		}
+		if i >= 70 {
+			edits[uid] = append(edits[uid], TlfEdit{
+				Filepath:  tlfName + "/" + fileName,
+				Type:      FileCreated,
+				LocalTime: now,
+			})
+		}
+		return
+	}
+
+	// Write to an old file.
+	fileName := fmt.Sprintf("file%d", i-50)
+	fileNode, _, err := kbfsOps.Lookup(ctx, rootNode, fileName)
+	if err != nil {
+		t.Fatalf("Couldn't lookup old file: %v", err)
+	}
+	err = kbfsOps.Write(ctx, fileNode, []byte{0}, 0)
+	if err != nil {
+		t.Fatalf("Couldn't write old file: %v", err)
+	}
+	err = kbfsOps.Sync(ctx, fileNode)
+	if err != nil {
+		t.Fatalf("Couldn't sync old file: %v", err)
+	}
+	if i >= 70 {
+		edits[uid] = append(edits[uid], TlfEdit{
+			Filepath:  tlfName + "/" + fileName,
+			Type:      FileModified,
+			LocalTime: now,
+		})
+	}
+}
+
+func TestLongTlfEditHistory(t *testing.T) {
+	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CheckConfigAndShutdown(t, config1)
+
+	clock, now := newTestClockAndTimeNow()
+	config1.SetClock(clock)
+
+	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	defer CheckConfigAndShutdown(t, config2)
+
+	name := userName1.String() + "," + userName2.String()
+
+	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	kbfsOps1 := config1.KBFSOps()
+	kbfsOps2 := config2.KBFSOps()
+
+	// First create 50 files.  These creates won't be part of the
+	// history.
+	i := 0
+	for ; i < 50; i++ {
+		_, _, err := kbfsOps1.CreateFile(ctx, rootNode1,
+			fmt.Sprintf("file%d", i), false, NoExcl)
+		if err != nil {
+			t.Fatalf("Couldn't create file: %v", err)
+		}
+	}
+
+	_, uid1, err := config1.KBPKI().GetCurrentUserInfo(context.Background())
+	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
+	createRemainders := map[keybase1.UID]int{
+		uid1: 0,
+		uid2: 1,
+	}
+
+	// Now alternately create and edit files between the two users.
+	expectedEdits := make(TlfWriterEdits)
+	for ; i < 90; i++ {
+		// This will alternate creates and modifies.
+		now = now.Add(1 * time.Minute)
+		clock.Set(now)
+
+		// User 1
+		testDoTlfEdit(t, ctx, name, kbfsOps1, rootNode1, i, uid1, now,
+			createRemainders, expectedEdits)
+		// User 2
+		testDoTlfEdit(t, ctx, name, kbfsOps2, rootNode2, i, uid2, now,
+			createRemainders, expectedEdits)
+	}
+
+	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %v", err)
+	}
+	err = kbfsOps2.SyncFromServerForTesting(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %v", err)
+	}
+
+	edits1, err := kbfsOps1.GetEditHistory(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't get history: %v", err)
+	}
+	edits2, err := kbfsOps2.GetEditHistory(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't get history: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedEdits, edits1) {
+		t.Fatalf("User1 has unexpected edit history: %v  \n\n %v", expectedEdits, edits1)
 	}
 	if !reflect.DeepEqual(expectedEdits, edits2) {
 		t.Fatalf("User2 has unexpected edit history: %v", edits2)


### PR DESCRIPTION
This provides users of the `KBFSOps` class a way to grab the last 20 file creates/edits for each writer of a TLF.  In the future, we may implement this class a client of chat/gregor.  For now, we'll do it the slow way: derive the edit list by downloading RootMetadata updates until the list is complete (or until we hit some maximum number of downloaded RMDs).

In a future PR I'll expose this list via a virtual file and an RPC from the GUI.  At that point I'll probably add DSL tests for more complicated scenarios.  For now the tests are fairly basic.

Adding @jzila as well as @akalin-keybase as reviewers, to hopefully spread more expertise about ops stuff around the group.
