### PR TITLE
[KBFS-1439] Sync blockJournal's in-memory map properly

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -861,6 +861,9 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 		return 0, err
 	}
 
+	// Remove any of the entry's refs that hasn't been modified by
+	// a subsequent block op (i.e., that has earliestOrdinal as a
+	// tag).
 	for id, idContexts := range entry.Contexts {
 		refs := j.refs[id]
 		if len(refs) == 0 {

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -5,7 +5,6 @@
 package libkbfs
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -60,9 +59,8 @@ type blockJournal struct {
 	log      logger.Logger
 	deferLog logger.Logger
 
-	j          diskJournal
-	refs       map[BlockID]blockRefMap
-	isShutdown bool
+	j    diskJournal
+	refs map[BlockID]blockRefMap
 
 	// Tracks the total size of on-disk blocks that will be flushed to
 	// the server (i.e., does not count reference adds).  It is only
@@ -73,24 +71,41 @@ type blockJournal struct {
 	unflushedBytes int64
 }
 
-type bserverOpName string
+type blockOpType int
 
 const (
-	blockPutOp    bserverOpName = "blockPut"
-	addRefOp      bserverOpName = "addReference"
-	removeRefsOp  bserverOpName = "removeReferences"
-	archiveRefsOp bserverOpName = "archiveReferences"
+	blockPutOp    blockOpType = 1
+	addRefOp      blockOpType = 2
+	removeRefsOp  blockOpType = 3
+	archiveRefsOp blockOpType = 4
 )
+
+func (t blockOpType) String() string {
+	switch t {
+	case blockPutOp:
+		return "blockPut"
+	case addRefOp:
+		return "addReference"
+	case removeRefsOp:
+		return "removeReferences"
+	case archiveRefsOp:
+		return "archiveReferences"
+	default:
+		return fmt.Sprintf("blockOpType(%d)", t)
+	}
+}
 
 // A blockJournalEntry is just the name of the operation and the
 // associated block ID and contexts. Fields are exported only for
 // serialization.
 type blockJournalEntry struct {
 	// Must be one of the four ops above.
-	Op bserverOpName
+	Op blockOpType
 	// Must have exactly one entry with one context for blockPutOp
 	// and addRefOp.
 	Contexts map[BlockID][]BlockContext
+
+	// TODO: Support unknown fields.
 }
 
 // Get the single context stored in this entry. Only applicable to
@@ -218,7 +233,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 				refs[id] = blockRefs
 			}
 
-			err = blockRefs.put(context, liveBlockRef)
+			err = blockRefs.put(context, liveBlockRef, i)
 			if err != nil {
 				return nil, 0, err
 			}
@@ -253,7 +268,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 				}
 
 				for _, context := range idContexts {
-					err := blockRefs.remove(context)
+					err := blockRefs.remove(context, nil)
 					if err != nil {
 						return nil, 0, err
 					}
@@ -271,7 +286,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 
 				for _, context := range idContexts {
 					err := blockRefs.put(
-						context, archivedBlockRef)
+						context, archivedBlockRef, i)
 					if err != nil {
 						return nil, 0, err
 					}
@@ -292,7 +307,8 @@ func (j *blockJournal) writeJournalEntry(
 }
 
 func (j *blockJournal) appendJournalEntry(
-	op bserverOpName, contexts map[BlockID][]BlockContext) error {
+	op blockOpType, contexts map[BlockID][]BlockContext) (
+	journalOrdinal, error) {
 	return j.j.appendJournalEntry(nil, blockJournalEntry{
 		Op:       op,
 		Contexts: contexts,
@@ -317,24 +333,24 @@ func (j *blockJournal) getRefEntry(
 	id BlockID, refNonce BlockRefNonce) (blockRefEntry, error) {
 	refs := j.refs[id]
 	if refs == nil {
-		return blockRefEntry{}, BServerErrorBlockNonExistent{}
+		return blockRefEntry{}, blockNonExistentError{id}
 	}
 
 	e, ok := refs[refNonce]
 	if !ok {
-		return blockRefEntry{}, BServerErrorBlockNonExistent{}
+		return blockRefEntry{}, blockNonExistentError{id}
 	}
 
 	return e, nil
 }
 
 func (j *blockJournal) putRefEntry(
-	id BlockID, refEntry blockRefEntry) error {
+	id BlockID, refEntry blockRefEntry, ordinal journalOrdinal) error {
 	existingRefEntry, err := j.getRefEntry(
-		id, refEntry.Context.GetRefNonce())
+		id, refEntry.context.GetRefNonce())
 	var exists bool
 	switch err.(type) {
-	case BServerErrorBlockNonExistent:
+	case blockNonExistentError:
 		exists = false
 	case nil:
 		exists = true
@@ -343,7 +359,7 @@ func (j *blockJournal) putRefEntry(
 	}
 
 	if exists {
-		err = existingRefEntry.checkContext(refEntry.Context)
+		err = existingRefEntry.checkContext(refEntry.context)
 		if err != nil {
 			return err
 		}
@@ -353,7 +369,7 @@ func (j *blockJournal) putRefEntry(
 		j.refs[id] = make(blockRefMap)
 	}
 
-	return j.refs[id].put(refEntry.Context, refEntry.Status)
+	return j.refs[id].put(refEntry.context, refEntry.status, ordinal)
 }
 
 func (j *blockJournal) getDataSize(id BlockID) (int64, error) {
@@ -368,8 +384,7 @@ func (j *blockJournal) getData(id BlockID) (
 	[]byte, BlockCryptKeyServerHalf, error) {
 	data, err := ioutil.ReadFile(j.blockDataPath(id))
 	if os.IsNotExist(err) {
-		return nil, BlockCryptKeyServerHalf{},
-			BServerErrorBlockNonExistent{}
+		return nil, BlockCryptKeyServerHalf{}, blockNonExistentError{id}
 	} else if err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
@@ -377,8 +392,7 @@ func (j *blockJournal) getData(id BlockID) (
 	keyServerHalfPath := j.keyServerHalfPath(id)
 	buf, err := ioutil.ReadFile(keyServerHalfPath)
 	if os.IsNotExist(err) {
-		return nil, BlockCryptKeyServerHalf{},
-			BServerErrorBlockNonExistent{}
+		return nil, BlockCryptKeyServerHalf{}, blockNonExistentError{id}
 	} else if err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
@@ -406,16 +420,23 @@ func (j *blockJournal) getData(id BlockID) (
 
 // All functions below are public functions.
 
-var errBlockJournalShutdown = errors.New("blockJournal is shutdown")
+func (j *blockJournal) hasRef(id BlockID) bool {
+	return j.refs[id] != nil
+}
+
+func (j *blockJournal) hasNonArchivedRef(id BlockID) bool {
+	refs := j.refs[id]
+	return (refs != nil) && refs.hasNonArchivedRef()
+}
+
+func (j *blockJournal) hasContext(id BlockID, context BlockContext) bool {
+	refs := j.refs[id]
+	return (refs != nil) && (refs.checkExists(context) == nil)
+}
 
 func (j *blockJournal) getDataWithContext(
 	id BlockID, context BlockContext) (
 	[]byte, BlockCryptKeyServerHalf, error) {
-	if j.isShutdown {
-		return nil, BlockCryptKeyServerHalf{},
-			errBlockJournalShutdown
-	}
-
 	refEntry, err := j.getRefEntry(id, context.GetRefNonce())
 	if err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
@@ -431,23 +452,10 @@ func (j *blockJournal) getDataWithContext(
 
 func (j *blockJournal) getAll() (
 	map[BlockID]map[BlockRefNonce]blockRefLocalStatus, error) {
-	if j.isShutdown {
-		return nil, errBlockJournalShutdown
-	}
-
 	res := make(map[BlockID]map[BlockRefNonce]blockRefLocalStatus)
-
 	for id, refs := range j.refs {
-		if len(refs) == 0 {
-			continue
-		}
-
-		res[id] = make(map[BlockRefNonce]blockRefLocalStatus)
-		for ref, refEntry := range refs {
-			res[id][ref] = refEntry.Status
-		}
+		res[id] = refs.getStatuses()
 	}
-
 	return res, nil
 }
 
@@ -469,15 +477,11 @@ func (j *blockJournal) putData(
 		return err
 	}
 
-	if j.isShutdown {
-		return errBlockJournalShutdown
-	}
-
 	// Check the data and retrieve the server half, if they exist.
 	_, existingServerHalf, err := j.getDataWithContext(id, context)
 	var exists bool
 	switch err.(type) {
-	case BServerErrorBlockNonExistent:
+	case blockNonExistentError:
 		exists = false
 	case nil:
 		exists = true
@@ -519,16 +523,16 @@ func (j *blockJournal) putData(
 		return err
 	}
 
-	err = j.putRefEntry(id, blockRefEntry{
-		Status:  liveBlockRef,
-		Context: context,
-	})
+	ordinal, err := j.appendJournalEntry(blockPutOp,
+		map[BlockID][]BlockContext{id: {context}})
 	if err != nil {
 		return err
 	}
 
-	return j.appendJournalEntry(
-		blockPutOp, map[BlockID][]BlockContext{id: {context}})
+	return j.putRefEntry(id, blockRefEntry{
+		status:  liveBlockRef,
+		context: context,
+	}, ordinal)
 }
 
 func (j *blockJournal) addReference(
@@ -544,45 +548,16 @@ func (j *blockJournal) addReference(
 		}
 	}()
 
-	if j.isShutdown {
-		return errBlockJournalShutdown
-	}
-
-	refs := j.refs[id]
-	if refs == nil {
-		return BServerErrorBlockNonExistent{fmt.Sprintf("Block ID %s "+
-			"doesn't exist and cannot be referenced.", id)}
-	}
-
-	// Only add it if there's a non-archived reference.
-	hasNonArchivedRef := false
-	for _, refEntry := range refs {
-		if refEntry.Status == liveBlockRef {
-			hasNonArchivedRef = true
-			break
-		}
-	}
-
-	if !hasNonArchivedRef {
-		return BServerErrorBlockArchived{fmt.Sprintf("Block ID %s has "+
-			"been archived and cannot be referenced.", id)}
-	}
-
-	// TODO: Figure out if we should allow adding a reference even
-	// if all the existing references are archived, or if we have
-	// no references at all. Also figure out what to do with an
-	// addReference without a preceding Put.
-
-	err = j.putRefEntry(id, blockRefEntry{
-		Status:  liveBlockRef,
-		Context: context,
-	})
+	ordinal, err := j.appendJournalEntry(addRefOp,
+		map[BlockID][]BlockContext{id: {context}})
 	if err != nil {
 		return err
 	}
 
-	return j.appendJournalEntry(
-		addRefOp, map[BlockID][]BlockContext{id: {context}})
+	return j.putRefEntry(id, blockRefEntry{
+		status:  liveBlockRef,
+		context: context,
+	}, ordinal)
 }
 
 // removeReferences fixes up the in-memory reference map to delete the
@@ -591,21 +566,15 @@ func (j *blockJournal) addReference(
 // that case, j.unflushedBytes will no longer be accurate and
 // shouldn't be relied upon.
 func (j *blockJournal) removeReferences(
-	ctx context.Context, contexts map[BlockID][]BlockContext,
-	removeUnreferencedBlocks bool) (liveCounts map[BlockID]int, err error) {
-	j.log.CDebugf(ctx, "Removing references for %v (remove unreferenced blocks=%t)",
-		contexts, removeUnreferencedBlocks)
+	ctx context.Context, contexts map[BlockID][]BlockContext) (
+	liveCounts map[BlockID]int, err error) {
+	j.log.CDebugf(ctx, "Removing references for %v", contexts)
 	defer func() {
 		if err != nil {
 			j.deferLog.CDebugf(ctx,
-				"Removing references for %v (remove unreferenced blocks=%t)",
-				contexts, removeUnreferencedBlocks, err)
+				"Removing references for %v", contexts, err)
 		}
 	}()
-
-	if j.isShutdown {
-		return nil, errBlockJournalShutdown
-	}
 
 	liveCounts = make(map[BlockID]int)
 
@@ -617,7 +586,7 @@ func (j *blockJournal) removeReferences(
 		}
 
 		for _, context := range idContexts {
-			err := refs.remove(context)
+			err := refs.remove(context, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -626,22 +595,24 @@ func (j *blockJournal) removeReferences(
 		count := len(refs)
 		if count == 0 {
 			delete(j.refs, id)
-			if removeUnreferencedBlocks {
-				err := os.RemoveAll(j.blockPath(id))
-				if err != nil {
-					return nil, err
-				}
-			}
 		}
 		liveCounts[id] = count
 	}
 
-	err = j.appendJournalEntry(removeRefsOp, contexts)
+	_, err = j.appendJournalEntry(removeRefsOp, contexts)
 	if err != nil {
 		return nil, err
 	}
 
 	return liveCounts, nil
+}
+
+func (j *blockJournal) removeBlockData(id BlockID) error {
+	if j.hasRef(id) {
+		return fmt.Errorf(
+			"Trying to remove data for referenced block %s", id)
+	}
+	return os.RemoveAll(j.blockPath(id))
 }
 
 func (j *blockJournal) archiveReferences(
@@ -654,8 +625,9 @@ func (j *blockJournal) archiveReferences(
 		}
 	}()
 
-	if j.isShutdown {
-		return errBlockJournalShutdown
+	ordinal, err := j.appendJournalEntry(archiveRefsOp, contexts)
+	if err != nil {
+		return err
 	}
 
 	for id, idContexts := range contexts {
@@ -663,34 +635,31 @@ func (j *blockJournal) archiveReferences(
 			refNonce := context.GetRefNonce()
 			refEntry, err := j.getRefEntry(id, refNonce)
 			switch err.(type) {
-			case BServerErrorBlockNonExistent:
-				return BServerErrorBlockNonExistent{
-					fmt.Sprintf(
-						"Block ID %s (ref %s) doesn't "+
-							"exist and cannot be archived.",
-						id, refNonce),
+			case blockNonExistentError:
+				refEntry = blockRefEntry{
+					status:  archivedBlockRef,
+					context: context,
 				}
+
 			case nil:
-				break
+				err = refEntry.checkContext(context)
+				if err != nil {
+					return err
+				}
+				refEntry.status = archivedBlockRef
 
 			default:
 				return err
 			}
 
-			err = refEntry.checkContext(context)
-			if err != nil {
-				return err
-			}
-
-			refEntry.Status = archivedBlockRef
-			err = j.putRefEntry(id, refEntry)
+			err = j.putRefEntry(id, refEntry, ordinal)
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	return j.appendJournalEntry(archiveRefsOp, contexts)
+	return nil
 }
 
 // blockEntriesToFlush is an internal data structure for blockJournal;
@@ -717,10 +686,6 @@ func (be blockEntriesToFlush) flushNeeded() bool {
 func (j *blockJournal) getNextEntriesToFlush(
 	ctx context.Context, end journalOrdinal) (
 	entries blockEntriesToFlush, err error) {
-	if j.isShutdown {
-		return blockEntriesToFlush{}, errBlockJournalShutdown
-	}
-
 	first, err := j.j.readEarliestOrdinal()
 	if os.IsNotExist(err) {
 		return blockEntriesToFlush{}, nil
@@ -862,14 +827,6 @@ func flushBlockEntries(ctx context.Context, log logger.Logger,
 func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 	ordinal journalOrdinal, entry blockJournalEntry) (
 	flushedBytes int64, err error) {
-	if j.isShutdown {
-		// TODO: This creates a race condition if we shut down
-		// after we've flushed an op but before we remove
-		// it. Make sure we handle re-flushed ops
-		// idempotently.
-		return 0, errBlockJournalShutdown
-	}
-
 	// Fix up the block byte count if we've finished a Put.
 	if entry.Op == blockPutOp {
 		id, _, err := entry.getSingleContext()
@@ -904,24 +861,28 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 		return 0, err
 	}
 
-	// TODO: This is a hack to work around KBFS-1439. Figure out a
-	// better way to update j.refs to reflect the removed entry.
-	refs, unflushedBytes, err := j.readJournal(ctx)
-	if err != nil {
-		return 0, err
+	for id, idContexts := range entry.Contexts {
+		refs := j.refs[id]
+		if len(refs) == 0 {
+			continue
+		}
+		for _, context := range idContexts {
+			err := refs.remove(context, earliestOrdinal)
+			if err != nil {
+				return 0, err
+			}
+			if len(refs) == 0 {
+				delete(j.refs, id)
+				break
+			}
+		}
 	}
-	j.refs = refs
-	j.unflushedBytes = unflushedBytes
 
 	return flushedBytes, nil
 }
 
 func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 	entries blockEntriesToFlush, tlfID TlfID, reporter Reporter) error {
-	if j.isShutdown {
-		return errBlockJournalShutdown
-	}
-
 	// Remove them all!
 	for i, entry := range entries.all {
 		flushedBytes, err := j.removeFlushedEntry(
@@ -941,17 +902,13 @@ func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 	return nil
 }
 
-func (j *blockJournal) shutdown() {
-	j.isShutdown = true
-
-	// Double-check the on-disk journal with the in-memory one.
-	ctx := context.Background()
+func (j *blockJournal) checkInSync(ctx context.Context) error {
 	refs, _, err := j.readJournal(ctx)
 	if err != nil {
-		panic(err)
+		return err
 	}
-
 	if !reflect.DeepEqual(refs, j.refs) {
-		panic(fmt.Sprintf("refs = %v != j.refs = %v", refs, j.refs))
+		return fmt.Errorf("refs = %v != j.refs = %v", refs, j.refs)
 	}
+	return nil
 }

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -22,144 +22,233 @@ func getBlockJournalLength(t *testing.T, j *blockJournal) int {
 	return int(len)
 }
 
-func TestBlockJournalBasic(t *testing.T) {
-	codec := NewCodecMsgpack()
-	crypto := MakeCryptoCommon(codec)
-
+func setupBlockJournalTest(t *testing.T) (
+	ctx context.Context, tempdir string, j *blockJournal) {
 	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
 	require.NoError(t, err)
+	// Clean up the tempdir if anything in the setup fails/panics.
 	defer func() {
-		err := os.RemoveAll(tempdir)
-		require.NoError(t, err)
+		if r := recover(); r != nil {
+			err := os.RemoveAll(tempdir)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+		}
 	}()
+
+	ctx = context.Background()
+	codec := NewCodecMsgpack()
+	crypto := MakeCryptoCommon(codec)
+	log := logger.NewTestLogger(t)
+	j, err = makeBlockJournal(ctx, codec, crypto, tempdir, log)
+	require.NoError(t, err)
+	require.Equal(t, 0, getBlockJournalLength(t, j))
+
+	return ctx, tempdir, j
+}
+
+func teardownBlockJournalTest(t *testing.T, tempdir string, j *blockJournal) {
+	ctx := context.Background()
+	err := j.checkInSync(ctx)
+	require.NoError(t, err)
+
+	err = os.RemoveAll(tempdir)
+	require.NoError(t, err)
+}
+
+func putBlockDataWithRev(ctx context.Context, t *testing.T,
+	j *blockJournal, data []byte, rev MetadataRevision) (
+	BlockID, BlockContext, BlockCryptKeyServerHalf) {
+	oldLength := getBlockJournalLength(t, j)
+
+	bID, err := j.crypto.MakePermanentBlockID(data)
+	require.NoError(t, err)
+
+	uid1 := keybase1.MakeTestUID(1)
+	bCtx := BlockContext{uid1, "", zeroBlockRefNonce}
+	serverHalf, err := j.crypto.MakeRandomBlockCryptKeyServerHalf()
+	require.NoError(t, err)
+
+	err = j.putData(ctx, bID, bCtx, data, serverHalf)
+	require.NoError(t, err)
+
+	require.Equal(t, oldLength+1, getBlockJournalLength(t, j))
+
+	return bID, bCtx, serverHalf
+}
+
+func putBlockData(ctx context.Context, t *testing.T,
+	j *blockJournal, data []byte) (
+	BlockID, BlockContext, BlockCryptKeyServerHalf) {
+	return putBlockDataWithRev(
+		ctx, t, j, data, MetadataRevisionUninitialized)
+}
+
+func addBlockRefWithRev(ctx context.Context, t *testing.T, j *blockJournal,
+	bID BlockID, rev MetadataRevision) BlockContext {
+	oldLength := getBlockJournalLength(t, j)
+
+	nonce, err := j.crypto.MakeBlockRefNonce()
+	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
 	uid2 := keybase1.MakeTestUID(2)
-
-	ctx := context.Background()
-
-	log := logger.NewTestLogger(t)
-	j, err := makeBlockJournal(ctx, codec, crypto, tempdir, log)
-	require.NoError(t, err)
-	defer j.shutdown()
-
-	require.Equal(t, 0, getBlockJournalLength(t, j))
-
-	bCtx := BlockContext{uid1, "", zeroBlockRefNonce}
-
-	data := []byte{1, 2, 3, 4}
-	bID, err := crypto.MakePermanentBlockID(data)
-	require.NoError(t, err)
-
-	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
-	require.NoError(t, err)
-
-	// Put the block.
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
-	require.NoError(t, err)
-	require.Equal(t, 1, getBlockJournalLength(t, j))
-
-	// Make sure we get the same block back.
-	buf, key, err := j.getDataWithContext(bID, bCtx)
-	require.NoError(t, err)
-	require.Equal(t, data, buf)
-	require.Equal(t, serverHalf, key)
-
-	// Add a reference.
-	nonce, err := crypto.MakeBlockRefNonce()
-	require.NoError(t, err)
 	bCtx2 := BlockContext{uid1, uid2, nonce}
 	err = j.addReference(ctx, bID, bCtx2)
 	require.NoError(t, err)
-	require.Equal(t, 2, getBlockJournalLength(t, j))
+	require.Equal(t, oldLength+1, getBlockJournalLength(t, j))
+	return bCtx2
+}
+
+func addBlockRef(ctx context.Context, t *testing.T, j *blockJournal,
+	bID BlockID) BlockContext {
+	return addBlockRefWithRev(ctx, t, j, bID, MetadataRevisionUninitialized)
+}
+
+func getAndCheckBlockData(ctx context.Context, t *testing.T, j *blockJournal,
+	bID BlockID, bCtx BlockContext, expectedData []byte,
+	expectedServerHalf BlockCryptKeyServerHalf) {
+	data, serverHalf, err := j.getDataWithContext(bID, bCtx)
+	require.NoError(t, err)
+	require.Equal(t, expectedData, data)
+	require.Equal(t, expectedServerHalf, serverHalf)
+}
+
+func TestBlockJournalBasic(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
+
+	// Put the block.
+	data := []byte{1, 2, 3, 4}
+	bID, bCtx, serverHalf := putBlockData(ctx, t, j, data)
+
+	// Make sure we get the same block back.
+	getAndCheckBlockData(ctx, t, j, bID, bCtx, data, serverHalf)
+
+	// Add a reference.
+	bCtx2 := addBlockRef(ctx, t, j, bID)
 
 	// Make sure we get the same block via that reference.
-	buf, key, err = j.getDataWithContext(bID, bCtx2)
-	require.NoError(t, err)
-	require.Equal(t, data, buf)
-	require.Equal(t, serverHalf, key)
-
-	unflushedBytes := j.unflushedBytes
-	require.Equal(t, unflushedBytes, int64(len(data)))
+	getAndCheckBlockData(ctx, t, j, bID, bCtx2, data, serverHalf)
 
 	// Shutdown and restart.
-	j.shutdown()
-	j, err = makeBlockJournal(ctx, codec, crypto, tempdir, log)
+	err := j.checkInSync(ctx)
 	require.NoError(t, err)
-	require.Equal(t, unflushedBytes, j.unflushedBytes)
+	j, err = makeBlockJournal(ctx, j.codec, j.crypto, tempdir, j.log)
+	require.NoError(t, err)
 
 	require.Equal(t, 2, getBlockJournalLength(t, j))
 
 	// Make sure we get the same block for both refs.
 
-	buf, key, err = j.getDataWithContext(bID, bCtx)
-	require.NoError(t, err)
-	require.Equal(t, data, buf)
-	require.Equal(t, serverHalf, key)
-
-	buf, key, err = j.getDataWithContext(bID, bCtx2)
-	require.NoError(t, err)
-	require.Equal(t, data, buf)
-	require.Equal(t, serverHalf, key)
+	getAndCheckBlockData(ctx, t, j, bID, bCtx, data, serverHalf)
+	getAndCheckBlockData(ctx, t, j, bID, bCtx2, data, serverHalf)
 }
 
-func TestBlockJournalFlush(t *testing.T) {
-	codec := NewCodecMsgpack()
-	crypto := MakeCryptoCommon(codec)
-
-	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
-	require.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(tempdir)
-		require.NoError(t, err)
-	}()
-
-	uid1 := keybase1.MakeTestUID(1)
-	uid2 := keybase1.MakeTestUID(2)
-
-	ctx := context.Background()
-
-	log := logger.NewTestLogger(t)
-	j, err := makeBlockJournal(ctx, codec, crypto, tempdir, log)
-	require.NoError(t, err)
-	defer j.shutdown()
-
-	// Put a block.
+func TestBlockJournalAddReference(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := crypto.MakePermanentBlockID(data)
+	bID, err := j.crypto.MakePermanentBlockID(data)
 	require.NoError(t, err)
+
+	// Add a reference, which should succeed.
+	bCtx := addBlockRef(ctx, t, j, bID)
+
+	// Of course, the block get should still fail.
+	_, _, err = j.getDataWithContext(bID, bCtx)
+	require.Equal(t, blockNonExistentError{bID}, err)
+}
+
+func TestBlockJournalRemoveReferences(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
+
+	// Put the block.
+	data := []byte{1, 2, 3, 4}
+	bID, bCtx, serverHalf := putBlockData(ctx, t, j, data)
+
+	// Add a reference.
+	bCtx2 := addBlockRef(ctx, t, j, bID)
+
+	// Remove references.
+	liveCounts, err := j.removeReferences(
+		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}})
+	require.NoError(t, err)
+	require.Equal(t, map[BlockID]int{bID: 0}, liveCounts)
+	require.Equal(t, 3, getBlockJournalLength(t, j))
+
+	// Make sure the block data is inaccessible.
+	_, _, err = j.getDataWithContext(bID, bCtx)
+	require.Equal(t, blockNonExistentError{bID}, err)
+
+	// But the actual data should remain (for flushing).
+	buf, half, err := j.getData(bID)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+	require.Equal(t, serverHalf, half)
+}
+
+func TestBlockJournalArchiveReferences(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
+
+	// Put the block.
+	data := []byte{1, 2, 3, 4}
+	bID, bCtx, serverHalf := putBlockData(ctx, t, j, data)
+
+	// Add a reference.
+	bCtx2 := addBlockRef(ctx, t, j, bID)
+
+	// Archive references.
+	err := j.archiveReferences(
+		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}})
+	require.NoError(t, err)
+	require.Equal(t, 3, getBlockJournalLength(t, j))
+
+	// Get block should still succeed.
+	getAndCheckBlockData(ctx, t, j, bID, bCtx, data, serverHalf)
+}
+
+func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
+
+	uid1 := keybase1.MakeTestUID(1)
 
 	bCtx := BlockContext{uid1, "", zeroBlockRefNonce}
 
-	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
+	data := []byte{1, 2, 3, 4}
+	bID, err := j.crypto.MakePermanentBlockID(data)
 	require.NoError(t, err)
 
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
+	// Archive references.
+	err = j.archiveReferences(
+		ctx, map[BlockID][]BlockContext{bID: {bCtx}})
 	require.NoError(t, err)
+}
+
+func TestBlockJournalFlush(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
+
+	// Put a block.
+
+	rev := MetadataRevisionInitial
+	data := []byte{1, 2, 3, 4}
+	bID, bCtx, serverHalf := putBlockDataWithRev(ctx, t, j, data, rev)
 
 	// Add some references.
 
-	nonce, err := crypto.MakeBlockRefNonce()
-	require.NoError(t, err)
-	bCtx2 := BlockContext{uid1, uid2, nonce}
-	err = j.addReference(ctx, bID, bCtx2)
+	rev++
+	bCtx2 := addBlockRefWithRev(ctx, t, j, bID, rev)
 
-	require.NoError(t, err)
-	nonce2, err := crypto.MakeBlockRefNonce()
-	require.NoError(t, err)
-	bCtx3 := BlockContext{uid1, uid2, nonce2}
-	err = j.addReference(ctx, bID, bCtx3)
-	require.NoError(t, err)
+	rev++
+	bCtx3 := addBlockRefWithRev(ctx, t, j, bID, rev)
 
-	// Archive one of the references.
-
-	require.NoError(t, err)
-	err = j.archiveReferences(
-		ctx, map[BlockID][]BlockContext{
-			bID: {bCtx3},
-		})
-	require.NoError(t, err)
+	// Flush the block put. (Interleave flushes to test
+	// checkInSync in intermediate states.)
 
 	blockServer := NewBlockServerMemory(newTestBlockServerLocalConfig(t))
 
@@ -168,184 +257,108 @@ func TestBlockJournalFlush(t *testing.T) {
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
 
-	flush := func() {
-		end, err := j.end()
+	flushOne := func() {
+		first, err := j.j.readEarliestOrdinal()
 		require.NoError(t, err)
-		if end == 0 {
-			return
-		}
-
-		// Test that the end parameter is respected.
-		partialEntries, err := j.getNextEntriesToFlush(ctx, end-1)
+		entries, err := j.getNextEntriesToFlush(ctx, first+1)
 		require.NoError(t, err)
-
-		entries, err := j.getNextEntriesToFlush(ctx, end)
+		require.Equal(t, 1, entries.length())
+		err = flushBlockEntries(ctx, j.log, blockServer,
+			bcache, reporter, tlfID, CanonicalTlfName("fake TLF"),
+			entries)
 		require.NoError(t, err)
-		require.Equal(t, partialEntries.length()+1, entries.length())
-
-		err = flushBlockEntries(ctx, log, blockServer, bcache, reporter,
-			tlfID, CanonicalTlfName("fake TLF"), entries)
-		require.NoError(t, err)
-
 		err = j.removeFlushedEntries(ctx, entries, tlfID, reporter)
+		require.NoError(t, err)
+		err = j.checkInSync(ctx)
 		require.NoError(t, err)
 	}
 
-	flush()
+	flushOne()
 
-	// Check the Put.
 	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
 
-	// Check the AddReference.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
-	require.NoError(t, err)
-	require.Equal(t, data, buf)
-	require.Equal(t, serverHalf, key)
+	// Remove some references.
 
-	// Check the archiving.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
-	require.NoError(t, err)
-	require.Equal(t, data, buf)
-	require.Equal(t, serverHalf, key)
-
-	// Now remove all the references.
+	rev++
 	liveCounts, err := j.removeReferences(
 		ctx, map[BlockID][]BlockContext{
-			bID: {bCtx, bCtx2, bCtx3},
-		}, false)
+			bID: {bCtx, bCtx2},
+		})
 	require.NoError(t, err)
-	require.Equal(t, map[BlockID]int{}, liveCounts)
+	require.Equal(t, map[BlockID]int{bID: 1}, liveCounts)
 
-	flush()
+	// Flush the reference adds.
 
-	// Check they're all gone.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx)
-	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+	flushOne()
+
 	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+	require.Equal(t, serverHalf, key)
+
+	flushOne()
+
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+	require.Equal(t, serverHalf, key)
+
+	// Archive the rest.
+
+	rev++
+	err = j.archiveReferences(
+		ctx, map[BlockID][]BlockContext{
+			bID: {bCtx3},
+		})
+	require.NoError(t, err)
+
+	// Flush the reference removals.
+
+	flushOne()
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID, bCtx)
 	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+	require.Equal(t, serverHalf, key)
+
+	// Remove the archived references.
+
+	rev++
+	liveCounts, err = j.removeReferences(
+		ctx, map[BlockID][]BlockContext{
+			bID: {bCtx3},
+		})
+	require.NoError(t, err)
+	require.Equal(t, map[BlockID]int{bID: 0}, liveCounts)
+
+	// Flush the reference archival.
+
+	flushOne()
+
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	require.NoError(t, err)
+	require.Equal(t, data, buf)
+	require.Equal(t, serverHalf, key)
+
+	// Flush the last removal.
+
+	flushOne()
+
 	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
 	require.IsType(t, BServerErrorBlockNonExistent{}, err)
 
-	length, err := j.length()
+	end, err := j.end()
 	require.NoError(t, err)
-	require.Zero(t, length)
-	require.Zero(t, j.unflushedBytes)
-}
-
-func TestBlockJournalRemoveReferences(t *testing.T) {
-	codec := NewCodecMsgpack()
-	crypto := MakeCryptoCommon(codec)
-
-	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
+	entries, err := j.getNextEntriesToFlush(ctx, end)
 	require.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(tempdir)
-		require.NoError(t, err)
-	}()
-
-	uid1 := keybase1.MakeTestUID(1)
-	uid2 := keybase1.MakeTestUID(2)
-
-	ctx := context.Background()
-
-	log := logger.NewTestLogger(t)
-	j, err := makeBlockJournal(ctx, codec, crypto, tempdir, log)
-	require.NoError(t, err)
-	defer j.shutdown()
-
-	require.Equal(t, 0, getBlockJournalLength(t, j))
-
-	bCtx := BlockContext{uid1, "", zeroBlockRefNonce}
-
-	data := []byte{1, 2, 3, 4}
-	bID, err := crypto.MakePermanentBlockID(data)
-	require.NoError(t, err)
-
-	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
-	require.NoError(t, err)
-
-	// Put the block.
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
-	require.NoError(t, err)
-	require.Equal(t, 1, getBlockJournalLength(t, j))
-
-	// Add a reference.
-	nonce, err := crypto.MakeBlockRefNonce()
-	require.NoError(t, err)
-	bCtx2 := BlockContext{uid1, uid2, nonce}
-	err = j.addReference(ctx, bID, bCtx2)
-	require.NoError(t, err)
-	require.Equal(t, 2, getBlockJournalLength(t, j))
-
-	// Remove references.
-	liveCounts, err := j.removeReferences(
-		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}}, true)
-	require.NoError(t, err)
-	require.Equal(t, map[BlockID]int{bID: 0}, liveCounts)
-	require.Equal(t, 3, getBlockJournalLength(t, j))
-
-	// Add reference back, which should error.
-	err = j.addReference(ctx, bID, bCtx2)
-	require.IsType(t, BServerErrorBlockNonExistent{}, err)
-	require.Equal(t, 3, getBlockJournalLength(t, j))
-}
-
-func TestBlockJournalArchiveReferences(t *testing.T) {
-	codec := NewCodecMsgpack()
-	crypto := MakeCryptoCommon(codec)
-
-	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
-	require.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(tempdir)
-		require.NoError(t, err)
-	}()
-
-	uid1 := keybase1.MakeTestUID(1)
-	uid2 := keybase1.MakeTestUID(2)
-
-	ctx := context.Background()
-
-	log := logger.NewTestLogger(t)
-	j, err := makeBlockJournal(ctx, codec, crypto, tempdir, log)
-	require.NoError(t, err)
-	defer j.shutdown()
-
-	require.Equal(t, 0, getBlockJournalLength(t, j))
-
-	bCtx := BlockContext{uid1, "", zeroBlockRefNonce}
-
-	data := []byte{1, 2, 3, 4}
-	bID, err := crypto.MakePermanentBlockID(data)
-	require.NoError(t, err)
-
-	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
-	require.NoError(t, err)
-
-	// Put the block.
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
-	require.NoError(t, err)
-	require.Equal(t, 1, getBlockJournalLength(t, j))
-
-	// Add a reference.
-	nonce, err := crypto.MakeBlockRefNonce()
-	require.NoError(t, err)
-	bCtx2 := BlockContext{uid1, uid2, nonce}
-	err = j.addReference(ctx, bID, bCtx2)
-	require.NoError(t, err)
-	require.Equal(t, 2, getBlockJournalLength(t, j))
-
-	// Archive references.
-	err = j.archiveReferences(
-		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}})
-	require.NoError(t, err)
-	require.Equal(t, 3, getBlockJournalLength(t, j))
-
-	// Add reference back, which should error.
-	err = j.addReference(ctx, bID, bCtx2)
-	require.IsType(t, BServerErrorBlockArchived{}, err)
-	require.Equal(t, 3, getBlockJournalLength(t, j))
+	require.Equal(t, 0, entries.length())
 }

--- a/libkbfs/block_ref_map.go
+++ b/libkbfs/block_ref_map.go
@@ -1,0 +1,95 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import "fmt"
+
+type blockContextMismatchError struct {
+	expected, actual BlockContext
+}
+
+func (e blockContextMismatchError) Error() string {
+	return fmt.Sprintf(
+		"Context mismatch: expected %s, got %s", e.expected, e.actual)
+}
+
+type blockRefEntry struct {
+	status  blockRefLocalStatus
+	context BlockContext
+	tag     interface{}
+}
+
+func (e blockRefEntry) checkContext(context BlockContext) error {
+	if e.context != context {
+		return blockContextMismatchError{e.context, context}
+	}
+	return nil
+}
+
+// blockRefMap is a map with additional checking methods.
+type blockRefMap map[BlockRefNonce]blockRefEntry
+
+func (refs blockRefMap) hasNonArchivedRef() bool {
+	for _, refEntry := range refs {
+		if refEntry.status == liveBlockRef {
+			return true
+		}
+	}
+	return false
+}
+
+func (refs blockRefMap) checkExists(context BlockContext) error {
+	refEntry, ok := refs[context.GetRefNonce()]
+	if !ok {
+		return blockNonExistentError{}
+	}
+
+	return refEntry.checkContext(context)
+}
+
+func (refs blockRefMap) getStatuses() map[BlockRefNonce]blockRefLocalStatus {
+	statuses := make(map[BlockRefNonce]blockRefLocalStatus)
+	for ref, refEntry := range refs {
+		statuses[ref] = refEntry.status
+	}
+	return statuses
+}
+
+func (refs blockRefMap) put(context BlockContext, status blockRefLocalStatus,
+	tag interface{}) error {
+	refNonce := context.GetRefNonce()
+	if refEntry, ok := refs[refNonce]; ok {
+		err := refEntry.checkContext(context)
+		if err != nil {
+			return err
+		}
+	}
+
+	refs[refNonce] = blockRefEntry{
+		status:  status,
+		context: context,
+		tag:     tag,
+	}
+	return nil
+}
+
+// remove removes the entry with the given context, if any. If tag is
+// non-nil, then the entry will be removed only if its tag (passed in
+// to put) matches the given one.
+func (refs blockRefMap) remove(context BlockContext, tag interface{}) error {
+	refNonce := context.GetRefNonce()
+	// If this check fails, this ref is already gone, which is not
+	// an error.
+	if refEntry, ok := refs[refNonce]; ok {
+		err := refEntry.checkContext(context)
+		if err != nil {
+			return err
+		}
+		if tag == nil || refEntry.tag == tag {
+			delete(refs, refNonce)
+		}
+	}
+	return nil
+}

--- a/libkbfs/block_ref_map.go
+++ b/libkbfs/block_ref_map.go
@@ -73,7 +73,7 @@ func (refs blockRefMap) put(context BlockContext, status blockRefLocalStatus,
 	refs[refNonce] = blockRefEntry{
 		status:        status,
 		context:       context,
-		mostRecentTag: mostRecentTag,
+		mostRecentTag: tag,
 	}
 	return nil
 }

--- a/libkbfs/block_ref_map.go
+++ b/libkbfs/block_ref_map.go
@@ -18,7 +18,10 @@ func (e blockContextMismatchError) Error() string {
 type blockRefEntry struct {
 	status  blockRefLocalStatus
 	context BlockContext
-	tag     interface{}
+	// mostRecentTag, if non-nil, is used by callers to figure out
+	// if an entry has been modified by something else. See
+	// blockRefMap.remove.
+	mostRecentTag interface{}
 }
 
 func (e blockRefEntry) checkContext(context BlockContext) error {
@@ -68,9 +71,9 @@ func (refs blockRefMap) put(context BlockContext, status blockRefLocalStatus,
 	}
 
 	refs[refNonce] = blockRefEntry{
-		status:  status,
-		context: context,
-		tag:     tag,
+		status:        status,
+		context:       context,
+		mostRecentTag: mostRecentTag,
 	}
 	return nil
 }
@@ -87,7 +90,7 @@ func (refs blockRefMap) remove(context BlockContext, tag interface{}) error {
 		if err != nil {
 			return err
 		}
-		if tag == nil || refEntry.tag == tag {
+		if tag == nil || refEntry.mostRecentTag == tag {
 			delete(refs, refNonce)
 		}
 	}

--- a/libkbfs/block_ref_map.go
+++ b/libkbfs/block_ref_map.go
@@ -79,8 +79,8 @@ func (refs blockRefMap) put(context BlockContext, status blockRefLocalStatus,
 }
 
 // remove removes the entry with the given context, if any. If tag is
-// non-nil, then the entry will be removed only if its tag (passed in
-// to put) matches the given one.
+// non-nil, then the entry will be removed only if its most recent tag
+// (passed in to put) matches the given one.
 func (refs blockRefMap) remove(context BlockContext, tag interface{}) error {
 	refNonce := context.GetRefNonce()
 	// If this check fails, this ref is already gone, which is not

--- a/libkbfs/bserver_errors.go
+++ b/libkbfs/bserver_errors.go
@@ -358,3 +358,14 @@ func (eu bServerErrorUnwrapper) UnwrapError(arg interface{}) (appError error, di
 
 	return appError, nil
 }
+
+func translateToBlockServerError(err error) error {
+	// TODO: Translate blockContextMismatchError, too, if the
+	// actual server returns a similar error.
+	switch err := err.(type) {
+	case blockNonExistentError:
+		return BServerErrorBlockNonExistent{err.Error()}
+	default:
+		return err
+	}
+}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1194,7 +1194,9 @@ func (e MutableBareRootMetadataNoImplError) Error() string {
 	return "Does not implement MutableBareRootMetadata"
 }
 
-// blockNonExistentError is returned when a block doesn't exist.
+// blockNonExistentError is returned when a block doesn't exist. This
+// is a generic error, suitable for use by non-server types, whereas
+// BServerErrorBlockNonExistent is used only by servers.
 type blockNonExistentError struct {
 	id BlockID
 }

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1193,3 +1193,12 @@ type MutableBareRootMetadataNoImplError struct {
 func (e MutableBareRootMetadataNoImplError) Error() string {
 	return "Does not implement MutableBareRootMetadata"
 }
+
+// blockNonExistentError is returned when a block doesn't exist.
+type blockNonExistentError struct {
+	id BlockID
+}
+
+func (e blockNonExistentError) Error() string {
+	return fmt.Sprintf("block %s does not exist", e.id)
+}

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -26,7 +26,7 @@ func (j journalBlockServer) Get(
 		switch err.(type) {
 		case nil:
 			return data, serverHalf, nil
-		case BServerErrorBlockNonExistent:
+		case blockNonExistentError:
 			return j.BlockServer.Get(ctx, tlfID, id, context)
 		default:
 			return nil, BlockCryptKeyServerHalf{}, err

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -16,8 +16,11 @@ var _ BlockServer = journalBlockServer{}
 
 func (j journalBlockServer) Get(
 	ctx context.Context, tlfID TlfID, id BlockID, context BlockContext) (
-	[]byte, BlockCryptKeyServerHalf, error) {
+	data []byte, serverHalf BlockCryptKeyServerHalf, err error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+		defer func() {
+			err = translateToBlockServerError(err)
+		}()
 		data, serverHalf, err := tlfJournal.getBlockDataWithContext(
 			id, context)
 		switch err.(type) {
@@ -35,8 +38,11 @@ func (j journalBlockServer) Get(
 
 func (j journalBlockServer) Put(
 	ctx context.Context, tlfID TlfID, id BlockID, context BlockContext,
-	buf []byte, serverHalf BlockCryptKeyServerHalf) error {
+	buf []byte, serverHalf BlockCryptKeyServerHalf) (err error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+		defer func() {
+			err = translateToBlockServerError(err)
+		}()
 		return tlfJournal.putBlockData(ctx, id, context, buf, serverHalf)
 	}
 
@@ -45,7 +51,7 @@ func (j journalBlockServer) Put(
 
 func (j journalBlockServer) AddBlockReference(
 	ctx context.Context, tlfID TlfID, id BlockID,
-	context BlockContext) error {
+	context BlockContext) (err error) {
 	if !j.enableAddBlockReference {
 		// TODO: Temporarily return an error until KBFS-1149 is
 		// fixed. This is needed despite
@@ -55,6 +61,9 @@ func (j journalBlockServer) AddBlockReference(
 	}
 
 	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+		defer func() {
+			err = translateToBlockServerError(err)
+		}()
 		return tlfJournal.addBlockReference(ctx, id, context)
 	}
 
@@ -66,6 +75,9 @@ func (j journalBlockServer) RemoveBlockReferences(
 	contexts map[BlockID][]BlockContext) (
 	liveCounts map[BlockID]int, err error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+		defer func() {
+			err = translateToBlockServerError(err)
+		}()
 		// TODO: Get server counts without making a
 		// RemoveBlockReferences call and merge it.
 		return tlfJournal.removeBlockReferences(ctx, contexts)
@@ -76,8 +88,11 @@ func (j journalBlockServer) RemoveBlockReferences(
 
 func (j journalBlockServer) ArchiveBlockReferences(
 	ctx context.Context, tlfID TlfID,
-	contexts map[BlockID][]BlockContext) error {
+	contexts map[BlockID][]BlockContext) (err error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+		defer func() {
+			err = translateToBlockServerError(err)
+		}()
 		return tlfJournal.archiveBlockReferences(ctx, contexts)
 	}
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -191,7 +191,8 @@ func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
 	if err != nil {
 		return err
 	}
-	return j.j.appendJournalEntry(&o, mdID)
+	_, err = j.j.appendJournalEntry(&o, mdID)
+	return err
 }
 
 func (j mdIDJournal) removeEarliest() (empty bool, err error) {

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -320,17 +320,11 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 			if !ok {
 				sc.log.CDebugf(ctx, "Bad block server: %T", jbs.BlockServer)
 			}
-			// For now skip state checking until KBFS-1439 is fixed,
-			// because block archive operations may be incorrectly
-			// rejected by the journal block server until then.  TODO:
-			// remove the rest of the code in this block.
-			sc.log.CDebugf(ctx, "XXX: Skipping state checking for a journal.")
-			return nil
 		}
-		if !ok {
-			return errors.New("StateChecker only works against " +
-				"BlockServerLocal")
-		}
+	}
+	if !ok {
+		return errors.New("StateChecker only works against " +
+			"BlockServerLocal")
 	}
 	bserverKnownBlocks, err := bserverLocal.getAll(ctx, tlf)
 	if err != nil {

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -317,7 +317,6 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 	if !ok {
 		if jbs, jok := sc.config.BlockServer().(journalBlockServer); jok {
 			bserverLocal, ok = jbs.BlockServer.(blockServerLocal)
-			sc.log.CDebugf(ctx, "BlockServer() is %v %T, jbs.BlockServer is %v %T", sc.config.BlockServer(), sc.config.BlockServer(), jbs.BlockServer, jbs.BlockServer)
 			if !ok {
 				sc.log.CDebugf(ctx, "Bad block server: %T", jbs.BlockServer)
 			}

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -317,7 +317,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 	if !ok {
 		if jbs, jok := sc.config.BlockServer().(journalBlockServer); jok {
 			bserverLocal, ok = jbs.BlockServer.(blockServerLocal)
-			sc.log.CDebugf(ctx, "BlockServer() type is %T, jbs.BlockServer type is %T", sc.config.BlockServer(), jbs.BlockServer)
+			sc.log.CDebugf(ctx, "BlockServer() is %v %T, jbs.BlockServer is %v %T", sc.config.BlockServer(), sc.config.BlockServer(), jbs.BlockServer, jbs.BlockServer)
 			if !ok {
 				sc.log.CDebugf(ctx, "Bad block server: %T", jbs.BlockServer)
 			}

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -317,6 +317,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf TlfID) error {
 	if !ok {
 		if jbs, jok := sc.config.BlockServer().(journalBlockServer); jok {
 			bserverLocal, ok = jbs.BlockServer.(blockServerLocal)
+			sc.log.CDebugf(ctx, "BlockServer() type is %T, jbs.BlockServer type is %T", sc.config.BlockServer(), jbs.BlockServer)
 			if !ok {
 				sc.log.CDebugf(ctx, "Bad block server: %T", jbs.BlockServer)
 			}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -142,7 +142,7 @@ type tlfJournal struct {
 	// TODO: Consider using https://github.com/pkg/singlefile
 	// instead.
 	journalLock sync.RWMutex
-
+	// both of these are nil after shutdown() is called.
 	blockJournal *blockJournal
 	mdJournal    *mdJournal
 
@@ -475,11 +475,25 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 	return nil
 }
 
+var errTLFJournalShutdown = errors.New("tlfJournal is shutdown")
+
+func (j *tlfJournal) checkShutdownLocked() error {
+	if j.blockJournal == nil || j.mdJournal == nil {
+		return errTLFJournalShutdown
+	}
+	return nil
+}
+
 func (j *tlfJournal) getNextBlockEntriesToFlush(
 	ctx context.Context, end journalOrdinal) (
 	entries blockEntriesToFlush, err error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return blockEntriesToFlush{}, err
+	}
+
 	return j.blockJournal.getNextEntriesToFlush(ctx, end)
 }
 
@@ -487,6 +501,11 @@ func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
 	entries blockEntriesToFlush) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return err
+	}
+
 	return j.blockJournal.removeFlushedEntries(ctx, entries, j.tlfID,
 		j.config.Reporter())
 }
@@ -528,6 +547,11 @@ func (j *tlfJournal) getNextMDEntryToFlush(ctx context.Context,
 	MdID, *RootMetadataSigned, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return MdID{}, nil, err
+	}
+
 	return j.mdJournal.getNextEntryToFlush(
 		ctx, currentUID, currentVerifyingKey, end, j.config.Crypto())
 }
@@ -538,9 +562,14 @@ func (j *tlfJournal) convertMDsToBranchAndGetNextEntry(
 	nextEntryEnd MetadataRevision) (MdID, *RootMetadataSigned, error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return MdID{}, nil, err
+	}
+
 	bid, err := j.mdJournal.convertToBranch(
-		ctx, currentUID, currentVerifyingKey, j.config.Crypto(), j.tlfID,
-		j.config.MDCache())
+		ctx, currentUID, currentVerifyingKey, j.config.Crypto(),
+		j.tlfID, j.config.MDCache())
 	if err != nil {
 		return MdID{}, nil, err
 	}
@@ -559,6 +588,11 @@ func (j *tlfJournal) removeFlushedMDEntry(ctx context.Context,
 	mdID MdID, rmds *RootMetadataSigned) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return err
+	}
+
 	return j.mdJournal.removeFlushedEntry(
 		ctx, currentUID, currentVerifyingKey, mdID, rmds)
 }
@@ -640,6 +674,11 @@ func (j *tlfJournal) getJournalEntryCounts() (
 	blockEntryCount, mdEntryCount uint64, err error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return 0, 0, err
+	}
+
 	blockEntryCount, err = j.blockJournal.length()
 	if err != nil {
 		return 0, 0, err
@@ -656,6 +695,11 @@ func (j *tlfJournal) getJournalEntryCounts() (
 func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
+
 	earliestRevision, err := j.mdJournal.readEarliestRevision()
 	if err != nil {
 		return TLFJournalStatus{}, err
@@ -689,9 +733,24 @@ func (j *tlfJournal) shutdown() {
 	default:
 	}
 
+	// This may happen before the background goroutine finishes,
+	// but that's ok.
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	j.blockJournal.shutdown()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		// Already shutdown.
+		return
+	}
+
+	ctx := context.Background()
+	err = j.blockJournal.checkInSync(ctx)
+	if err != nil {
+		panic(err)
+	}
+	// Make further accesses error out.
+	j.blockJournal = nil
+	j.mdJournal = nil
 }
 
 // All the functions below just do the equivalent blockJournal or
@@ -702,6 +761,11 @@ func (j *tlfJournal) getBlockDataWithContext(
 	[]byte, BlockCryptKeyServerHalf, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return nil, BlockCryptKeyServerHalf{}, err
+	}
+
 	return j.blockJournal.getDataWithContext(id, context)
 }
 
@@ -710,7 +774,12 @@ func (j *tlfJournal) putBlockData(
 	serverHalf BlockCryptKeyServerHalf) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.blockJournal.putData(ctx, id, context, buf, serverHalf)
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return err
+	}
+
+	err = j.blockJournal.putData(ctx, id, context, buf, serverHalf)
 	if err != nil {
 		return err
 	}
@@ -733,7 +802,12 @@ func (j *tlfJournal) addBlockReference(
 	ctx context.Context, id BlockID, context BlockContext) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.blockJournal.addReference(ctx, id, context)
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return err
+	}
+
+	err = j.blockJournal.addReference(ctx, id, context)
 	if err != nil {
 		return err
 	}
@@ -748,14 +822,18 @@ func (j *tlfJournal) removeBlockReferences(
 	liveCounts map[BlockID]int, err error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return nil, err
+	}
+
 	// Don't remove the block data if we remove the last
 	// reference; we still need it to flush the initial put
 	// operation.
 	//
 	// TODO: It would be nice if we could detect that case and
 	// avoid having to flush the put.
-	liveCounts, err = j.blockJournal.removeReferences(
-		ctx, contexts, false)
+	liveCounts, err = j.blockJournal.removeReferences(ctx, contexts)
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +847,12 @@ func (j *tlfJournal) archiveBlockReferences(
 	ctx context.Context, contexts map[BlockID][]BlockContext) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.blockJournal.archiveReferences(ctx, contexts)
+	err := j.checkShutdownLocked()
+	if err != nil {
+		return err
+	}
+
+	err = j.blockJournal.archiveReferences(ctx, contexts)
 	if err != nil {
 		return err
 	}
@@ -789,6 +872,11 @@ func (j *tlfJournal) getMDHead(
 
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return ImmutableBareRootMetadata{}, err
+	}
+
 	return j.mdJournal.getHead(uid, key)
 }
 
@@ -803,6 +891,11 @@ func (j *tlfJournal) getMDRange(
 
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return nil, err
+	}
+
 	return j.mdJournal.getRange(uid, key, start, stop)
 }
 
@@ -816,6 +909,11 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return MdID{}, err
+	}
+
 	mdID, err := j.mdJournal.put(ctx, uid, key, j.config.Crypto(),
 		j.config.encryptionKeyGetter(), j.config.BlockSplitter(), rmd)
 	if err != nil {
@@ -840,6 +938,11 @@ func (j *tlfJournal) clearMDs(ctx context.Context, bid BranchID) error {
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
+	err = j.checkShutdownLocked()
+	if err != nil {
+		return err
+	}
+
 	// No need to signal work in this case.
 	return j.mdJournal.clear(ctx, uid, key, bid)
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -489,8 +489,7 @@ func (j *tlfJournal) getNextBlockEntriesToFlush(
 	entries blockEntriesToFlush, err error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return blockEntriesToFlush{}, err
 	}
 
@@ -501,8 +500,7 @@ func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
 	entries blockEntriesToFlush) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return err
 	}
 
@@ -547,8 +545,7 @@ func (j *tlfJournal) getNextMDEntryToFlush(ctx context.Context,
 	MdID, *RootMetadataSigned, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return MdID{}, nil, err
 	}
 
@@ -562,8 +559,7 @@ func (j *tlfJournal) convertMDsToBranchAndGetNextEntry(
 	nextEntryEnd MetadataRevision) (MdID, *RootMetadataSigned, error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return MdID{}, nil, err
 	}
 
@@ -588,8 +584,7 @@ func (j *tlfJournal) removeFlushedMDEntry(ctx context.Context,
 	mdID MdID, rmds *RootMetadataSigned) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return err
 	}
 
@@ -674,8 +669,7 @@ func (j *tlfJournal) getJournalEntryCounts() (
 	blockEntryCount, mdEntryCount uint64, err error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return 0, 0, err
 	}
 
@@ -695,8 +689,7 @@ func (j *tlfJournal) getJournalEntryCounts() (
 func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return TLFJournalStatus{}, err
 	}
 
@@ -737,14 +730,13 @@ func (j *tlfJournal) shutdown() {
 	// but that's ok.
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		// Already shutdown.
 		return
 	}
 
 	ctx := context.Background()
-	err = j.blockJournal.checkInSync(ctx)
+	err := j.blockJournal.checkInSync(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -761,8 +753,7 @@ func (j *tlfJournal) getBlockDataWithContext(
 	[]byte, BlockCryptKeyServerHalf, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
 
@@ -774,12 +765,11 @@ func (j *tlfJournal) putBlockData(
 	serverHalf BlockCryptKeyServerHalf) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return err
 	}
 
-	err = j.blockJournal.putData(ctx, id, context, buf, serverHalf)
+	err := j.blockJournal.putData(ctx, id, context, buf, serverHalf)
 	if err != nil {
 		return err
 	}
@@ -802,12 +792,11 @@ func (j *tlfJournal) addBlockReference(
 	ctx context.Context, id BlockID, context BlockContext) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return err
 	}
 
-	err = j.blockJournal.addReference(ctx, id, context)
+	err := j.blockJournal.addReference(ctx, id, context)
 	if err != nil {
 		return err
 	}
@@ -822,8 +811,7 @@ func (j *tlfJournal) removeBlockReferences(
 	liveCounts map[BlockID]int, err error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return nil, err
 	}
 
@@ -847,12 +835,11 @@ func (j *tlfJournal) archiveBlockReferences(
 	ctx context.Context, contexts map[BlockID][]BlockContext) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return err
 	}
 
-	err = j.blockJournal.archiveReferences(ctx, contexts)
+	err := j.blockJournal.archiveReferences(ctx, contexts)
 	if err != nil {
 		return err
 	}
@@ -872,8 +859,7 @@ func (j *tlfJournal) getMDHead(
 
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return ImmutableBareRootMetadata{}, err
 	}
 
@@ -891,8 +877,7 @@ func (j *tlfJournal) getMDRange(
 
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return nil, err
 	}
 
@@ -909,8 +894,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return MdID{}, err
 	}
 
@@ -938,8 +922,7 @@ func (j *tlfJournal) clearMDs(ctx context.Context, bid BranchID) error {
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err = j.checkShutdownLocked()
-	if err != nil {
+	if err := j.checkShutdownLocked(); err != nil {
 		return err
 	}
 

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -60,16 +60,6 @@ func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(t, users...)
 
-	if journal {
-		jdir, err := ioutil.TempDir(os.TempDir(), "kbfs_journal")
-		if err != nil {
-			k.t.Fatalf("Couldn't enable journaling: %v", err)
-		}
-		k.journalDir = jdir
-		k.t.Logf("Journal directory: %s", k.journalDir)
-		config.EnableJournaling(filepath.Join(jdir, users[0].String()))
-	}
-
 	setBlockSizes(t, config, blockSize, blockChangeSize)
 	maybeSetBw(t, config, bwKBps)
 	k.opTimeout = opTimeout
@@ -94,6 +84,20 @@ func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 			c.EnableJournaling(filepath.Join(k.journalDir, name.String()))
 		}
 	}
+
+	if journal {
+		jdir, err := ioutil.TempDir(os.TempDir(), "kbfs_journal")
+		if err != nil {
+			k.t.Fatalf("Couldn't enable journaling: %v", err)
+		}
+		k.journalDir = jdir
+		k.t.Logf("Journal directory: %s", k.journalDir)
+		for name, c := range userMap {
+			c.(*libkbfs.ConfigLocal).EnableJournaling(
+				filepath.Join(jdir, name.String()))
+		}
+	}
+
 	return userMap
 }
 

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -80,9 +80,6 @@ func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 		userMap[name] = c
 		k.refs[c] = make(map[libkbfs.Node]bool)
 		k.updateChannels[c] = make(map[libkbfs.FolderBranch]chan<- struct{})
-		if journal && k.journalDir != "" {
-			c.EnableJournaling(filepath.Join(k.journalDir, name.String()))
-		}
 	}
 
 	if journal {


### PR DESCRIPTION
Add a tag field to blockRefMap and populate it with
the ordinal. Use that to efficiently remove map
entries on a flush.

Move BlockServerDisk-specific logic out of blockJournal,
and remove more BlockServer-isms in it.

Clean up block_journal_test.go.

Move shutdown logic out of blockJournal and into
tlfJournal and BlockServerDisk.