### PR TITLE
libkbfs: fix CR and QR block change unembedding

### DIFF
--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -123,5 +123,5 @@ func (b *BlockSplitterSimple) CheckSplit(block *FileBlock) int64 {
 // BlockSplitterSimple.
 func (b *BlockSplitterSimple) ShouldEmbedBlockChanges(
 	bc *BlockChanges) bool {
-	return bc.sizeEstimate <= b.blockChangeEmbedMaxSize
+	return bc.SizeEstimate() <= b.blockChangeEmbedMaxSize
 }

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2619,8 +2619,12 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	unrefs := make(map[BlockPointer]bool)
 	for _, op := range md.data.Changes.Ops {
 		for _, ptr := range op.Refs() {
-			// Don't add usage if it's an unembedded block change pointer.
-			if _, ok := unmergedChains.blockChangePointers[ptr]; !ok {
+			// Don't add usage if it's an unembedded block change
+			// pointer.  Also, we shouldn't be referencing this
+			// anymore!
+			if _, ok := unmergedChains.blockChangePointers[ptr]; ok {
+				op.DelRefBlock(ptr)
+			} else {
 				refs[ptr] = true
 			}
 		}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -572,7 +572,9 @@ type BlockChanges struct {
 // BlockChanges.  Currently does not check for equality at the
 // operation level.
 func (bc BlockChanges) Equals(other BlockChanges) bool {
-	if bc.Info != other.Info || len(bc.Ops) != len(other.Ops) {
+	if bc.Info != other.Info || len(bc.Ops) != len(other.Ops) ||
+		(bc.sizeEstimate != 0 && other.sizeEstimate != 0 &&
+			bc.sizeEstimate != other.sizeEstimate) {
 		return false
 	}
 	// TODO: check for op equality?

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -572,48 +572,60 @@ type BlockChanges struct {
 // BlockChanges.  Currently does not check for equality at the
 // operation level.
 func (bc BlockChanges) Equals(other BlockChanges) bool {
-	if bc.Info != other.Info || len(bc.Ops) != len(other.Ops) ||
-		bc.sizeEstimate != other.sizeEstimate {
+	if bc.Info != other.Info || len(bc.Ops) != len(other.Ops) {
 		return false
 	}
 	// TODO: check for op equality?
 	return true
 }
 
-func (bc *BlockChanges) addBPSize() {
-	// We want an estimate of the codec-encoded size, but the
-	// in-memory size is good enough.
-	bc.sizeEstimate += bpSize
-}
-
 // AddRefBlock adds the newly-referenced block to this BlockChanges
 // and updates the size estimate.
 func (bc *BlockChanges) AddRefBlock(ptr BlockPointer) {
+	if bc.sizeEstimate != 0 {
+		panic("Can't alter block changes after the size is estimated")
+	}
 	bc.Ops[len(bc.Ops)-1].AddRefBlock(ptr)
-	bc.addBPSize()
 }
 
 // AddUnrefBlock adds the newly unreferenced block to this BlockChanges
 // and updates the size estimate.
 func (bc *BlockChanges) AddUnrefBlock(ptr BlockPointer) {
+	if bc.sizeEstimate != 0 {
+		panic("Can't alter block changes after the size is estimated")
+	}
 	bc.Ops[len(bc.Ops)-1].AddUnrefBlock(ptr)
-	bc.addBPSize()
 }
 
 // AddUpdate adds the newly updated block to this BlockChanges
 // and updates the size estimate.
 func (bc *BlockChanges) AddUpdate(oldPtr BlockPointer, newPtr BlockPointer) {
+	if bc.sizeEstimate != 0 {
+		panic("Can't alter block changes after the size is estimated")
+	}
 	bc.Ops[len(bc.Ops)-1].AddUpdate(oldPtr, newPtr)
-	// add sizes for both block pointers
-	bc.addBPSize()
-	bc.addBPSize()
 }
 
 // AddOp starts a new operation for this BlockChanges.  Subsequent
 // Add* calls will populate this operation.
 func (bc *BlockChanges) AddOp(o op) {
+	if bc.sizeEstimate != 0 {
+		panic("Can't alter block changes after the size is estimated")
+	}
 	bc.Ops = append(bc.Ops, o)
-	bc.sizeEstimate += o.SizeExceptUpdates()
+}
+
+// SizeEstimate calculates the estimated size of the encoded version
+// of this BlockChanges.
+func (bc *BlockChanges) SizeEstimate() uint64 {
+	if bc.sizeEstimate == 0 {
+		for _, op := range bc.Ops {
+			numPtrs := len(op.Refs()) + len(op.Unrefs()) +
+				2*len(op.AllUpdates())
+			bc.sizeEstimate += uint64(numPtrs)*bpSize + op.SizeExceptUpdates()
+		}
+	}
+	return bc.sizeEstimate
 }
 
 // EntryType is the type of a directory entry.

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -151,6 +151,10 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	clock.Set(now)
 	config.SetClock(&clock)
 
+	// Allow for big embedded block changes, so they don't confuse our
+	// block-checking logic.
+	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 16 << 20
+
 	rootNode := GetRootNodeOrBust(t, config, userName.String(), false)
 	// Do a bunch of operations.
 	kbfsOps := config.KBFSOps()

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1723,13 +1723,16 @@ func (fbo *folderBranchOps) syncBlockAndCheckEmbedLocked(ctx context.Context,
 		return path{}, DirEntry{}, nil, err
 	}
 
-	// do the block changes need their own blocks?
-	bsplit := fbo.config.BlockSplitter()
-	if !bsplit.ShouldEmbedBlockChanges(&md.data.Changes) {
-		err = fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes,
-			uid)
-		if err != nil {
-			return path{}, DirEntry{}, nil, err
+	// Do the block changes need their own blocks?  Unembed only if
+	// this is the final call to this function with this MD.
+	if stopAt == zeroPtr {
+		bsplit := fbo.config.BlockSplitter()
+		if !bsplit.ShouldEmbedBlockChanges(&md.data.Changes) {
+			err = fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes,
+				uid)
+			if err != nil {
+				return path{}, DirEntry{}, nil, err
+			}
 		}
 	}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -541,6 +541,13 @@ func (fbo *folderBranchOps) setHeadLocked(
 		fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision(), false)
 	}
 
+	// Make sure that any unembedded block changes have been swapped
+	// back in.
+	if md.data.Changes.Info.BlockPointer != zeroPtr &&
+		len(md.data.Changes.Ops) == 0 {
+		return errors.New("Must swap in block changes before setting head")
+	}
+
 	fbo.head = md
 	fbo.status.setRootMetadata(md)
 	if isFirstHead {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -947,6 +947,41 @@ func (fbo *folderBranchOps) putBlockCheckQuota(
 	return err
 }
 
+func (fbo *folderBranchOps) maybeUnembedAndPutOneBlock(ctx context.Context,
+	md *RootMetadata) error {
+	if fbo.config.BlockSplitter().ShouldEmbedBlockChanges(&md.data.Changes) {
+		return nil
+	}
+
+	_, uid, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return err
+	}
+
+	bps := newBlockPutState(1)
+	err = fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes, uid)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			fbo.fbm.cleanUpBlockState(md.ReadOnly(), bps, blockDeleteOnMDFail)
+		}
+	}()
+
+	ptrsToDelete, err := fbo.doBlockPuts(
+		ctx, md.TlfID(), md.GetTlfHandle().GetCanonicalName(), *bps)
+	if err != nil {
+		return err
+	}
+	if len(ptrsToDelete) > 0 {
+		return fmt.Errorf("Unexpected pointers to delete after "+
+			"unembedding block changes in gc op: %v", ptrsToDelete)
+	}
+	return nil
+}
+
 func (fbo *folderBranchOps) initMDLocked(
 	ctx context.Context, lState *lockState, md *RootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -989,8 +1024,7 @@ func (fbo *folderBranchOps) initMDLocked(
 		return InvalidKeyGenerationError{md.TlfID(), keyGen}
 	}
 	info, plainSize, readyBlockData, err :=
-		fbo.blocks.ReadyBlock(
-			ctx, md.ReadOnly(), newDblock, uid)
+		fbo.blocks.ReadyBlock(ctx, md.ReadOnly(), newDblock, uid)
 	if err != nil {
 		return err
 	}
@@ -1017,6 +1051,10 @@ func (fbo *folderBranchOps) initMDLocked(
 	}
 	if err = fbo.config.BlockCache().Put(
 		info.BlockPointer, fbo.id(), newDblock, TransientEntry); err != nil {
+		return err
+	}
+
+	if err := fbo.maybeUnembedAndPutOneBlock(ctx, md); err != nil {
 		return err
 	}
 
@@ -2059,37 +2097,9 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *gcOp) (
 
 	md.AddOp(gco)
 
-	if !fbo.config.BlockSplitter().ShouldEmbedBlockChanges(&md.data.Changes) {
-		var uid keybase1.UID
-		_, uid, err = fbo.config.KBPKI().GetCurrentUserInfo(ctx)
-		if err != nil {
-			return err
-		}
-
-		bps := newBlockPutState(1)
-		err = fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes, uid)
-		if err != nil {
-			return err
-		}
-
-		defer func() {
-			if err != nil {
-				fbo.fbm.cleanUpBlockState(
-					md.ReadOnly(), bps, blockDeleteOnMDFail)
-			}
-		}()
-
-		ptrsToDelete, err := fbo.doBlockPuts(
-			ctx, md.TlfID(), md.GetTlfHandle().GetCanonicalName(), *bps)
-		if err != nil {
-			return err
-		}
-		if len(ptrsToDelete) > 0 {
-			return fmt.Errorf("Unexpected pointers to delete after "+
-				"unembedding block changes in gc op: %v", ptrsToDelete)
-		}
+	if err := fbo.maybeUnembedAndPutOneBlock(ctx, md); err != nil {
+		return err
 	}
-
 	oldPrevRoot := md.PrevRoot()
 
 	// finally, write out the new metadata

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2032,6 +2032,8 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 		fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
 	}
 
+	md.swapCachedBlockChanges()
+
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
 	return fbo.setHeadSuccessorLocked(ctx, lState,
@@ -4411,6 +4413,8 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	if md.IsRekeySet() {
 		defer fbo.config.RekeyQueue().Enqueue(md.TlfID())
 	}
+
+	md.swapCachedBlockChanges()
 
 	// Set the head to the new MD.
 	fbo.headLock.Lock(lState)

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -351,7 +351,8 @@ func (j journalMDOps) Put(ctx context.Context, rmd *RootMetadata) (
 		bundle.lock.Lock()
 		defer bundle.lock.Unlock()
 		return bundle.mdJournal.put(ctx, j.jServer.config.Crypto(),
-			j.jServer.config.KeyManager(), rmd, uid, key)
+			j.jServer.config.KeyManager(), j.jServer.config.BlockSplitter(),
+			rmd, uid, key)
 	}
 
 	return j.MDOps.Put(ctx, rmd)
@@ -396,7 +397,8 @@ func (j journalMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (
 		bundle.lock.Lock()
 		defer bundle.lock.Unlock()
 		return bundle.mdJournal.put(ctx, j.jServer.config.Crypto(),
-			j.jServer.config.KeyManager(), rmd, uid, key)
+			j.jServer.config.KeyManager(), j.jServer.config.BlockSplitter(),
+			rmd, uid, key)
 	}
 
 	return j.MDOps.PutUnmerged(ctx, rmd)

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -189,7 +189,8 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
 		&rmd.data, TLFCryptKey{}).Return(EncryptedPrivateMetadata{}, nil)
 	config.mockCrypto.EXPECT().Sign(gomock.Any(), gomock.Any()).Times(2).Return(SignatureInfo{}, nil)
-
+	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
+		Return(true)
 	config.mockMdserv.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
 }
 
@@ -662,6 +663,8 @@ func TestMDOpsPutFailEncode(t *testing.T) {
 	expectGetTLFCryptKeyForEncryption(config, rmd)
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
 		&rmd.data, TLFCryptKey{}).Return(EncryptedPrivateMetadata{}, nil)
+	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
+		Return(true)
 
 	err := errors.New("Fake fail")
 	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(nil, err)

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -17,6 +17,7 @@ import (
 // op represents a single file-system remote-sync operation
 type op interface {
 	AddRefBlock(ptr BlockPointer)
+	DelRefBlock(ptr BlockPointer)
 	AddUnrefBlock(ptr BlockPointer)
 	AddUpdate(oldPtr BlockPointer, newPtr BlockPointer)
 	SizeExceptUpdates() uint64
@@ -140,6 +141,17 @@ type OpCommon struct {
 // for this op.
 func (oc *OpCommon) AddRefBlock(ptr BlockPointer) {
 	oc.RefBlocks = append(oc.RefBlocks, ptr)
+}
+
+// DelRefBlock removes the first reference of the given block from the
+// list of newly-referenced blocks for this op.
+func (oc *OpCommon) DelRefBlock(ptr BlockPointer) {
+	for i, ref := range oc.RefBlocks {
+		if ptr == ref {
+			oc.RefBlocks = append(oc.RefBlocks[:i], oc.RefBlocks[i+1:]...)
+			break
+		}
+	}
 }
 
 // AddUnrefBlock adds this block to the list of newly-unreferenced blocks


### PR DESCRIPTION
CR and QR didn't properly unembed big block changes, because they add pointers directly to ops, rather than going via the MD accessors, resulting in an incorrect block change size estimate.

Instead, let's calculate the block change size by iterating over all the ops after the MD is complete.

Also, fixing this exposes a few other issues: 1) CR was leaving unmerged block changes pointers as ref pointers in the original ops, and 2) CR and Rekey weren't properly swapping block changes back into the expected place in the MD object after putting it to the mdserver.

Issue: KBFS-1338