### PR TITLE
md_ops: parallelize MD decrypts

### DIFF
--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -44,6 +44,12 @@ func expectGetTLFCryptKeyForMDDecryption(config *ConfigMock, kmd KeyMetadata) {
 		kmdMatcher{kmd}, kmdMatcher{kmd}).Return(TLFCryptKey{}, nil)
 }
 
+func expectGetTLFCryptKeyForMDDecryptionAtMostOnce(config *ConfigMock,
+	kmd KeyMetadata) {
+	config.mockKeyman.EXPECT().GetTLFCryptKeyForMDDecryption(gomock.Any(),
+		kmdMatcher{kmd}, kmdMatcher{kmd}).MaxTimes(1).Return(TLFCryptKey{}, nil)
+}
+
 // TODO: Add test coverage for decryption of blocks with an old key
 // generation.
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -350,7 +350,7 @@ func (md *MDOpsStandard) GetUnmergedForTLF(
 func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 	bid BranchID, rmdses []*RootMetadataSigned) (
 	[]ImmutableRootMetadata, error) {
-	if rmdses == nil {
+	if len(rmdses) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
Otherwise, fetching the block changes for MDs with unembedded blocks in a range takes a long time because they all happen in serial.

I'm not 100% sure this is the best way to do it, but it was the simplest I could think of.  Let me know if you can think of anything better.
