### PR TITLE
Fix overly-aggressive check in makeMDJournal

### DIFF
--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -25,6 +25,11 @@ import (
 // stored along with a local timestamp. ImmutableBareRootMetadata
 // objects can be assumed to never alias a (modifiable) BareRootMetadata.
 //
+// Note that crypto.MakeMdID() on an ImmutableBareRootMetadata will
+// compute the wrong result, since anonymous fields of interface type
+// are not encoded inline by the codec. Use
+// crypto.MakeMDID(ibrmd.BareRootMetadata) instead.
+//
 // TODO: Move this to bare_root_metadata.go if it's used in more
 // places.
 type ImmutableBareRootMetadata struct {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -152,7 +152,9 @@ func (j mdJournal) mdPath(id MdID) string {
 
 // getMD verifies the MD data and the writer signature (but not the
 // key) for the given ID and returns it. It also returns the
-// last-modified timestamp of the file.
+// last-modified timestamp of the file. verifyBranchID should be false
+// only when called from makeMDJournal, i.e. when figuring out what to
+// set j.branchID in the first place.
 func (j mdJournal) getMD(currentUID keybase1.UID,
 	currentVerifyingKey VerifyingKey, id MdID, verifyBranchID bool) (
 	BareRootMetadata, time.Time, error) {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -438,15 +438,22 @@ func (j *mdJournal) convertToBranch(
 	// and then perform the swap by atomically changing the
 	// symlink to point to the new journal directory.
 
-	oldDir, err := j.j.move(journalTempDir + ".old")
+	oldJournalNewDir := journalTempDir + ".old"
+	dir, err := j.j.move(oldJournalNewDir)
 	if err != nil {
 		return err
 	}
 
-	_, err = tempJournal.move(oldDir)
+	j.log.CDebugf(ctx, "Moved old journal from %s to %s",
+		dir, oldJournalNewDir)
+
+	newJournalOldDir, err := tempJournal.move(dir)
 	if err != nil {
 		return err
 	}
+
+	j.log.CDebugf(ctx, "Moved new journal from %s to %s",
+		newJournalOldDir, dir)
 
 	j.j = tempJournal
 	j.branchID = bid

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -227,28 +227,8 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
-	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
-	require.Equal(t, Unmerged, ibrmds[0].MergedStatus())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto)
-	require.NoError(t, err)
-	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
-	require.NoError(t, err)
-
-	bid := ibrmds[0].BID()
-	require.NotEqual(t, NullBranchID, bid)
-
-	for i := 1; i < len(ibrmds); i++ {
-		require.Equal(t, Unmerged, ibrmds[i].MergedStatus())
-		require.Equal(t, bid, ibrmds[i].BID())
-		err := ibrmds[i].IsValidAndSigned(codec, crypto)
-		require.NoError(t, err)
-		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
-		require.NoError(t, err)
-		err = ibrmds[i-1].CheckValidSuccessor(
-			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
-		require.NoError(t, err)
-	}
+	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+		ibrmds, firstRevision, firstPrevRoot, Unmerged, ibrmds[0].BID())
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
@@ -297,25 +277,8 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
-	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
-	require.Equal(t, Merged, ibrmds[0].MergedStatus())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto)
-	require.NoError(t, err)
-	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
-	require.NoError(t, err)
-
-	for i := 1; i < len(ibrmds); i++ {
-		require.Equal(t, Merged, ibrmds[i].MergedStatus())
-		require.Equal(t, NullBranchID, ibrmds[i].BID())
-		err := ibrmds[i].IsValidAndSigned(codec, crypto)
-		require.NoError(t, err)
-		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
-		require.NoError(t, err)
-		err = ibrmds[i-1].CheckValidSuccessor(
-			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
-		require.NoError(t, err)
-	}
+	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
@@ -398,29 +361,13 @@ func TestMDJournalRestart(t *testing.T) {
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
-	// Should now be non-empty.
-
 	ibrmds, err := j.getRange(
 		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
-	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto)
-	require.NoError(t, err)
-	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
-	require.NoError(t, err)
-
-	for i := 1; i < len(ibrmds); i++ {
-		err := ibrmds[i].IsValidAndSigned(codec, crypto)
-		require.NoError(t, err)
-		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
-		require.NoError(t, err)
-		err = ibrmds[i-1].CheckValidSuccessor(
-			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
-		require.NoError(t, err)
-	}
+	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 }
 
 func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
@@ -450,27 +397,11 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
-	// Should now be non-empty.
-
 	ibrmds, err := j.getRange(
 		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
-	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
-	err = ibrmds[0].IsValidAndSigned(codec, crypto)
-	require.NoError(t, err)
-	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
-	require.NoError(t, err)
-
-	for i := 1; i < len(ibrmds); i++ {
-		err := ibrmds[i].IsValidAndSigned(codec, crypto)
-		require.NoError(t, err)
-		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
-		require.NoError(t, err)
-		err = ibrmds[i-1].CheckValidSuccessor(
-			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
-		require.NoError(t, err)
-	}
+	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+		ibrmds, firstRevision, firstPrevRoot, Unmerged, ibrmds[0].BID())
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -33,10 +33,10 @@ func getMDJournalLength(t *testing.T, j *mdJournal) int {
 }
 
 func setupMDJournalTest(t *testing.T) (
-	codec Codec, crypto CryptoCommon,
-	uid keybase1.UID, id TlfID, signer cryptoSigner,
-	verifyingKey VerifyingKey, ekg singleEncryptionKeyGetter,
-	bsplit BlockSplitter, tempdir string, j *mdJournal) {
+	uid keybase1.UID, verifyingKey VerifyingKey, codec Codec,
+	crypto CryptoCommon, id TlfID, signer cryptoSigner,
+	ekg singleEncryptionKeyGetter, bsplit BlockSplitter, tempdir string,
+	j *mdJournal) {
 	codec = NewCodecMsgpack()
 	crypto = MakeCryptoCommon(codec)
 
@@ -66,7 +66,7 @@ func setupMDJournalTest(t *testing.T) (
 
 	bsplit = &BlockSplitterSimple{64 * 1024, 8 * 1024}
 
-	return codec, crypto, uid, id, signer, verifyingKey, ekg,
+	return uid, verifyingKey, codec, crypto, id, signer, ekg,
 		bsplit, tempdir, j
 }
 
@@ -89,7 +89,7 @@ func makeMDForTest(t *testing.T, id TlfID, revision MetadataRevision,
 }
 
 func TestMDJournalBasic(t *testing.T) {
-	codec, crypto, uid, id, signer, verifyingKey, ekg,
+	uid, verifyingKey, codec, crypto, id, signer, ekg,
 		bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -150,7 +150,7 @@ func TestMDJournalBasic(t *testing.T) {
 }
 
 func TestMDJournalReplaceHead(t *testing.T) {
-	_, _, uid, id, signer, verifyingKey, ekg, bsplit, tempdir, j :=
+	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -189,7 +189,7 @@ func TestMDJournalReplaceHead(t *testing.T) {
 }
 
 func TestMDJournalBranchConversion(t *testing.T) {
-	codec, crypto, uid, id, signer, verifyingKey, ekg, bsplit, tempdir, j :=
+	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -262,7 +262,7 @@ func (s *limitedCryptoSigner) Sign(ctx context.Context, msg []byte) (
 }
 
 func TestMDJournalBranchConversionAtomic(t *testing.T) {
-	codec, crypto, uid, id, signer, verifyingKey, ekg, bsplit, tempdir, j :=
+	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -323,7 +323,7 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 }
 
 func TestMDJournalClear(t *testing.T) {
-	_, _, uid, id, signer, verifyingKey, ekg, bsplit, tempdir, j :=
+	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -386,7 +386,7 @@ func TestMDJournalClear(t *testing.T) {
 }
 
 func TestMDJournalRestart(t *testing.T) {
-	codec, crypto, uid, id, signer, verifyingKey, ekg,
+	uid, verifyingKey, codec, crypto, id, signer, ekg,
 		bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -440,7 +440,7 @@ func TestMDJournalRestart(t *testing.T) {
 }
 
 func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
-	codec, crypto, uid, id, signer, verifyingKey, ekg,
+	uid, verifyingKey, codec, crypto, id, signer, ekg,
 		bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -222,6 +222,16 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	err := j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
+	// Branch conversion shouldn't leave old folders behind.
+	fileInfos, err := ioutil.ReadDir(j.dir)
+	require.NoError(t, err)
+	for _, fileInfo := range fileInfos {
+		t.Logf("name = %s", fileInfo.Name())
+	}
+	require.Equal(t, 2, len(fileInfos))
+	require.Equal(t, "md_journal", fileInfos[0].Name())
+	require.Equal(t, "mds", fileInfos[1].Name())
+
 	ibrmds, err := j.getRange(
 		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -384,3 +384,57 @@ func TestMDJournalClear(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 }
+
+func TestMDJournalRestart(t *testing.T) {
+	codec, crypto, uid, id, signer, verifyingKey, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	// Push some new metadata blocks.
+
+	ctx := context.Background()
+
+	firstRevision := MetadataRevision(10)
+	firstPrevRoot := fakeMdID(1)
+	mdCount := 10
+
+	prevRoot := firstPrevRoot
+	for i := 0; i < mdCount; i++ {
+		revision := firstRevision + MetadataRevision(i)
+		md := makeMDForTest(t, id, revision, uid, prevRoot)
+		mdID, err := j.put(
+			ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+		require.NoError(t, err)
+		prevRoot = mdID
+	}
+
+	// Restart journal.
+	j, err := makeMDJournal(uid, verifyingKey, codec, crypto, j.dir, j.log)
+	require.NoError(t, err)
+
+	require.Equal(t, mdCount, getMDJournalLength(t, j))
+
+	// Should now be non-empty.
+
+	ibrmds, err := j.getRange(
+		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
+	require.NoError(t, err)
+	require.Equal(t, mdCount, len(ibrmds))
+
+	require.Equal(t, firstRevision, ibrmds[0].RevisionNumber())
+	require.Equal(t, firstPrevRoot, ibrmds[0].GetPrevRoot())
+	err = ibrmds[0].IsValidAndSigned(codec, crypto)
+	require.NoError(t, err)
+	err = ibrmds[0].IsLastModifiedBy(uid, verifyingKey)
+	require.NoError(t, err)
+
+	for i := 1; i < len(ibrmds); i++ {
+		err := ibrmds[i].IsValidAndSigned(codec, crypto)
+		require.NoError(t, err)
+		err = ibrmds[i].IsLastModifiedBy(uid, verifyingKey)
+		require.NoError(t, err)
+		err = ibrmds[i-1].CheckValidSuccessor(
+			ibrmds[i-1].mdID, ibrmds[i].BareRootMetadata)
+		require.NoError(t, err)
+	}
+}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -123,18 +123,13 @@ func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
 	expectedMergeStatus MergeStatus, expectedBranchID BranchID) {
 	uid := c.cig.uid
 	verifyingKey := c.crypto.signingKey.GetVerifyingKey()
-
-	require.Equal(c.t, expectedRevision, rmds.MD.RevisionNumber())
-	require.Equal(c.t, expectedPrevRoot, rmds.MD.GetPrevRoot())
-	require.Equal(c.t, expectedMergeStatus, rmds.MD.MergedStatus())
+	checkBRMD(c.t, uid, verifyingKey, c.Codec(), c.Crypto(),
+		rmds.MD, expectedRevision, expectedPrevRoot,
+		expectedMergeStatus, expectedBranchID)
 	err := rmds.IsValidAndSigned(c.Codec(), c.Crypto())
 	require.NoError(c.t, err)
 	err = rmds.IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(c.t, err)
-
-	require.Equal(c.t, expectedMergeStatus == Merged,
-		expectedBranchID == NullBranchID)
-	require.Equal(c.t, expectedBranchID, rmds.MD.BID())
 }
 
 func (c testTLFJournalConfig) checkRange(rmdses []*RootMetadataSigned,


### PR DESCRIPTION
makeMDJournal has to load MDs to set its branch ID,
but doing so checks the loaded MDs against the
(empty) branch ID, so if the journal is on a
branch, it would refuse to load.

Also fix an incorrect path for the tempdir used
in branch conversion, and guarantee that it's
cleaned up.

Add regression tests for both.

Clean up md_journal_test.go a bit.