### PR TITLE
[KBFS-1280] Add journal status info to .kbfs_status

### DIFF
--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -43,6 +43,7 @@ type KBFSStatus struct {
 	UsageBytes      int64
 	LimitBytes      int64
 	FailingServices map[string]error
+	JournalServer   *JournalServerStatus
 }
 
 // StatusUpdate is a dummy type used to indicate status has been updated.

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -33,7 +33,7 @@ type FolderBranchStatus struct {
 	Unmerged []*crChainSummary
 	Merged   []*crChainSummary
 
-	Journal *TLFJournalStatus
+	Journal *TLFJournalStatus `json:",omitempty"`
 }
 
 // KBFSStatus represents the content of the top-level status file. It is
@@ -45,7 +45,7 @@ type KBFSStatus struct {
 	UsageBytes      int64
 	LimitBytes      int64
 	FailingServices map[string]error
-	JournalServer   *JournalServerStatus
+	JournalServer   *JournalServerStatus `json:",omitempty"`
 }
 
 // StatusUpdate is a dummy type used to indicate status has been updated.

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -177,10 +177,7 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context) (
 		fbs.Revision = fbsk.md.Revision
 
 		jServer, err := GetJournalServer(fbsk.config)
-		if err != nil {
-			log := fbsk.config.MakeLogger("")
-			log.CWarningf(ctx, "Error getting journal server: %v", err)
-		} else {
+		if err == nil {
 			jStatus, err := jServer.JournalStatus(fbsk.md.ID)
 			if err != nil {
 				log := fbsk.config.MakeLogger("")

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -154,7 +154,8 @@ func (fbsk *folderBranchStatusKeeper) convertNodesToPathsLocked(
 }
 
 // getStatus returns a FolderBranchStatus-representation of the
-// current status.
+// current status. The returned channel is closed whenever the status
+// changes, except for journal status changes.
 func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context) (
 	FolderBranchStatus, <-chan StatusUpdate, error) {
 	fbsk.dataMutex.Lock()
@@ -176,6 +177,9 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context) (
 		fbs.FolderID = fbsk.md.ID.String()
 		fbs.Revision = fbsk.md.Revision
 
+		// TODO: Ideally, the journal would push status
+		// updates to this object instead, so we can notify
+		// listeners.
 		jServer, err := GetJournalServer(fbsk.config)
 		if err == nil {
 			jStatus, err := jServer.JournalStatus(fbsk.md.ID)

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -35,6 +35,15 @@ type JournalServerStatus struct {
 	JournalCount int
 }
 
+// TLFJournalStatus represents the status of a TLF's journal for
+// display in diagnostics. It is suitable for encoding directly as
+// JSON.
+type TLFJournalStatus struct {
+	RevisionStart MetadataRevision
+	RevisionEnd   MetadataRevision
+	BlockOpCount  uint64
+}
+
 // JournalServer is the server that handles write journals. It
 // interposes itself in front of BlockServer and MDOps. It uses MDOps
 // instead of MDServer because it has to potentially modify the
@@ -306,4 +315,8 @@ func (j *JournalServer) Status() JournalServerStatus {
 		RootDir:      j.dir,
 		JournalCount: journalCount,
 	}
+}
+
+func (j *JournalServer) JournalStatus(tlfID TlfID) (TLFJournalStatus, error) {
+	return TLFJournalStatus{}, nil
 }

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -27,6 +27,14 @@ type tlfJournalBundle struct {
 	mdJournal    *mdJournal
 }
 
+// JournalServerStatus represents the overall status of the
+// JournalServer for display in diagnostics. It is suitable for
+// encoding directly as JSON.
+type JournalServerStatus struct {
+	RootDir      string
+	JournalCount int
+}
+
 // JournalServer is the server that handles write journals. It
 // interposes itself in front of BlockServer and MDOps. It uses MDOps
 // instead of MDServer because it has to potentially modify the
@@ -286,4 +294,16 @@ func (j *JournalServer) blockServer() journalBlockServer {
 
 func (j *JournalServer) mdOps() journalMDOps {
 	return journalMDOps{j.delegateMDOps, j}
+}
+
+func (j *JournalServer) Status() JournalServerStatus {
+	journalCount := func() int {
+		j.lock.RLock()
+		defer j.lock.RUnlock()
+		return len(j.tlfBundles)
+	}()
+	return JournalServerStatus{
+		RootDir:      j.dir,
+		JournalCount: journalCount,
+	}
 }

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -305,6 +305,8 @@ func (j *JournalServer) mdOps() journalMDOps {
 	return journalMDOps{j.delegateMDOps, j}
 }
 
+// Status returns a JournalServerStatus object suitable for
+// diagnostics.
 func (j *JournalServer) Status() JournalServerStatus {
 	journalCount := func() int {
 		j.lock.RLock()
@@ -317,6 +319,8 @@ func (j *JournalServer) Status() JournalServerStatus {
 	}
 }
 
+// JournalStatus returns a TLFServerStatus object for the given TLF
+// suitable for diagnostics.
 func (j *JournalServer) JournalStatus(tlfID TlfID) (TLFJournalStatus, error) {
 	bundle, ok := j.getBundle(tlfID)
 	if !ok {

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -509,12 +509,21 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		}
 	}
 	failures, ch := fs.currentStatus.CurrentStatus()
+	var jServerStatus *JournalServerStatus
+	jServer, err := GetJournalServer(fs.config)
+	if err != nil {
+		fs.log.CWarningf(ctx, "Error getting journal server: %v", err)
+	} else {
+		status := jServer.Status()
+		jServerStatus = &status
+	}
 	return KBFSStatus{
 		CurrentUser:     username.String(),
 		IsConnected:     fs.config.MDServer().IsConnected(),
 		UsageBytes:      usageBytes,
 		LimitBytes:      limitBytes,
 		FailingServices: failures,
+		JournalServer:   jServerStatus,
 	}, ch, err
 }
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -511,9 +511,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	failures, ch := fs.currentStatus.CurrentStatus()
 	var jServerStatus *JournalServerStatus
 	jServer, err := GetJournalServer(fs.config)
-	if err != nil {
-		fs.log.CWarningf(ctx, "Error getting journal server: %v", err)
-	} else {
+	if err == nil {
 		status := jServer.Status()
 		jServerStatus = &status
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -378,6 +378,14 @@ func (j mdJournal) pushEarliestToServer(
 
 // All functions below are public functions.
 
+func (j mdJournal) readEarliestRevision() (MetadataRevision, error) {
+	return j.j.readEarliestRevision()
+}
+
+func (j mdJournal) readLatestRevision() (MetadataRevision, error) {
+	return j.j.readLatestRevision()
+}
+
 func (j mdJournal) length() (uint64, error) {
 	return j.j.length()
 }


### PR DESCRIPTION
Add root dir and journal count to top-level .kbfs_status,
and add revision start/end and block op count to
per-folder .kbfs_status.