### PR TITLE
Fix accidentally-shadowed variable

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -544,8 +544,8 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	}
 	failures, ch := fs.currentStatus.CurrentStatus()
 	var jServerStatus *JournalServerStatus
-	jServer, err := GetJournalServer(fs.config)
-	if err == nil {
+	jServer, jErr := GetJournalServer(fs.config)
+	if jErr == nil {
 		status := jServer.Status()
 		jServerStatus = &status
 	}


### PR DESCRIPTION
This was erroneously causing KBFSOps.Status calls
to fail when the journal is disabled (the default).