### PR TITLE
fs: expose TLF edit history as a file

### DIFF
--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -221,6 +221,10 @@ func (d *Dir) open(ctx context.Context, oc *openContext, path []string) (dokan.F
 		folderBranch := d.folder.getFolderBranch()
 		return NewStatusFile(d.folder.fs, &folderBranch), false, nil
 
+	case libfs.EditHistoryName:
+		folderBranch := d.folder.getFolderBranch()
+		return NewTlfEditHistoryFile(d.folder.fs, folderBranch), false, nil
+
 	case libfs.UnstageFileName:
 		child := &UnstageFile{
 			folder: d.folder,

--- a/libdokan/tlf_edit_history_file.go
+++ b/libdokan/tlf_edit_history_file.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libdokan
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// NewTlfEditHistoryFile returns a special read file that contains a text
+// representation of the file edit history for that TLF.
+func NewTlfEditHistoryFile(fs *FS,
+	folderBranch libkbfs.FolderBranch) *SpecialReadFile {
+	return &SpecialReadFile{
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			return libfs.GetEncodedTlfEditHistory(ctx, fs.config, folderBranch)
+		},
+		fs: fs,
+	}
+}

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -50,3 +50,7 @@ const FlushJournalFileName = ".kbfs_flush_journal"
 // DisableJournalFileName is the name of the journal-disabling
 // file. It can be reached anywhere within a top-level folder.
 const DisableJournalFileName = ".kbfs_disable_journal"
+
+// EditHistoryName is the name of the KBFS TLF edit history file --
+// it can be reached anywhere within a top-level folder.
+const EditHistoryName = ".kbfs_edit_history"

--- a/libfs/tlf_edit_history_file.go
+++ b/libfs/tlf_edit_history_file.go
@@ -1,0 +1,32 @@
+// Copyright 2015-2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// GetEncodedTlfEditHistory returns serialized JSON containing the
+// file edit history for a folder.
+func GetEncodedTlfEditHistory(ctx context.Context, config libkbfs.Config,
+	folderBranch libkbfs.FolderBranch) (
+	data []byte, t time.Time, err error) {
+	edits, err := config.KBFSOps().GetEditHistory(ctx, folderBranch)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	data, err = json.MarshalIndent(edits, "", "  ")
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	data = append(data, '\n')
+	return data, time.Time{}, err
+}

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -360,6 +360,10 @@ func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.Lo
 	case UpdateHistoryFileName:
 		return NewUpdateHistoryFile(d.folder, resp), nil
 
+	case libfs.EditHistoryName:
+		folderBranch := d.folder.getFolderBranch()
+		return NewTlfEditHistoryFile(d.folder.fs, folderBranch, resp), nil
+
 	case libfs.UnstageFileName:
 		resp.EntryValid = 0
 		child := &UnstageFile{

--- a/libfuse/tlf_edit_history_file.go
+++ b/libfuse/tlf_edit_history_file.go
@@ -1,0 +1,27 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"time"
+
+	"bazil.org/fuse"
+	"golang.org/x/net/context"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+)
+
+// NewTlfEditHistoryFile returns a special read file that contains a text
+// representation of the file edit history for that TLF.
+func NewTlfEditHistoryFile(fs *FS, folderBranch libkbfs.FolderBranch,
+	resp *fuse.LookupResponse) *SpecialReadFile {
+	resp.EntryValid = 0
+	return &SpecialReadFile{
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			return libfs.GetEncodedTlfEditHistory(ctx, fs.config, folderBranch)
+		},
+	}
+}


### PR DESCRIPTION
`.kbfs_edit_history` in any TLF will show the history.

Contains #218 and #217, so if you review before those are merged, only look at the `libfs`, `libfuse`, and `libdokan` changes.

Issue: KBFS-1303
