### PR TITLE
[KBFS-1399] Handle version conflicts during journal flushes

### DIFF
--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -228,8 +228,17 @@ func TestMDJournalBranchConversion(t *testing.T) {
 
 type shimMDServer struct {
 	MDServer
-	rmdses  []*RootMetadataSigned
-	nextErr error
+	rmdses       []*RootMetadataSigned
+	nextGetRange []*RootMetadataSigned
+	nextErr      error
+}
+
+func (s *shimMDServer) GetRange(
+	ctx context.Context, id TlfID, bid BranchID, mStatus MergeStatus,
+	start, stop MetadataRevision) ([]*RootMetadataSigned, error) {
+	rmdses := s.nextGetRange
+	s.nextGetRange = nil
+	return rmdses, nil
 }
 
 func (s *shimMDServer) Put(


### PR DESCRIPTION
Check if the MD has already been put, and go on
if so.