### PR TITLE
Add GetDeviceKIDs to BareRootMetadata

### DIFF
--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -516,9 +516,10 @@ func (md *BareRootMetadata) getTLFKeyBundles(keyGen KeyGen) (
 	return &md.WKeys[i], &md.RKeys[i], nil
 }
 
-// GetDeviceKIDs returns the KIDs for all known devices for the given
-// user at the given key generation, if any.  Returns an error if the
-// TLF is public, or if the given key generation is invalid.
+// GetDeviceKIDs returns the KIDs (of CryptPublicKeys) for all known
+// devices for the given user at the given key generation, if any.
+// Returns an error if the TLF is public, or if the given key
+// generation is invalid.
 func (md *BareRootMetadata) GetDeviceKIDs(
 	keyGen KeyGen, user keybase1.UID) ([]keybase1.KID, error) {
 	wkb, rkb, err := md.getTLFKeyBundles(keyGen)

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -533,7 +533,7 @@ func (md *BareRootMetadata) GetDeviceKIDs(
 	}
 
 	var kids []keybase1.KID
-	for kid, _ := range dkim {
+	for kid := range dkim {
 		kids = append(kids, kid)
 	}
 

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -516,6 +516,29 @@ func (md *BareRootMetadata) getTLFKeyBundles(keyGen KeyGen) (
 	return &md.WKeys[i], &md.RKeys[i], nil
 }
 
+// GetTLFCryptPublicKeys returns the public crypt keys for the given
+// user at the given key generation, if any.  Returns an error if the
+// TLF is public, or if the given key generation is invalid.
+func (md *BareRootMetadata) GetTLFCryptPublicKeys(
+	keyGen KeyGen, user keybase1.UID) ([]CryptPublicKey, error) {
+	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
+	if err != nil {
+		return nil, err
+	}
+
+	dkim := wkb.WKeys[user]
+	if len(dkim) == 0 {
+		dkim = rkb.RKeys[user]
+	}
+
+	var keys []CryptPublicKey
+	for kid, _ := range dkim {
+		keys = append(keys, MakeCryptPublicKey(kid))
+	}
+
+	return keys, nil
+}
+
 // HasKeyForUser returns whether or not the given user has keys for at
 // least one device at the given key generation. Returns false if the
 // TLF is public, or if the given key generation is invalid.

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -530,9 +530,12 @@ func (md *BareRootMetadata) GetDeviceKIDs(
 	dkim := wkb.WKeys[user]
 	if len(dkim) == 0 {
 		dkim = rkb.RKeys[user]
+		if len(dkim) == 0 {
+			return nil, nil
+		}
 	}
 
-	var kids []keybase1.KID
+	kids := make([]keybase1.KID, 0, len(dkim))
 	for kid := range dkim {
 		kids = append(kids, kid)
 	}

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -519,7 +519,7 @@ func (md *BareRootMetadata) getTLFKeyBundles(keyGen KeyGen) (
 // HasKeyForUser returns whether or not the given user has keys for at
 // least one device at the given key generation. Returns false if the
 // TLF is public, or if the given key generation is invalid.
-func (md *RootMetadata) HasKeyForUser(
+func (md *BareRootMetadata) HasKeyForUser(
 	keyGen KeyGen, user keybase1.UID) bool {
 	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
 	if err != nil {

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -516,11 +516,11 @@ func (md *BareRootMetadata) getTLFKeyBundles(keyGen KeyGen) (
 	return &md.WKeys[i], &md.RKeys[i], nil
 }
 
-// GetTLFCryptPublicKeys returns the public crypt keys for the given
+// GetDeviceKIDs returns the KIDs for all known devices for the given
 // user at the given key generation, if any.  Returns an error if the
 // TLF is public, or if the given key generation is invalid.
-func (md *BareRootMetadata) GetTLFCryptPublicKeys(
-	keyGen KeyGen, user keybase1.UID) ([]CryptPublicKey, error) {
+func (md *BareRootMetadata) GetDeviceKIDs(
+	keyGen KeyGen, user keybase1.UID) ([]keybase1.KID, error) {
 	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
 	if err != nil {
 		return nil, err
@@ -531,17 +531,20 @@ func (md *BareRootMetadata) GetTLFCryptPublicKeys(
 		dkim = rkb.RKeys[user]
 	}
 
-	var keys []CryptPublicKey
+	var kids []keybase1.KID
 	for kid, _ := range dkim {
-		keys = append(keys, MakeCryptPublicKey(kid))
+		kids = append(kids, kid)
 	}
 
-	return keys, nil
+	return kids, nil
 }
 
 // HasKeyForUser returns whether or not the given user has keys for at
 // least one device at the given key generation. Returns false if the
-// TLF is public, or if the given key generation is invalid.
+// TLF is public, or if the given key generation is invalid. Equivalent to:
+//
+//   kids, err := GetDevice(kids(keyGen, user))
+//   return (err == nil) && (len(kids) > 0)
 func (md *BareRootMetadata) HasKeyForUser(
 	keyGen KeyGen, user keybase1.UID) bool {
 	wkb, rkb, err := md.getTLFKeyBundles(keyGen)

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -544,7 +544,7 @@ func (md *BareRootMetadata) GetDeviceKIDs(
 // least one device at the given key generation. Returns false if the
 // TLF is public, or if the given key generation is invalid. Equivalent to:
 //
-//   kids, err := GetDevice(kids(keyGen, user))
+//   kids, err := GetDeviceKIDs(keyGen, user)
 //   return (err == nil) && (len(kids) > 0)
 func (md *BareRootMetadata) HasKeyForUser(
 	keyGen KeyGen, user keybase1.UID) bool {


### PR DESCRIPTION
This used to be GetCryptPublicKeys, which is
actually still used by server code.

Also fix object type for HasKeyForUser.