### PR TITLE
kbfs_cr_test: fix unembedded test on 386 platforms

### DIFF
--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -442,8 +442,10 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 		if !ok1 || !ok2 {
 			t.Fatalf("Couldn't convert BlockSplitters!")
 		}
-		bss1.blockChangeEmbedMaxSize = 256
-		bss2.blockChangeEmbedMaxSize = 256
+		// 128 seems to be a good size that works on both 386 and x64
+		// platforms.
+		bss1.blockChangeEmbedMaxSize = 128
+		bss2.blockChangeEmbedMaxSize = 128
 	}
 
 	name := userName1.String() + "," + userName2.String()


### PR DESCRIPTION
For some reason on 386 platforms, the CR revision is less than 256
bytes, but on x64 platforms it's more.  Handle both by dropping the
limit down to 128 bytes.

Issue: KBFS-1480