### PR TITLE
dsl_test: allow journaling

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -727,7 +727,7 @@ func (c *ConfigLocal) Shutdown() error {
 					return err
 				}
 				if jServer, err := GetJournalServer(config); err == nil {
-					if err := jServer.Flush(context.Background(),
+					if err := jServer.Wait(context.Background(),
 						fbo.id()); err != nil {
 						return err
 					}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4168,8 +4168,9 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 		return errors.New("Can't sync from server while dirty.")
 	}
 
+	// A journal flush, if needed.
 	if jServer, err := GetJournalServer(fbo.config); err == nil {
-		if err := jServer.Flush(context.Background(),
+		if err := jServer.Wait(context.Background(),
 			fbo.id()); err != nil {
 			return err
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4168,6 +4168,13 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 		return errors.New("Can't sync from server while dirty.")
 	}
 
+	if jServer, err := GetJournalServer(fbo.config); err == nil {
+		if err := jServer.Flush(context.Background(),
+			fbo.id()); err != nil {
+			return err
+		}
+	}
+
 	if err := fbo.getAndApplyMDUpdates(ctx, lState, fbo.applyMDUpdates); err != nil {
 		if applyErr, ok := err.(MDRevisionMismatch); ok {
 			if applyErr.rev == applyErr.curr {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -14,8 +14,6 @@ import (
 	"runtime/pprof"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 )
@@ -372,24 +370,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	// used.
 
 	if len(params.WriteJournalRoot) > 0 {
-		// TODO: Sanity-check the root directory, e.g. create
-		// it if it doesn't exist, make sure that it doesn't
-		// point to /keybase itself, etc.
-		log := config.MakeLogger("")
-		jServer := makeJournalServer(
-			config, log, params.WriteJournalRoot,
-			config.BlockCache(),
-			config.BlockServer(), config.MDOps())
-		ctx := context.Background()
-		err := jServer.EnableExistingJournals(
-			ctx, TLFJournalBackgroundWorkEnabled)
-		if err == nil {
-			config.SetBlockCache(jServer.blockCache())
-			config.SetBlockServer(jServer.blockServer())
-			config.SetMDOps(jServer.mdOps())
-		} else {
-			log.Warning("Failed to enable existing journals: %v", err)
-		}
+		config.EnableJournaling(params.WriteJournalRoot)
 	}
 
 	return config, nil

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -189,6 +189,20 @@ func (j *JournalServer) Flush(ctx context.Context, tlfID TlfID) (err error) {
 	return nil
 }
 
+// Wait blocks until the write journal has finished flushing
+// everything.  It is essentially the same as Flush() when the journal
+// is enabled and unpaused, except that it is safe to cancel the
+// context without leaving the journal in a partially-flushed state.
+func (j *JournalServer) Wait(ctx context.Context, tlfID TlfID) (err error) {
+	j.log.CDebugf(ctx, "Waiting on journal for %s", tlfID)
+	if tlfJournal, ok := j.getTLFJournal(tlfID); ok {
+		return tlfJournal.wait(ctx)
+	}
+
+	j.log.CDebugf(ctx, "Journal not enabled for %s", tlfID)
+	return nil
+}
+
 // Disable turns off the write journal for the given TLF.
 func (j *JournalServer) Disable(ctx context.Context, tlfID TlfID) (err error) {
 	j.log.CDebugf(ctx, "Disabling journal for %s", tlfID)

--- a/test/engine.go
+++ b/test/engine.go
@@ -41,7 +41,7 @@ type Engine interface {
 	// default engine timeout, or if it is zero, it has no effect.
 	InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 		bwKBps int, opTimeout time.Duration, users []libkb.NormalizedUsername,
-		clock libkbfs.Clock) map[libkb.NormalizedUsername]User
+		clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User
 	// GetUID is called by the test harness to retrieve a user instance's UID.
 	GetUID(u User) keybase1.UID
 	// GetFavorites returns the set of all public or private
@@ -118,6 +118,12 @@ type Engine interface {
 	AddNewAssertion(u User, oldAssertion, newAssertion string) (err error)
 	// Rekey rekeys the given TLF under the given user.
 	Rekey(u User, tlfName string, isPublic bool) (err error)
+	// EnableJournal is called by the test harness as the given
+	// user to enable journaling.
+	EnableJournal(u User, tlfName string, isPublic bool) (err error)
+	// FlushJournal is called by the test harness as the given
+	// user to wait for the journal to flush, if enabled.
+	FlushJournal(u User, tlfName string, isPublic bool) (err error)
 	// Shutdown is called by the test harness when it is done with the
 	// given user.
 	Shutdown(u User) error

--- a/test/journal_test.go
+++ b/test/journal_test.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// These tests all do one conflict-free operation while a user is unstaged.
+
+package test
+
+import (
+	"testing"
+)
+
+// bob creates a file while running the journal.
+func TestJournalSimple(t *testing.T) {
+	test(t, journal(),
+		users("alice", "bob"),
+		as(alice,
+			mkdir("a"),
+		),
+		as(bob,
+			enableJournal(),
+			mkfile("a/b", "hello"),
+			// Check the data -- this should read from the journal if
+			// it hasn't flushed yet.
+			lsdir("a/", m{"b$": "FILE"}),
+			read("a/b", "hello"),
+			flushJournal(),
+		),
+		as(alice,
+			lsdir("a/", m{"b$": "FILE"}),
+			read("a/b", "hello"),
+		),
+	)
+}


### PR DESCRIPTION
This will be useful in upcoming PRs for KBFS-1267 and KBFS-1268.

Note that once #295 is in, we can hopefully remove the new StateChecker-skipping code.