### PR TITLE
block_journal: track the number of block bytes in a TLF's journal

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -63,13 +63,13 @@ type blockJournal struct {
 	refs       map[BlockID]blockRefMap
 	isShutdown bool
 
-	// Tracks the total size of on-disk blocks that will be put to the
-	// server (i.e., does not count reference adds).  It is only
+	// Tracks the total size of on-disk blocks that will be flushed to
+	// the server (i.e., does not count reference adds).  It is only
 	// accurate for users of this journal that properly flush entries;
-	// in particular, direct calls to `removeReferences` can cause
-	// this count to deviate from the actual disk usage of the
-	// journal.
-	blockBytes int64
+	// in particular, calls to `removeReferences` with
+	// removeUnreferencedBlocks set to true can cause this count to
+	// deviate from the actual disk usage of the journal.
+	unflushedBytes int64
 }
 
 type bserverOpName string
@@ -135,12 +135,13 @@ func makeBlockJournal(
 		j:        j,
 	}
 
-	refs, err := journal.readJournal(ctx)
+	refs, unflushedBytes, err := journal.readJournal(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	journal.refs = refs
+	journal.unflushedBytes = unflushedBytes
 	return journal, nil
 }
 
@@ -176,29 +177,30 @@ func (j *blockJournal) readJournalEntry(ordinal journalOrdinal) (
 }
 
 // readJournal reads the journal and returns a map of all the block
-// references in the journal.
+// references in the journal and the total number of bytes that need
+// flushing.
 func (j *blockJournal) readJournal(ctx context.Context) (
-	map[BlockID]blockRefMap, error) {
+	map[BlockID]blockRefMap, int64, error) {
 	refs := make(map[BlockID]blockRefMap)
 
 	first, err := j.j.readEarliestOrdinal()
 	if os.IsNotExist(err) {
-		return refs, nil
+		return refs, 0, nil
 	} else if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	last, err := j.j.readLatestOrdinal()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	j.log.CDebugf(ctx, "Reading journal entries %d to %d", first, last)
 
-	var blockBytes int64
+	var unflushedBytes int64
 	for i := first; i <= last; i++ {
 		e, err := j.readJournalEntry(i)
 		if err != nil {
-			return nil, err
+			return nil, 0, err
 		}
 
 		// Handle single ops separately.
@@ -206,7 +208,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 		case blockPutOp, addRefOp:
 			id, context, err := e.getSingleContext()
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 
 			blockRefs := refs[id]
@@ -217,7 +219,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 
 			err = blockRefs.put(context, liveBlockRef)
 			if err != nil {
-				return nil, err
+				return nil, 0, err
 			}
 
 			// Only puts count as bytes, on the assumption that the
@@ -230,9 +232,9 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 				// BlockServerDisk can remove block data without
 				// deleting the corresponding addRef.
 				if err != nil && !os.IsNotExist(err) {
-					return nil, err
+					return nil, 0, err
 				}
-				blockBytes += b
+				unflushedBytes += b
 			}
 
 			continue
@@ -252,7 +254,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 				for _, context := range idContexts {
 					err := blockRefs.remove(context)
 					if err != nil {
-						return nil, err
+						return nil, 0, err
 					}
 				}
 
@@ -270,18 +272,17 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 					err := blockRefs.put(
 						context, archivedBlockRef)
 					if err != nil {
-						return nil, err
+						return nil, 0, err
 					}
 				}
 
 			default:
-				return nil, fmt.Errorf("Unknown op %s", e.Op)
+				return nil, 0, fmt.Errorf("Unknown op %s", e.Op)
 			}
 		}
 	}
-	j.log.CDebugf(ctx, "Found %d block bytes in the journal", blockBytes)
-	j.blockBytes = blockBytes
-	return refs, nil
+	j.log.CDebugf(ctx, "Found %d block bytes in the journal", unflushedBytes)
+	return refs, unflushedBytes, nil
 }
 
 func (j *blockJournal) writeJournalEntry(
@@ -497,7 +498,7 @@ func (j *blockJournal) putData(
 	if err != nil {
 		return err
 	}
-	j.blockBytes += int64(len(buf))
+	j.unflushedBytes += int64(len(buf))
 
 	// TODO: Add integrity-checking for key server half?
 
@@ -573,6 +574,11 @@ func (j *blockJournal) addReference(
 		addRefOp, map[BlockID][]BlockContext{id: {context}})
 }
 
+// removeReferences fixes up the in-memory reference map to delete the
+// given references.  If removeUnreferencedBlocks is true, it will
+// also delete the corresponding blocks from the disk.  However, in
+// that case, j.unflushedBytes will no longer be accurate and
+// shouldn't be relied upon.
 func (j *blockJournal) removeReferences(
 	ctx context.Context, contexts map[BlockID][]BlockContext,
 	removeUnreferencedBlocks bool) (liveCounts map[BlockID]int, err error) {
@@ -610,8 +616,6 @@ func (j *blockJournal) removeReferences(
 		if count == 0 {
 			delete(j.refs, id)
 			if removeUnreferencedBlocks {
-				// TODO: Decrement j.blockBytes, but only if the block
-				// was part of a blockPutOp, not an addRefOp.
 				err := os.RemoveAll(j.blockPath(id))
 				if err != nil {
 					return nil, err
@@ -795,11 +799,11 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 			return err
 		}
 
-		if b > j.blockBytes {
+		if b > j.unflushedBytes {
 			return fmt.Errorf("Block %v is bigger than our current count "+
-				"of journal block bytes (%d > %d)", id, b, j.blockBytes)
+				"of journal block bytes (%d > %d)", id, b, j.unflushedBytes)
 		}
-		j.blockBytes -= b
+		j.unflushedBytes -= b
 	}
 
 	earliestOrdinal, err := j.j.readEarliestOrdinal()
@@ -819,11 +823,12 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 
 	// TODO: This is a hack to work around KBFS-1439. Figure out a
 	// better way to update j.refs to reflect the removed entry.
-	refs, err := j.readJournal(ctx)
+	refs, unflushedBytes, err := j.readJournal(ctx)
 	if err != nil {
 		return err
 	}
 	j.refs = refs
+	j.unflushedBytes = unflushedBytes
 
 	return nil
 }
@@ -833,7 +838,7 @@ func (j *blockJournal) shutdown() {
 
 	// Double-check the on-disk journal with the in-memory one.
 	ctx := context.Background()
-	refs, err := j.readJournal(ctx)
+	refs, _, err := j.readJournal(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -79,10 +79,14 @@ func TestBlockJournalBasic(t *testing.T) {
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
 
+	blockBytes := j.blockBytes
+	require.Equal(t, blockBytes, int64(len(data)))
+
 	// Shutdown and restart.
 	j.shutdown()
 	j, err = makeBlockJournal(ctx, codec, crypto, tempdir, log)
 	require.NoError(t, err)
+	require.Equal(t, blockBytes, j.blockBytes)
 
 	require.Equal(t, 2, getBlockJournalLength(t, j))
 
@@ -146,7 +150,7 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 
 	// Remove references.
 	liveCounts, err := j.removeReferences(
-		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}}, true)
+		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}}, false)
 	require.NoError(t, err)
 	require.Equal(t, map[BlockID]int{bID: 0}, liveCounts)
 	require.Equal(t, 3, getBlockJournalLength(t, j))

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -79,14 +79,14 @@ func TestBlockJournalBasic(t *testing.T) {
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
 
-	blockBytes := j.blockBytes
-	require.Equal(t, blockBytes, int64(len(data)))
+	unflushedBytes := j.unflushedBytes
+	require.Equal(t, unflushedBytes, int64(len(data)))
 
 	// Shutdown and restart.
 	j.shutdown()
 	j, err = makeBlockJournal(ctx, codec, crypto, tempdir, log)
 	require.NoError(t, err)
-	require.Equal(t, blockBytes, j.blockBytes)
+	require.Equal(t, unflushedBytes, j.unflushedBytes)
 
 	require.Equal(t, 2, getBlockJournalLength(t, j))
 
@@ -150,7 +150,7 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 
 	// Remove references.
 	liveCounts, err := j.removeReferences(
-		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}}, false)
+		ctx, map[BlockID][]BlockContext{bID: {bCtx, bCtx2}}, true)
 	require.NoError(t, err)
 	require.Equal(t, map[BlockID]int{bID: 0}, liveCounts)
 	require.Equal(t, 3, getBlockJournalLength(t, j))

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -19,9 +19,9 @@ import (
 // JournalServer for display in diagnostics. It is suitable for
 // encoding directly as JSON.
 type JournalServerStatus struct {
-	RootDir      string
-	JournalCount int
-	BlockBytes   int64 // (signed because os.FileInfo.Size() is signed)
+	RootDir        string
+	JournalCount   int
+	UnflushedBytes int64 // (signed because os.FileInfo.Size() is signed)
 }
 
 // TODO: JournalServer isn't really a server, although it can create
@@ -242,19 +242,19 @@ func (j *JournalServer) mdOps() journalMDOps {
 // Status returns a JournalServerStatus object suitable for
 // diagnostics.
 func (j *JournalServer) Status() JournalServerStatus {
-	journalCount, blockBytes := func() (int, int64) {
+	journalCount, unflushedBytes := func() (int, int64) {
 		j.lock.RLock()
 		defer j.lock.RUnlock()
-		var blockBytes int64
+		var unflushedBytes int64
 		for _, tlfJournal := range j.tlfJournals {
-			blockBytes += tlfJournal.getBlockBytes()
+			unflushedBytes += tlfJournal.getUnflushedBytes()
 		}
-		return len(j.tlfJournals), blockBytes
+		return len(j.tlfJournals), unflushedBytes
 	}()
 	return JournalServerStatus{
-		RootDir:      j.dir,
-		JournalCount: journalCount,
-		BlockBytes:   blockBytes,
+		RootDir:        j.dir,
+		JournalCount:   journalCount,
+		UnflushedBytes: unflushedBytes,
 	}
 }
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -49,6 +49,7 @@ type TLFJournalStatus struct {
 	RevisionEnd   MetadataRevision
 	BranchID      string
 	BlockOpCount  uint64
+	BlockBytes    int64 // (signed because os.FileInfo.Size() is signed)
 }
 
 // TLFJournalBackgroundWorkStatus indicates whether a journal should
@@ -602,7 +603,14 @@ func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 		RevisionStart: earliestRevision,
 		RevisionEnd:   latestRevision,
 		BlockOpCount:  blockEntryCount,
+		BlockBytes:    j.blockJournal.blockBytes,
 	}, nil
+}
+
+func (j *tlfJournal) getBlockBytes() int64 {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	return j.blockJournal.blockBytes
 }
 
 func (j *tlfJournal) shutdown() {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -45,11 +45,11 @@ func (ca tlfJournalConfigAdapter) encryptionKeyGetter() encryptionKeyGetter {
 // display in diagnostics. It is suitable for encoding directly as
 // JSON.
 type TLFJournalStatus struct {
-	RevisionStart MetadataRevision
-	RevisionEnd   MetadataRevision
-	BranchID      string
-	BlockOpCount  uint64
-	BlockBytes    int64 // (signed because os.FileInfo.Size() is signed)
+	RevisionStart  MetadataRevision
+	RevisionEnd    MetadataRevision
+	BranchID       string
+	BlockOpCount   uint64
+	UnflushedBytes int64 // (signed because os.FileInfo.Size() is signed)
 }
 
 // TLFJournalBackgroundWorkStatus indicates whether a journal should
@@ -599,18 +599,18 @@ func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 		return TLFJournalStatus{}, err
 	}
 	return TLFJournalStatus{
-		BranchID:      j.mdJournal.getBranchID().String(),
-		RevisionStart: earliestRevision,
-		RevisionEnd:   latestRevision,
-		BlockOpCount:  blockEntryCount,
-		BlockBytes:    j.blockJournal.blockBytes,
+		BranchID:       j.mdJournal.getBranchID().String(),
+		RevisionStart:  earliestRevision,
+		RevisionEnd:    latestRevision,
+		BlockOpCount:   blockEntryCount,
+		UnflushedBytes: j.blockJournal.unflushedBytes,
 	}, nil
 }
 
-func (j *tlfJournal) getBlockBytes() int64 {
+func (j *tlfJournal) getUnflushedBytes() int64 {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	return j.blockJournal.blockBytes
+	return j.blockJournal.unflushedBytes
 }
 
 func (j *tlfJournal) shutdown() {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -485,6 +485,7 @@ func TestTLFJournalFlushBlock(t *testing.T) {
 	bID, bCtx, serverHalf := config.makeBlock(data)
 	err := tlfJournal.putBlockData(ctx, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
+	require.NotZero(t, tlfJournal.blockJournal.blockBytes)
 
 	// Add some references.
 
@@ -597,6 +598,7 @@ func TestTLFJournalFlushBlock(t *testing.T) {
 	_, e, _, _, err := tlfJournal.blockJournal.getNextEntryToFlush(ctx)
 	require.NoError(t, err)
 	require.Nil(t, e)
+	require.Zero(t, tlfJournal.blockJournal.blockBytes)
 }
 
 type shimMDServer struct {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -485,7 +485,7 @@ func TestTLFJournalFlushBlock(t *testing.T) {
 	bID, bCtx, serverHalf := config.makeBlock(data)
 	err := tlfJournal.putBlockData(ctx, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
-	require.NotZero(t, tlfJournal.blockJournal.blockBytes)
+	require.NotZero(t, tlfJournal.getUnflushedBytes())
 
 	// Add some references.
 
@@ -598,7 +598,7 @@ func TestTLFJournalFlushBlock(t *testing.T) {
 	_, e, _, _, err := tlfJournal.blockJournal.getNextEntryToFlush(ctx)
 	require.NoError(t, err)
 	require.Nil(t, e)
-	require.Zero(t, tlfJournal.blockJournal.blockBytes)
+	require.Zero(t, tlfJournal.getUnflushedBytes())
 }
 
 type shimMDServer struct {


### PR DESCRIPTION
For now, don't count addRefOps as having block bytes, even though they
have blocks on disk, since they won't actually be transferred in most
cases.

Also, roll all journal blockBytes into the overall KBFS status file.

Issue: KBFS-1411