### PR TITLE
[KBFS-1345] Read existing journals on start

### DIFF
--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -56,7 +56,7 @@ func (a JournalAction) Execute(
 		}
 
 	case JournalDisable:
-		err := jServer.Disable(tlf)
+		err := jServer.Disable(ctx, tlf)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -14,6 +14,8 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 )
@@ -376,7 +378,8 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 			config, log, params.WriteJournalRoot,
 			config.BlockCache(),
 			config.BlockServer(), config.MDOps())
-		err := jServer.EnableExistingJournals()
+		ctx := context.Background()
+		err := jServer.EnableExistingJournals(ctx)
 		if err == nil {
 			config.SetBlockCache(jServer.blockCache())
 			config.SetBlockServer(jServer.blockServer())

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -376,9 +376,14 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 			config, log, params.WriteJournalRoot,
 			config.BlockCache(),
 			config.BlockServer(), config.MDOps())
-		config.SetBlockCache(jServer.blockCache())
-		config.SetBlockServer(jServer.blockServer())
-		config.SetMDOps(jServer.mdOps())
+		err := jServer.EnableExistingJournals()
+		if err == nil {
+			config.SetBlockCache(jServer.blockCache())
+			config.SetBlockServer(jServer.blockServer())
+			config.SetMDOps(jServer.mdOps())
+		} else {
+			log.Warning("Failed to enable existing journals: %v", err)
+		}
 	}
 
 	return config, nil

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -23,6 +23,8 @@ func setupJournalBlockServerTest(t *testing.T) (
 	jServer = makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
 		config.BlockServer(), config.MDOps())
+	err = jServer.EnableExistingJournals()
+	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())
 	blockServer := jServer.blockServer()
 	// Turn this on for testing.

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -23,7 +23,8 @@ func setupJournalBlockServerTest(t *testing.T) (
 	jServer = makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
 		config.BlockServer(), config.MDOps())
-	err = jServer.EnableExistingJournals()
+	ctx := context.Background()
+	err = jServer.EnableExistingJournals(ctx)
 	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())
 	blockServer := jServer.blockServer()

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -33,7 +33,9 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	jServer := makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
 		config.BlockServer(), config.MDOps())
-	err = jServer.EnableExistingJournals()
+
+	ctx := context.Background()
+	err = jServer.EnableExistingJournals(ctx)
 	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())
 	config.SetBlockServer(jServer.blockServer())
@@ -42,7 +44,6 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	config.SetMDOps(jServer.mdOps())
 
 	mdOps := config.MDOps()
-	ctx := context.Background()
 
 	_, uid, err := config.KBPKI().GetCurrentUserInfo(ctx)
 	require.NoError(t, err)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -33,6 +33,8 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	jServer := makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
 		config.BlockServer(), config.MDOps())
+	err = jServer.EnableExistingJournals()
+	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())
 	config.SetBlockServer(jServer.blockServer())
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -78,11 +78,10 @@ func (j *JournalServer) getBundle(tlfID TlfID) (*tlfJournalBundle, bool) {
 // JournalServer must not be used.
 func (j *JournalServer) EnableExistingJournals(
 	ctx context.Context) (err error) {
-	// TODO: Use CDebugf
-	j.log.Debug("Enabling existing journals")
+	j.log.CDebugf(ctx, "Enabling existing journals")
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Error when enabling existing journals: %v",
 				err)
 		}
@@ -98,19 +97,20 @@ func (j *JournalServer) EnableExistingJournals(
 	for _, fi := range fileInfos {
 		name := fi.Name()
 		if !fi.IsDir() {
-			j.log.Debug("Skipping file %q", name)
+			j.log.CDebugf(ctx, "Skipping file %q", name)
 			continue
 		}
 		tlfID, err := ParseTlfID(fi.Name())
 		if err != nil {
-			j.log.Debug("Skipping non-TLF dir %q", name)
+			j.log.CDebugf(ctx, "Skipping non-TLF dir %q", name)
 			continue
 		}
 
 		err = j.Enable(ctx, tlfID)
 		if err != nil {
 			// Don't treat per-TLF errors as fatal.
-			j.log.Warning("Error when enabling existing journal for %s: %v",
+			j.log.CWarningf(
+				ctx, "Error when enabling existing journal for %s: %v",
 				tlfID, err)
 			continue
 		}
@@ -121,10 +121,10 @@ func (j *JournalServer) EnableExistingJournals(
 
 // Enable turns on the write journal for the given TLF.
 func (j *JournalServer) Enable(ctx context.Context, tlfID TlfID) (err error) {
-	j.log.Debug("Enabling journal for %s", tlfID)
+	j.log.CDebugf(ctx, "Enabling journal for %s", tlfID)
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Error when enabling journal for %s: %v",
 				tlfID, err)
 		}
@@ -134,12 +134,12 @@ func (j *JournalServer) Enable(ctx context.Context, tlfID TlfID) (err error) {
 	defer j.lock.Unlock()
 	_, ok := j.tlfBundles[tlfID]
 	if ok {
-		j.log.Debug("Journal already enabled for %s", tlfID)
+		j.log.CDebugf(ctx, "Journal already enabled for %s", tlfID)
 		return nil
 	}
 
 	tlfDir := filepath.Join(j.dir, tlfID.String())
-	j.log.Debug("Enabled journal for %s with path %s", tlfID, tlfDir)
+	j.log.CDebugf(ctx, "Enabled journal for %s with path %s", tlfID, tlfDir)
 
 	log := j.config.MakeLogger("")
 	bundle := &tlfJournalBundle{}
@@ -159,12 +159,12 @@ func (j *JournalServer) Enable(ctx context.Context, tlfID TlfID) (err error) {
 
 // Flush flushes the write journal for the given TLF.
 func (j *JournalServer) Flush(ctx context.Context, tlfID TlfID) (err error) {
-	j.log.Debug("Flushing journal for %s", tlfID)
+	j.log.CDebugf(ctx, "Flushing journal for %s", tlfID)
 	flushedBlockEntries := 0
 	flushedMDEntries := 0
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Flushed %d block entries and %d MD entries "+
 					"for %s, but got error %v",
 				flushedBlockEntries, flushedMDEntries,
@@ -173,7 +173,7 @@ func (j *JournalServer) Flush(ctx context.Context, tlfID TlfID) (err error) {
 	}()
 	bundle, ok := j.getBundle(tlfID)
 	if !ok {
-		j.log.Debug("Journal not enabled for %s", tlfID)
+		j.log.CDebugf(ctx, "Journal not enabled for %s", tlfID)
 		return nil
 	}
 
@@ -225,18 +225,18 @@ func (j *JournalServer) Flush(ctx context.Context, tlfID TlfID) (err error) {
 		flushedMDEntries++
 	}
 
-	j.log.Debug("Flushed %d block entries and %d MD entries for %s",
+	j.log.CDebugf(ctx, "Flushed %d block entries and %d MD entries for %s",
 		flushedBlockEntries, flushedMDEntries, tlfID)
 
 	return nil
 }
 
 // Disable turns off the write journal for the given TLF.
-func (j *JournalServer) Disable(tlfID TlfID) (err error) {
-	j.log.Debug("Disabling journal for %s", tlfID)
+func (j *JournalServer) Disable(ctx context.Context, tlfID TlfID) (err error) {
+	j.log.CDebugf(ctx, "Disabling journal for %s", tlfID)
 	defer func() {
 		if err != nil {
-			j.deferLog.Debug(
+			j.deferLog.CDebugf(ctx,
 				"Error when disabling journal for %s: %v",
 				tlfID, err)
 		}
@@ -246,7 +246,7 @@ func (j *JournalServer) Disable(tlfID TlfID) (err error) {
 	defer j.lock.Unlock()
 	bundle, ok := j.tlfBundles[tlfID]
 	if !ok {
-		j.log.Debug("Journal already disabled for %s", tlfID)
+		j.log.CDebugf(ctx, "Journal already disabled for %s", tlfID)
 		return nil
 	}
 
@@ -270,7 +270,7 @@ func (j *JournalServer) Disable(tlfID TlfID) (err error) {
 		return fmt.Errorf("Journal still has %d MD entries", length)
 	}
 
-	j.log.Debug("Disabled journal for %s", tlfID)
+	j.log.CDebugf(ctx, "Disabled journal for %s", tlfID)
 
 	delete(j.tlfBundles, tlfID)
 	return nil

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -70,6 +70,14 @@ func (j *JournalServer) getBundle(tlfID TlfID) (*tlfJournalBundle, bool) {
 	return bundle, ok
 }
 
+// EnableExistingJournals turns on the write journal for all TLFs with
+// an existing journal. This must be the first thing done to a
+// JournalServer. Any returned error is fatal, and means that the
+// JournalServer must not be used.
+func (j *JournalServer) EnableExistingJournals() (err error) {
+	return nil
+}
+
 // Enable turns on the write journal for the given TLF.
 func (j *JournalServer) Enable(ctx context.Context, tlfID TlfID) (err error) {
 	j.log.Debug("Enabling journal for %s", tlfID)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -112,5 +112,5 @@ func TestJournalServerRestart(t *testing.T) {
 
 	head, err := mdOps.GetForTLF(ctx, tlfID)
 	require.NoError(t, err)
-	require.Equal(t, head, rmd)
+	require.Equal(t, rmd.Revision, head.Revision)
 }

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -1,0 +1,116 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/keybase/client/go/protocol"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func setupJournalServerTest(t *testing.T) (
+	tempdir string, config Config, jServer *JournalServer) {
+	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
+	require.NoError(t, err)
+	config = MakeTestConfigOrBust(t, "test_user")
+	log := config.MakeLogger("")
+	jServer = makeJournalServer(
+		config, log, tempdir, config.BlockCache(),
+		config.BlockServer(), config.MDOps())
+	ctx := context.Background()
+	err = jServer.EnableExistingJournals(ctx)
+	require.NoError(t, err)
+	config.SetBlockCache(jServer.blockCache())
+	config.SetBlockServer(jServer.blockServer())
+	config.SetMDOps(jServer.mdOps())
+	return tempdir, config, jServer
+}
+
+func teardownJournalServerTest(
+	t *testing.T, tempdir string, config Config) {
+	err := os.RemoveAll(tempdir)
+	require.NoError(t, err)
+	CheckConfigAndShutdown(t, config)
+}
+
+func TestJournalServerRestart(t *testing.T) {
+	tempdir, config, jServer := setupJournalServerTest(t)
+	defer teardownJournalServerTest(t, tempdir, config)
+
+	// Use a shutdown-only BlockServer so that it errors if the
+	// journal tries to access it.
+	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
+
+	ctx := context.Background()
+
+	tlfID := FakeTlfID(2, false)
+	err := jServer.Enable(ctx, tlfID)
+	require.NoError(t, err)
+
+	blockServer := config.BlockServer()
+	mdOps := config.MDOps()
+	crypto := config.Crypto()
+
+	uid := keybase1.MakeTestUID(1)
+	bh, err := MakeBareTlfHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	require.NoError(t, err)
+
+	bCtx := BlockContext{uid, "", zeroBlockRefNonce}
+	data := []byte{1, 2, 3, 4}
+	bID, err := crypto.MakePermanentBlockID(data)
+	require.NoError(t, err)
+
+	// Put a block.
+
+	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
+	require.NoError(t, err)
+	err = blockServer.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
+	require.NoError(t, err)
+
+	// Put an MD.
+
+	var rmd RootMetadata
+	err = updateNewBareRootMetadata(&rmd.BareRootMetadata, tlfID, bh)
+	require.NoError(t, err)
+	rmd.tlfHandle = h
+	rmd.Revision = MetadataRevision(1)
+	rekeyDone, _, err := config.KeyManager().Rekey(ctx, &rmd, false)
+	require.NoError(t, err)
+	require.True(t, rekeyDone)
+
+	_, err = mdOps.Put(ctx, &rmd)
+	require.NoError(t, err)
+
+	// Simulate a restart.
+
+	jServer = makeJournalServer(
+		config, jServer.log, tempdir, jServer.delegateBlockCache,
+		jServer.delegateBlockServer, jServer.delegateMDOps)
+	err = jServer.EnableExistingJournals(ctx)
+	require.NoError(t, err)
+	config.SetBlockCache(jServer.blockCache())
+	config.SetBlockServer(jServer.blockServer())
+	config.SetMDOps(jServer.mdOps())
+
+	// Get the block.
+
+	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+	require.Equal(t, serverHalf, key)
+
+	// Get the MD.
+
+	head, err := mdOps.GetForTLF(ctx, tlfID)
+	require.NoError(t, err)
+	require.Equal(t, head, rmd)
+}


### PR DESCRIPTION
This makes journals actually behave
persistently.

Also fix JournalServer logs to use a context.