### PR TITLE
cr: fix infinite loop when a previous resolution didn't include all rmOps

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -676,7 +676,10 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 		if ri, ok := unmergedChains.renamedOriginals[currOriginal]; ok {
 			oldParent, ok := unmergedChains.byOriginal[ri.originalOldParent]
 			if !ok {
-				continue
+				cr.log.CDebugf(ctx, "Couldn't find chain for original "+
+					"old parent: %v", ri.originalOldParent)
+				return path{}, BlockPointer{}, nil,
+					NoChainFoundError{ri.originalOldParent}
 			}
 			for _, op := range oldParent.ops {
 				ro, ok := op.(*rmOp)
@@ -693,7 +696,10 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 			// which contains the proper refblock.
 			newParent, ok := unmergedChains.byOriginal[ri.originalNewParent]
 			if !ok {
-				continue
+				cr.log.CDebugf(ctx, "Couldn't find chain for original new "+
+					"parent: %v", ri.originalNewParent)
+				return path{}, BlockPointer{}, nil,
+					NoChainFoundError{ri.originalNewParent}
 			}
 			for i, op := range newParent.ops {
 				oldCo, ok := op.(*createOp)

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -432,9 +432,6 @@ func (rmea *rmMergedEntryAction) swapUnmergedBlock(
 func (rmea *rmMergedEntryAction) do(ctx context.Context,
 	unmergedCopier fileBlockDeepCopier, mergedCopier fileBlockDeepCopier,
 	unmergedBlock *DirBlock, mergedBlock *DirBlock) error {
-	if _, ok := mergedBlock.Children[rmea.name]; !ok {
-		return NoSuchNameError{rmea.name}
-	}
 	delete(mergedBlock.Children, rmea.name)
 	return nil
 }


### PR DESCRIPTION
resolutionOps may delete entire directory trees but only include the top-most rmOp.  This means that another resolution may encounter a node that has been deleted, without its parent having any listed ops in the merged chain.  In that case, avoid an infinite loop since we don't actually need to remove the corresponding rmOps from the merged chain (since there are none).

Will track separate issues for the other issues this exposes:
1. the previous resolution should probably contain all rmOps (KBFS-1424)
2. rmOps shouldn't cause the parent directories to be recreated (KBFS-1423)

Issue: KBFS-1357
