### PR TITLE
[KBFS-1398] Allow head replacement in mdJournal

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -862,6 +862,10 @@ func (fbo *folderBranchOps) getMDForReadNeedIdentify(
 	return fbo.getMDForReadHelper(ctx, lState, mdReadNeedIdentify)
 }
 
+// getMDForWriteLocked returns a new RootMetadata object with an
+// incremented version number for modification. If the returned object
+// is put to the MDServer (via MDOps), mdWriterLock must be held until
+// then. (See comments for mdWriterLock above.)
 func (fbo *folderBranchOps) getMDForWriteLocked(
 	ctx context.Context, lState *lockState) (*RootMetadata, error) {
 	fbo.mdWriterLock.AssertLocked(lState)

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -17,6 +17,9 @@ import (
 // other stuff besides metadata puts. But doing so would be difficult,
 // since then we would require the ordinals to be something other than
 // MetadataRevisions.
+//
+// TODO: Write unit tests for this. For now, we're relying on
+// md_journal.go's unit tests.
 type mdIDJournal struct {
 	j diskJournal
 }

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -163,6 +163,14 @@ func (j mdIDJournal) getRange(
 	return start, mdIDs, nil
 }
 
+func (j mdIDJournal) replaceHead(mdID MdID) error {
+	o, err := j.j.readLatestOrdinal()
+	if err != nil {
+		return err
+	}
+	return j.j.writeJournalEntry(o, mdID)
+}
+
 func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
 	o, err := revisionToOrdinal(r)
 	if err != nil {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -428,7 +428,9 @@ func (e MDJournalConflictError) Error() string {
 // put verifies and stores the given RootMetadata in the journal,
 // modifying it as needed. In particular, if this is an unmerged
 // RootMetadata but the branch ID isn't set, it will be set to the
-// journal's branch ID, which is assumed to be non-zero.
+// journal's branch ID, which is assumed to be non-zero. As a special
+// case, if the revision of the given RootMetadata matches that of the
+// head, the given RootMetadata will replace the head.
 func (j *mdJournal) put(
 	ctx context.Context, signer cryptoSigner, ekg encryptionKeyGetter,
 	rmd *RootMetadata, currentUID keybase1.UID,
@@ -494,10 +496,12 @@ func (j *mdJournal) put(
 		}
 
 		// Consistency checks
-		err = head.CheckValidSuccessorForServer(
-			head.mdID, &rmd.BareRootMetadata)
-		if err != nil {
-			return MdID{}, err
+		if rmd.Revision != head.Revision {
+			err = head.CheckValidSuccessorForServer(
+				head.mdID, &rmd.BareRootMetadata)
+			if err != nil {
+				return MdID{}, err
+			}
 		}
 	}
 
@@ -513,9 +517,17 @@ func (j *mdJournal) put(
 		return MdID{}, err
 	}
 
-	err = j.j.append(brmd.Revision, id)
-	if err != nil {
-		return MdID{}, err
+	if head != (ImmutableBareRootMetadata{}) &&
+		rmd.Revision == head.Revision {
+		err = j.j.replaceHead(id)
+		if err != nil {
+			return MdID{}, err
+		}
+	} else {
+		err = j.j.append(brmd.Revision, id)
+		if err != nil {
+			return MdID{}, err
+		}
 	}
 
 	// Since the journal is now non-empty, clear these fields.

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -519,6 +519,9 @@ func (j *mdJournal) put(
 
 	if head != (ImmutableBareRootMetadata{}) &&
 		rmd.Revision == head.Revision {
+		j.log.CDebugf(
+			ctx, "Replacing head MD for TLF=%s with rev=%s bid=%s",
+			rmd.ID, rmd.Revision, rmd.BID)
 		err = j.j.replaceHead(id)
 		if err != nil {
 			return MdID{}, err


### PR DESCRIPTION
This handles the case where we interrupt an MD put
into the journal. We can safely replace the head
since it hasn't been pushed to the server yet.