### PR TITLE
[KBFS-1344] Fix journal race with branch IDs

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -411,7 +411,7 @@ func (j *blockJournal) putData(
 		len(buf), id, context)
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Put for block %s with context %v failed with %v",
 				id, context, err)
 		}
@@ -490,7 +490,7 @@ func (j *blockJournal) addReference(
 		id, context)
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Adding reference for block %s with context %v failed with %v",
 				id, context, err)
 		}
@@ -544,7 +544,7 @@ func (j *blockJournal) removeReferences(
 		contexts, removeUnreferencedBlocks)
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Removing references for %v (remove unreferenced blocks=%t)",
 				contexts, removeUnreferencedBlocks, err)
 		}
@@ -596,7 +596,7 @@ func (j *blockJournal) archiveReferences(
 	j.log.CDebugf(ctx, "Archiving references for %v", contexts)
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Archiving references for %v,", contexts, err)
 		}
 	}()
@@ -710,7 +710,7 @@ func (j *blockJournal) flushOne(
 		return false, fmt.Errorf("Unknown op %s", e.Op)
 	}
 
-	err = j.j.removeEarliest()
+	_, err = j.j.removeEarliest()
 	if err != nil {
 		return false, err
 	}

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -126,27 +126,31 @@ func (j diskJournal) clearOrdinals() error {
 	return os.Remove(j.latestPath())
 }
 
-func (j diskJournal) removeEarliest() error {
+func (j diskJournal) removeEarliest() (empty bool, err error) {
 	earliestOrdinal, err := j.readEarliestOrdinal()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	latestOrdinal, err := j.readLatestOrdinal()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if earliestOrdinal == latestOrdinal {
-		return j.clearOrdinals()
+		err := j.clearOrdinals()
+		if err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 
 	err = j.writeEarliestOrdinal(earliestOrdinal + 1)
 	if err != nil {
-		return err
+		return false, err
 	}
 
-	return nil
+	return false, nil
 }
 
 // The functions below are for reading and writing journal entries.

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -22,7 +22,7 @@ type tlfJournalBundle struct {
 	lock sync.RWMutex
 
 	blockJournal *blockJournal
-	mdJournal    mdJournal
+	mdJournal    *mdJournal
 }
 
 // JournalServer is the server that handles write journals. It

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -171,7 +171,7 @@ func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
 	return j.j.appendJournalEntry(&o, mdID)
 }
 
-func (j mdIDJournal) removeEarliest() error {
+func (j mdIDJournal) removeEarliest() (empty bool, err error) {
 	return j.j.removeEarliest()
 }
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -349,6 +349,9 @@ func TestMDJournalFlushConflict(t *testing.T) {
 	}
 }
 
+// TestMDJournalPreservesBranchID tests that the branch ID is
+// preserved even if the journal is fully drained. This is a
+// regression test for KBFS-1344.
 func TestMDJournalPreservesBranchID(t *testing.T) {
 	codec, crypto, uid, id, h, signer, verifyingKey, ekg, tempdir, j :=
 		setupMDJournalTest(t)


### PR DESCRIPTION
Without this fix, it's possible to get into a state
where one picks up a new branch ID if the journal
is completely flushed.

Also fix a few more places to use CDebugf.