### PR TITLE
lib{dokan,fuse}: Small cleanup

### DIFF
--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -245,41 +245,35 @@ func openSpecialFile(name string, folder *Folder) dokan.File {
 		return NewTlfEditHistoryFile(folder.fs, folderBranch)
 
 	case libfs.UnstageFileName:
-		child := &UnstageFile{
+		return &UnstageFile{
 			folder: folder,
 		}
-		return child
 
 	case libfs.DisableUpdatesFileName:
-		child := &UpdatesFile{
+		return &UpdatesFile{
 			folder: folder,
 		}
-		return child
 
 	case libfs.EnableUpdatesFileName:
-		child := &UpdatesFile{
+		return &UpdatesFile{
 			folder: folder,
 			enable: true,
 		}
-		return child
 
 	case libfs.RekeyFileName:
-		child := &RekeyFile{
+		return &RekeyFile{
 			folder: folder,
 		}
-		return child
 
 	case libfs.ReclaimQuotaFileName:
-		child := &ReclaimQuotaFile{
+		return &ReclaimQuotaFile{
 			folder: folder,
 		}
-		return child
 
 	case libfs.SyncFromServerFileName:
-		child := &SyncFromServerFile{
+		return &SyncFromServerFile{
 			folder: folder,
 		}
-		return child
 	}
 
 	return nil

--- a/libdokan/file.go
+++ b/libdokan/file.go
@@ -72,8 +72,7 @@ func (f *File) FlushFileBuffers(ctx context.Context, fi *dokan.FileInfo) (err er
 	f.folder.fs.logEnter(ctx, "File FlushFileBuffers")
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
-	err = f.folder.fs.config.KBFSOps().Sync(ctx, f.node)
-	return err
+	return f.folder.fs.config.KBFSOps().Sync(ctx, f.node)
 }
 
 // ReadFile for dokan reads.
@@ -101,8 +100,7 @@ func (f *File) WriteFile(ctx context.Context, fi *dokan.FileInfo, bs []byte, off
 		offset = int64(ei.Size)
 	}
 
-	err = f.folder.fs.config.KBFSOps().Write(
-		ctx, f.node, bs, offset)
+	err = f.folder.fs.config.KBFSOps().Write(ctx, f.node, bs, offset)
 	return len(bs), err
 }
 
@@ -125,10 +123,9 @@ func (f *File) SetAllocationSize(ctx context.Context, fi *dokan.FileInfo, newSiz
 	if err != nil {
 		return err
 	}
-	current := int64(ei.Size)
 
 	// Refuse to grow the file.
-	if current <= newSize {
+	if int64(ei.Size) <= newSize {
 		return nil
 	}
 

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -30,7 +30,7 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 func (f *File) attr(ctx context.Context, a *fuse.Attr) (err error) {
 	de, err := f.folder.fs.config.KBFSOps().Stat(ctx, f.node)
 	if err != nil {
-		if _, ok := err.(libkbfs.NoSuchNameError); ok {
+		if isNoSuchNameError(err) {
 			return fuse.ESTALE
 		}
 		return err


### PR DESCRIPTION
+ Cleanup code in libdokan and libfuse
+ Ensure special files set `resp.EntryValid = 0` in `libfuse/dir.go`
+ Add `isNoSuchNameError` helper to libfuse to avoid some type assertions