### PR TITLE
Taruti/dokan extra api

### DIFF
--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -357,7 +357,7 @@ error_t kbfsLibdokanRun(struct kbfsLibdokanCtx* ctx) {
 	if(!kbfsLibdokanPtr_Main)
 		kbfsLibdokanLoadLibrary(L"DOKAN" DOKAN_MAJOR_API_VERSION L".DLL");
 	if(!kbfsLibdokanPtr_Main)
-		return -99;
+		return kbfsLibDokan_DLL_LOAD_ERROR;
 	if(ctx->dokan_options.Options & kbfsLibdokanUseFindFilesWithPattern != 0) {
 	  ctx->dokan_options.Options &= ~kbfsLibdokanUseFindFilesWithPattern;
 	  ctx->dokan_operations.FindFilesWithPattern = kbfsLibdokanC_FindFilesWithPattern;

--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -125,12 +125,17 @@ static DOKAN_CALLBACK  NTSTATUS kbfsLibdokanC_FindFiles(LPCWSTR PathName,
   return kbfsLibdokanFindFiles(PathName, FindData, FileInfo);
 }
 
-/*
 extern NTSTATUS kbfsLibdokanFindFilesWithPattern(LPCWSTR PathName,
 						   LPCWSTR SearchPattern,
 						   PFillFindData FindData, // call this function with PWIN32_FIND_DATAW
 						   PDOKAN_FILE_INFO FileInfo);
-*/
+static DOKAN_CALLBACK  NTSTATUS kbfsLibdokanC_FindFilesWithPattern(LPCWSTR PathName,
+								   LPCWSTR SearchPattern,
+								   PFillFindData FindData,	// call this function with PWIN32_FIND_DATAW
+								   PDOKAN_FILE_INFO FileInfo) {
+  return kbfsLibdokanFindFilesWithPattern(PathName, SearchPattern, FindData, FileInfo);
+}
+
 extern NTSTATUS kbfsLibdokanSetFileAttributes(LPCWSTR FileName,
 						DWORD FileAttributes,
 						PDOKAN_FILE_INFO FileInfo);
@@ -314,8 +319,6 @@ struct kbfsLibdokanCtx* kbfsLibdokanAllocCtx(ULONG64 slot) {
   ctx->dokan_operations.FlushFileBuffers = kbfsLibdokanC_FlushFileBuffers;
   ctx->dokan_operations.GetFileInformation = kbfsLibdokanC_GetFileInformation;
   ctx->dokan_operations.FindFiles = kbfsLibdokanC_FindFiles;
-  //FIXME: perhaps switch to FindFilesWithPattern later?
-  //  ctx->dokan_operations.FindFilesWithPattern = kbfsLibdokanC_FindFilesWithPattern;
   ctx->dokan_operations.SetFileAttributes = kbfsLibdokanC_SetFileAttributes;
   ctx->dokan_operations.SetFileTime = kbfsLibdokanC_SetFileTime;
   ctx->dokan_operations.DeleteFile = kbfsLibdokanC_DeleteFile;
@@ -355,6 +358,10 @@ error_t kbfsLibdokanRun(struct kbfsLibdokanCtx* ctx) {
 		kbfsLibdokanLoadLibrary(L"DOKAN" DOKAN_MAJOR_API_VERSION L".DLL");
 	if(!kbfsLibdokanPtr_Main)
 		return -99;
+	if(ctx->dokan_options.Options & kbfsLibdokanUseFindFilesWithPattern != 0) {
+	  ctx->dokan_options.Options &= ~kbfsLibdokanUseFindFilesWithPattern;
+	  ctx->dokan_operations.FindFilesWithPattern = kbfsLibdokanC_FindFilesWithPattern;
+	}
 	int status = (*kbfsLibdokanPtr_Main)(&ctx->dokan_options, &ctx->dokan_operations);
 	return status;
 }

--- a/dokan/bridge.h
+++ b/dokan/bridge.h
@@ -52,6 +52,7 @@ enum {
   kbfsLibdokanRemovable = DOKAN_OPTION_REMOVABLE,
   kbfsLibdokanMountManager = DOKAN_OPTION_MOUNT_MANAGER,
   kbfsLibdokanCurrentSession = DOKAN_OPTION_CURRENT_SESSION,
+  kbfsLibdokanUseFindFilesWithPattern = 1<<24;
 };
 
 #endif /* windows check */

--- a/dokan/bridge.h
+++ b/dokan/bridge.h
@@ -52,7 +52,7 @@ enum {
   kbfsLibdokanRemovable = DOKAN_OPTION_REMOVABLE,
   kbfsLibdokanMountManager = DOKAN_OPTION_MOUNT_MANAGER,
   kbfsLibdokanCurrentSession = DOKAN_OPTION_CURRENT_SESSION,
-  kbfsLibdokanUseFindFilesWithPattern = 1<<24;
+  kbfsLibdokanUseFindFilesWithPattern = 1<<24,
 
   kbfsLibDokan_ERROR = DOKAN_ERROR,
   kbfsLibDokan_DRIVE_LETTER_ERROR = DOKAN_DRIVE_LETTER_ERROR,

--- a/dokan/bridge.h
+++ b/dokan/bridge.h
@@ -53,6 +53,15 @@ enum {
   kbfsLibdokanMountManager = DOKAN_OPTION_MOUNT_MANAGER,
   kbfsLibdokanCurrentSession = DOKAN_OPTION_CURRENT_SESSION,
   kbfsLibdokanUseFindFilesWithPattern = 1<<24;
+
+  kbfsLibDokan_ERROR = DOKAN_ERROR,
+  kbfsLibDokan_DRIVE_LETTER_ERROR = DOKAN_DRIVE_LETTER_ERROR,
+  kbfsLibDokan_DRIVER_INSTALL_ERROR = DOKAN_DRIVER_INSTALL_ERROR,
+  kbfsLibDokan_START_ERROR = DOKAN_START_ERROR,
+  kbfsLibDokan_MOUNT_ERROR = DOKAN_MOUNT_ERROR,
+  kbfsLibDokan_MOUNT_POINT_ERROR = DOKAN_MOUNT_POINT_ERROR,
+  kbfsLibDokan_VERSION_ERROR = DOKAN_VERSION_ERROR,
+  kbfsLibDokan_DLL_LOAD_ERROR = -99,
 };
 
 #endif /* windows check */

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -216,6 +216,26 @@ func kbfsLibdokanFindFiles(
 	FindData C.PFillFindData, // call this function with PWIN32_FIND_DATAW
 	pfi C.PDOKAN_FILE_INFO) C.NTSTATUS {
 	debugf("FindFiles '%v' %v", d16{PathName}, *pfi)
+	return kbfsLibdokanFindFilesImpl(PathName, "", FindData, pfi)
+}
+
+//export kbfsLibdokanFindFilesWithPattern
+func kbfsLibdokanFindFilesWithPattern(
+	PathName C.LPCWSTR,
+	SearchPattern C.LPCWSTR,
+	PFillFindData uintptr, // call this function with PWIN32_FIND_DATAW
+	pfi C.PDOKAN_FILE_INFO) C.NTSTATUS {
+	pattern := lpcwstrToString(SearchPattern)
+	debugf("FindFilesWithPattern '%v' %v %q", d16{PathName}, *pfi, pattern)
+	return kbfsLibdokanFindFilesImpl(PathName, pattern, FindData, pfi)
+}
+
+func kbfsLibdokanFindFilesImpl(
+	PathName C.LPCWSTR,
+	pattern string,
+	FindData C.PFillFindData,
+	pfi C.PDOKAN_FILE_INFO) C.NTSTATUS {
+	debugf("FindFiles '%v' %v", d16{PathName}, *pfi)
 	ctx, cancel := getContext(pfi)
 	if cancel != nil {
 		defer cancel()
@@ -244,21 +264,9 @@ func kbfsLibdokanFindFiles(
 		}
 		return nil
 	}
-	err := getfi(pfi).FindFiles(ctx, makeFI(PathName, pfi), fun)
+	err := getfi(pfi).FindFiles(ctx, makeFI(PathName, pfi), pattern, fun)
 	return errToNT(err)
 }
-
-/* This is disabled from the C side currently.
-//export kbfsLibdokanFindFilesWithPattern
-func kbfsLibdokanFindFilesWithPattern (
-	PathName C.LPCWSTR,
-	SearchPattern C.LPCWSTR,
-	PFillFindData uintptr, // call this function with PWIN32_FIND_DATAW
-	pfi C.PDOKAN_FILE_INFO) C.NTSTATUS {
-
-
-}
-*/
 
 //export kbfsLibdokanSetFileAttributes
 func kbfsLibdokanSetFileAttributes(

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -593,9 +593,32 @@ func (ctx *dokanCtx) Run(path string, flags MountFlag) error {
 	C.kbfsLibdokanSet_path(ctx.ptr, stringToUtf16Ptr(path))
 	ec := C.kbfsLibdokanRun(ctx.ptr)
 	if ec != 0 {
-		return fmt.Errorf("Dokan failed: %d", ec)
+		return fmt.Errorf("Dokan failed: code=%d %q", ec, dokanErrString(ec))
 	}
 	return nil
+}
+
+func dokanErrString(code int32) string {
+	switch code {
+	case kbfsLibDokan_ERROR:
+		return "General error"
+	case kbfsLibDokan_DRIVE_LETTER_ERROR:
+		return "Drive letter error"
+	case kbfsLibDokan_DRIVER_INSTALL_ERROR:
+		return "Driver install error"
+	case kbfsLibDokan_START_ERROR:
+		return "Start error"
+	case kbfsLibDokan_MOUNT_ERROR:
+		return "Mount error"
+	case kbfsLibDokan_MOUNT_POINT_ERROR:
+		return "Mount point error"
+	case kbfsLibDokan_VERSION_ERROR:
+		return "Version error"
+	case kbfsLibDokan_DLL_LOAD_ERROR:
+		return "Error loading Dokan DLL"
+	default:
+		return "UNKNOWN"
+	}
 }
 
 func (ctx *dokanCtx) Free() {

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -29,11 +29,12 @@ import (
 type SID syscall.SID
 
 const (
-	kbfsLibdokanDebug          = MountFlag(C.kbfsLibdokanDebug)
-	kbfsLibdokanStderr         = MountFlag(C.kbfsLibdokanStderr)
-	kbfsLibdokanRemovable      = MountFlag(C.kbfsLibdokanRemovable)
-	kbfsLibdokanMountManager   = MountFlag(C.kbfsLibdokanMountManager)
-	kbfsLibdokanCurrentSession = MountFlag(C.kbfsLibdokanCurrentSession)
+	kbfsLibdokanDebug                   = MountFlag(C.kbfsLibdokanDebug)
+	kbfsLibdokanStderr                  = MountFlag(C.kbfsLibdokanStderr)
+	kbfsLibdokanRemovable               = MountFlag(C.kbfsLibdokanRemovable)
+	kbfsLibdokanMountManager            = MountFlag(C.kbfsLibdokanMountManager)
+	kbfsLibdokanCurrentSession          = MountFlag(C.kbfsLibdokanCurrentSession)
+	kbfsLibdokanUseFindFilesWithPattern = MountFlag(C.kbfsLibdokanUseFindFilesWithPattern)
 )
 
 // loadDokanDLL can be called to init the system with custom Dokan location,
@@ -223,7 +224,7 @@ func kbfsLibdokanFindFiles(
 func kbfsLibdokanFindFilesWithPattern(
 	PathName C.LPCWSTR,
 	SearchPattern C.LPCWSTR,
-	PFillFindData uintptr, // call this function with PWIN32_FIND_DATAW
+	FindData C.PFillFindData, // call this function with PWIN32_FIND_DATAW
 	pfi C.PDOKAN_FILE_INFO) C.NTSTATUS {
 	pattern := lpcwstrToString(SearchPattern)
 	debugf("FindFilesWithPattern '%v' %v %q", d16{PathName}, *pfi, pattern)
@@ -593,28 +594,28 @@ func (ctx *dokanCtx) Run(path string, flags MountFlag) error {
 	C.kbfsLibdokanSet_path(ctx.ptr, stringToUtf16Ptr(path))
 	ec := C.kbfsLibdokanRun(ctx.ptr)
 	if ec != 0 {
-		return fmt.Errorf("Dokan failed: code=%d %q", ec, dokanErrString(ec))
+		return fmt.Errorf("Dokan failed: code=%d %q", ec, dokanErrString(int32(ec)))
 	}
 	return nil
 }
 
 func dokanErrString(code int32) string {
 	switch code {
-	case kbfsLibDokan_ERROR:
+	case C.kbfsLibDokan_ERROR:
 		return "General error"
-	case kbfsLibDokan_DRIVE_LETTER_ERROR:
+	case C.kbfsLibDokan_DRIVE_LETTER_ERROR:
 		return "Drive letter error"
-	case kbfsLibDokan_DRIVER_INSTALL_ERROR:
+	case C.kbfsLibDokan_DRIVER_INSTALL_ERROR:
 		return "Driver install error"
-	case kbfsLibDokan_START_ERROR:
+	case C.kbfsLibDokan_START_ERROR:
 		return "Start error"
-	case kbfsLibDokan_MOUNT_ERROR:
+	case C.kbfsLibDokan_MOUNT_ERROR:
 		return "Mount error"
-	case kbfsLibDokan_MOUNT_POINT_ERROR:
+	case C.kbfsLibDokan_MOUNT_POINT_ERROR:
 		return "Mount point error"
-	case kbfsLibDokan_VERSION_ERROR:
+	case C.kbfsLibDokan_VERSION_ERROR:
 		return "Version error"
-	case kbfsLibDokan_DLL_LOAD_ERROR:
+	case C.kbfsLibDokan_DLL_LOAD_ERROR:
 		return "Error loading Dokan DLL"
 	default:
 		return "UNKNOWN"

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"runtime"
 	"syscall"
 	"time"
 	"unicode/utf16"
@@ -666,6 +667,8 @@ func (fi *FileInfo) isRequestorUserSidEqualTo(sid *SID) bool {
 		u2, _ := tokUser.User.Sid.String()
 		debugf("IsRequestorUserSidEqualTo: EqualSID(%q,%q) => %v (expecting non-zero)\n", u1, u2, res)
 	}
+	runtime.KeepAlive(sid)
+	runtime.KeepAlive(tokUser.User.Sid)
 	return res != 0
 }
 

--- a/dokan/dummy.go
+++ b/dokan/dummy.go
@@ -42,11 +42,12 @@ func unmount(path string) error {
 type SID struct{}
 
 const (
-	kbfsLibdokanDebug          = 0
-	kbfsLibdokanStderr         = 0
-	kbfsLibdokanRemovable      = 0
-	kbfsLibdokanMountManager   = 0
-	kbfsLibdokanCurrentSession = 0
+	kbfsLibdokanDebug = MountFlag(0)
+	kbfsLibdokanStderr
+	kbfsLibdokanRemovable
+	kbfsLibdokanMountManager
+	kbfsLibdokanCurrentSession
+	kbfsLibdokanUseFindFilesWithPattern
 )
 
 func currentProcessUserSid() (*SID, error) {

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -59,6 +59,9 @@ const (
 	Removable      = MountFlag(kbfsLibdokanRemovable)
 	MountManager   = MountFlag(kbfsLibdokanMountManager)
 	CurrentSession = MountFlag(kbfsLibdokanCurrentSession)
+	// UseFindFilesWithPattern enables FindFiles calls to be with a search
+	// pattern string. Otherwise the string will be empty in all calls.
+	UseFindFilesWithPattern = MountFlag(kbfsLibdokanUseFindFilesWithPattern)
 )
 
 // CreateData contains all the info needed to create a file.
@@ -116,12 +119,14 @@ type File interface {
 
 	// GetFileInformation - corresponds to stat.
 	GetFileInformation(ctx context.Context, fi *FileInfo) (*Stat, error)
-	// FindFiles is the readdir. The function is a callback that
-	// should be called with each file. The same NamedStat may
-	// be reused for subsequent calls.
-	FindFiles(ctx context.Context, fi *FileInfo, fillStatCallback func(*NamedStat) error) error
 
-	//FindFilesWithPattern
+	// FindFiles is the readdir. The function is a callback that should be called
+	// with each file. The same NamedStat may be reused for subsequent calls.
+	//
+	// Pattern will be an empty string unless UseFindFilesWithPattern is enabled - then
+	// it may be a pattern like `*.png` to match. All implementations must be prepared
+	// to handle empty strings as patterns.
+	FindFiles(ctx context.Context, fi *FileInfo, pattern string, fillStatCallback func(*NamedStat) error) error
 
 	// SetFileTime sets the file time. Test times with .IsZero
 	// whether they should be set.

--- a/dokan/testfs_test.go
+++ b/dokan/testfs_test.go
@@ -285,7 +285,7 @@ func (t emptyFile) GetFileInformation(ctx context.Context, fi *FileInfo) (*Stat,
 	st.FileAttributes = FileAttributeNormal
 	return &st, nil
 }
-func (t emptyFile) FindFiles(context.Context, *FileInfo, func(*NamedStat) error) error {
+func (t emptyFile) FindFiles(context.Context, *FileInfo, string, func(*NamedStat) error) error {
 	debug("emptyFile.FindFiles")
 	return nil
 }
@@ -358,7 +358,7 @@ type testDir struct {
 
 const helloStr = "hello world\r\n"
 
-func (t testDir) FindFiles(ctx context.Context, fi *FileInfo, cb func(*NamedStat) error) error {
+func (t testDir) FindFiles(ctx context.Context, fi *FileInfo, p string, cb func(*NamedStat) error) error {
 	debug("testDir.FindFiles")
 	st := NamedStat{}
 	st.Name = "hello.txt"

--- a/dokan/unsafe.go
+++ b/dokan/unsafe.go
@@ -12,7 +12,7 @@ import (
 // bufToSlice returns a byte slice aliasing the pointer and length given as arguments.
 func bufToSlice(ptr unsafe.Pointer, nbytes uint32) []byte {
 	return *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(ptr)),
+		Data: uintptr(ptr),
 		Len:  int(nbytes),
 		Cap:  int(nbytes)}))
 }

--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -294,7 +294,7 @@ func (d *Dir) open(ctx context.Context, oc *openContext, path []string) (dokan.F
 		if c := lowerTranslateCandidate(oc, path[0]); c != "" {
 			var hit string
 			var nhits int
-			d.FindFiles(ctx, nil, func(ns *dokan.NamedStat) error {
+			d.FindFiles(ctx, nil, c, func(ns *dokan.NamedStat) error {
 				if strings.ToLower(ns.Name) == c {
 					hit = ns.Name
 					nhits++
@@ -453,7 +453,7 @@ func (d *Dir) mkdir(ctx context.Context, oc *openContext, name string) (f *Dir, 
 }
 
 // FindFiles does readdir for dokan.
-func (d *Dir) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func(*dokan.NamedStat) error) (err error) {
+func (d *Dir) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
 	d.folder.fs.logEnter(ctx, "Dir FindFiles")
 	defer func() { d.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
 

--- a/libdokan/empty_folder.go
+++ b/libdokan/empty_folder.go
@@ -28,6 +28,6 @@ func (*EmptyFolder) GetFileInformation(context.Context, *dokan.FileInfo) (a *dok
 }
 
 // FindFiles for dokan.
-func (*EmptyFolder) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func(*dokan.NamedStat) error) (err error) {
+func (*EmptyFolder) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
 	return nil
 }

--- a/libdokan/emptyfs.go
+++ b/libdokan/emptyfs.go
@@ -34,7 +34,7 @@ func (t emptyFile) WriteFile(ctx context.Context, fi *dokan.FileInfo, bs []byte,
 func (t emptyFile) FlushFileBuffers(ctx context.Context, fi *dokan.FileInfo) error {
 	return dokan.ErrAccessDenied
 }
-func (t emptyFile) FindFiles(ctx context.Context, fi *dokan.FileInfo, cb func(*dokan.NamedStat) error) error {
+func (t emptyFile) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, cb func(*dokan.NamedStat) error) error {
 	return dokan.ErrAccessDenied
 }
 func (t emptyFile) SetFileTime(context.Context, *dokan.FileInfo, time.Time, time.Time, time.Time) error {

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -173,7 +173,7 @@ func (fl *FolderList) forgetFolder(folderName string) {
 }
 
 // FindFiles for dokan.
-func (fl *FolderList) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func(*dokan.NamedStat) error) (err error) {
+func (fl *FolderList) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
 	fl.fs.logEnter(ctx, "FL FindFiles")
 	defer func() { fl.fs.reportErr(ctx, libkbfs.ReadMode, err) }()
 

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -496,7 +496,7 @@ func (r *Root) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (*dok
 }
 
 // FindFiles for dokan readdir.
-func (r *Root) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func(*dokan.NamedStat) error) error {
+func (r *Root) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) error {
 	var ns dokan.NamedStat
 	var err error
 	ns.FileAttributes = dokan.FileAttributeDirectory

--- a/libdokan/profilelist.go
+++ b/libdokan/profilelist.go
@@ -41,7 +41,7 @@ func (pl ProfileList) open(ctx context.Context, oc *openContext, path []string) 
 }
 
 // FindFiles does readdir for dokan.
-func (ProfileList) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func(*dokan.NamedStat) error) (err error) {
+func (ProfileList) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
 	profiles := pprof.Profiles()
 	var ns dokan.NamedStat
 	ns.FileAttributes = dokan.FileAttributeReadonly

--- a/libdokan/tlf.go
+++ b/libdokan/tlf.go
@@ -175,7 +175,7 @@ func (tlf *TLF) open(ctx context.Context, oc *openContext, path []string) (dokan
 }
 
 // FindFiles does readdir for dokan.
-func (tlf *TLF) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func(*dokan.NamedStat) error) (err error) {
+func (tlf *TLF) FindFiles(ctx context.Context, fi *dokan.FileInfo, pattern string, callback func(*dokan.NamedStat) error) (err error) {
 	tlf.folder.fs.logEnter(ctx, "TLF FindFiles")
 	dir, exitEarly, err := tlf.loadDirAllowNonexistent(ctx, "FindFiles")
 	if err != nil {
@@ -184,7 +184,7 @@ func (tlf *TLF) FindFiles(ctx context.Context, fi *dokan.FileInfo, callback func
 	if exitEarly {
 		return dokan.ErrObjectNameNotFound
 	}
-	return dir.FindFiles(ctx, fi, callback)
+	return dir.FindFiles(ctx, fi, pattern, callback)
 }
 
 // CanDeleteDirectory - return just nil because tlfs


### PR DESCRIPTION
This adds support for:
- FindFiles with patterns - not used at the moment but wanted for the API
- Format Dokan error codes (e.g. -5) with descriptive strings if known  