### PR TITLE
[KBFS-1342] Make BServer and MDServer errors unambiguous

### DIFF
--- a/libkbfs/bserver_errors.go
+++ b/libkbfs/bserver_errors.go
@@ -53,7 +53,7 @@ func (e BServerError) ToStatus() (s keybase1.Status) {
 
 // Error implements the Error interface for BServerError.
 func (e BServerError) Error() string {
-	return e.Msg
+	return "BServerError{" + e.Msg + "}"
 }
 
 // BServerErrorBadRequest is a generic client-side error.
@@ -74,7 +74,7 @@ func (e BServerErrorBadRequest) Error() string {
 	if e.Msg == "" {
 		return "BServer: bad client request"
 	}
-	return e.Msg
+	return "BServerErrorBadRequest{" + e.Msg + "}"
 }
 
 // BServerErrorUnauthorized is a generic client-side error.
@@ -95,7 +95,7 @@ func (e BServerErrorUnauthorized) Error() string {
 	if e.Msg == "" {
 		return "BServer: session not validated"
 	}
-	return e.Msg
+	return "BServerErrorUnauthorized{" + e.Msg + "}"
 }
 
 // BServerErrorOverQuota is a generic client-side error.
@@ -134,7 +134,7 @@ func (e BServerErrorOverQuota) Error() string {
 	if e.Msg == "" {
 		return "BServer: user has exceeded quota"
 	}
-	return e.Msg
+	return "BServerErrorOverQuota{" + e.Msg + "}"
 }
 
 //BServerErrorBlockNonExistent is an exportable error from bserver
@@ -155,7 +155,7 @@ func (e BServerErrorBlockNonExistent) Error() string {
 	if e.Msg == "" {
 		return "BServer: block does not exist"
 	}
-	return e.Msg
+	return "BServerErrorBlockNonExistent{" + e.Msg + "}"
 }
 
 //BServerErrorBlockArchived is an exportable error from bserver
@@ -176,7 +176,7 @@ func (e BServerErrorBlockArchived) Error() string {
 	if e.Msg == "" {
 		return "BServer: block is archived"
 	}
-	return e.Msg
+	return "BServerErrorBlockArchived{" + e.Msg + "}"
 }
 
 //BServerErrorBlockDeleted is an exportable error from bserver
@@ -197,7 +197,7 @@ func (e BServerErrorBlockDeleted) Error() string {
 	if e.Msg == "" {
 		return "BServer: block is deleted"
 	}
-	return e.Msg
+	return "BServerErrorBlockDeleted{" + e.Msg + "}"
 }
 
 //BServerErrorNoPermission is an exportable error from bserver
@@ -218,7 +218,7 @@ func (e BServerErrorNoPermission) Error() string {
 	if e.Msg == "" {
 		return "BServer: permission denied"
 	}
-	return e.Msg
+	return "BServerErrorNoPermission{" + e.Msg + "}"
 }
 
 //BServerErrorNonceNonExistent is an exportable error from bserver
@@ -239,7 +239,7 @@ func (e BServerErrorNonceNonExistent) Error() string {
 	if e.Msg == "" {
 		return "BServer: reference nonce does not exist"
 	}
-	return e.Msg
+	return "BServerErrorNonceNonExistent{" + e.Msg + "}"
 }
 
 //BServerErrorMaxRefExceeded is an exportable error from bserver
@@ -260,7 +260,7 @@ func (e BServerErrorMaxRefExceeded) Error() string {
 	if e.Msg == "" {
 		return "BServer: maximum allowed number of references exceeded"
 	}
-	return e.Msg
+	return "BServerErrorMaxRefExceeded{" + e.Msg + "}"
 }
 
 // BServerErrorThrottle is returned when the server wants the client to backoff.
@@ -270,7 +270,7 @@ type BServerErrorThrottle struct {
 
 // Error implements the Error interface for BServerErrorThrottle.
 func (e BServerErrorThrottle) Error() string {
-	return e.Msg
+	return "BServerErrorThrottle{" + e.Msg + "}"
 }
 
 // ToStatus implements the ExportableError interface for BServerErrorThrottle.

--- a/libkbfs/mdserver_errors.go
+++ b/libkbfs/mdserver_errors.go
@@ -59,7 +59,7 @@ func (e MDServerError) Error() string {
 	if e.Err != nil {
 		return e.Err.Error()
 	}
-	return "Generic error"
+	return "MDServerError"
 }
 
 // MDServerErrorBadRequest is a generic client-side error.
@@ -77,7 +77,7 @@ func (e MDServerErrorBadRequest) ToStatus() (s keybase1.Status) {
 
 // Error implements the Error interface for MDServerErrorBadRequest.
 func (e MDServerErrorBadRequest) Error() string {
-	return fmt.Sprintf("Bad request: %s", e.Reason)
+	return fmt.Sprintf("Bad MD server request: %s", e.Reason)
 }
 
 // MDServerErrorConflictRevision is returned when the passed MD block is inconsistent with current history.
@@ -92,7 +92,7 @@ func (e MDServerErrorConflictRevision) Error() string {
 	if e.Desc == "" {
 		return fmt.Sprintf("Conflict: expected revision %d, actual %d", e.Expected, e.Actual)
 	}
-	return e.Desc
+	return "MDServerConflictRevision{" + e.Desc + "}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorConflictRevision.
@@ -115,7 +115,7 @@ func (e MDServerErrorConflictPrevRoot) Error() string {
 	if e.Desc == "" {
 		return fmt.Sprintf("Conflict: expected previous root %v, actual %v", e.Expected, e.Actual)
 	}
-	return e.Desc
+	return "MDServerConflictPrevRoot{" + e.Desc + "}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorConflictPrevRoot.
@@ -146,7 +146,7 @@ func (e MDServerErrorConflictDiskUsage) Error() string {
 	if e.Desc == "" {
 		return fmt.Sprintf("Conflict: expected disk usage %d, actual %d", e.Expected, e.Actual)
 	}
-	return e.Desc
+	return "MDServerConflictDiskUsage{" + e.Desc + "}"
 }
 
 // MDServerErrorLocked is returned when the folder truncation lock is acquired by someone else.
@@ -155,7 +155,7 @@ type MDServerErrorLocked struct {
 
 // Error implements the Error interface for MDServerErrorLocked.
 func (e MDServerErrorLocked) Error() string {
-	return "Locked"
+	return "MDServerErrorLocked{}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorLocked.
@@ -173,7 +173,7 @@ type MDServerErrorUnauthorized struct {
 
 // Error implements the Error interface for MDServerErrorUnauthorized.
 func (e MDServerErrorUnauthorized) Error() string {
-	msg := "Unauthorized"
+	msg := "MDServer Unauthorized"
 	if e.Err != nil {
 		msg += ": " + e.Err.Error()
 	}
@@ -194,7 +194,7 @@ type MDServerErrorWriteAccess struct{}
 
 // Error implements the Error interface for MDServerErrorWriteAccess.
 func (e MDServerErrorWriteAccess) Error() string {
-	return "WriteAccess"
+	return "MDServerErrorWriteAccess{}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorWriteAccess.
@@ -212,7 +212,7 @@ type MDServerErrorThrottle struct {
 
 // Error implements the Error interface for MDServerErrorThrottle.
 func (e MDServerErrorThrottle) Error() string {
-	return e.Err.Error()
+	return "MDServerErrorThrottle{" + e.Err.Error() + "}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorThrottle.
@@ -231,7 +231,7 @@ type MDServerErrorConditionFailed struct {
 
 // Error implements the Error interface for MDServerErrorConditionFailed.
 func (e MDServerErrorConditionFailed) Error() string {
-	return e.Err.Error()
+	return "MDServerErrorConditionFailed{" + e.Err.Error() + "}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorConditionFailed.
@@ -256,7 +256,7 @@ func (e MDServerErrorConflictFolderMapping) Error() string {
 		return fmt.Sprintf("Conflict: expected folder ID %s, actual %s",
 			e.Expected, e.Actual)
 	}
-	return e.Desc
+	return "MDServerErrorConflictFolderMapping{" + e.Desc + "}"
 }
 
 // ToStatus implements the ExportableError interface for MDServerErrorConflictFolderMapping


### PR DESCRIPTION
Make it so that we know the exact BServer/MDServer
error type from logs.