### PR TITLE
Make everything use {B,}RMD.IsValidAndSigned

### DIFF
--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -566,7 +566,7 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 
 	if (md.MergedStatus() == Merged) != (md.BID() == NullBranchID) {
 		return fmt.Errorf("Branch ID %s doesn't match merged status %s",
-			md.BID, md.MergedStatus())
+			md.BID(), md.MergedStatus())
 	}
 
 	handle, err := md.MakeBareTlfHandle()

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -555,10 +555,6 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 				return errors.New("No PrevRoot for non-initial final revision")
 			}
 		}
-
-		if len(md.SerializedPrivateMetadata) != 0 {
-			return errors.New("Non-empty private metadata for final revision")
-		}
 	} else {
 		if md.Revision < MetadataRevisionInitial {
 			return fmt.Errorf("Invalid revision %d", md.Revision)
@@ -573,10 +569,10 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 				return errors.New("No PrevRoot for non-initial revision")
 			}
 		}
+	}
 
-		if len(md.SerializedPrivateMetadata) == 0 {
-			return errors.New("No private metadata for non-final revision")
-		}
+	if len(md.SerializedPrivateMetadata) == 0 {
+		return errors.New("No private metadata")
 	}
 
 	if (md.MergedStatus() == Merged) != (md.BID() == NullBranchID) {

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -588,7 +588,7 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 
 	// Verify signature. We have to re-marshal the WriterMetadata,
 	// since it's embedded.
-	buf, err := codec.Encode(md.WriterMetadata)
+	buf, err := codec.Encode(md.WriterMetadataV2)
 	if err != nil {
 		return err
 	}
@@ -606,7 +606,7 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 func (md *BareRootMetadataV2) IsLastModifiedBy(
 	currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error {
 	// Verify the user and device are the writer.
-	writer := md.LastModifyingWriter
+	writer := md.LastModifyingWriter()
 	if !md.IsWriterMetadataCopiedSet() {
 		if writer != currentUID {
 			return fmt.Errorf(

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -406,7 +406,7 @@ func (md *BareRootMetadataV2) MakeBareTlfHandle() (BareTlfHandle, error) {
 		md.TlfHandleExtensions())
 }
 
-// TlfHandleExtensions returns a list of handle extensions associated with the TLf.
+// TlfHandleExtensions implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) TlfHandleExtensions() (
 	extensions []TlfHandleExtension) {
 	if md.ConflictInfo != nil {

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -598,11 +598,17 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 		}
 	}
 
+	// Make sure the last modifier is valid.
+	user := md.GetLastModifyingUser()
+	if !handle.IsReader(user) {
+		return fmt.Errorf("Invalid modifying user %s", user)
+	}
+
 	// Verify the user and device are the last modifier.
-	if md.GetLastModifyingUser() != currentUID {
+	if user != currentUID {
 		return fmt.Errorf(
 			"Last modifier %s doesn't match current user %s",
-			md.LastModifyingUser, currentUID)
+			user, currentUID)
 	}
 
 	// Verify signature.

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -406,19 +406,8 @@ func (md *BareRootMetadataV2) MakeBareTlfHandle() (BareTlfHandle, error) {
 		md.TlfHandleExtensions())
 }
 
-// MakeBareTlfHandle makes a BareTlfHandle for this
-// BareRootMetadata. Should be used only by servers and MDOps.
-func (md *BareRootMetadata) MakeBareTlfHandle() (BareTlfHandle, error) {
-	return md.makeBareTlfHandle()
-}
-
-// writerKID returns the KID of the writer.
-func (md *BareRootMetadata) writerKID() keybase1.KID {
-	return md.WriterMetadataSigInfo.VerifyingKey.KID()
-}
-
 // TlfHandleExtensions returns a list of handle extensions associated with the TLf.
-func (md *BareRootMetadata) TlfHandleExtensions() (
+func (md *BareRootMetadataV2) TlfHandleExtensions() (
 	extensions []TlfHandleExtension) {
 	if md.ConflictInfo != nil {
 		extensions = append(extensions, *md.ConflictInfo)
@@ -612,11 +601,9 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 	return nil
 }
 
-// IsLastModifiedBy verifies that the BareRootMetadata is written by
-// the given user and device (identified by the KID of the device
-// verifying key), and returns an error if not. Should be called only
-// after IsValidAndSigned.
-func (md *BareRootMetadata) IsLastModifiedBy(
+// IsLastModifiedBy implements the BareRootMetadata interface for
+// BareRootMetadataV2.
+func (md *BareRootMetadataV2) IsLastModifiedBy(
 	currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error {
 	// Verify the user and device are the writer.
 	writer := md.LastModifyingWriter

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -604,28 +604,24 @@ func (md *BareRootMetadataV2) IsValidAndSigned(
 // IsLastModifiedBy implements the BareRootMetadata interface for
 // BareRootMetadataV2.
 func (md *BareRootMetadataV2) IsLastModifiedBy(
-	currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error {
+	uid keybase1.UID, key VerifyingKey) error {
 	// Verify the user and device are the writer.
 	writer := md.LastModifyingWriter()
 	if !md.IsWriterMetadataCopiedSet() {
-		if writer != currentUID {
-			return fmt.Errorf(
-				"Last writer %s doesn't match current user %s",
-				writer, currentUID)
+		if writer != uid {
+			return fmt.Errorf("Last writer %s != %s", writer, uid)
 		}
-		if md.WriterMetadataSigInfo.VerifyingKey != currentVerifyingKey {
+		if md.WriterMetadataSigInfo.VerifyingKey != key {
 			return fmt.Errorf(
-				"Last writer verifying key %v doesn't match current verifying key %v",
-				md.WriterMetadataSigInfo.VerifyingKey, currentVerifyingKey)
+				"Last writer verifying key %v != %v",
+				md.WriterMetadataSigInfo.VerifyingKey, key)
 		}
 	}
 
 	// Verify the user and device are the last modifier.
 	user := md.GetLastModifyingUser()
-	if user != currentUID {
-		return fmt.Errorf(
-			"Last modifier %s doesn't match current user %s",
-			user, currentUID)
+	if user != uid {
+		return fmt.Errorf("Last modifier %s != %s", user, uid)
 	}
 
 	return nil

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -350,14 +350,16 @@ func (e MDMissingDataError) Error() string {
 // MDMismatchError indicates an inconsistent or unverifiable MD object
 // for the given top-level folder.
 type MDMismatchError struct {
-	Dir string
-	Err error
+	Revision MetadataRevision
+	Dir      string
+	TlfID    TlfID
+	Err      error
 }
 
 // Error implements the error interface for MDMismatchError
 func (e MDMismatchError) Error() string {
-	return fmt.Sprintf("Could not verify metadata for directory %s: %s",
-		e.Dir, e.Err)
+	return fmt.Sprintf("Could not verify metadata (revision=%d) for directory %s (id=%s): %s",
+		e.Revision, e.Dir, e.TlfID, e.Err)
 }
 
 // NoSuchMDError indicates that there is no MD object for the given

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1515,11 +1515,15 @@ type BareRootMetadata interface {
 	GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 		TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
 		TLFCryptKeyServerHalfID, bool, error)
-	// IsValidAndSigned verifies the BareRootMetadata given the current
-	// user and device (identified by the KID of the device verifying
-	// key), checks the writer signature, and returns an error if a
-	// problem was found.
-	IsValidAndSigned(codec Codec, crypto cryptoPure,
+	// IsValidAndSigned verifies the BareRootMetadata, checks the
+	// writer signature, and returns an error if a problem was
+	// found.
+	IsValidAndSigned(codec Codec, crypto cryptoPure) error
+	// IsLastModifiedBy verifies that the BareRootMetadata is written by
+	// the given user and device (identified by the KID of the device
+	// verifying key), and returns an error if not. Should be called only
+	// after IsValidAndSigned.
+	IsLastModifiedBy(
 		currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error
 	// LastModifyingWriter return the UID of the last user to modify the writer metadata.
 	LastModifyingWriter() keybase1.UID

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1517,7 +1517,8 @@ type BareRootMetadata interface {
 		TLFCryptKeyServerHalfID, bool, error)
 	// IsValidAndSigned verifies the BareRootMetadata, checks the
 	// writer signature, and returns an error if a problem was
-	// found.
+	// found. This should be the first thing checked on a BRMD
+	// retrieved from an untrusted source.
 	IsValidAndSigned(codec Codec, crypto cryptoPure) error
 	// IsLastModifiedBy verifies that the BareRootMetadata is
 	// written by the given user and device (identified by the KID

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1519,12 +1519,10 @@ type BareRootMetadata interface {
 	// writer signature, and returns an error if a problem was
 	// found.
 	IsValidAndSigned(codec Codec, crypto cryptoPure) error
-	// IsLastModifiedBy verifies that the BareRootMetadata is written by
-	// the given user and device (identified by the KID of the device
-	// verifying key), and returns an error if not. Should be called only
-	// after IsValidAndSigned.
-	IsLastModifiedBy(
-		currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error
+	// IsLastModifiedBy verifies that the BareRootMetadata is
+	// written by the given user and device (identified by the KID
+	// of the device verifying key), and returns an error if not.
+	IsLastModifiedBy(uid keybase1.UID, key VerifyingKey) error
 	// LastModifyingWriter return the UID of the last user to modify the writer metadata.
 	LastModifyingWriter() keybase1.UID
 	// LastModifyingWriterKID returns the KID of the last device to modify the writer metadata.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1518,7 +1518,10 @@ type BareRootMetadata interface {
 	// IsValidAndSigned verifies the BareRootMetadata, checks the
 	// writer signature, and returns an error if a problem was
 	// found. This should be the first thing checked on a BRMD
-	// retrieved from an untrusted source.
+	// retrieved from an untrusted source, and then the signing
+	// user and key should be validated, either by comparing to
+	// the current device key (using IsLastModifiedBy), or by
+	// checking with KBPKI.
 	IsValidAndSigned(codec Codec, crypto cryptoPure) error
 	// IsLastModifiedBy verifies that the BareRootMetadata is
 	// written by the given user and device (identified by the KID

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1494,9 +1494,6 @@ type BareRootMetadata interface {
 	// MakeBareTlfHandle makes a BareTlfHandle for this
 	// BareRootMetadata. Should be used only by servers and MDOps.
 	MakeBareTlfHandle() (BareTlfHandle, error)
-	// VerifyWriterMetadata verifies md's WriterMetadata against md's
-	// WriterMetadataSigInfo, assuming the verifying key there is valid.
-	VerifyWriterMetadata(codec Codec, crypto cryptoPure) error
 	// TlfHandleExtensions returns a list of handle extensions associated with the TLf.
 	TlfHandleExtensions() (extensions []TlfHandleExtension)
 	// GetDeviceKIDs returns the KIDs (of CryptPublicKeys) for all known

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -183,7 +183,7 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 			"Metadata ID mismatch: expected %s, got %s", id, mdID)
 	}
 
-	err = rmd.VerifyWriterMetadata(j.codec, j.crypto)
+	err = rmd.IsValidAndSigned(j.codec, j.crypto)
 	if err != nil {
 		return nil, time.Time{}, err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -201,8 +201,12 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 func (j mdJournal) putMD(
 	rmd BareRootMetadata, currentUID keybase1.UID,
 	currentVerifyingKey VerifyingKey) (MdID, error) {
-	err := rmd.IsValidAndSigned(
-		j.codec, j.crypto, currentUID, currentVerifyingKey)
+	err := rmd.IsValidAndSigned(j.codec, j.crypto)
+	if err != nil {
+		return MdID{}, err
+	}
+
+	err = rmd.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -179,9 +179,8 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 			"Metadata ID mismatch: expected %s, got %s", id, mdID)
 	}
 
-	// Verify RMD. TODO: Also verify the verifying keys, like in
-	// MDOpsStandard.processMetadata(). May have to do this in
-	// journalMDOps.
+	// TODO: Plumb through currentUID and currentVerifyingKey and
+	// call IsLastModifiedBy().
 
 	err = rmd.IsValidAndSigned(j.codec, j.crypto)
 	if err != nil {
@@ -206,9 +205,6 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 func (j mdJournal) putMD(
 	rmd BareRootMetadata, currentUID keybase1.UID,
 	currentVerifyingKey VerifyingKey) (MdID, error) {
-	// TODO: Also verify the verifying keys, like in
-	// MDOpsStandard.processMetadata(). May have to do this in
-	// journalMDOps.
 	err := rmd.IsValidAndSigned(j.codec, j.crypto)
 	if err != nil {
 		return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -168,11 +168,7 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 
 	// Check integrity.
 
-	if rmd.BID() != j.branchID {
-		return nil, time.Time{}, fmt.Errorf(
-			"Branch ID mismatch: expected %s, got %s", j.branchID, rmd.BID())
-	}
-
+	// TODO: MakeMdID serializes rmd -- use data instead.
 	mdID, err := j.crypto.MakeMdID(&rmd)
 	if err != nil {
 		return nil, time.Time{}, err
@@ -183,9 +179,18 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 			"Metadata ID mismatch: expected %s, got %s", id, mdID)
 	}
 
+	// Verify RMD. TODO: Also verify the verifying keys, like in
+	// MDOpsStandard.processMetadata(). May have to do this in
+	// journalMDOps.
+
 	err = rmd.IsValidAndSigned(j.codec, j.crypto)
 	if err != nil {
 		return nil, time.Time{}, err
+	}
+
+	if rmd.BID() != j.branchID {
+		return nil, time.Time{}, fmt.Errorf(
+			"Branch ID mismatch: expected %s, got %s", j.branchID, rmd.BID())
 	}
 
 	fi, err := os.Stat(path)
@@ -201,6 +206,9 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 func (j mdJournal) putMD(
 	rmd BareRootMetadata, currentUID keybase1.UID,
 	currentVerifyingKey VerifyingKey) (MdID, error) {
+	// TODO: Also verify the verifying keys, like in
+	// MDOpsStandard.processMetadata(). May have to do this in
+	// journalMDOps.
 	err := rmd.IsValidAndSigned(j.codec, j.crypto)
 	if err != nil {
 		return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -189,7 +189,8 @@ func (j mdJournal) getMD(id MdID) (BareRootMetadata, time.Time, error) {
 
 	if rmd.BID() != j.branchID {
 		return nil, time.Time{}, fmt.Errorf(
-			"Branch ID mismatch: expected %s, got %s", j.branchID, rmd.BID())
+			"Branch ID mismatch: expected %s, got %s",
+			j.branchID, rmd.BID())
 	}
 
 	fi, err := os.Stat(path)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -119,12 +119,15 @@ func TestMDJournalBasic(t *testing.T) {
 
 	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
 	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto, uid, verifyingKey)
+	err = ibrmds[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
 
 	for i := 1; i < len(ibrmds); i++ {
-		err := ibrmds[i].IsValidAndSigned(
-			codec, crypto, uid, verifyingKey)
+		err := ibrmds[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
 		require.NoError(t, err)
 		err = ibrmds[i-1].CheckValidSuccessor(
 			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
@@ -204,7 +207,9 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
 	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
 	require.Equal(t, Unmerged, ibrmds[0].MergedStatus())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto, uid, verifyingKey)
+	err = ibrmds[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
 
 	bid := ibrmds[0].BID()
@@ -213,8 +218,9 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	for i := 1; i < len(ibrmds); i++ {
 		require.Equal(t, Unmerged, ibrmds[i].MergedStatus())
 		require.Equal(t, bid, ibrmds[i].BID())
-		err := ibrmds[i].IsValidAndSigned(
-			codec, crypto, uid, verifyingKey)
+		err := ibrmds[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
 		require.NoError(t, err)
 		err = ibrmds[i-1].CheckValidSuccessor(
 			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
@@ -278,14 +284,17 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
 	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
 	require.Equal(t, Merged, ibrmds[0].MergedStatus())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto, uid, verifyingKey)
+	err = ibrmds[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
 
 	for i := 1; i < len(ibrmds); i++ {
 		require.Equal(t, Merged, ibrmds[i].MergedStatus())
 		require.Equal(t, NullBranchID, ibrmds[i].BID())
-		err := ibrmds[i].IsValidAndSigned(
-			codec, crypto, uid, verifyingKey)
+		err := ibrmds[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
 		require.NoError(t, err)
 		err = ibrmds[i-1].CheckValidSuccessor(
 			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
@@ -372,12 +381,15 @@ func TestMDJournalFlushBasic(t *testing.T) {
 
 	require.Equal(t, firstRevision, rmdses[0].MD.RevisionNumber())
 	require.Equal(t, firstPrevRoot, rmdses[0].MD.GetPrevRoot())
-	err = rmdses[0].IsValidAndSigned(codec, crypto, uid, verifyingKey)
+	err = rmdses[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = rmdses[0].IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
 
 	for i := 1; i < len(rmdses); i++ {
-		err := rmdses[i].IsValidAndSigned(
-			codec, crypto, uid, verifyingKey)
+		err := rmdses[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = rmdses[i].IsLastModifiedBy(uid, verifyingKey)
 		require.NoError(t, err)
 		prevID, err := crypto.MakeMdID(rmdses[i-1].MD)
 		require.NoError(t, err)
@@ -456,7 +468,9 @@ func TestMDJournalFlushConflict(t *testing.T) {
 	require.Equal(t, firstRevision, rmdses[0].MD.RevisionNumber())
 	require.Equal(t, firstPrevRoot, rmdses[0].MD.GetPrevRoot())
 	require.Equal(t, Unmerged, rmdses[0].MD.MergedStatus())
-	err = rmdses[0].IsValidAndSigned(codec, crypto, uid, verifyingKey)
+	err = rmdses[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = rmdses[0].IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
 
 	bid := rmdses[0].MD.BID()
@@ -465,8 +479,9 @@ func TestMDJournalFlushConflict(t *testing.T) {
 	for i := 1; i < len(rmdses); i++ {
 		require.Equal(t, Unmerged, rmdses[i].MD.MergedStatus())
 		require.Equal(t, bid, rmdses[i].MD.BID())
-		err := rmdses[i].IsValidAndSigned(
-			codec, crypto, uid, verifyingKey)
+		err := rmdses[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = rmdses[i].IsLastModifiedBy(uid, verifyingKey)
 		require.NoError(t, err)
 		prevID, err := crypto.MakeMdID(rmdses[i-1].MD)
 		require.NoError(t, err)
@@ -548,7 +563,9 @@ func TestMDJournalPreservesBranchID(t *testing.T) {
 	require.Equal(t, firstRevision, rmdses[0].MD.RevisionNumber())
 	require.Equal(t, firstPrevRoot, rmdses[0].MD.GetPrevRoot())
 	require.Equal(t, Unmerged, rmdses[0].MD.MergedStatus())
-	err = rmdses[0].IsValidAndSigned(codec, crypto, uid, verifyingKey)
+	err = rmdses[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = rmdses[0].IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
 
 	bid := rmdses[0].MD.BID()
@@ -557,8 +574,9 @@ func TestMDJournalPreservesBranchID(t *testing.T) {
 	for i := 1; i < len(rmdses); i++ {
 		require.Equal(t, Unmerged, rmdses[i].MD.MergedStatus())
 		require.Equal(t, bid, rmdses[i].MD.BID())
-		err := rmdses[i].IsValidAndSigned(
-			codec, crypto, uid, verifyingKey)
+		err := rmdses[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = rmdses[i].IsLastModifiedBy(uid, verifyingKey)
 		require.NoError(t, err)
 		prevID, err := crypto.MakeMdID(rmdses[i-1].MD)
 		require.NoError(t, err)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -125,7 +125,7 @@ func (md *MDOpsStandard) processMetadata(
 	ImmutableRootMetadata, error) {
 	// A blank sig means this is a brand new MD object, and
 	// there's nothing to do.
-	if !rmds.IsInitialized() {
+	if rmds.SigInfo.IsNil() {
 		return ImmutableRootMetadata{}, errors.New(
 			"Missing RootMetadata signature")
 	}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -126,8 +126,8 @@ func (md *MDOpsStandard) processMetadata(
 	err := rmds.IsValidAndSigned(md.config.Codec(), md.config.Crypto())
 	if err != nil {
 		return ImmutableRootMetadata{}, MDMismatchError{
-			rmds.MD.Revision, handle.GetCanonicalPath(),
-			rmds.MD.ID, err,
+			rmds.MD.RevisionNumber(), handle.GetCanonicalPath(),
+			rmds.MD.TlfID(), err,
 		}
 	}
 
@@ -138,11 +138,11 @@ func (md *MDOpsStandard) processMetadata(
 
 	if handle.IsFinal() {
 		err = md.config.KBPKI().HasUnverifiedVerifyingKey(
-			ctx, rmds.MD.LastModifyingUser,
+			ctx, rmds.MD.GetLastModifyingUser(),
 			rmds.SigInfo.VerifyingKey)
 	} else {
 		err = md.config.KBPKI().HasVerifyingKey(
-			ctx, rmds.MD.LastModifyingUser,
+			ctx, rmds.MD.GetLastModifyingUser(),
 			rmds.SigInfo.VerifyingKey,
 			rmds.untrustedServerTimestamp)
 	}
@@ -229,8 +229,8 @@ func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 	mdHandlePath := mdHandle.GetCanonicalPath()
 	if !handleResolvesToMdHandle && !mdHandleResolvesToHandle {
 		return TlfID{}, ImmutableRootMetadata{}, MDMismatchError{
-			rmds.MD.Revision, handle.GetCanonicalPath(),
-			rmds.MD.ID,
+			rmds.MD.RevisionNumber(), handle.GetCanonicalPath(),
+			rmds.MD.TlfID(),
 			fmt.Errorf(
 				"MD contained unexpected handle path %s (%s -> %s) (%s -> %s)",
 				mdHandlePath,
@@ -264,7 +264,7 @@ func (md *MDOpsStandard) processMetadataWithID(ctx context.Context,
 	// Make sure the signed-over ID matches
 	if id != rmds.MD.TlfID() {
 		return ImmutableRootMetadata{}, MDMismatchError{
-			rmds.MD.Revision, id.String(), rmds.MD.ID,
+			rmds.MD.RevisionNumber(), id.String(), rmds.MD.TlfID(),
 			fmt.Errorf("MD contained unexpected folder id %s, expected %s",
 				rmds.MD.TlfID().String(), id.String()),
 		}
@@ -272,7 +272,7 @@ func (md *MDOpsStandard) processMetadataWithID(ctx context.Context,
 	// Make sure the signed-over branch ID matches
 	if bid != NullBranchID && bid != rmds.MD.BID() {
 		return ImmutableRootMetadata{}, MDMismatchError{
-			rmds.MD.Revision, id.String(), rmds.MD.ID,
+			rmds.MD.RevisionNumber(), id.String(), rmds.MD.TlfID(),
 			fmt.Errorf("MD contained unexpected branch id %s, expected %s, "+
 				"folder id %s", rmds.MD.BID().String(), bid.String(), id.String()),
 		}
@@ -417,9 +417,9 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 				prevIRMD.mdID, irmd.bareMd)
 			if err != nil {
 				return nil, MDMismatchError{
-					prevIRMD.Revision,
+					prevIRMD.Revision(),
 					irmd.GetTlfHandle().GetCanonicalPath(),
-					prevIRMD.ID, err,
+					prevIRMD.TlfID(), err,
 				}
 			}
 		}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -90,6 +90,7 @@ func addFakeRMDSData(rmds *RootMetadataSigned, h *TlfHandle) {
 	rmds.MD.SetSerializedPrivateMetadata([]byte{1})
 	rmds.MD.SetLastModifyingWriter(h.FirstResolvedWriter())
 	rmds.MD.SetLastModifyingUser(h.FirstResolvedWriter())
+	fakeVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
 	rmds.MD.SetWriterMetadataSigInfo(SignatureInfo{
 		Version:      SigED25519,
 		Signature:    []byte{41},
@@ -127,7 +128,7 @@ func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	packedData := []byte{4, 3, 2, 1}
 	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(packedData, nil).AnyTimes()
 
-	config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.WriterMetadataSigInfo).Return(nil)
+	config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.GetWriterMetadataSigInfo()).Return(nil)
 	config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).Return(verifyErr)
 	if verifyErr != nil {
 		return
@@ -140,7 +141,7 @@ func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	}
 
 	config.mockCodec.EXPECT().Decode(
-		rmds.MD.SerializedPrivateMetadata, gomock.Any()).Return(nil)
+		rmds.MD.GetSerializedPrivateMetadata(), gomock.Any()).Return(nil)
 }
 
 func verifyMDForPrivateHelper(

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -57,6 +57,12 @@ func addFakeRMDData(rmd *RootMetadata, h *TlfHandle) {
 	rmd.SetRevision(MetadataRevision(1))
 	rmd.SetLastModifyingWriter(h.FirstResolvedWriter())
 	rmd.SetLastModifyingUser(h.FirstResolvedWriter())
+	fakeVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
+	rmd.SetWriterMetadataSigInfo(SignatureInfo{
+		Version:      SigED25519,
+		Signature:    []byte{41},
+		VerifyingKey: fakeVerifyingKey,
+	})
 
 	if !h.IsPublic() {
 		rmd.FakeInitialRekey(h.ToBareHandleOrBust())
@@ -84,10 +90,15 @@ func addFakeRMDSData(rmds *RootMetadataSigned, h *TlfHandle) {
 	rmds.MD.SetSerializedPrivateMetadata([]byte{1})
 	rmds.MD.SetLastModifyingWriter(h.FirstResolvedWriter())
 	rmds.MD.SetLastModifyingUser(h.FirstResolvedWriter())
+	rmds.MD.SetWriterMetadataSigInfo(SignatureInfo{
+		Version:      SigED25519,
+		Signature:    []byte{41},
+		VerifyingKey: fakeVerifyingKey,
+	})
 	rmds.SigInfo = SignatureInfo{
 		Version:      SigED25519,
 		Signature:    []byte{42},
-		VerifyingKey: MakeFakeVerifyingKeyOrBust("fake key"),
+		VerifyingKey: fakeVerifyingKey,
 	}
 	rmds.untrustedServerTimestamp = time.Now()
 
@@ -112,21 +123,24 @@ func newRMDS(t *testing.T, config Config, public bool) (
 }
 
 func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
-	hasVerifyingKeyErr error, verifyErr error) {
+	verifyErr, hasVerifyingKeyErr error) {
 	packedData := []byte{4, 3, 2, 1}
 	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(packedData, nil).AnyTimes()
 
+	config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.WriterMetadataSigInfo).Return(nil)
+	config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).Return(verifyErr)
+	if verifyErr != nil {
+		return
+	}
 	config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).AnyTimes().Return(hasVerifyingKeyErr)
-	if hasVerifyingKeyErr == nil {
-		config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.GetWriterMetadataSigInfo()).Return(nil)
-		config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).Return(verifyErr)
-		if verifyErr == nil {
-			config.mockCodec.EXPECT().Decode(
-				rmds.MD.GetSerializedPrivateMetadata(),
-				gomock.Any()).Return(nil)
-		}
+
+	if hasVerifyingKeyErr != nil {
+		return
 	}
+
+	config.mockCodec.EXPECT().Decode(
+		rmds.MD.SerializedPrivateMetadata, gomock.Any()).Return(nil)
 }
 
 func verifyMDForPrivateHelper(
@@ -340,7 +354,7 @@ func TestMDOpsGetForHandlePublicFailFindKey(t *testing.T) {
 	rmds, h := newRMDS(t, config, true)
 
 	// Do this before setting tlfHandle to nil.
-	verifyMDForPublic(config, rmds, KeyNotFoundError{}, nil)
+	verifyMDForPublic(config, rmds, nil, KeyNotFoundError{})
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 
@@ -358,7 +372,7 @@ func TestMDOpsGetForHandlePublicFailVerify(t *testing.T) {
 
 	// Do this before setting tlfHandle to nil.
 	expectedErr := libkb.VerificationError{}
-	verifyMDForPublic(config, rmds, nil, expectedErr)
+	verifyMDForPublic(config, rmds, expectedErr, nil)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -339,8 +339,6 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 		return MDServerErrorBadRequest{Reason: err.Error()}
 	}
 
-	// Assume that currentVerifyingKey is valid.
-
 	err = rmds.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {
 		return MDServerErrorBadRequest{Reason: err.Error()}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -333,9 +333,12 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 		return MDServerError{err}
 	}
 
-	err = rmds.IsValidAndSigned(
-		md.config.Codec(), md.config.Crypto(),
-		currentUID, currentVerifyingKey)
+	err = rmds.IsValidAndSigned(md.config.Codec(), md.config.Crypto())
+	if err != nil {
+		return MDServerErrorBadRequest{Reason: err.Error()}
+	}
+
+	err = rmds.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {
 		return MDServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -328,7 +328,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 		return MDServerError{err}
 	}
 
-	currentVerifyingKey, err := md.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	currentVerifyingKey, err :=
+		md.config.KBPKI().GetCurrentVerifyingKey(ctx)
 	if err != nil {
 		return MDServerError{err}
 	}
@@ -337,6 +338,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned) err
 	if err != nil {
 		return MDServerErrorBadRequest{Reason: err.Error()}
 	}
+
+	// Assume that currentVerifyingKey is valid.
 
 	err = rmds.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -319,8 +319,12 @@ func (s *mdServerTlfStorage) put(
 		return false, errMDServerTlfStorageShutdown
 	}
 
-	err = rmds.IsValidAndSigned(
-		s.codec, s.crypto, currentUID, currentVerifyingKey)
+	err = rmds.IsValidAndSigned(s.codec, s.crypto)
+	if err != nil {
+		return false, MDServerErrorBadRequest{Reason: err.Error()}
+	}
+
+	err = rmds.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -324,8 +324,6 @@ func (s *mdServerTlfStorage) put(
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
 	}
 
-	// Assume that currentVerifyingKey is valid.
-
 	err = rmds.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -324,6 +324,8 @@ func (s *mdServerTlfStorage) put(
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
 	}
 
+	// Assume that currentVerifyingKey is valid.
+
 	err = rmds.IsLastModifiedBy(currentUID, currentVerifyingKey)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4314,16 +4314,6 @@ func (_mr *_MockBareRootMetadataRecorder) MakeBareTlfHandle() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle")
 }
 
-func (_m *MockBareRootMetadata) VerifyWriterMetadata(codec Codec, crypto cryptoPure) error {
-	ret := _m.ctrl.Call(_m, "VerifyWriterMetadata", codec, crypto)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockBareRootMetadataRecorder) VerifyWriterMetadata(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyWriterMetadata", arg0, arg1)
-}
-
 func (_m *MockBareRootMetadata) TlfHandleExtensions() []TlfHandleExtension {
 	ret := _m.ctrl.Call(_m, "TlfHandleExtensions")
 	ret0, _ := ret[0].([]TlfHandleExtension)
@@ -4672,16 +4662,6 @@ func (_m *MockMutableBareRootMetadata) MakeBareTlfHandle() (BareTlfHandle, error
 
 func (_mr *_MockMutableBareRootMetadataRecorder) MakeBareTlfHandle() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle")
-}
-
-func (_m *MockMutableBareRootMetadata) VerifyWriterMetadata(codec Codec, crypto cryptoPure) error {
-	ret := _m.ctrl.Call(_m, "VerifyWriterMetadata", codec, crypto)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) VerifyWriterMetadata(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "VerifyWriterMetadata", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) TlfHandleExtensions() []TlfHandleExtension {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4369,8 +4369,8 @@ func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1)
 }
 
-func (_m *MockBareRootMetadata) IsLastModifiedBy(currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
-	ret := _m.ctrl.Call(_m, "IsLastModifiedBy", currentUID, currentVerifyingKey)
+func (_m *MockBareRootMetadata) IsLastModifiedBy(uid protocol.UID, key VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsLastModifiedBy", uid, key)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -4729,8 +4729,8 @@ func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1)
 }
 
-func (_m *MockMutableBareRootMetadata) IsLastModifiedBy(currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
-	ret := _m.ctrl.Call(_m, "IsLastModifiedBy", currentUID, currentVerifyingKey)
+func (_m *MockMutableBareRootMetadata) IsLastModifiedBy(uid protocol.UID, key VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsLastModifiedBy", uid, key)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4359,14 +4359,24 @@ func (_mr *_MockBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
 }
 
-func (_m *MockBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure, currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
-	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto, currentUID, currentVerifyingKey)
+func (_m *MockBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3)
+func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1)
+}
+
+func (_m *MockBareRootMetadata) IsLastModifiedBy(currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsLastModifiedBy", currentUID, currentVerifyingKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) IsLastModifiedBy(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsLastModifiedBy", arg0, arg1)
 }
 
 func (_m *MockBareRootMetadata) LastModifyingWriter() protocol.UID {
@@ -4709,14 +4719,24 @@ func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
 }
 
-func (_m *MockMutableBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure, currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
-	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto, currentUID, currentVerifyingKey)
+func (_m *MockMutableBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) IsLastModifiedBy(currentUID protocol.UID, currentVerifyingKey VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsLastModifiedBy", currentUID, currentVerifyingKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) IsLastModifiedBy(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsLastModifiedBy", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) LastModifyingWriter() protocol.UID {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -732,7 +732,7 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 		return err
 	}
 
-	md := &rmds.MD
+	md := rmds.MD
 	if rmds.MD.IsFinal() {
 		// Since we're just working with the immediate fields
 		// of RootMetadata, we can get away with a shallow
@@ -742,10 +742,10 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 		// Mask out finalized additions.  These are the only
 		// things allowed to change in the finalized metadata
 		// block.
-		mdCopy.Flags &= ^MetadataFlagFinal
-		mdCopy.Revision--
-		mdCopy.FinalizedInfo = nil
-		md = &mdCopy
+		mdCopy.SetFinalBit()
+		mdCopy.SetRevision(md.RevisionNumber() - 1)
+		mdCopy.SetFinalizedInfo(nil)
+		md = mdCopy
 	}
 	// Re-marshal the whole RootMetadata. This is not avoidable
 	// without support from ugorji/codec.

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -718,7 +718,9 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(config Config) (
 }
 
 // IsValidAndSigned verifies the RootMetadataSigned, checks the root
-// signature, and returns an error if a problem was found.
+// signature, and returns an error if a problem was found.  This
+// should be the first thing checked on an RMDS retrieved from an
+// untrusted source.
 func (rmds *RootMetadataSigned) IsValidAndSigned(
 	codec Codec, crypto cryptoPure) error {
 	// Optimization -- if the RootMetadata signature is nil, it

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -767,8 +767,7 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 
 // IsLastModifiedBy verifies that the RootMetadataSigned is written by
 // the given user and device (identified by the KID of the device
-// verifying key), and returns an error if not. Should be called only
-// after IsValidAndSigned.
+// verifying key), and returns an error if not.
 func (rmds *RootMetadataSigned) IsLastModifiedBy(
 	uid keybase1.UID, key VerifyingKey) error {
 	err := rmds.MD.IsLastModifiedBy(uid, key)

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -770,16 +770,15 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 // verifying key), and returns an error if not. Should be called only
 // after IsValidAndSigned.
 func (rmds *RootMetadataSigned) IsLastModifiedBy(
-	currentUID keybase1.UID, currentVerifyingKey VerifyingKey) error {
-	err := rmds.MD.IsLastModifiedBy(currentUID, currentVerifyingKey)
+	uid keybase1.UID, key VerifyingKey) error {
+	err := rmds.MD.IsLastModifiedBy(uid, key)
 	if err != nil {
 		return err
 	}
 
-	if rmds.SigInfo.VerifyingKey != currentVerifyingKey {
-		return fmt.Errorf(
-			"Last modifier verifying key %v doesn't match current verifying key %v",
-			rmds.SigInfo.VerifyingKey, currentVerifyingKey)
+	if rmds.SigInfo.VerifyingKey != key {
+		return fmt.Errorf("Last modifier verifying key %v != %v",
+			rmds.SigInfo.VerifyingKey, Key)
 	}
 
 	return nil

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -779,7 +779,7 @@ func (rmds *RootMetadataSigned) IsLastModifiedBy(
 
 	if rmds.SigInfo.VerifyingKey != key {
 		return fmt.Errorf("Last modifier verifying key %v != %v",
-			rmds.SigInfo.VerifyingKey, Key)
+			rmds.SigInfo.VerifyingKey, key)
 	}
 
 	return nil

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -720,7 +720,9 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(config Config) (
 // IsValidAndSigned verifies the RootMetadataSigned, checks the root
 // signature, and returns an error if a problem was found.  This
 // should be the first thing checked on an RMDS retrieved from an
-// untrusted source.
+// untrusted source, and then the signing users and keys should be
+// validated, either by comparing to the current device key (using
+// IsLastModifiedBy), or by checking with KBPKI.
 func (rmds *RootMetadataSigned) IsValidAndSigned(
 	codec Codec, crypto cryptoPure) error {
 	// Optimization -- if the RootMetadata signature is nil, it

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -672,13 +672,6 @@ func NewRootMetadataSigned() *RootMetadataSigned {
 	return &RootMetadataSigned{MD: &BareRootMetadataV2{}}
 }
 
-// IsInitialized returns whether or not this RootMetadataSigned object
-// has been finalized by some writer.
-func (rmds *RootMetadataSigned) IsInitialized() bool {
-	// The data is initialized only if there is a signature.
-	return !rmds.SigInfo.IsNil()
-}
-
 // VerifyRootMetadata verifies rmd's MD against rmd's SigInfo,
 // assuming the verifying key there is valid.
 func (rmds *RootMetadataSigned) VerifyRootMetadata(

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -195,7 +195,7 @@ func TestRootMetadataLatestKeyGenerationPublic(t *testing.T) {
 
 // Test that old encoded WriterMetadata objects (i.e., without any
 // extra fields) can be deserialized and serialized to the same form,
-// which is important for RootMetadata.VerifyWriterMetadata().
+// which is important for RootMetadata.IsValidAndSigned().
 func TestWriterMetadataUnchangedEncoding(t *testing.T) {
 	encodedWm := []byte{
 		0x89, 0xa3, 0x42, 0x49, 0x44, 0xc4, 0x10, 0x0,

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -645,12 +645,12 @@ func TestRootMetadataFinalVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	FakeInitialRekey(&rmds.MD, h)
-	rmds.MD.LastModifyingWriter = h.Writers[0]
-	rmds.MD.LastModifyingUser = h.Writers[0]
-	rmds.MD.SerializedPrivateMetadata = []byte{42}
+	rmds.MD.FakeInitialRekey(h)
+	rmds.MD.SetLastModifyingWriter(h.Writers[0])
+	rmds.MD.SetLastModifyingUser(h.Writers[0])
+	rmds.MD.SetSerializedPrivateMetadata([]byte{42})
 
-	buf, err := config.Codec().Encode(rmds.MD.WriterMetadata)
+	buf, err := rmds.MD.GetSerializedWriterMetadata(config.Codec())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -648,6 +648,7 @@ func TestRootMetadataFinalVerify(t *testing.T) {
 	FakeInitialRekey(&rmds.MD, h)
 	rmds.MD.LastModifyingWriter = h.Writers[0]
 	rmds.MD.LastModifyingUser = h.Writers[0]
+	rmds.MD.SerializedPrivateMetadata = []byte{42}
 
 	buf, err := config.Codec().Encode(rmds.MD.WriterMetadata)
 	if err != nil {
@@ -669,7 +670,7 @@ func TestRootMetadataFinalVerify(t *testing.T) {
 	rmds.SigInfo = sigInfo
 
 	// verify it
-	err = rmds.VerifyRootMetadata(config.Codec(), config.Crypto())
+	err = rmds.IsValidAndSigned(config.Codec(), config.Crypto())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
In particular, the verification done in MDOps.

Split off IsLastModifiedBy from IsValidAndSigned.

Fix checks to account for final revisions.