### PR TITLE
keybase_daemon_rpc: oops, we have to register for notifications!

### DIFF
--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -458,8 +458,9 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 	// recursion.
 	c := keybase1.NotifyCtlClient{Cli: rawClient}
 	err := c.SetNotifications(ctx, keybase1.NotificationChannels{
-		Session: true,
-		Users:   true,
+		Session:   true,
+		Paperkeys: true,
+		Keyfamily: true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
I thought that registering for a specific notification protocol was
enough to receive the notifications, but apparently we also have to
explicitly subscribe to the right notification channels.

Issue: KBFS-1341