### PR TITLE
folder_block_ops: fix missing block when switching to indirect

### DIFF
--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -169,6 +169,10 @@ func (*fsEngine) WriteFile(u User, file Node, data []byte, off int64, sync bool)
 		return err
 	}
 	defer f.Close()
+	_, err = f.Seek(off, 0)
+	if err != nil {
+		return err
+	}
 	_, err = f.Write(data)
 	if err != nil {
 		return err

--- a/test/multi_blocks_test.go
+++ b/test/multi_blocks_test.go
@@ -21,6 +21,22 @@ func TestWriteMultiblockFile(t *testing.T) {
 	)
 }
 
+func TestSwitchToMultiblockFile(t *testing.T) {
+	test(t,
+		blockSize(20), users("alice", "bob"),
+		as(alice,
+			// Fill up the first block (a desired encrypted block size
+			// of 20 ends up with a plaintext size of 12).
+			write("a/b", ntimesString(3, "0123")),
+			// Then append to the end of the file to force a split.
+			pwriteBS("a/b", []byte(ntimesString(3, "0123")), 12),
+		),
+		as(bob,
+			read("a/b", ntimesString(6, "0123")),
+		),
+	)
+}
+
 // alice writes a file, and bob overwrites it with a multi-block file
 func TestOverwriteMultiblockFile(t *testing.T) {
 	test(t,


### PR DESCRIPTION
If a series of writes exactly fills up a one-block file, and then a
new write comes in, we transition to an file with a top-level indirect
block, that has two direct file blocks under it -- the original direct
file block, plus a new empty one that receives the write.  However, we
were failing to mark this new block as dirty, because in this case
nCopied == 0 on the first write attempt (because the original block
was full).

In this case, we should dirty that first block, since it needs to be
re-uploaded under a new BlockPointer.

Noticed this while running our benchmark tests.

Issue: KBFS-1364