### PR TITLE
tlf_edit_history: update cached history in response to new MD updates

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3249,6 +3249,7 @@ func (fbo *folderBranchOps) notifyBatchLocked(
 
 	lastOp := md.data.Changes.Ops[len(md.data.Changes.Ops)-1]
 	fbo.notifyOneOpLocked(ctx, lState, lastOp, md)
+	fbo.editHistory.UpdateHistory(ctx, []ImmutableRootMetadata{md})
 }
 
 // searchForNode tries to figure out the path to the given
@@ -3550,6 +3551,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			fbo.notifyOneOpLocked(ctx, lState, op, rmd)
 		}
 	}
+	fbo.editHistory.UpdateHistory(ctx, rmds)
 	return nil
 }
 
@@ -3609,6 +3611,7 @@ func (fbo *folderBranchOps) undoMDUpdatesLocked(ctx context.Context,
 			fbo.notifyOneOpLocked(ctx, lState, io, rmd)
 		}
 	}
+	// TODO: update the edit history?
 	return nil
 }
 
@@ -4115,6 +4118,9 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 	if err := fbo.fbm.waitForDeletingBlocks(ctx); err != nil {
 		return err
 	}
+	if err := fbo.editHistory.Wait(ctx); err != nil {
+		return err
+	}
 	return fbo.fbm.waitForQuotaReclamations(ctx)
 }
 
@@ -4400,6 +4406,7 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	for _, op := range newOps {
 		fbo.notifyOneOpLocked(ctx, lState, op, irmd)
 	}
+	fbo.editHistory.UpdateHistory(ctx, []ImmutableRootMetadata{irmd})
 	return nil
 }
 

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -77,6 +77,37 @@ func (we TlfWriterEdits) isComplete() bool {
 	return true
 }
 
+// updateOldEdits removes edits from `we` belonging to files that have
+// been removed, and renames ones that have been renamed.
+func (we *TlfWriterEdits) updateOldEdits(removed map[string]bool,
+	renamed map[string]string) {
+	if len(removed) == 0 && len(renamed) == 0 {
+		return
+	}
+	for writer, edits := range *we {
+		var newEdits TlfEditList
+		for _, edit := range edits {
+			if removed[edit.Filepath] {
+				continue
+			}
+			if newName, ok := renamed[edit.Filepath]; ok {
+				edit.Filepath = newName
+			}
+			newEdits = append(newEdits, edit)
+		}
+		(*we)[writer] = newEdits
+	}
+}
+
+// addNewEdits simply adds in edits from the new list to `we`.
+func (we *TlfWriterEdits) addNewEdits(newEdits TlfWriterEdits) {
+	for w, edits := range newEdits {
+		for _, edit := range edits {
+			(*we)[w] = append((*we)[w], edit)
+		}
+	}
+}
+
 type writerEditEstimates map[keybase1.UID]int
 
 func (wee writerEditEstimates) isComplete() bool {
@@ -127,10 +158,9 @@ type TlfEditHistory struct {
 	rmdsChan chan []ImmutableRootMetadata
 	wg       RepeatedWaitGroup
 
-	lock      sync.Mutex
-	edits     TlfWriterEdits
-	editsTime time.Time
-	cancel    context.CancelFunc
+	lock   sync.Mutex
+	edits  TlfWriterEdits
+	cancel context.CancelFunc
 }
 
 // NewTlfEditHistory makes a new TLF edit history.
@@ -168,12 +198,6 @@ func (teh *TlfEditHistory) getEditsCopyLocked() TlfWriterEdits {
 	if teh.edits == nil {
 		return nil
 	}
-	// Until we listen for later updates and repair the edits list,
-	// let's not cache this for too long.  TODO: fix me.
-	if teh.config.Clock().Now().After(teh.editsTime.Add(1 * time.Minute)) {
-		teh.edits = nil
-		return nil
-	}
 
 	edits := make(TlfWriterEdits)
 	for user, userEdits := range teh.edits {
@@ -200,17 +224,17 @@ func (teh *TlfEditHistory) updateRmds(rmds []ImmutableRootMetadata,
 }
 
 func (teh *TlfEditHistory) calculateEditCounts(ctx context.Context,
-	rmds []ImmutableRootMetadata) (TlfWriterEdits, error) {
+	rmds []ImmutableRootMetadata) (TlfWriterEdits, *crChains, error) {
 	chains, err := newCRChains(ctx, teh.config, rmds, &teh.fbo.blocks, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Set the paths on all the ops
 	_, err = chains.getPaths(ctx, &teh.fbo.blocks, teh.log, teh.fbo.nodeCache,
 		true)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	edits := make(TlfWriterEdits)
@@ -297,7 +321,25 @@ outer:
 		}
 	}
 
-	return edits, nil
+	return edits, chains, nil
+}
+
+func (teh *TlfEditHistory) setEdits(ctx context.Context,
+	currEdits TlfWriterEdits, rmds []ImmutableRootMetadata) {
+	// Sort each of the edit lists by timestamp
+	for w, list := range currEdits {
+		sort.Sort(list)
+		if len(list) > desiredEditsPerWriter {
+			list = list[len(list)-desiredEditsPerWriter:]
+		}
+		currEdits[w] = list
+	}
+	teh.log.CDebugf(ctx, "Edits complete: %d revisions, starting from "+
+		"revision %d", len(rmds), rmds[0].Revision)
+
+	teh.lock.Lock()
+	defer teh.lock.Unlock()
+	teh.edits = currEdits
 }
 
 // GetComplete returns the most recently known set of clustered edit
@@ -310,7 +352,8 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 	}
 
 	// We have no history -- fetch from the server until we have a
-	// complete history.
+	// complete history.  TODO: make sure only one goroutine tries to
+	// calculate the edit history at a time?
 
 	estimates := make(writerEditEstimates)
 	for _, writer := range head.GetTlfHandle().ResolvedWriters() {
@@ -339,7 +382,7 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 			// calculate the chains using all those MDs, and build the
 			// real edit map (discounting deleted files, etc).
 			var err error
-			currEdits, err = teh.calculateEditCounts(ctx, rmds)
+			currEdits, _, err = teh.calculateEditCounts(ctx, rmds)
 			if err != nil {
 				return nil, err
 			}
@@ -383,31 +426,17 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 	if currEdits == nil {
 		// We broke out of the loop early.
 		var err error
-		currEdits, err = teh.calculateEditCounts(ctx, rmds)
+		currEdits, _, err = teh.calculateEditCounts(ctx, rmds)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	// Sort each of the edit lists by timestamp
-	for w, list := range currEdits {
-		sort.Sort(list)
-		if len(list) > desiredEditsPerWriter {
-			list = list[len(list)-desiredEditsPerWriter:]
-		}
-		currEdits[w] = list
-	}
-	teh.log.CDebugf(ctx, "Edits complete: %d revisions, starting from "+
-		"revision %d", len(rmds), rmds[0].Revision)
-
-	teh.lock.Lock()
-	defer teh.lock.Unlock()
-	teh.edits = currEdits
-	teh.editsTime = teh.config.Clock().Now()
+	teh.setEdits(ctx, currEdits, rmds)
 	return teh.getEditsCopyLocked(), nil
 }
 
-func (teh *TlfEditHistory) processMDs(ctx context.Context,
+func (teh *TlfEditHistory) updateHistory(ctx context.Context,
 	rmds []ImmutableRootMetadata) error {
 	defer teh.wg.Done()
 	if len(rmds) == 0 {
@@ -416,20 +445,96 @@ func (teh *TlfEditHistory) processMDs(ctx context.Context,
 	teh.log.CDebugf(ctx, "Processing %d MDs for notifications "+
 		"(most recent revision: %d)", len(rmds), rmds[len(rmds)-1].Revision)
 
-	chains, err := newCRChains(ctx, teh.config, rmds, &teh.fbo.blocks, false)
+	currEdits := teh.getEditsCopy()
+	if currEdits == nil {
+		teh.log.CDebugf(ctx, "No history to update; ignoring")
+		return nil
+	}
+
+	wasComplete := currEdits.isComplete()
+
+	newEdits, chains, err := teh.calculateEditCounts(ctx, rmds)
 	if err != nil {
 		return err
 	}
 
-	// Set the paths on all the ops
-	_, err = chains.getPaths(ctx, &teh.fbo.blocks, teh.log, teh.fbo.nodeCache,
-		true)
-	if err != nil {
+	// Which paths have been removed?
+	removed := make(map[string]bool)
+	// TODO: can I used chains.deletedOriginals instead?  It's hard to
+	// get the full path that way.
+	for _, chain := range chains.byOriginal {
+		for _, op := range chain.ops {
+			rop, ok := op.(*rmOp)
+			if !ok {
+				continue
+			}
+			path := rop.getFinalPath().String() + "/" + rop.OldName
+			// A rename op might show later that this was only renamed.
+			removed[path] = true
+		}
+	}
+
+	// Which paths have been renamed?
+	renamed := make(map[string]string)
+	for original, ri := range chains.renamedOriginals {
+		// Find both the old path and the new path using the old and
+		// new parents (which are each guaranteed to have at least one
+		// op, since the rename operation is split up into two ops).
+		oldParentChain, ok := chains.byOriginal[ri.originalOldParent]
+		if !ok || len(oldParentChain.ops) == 0 {
+			teh.log.CDebugf(ctx, "Couldn't find old parent to a rename "+
+				"op for original ptr %v", original)
+		}
+		oldPath := oldParentChain.ops[0].getFinalPath().String() + "/" +
+			ri.oldName
+
+		newParentChain, ok := chains.byOriginal[ri.originalNewParent]
+		if !ok || len(newParentChain.ops) == 0 {
+			teh.log.CDebugf(ctx, "Couldn't find new parent to a rename "+
+				"op for original ptr %v", original)
+		}
+		newPath := newParentChain.ops[0].getFinalPath().String() + "/" +
+			ri.newName
+
+		// Ignore any previous rmOps.
+		delete(removed, oldPath)
+		// If a file was overwritten, ignore all the old edits.
+		removed[newPath] = true
+		// Rename the file.
+		renamed[oldPath] = newPath
+	}
+
+	// Also, remove old edits for new file paths, because the newer
+	// edits take precedence.
+	for _, edits := range newEdits {
+		for _, edit := range edits {
+			removed[edit.Filepath] = true
+			delete(renamed, edit.Filepath)
+		}
+	}
+
+	// Remove and rename old edits as needed.
+	if len(removed)+len(renamed) > 0 {
+		teh.log.CDebugf(ctx, "Removed paths: %v, renamed paths: %v",
+			removed, renamed)
+		currEdits.updateOldEdits(removed, renamed)
+	}
+
+	currEdits.addNewEdits(newEdits)
+	// If we have a net negative removed, we have to search back
+	// farther in time to become complete again.
+	if !currEdits.isComplete() && wasComplete {
+		teh.log.CDebugf(ctx, "Too many removals; re-calculating edit history")
+		func() {
+			teh.lock.Lock()
+			defer teh.lock.Unlock()
+			teh.edits = nil
+		}()
+		_, err := teh.GetComplete(ctx, rmds[len(rmds)-1])
 		return err
 	}
 
-	// For every file create, sync, delete, or rename, update the
-	// cached history.
+	teh.setEdits(ctx, currEdits, rmds)
 	return nil
 }
 
@@ -443,7 +548,7 @@ func (teh *TlfEditHistory) process() {
 
 	for rmds := range teh.rmdsChan {
 		ctx := ctxWithRandomID(ctx, CtxFBOIDKey, CtxFBOOpID, teh.log)
-		err := teh.processMDs(ctx, rmds)
+		err := teh.updateHistory(ctx, rmds)
 		if err != nil {
 			teh.log.CWarningf(ctx,
 				"Error while processing edit notifications: %v", err)
@@ -456,10 +561,10 @@ func (teh *TlfEditHistory) process() {
 	}
 }
 
-// ProcessMDs updates the cached edit history, and sends FS
+// UpdateHistory updates the cached edit history, and sends FS
 // notifications about the changes.  This assumes the last
 // ImmutableRootMetadata in rmds is the current head.
-func (teh *TlfEditHistory) ProcessMDs(ctx context.Context,
+func (teh *TlfEditHistory) UpdateHistory(ctx context.Context,
 	rmds []ImmutableRootMetadata) error {
 	teh.wg.Add(1)
 	select {

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -79,12 +79,12 @@ func (we TlfWriterEdits) isComplete() bool {
 
 // updateOldEdits removes edits from `we` belonging to files that have
 // been removed, and renames ones that have been renamed.
-func (we *TlfWriterEdits) updateOldEdits(removed map[string]bool,
+func (we TlfWriterEdits) updateOldEdits(removed map[string]bool,
 	renamed map[string]string) {
 	if len(removed) == 0 && len(renamed) == 0 {
 		return
 	}
-	for writer, edits := range *we {
+	for writer, edits := range we {
 		var newEdits TlfEditList
 		for _, edit := range edits {
 			if removed[edit.Filepath] {
@@ -95,15 +95,15 @@ func (we *TlfWriterEdits) updateOldEdits(removed map[string]bool,
 			}
 			newEdits = append(newEdits, edit)
 		}
-		(*we)[writer] = newEdits
+		we[writer] = newEdits
 	}
 }
 
 // addNewEdits simply adds in edits from the new list to `we`.
-func (we *TlfWriterEdits) addNewEdits(newEdits TlfWriterEdits) {
+func (we TlfWriterEdits) addNewEdits(newEdits TlfWriterEdits) {
 	for w, edits := range newEdits {
 		for _, edit := range edits {
-			(*we)[w] = append((*we)[w], edit)
+			we[w] = append(we[w], edit)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds a background processor to `TlfEditHistory` that processes batches of `RootMetadata`s and updates the cached edit history in response, if one has already been cached.  It adds edits for newly-created and newly-edited files, and it also removes deleted files and renames moved files.

Issue: KBFS-912