### PR TITLE
dirty_bcache: don't increase buffer size on small syncs

### DIFF
--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -556,7 +556,7 @@ func (d *DirtyBlockCacheStandard) SyncFinished(size int64) {
 	// We don't want a series of small writes to increase the buffer
 	// size, since that doesn't give us any real information about the
 	// throughput of the connection.
-	if bufferIncrease >= d.minSyncBufCap {
+	if bufferIncrease >= d.syncBufferCap {
 		d.syncBufferCap += bufferIncrease
 		if d.syncBufferCap > d.maxSyncBufCap {
 			d.syncBufferCap = d.maxSyncBufCap


### PR DESCRIPTION
If the sync was smaller than the current buffer size, it doesn't
really convey any info about how much data the connection can handle.

Add a benchmark that mixes big and small files, which fails without
this change.

Issue: KBFS-1316