### PR TITLE
tlf_edit_history: some fixes

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -721,7 +721,11 @@ func (ccs *crChains) summary(identifyChains *crChains,
 }
 
 func (ccs *crChains) removeChain(ptr BlockPointer) {
-	delete(ccs.byOriginal, ptr)
+	if chain, ok := ccs.byMostRecent[ptr]; ok {
+		delete(ccs.byOriginal, chain.original)
+	} else {
+		delete(ccs.byOriginal, ptr)
+	}
 	delete(ccs.byMostRecent, ptr)
 }
 

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -209,9 +209,19 @@ outer:
 					break
 				}
 
-				// If a chain exists for the file, ignore this create.
-				if _, ok := chains.byOriginal[ptr]; ok {
-					continue
+				// If a chain exists with sync ops for the file,
+				// ignore this create.
+				if fileChain, ok := chains.byOriginal[ptr]; ok {
+					syncOpFound := false
+					for _, fileOp := range fileChain.ops {
+						if _, ok := fileOp.(*syncOp); ok {
+							syncOpFound = true
+							break
+						}
+					}
+					if syncOpFound {
+						continue
+					}
 				}
 
 				writer := op.getWriterInfo().uid


### PR DESCRIPTION
Some things I noticed when trying to use this on real data:

* Without caching, reading it through the file system is awful.  So this allows us to cache it for up to a minute.
* Some (hopefully) old conflict resolution bugs didn't always properly mark block pointers as removed, and `crChains.getPaths()` weren't properly removing those chains.
* If a file was created, but only has a `setAttrOp`, its `createOp` would get skipped and then it would never be added a notification since there was no `syncOp`.