### PR TITLE
libkbfs: Fix non-creation of empty TLFs

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -433,19 +433,23 @@ func (fbo *folderBranchOps) AddFavorite(ctx context.Context,
 
 func (fbo *folderBranchOps) addToFavorites(ctx context.Context,
 	favorites *Favorites, created bool) (err error) {
-	if _, _, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx); err != nil {
-		// Can't favorite while not logged in
-		return nil
-	}
-
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
 	if head == (ImmutableRootMetadata{}) {
 		return OpsCantHandleFavorite{"Can't add a favorite without a handle"}
 	}
 
-	h := head.GetTlfHandle()
-	favorites.AddAsync(ctx, h.toFavToAdd(created))
+	return fbo.addToFavoritesByHandle(ctx, favorites, head.GetTlfHandle(), created)
+}
+
+func (fbo *folderBranchOps) addToFavoritesByHandle(ctx context.Context,
+	favorites *Favorites, handle *TlfHandle, created bool) (err error) {
+	if _, _, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx); err != nil {
+		// Can't favorite while not logged in
+		return nil
+	}
+
+	favorites.AddAsync(ctx, handle.toFavToAdd(created))
 	return nil
 }
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -252,7 +252,6 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(
 	ctx context.Context, mdops MDOps, h *TlfHandle, create bool) (initialized bool,
 	md ImmutableRootMetadata, id TlfID, err error) {
 	id, md, err = mdops.GetForHandle(ctx, h, Merged)
-	fs.log.CDebugf(ctx, "mdops.GetForHandle: %v, %v, %v", id, md, err)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, id, err
 	}


### PR DESCRIPTION
This fixes non-creation of TLFs in certain cituations. KBFS-1157 was broken by rebases.