### PR TITLE
Fix crash on kbfsfuse --help

### DIFF
--- a/libkbfs/flag_size.go
+++ b/libkbfs/flag_size.go
@@ -20,7 +20,12 @@ func (sf SizeFlag) Get() interface{} { return *sf.v }
 
 // String for flag interface.
 func (sf SizeFlag) String() string {
-	v := int64(*sf.v)
+	// This happens when izZeroValue() from flag.go makes a zero
+	// value from the type of a flag.
+	if sf.v == nil {
+		return "0"
+	}
+	v := *sf.v
 	var suffix string
 	const units = "kmgt"
 	var c byte

--- a/libkbfs/flag_size_test.go
+++ b/libkbfs/flag_size_test.go
@@ -36,3 +36,11 @@ func TestSizeFlag(t *testing.T) {
 		mult *= 1024
 	}
 }
+
+func TestSizeFlagZero(t *testing.T) {
+	var f SizeFlag
+	s := f.String()
+	if s != "0" {
+		t.Errorf("Expected 0, got %s", s)
+	}
+}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -124,9 +124,9 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.StringVar(&params.LogFileConfig.Path, "log-file", "", "Path to log file")
 	flags.DurationVar(&params.LogFileConfig.MaxAge, "log-file-max-age", defaultParams.LogFileConfig.MaxAge, "Maximum age of a log file before rotation")
 	params.LogFileConfig.MaxSize = defaultParams.LogFileConfig.MaxSize
-	flag.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
+	flags.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
 	// The default is to *DELETE* old log files for kbfs.
-	flag.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
+	flags.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
 	flags.StringVar(&params.WriteJournalRoot, "write-journal-root-this-may-lose-data", "", "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	return &params
 }


### PR DESCRIPTION
flag.go was creating a zero value from each flag type,
which was causing a panic in FlagSize.

Also set the string value of FlagSize to be "0"
(instead of "0t").

Also fix a few typos in init.go.