### PR TITLE
[KBFS-1366] Work around block server behavior

### DIFF
--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -374,7 +374,9 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 		log := config.MakeLogger("")
 		jServer := makeJournalServer(
 			config, log, params.WriteJournalRoot,
+			config.BlockCache(),
 			config.BlockServer(), config.MDOps())
+		config.SetBlockCache(jServer.blockCache())
 		config.SetBlockServer(jServer.blockServer())
 		config.SetMDOps(jServer.mdOps())
 	}

--- a/libkbfs/journal_block_cache.go
+++ b/libkbfs/journal_block_cache.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+type journalBlockCache struct {
+	jServer *JournalServer
+	BlockCache
+}
+
+var _ BlockCache = journalBlockCache{}
+
+// CheckForKnownPtr implements BlockCache.
+func (j journalBlockCache) CheckForKnownPtr(
+	tlfID TlfID, block *FileBlock) (BlockPointer, error) {
+	_, ok := j.jServer.getBundle(tlfID)
+	if !ok {
+		return j.BlockCache.CheckForKnownPtr(tlfID, block)
+	}
+
+	// Temporarily disable de-duping for the journal server until
+	// KBFS-1149 is fixed.
+	return BlockPointer{}, nil
+}

--- a/libkbfs/journal_block_cache.go
+++ b/libkbfs/journal_block_cache.go
@@ -20,6 +20,7 @@ func (j journalBlockCache) CheckForKnownPtr(
 	}
 
 	// Temporarily disable de-duping for the journal server until
-	// KBFS-1149 is fixed.
+	// KBFS-1149 is fixed. (See also
+	// journalBlockServer.AddReference.)
 	return BlockPointer{}, nil
 }

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -53,15 +53,11 @@ func (j journalBlockServer) Put(
 func (j journalBlockServer) AddBlockReference(
 	ctx context.Context, tlfID TlfID, id BlockID,
 	context BlockContext) error {
-	_, ok := j.jServer.getBundle(tlfID)
-	bundle, ok := j.jServer.getBundle(tlfID)
-	if ok {
-		bundle.lock.Lock()
-		defer bundle.lock.Unlock()
-		return bundle.blockJournal.addReference(ctx, id, context)
-	}
-
-	return j.BlockServer.AddBlockReference(ctx, tlfID, id, context)
+	// TODO: Temporarily return an error until KBFS-1149 is
+	// fixed. This is needed despite
+	// journalBlockCache.CheckForBlockPtr, since CheckForBlockPtr
+	// may be called before journaling is turned on for a TLF.
+	return BServerErrorBlockNonExistent{}
 }
 
 func (j journalBlockServer) RemoveBlockReferences(

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -24,7 +24,10 @@ func setupJournalBlockServerTest(t *testing.T) (
 		config, log, tempdir, config.BlockCache(),
 		config.BlockServer(), config.MDOps())
 	config.SetBlockCache(jServer.blockCache())
-	config.SetBlockServer(jServer.blockServer())
+	blockServer := jServer.blockServer()
+	// Turn this on for testing.
+	blockServer.enableAddBlockReference = true
+	config.SetBlockServer(blockServer)
 	config.SetMDOps(jServer.mdOps())
 	return tempdir, config, jServer
 }

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -21,7 +21,9 @@ func setupJournalBlockServerTest(t *testing.T) (
 	config = MakeTestConfigOrBust(t, "test_user")
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
-		config, log, tempdir, config.BlockServer(), config.MDOps())
+		config, log, tempdir, config.BlockCache(),
+		config.BlockServer(), config.MDOps())
+	config.SetBlockCache(jServer.blockCache())
 	config.SetBlockServer(jServer.blockServer())
 	config.SetMDOps(jServer.mdOps())
 	return tempdir, config, jServer

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -31,7 +31,9 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	log := config.MakeLogger("")
 	jServer := makeJournalServer(
-		config, log, tempdir, config.BlockServer(), config.MDOps())
+		config, log, tempdir, config.BlockCache(),
+		config.BlockServer(), config.MDOps())
+	config.SetBlockCache(jServer.blockCache())
 	config.SetBlockServer(jServer.blockServer())
 
 	oldMDOps := config.MDOps()

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -232,7 +232,7 @@ func (j *JournalServer) blockCache() journalBlockCache {
 }
 
 func (j *JournalServer) blockServer() journalBlockServer {
-	return journalBlockServer{j, j.delegateBlockServer}
+	return journalBlockServer{j, j.delegateBlockServer, false}
 }
 
 func (j *JournalServer) mdOps() journalMDOps {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -39,6 +39,7 @@ type JournalServer struct {
 
 	dir string
 
+	delegateBlockCache  BlockCache
 	delegateBlockServer BlockServer
 	delegateMDOps       MDOps
 
@@ -48,12 +49,13 @@ type JournalServer struct {
 
 func makeJournalServer(
 	config Config, log logger.Logger, dir string,
-	bserver BlockServer, mdOps MDOps) *JournalServer {
+	bcache BlockCache, bserver BlockServer, mdOps MDOps) *JournalServer {
 	jServer := JournalServer{
 		config:              config,
 		log:                 log,
 		deferLog:            log.CloneWithAddedDepth(1),
 		dir:                 dir,
+		delegateBlockCache:  bcache,
 		delegateBlockServer: bserver,
 		delegateMDOps:       mdOps,
 		tlfBundles:          make(map[TlfID]*tlfJournalBundle),
@@ -223,6 +225,10 @@ func (j *JournalServer) Disable(tlfID TlfID) (err error) {
 
 	delete(j.tlfBundles, tlfID)
 	return nil
+}
+
+func (j *JournalServer) blockCache() journalBlockCache {
+	return journalBlockCache{j, j.delegateBlockCache}
 }
 
 func (j *JournalServer) blockServer() journalBlockServer {


### PR DESCRIPTION
Specifically, the fact that it doesn't handle
re-putting a block. Do so by stubbing out the
block cache and turning off block dupe detection.