### PR TITLE
kbfs_ops: don't "create" a favorite except on TLF initialization

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -334,7 +334,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 			}
 			fb := FolderBranch{Tlf: id, Branch: MasterBranch}
 			fops := fs.getOpsByHandle(ctx, h, fb)
-			if err := fops.addToFavoritesByHandle(ctx, fs.favs, h, true); err != nil {
+			if err := fops.addToFavoritesByHandle(ctx, fs.favs, h, false); err != nil {
 				// Failure to favorite shouldn't cause a failure.  Just log
 				// and move on.
 				fs.log.CDebugf(ctx, "Couldn't add favorite: %v", err)


### PR DESCRIPTION
Otherwise the service could allocate multiple invites for an SBS user.
This came about when we started allowing empty TLFs for read
operations when the TLF hadn't yet been created.

Issue: keybase/client#4082