### PR TITLE
libfuse should not ignore errors from libkfs init procedure, this res…

### DIFF
--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -24,7 +24,10 @@ type StartOptions struct {
 // Start the filesystem
 func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// InitLog errors are non-fatal and are ignored.
-	log, _ := libkbfs.InitLog(options.KbfsParams, kbCtx)
+	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
+	if err != nil {
+		return libfs.InitError(err.Error())
+	}
 
 	if options.RuntimeDir != "" {
 		info := libkb.NewServiceInfo(libkbfs.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())


### PR DESCRIPTION
libfuse should not ignore errors from libkfs init procedure, this results in runtime panics in certain situations.