### PR TITLE
Metadata refactor in preparation for V3

### DIFF
--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -67,7 +67,7 @@ outer:
 			"Could not get TLF ID for %q", tlfStr)
 	}
 
-	return irmd.ID, nil
+	return irmd.TlfID(), nil
 }
 
 func getBranchID(ctx context.Context, config libkbfs.Config,
@@ -85,7 +85,7 @@ func getBranchID(ctx context.Context, config libkbfs.Config,
 		if irmd == (libkbfs.ImmutableRootMetadata{}) {
 			return libkbfs.NullBranchID, nil
 		}
-		return irmd.BID, nil
+		return irmd.BID(), nil
 	}
 
 	return libkbfs.ParseBranchID(branchStr)
@@ -101,7 +101,7 @@ func getRevision(ctx context.Context, config libkbfs.Config,
 				return libkbfs.MetadataRevisionUninitialized,
 					err
 			}
-			return irmd.Revision, nil
+			return irmd.Revision(), nil
 		}
 
 		irmd, err := config.MDOps().GetUnmergedForTLF(
@@ -109,7 +109,7 @@ func getRevision(ctx context.Context, config libkbfs.Config,
 		if err != nil {
 			return libkbfs.MetadataRevisionUninitialized, err
 		}
-		return irmd.Revision, nil
+		return irmd.Revision(), nil
 	}
 
 	base := 10
@@ -194,7 +194,7 @@ func mdDumpOne(ctx context.Context, config libkbfs.Config,
 	rmd libkbfs.ImmutableRootMetadata) error {
 	fmt.Printf("MD ID: %s\n", rmd.MdID())
 
-	buf, err := config.Codec().Encode(&rmd.BareRootMetadata)
+	buf, err := config.Codec().Encode(rmd.GetBareRootMetadata())
 	if err != nil {
 		return err
 	}
@@ -204,10 +204,10 @@ func mdDumpOne(ctx context.Context, config libkbfs.Config,
 	fmt.Print("Reader/writer metadata\n")
 	fmt.Print("----------------------\n")
 	fmt.Printf("Last modifying user: %s\n",
-		getUserString(ctx, config, rmd.LastModifyingUser))
+		getUserString(ctx, config, rmd.LastModifyingUser()))
 	// TODO: Print flags.
-	fmt.Printf("Revision: %s\n", rmd.Revision)
-	fmt.Printf("Prev MD ID: %s\n", rmd.PrevRoot)
+	fmt.Printf("Revision: %s\n", rmd.Revision())
+	fmt.Printf("Prev MD ID: %s\n", rmd.PrevRoot())
 	// TODO: Print RKeys, unresolved readers, conflict info,
 	// finalized info, and unknown fields.
 	fmt.Print("\n")
@@ -215,20 +215,20 @@ func mdDumpOne(ctx context.Context, config libkbfs.Config,
 	fmt.Print("Writer metadata\n")
 	fmt.Print("---------------\n")
 	fmt.Printf("Last modifying writer: %s\n",
-		getUserString(ctx, config, rmd.LastModifyingWriter))
+		getUserString(ctx, config, rmd.LastModifyingWriter()))
 	// TODO: Print Writers/WKeys and unresolved writers.
-	fmt.Printf("TLF ID: %s\n", rmd.ID)
-	fmt.Printf("Branch ID: %s\n", rmd.BID)
+	fmt.Printf("TLF ID: %s\n", rmd.TlfID())
+	fmt.Printf("Branch ID: %s\n", rmd.BID())
 	// TODO: Print writer flags.
-	fmt.Printf("Disk usage: %d\n", rmd.DiskUsage)
-	fmt.Printf("Bytes in new blocks: %d\n", rmd.RefBytes)
-	fmt.Printf("Bytes in unreferenced blocks: %d\n", rmd.UnrefBytes)
+	fmt.Printf("Disk usage: %d\n", rmd.DiskUsage())
+	fmt.Printf("Bytes in new blocks: %d\n", rmd.RefBytes())
+	fmt.Printf("Bytes in unreferenced blocks: %d\n", rmd.UnrefBytes())
 	// TODO: Print unknown fields.
 	fmt.Print("\n")
 
 	fmt.Print("Private metadata\n")
 	fmt.Print("----------------\n")
-	fmt.Printf("Serialized size: %d bytes\n", len(rmd.SerializedPrivateMetadata))
+	fmt.Printf("Serialized size: %d bytes\n", len(rmd.GetSerializedPrivateMetadata()))
 
 	data := rmd.Data()
 	// TODO: Clean up output.

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -275,7 +275,7 @@ func (cr *ConflictResolver) updateCurrInput(ctx context.Context,
 	}()
 
 	if len(unmerged) > 0 {
-		rev := unmerged[len(unmerged)-1].Revision
+		rev := unmerged[len(unmerged)-1].bareMd.RevisionNumber()
 		if rev < cr.currInput.unmerged {
 			return fmt.Errorf("Unmerged revision %d is lower than the "+
 				"expected unmerged revision %d", rev, cr.currInput.unmerged)
@@ -283,7 +283,7 @@ func (cr *ConflictResolver) updateCurrInput(ctx context.Context,
 		cr.currInput.unmerged = rev
 	}
 	if len(merged) > 0 {
-		rev := merged[len(merged)-1].Revision
+		rev := merged[len(merged)-1].bareMd.RevisionNumber()
 		if rev < cr.currInput.merged {
 			return fmt.Errorf("Merged revision %d is lower than the "+
 				"expected merged revision %d", rev, cr.currInput.merged)
@@ -1046,7 +1046,7 @@ func (cr *ConflictResolver) addRecreateOpsToUnmergedChains(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	winfo, err := newWriterInfo(ctx, cr.config, uid, unmergedChains.mostRecentMD.writerKID())
+	winfo, err := newWriterInfo(ctx, cr.config, uid, unmergedChains.mostRecentMD.LastModifyingWriterKID())
 	if err != nil {
 		return nil, err
 	}
@@ -1588,8 +1588,8 @@ func (cr *ConflictResolver) addMergedRecreates(ctx context.Context,
 					}
 					co.AddRefBlock(c.mostRecent)
 					winfo, err := newWriterInfo(ctx, cr.config,
-						mergedChains.mostRecentMD.LastModifyingWriter,
-						mergedChains.mostRecentMD.writerKID())
+						mergedChains.mostRecentMD.LastModifyingWriter(),
+						mergedChains.mostRecentMD.LastModifyingWriterKID())
 					if err != nil {
 						return err
 					}
@@ -2176,7 +2176,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 	lState *lockState, unmergedPaths []path, unmergedChains *crChains,
 	mergedChains *crChains) (*RootMetadata, error) {
 	currMD := mergedChains.mostRecentMD
-	currMDID, err := cr.config.Crypto().MakeMdID(&currMD.BareRootMetadata)
+	currMDID, err := cr.config.Crypto().MakeMdID(currMD.bareMd)
 	if err != nil {
 		return nil, err
 	}
@@ -2610,9 +2610,9 @@ func (cr *ConflictResolver) syncTree(ctx context.Context, lState *lockState,
 func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState,
 	unmergedChains *crChains, mergedChains *crChains) error {
-	md.RefBytes = 0
-	md.UnrefBytes = 0
-	md.DiskUsage = mergedChains.mostRecentMD.DiskUsage
+	md.SetRefBytes(0)
+	md.SetUnrefBytes(0)
+	md.SetDiskUsage(mergedChains.mostRecentMD.DiskUsage())
 
 	// Track the refs and unrefs in a set, to ensure no duplicates
 	refs := make(map[BlockPointer]bool)
@@ -2668,8 +2668,8 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 
 		cr.log.CDebugf(ctx, "Ref'ing block %v", ptr)
 		size := uint64(block.GetEncodedSize())
-		md.RefBytes += size
-		md.DiskUsage += size
+		md.AddRefBytes(size)
+		md.AddDiskUsage(size)
 	}
 
 	// Subtract bytes for every unref'd block that wasn't created in
@@ -2703,8 +2703,8 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 
 		cr.log.CDebugf(ctx, "Unref'ing block %v", ptr)
 		size := uint64(block.GetEncodedSize())
-		md.UnrefBytes += size
-		md.DiskUsage -= size
+		md.AddUnrefBytes(size)
+		md.SetDiskUsage(md.DiskUsage() - size)
 	}
 
 	// Any blocks that were created on the unmerged branch, but didn't
@@ -3197,7 +3197,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 
 	// Put all the blocks.  TODO: deal with recoverable block errors?
 	_, err = cr.fbo.doBlockPuts(
-		ctx, md.ID, md.GetTlfHandle().GetCanonicalName(), *bps)
+		ctx, md.TlfID(), md.GetTlfHandle().GetCanonicalName(), *bps)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -59,8 +59,8 @@ func TestCRInput(t *testing.T) {
 	mergedHead := MetadataRevision(15)
 
 	cr.fbo.head = MakeImmutableRootMetadata(&RootMetadata{
-		BareRootMetadata: BareRootMetadata{
-			WriterMetadata: WriterMetadata{
+		bareMd: &BareRootMetadataV2{
+			WriterMetadataV2: WriterMetadataV2{
 				ID:     FakeTlfID(0x1, false),
 				WFlags: MetadataFlagUnmerged,
 			},
@@ -73,8 +73,8 @@ func TestCRInput(t *testing.T) {
 	for i := unmergedHead; i >= branchPoint+1; i-- {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
 			MakeImmutableRootMetadata(&RootMetadata{
-				BareRootMetadata: BareRootMetadata{
-					WriterMetadata: WriterMetadata{
+				bareMd: &BareRootMetadataV2{
+					WriterMetadataV2: WriterMetadataV2{
 						ID:     FakeTlfID(0x1, false),
 						WFlags: MetadataFlagUnmerged,
 						BID:    cr.fbo.bid,
@@ -94,8 +94,8 @@ func TestCRInput(t *testing.T) {
 	for i := branchPoint + 1; i <= mergedHead; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
 			MakeImmutableRootMetadata(&RootMetadata{
-				BareRootMetadata: BareRootMetadata{
-					WriterMetadata: WriterMetadata{
+				bareMd: &BareRootMetadataV2{
+					WriterMetadataV2: WriterMetadataV2{
 						ID: FakeTlfID(0x1, false),
 					},
 					Revision: i,
@@ -143,8 +143,8 @@ func TestCRInputFracturedRange(t *testing.T) {
 	mergedHead := MetadataRevision(15)
 
 	cr.fbo.head = MakeImmutableRootMetadata(&RootMetadata{
-		BareRootMetadata: BareRootMetadata{
-			WriterMetadata: WriterMetadata{
+		bareMd: &BareRootMetadataV2{
+			WriterMetadataV2: WriterMetadataV2{
 				ID:     FakeTlfID(0x1, false),
 				WFlags: MetadataFlagUnmerged,
 			},
@@ -157,9 +157,9 @@ func TestCRInputFracturedRange(t *testing.T) {
 	for i := unmergedHead; i >= branchPoint+1; i-- {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
 			MakeImmutableRootMetadata(&RootMetadata{
-				BareRootMetadata: BareRootMetadata{
+				bareMd: &BareRootMetadataV2{
 					Revision: i,
-					WriterMetadata: WriterMetadata{
+					WriterMetadataV2: WriterMetadataV2{
 						ID:     FakeTlfID(0x1, false),
 						WFlags: MetadataFlagUnmerged,
 						BID:    cr.fbo.bid,
@@ -183,8 +183,8 @@ func TestCRInputFracturedRange(t *testing.T) {
 			config.mockMdcache.EXPECT().Get(cr.fbo.id(), i,
 				NullBranchID).Return(
 				MakeImmutableRootMetadata(&RootMetadata{
-					BareRootMetadata: BareRootMetadata{
-						WriterMetadata: WriterMetadata{
+					bareMd: &BareRootMetadataV2{
+						WriterMetadataV2: WriterMetadataV2{
 							ID: FakeTlfID(0x1, false),
 						},
 						Revision: i,
@@ -200,8 +200,8 @@ func TestCRInputFracturedRange(t *testing.T) {
 	config.mockMdops.EXPECT().GetRange(gomock.Any(), cr.fbo.id(),
 		skipCacheRevision, skipCacheRevision).Return(
 		[]ImmutableRootMetadata{MakeImmutableRootMetadata(&RootMetadata{
-			BareRootMetadata: BareRootMetadata{
-				WriterMetadata: WriterMetadata{
+			bareMd: &BareRootMetadataV2{
+				WriterMetadataV2: WriterMetadataV2{
 					ID: FakeTlfID(0x1, false),
 				},
 				Revision: skipCacheRevision,

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -639,8 +639,8 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 			continue
 		}
 
-		winfo, err := newWriterInfo(ctx, cfg, rmd.LastModifyingWriter,
-			rmd.writerKID())
+		winfo, err := newWriterInfo(ctx, cfg, rmd.LastModifyingWriter(),
+			rmd.LastModifyingWriterKID())
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -151,8 +151,8 @@ func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
 	}
 	immutableRmds := make([]ImmutableRootMetadata, len(rmds))
 	for i, rmd := range rmds {
-		rmd.LastModifyingWriter = uid
-		rmd.ID = FakeTlfID(1, false)
+		rmd.SetLastModifyingWriter(uid)
+		rmd.SetTlfID(FakeTlfID(1, false))
 		immutableRmds[i] = MakeImmutableRootMetadata(rmd,
 			fakeMdID(1), time.Unix(0, 0))
 	}
@@ -160,7 +160,7 @@ func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
 }
 
 func TestCRChainsSingleOp(t *testing.T) {
-	rmd := &RootMetadata{}
+	rmd := NewRootMetadata()
 
 	currPtr, ptrs, revPtrs := testCRInitPtrs(3)
 	rootPtrUnref := ptrs[0]
@@ -190,7 +190,7 @@ func TestCRChainsSingleOp(t *testing.T) {
 }
 
 func TestCRChainsRenameOp(t *testing.T) {
-	rmd := &RootMetadata{}
+	rmd := NewRootMetadata()
 
 	currPtr, ptrs, revPtrs := testCRInitPtrs(3)
 	rootPtrUnref := ptrs[0]
@@ -255,7 +255,7 @@ func TestCRChainsMultiOps(t *testing.T) {
 	expected := make(map[BlockPointer]BlockPointer)
 	expectedRenames := make(map[BlockPointer]renameInfo)
 
-	bigRmd := &RootMetadata{}
+	bigRmd := NewRootMetadata()
 	var multiRmds []*RootMetadata
 
 	// setex root/dir3/file2
@@ -265,7 +265,7 @@ func TestCRChainsMultiOps(t *testing.T) {
 		[]BlockPointer{rootPtrUnref, dir3Unref}, op1)
 	expected[file2Ptr] = file2Ptr // no update to the file ptr
 	bigRmd.AddOp(op1)
-	newRmd := &RootMetadata{}
+	newRmd := NewRootMetadata()
 	newRmd.AddOp(op1)
 	newRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	multiRmds = append(multiRmds, newRmd)
@@ -276,7 +276,7 @@ func TestCRChainsMultiOps(t *testing.T) {
 	currPtr = testCRFillOpPtrs(currPtr, expected, revPtrs,
 		[]BlockPointer{expected[rootPtrUnref], dir1Unref}, op2)
 	bigRmd.AddOp(op2)
-	newRmd = &RootMetadata{}
+	newRmd = NewRootMetadata()
 	newRmd.AddOp(op2)
 	newRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	multiRmds = append(multiRmds, newRmd)
@@ -290,7 +290,7 @@ func TestCRChainsMultiOps(t *testing.T) {
 		[]BlockPointer{expected[rootPtrUnref], expected[dir1Unref],
 			expected[dir3Unref]}, op3)
 	bigRmd.AddOp(op3)
-	newRmd = &RootMetadata{}
+	newRmd = NewRootMetadata()
 	newRmd.AddOp(op3)
 	newRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	multiRmds = append(multiRmds, newRmd)
@@ -302,7 +302,7 @@ func TestCRChainsMultiOps(t *testing.T) {
 		[]BlockPointer{expected[rootPtrUnref], expected[dir1Unref], file4Unref},
 		op4)
 	bigRmd.AddOp(op4)
-	newRmd = &RootMetadata{}
+	newRmd = NewRootMetadata()
 	newRmd.AddOp(op4)
 	newRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	multiRmds = append(multiRmds, newRmd)
@@ -314,7 +314,7 @@ func TestCRChainsMultiOps(t *testing.T) {
 		[]BlockPointer{expected[rootPtrUnref], expected[dir1Unref], dir2Unref},
 		op5)
 	bigRmd.AddOp(op5)
-	newRmd = &RootMetadata{}
+	newRmd = NewRootMetadata()
 	newRmd.AddOp(op5)
 	newRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	multiRmds = append(multiRmds, newRmd)
@@ -404,7 +404,7 @@ func TestCRChainsCollapse(t *testing.T) {
 	expected := make(map[BlockPointer]BlockPointer)
 	expectedRenames := make(map[BlockPointer]renameInfo)
 
-	rmd := &RootMetadata{}
+	rmd := NewRootMetadata()
 
 	// createfile root/dir1/file2
 	op1, err := newCreateOp(f2, dir1Unref, File)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -69,11 +69,11 @@ func (c CryptoCommon) MakeRandomBranchID() (BranchID, error) {
 }
 
 // MakeMdID implements the Crypto interface for CryptoCommon.
-func (c CryptoCommon) MakeMdID(md *BareRootMetadata) (MdID, error) {
+func (c CryptoCommon) MakeMdID(md BareRootMetadata) (MdID, error) {
 	// Make sure that the serialized metadata is set; otherwise we
 	// won't get the right MdID.
-	if md.SerializedPrivateMetadata == nil {
-		return MdID{}, MDMissingDataError{md.ID}
+	if md.GetSerializedPrivateMetadata() == nil {
+		return MdID{}, MDMissingDataError{md.TlfID()}
 	}
 
 	buf, err := c.codec.Encode(md)

--- a/libkbfs/crypto_measured.go
+++ b/libkbfs/crypto_measured.go
@@ -25,7 +25,7 @@ func NewCryptoMeasured(delegate Crypto, r metrics.Registry) CryptoMeasured {
 }
 
 // MakeMdID implements the Crypto interface for CryptoMeasured.
-func (c CryptoMeasured) MakeMdID(md *BareRootMetadata) (mdID MdID, err error) {
+func (c CryptoMeasured) MakeMdID(md BareRootMetadata) (mdID MdID, err error) {
 	c.makeMdIDTimer.Time(func() {
 		mdID, err = c.Crypto.MakeMdID(md)
 	})

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1181,3 +1181,13 @@ type UnmergedSelfConflictError struct {
 func (e UnmergedSelfConflictError) Error() string {
 	return fmt.Sprintf("Unmerged self conflict: %v", e.Err)
 }
+
+// MutableBareRootMetadataNoImplError is returned when an interface expected
+// to implement MutableBareRootMetadata does not do so.
+type MutableBareRootMetadataNoImplError struct {
+}
+
+// Error implements the error interface for MutableBareRootMetadataNoImplError
+func (e MutableBareRootMetadataNoImplError) Error() string {
+	return "Does not implement MutableBareRootMetadata"
+}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2012,16 +2012,16 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 		si.bps = newBlockPutState(1)
 	} else {
 		// reinstate byte accounting from the previous Sync
-		md.RefBytes = si.refBytes
-		md.DiskUsage += si.refBytes
-		md.UnrefBytes = si.unrefBytes
-		md.DiskUsage -= si.unrefBytes
+		md.SetRefBytes(si.refBytes)
+		md.AddDiskUsage(si.refBytes)
+		md.SetUnrefBytes(si.unrefBytes)
+		md.SetDiskUsage(md.DiskUsage() - si.unrefBytes)
 		syncState.newIndirectFileBlockPtrs = append(
 			syncState.newIndirectFileBlockPtrs, si.op.Refs()...)
 	}
 	defer func() {
-		si.refBytes = md.RefBytes
-		si.unrefBytes = md.UnrefBytes
+		si.refBytes = md.RefBytes()
+		si.unrefBytes = md.UnrefBytes()
 	}()
 
 	bcache := fbo.config.BlockCache()

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -166,26 +166,26 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context) (
 	var fbs FolderBranchStatus
 
 	if fbsk.md != (ImmutableRootMetadata{}) {
-		fbs.Staged = (fbsk.md.WFlags & MetadataFlagUnmerged) != 0
-		name, err := fbsk.config.KBPKI().GetNormalizedUsername(ctx, fbsk.md.LastModifyingWriter)
+		fbs.Staged = fbsk.md.IsUnmergedSet()
+		name, err := fbsk.config.KBPKI().GetNormalizedUsername(ctx, fbsk.md.LastModifyingWriter())
 		if err != nil {
 			return FolderBranchStatus{}, nil, err
 		}
 		fbs.HeadWriter = name
-		fbs.DiskUsage = fbsk.md.DiskUsage
-		fbs.RekeyPending = fbsk.config.RekeyQueue().IsRekeyPending(fbsk.md.ID)
-		fbs.FolderID = fbsk.md.ID.String()
-		fbs.Revision = fbsk.md.Revision
+		fbs.DiskUsage = fbsk.md.DiskUsage()
+		fbs.RekeyPending = fbsk.config.RekeyQueue().IsRekeyPending(fbsk.md.TlfID())
+		fbs.FolderID = fbsk.md.TlfID().String()
+		fbs.Revision = fbsk.md.Revision()
 
 		// TODO: Ideally, the journal would push status
 		// updates to this object instead, so we can notify
 		// listeners.
 		jServer, err := GetJournalServer(fbsk.config)
 		if err == nil {
-			jStatus, err := jServer.JournalStatus(fbsk.md.ID)
+			jStatus, err := jServer.JournalStatus(fbsk.md.TlfID())
 			if err != nil {
 				log := fbsk.config.MakeLogger("")
-				log.CWarningf(ctx, "Error getting journal status for %s: %v", fbsk.md.ID, err)
+				log.CWarningf(ctx, "Error getting journal status for %s: %v", fbsk.md.TlfID(), err)
 			} else {
 				fbs.Journal = &jStatus
 			}

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -105,8 +105,8 @@ func TestFBStatusAllFields(t *testing.T) {
 	h := parseTlfHandleOrBust(t, config, "alice", false)
 	u := h.FirstResolvedWriter()
 	md := newRootMetadataOrBust(t, id, h)
-	md.WFlags = MetadataFlagUnmerged
-	md.LastModifyingWriter = u
+	md.SetUnmerged()
+	md.SetLastModifyingWriter(u)
 
 	// make two nodes with expected PathFromNode calls
 	n1 := newMockNode(mockCtrl)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -78,16 +78,16 @@ func TestJournalServerRestart(t *testing.T) {
 
 	// Put an MD.
 
-	var rmd RootMetadata
-	err = updateNewBareRootMetadata(&rmd.BareRootMetadata, tlfID, bh)
+	rmd := NewRootMetadata()
+	err = rmd.Update(tlfID, bh)
 	require.NoError(t, err)
 	rmd.tlfHandle = h
-	rmd.Revision = MetadataRevision(1)
-	rekeyDone, _, err := config.KeyManager().Rekey(ctx, &rmd, false)
+	rmd.SetRevision(MetadataRevision(1))
+	rekeyDone, _, err := config.KeyManager().Rekey(ctx, rmd, false)
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
 
-	_, err = mdOps.Put(ctx, &rmd)
+	_, err = mdOps.Put(ctx, rmd)
 	require.NoError(t, err)
 
 	// Simulate a restart.
@@ -112,5 +112,5 @@ func TestJournalServerRestart(t *testing.T) {
 
 	head, err := mdOps.GetForTLF(ctx, tlfID)
 	require.NoError(t, err)
-	require.Equal(t, rmd.Revision, head.Revision)
+	require.Equal(t, rmd.Revision(), head.Revision())
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -330,7 +330,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		return nil, EntryInfo{}, identifyHandle(ctx, kbpki, kbpki, h)
 	}
 
-	fb := FolderBranch{Tlf: md.ID, Branch: branch}
+	fb := FolderBranch{Tlf: md.TlfID(), Branch: branch}
 
 	// we might not be able to read the metadata if we aren't in the
 	// key group yet.

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -229,7 +229,7 @@ func (km *KeyManagerStandard) updateKeyBundle(ctx context.Context,
 	md *RootMetadata, keyGen KeyGen, wKeys map[keybase1.UID][]CryptPublicKey,
 	rKeys map[keybase1.UID][]CryptPublicKey, ePubKey TLFEphemeralPublicKey,
 	ePrivKey TLFEphemeralPrivateKey, tlfCryptKey TLFCryptKey) error {
-	wkb, rkb, err := md.getTLFKeyBundles(keyGen)
+	wkb, rkb, err := md.bareMd.GetTLFKeyBundles(keyGen)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (km *KeyManagerStandard) deleteKeysForRemovedDevices(ctx context.Context,
 			// shouldn't happen but might as well make it work just in
 			// case.
 			km.log.CInfof(ctx, "Rekey %s: removing all server key halves "+
-				"for user %s", md.ID, u)
+				"for user %s", md.TlfID(), u)
 			usersToDelete = append(usersToDelete, u)
 			for kid, keyInfo := range kids {
 				err := kops.DeleteTLFCryptKeyServerHalf(ctx, u, kid,
@@ -341,7 +341,7 @@ func (km *KeyManagerStandard) deleteKeysForRemovedDevices(ctx context.Context,
 			if !keyLookup[kid] {
 				toRemove = append(toRemove, kid)
 				km.log.CInfof(ctx, "Rekey %s: removing server key halves "+
-					" for device %s of user %s", md.ID, kid, u)
+					" for device %s of user %s", md.TlfID(), kid, u)
 				err := kops.DeleteTLFCryptKeyServerHalf(ctx, u, kid,
 					keyInfo.ServerHalfID)
 				if err != nil {
@@ -397,18 +397,18 @@ func (km *KeyManagerStandard) generateKeyMapForUsers(ctx context.Context, users 
 func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promptPaper bool) (
 	rekeyDone bool, cryptKey *TLFCryptKey, err error) {
 	km.log.CDebugf(ctx, "Rekey %s (prompt for paper key: %t)",
-		md.ID, promptPaper)
-	defer func() { km.deferLog.CDebugf(ctx, "Rekey %s done: %#v", md.ID, err) }()
+		md.TlfID(), promptPaper)
+	defer func() { km.deferLog.CDebugf(ctx, "Rekey %s done: %#v", md.TlfID(), err) }()
 
 	currKeyGen := md.LatestKeyGeneration()
-	if md.ID.IsPublic() != (currKeyGen == PublicKeyGen) {
+	if md.TlfID().IsPublic() != (currKeyGen == PublicKeyGen) {
 		return false, nil, fmt.Errorf(
 			"ID %v has isPublic=%t but currKeyGen is %d (isPublic=%t)",
-			md.ID, md.ID.IsPublic(), currKeyGen, currKeyGen == PublicKeyGen)
+			md.TlfID(), md.TlfID().IsPublic(), currKeyGen, currKeyGen == PublicKeyGen)
 	}
 
-	if promptPaper && md.ID.IsPublic() {
-		return false, nil, fmt.Errorf("promptPaper set for public TLF %v", md.ID)
+	if promptPaper && md.TlfID().IsPublic() {
+		return false, nil, fmt.Errorf("promptPaper set for public TLF %v", md.TlfID())
 	}
 
 	handle := md.GetTlfHandle()
@@ -424,7 +424,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	}
 
 	isWriter := resolvedHandle.IsWriter(uid)
-	if !md.ID.IsPublic() && !isWriter {
+	if !md.TlfID().IsPublic() && !isWriter {
 		// If I was already a reader, there's nothing more to do
 		if handle.IsReader(uid) {
 			resolvedHandle = handle
@@ -451,7 +451,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 			resolvedHandle.GetCanonicalPath())
 
 		// Check with the server to see if the handle became a conflict.
-		latestHandle, err := km.config.MDOps().GetLatestHandleForTLF(ctx, md.ID)
+		latestHandle, err := km.config.MDOps().GetLatestHandleForTLF(ctx, md.TlfID())
 		if latestHandle.ConflictInfo != nil {
 			km.log.CDebugf(ctx, "handle for %s is conflicted",
 				handle.GetCanonicalPath())
@@ -465,11 +465,11 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	// For a public TLF there's no rekeying to be done, but we
 	// should still update the writer list.
-	if md.ID.IsPublic() {
+	if md.TlfID().IsPublic() {
 		if !handleChanged {
 			km.log.CDebugf(ctx,
 				"Skipping rekeying %s (public): handle hasn't changed",
-				md.ID)
+				md.TlfID())
 			return false, nil, nil
 		}
 		return true, nil, md.updateFromTlfHandle(resolvedHandle)
@@ -509,18 +509,18 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	if !incKeyGen {
 		// See if there is at least one new device in relation to the
 		// current key bundle
-		wkb, rkb, err := md.getTLFKeyBundles(currKeyGen)
+		wkb, rkb, err := md.bareMd.GetTLFKeyBundles(currKeyGen)
 		if err != nil {
 			return false, nil, err
 		}
 
-		newWriterUsers = km.usersWithNewDevices(ctx, md.ID, wkb.WKeys, wKeys)
-		newReaderUsers = km.usersWithNewDevices(ctx, md.ID, rkb.RKeys, rKeys)
+		newWriterUsers = km.usersWithNewDevices(ctx, md.TlfID(), wkb.WKeys, wKeys)
+		newReaderUsers = km.usersWithNewDevices(ctx, md.TlfID(), rkb.RKeys, rKeys)
 		addNewWriterDevice = len(newWriterUsers) > 0
 		addNewReaderDevice = len(newReaderUsers) > 0
 
-		wRemoved := km.usersWithRemovedDevices(ctx, md.ID, wkb.WKeys, wKeys)
-		rRemoved := km.usersWithRemovedDevices(ctx, md.ID, rkb.RKeys, rKeys)
+		wRemoved := km.usersWithRemovedDevices(ctx, md.TlfID(), wkb.WKeys, wKeys)
+		rRemoved := km.usersWithRemovedDevices(ctx, md.TlfID(), rkb.RKeys, rKeys)
 		incKeyGen = len(wRemoved) > 0 || len(rRemoved) > 0
 
 		promotedReaders = make(map[keybase1.UID]bool, len(rRemoved))
@@ -546,7 +546,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 			newWriterUsers[u] = true
 		}
 
-		if err := km.identifyUIDSets(ctx, md.ID, newWriterUsers, newReaderUsers); err != nil {
+		if err := km.identifyUIDSets(ctx, md.TlfID(), newWriterUsers, newReaderUsers); err != nil {
 			return false, nil, err
 		}
 	}
@@ -555,7 +555,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		!handleChanged {
 		km.log.CDebugf(ctx,
 			"Skipping rekeying %s (private): no new or removed devices, no new keygen, and handle hasn't changed",
-			md.ID)
+			md.TlfID())
 		return false, nil, nil
 	}
 
@@ -599,7 +599,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 			// If there are readers that need to be promoted to writers, do
 			// that here.
-			wkb, rkb, err := md.getTLFKeyBundles(keyGen)
+			wkb, rkb, err := md.bareMd.GetTLFKeyBundles(keyGen)
 			if err != nil {
 				return false, nil, err
 			}
@@ -620,7 +620,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// have to do this here, before adding a new key generation, since
 	// decryptMDPrivateData assumes that the MD is always encrypted
 	// using the latest key gen.
-	if !md.IsReadable() && len(md.SerializedPrivateMetadata) > 0 {
+	if !md.IsReadable() && len(md.GetSerializedPrivateMetadata()) > 0 {
 		if err := decryptMDPrivateData(ctx, km.config, md, md.ReadOnly()); err != nil {
 			return false, nil, err
 		}
@@ -679,7 +679,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	// Delete server-side key halves for any revoked devices.
 	for keygen := KeyGen(FirstValidKeyGen); keygen <= currKeyGen; keygen++ {
-		wkb, rkb, err := md.getTLFKeyBundles(keygen)
+		wkb, rkb, err := md.bareMd.GetTLFKeyBundles(keygen)
 		if err != nil {
 			return false, nil, err
 		}

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -220,7 +220,7 @@ func TestKeyManagerUncachedSecretKeyForEncryptionSuccess(t *testing.T) {
 	subkey := MakeFakeCryptPublicKeyOrBust("crypt public key")
 	AddNewKeysOrBust(t, rmd, NewEmptyTLFWriterKeyBundle(), makeDirRKeyBundle(uid, subkey))
 
-	expectUncachedGetTLFCryptKey(config, rmd.ID, rmd.LatestKeyGeneration(), uid, subkey, true)
+	expectUncachedGetTLFCryptKey(config, rmd.TlfID(), rmd.LatestKeyGeneration(), uid, subkey, true)
 
 	if _, err := config.KeyManager().
 		GetTLFCryptKeyForEncryption(ctx, rmd.ReadOnly()); err != nil {
@@ -240,7 +240,7 @@ func TestKeyManagerUncachedSecretKeyForMDDecryptionSuccess(t *testing.T) {
 	subkey := MakeFakeCryptPublicKeyOrBust("crypt public key")
 	AddNewKeysOrBust(t, rmd, NewEmptyTLFWriterKeyBundle(), makeDirRKeyBundle(uid, subkey))
 
-	expectUncachedGetTLFCryptKeyAnyDevice(config, rmd.ID, rmd.LatestKeyGeneration(), uid, subkey, false)
+	expectUncachedGetTLFCryptKeyAnyDevice(config, rmd.TlfID(), rmd.LatestKeyGeneration(), uid, subkey, false)
 
 	if _, err := config.KeyManager().
 		GetTLFCryptKeyForMDDecryption(ctx, rmd.ReadOnly(), rmd.ReadOnly()); err != nil {
@@ -262,7 +262,7 @@ func TestKeyManagerUncachedSecretKeyForBlockDecryptionSuccess(t *testing.T) {
 	AddNewKeysOrBust(t, rmd, NewEmptyTLFWriterKeyBundle(), makeDirRKeyBundle(uid, subkey))
 
 	keyGen := rmd.LatestKeyGeneration() - 1
-	expectUncachedGetTLFCryptKey(config, rmd.ID, keyGen, uid, subkey, false)
+	expectUncachedGetTLFCryptKey(config, rmd.TlfID(), keyGen, uid, subkey, false)
 
 	if _, err := config.KeyManager().GetTLFCryptKeyForBlockDecryption(
 		ctx, rmd.ReadOnly(), BlockPointer{KeyGen: keyGen}); err != nil {
@@ -406,7 +406,7 @@ func TestKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T) {
 	// generation number.
 	daemon.addNewAssertionForTestOrBust("dave", "dave@twitter")
 	oldKeyGen = rmd.LatestKeyGeneration()
-	expectCachedGetTLFCryptKey(config, rmd.ID, oldKeyGen)
+	expectCachedGetTLFCryptKey(config, rmd.TlfID(), oldKeyGen)
 	expectRekey(config, oldHandle.ToBareHandleOrBust(), 1, true)
 	subkey := MakeFakeCryptPublicKeyOrBust("crypt public key")
 	config.mockKbpki.EXPECT().GetCryptPublicKeys(gomock.Any(), gomock.Any()).
@@ -509,7 +509,7 @@ func TestKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T) {
 	oldKeyGen = rmd.LatestKeyGeneration()
 	// Pretend bob has the key in the cache (in reality it would be
 	// decrypted via bob's paper key)
-	expectCachedGetTLFCryptKey(config, rmd.ID, oldKeyGen)
+	expectCachedGetTLFCryptKey(config, rmd.TlfID(), oldKeyGen)
 	expectRekey(config, h.ToBareHandleOrBust(), 1, false)
 	subkey := MakeFakeCryptPublicKeyOrBust("crypt public key")
 	config.mockKbpki.EXPECT().GetCryptPublicKeys(gomock.Any(), gomock.Any()).
@@ -1144,13 +1144,13 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	// rekey is still needed (due to the revoke, which has to be
 	// rekeyed by a writer).
 	ops := getOps(config2Dev2, root2Dev2.GetFolderBranch().Tlf)
-	rev1 := ops.head.Revision
+	rev1 := ops.head.Revision()
 	err = kbfsOps2Dev2.Rekey(ctx, root2Dev2.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Expected reader rekey to partially complete. "+
 			"Actual error: %#v", err)
 	}
-	rev2 := ops.head.Revision
+	rev2 := ops.head.Revision()
 	if rev1 != rev2 {
 		t.Fatalf("Reader rekey made two incomplete rekeys in a row.")
 	}
@@ -1499,7 +1499,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	}
 
 	ops := getOps(config2Dev2, rootNode1.GetFolderBranch().Tlf)
-	rev1 := ops.head.Revision
+	rev1 := ops.head.Revision()
 
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.  This shouldn't increase the MD version.
@@ -1507,7 +1507,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Second rekey failed %v", err)
 	}
-	rev2 := ops.head.Revision
+	rev2 := ops.head.Revision()
 
 	if rev1 != rev2 {
 		t.Errorf("Revision changed after second rekey: %v vs %v", rev1, rev2)
@@ -1610,7 +1610,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	}
 
 	ops := getOps(config2Dev2, rootNode1.GetFolderBranch().Tlf)
-	rev1 := ops.head.Revision
+	rev1 := ops.head.Revision()
 
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.  This shouldn't increase the MD version.
@@ -1618,7 +1618,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Second rekey failed %v", err)
 	}
-	rev2 := ops.head.Revision
+	rev2 := ops.head.Revision()
 
 	if rev1 != rev2 {
 		t.Errorf("Revision changed after second rekey: %v vs %v", rev1, rev2)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -37,12 +37,12 @@ func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 
 	tlf := handle.GetCanonicalPath()
 	writer, nameErr := md.config.KBPKI().GetNormalizedUsername(ctx,
-		rmds.MD.LastModifyingWriter)
+		rmds.MD.LastModifyingWriter())
 	if nameErr != nil {
 		writer = libkb.NormalizedUsername("uid: " +
-			rmds.MD.LastModifyingWriter.String())
+			rmds.MD.LastModifyingWriter().String())
 	}
-	md.log.CDebugf(ctx, "Unverifiable update for TLF %s", rmds.MD.ID)
+	md.log.CDebugf(ctx, "Unverifiable update for TLF %s", rmds.MD.TlfID())
 	return UnverifiableTlfUpdateError{tlf, writer, err}
 }
 
@@ -52,12 +52,12 @@ func (md *MDOpsStandard) verifyWriterKey(
 		var err error
 		if handle.IsFinal() {
 			err = md.config.KBPKI().HasUnverifiedVerifyingKey(ctx,
-				rmds.MD.LastModifyingWriter,
-				rmds.MD.WriterMetadataSigInfo.VerifyingKey)
+				rmds.MD.LastModifyingWriter(),
+				rmds.MD.GetWriterMetadataSigInfo().VerifyingKey)
 		} else {
 			err = md.config.KBPKI().HasVerifyingKey(ctx,
-				rmds.MD.LastModifyingWriter,
-				rmds.MD.WriterMetadataSigInfo.VerifyingKey,
+				rmds.MD.LastModifyingWriter(),
+				rmds.MD.GetWriterMetadataSigInfo().VerifyingKey,
 				rmds.untrustedServerTimestamp)
 		}
 		if err != nil {
@@ -71,7 +71,7 @@ func (md *MDOpsStandard) verifyWriterKey(
 	// writer MD was actually signed, since it was copied from a
 	// previous revision.  Search backwards for the most recent
 	// uncopied writer MD to get the right timestamp.
-	prevHead := rmds.MD.Revision - 1
+	prevHead := rmds.MD.RevisionNumber() - 1
 	for {
 		startRev := prevHead - maxMDsAtATime + 1
 		if startRev < MetadataRevisionInitial {
@@ -83,7 +83,7 @@ func (md *MDOpsStandard) verifyWriterKey(
 		// extra work by downloading the same MDs twice (for those
 		// that aren't yet in the cache).  That should be so rare that
 		// it's not worth optimizing.
-		prevMDs, err := getMDRange(ctx, md.config, rmds.MD.ID, rmds.MD.BID,
+		prevMDs, err := getMDRange(ctx, md.config, rmds.MD.TlfID(), rmds.MD.BID(),
 			startRev, prevHead, rmds.MD.MergedStatus())
 		if err != nil {
 			return err
@@ -92,16 +92,16 @@ func (md *MDOpsStandard) verifyWriterKey(
 		for i := len(prevMDs) - 1; i >= 0; i-- {
 			if !prevMDs[i].IsWriterMetadataCopiedSet() {
 				ok, err := CodecEqual(md.config.Codec(),
-					rmds.MD.WriterMetadataSigInfo,
-					prevMDs[i].WriterMetadataSigInfo)
+					rmds.MD.GetWriterMetadataSigInfo(),
+					prevMDs[i].GetWriterMetadataSigInfo())
 				if err != nil {
 					return err
 				}
 				if !ok {
 					return fmt.Errorf("Previous uncopied writer MD sig info "+
 						"for revision %d of folder %s doesn't match copied "+
-						"revision %d", prevMDs[i].Revision, rmds.MD.ID,
-						rmds.MD.Revision)
+						"revision %d", prevMDs[i].Revision(), rmds.MD.TlfID(),
+						rmds.MD.RevisionNumber())
 				}
 				// The fact the fact that we were able to process this
 				// MD correctly means that we already verified its key
@@ -114,9 +114,9 @@ func (md *MDOpsStandard) verifyWriterKey(
 		if len(prevMDs) < maxMDsAtATime {
 			return fmt.Errorf("Couldn't find uncopied MD previous to "+
 				"revision %d of folder %s for checking the writer "+
-				"timestamp", rmds.MD.Revision, rmds.MD.ID)
+				"timestamp", rmds.MD.RevisionNumber(), rmds.MD.TlfID())
 		}
-		prevHead = prevMDs[0].Revision - 1
+		prevHead = prevMDs[0].Revision() - 1
 	}
 }
 
@@ -133,21 +133,21 @@ func (md *MDOpsStandard) processMetadata(
 	// Otherwise, verify signatures and deserialize private data.
 
 	// Make sure the last writer is really a valid writer
-	writer := rmds.MD.LastModifyingWriter
+	writer := rmds.MD.LastModifyingWriter()
 	if !handle.IsWriter(writer) {
 		return ImmutableRootMetadata{}, MDMismatchError{
 			handle.GetCanonicalPath(),
 			fmt.Errorf("Writer MD (id=%s) was written by a non-writer %s",
-				rmds.MD.ID, writer)}
+				rmds.MD.TlfID(), writer)}
 	}
 
 	// Make sure the last user to change the blob is really a valid reader
-	user := rmds.MD.LastModifyingUser
+	user := rmds.MD.GetLastModifyingUser()
 	if !handle.IsReader(user) {
 		return ImmutableRootMetadata{}, MDMismatchError{
 			handle.GetCanonicalPath(),
 			fmt.Errorf("MD (id=%s) was changed by a non-reader %s",
-				rmds.MD.ID, user),
+				rmds.MD.TlfID(), user),
 		}
 	}
 
@@ -180,8 +180,8 @@ func (md *MDOpsStandard) processMetadata(
 	}
 
 	rmd := RootMetadata{
-		BareRootMetadata: rmds.MD,
-		tlfHandle:        handle,
+		bareMd:    rmds.MD,
+		tlfHandle: handle,
 	}
 
 	// Try to decrypt using the keys available in this md.  If that
@@ -193,7 +193,7 @@ func (md *MDOpsStandard) processMetadata(
 		return ImmutableRootMetadata{}, err
 	}
 
-	mdID, err := md.config.Crypto().MakeMdID(&rmd.BareRootMetadata)
+	mdID, err := md.config.Crypto().MakeMdID(rmd.bareMd)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -261,7 +261,7 @@ func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 			handle.GetCanonicalPath(),
 			fmt.Errorf(
 				"MD (id=%s) contained unexpected handle path %s (%s -> %s) (%s -> %s)",
-				rmds.MD.ID, mdHandlePath,
+				rmds.MD.TlfID(), mdHandlePath,
 				handle.GetCanonicalPath(),
 				partialResolvedHandle.GetCanonicalPath(),
 				mdHandle.GetCanonicalPath(),
@@ -290,19 +290,19 @@ func (md *MDOpsStandard) processMetadataWithID(ctx context.Context,
 	id TlfID, bid BranchID, handle *TlfHandle, rmds *RootMetadataSigned) (
 	ImmutableRootMetadata, error) {
 	// Make sure the signed-over ID matches
-	if id != rmds.MD.ID {
+	if id != rmds.MD.TlfID() {
 		return ImmutableRootMetadata{}, MDMismatchError{
 			id.String(),
 			fmt.Errorf("MD contained unexpected folder id %s, expected %s",
-				rmds.MD.ID.String(), id.String()),
+				rmds.MD.TlfID().String(), id.String()),
 		}
 	}
 	// Make sure the signed-over branch ID matches
-	if bid != NullBranchID && bid != rmds.MD.BID {
+	if bid != NullBranchID && bid != rmds.MD.BID() {
 		return ImmutableRootMetadata{}, MDMismatchError{
 			id.String(),
 			fmt.Errorf("MD contained unexpected branch id %s, expected %s, "+
-				"folder id %s", rmds.MD.BID.String(), bid.String(), id.String()),
+				"folder id %s", rmds.MD.BID().String(), bid.String(), id.String()),
 		}
 	}
 
@@ -416,16 +416,16 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 
 	// Sort into slice based on revision.
 	irmds := make([]ImmutableRootMetadata, len(rmdses))
-	startRev := rmdses[0].MD.Revision
+	startRev := rmdses[0].MD.RevisionNumber()
 	numExpected := MetadataRevision(len(irmds))
 	for irmd := range irmdChan {
-		i := irmd.Revision - startRev
+		i := irmd.Revision() - startRev
 		if i < 0 || i >= numExpected {
 			return nil, fmt.Errorf("Unexpected revision %d; expected "+
-				"something between %d and %d inclusive", irmd.Revision,
+				"something between %d and %d inclusive", irmd.Revision(),
 				startRev, startRev+numExpected-1)
 		} else if irmds[i] != (ImmutableRootMetadata{}) {
-			return nil, fmt.Errorf("Got revision %d twice", irmd.Revision)
+			return nil, fmt.Errorf("Got revision %d twice", irmd.Revision())
 		}
 		irmds[i] = irmd
 	}
@@ -441,8 +441,8 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 			// an ImmutableRootMetadata in
 			// processMetadataWithID below, and we want to
 			// do this check before then.
-			err = prevIRMD.BareRootMetadata.CheckValidSuccessor(
-				prevIRMD.mdID, &irmd.BareRootMetadata)
+			err = prevIRMD.bareMd.CheckValidSuccessor(
+				prevIRMD.mdID, irmd.bareMd)
 			if err != nil {
 				return nil, MDMismatchError{
 					irmd.GetTlfHandle().GetCanonicalPath(),
@@ -503,9 +503,12 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
-	rmds := RootMetadataSigned{
-		MD: *brmd,
+	mbrmd, ok := brmd.(MutableBareRootMetadata)
+	if !ok {
+		return MdID{}, MutableBareRootMetadataNoImplError{}
 	}
+
+	rmds := RootMetadataSigned{MD: mbrmd}
 
 	err = signMD(ctx, md.config.Codec(), md.config.Crypto(), &rmds)
 	if err != nil {
@@ -517,12 +520,12 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
-	mdID, err := md.config.Crypto().MakeMdID(&rmds.MD)
+	mdID, err := md.config.Crypto().MakeMdID(rmds.MD)
 	if err != nil {
 		return MdID{}, err
 	}
 
-	rmd.BareRootMetadata = rmds.MD
+	rmd.bareMd = rmds.MD
 	return mdID, nil
 }
 
@@ -538,14 +541,14 @@ func (md *MDOpsStandard) Put(
 // PutUnmerged implements the MDOps interface for MDOpsStandard.
 func (md *MDOpsStandard) PutUnmerged(
 	ctx context.Context, rmd *RootMetadata) (MdID, error) {
-	rmd.WFlags |= MetadataFlagUnmerged
-	if rmd.BID == NullBranchID {
+	rmd.SetUnmerged()
+	if rmd.BID() == NullBranchID {
 		// new branch ID
 		bid, err := md.config.Crypto().MakeRandomBranchID()
 		if err != nil {
 			return MdID{}, err
 		}
-		rmd.BID = bid
+		rmd.SetBranchID(bid)
 	}
 	return md.put(ctx, rmd)
 }

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -21,7 +21,7 @@ type shimCrypto struct {
 	pure cryptoPure
 }
 
-func (c shimCrypto) MakeMdID(md *BareRootMetadata) (MdID, error) {
+func (c shimCrypto) MakeMdID(md BareRootMetadata) (MdID, error) {
 	return c.pure.MakeMdID(md)
 }
 
@@ -54,12 +54,12 @@ func mdOpsShutdown(mockCtrl *gomock.Controller, config *ConfigMock) {
 }
 
 func addFakeRMDData(rmd *RootMetadata, h *TlfHandle) {
-	rmd.Revision = MetadataRevision(1)
-	rmd.LastModifyingWriter = h.FirstResolvedWriter()
-	rmd.LastModifyingUser = h.FirstResolvedWriter()
+	rmd.SetRevision(MetadataRevision(1))
+	rmd.SetLastModifyingWriter(h.FirstResolvedWriter())
+	rmd.SetLastModifyingUser(h.FirstResolvedWriter())
 
 	if !h.IsPublic() {
-		FakeInitialRekey(&rmd.BareRootMetadata, h.ToBareHandleOrBust())
+		rmd.FakeInitialRekey(h.ToBareHandleOrBust())
 	}
 }
 
@@ -68,9 +68,8 @@ func newRMD(t *testing.T, config Config, public bool) (
 	id := FakeTlfID(1, public)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", public)
-	rmd := &RootMetadata{}
-	err := updateNewBareRootMetadata(
-		&rmd.BareRootMetadata, id, h.ToBareHandleOrBust())
+	rmd := NewRootMetadata()
+	err := rmd.Update(id, h.ToBareHandleOrBust())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,10 +80,10 @@ func newRMD(t *testing.T, config Config, public bool) (
 }
 
 func addFakeRMDSData(rmds *RootMetadataSigned, h *TlfHandle) {
-	rmds.MD.Revision = MetadataRevision(1)
-	rmds.MD.SerializedPrivateMetadata = []byte{1}
-	rmds.MD.LastModifyingWriter = h.FirstResolvedWriter()
-	rmds.MD.LastModifyingUser = h.FirstResolvedWriter()
+	rmds.MD.SetRevision(MetadataRevision(1))
+	rmds.MD.SetSerializedPrivateMetadata([]byte{1})
+	rmds.MD.SetLastModifyingWriter(h.FirstResolvedWriter())
+	rmds.MD.SetLastModifyingUser(h.FirstResolvedWriter())
 	rmds.SigInfo = SignatureInfo{
 		Version:      SigED25519,
 		Signature:    []byte{42},
@@ -93,7 +92,7 @@ func addFakeRMDSData(rmds *RootMetadataSigned, h *TlfHandle) {
 	rmds.untrustedServerTimestamp = time.Now()
 
 	if !h.IsPublic() {
-		FakeInitialRekey(&rmds.MD, h.ToBareHandleOrBust())
+		rmds.MD.FakeInitialRekey(h.ToBareHandleOrBust())
 	}
 }
 
@@ -102,12 +101,11 @@ func newRMDS(t *testing.T, config Config, public bool) (
 	id := FakeTlfID(1, public)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", public)
-	rmds := &RootMetadataSigned{}
-	err := updateNewBareRootMetadata(&rmds.MD, id, h.ToBareHandleOrBust())
+	rmds := NewRootMetadataSigned()
+	err := rmds.MD.Update(id, h.ToBareHandleOrBust())
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	addFakeRMDSData(rmds, h)
 
 	return rmds, h
@@ -121,11 +119,11 @@ func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).AnyTimes().Return(hasVerifyingKeyErr)
 	if hasVerifyingKeyErr == nil {
-		config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.WriterMetadataSigInfo).Return(nil)
+		config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.GetWriterMetadataSigInfo()).Return(nil)
 		config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).Return(verifyErr)
 		if verifyErr == nil {
 			config.mockCodec.EXPECT().Decode(
-				rmds.MD.SerializedPrivateMetadata,
+				rmds.MD.GetSerializedPrivateMetadata(),
 				gomock.Any()).Return(nil)
 		}
 	}
@@ -138,10 +136,10 @@ func verifyMDForPrivateHelper(
 		Return(packedData, nil).AnyTimes()
 
 	config.mockCodec.EXPECT().
-		Decode(rmds.MD.SerializedPrivateMetadata, gomock.Any()).
+		Decode(rmds.MD.GetSerializedPrivateMetadata(), gomock.Any()).
 		MinTimes(minTimes).MaxTimes(maxTimes).Return(nil)
 	fakeRMD := RootMetadata{
-		BareRootMetadata: rmds.MD,
+		bareMd: rmds.MD,
 	}
 	expectGetTLFCryptKeyForMDDecryptionAtMostOnce(config, &fakeRMD)
 	var pmd PrivateMetadata
@@ -152,6 +150,8 @@ func verifyMDForPrivateHelper(
 	if rmds.MD.IsFinal() {
 		config.mockKbpki.EXPECT().HasUnverifiedVerifyingKey(gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return(nil)
+		config.mockCodec.EXPECT().
+			Decode(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	} else {
 		config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
@@ -160,7 +160,7 @@ func verifyMDForPrivateHelper(
 	config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).
 		MinTimes(minTimes).MaxTimes(maxTimes).Return(nil)
 	config.mockCrypto.EXPECT().
-		Verify(packedData, rmds.MD.WriterMetadataSigInfo).
+		Verify(packedData, rmds.MD.GetWriterMetadataSigInfo()).
 		MinTimes(minTimes).MaxTimes(maxTimes).Return(nil)
 }
 
@@ -190,7 +190,7 @@ func TestMDOpsGetForHandlePublicSuccess(t *testing.T) {
 
 	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
-	require.Equal(t, rmds.MD, rmd2.BareRootMetadata)
+	require.Equal(t, rmds.MD, rmd2.bareMd)
 }
 
 func TestMDOpsGetForHandlePrivateSuccess(t *testing.T) {
@@ -205,7 +205,7 @@ func TestMDOpsGetForHandlePrivateSuccess(t *testing.T) {
 
 	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
-	require.Equal(t, rmds.MD, rmd2.BareRootMetadata)
+	require.Equal(t, rmds.MD, rmd2.bareMd)
 }
 
 func TestMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T) {
@@ -258,18 +258,18 @@ func TestMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T) {
 		"alice,bob@twitter,charlie@twitter", true)
 	require.NoError(t, err)
 
-	rmds1 := &RootMetadataSigned{}
-	err = updateNewBareRootMetadata(&rmds1.MD, id, mdHandle1.ToBareHandleOrBust())
+	rmds1 := NewRootMetadataSigned()
+	err = rmds1.MD.Update(id, mdHandle1.ToBareHandleOrBust())
 	require.NoError(t, err)
 	addFakeRMDSData(rmds1, mdHandle1)
 
-	rmds2 := &RootMetadataSigned{}
-	err = updateNewBareRootMetadata(&rmds2.MD, id, mdHandle2.ToBareHandleOrBust())
+	rmds2 := NewRootMetadataSigned()
+	err = rmds2.MD.Update(id, mdHandle2.ToBareHandleOrBust())
 	require.NoError(t, err)
 	addFakeRMDSData(rmds2, mdHandle2)
 
-	rmds3 := &RootMetadataSigned{}
-	err = updateNewBareRootMetadata(&rmds3.MD, id, mdHandle3.ToBareHandleOrBust())
+	rmds3 := NewRootMetadataSigned()
+	err = rmds3.MD.Update(id, mdHandle3.ToBareHandleOrBust())
 	require.NoError(t, err)
 	addFakeRMDSData(rmds3, mdHandle3)
 
@@ -408,11 +408,11 @@ func TestMDOpsGetSuccess(t *testing.T) {
 	// Do this before setting tlfHandle to nil.
 	verifyMDForPrivate(config, rmds)
 
-	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.ID, NullBranchID, Merged).Return(rmds, nil)
+	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), NullBranchID, Merged).Return(rmds, nil)
 
-	rmd2, err := config.MDOps().GetForTLF(ctx, rmds.MD.ID)
+	rmd2, err := config.MDOps().GetForTLF(ctx, rmds.MD.TlfID())
 	require.NoError(t, err)
-	require.Equal(t, rmds.MD, rmd2.BareRootMetadata)
+	require.Equal(t, rmds.MD, rmd2.bareMd)
 }
 
 func TestMDOpsGetBlankSigFailure(t *testing.T) {
@@ -423,9 +423,9 @@ func TestMDOpsGetBlankSigFailure(t *testing.T) {
 	rmds.SigInfo = SignatureInfo{}
 
 	// only the get happens, no verify needed with a blank sig
-	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.ID, NullBranchID, Merged).Return(rmds, nil)
+	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), NullBranchID, Merged).Return(rmds, nil)
 
-	if _, err := config.MDOps().GetForTLF(ctx, rmds.MD.ID); err == nil {
+	if _, err := config.MDOps().GetForTLF(ctx, rmds.MD.TlfID()); err == nil {
 		t.Error("Got no error on get")
 	}
 }
@@ -468,9 +468,9 @@ func makeRMDSRange(t *testing.T, config Config,
 	var prevID MdID
 	for i := 0; i < count; i++ {
 		rmds, _ := newRMDS(t, config, false)
-		rmds.MD.PrevRoot = prevID
-		rmds.MD.Revision = start + MetadataRevision(i)
-		currID, err := config.Crypto().MakeMdID(&rmds.MD)
+		rmds.MD.SetPrevRoot(prevID)
+		rmds.MD.SetRevision(start + MetadataRevision(i))
+		currID, err := config.Crypto().MakeMdID(rmds.MD)
 		require.NoError(t, err)
 		prevID = currID
 		rmdses = append(rmdses, rmds)
@@ -494,14 +494,14 @@ func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
 		verifyMDForPrivate(config, rmds)
 	}
 
-	config.mockMdserv.EXPECT().GetRange(ctx, rmdses[0].MD.ID, NullBranchID, Merged, start,
+	config.mockMdserv.EXPECT().GetRange(ctx, rmdses[0].MD.TlfID(), NullBranchID, Merged, start,
 		stop).Return(rmdses, nil)
 
-	rmds, err := config.MDOps().GetRange(ctx, rmdses[0].MD.ID, start, stop)
+	rmds, err := config.MDOps().GetRange(ctx, rmdses[0].MD.TlfID(), start, stop)
 	require.NoError(t, err)
 	require.Equal(t, len(rmdses), len(rmds))
 	for i := 0; i < len(rmdses); i++ {
-		require.Equal(t, rmdses[i].MD, rmds[i].BareRootMetadata)
+		require.Equal(t, rmdses[i].MD, rmds[i].bareMd)
 	}
 }
 
@@ -519,7 +519,7 @@ func TestMDOpsGetRangeFailBadPrevRoot(t *testing.T) {
 
 	rmdses := makeRMDSRange(t, config, 100, 5)
 
-	rmdses[2].MD.PrevRoot = fakeMdID(1)
+	rmdses[2].MD.SetPrevRoot(fakeMdID(1))
 
 	start := MetadataRevision(100)
 	stop := start + MetadataRevision(len(rmdses))
@@ -530,10 +530,10 @@ func TestMDOpsGetRangeFailBadPrevRoot(t *testing.T) {
 		verifyMDForPrivateHelper(config, rmds, 0, 1)
 	}
 
-	config.mockMdserv.EXPECT().GetRange(ctx, rmdses[0].MD.ID, NullBranchID, Merged, start,
+	config.mockMdserv.EXPECT().GetRange(ctx, rmdses[0].MD.TlfID(), NullBranchID, Merged, start,
 		stop).Return(rmdses, nil)
 
-	_, err := config.MDOps().GetRange(ctx, rmdses[0].MD.ID, start, stop)
+	_, err := config.MDOps().GetRange(ctx, rmdses[0].MD.TlfID(), start, stop)
 	require.IsType(t, MDMismatchError{}, err)
 }
 
@@ -561,24 +561,24 @@ func (s *fakeMDServerPut) Shutdown() {}
 
 func validatePutPublicRMDS(
 	ctx context.Context, t *testing.T, config Config,
-	inputRmd *BareRootMetadata, rmds *RootMetadataSigned) {
+	inputRmd BareRootMetadata, rmds *RootMetadataSigned) {
 	// TODO: Handle private RMDS, too.
 
 	// Verify LastModifying* fields.
 	_, me, err := config.KBPKI().GetCurrentUserInfo(ctx)
 	require.NoError(t, err)
-	require.Equal(t, me, rmds.MD.LastModifyingWriter)
-	require.Equal(t, me, rmds.MD.LastModifyingUser)
+	require.Equal(t, me, rmds.MD.LastModifyingWriter())
+	require.Equal(t, me, rmds.MD.GetLastModifyingUser())
 
 	// Verify signature of WriterMetadata.
-	buf, err := config.Codec().Encode(rmds.MD.WriterMetadata)
+	buf, err := rmds.MD.GetSerializedWriterMetadata(config.Codec())
 	require.NoError(t, err)
-	err = config.Crypto().Verify(buf, rmds.MD.WriterMetadataSigInfo)
+	err = config.Crypto().Verify(buf, rmds.MD.GetWriterMetadataSigInfo())
 	require.NoError(t, err)
 
 	// Verify encoded PrivateMetadata.
 	var data PrivateMetadata
-	err = config.Codec().Decode(rmds.MD.SerializedPrivateMetadata, &data)
+	err = config.Codec().Decode(rmds.MD.GetSerializedPrivateMetadata(), &data)
 	require.NoError(t, err)
 
 	// Verify signature of RootMetadata.
@@ -587,17 +587,17 @@ func validatePutPublicRMDS(
 	err = config.Crypto().Verify(buf, rmds.SigInfo)
 	require.NoError(t, err)
 
-	var expectedRmd BareRootMetadata
+	var expectedRmd BareRootMetadataV2
 	err = CodecUpdate(config.Codec(), &expectedRmd, inputRmd)
 	require.NoError(t, err)
 
 	// Overwrite written fields.
-	expectedRmd.LastModifyingWriter = rmds.MD.LastModifyingWriter
-	expectedRmd.LastModifyingUser = rmds.MD.LastModifyingUser
-	expectedRmd.WriterMetadataSigInfo = rmds.MD.WriterMetadataSigInfo
-	expectedRmd.SerializedPrivateMetadata = rmds.MD.SerializedPrivateMetadata
+	expectedRmd.SetLastModifyingWriter(rmds.MD.LastModifyingWriter())
+	expectedRmd.SetLastModifyingUser(rmds.MD.GetLastModifyingUser())
+	expectedRmd.SetWriterMetadataSigInfo(rmds.MD.GetWriterMetadataSigInfo())
+	expectedRmd.SetSerializedPrivateMetadata(rmds.MD.GetSerializedPrivateMetadata())
 
-	require.Equal(t, expectedRmd, rmds.MD)
+	require.Equal(t, &expectedRmd, rmds.MD)
 }
 
 func TestMDOpsPutPublicSuccess(t *testing.T) {
@@ -611,17 +611,17 @@ func TestMDOpsPutPublicSuccess(t *testing.T) {
 	id := FakeTlfID(1, true)
 	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
 
-	var rmd RootMetadata
-	err := updateNewBareRootMetadata(&rmd.BareRootMetadata, id, h.ToBareHandleOrBust())
+	rmd := NewRootMetadata()
+	err := rmd.Update(id, h.ToBareHandleOrBust())
 	require.NoError(t, err)
 	rmd.data = makeFakePrivateMetadataFuture(t).toCurrent()
 	rmd.tlfHandle = h
 
 	ctx := context.Background()
-	_, err = config.MDOps().Put(ctx, &rmd)
+	_, err = config.MDOps().Put(ctx, rmd)
 
 	rmds := mdServer.getLastRmds()
-	validatePutPublicRMDS(ctx, t, config, &rmd.BareRootMetadata, rmds)
+	validatePutPublicRMDS(ctx, t, config, rmd.bareMd, rmds)
 }
 
 func TestMDOpsPutPrivateSuccess(t *testing.T) {
@@ -663,8 +663,8 @@ func TestMDOpsGetRangeFailFinal(t *testing.T) {
 	defer mdOpsShutdown(mockCtrl, config)
 
 	rmdses := makeRMDSRange(t, config, 100, 5)
-	rmdses[2].MD.Flags |= MetadataFlagFinal
-	rmdses[2].MD.PrevRoot = rmdses[1].MD.PrevRoot
+	rmdses[2].MD.SetFinalBit()
+	rmdses[2].MD.SetPrevRoot(rmdses[1].MD.GetPrevRoot())
 
 	start := MetadataRevision(100)
 	stop := start + MetadataRevision(len(rmdses))
@@ -676,9 +676,9 @@ func TestMDOpsGetRangeFailFinal(t *testing.T) {
 	}
 
 	config.mockMdserv.EXPECT().GetRange(
-		ctx, rmdses[0].MD.ID, NullBranchID, Merged, start, stop).Return(
+		ctx, rmdses[0].MD.TlfID(), NullBranchID, Merged, start, stop).Return(
 		rmdses, nil)
 
-	_, err := config.MDOps().GetRange(ctx, rmdses[0].MD.ID, start, stop)
+	_, err := config.MDOps().GetRange(ctx, rmdses[0].MD.TlfID(), start, stop)
 	require.IsType(t, MDMismatchError{}, err)
 }

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -45,7 +45,7 @@ func (md *MDCacheStandard) Get(tlf TlfID, rev MetadataRevision, bid BranchID) (
 
 // Put implements the MDCache interface for MDCacheStandard.
 func (md *MDCacheStandard) Put(rmd ImmutableRootMetadata) error {
-	key := mdCacheKey{rmd.ID, rmd.Revision, rmd.BID}
+	key := mdCacheKey{rmd.TlfID(), rmd.Revision(), rmd.BID()}
 	md.lru.Add(key, rmd)
 	return nil
 }

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -31,19 +31,19 @@ func mdCacheShutdown(mockCtrl *gomock.Controller, config *ConfigMock) {
 func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	mStatus MergeStatus, bid BranchID, h *TlfHandle, config *ConfigMock) {
 	rmd := &RootMetadata{
-		BareRootMetadata: BareRootMetadata{
-			WriterMetadata: WriterMetadata{
+		bareMd: &BareRootMetadataV2{
+			WriterMetadataV2: WriterMetadataV2{
 				ID:    tlf,
-				WKeys: make(TLFWriterKeyGenerations, 1, 1),
+				WKeys: make(TLFWriterKeyGenerations, 0, 1),
 				BID:   bid,
 			},
 			Revision: rev,
 			RKeys:    make(TLFReaderKeyGenerations, 1, 1),
 		},
 	}
-	rmd.WKeys[0] = NewEmptyTLFWriterKeyBundle()
+	rmd.AddNewKeys(NewEmptyTLFWriterKeyBundle(), TLFReaderKeyBundle{})
 	if mStatus == Unmerged {
-		rmd.WFlags |= MetadataFlagUnmerged
+		rmd.SetUnmerged()
 	}
 
 	// put the md

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -369,7 +369,7 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 		return MDServerError{err}
 	}
 
-	tlfStorage, err := md.getStorage(rmds.MD.ID)
+	tlfStorage, err := md.getStorage(rmds.MD.TlfID())
 	if err != nil {
 		return err
 	}
@@ -382,7 +382,7 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 
 	// Record branch ID
 	if recordBranchID {
-		err = md.putBranchID(ctx, rmds.MD.ID, rmds.MD.BID)
+		err = md.putBranchID(ctx, rmds.MD.TlfID(), rmds.MD.BID())
 		if err != nil {
 			return MDServerError{err}
 		}
@@ -393,7 +393,7 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error
 		// Don't send notifies if it's just a rekey (the real mdserver
 		// sends a "folder needs rekey" notification in this case).
 		!(rmds.MD.IsRekeySet() && rmds.MD.IsWriterMetadataCopiedSet()) {
-		md.updateManager.setHead(rmds.MD.ID, md)
+		md.updateManager.setHead(rmds.MD.TlfID(), md)
 	}
 
 	return nil
@@ -426,7 +426,7 @@ func (md *MDServerDisk) getCurrentMergedHeadRevision(
 		return 0, err
 	}
 	if head != nil {
-		rev = head.MD.Revision
+		rev = head.MD.RevisionNumber()
 	}
 	return
 }

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -15,7 +15,7 @@ import (
 // access TLF metadata. mergedMasterHead can be nil, in which case
 // true is returned.
 func isReader(currentUID keybase1.UID,
-	mergedMasterHead *BareRootMetadata) (bool, error) {
+	mergedMasterHead BareRootMetadata) (bool, error) {
 	h, err := mergedMasterHead.MakeBareTlfHandle()
 	if err != nil {
 		return false, err
@@ -27,7 +27,7 @@ func isReader(currentUID keybase1.UID,
 // access TLF metadata. mergedMasterHead can be nil, in which case
 // true is returned.
 func isWriterOrValidRekey(codec Codec, currentUID keybase1.UID,
-	mergedMasterHead, newMd *BareRootMetadata) (bool, error) {
+	mergedMasterHead, newMd BareRootMetadata) (bool, error) {
 	h, err := mergedMasterHead.MakeBareTlfHandle()
 	if err != nil {
 		return false, err

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -409,20 +409,13 @@ func (md *MDServerRemote) get(ctx context.Context, id TlfID,
 	// deserialize blocks
 	rmdses := make([]*RootMetadataSigned, len(response.MdBlocks))
 	for i, block := range response.MdBlocks {
-		ver := MetadataVer(block.Version)
-		if ver < FirstValidMetadataVer {
-			return id, nil, InvalidMetadataVersionError{id, ver}
-		} else if ver > md.config.MetadataVersion() {
-			return id, nil, NewMetadataVersionError{id, ver}
-		}
-
-		var rmds RootMetadataSigned
-		err = md.config.Codec().Decode(block.Block, &rmds)
+		ver, max := MetadataVer(block.Version), md.config.MetadataVersion()
+		rmds, err := DecodeRootMetadataSigned(md.config.Codec(), id, ver, max, block.Block)
 		if err != nil {
-			return id, rmdses, err
+			return id, nil, err
 		}
 		rmds.untrustedServerTimestamp = keybase1.FromTime(block.Timestamp)
-		rmdses[i] = &rmds
+		rmdses[i] = rmds
 	}
 	return id, rmdses, nil
 }

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -63,7 +63,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		recordBranchID, err := s.put(uid, verifyingKey, rmds)
 		require.NoError(t, err)
 		require.False(t, recordBranchID)
-		prevRoot, err = crypto.MakeMdID(&rmds.MD)
+		prevRoot, err = crypto.MakeMdID(rmds.MD)
 		require.NoError(t, err)
 		if i == 5 {
 			middleRoot = prevRoot
@@ -88,13 +88,13 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	bid := FakeBranchID(1)
 	for i := MetadataRevision(6); i < 41; i++ {
 		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
-		rmds.MD.WFlags |= MetadataFlagUnmerged
-		rmds.MD.BID = bid
+		rmds.MD.SetUnmerged()
+		rmds.MD.SetBranchID(bid)
 		signRMDSForTest(t, codec, signer, rmds)
 		recordBranchID, err := s.put(uid, verifyingKey, rmds)
 		require.NoError(t, err)
 		require.Equal(t, i == MetadataRevision(6), recordBranchID)
-		prevRoot, err = crypto.MakeMdID(&rmds.MD)
+		prevRoot, err = crypto.MakeMdID(rmds.MD)
 		require.NoError(t, err)
 	}
 
@@ -106,7 +106,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	head, err = s.getForTLF(uid, bid)
 	require.NoError(t, err)
 	require.NotNil(t, head)
-	require.Equal(t, MetadataRevision(40), head.MD.Revision)
+	require.Equal(t, MetadataRevision(40), head.MD.RevisionNumber())
 
 	require.Equal(t, 10, getMDJournalLength(t, s, NullBranchID))
 	require.Equal(t, 35, getMDJournalLength(t, s, bid))
@@ -117,7 +117,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 35, len(rmdses))
 	for i := MetadataRevision(6); i < 16; i++ {
-		require.Equal(t, i, rmdses[i-6].MD.Revision)
+		require.Equal(t, i, rmdses[i-6].MD.RevisionNumber())
 	}
 
 	// Nothing corresponds to (7) - (9) from MDServerTestBasics.
@@ -127,7 +127,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	head, err = s.getForTLF(uid, NullBranchID)
 	require.NoError(t, err)
 	require.NotNil(t, head)
-	require.Equal(t, MetadataRevision(10), head.MD.Revision)
+	require.Equal(t, MetadataRevision(10), head.MD.RevisionNumber())
 
 	// (11) Try to get merged range.
 
@@ -135,7 +135,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 10, len(rmdses))
 	for i := MetadataRevision(1); i <= 10; i++ {
-		require.Equal(t, i, rmdses[i-1].MD.Revision)
+		require.Equal(t, i, rmdses[i-1].MD.RevisionNumber())
 	}
 
 	require.Equal(t, 10, getMDJournalLength(t, s, NullBranchID))

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1552,7 +1552,7 @@ func (_mr *_MockcryptoPureRecorder) MakeRandomBranchID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomBranchID")
 }
 
-func (_m *MockcryptoPure) MakeMdID(md *BareRootMetadata) (MdID, error) {
+func (_m *MockcryptoPure) MakeMdID(md BareRootMetadata) (MdID, error) {
 	ret := _m.ctrl.Call(_m, "MakeMdID", md)
 	ret0, _ := ret[0].(MdID)
 	ret1, _ := ret[1].(error)
@@ -1881,7 +1881,7 @@ func (_mr *_MockCryptoRecorder) MakeRandomBranchID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeRandomBranchID")
 }
 
-func (_m *MockCrypto) MakeMdID(md *BareRootMetadata) (MdID, error) {
+func (_m *MockCrypto) MakeMdID(md BareRootMetadata) (MdID, error) {
 	ret := _m.ctrl.Call(_m, "MakeMdID", md)
 	ret0, _ := ret[0].(MdID)
 	ret1, _ := ret[1].(error)
@@ -4158,4 +4158,970 @@ func (_m *MockRekeyQueue) Wait(ctx context.Context) error {
 
 func (_mr *_MockRekeyQueueRecorder) Wait(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Wait", arg0)
+}
+
+// Mock of BareRootMetadata interface
+type MockBareRootMetadata struct {
+	ctrl     *gomock.Controller
+	recorder *_MockBareRootMetadataRecorder
+}
+
+// Recorder for MockBareRootMetadata (not exported)
+type _MockBareRootMetadataRecorder struct {
+	mock *MockBareRootMetadata
+}
+
+func NewMockBareRootMetadata(ctrl *gomock.Controller) *MockBareRootMetadata {
+	mock := &MockBareRootMetadata{ctrl: ctrl}
+	mock.recorder = &_MockBareRootMetadataRecorder{mock}
+	return mock
+}
+
+func (_m *MockBareRootMetadata) EXPECT() *_MockBareRootMetadataRecorder {
+	return _m.recorder
+}
+
+func (_m *MockBareRootMetadata) TlfID() TlfID {
+	ret := _m.ctrl.Call(_m, "TlfID")
+	ret0, _ := ret[0].(TlfID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) TlfID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfID")
+}
+
+func (_m *MockBareRootMetadata) LatestKeyGeneration() KeyGen {
+	ret := _m.ctrl.Call(_m, "LatestKeyGeneration")
+	ret0, _ := ret[0].(KeyGen)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) LatestKeyGeneration() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestKeyGeneration")
+}
+
+func (_m *MockBareRootMetadata) IsValidRekeyRequest(codec Codec, prevMd BareRootMetadata, user protocol.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsValidRekeyRequest", codec, prevMd, user)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsValidRekeyRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidRekeyRequest", arg0, arg1, arg2)
+}
+
+func (_m *MockBareRootMetadata) MergedStatus() MergeStatus {
+	ret := _m.ctrl.Call(_m, "MergedStatus")
+	ret0, _ := ret[0].(MergeStatus)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) MergedStatus() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MergedStatus")
+}
+
+func (_m *MockBareRootMetadata) IsRekeySet() bool {
+	ret := _m.ctrl.Call(_m, "IsRekeySet")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsRekeySet() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsRekeySet")
+}
+
+func (_m *MockBareRootMetadata) IsWriterMetadataCopiedSet() bool {
+	ret := _m.ctrl.Call(_m, "IsWriterMetadataCopiedSet")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsWriterMetadataCopiedSet() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriterMetadataCopiedSet")
+}
+
+func (_m *MockBareRootMetadata) IsFinal() bool {
+	ret := _m.ctrl.Call(_m, "IsFinal")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsFinal() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFinal")
+}
+
+func (_m *MockBareRootMetadata) IsWriter(user protocol.UID, deviceKID protocol.KID) bool {
+	ret := _m.ctrl.Call(_m, "IsWriter", user, deviceKID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsWriter(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) IsReader(user protocol.UID, deviceKID protocol.KID) bool {
+	ret := _m.ctrl.Call(_m, "IsReader", user, deviceKID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsReader(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) DeepCopy(codec Codec) (BareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "DeepCopy", codec)
+	ret0, _ := ret[0].(BareRootMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
+}
+
+func (_m *MockBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
+	ret := _m.ctrl.Call(_m, "CheckValidSuccessor", currID, nextMd)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) CheckValidSuccessor(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckValidSuccessor", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) CheckValidSuccessorForServer(currID MdID, nextMd BareRootMetadata) error {
+	ret := _m.ctrl.Call(_m, "CheckValidSuccessorForServer", currID, nextMd)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) CheckValidSuccessorForServer(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckValidSuccessorForServer", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) MakeBareTlfHandle() (BareTlfHandle, error) {
+	ret := _m.ctrl.Call(_m, "MakeBareTlfHandle")
+	ret0, _ := ret[0].(BareTlfHandle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBareRootMetadataRecorder) MakeBareTlfHandle() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle")
+}
+
+func (_m *MockBareRootMetadata) VerifyWriterMetadata(codec Codec, crypto cryptoPure) error {
+	ret := _m.ctrl.Call(_m, "VerifyWriterMetadata", codec, crypto)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) VerifyWriterMetadata(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyWriterMetadata", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) TlfHandleExtensions() []TlfHandleExtension {
+	ret := _m.ctrl.Call(_m, "TlfHandleExtensions")
+	ret0, _ := ret[0].([]TlfHandleExtension)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) TlfHandleExtensions() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfHandleExtensions")
+}
+
+func (_m *MockBareRootMetadata) GetDeviceKIDs(keyGen KeyGen, user protocol.UID) ([]protocol.KID, error) {
+	ret := _m.ctrl.Call(_m, "GetDeviceKIDs", keyGen, user)
+	ret0, _ := ret[0].([]protocol.KID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetDeviceKIDs(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDeviceKIDs", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) HasKeyForUser(keyGen KeyGen, user protocol.UID) bool {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user protocol.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key)
+	ret0, _ := ret[0].(TLFEphemeralPublicKey)
+	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
+	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
+	ret3, _ := ret[3].(bool)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
+}
+
+func (_m *MockBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure, currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto, currentUID, currentVerifyingKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockBareRootMetadata) LastModifyingWriter() protocol.UID {
+	ret := _m.ctrl.Call(_m, "LastModifyingWriter")
+	ret0, _ := ret[0].(protocol.UID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) LastModifyingWriter() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriter")
+}
+
+func (_m *MockBareRootMetadata) LastModifyingWriterKID() protocol.KID {
+	ret := _m.ctrl.Call(_m, "LastModifyingWriterKID")
+	ret0, _ := ret[0].(protocol.KID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) LastModifyingWriterKID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriterKID")
+}
+
+func (_m *MockBareRootMetadata) GetLastModifyingUser() protocol.UID {
+	ret := _m.ctrl.Call(_m, "GetLastModifyingUser")
+	ret0, _ := ret[0].(protocol.UID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetLastModifyingUser() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLastModifyingUser")
+}
+
+func (_m *MockBareRootMetadata) RefBytes() uint64 {
+	ret := _m.ctrl.Call(_m, "RefBytes")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) RefBytes() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RefBytes")
+}
+
+func (_m *MockBareRootMetadata) UnrefBytes() uint64 {
+	ret := _m.ctrl.Call(_m, "UnrefBytes")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) UnrefBytes() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnrefBytes")
+}
+
+func (_m *MockBareRootMetadata) DiskUsage() uint64 {
+	ret := _m.ctrl.Call(_m, "DiskUsage")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) DiskUsage() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskUsage")
+}
+
+func (_m *MockBareRootMetadata) RevisionNumber() MetadataRevision {
+	ret := _m.ctrl.Call(_m, "RevisionNumber")
+	ret0, _ := ret[0].(MetadataRevision)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) RevisionNumber() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevisionNumber")
+}
+
+func (_m *MockBareRootMetadata) BID() BranchID {
+	ret := _m.ctrl.Call(_m, "BID")
+	ret0, _ := ret[0].(BranchID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) BID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BID")
+}
+
+func (_m *MockBareRootMetadata) GetPrevRoot() MdID {
+	ret := _m.ctrl.Call(_m, "GetPrevRoot")
+	ret0, _ := ret[0].(MdID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetPrevRoot() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPrevRoot")
+}
+
+func (_m *MockBareRootMetadata) IsUnmergedSet() bool {
+	ret := _m.ctrl.Call(_m, "IsUnmergedSet")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsUnmergedSet() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsUnmergedSet")
+}
+
+func (_m *MockBareRootMetadata) GetSerializedPrivateMetadata() []byte {
+	ret := _m.ctrl.Call(_m, "GetSerializedPrivateMetadata")
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetSerializedPrivateMetadata() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedPrivateMetadata")
+}
+
+func (_m *MockBareRootMetadata) GetSerializedWriterMetadata(codec Codec) ([]byte, error) {
+	ret := _m.ctrl.Call(_m, "GetSerializedWriterMetadata", codec)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetSerializedWriterMetadata(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedWriterMetadata", arg0)
+}
+
+func (_m *MockBareRootMetadata) GetWriterMetadataSigInfo() SignatureInfo {
+	ret := _m.ctrl.Call(_m, "GetWriterMetadataSigInfo")
+	ret0, _ := ret[0].(SignatureInfo)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetWriterMetadataSigInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriterMetadataSigInfo")
+}
+
+func (_m *MockBareRootMetadata) Version() MetadataVer {
+	ret := _m.ctrl.Call(_m, "Version")
+	ret0, _ := ret[0].(MetadataVer)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) Version() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
+}
+
+// Mock of MutableBareRootMetadata interface
+type MockMutableBareRootMetadata struct {
+	ctrl     *gomock.Controller
+	recorder *_MockMutableBareRootMetadataRecorder
+}
+
+// Recorder for MockMutableBareRootMetadata (not exported)
+type _MockMutableBareRootMetadataRecorder struct {
+	mock *MockMutableBareRootMetadata
+}
+
+func NewMockMutableBareRootMetadata(ctrl *gomock.Controller) *MockMutableBareRootMetadata {
+	mock := &MockMutableBareRootMetadata{ctrl: ctrl}
+	mock.recorder = &_MockMutableBareRootMetadataRecorder{mock}
+	return mock
+}
+
+func (_m *MockMutableBareRootMetadata) EXPECT() *_MockMutableBareRootMetadataRecorder {
+	return _m.recorder
+}
+
+func (_m *MockMutableBareRootMetadata) TlfID() TlfID {
+	ret := _m.ctrl.Call(_m, "TlfID")
+	ret0, _ := ret[0].(TlfID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) TlfID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfID")
+}
+
+func (_m *MockMutableBareRootMetadata) LatestKeyGeneration() KeyGen {
+	ret := _m.ctrl.Call(_m, "LatestKeyGeneration")
+	ret0, _ := ret[0].(KeyGen)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) LatestKeyGeneration() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestKeyGeneration")
+}
+
+func (_m *MockMutableBareRootMetadata) IsValidRekeyRequest(codec Codec, prevMd BareRootMetadata, user protocol.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsValidRekeyRequest", codec, prevMd, user)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsValidRekeyRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidRekeyRequest", arg0, arg1, arg2)
+}
+
+func (_m *MockMutableBareRootMetadata) MergedStatus() MergeStatus {
+	ret := _m.ctrl.Call(_m, "MergedStatus")
+	ret0, _ := ret[0].(MergeStatus)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) MergedStatus() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MergedStatus")
+}
+
+func (_m *MockMutableBareRootMetadata) IsRekeySet() bool {
+	ret := _m.ctrl.Call(_m, "IsRekeySet")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsRekeySet() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsRekeySet")
+}
+
+func (_m *MockMutableBareRootMetadata) IsWriterMetadataCopiedSet() bool {
+	ret := _m.ctrl.Call(_m, "IsWriterMetadataCopiedSet")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsWriterMetadataCopiedSet() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriterMetadataCopiedSet")
+}
+
+func (_m *MockMutableBareRootMetadata) IsFinal() bool {
+	ret := _m.ctrl.Call(_m, "IsFinal")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsFinal() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFinal")
+}
+
+func (_m *MockMutableBareRootMetadata) IsWriter(user protocol.UID, deviceKID protocol.KID) bool {
+	ret := _m.ctrl.Call(_m, "IsWriter", user, deviceKID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsWriter(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) IsReader(user protocol.UID, deviceKID protocol.KID) bool {
+	ret := _m.ctrl.Call(_m, "IsReader", user, deviceKID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsReader(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) DeepCopy(codec Codec) (BareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "DeepCopy", codec)
+	ret0, _ := ret[0].(BareRootMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
+	ret := _m.ctrl.Call(_m, "CheckValidSuccessor", currID, nextMd)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) CheckValidSuccessor(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckValidSuccessor", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) CheckValidSuccessorForServer(currID MdID, nextMd BareRootMetadata) error {
+	ret := _m.ctrl.Call(_m, "CheckValidSuccessorForServer", currID, nextMd)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) CheckValidSuccessorForServer(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckValidSuccessorForServer", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) MakeBareTlfHandle() (BareTlfHandle, error) {
+	ret := _m.ctrl.Call(_m, "MakeBareTlfHandle")
+	ret0, _ := ret[0].(BareTlfHandle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) MakeBareTlfHandle() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle")
+}
+
+func (_m *MockMutableBareRootMetadata) VerifyWriterMetadata(codec Codec, crypto cryptoPure) error {
+	ret := _m.ctrl.Call(_m, "VerifyWriterMetadata", codec, crypto)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) VerifyWriterMetadata(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyWriterMetadata", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) TlfHandleExtensions() []TlfHandleExtension {
+	ret := _m.ctrl.Call(_m, "TlfHandleExtensions")
+	ret0, _ := ret[0].([]TlfHandleExtension)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) TlfHandleExtensions() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfHandleExtensions")
+}
+
+func (_m *MockMutableBareRootMetadata) GetDeviceKIDs(keyGen KeyGen, user protocol.UID) ([]protocol.KID, error) {
+	ret := _m.ctrl.Call(_m, "GetDeviceKIDs", keyGen, user)
+	ret0, _ := ret[0].([]protocol.KID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetDeviceKIDs(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDeviceKIDs", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) HasKeyForUser(keyGen KeyGen, user protocol.UID) bool {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user protocol.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key)
+	ret0, _ := ret[0].(TLFEphemeralPublicKey)
+	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
+	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
+	ret3, _ := ret[3].(bool)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
+}
+
+func (_m *MockMutableBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure, currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto, currentUID, currentVerifyingKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockMutableBareRootMetadata) LastModifyingWriter() protocol.UID {
+	ret := _m.ctrl.Call(_m, "LastModifyingWriter")
+	ret0, _ := ret[0].(protocol.UID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) LastModifyingWriter() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriter")
+}
+
+func (_m *MockMutableBareRootMetadata) LastModifyingWriterKID() protocol.KID {
+	ret := _m.ctrl.Call(_m, "LastModifyingWriterKID")
+	ret0, _ := ret[0].(protocol.KID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) LastModifyingWriterKID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriterKID")
+}
+
+func (_m *MockMutableBareRootMetadata) GetLastModifyingUser() protocol.UID {
+	ret := _m.ctrl.Call(_m, "GetLastModifyingUser")
+	ret0, _ := ret[0].(protocol.UID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetLastModifyingUser() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetLastModifyingUser")
+}
+
+func (_m *MockMutableBareRootMetadata) RefBytes() uint64 {
+	ret := _m.ctrl.Call(_m, "RefBytes")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) RefBytes() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RefBytes")
+}
+
+func (_m *MockMutableBareRootMetadata) UnrefBytes() uint64 {
+	ret := _m.ctrl.Call(_m, "UnrefBytes")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) UnrefBytes() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnrefBytes")
+}
+
+func (_m *MockMutableBareRootMetadata) DiskUsage() uint64 {
+	ret := _m.ctrl.Call(_m, "DiskUsage")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) DiskUsage() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskUsage")
+}
+
+func (_m *MockMutableBareRootMetadata) RevisionNumber() MetadataRevision {
+	ret := _m.ctrl.Call(_m, "RevisionNumber")
+	ret0, _ := ret[0].(MetadataRevision)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) RevisionNumber() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevisionNumber")
+}
+
+func (_m *MockMutableBareRootMetadata) BID() BranchID {
+	ret := _m.ctrl.Call(_m, "BID")
+	ret0, _ := ret[0].(BranchID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) BID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BID")
+}
+
+func (_m *MockMutableBareRootMetadata) GetPrevRoot() MdID {
+	ret := _m.ctrl.Call(_m, "GetPrevRoot")
+	ret0, _ := ret[0].(MdID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetPrevRoot() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPrevRoot")
+}
+
+func (_m *MockMutableBareRootMetadata) IsUnmergedSet() bool {
+	ret := _m.ctrl.Call(_m, "IsUnmergedSet")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsUnmergedSet() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsUnmergedSet")
+}
+
+func (_m *MockMutableBareRootMetadata) GetSerializedPrivateMetadata() []byte {
+	ret := _m.ctrl.Call(_m, "GetSerializedPrivateMetadata")
+	ret0, _ := ret[0].([]byte)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetSerializedPrivateMetadata() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedPrivateMetadata")
+}
+
+func (_m *MockMutableBareRootMetadata) GetSerializedWriterMetadata(codec Codec) ([]byte, error) {
+	ret := _m.ctrl.Call(_m, "GetSerializedWriterMetadata", codec)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetSerializedWriterMetadata(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedWriterMetadata", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) GetWriterMetadataSigInfo() SignatureInfo {
+	ret := _m.ctrl.Call(_m, "GetWriterMetadataSigInfo")
+	ret0, _ := ret[0].(SignatureInfo)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetWriterMetadataSigInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriterMetadataSigInfo")
+}
+
+func (_m *MockMutableBareRootMetadata) Version() MetadataVer {
+	ret := _m.ctrl.Call(_m, "Version")
+	ret0, _ := ret[0].(MetadataVer)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) Version() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
+}
+
+func (_m *MockMutableBareRootMetadata) SetRefBytes(refBytes uint64) {
+	_m.ctrl.Call(_m, "SetRefBytes", refBytes)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetRefBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRefBytes", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetUnrefBytes(unrefBytes uint64) {
+	_m.ctrl.Call(_m, "SetUnrefBytes", unrefBytes)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetUnrefBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUnrefBytes", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetDiskUsage(diskUsage uint64) {
+	_m.ctrl.Call(_m, "SetDiskUsage", diskUsage)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetDiskUsage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDiskUsage", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) AddRefBytes(refBytes uint64) {
+	_m.ctrl.Call(_m, "AddRefBytes", refBytes)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) AddRefBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddRefBytes", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) AddUnrefBytes(unrefBytes uint64) {
+	_m.ctrl.Call(_m, "AddUnrefBytes", unrefBytes)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) AddUnrefBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddUnrefBytes", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) AddDiskUsage(diskUsage uint64) {
+	_m.ctrl.Call(_m, "AddDiskUsage", diskUsage)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) AddDiskUsage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddDiskUsage", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) ClearRekeyBit() {
+	_m.ctrl.Call(_m, "ClearRekeyBit")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) ClearRekeyBit() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearRekeyBit")
+}
+
+func (_m *MockMutableBareRootMetadata) ClearWriterMetadataCopiedBit() {
+	_m.ctrl.Call(_m, "ClearWriterMetadataCopiedBit")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) ClearWriterMetadataCopiedBit() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearWriterMetadataCopiedBit")
+}
+
+func (_m *MockMutableBareRootMetadata) ClearFinalBit() {
+	_m.ctrl.Call(_m, "ClearFinalBit")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) ClearFinalBit() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearFinalBit")
+}
+
+func (_m *MockMutableBareRootMetadata) SetUnmerged() {
+	_m.ctrl.Call(_m, "SetUnmerged")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetUnmerged() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUnmerged")
+}
+
+func (_m *MockMutableBareRootMetadata) SetBranchID(bid BranchID) {
+	_m.ctrl.Call(_m, "SetBranchID", bid)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetBranchID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBranchID", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetPrevRoot(mdID MdID) {
+	_m.ctrl.Call(_m, "SetPrevRoot", mdID)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetPrevRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetPrevRoot", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetSerializedPrivateMetadata(spmd []byte) {
+	_m.ctrl.Call(_m, "SetSerializedPrivateMetadata", spmd)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetSerializedPrivateMetadata(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSerializedPrivateMetadata", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetWriterMetadataSigInfo(sigInfo SignatureInfo) {
+	_m.ctrl.Call(_m, "SetWriterMetadataSigInfo", sigInfo)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetWriterMetadataSigInfo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriterMetadataSigInfo", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetLastModifyingWriter(user protocol.UID) {
+	_m.ctrl.Call(_m, "SetLastModifyingWriter", user)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetLastModifyingWriter(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLastModifyingWriter", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetLastModifyingUser(user protocol.UID) {
+	_m.ctrl.Call(_m, "SetLastModifyingUser", user)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetLastModifyingUser(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLastModifyingUser", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetRekeyBit() {
+	_m.ctrl.Call(_m, "SetRekeyBit")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetRekeyBit() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRekeyBit")
+}
+
+func (_m *MockMutableBareRootMetadata) SetFinalBit() {
+	_m.ctrl.Call(_m, "SetFinalBit")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetFinalBit() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFinalBit")
+}
+
+func (_m *MockMutableBareRootMetadata) SetWriterMetadataCopiedBit() {
+	_m.ctrl.Call(_m, "SetWriterMetadataCopiedBit")
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetWriterMetadataCopiedBit() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriterMetadataCopiedBit")
+}
+
+func (_m *MockMutableBareRootMetadata) SetRevision(revision MetadataRevision) {
+	_m.ctrl.Call(_m, "SetRevision", revision)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetRevision(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRevision", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) AddNewKeys(wkb TLFWriterKeyBundle, rkb TLFReaderKeyBundle) {
+	_m.ctrl.Call(_m, "AddNewKeys", wkb, rkb)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) AddNewKeys(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddNewKeys", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) SetUnresolvedReaders(readers []protocol.SocialAssertion) {
+	_m.ctrl.Call(_m, "SetUnresolvedReaders", readers)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetUnresolvedReaders(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUnresolvedReaders", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetUnresolvedWriters(writers []protocol.SocialAssertion) {
+	_m.ctrl.Call(_m, "SetUnresolvedWriters", writers)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetUnresolvedWriters(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUnresolvedWriters", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetConflictInfo(ci *TlfHandleExtension) {
+	_m.ctrl.Call(_m, "SetConflictInfo", ci)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetConflictInfo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetConflictInfo", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetFinalizedInfo(fi *TlfHandleExtension) {
+	_m.ctrl.Call(_m, "SetFinalizedInfo", fi)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetFinalizedInfo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFinalizedInfo", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetWriters(writers []protocol.UID) {
+	_m.ctrl.Call(_m, "SetWriters", writers)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetWriters(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriters", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetTlfID(tlf TlfID) {
+	_m.ctrl.Call(_m, "SetTlfID", tlf)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetTlfID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTlfID", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) FakeInitialRekey(h BareTlfHandle) {
+	_m.ctrl.Call(_m, "FakeInitialRekey", h)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) FakeInitialRekey(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FakeInitialRekey", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) Update(tlf TlfID, h BareTlfHandle) error {
+	ret := _m.ctrl.Call(_m, "Update", tlf, h)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) Update(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) GetTLFKeyBundles(keyGen KeyGen) (*TLFWriterKeyBundle, *TLFReaderKeyBundle, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFKeyBundles", keyGen)
+	ret0, _ := ret[0].(*TLFWriterKeyBundle)
+	ret1, _ := ret[1].(*TLFReaderKeyBundle)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFKeyBundles(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFKeyBundles", arg0)
 }

--- a/libkbfs/root_metadata_test_util.go
+++ b/libkbfs/root_metadata_test_util.go
@@ -9,41 +9,10 @@ package libkbfs
 
 // NewRootMetadataSignedForTest returns a new RootMetadataSigned for testing.
 func NewRootMetadataSignedForTest(id TlfID, h BareTlfHandle) (*RootMetadataSigned, error) {
-	rmds := &RootMetadataSigned{}
-	err := updateNewBareRootMetadata(&rmds.MD, id, h)
+	rmds := NewRootMetadataSigned()
+	err := rmds.MD.Update(id, h)
 	if err != nil {
 		return nil, err
 	}
 	return rmds, nil
-}
-
-// FakeInitialRekey fakes the initial rekey for the given
-// BareRootMetadata. This is necessary since newly-created
-// BareRootMetadata objects don't have enough data to build a
-// TlfHandle from until the first rekey.
-func FakeInitialRekey(rmd *BareRootMetadata, h BareTlfHandle) {
-	if rmd.ID.IsPublic() {
-		panic("Called FakeInitialRekey on public TLF")
-	}
-	wkb := TLFWriterKeyBundle{
-		WKeys: make(UserDeviceKeyInfoMap),
-	}
-	for _, w := range h.Writers {
-		k := MakeFakeCryptPublicKeyOrBust(string(w))
-		wkb.WKeys[w] = DeviceKeyInfoMap{
-			k.kid: TLFCryptKeyInfo{},
-		}
-	}
-	rmd.WKeys = TLFWriterKeyGenerations{wkb}
-
-	rkb := TLFReaderKeyBundle{
-		RKeys: make(UserDeviceKeyInfoMap),
-	}
-	for _, r := range h.Readers {
-		k := MakeFakeCryptPublicKeyOrBust(string(r))
-		rkb.RKeys[r] = DeviceKeyInfoMap{
-			k.kid: TLFCryptKeyInfo{},
-		}
-	}
-	rmd.RKeys = TLFReaderKeyGenerations{rkb}
 }

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -206,7 +206,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 						// indicates a failed and retried sync), the
 						// corresponding block should already be
 						// cleaned up.
-						if rmd.Revision <= gcRevision || opRefs[ptr] {
+						if rmd.Revision() <= gcRevision || opRefs[ptr] {
 							delete(archivedBlocks, ptr)
 						} else {
 							archivedBlocks[ptr] = true
@@ -217,7 +217,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 			for _, update := range op.AllUpdates() {
 				delete(expectedLiveBlocks, update.Unref)
 				if update.Unref != zeroPtr && update.Ref != update.Unref {
-					if rmd.Revision <= gcRevision {
+					if rmd.Revision() <= gcRevision {
 						delete(archivedBlocks, update.Unref)
 					} else {
 						archivedBlocks[update.Unref] = true
@@ -228,8 +228,8 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 				}
 			}
 		}
-		expectedRef += rmd.RefBytes
-		expectedRef -= rmd.UnrefBytes
+		expectedRef += rmd.RefBytes()
+		expectedRef -= rmd.UnrefBytes()
 
 		if len(rmd.data.Changes.Ops) == 1 && hasGCOp {
 			// Don't check GC status for GC revisions
@@ -242,10 +242,10 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 		// to there being too many pointers to collect in one sweep.
 		mtime := time.Unix(0, rmd.data.Dir.Mtime)
 		if !lastGCRevisionTime.Before(mtime) {
-			if rmd.Revision > gcRevision {
+			if rmd.Revision() > gcRevision {
 				return fmt.Errorf("Revision %d happened before the last "+
 					"gc time %s, but was not included in the latest gc op "+
-					"revision %d", rmd.Revision, lastGCRevisionTime, gcRevision)
+					"revision %d", rmd.Revision(), lastGCRevisionTime, gcRevision)
 			}
 		}
 	}
@@ -253,7 +253,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 		tlf, len(expectedLiveBlocks), expectedRef)
 
 	currMD := rmds[len(rmds)-1]
-	expectedUsage := currMD.DiskUsage
+	expectedUsage := currMD.DiskUsage()
 	if expectedUsage != expectedRef {
 		return fmt.Errorf("Expected ref bytes %d doesn't match latest disk "+
 			"usage %d", expectedRef, expectedUsage)

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -122,7 +122,7 @@ func (wee *writerEditEstimates) update(rmds []ImmutableRootMetadata) {
 		if rmd.IsWriterMetadataCopiedSet() {
 			continue
 		}
-		writer := rmd.LastModifyingWriter
+		writer := rmd.LastModifyingWriter()
 		for _, op := range rmd.data.Changes.Ops {
 			// Estimate the number of writes just based on operations
 			// (without yet taking into account whether the same file
@@ -376,8 +376,8 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 
 	// If unmerged, get all the unmerged updates.
 	if head.MergedStatus() == Unmerged {
-		_, unmergedRmds, err := getUnmergedMDUpdates(ctx, teh.config, head.ID,
-			head.BID, head.Revision-1)
+		_, unmergedRmds, err := getUnmergedMDUpdates(ctx, teh.config, head.TlfID(),
+			head.BID(), head.Revision()-1)
 		if err != nil {
 			return nil, err
 		}
@@ -387,7 +387,7 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 
 	for (currEdits == nil || !currEdits.isComplete()) &&
 		len(rmds) < maxMDsToInspect &&
-		rmds[0].Revision > MetadataRevisionInitial {
+		rmds[0].Revision() > MetadataRevisionInitial {
 		teh.log.CDebugf(ctx, "Edits not complete after %d revisions", len(rmds))
 		if estimates.isComplete() {
 			// Once the estimate hits the threshold for each writer,
@@ -407,10 +407,10 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 		}
 
 		for !estimates.isComplete() && len(rmds) < maxMDsToInspect &&
-			rmds[0].Revision > MetadataRevisionInitial {
+			rmds[0].Revision() > MetadataRevisionInitial {
 			// Starting from the head/branchpoint, work backwards
 			// mdMax revisions at a time.
-			endRev := rmds[0].Revision - 1
+			endRev := rmds[0].Revision() - 1
 			startRev := endRev - maxMDsAtATime + 1
 			if startRev < MetadataRevisionInitial {
 				startRev = MetadataRevisionInitial
@@ -422,7 +422,7 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 					int64(len(rmds)) + (int64(endRev) - maxMDsToInspect) + 1)
 			}
 
-			olderRmds, err := getMDRange(ctx, teh.config, head.ID, NullBranchID,
+			olderRmds, err := getMDRange(ctx, teh.config, head.TlfID(), NullBranchID,
 				startRev, endRev, Merged)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
This unembeds `BareRootMetadata` from `RootMetadata` and makes it an interface. It also converts the former `BareRootMetadata` to a versioned implementation of the interface.