### PR TITLE
[KBFS-1489] Fix tricky edge cases in journalMDOps.PutUnmerged

### DIFF
--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -330,23 +330,7 @@ func (j journalMDOps) Put(ctx context.Context, rmd *RootMetadata) (
 func (j journalMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
-		// TODO: The code below races with PruneBranch, since
-		// the branch may get prunes after the
-		// GerUnmergedForTLF call and before the putMD
-		// call. Fix this.
-
 		rmd.SetUnmerged()
-		if rmd.BID() == NullBranchID {
-			head, err := j.GetUnmergedForTLF(
-				ctx, rmd.TlfID(), NullBranchID)
-			if err != nil {
-				return MdID{}, err
-			}
-			if head != (ImmutableRootMetadata{}) {
-				rmd.SetBranchID(head.BID())
-			}
-		}
-
 		return tlfJournal.putMD(ctx, rmd)
 	}
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -342,14 +342,7 @@ func (j journalMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (
 			if err != nil {
 				return MdID{}, err
 			}
-			if head == (ImmutableRootMetadata{}) {
-				// new branch ID
-				bid, err := j.jServer.config.Crypto().MakeRandomBranchID()
-				if err != nil {
-					return MdID{}, err
-				}
-				rmd.SetBranchID(bid)
-			} else {
+			if head != (ImmutableRootMetadata{}) {
 				rmd.SetBranchID(head.BID())
 			}
 		}

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -245,7 +245,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 // TODO: Add a test for GetRange where the server has an overlapping
 // range with the journal.
 
-func TestJournalMDOpsPutUnmerged(t *testing.T) {
+func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	tempdir, config, _, jServer := setupJournalMDOpsTest(t)
 	defer teardownJournalMDOpsTest(t, tempdir, config)
 
@@ -271,5 +271,5 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, MetadataRevision(1))
 
 	_, err = mdOps.PutUnmerged(ctx, rmd)
-	require.NotNil(t, err)
+	require.Error(t, err, "Unmerged put with rmd.BID() == j.branchID == NullBranchID")
 }

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -271,8 +271,5 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, MetadataRevision(1))
 
 	_, err = mdOps.PutUnmerged(ctx, rmd)
-	require.NoError(t, err)
-
-	require.Equal(t, Unmerged, rmd.MergedStatus())
-	require.NotEqual(t, NullBranchID, rmd.BID())
+	require.NotNil(t, err)
 }

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -654,28 +654,10 @@ func (j *mdJournal) put(
 
 	if (mStatus == Unmerged) && (rmd.BID() == NullBranchID) {
 		if lastBranchID == NullBranchID {
-			if (head != ImmutableBareRootMetadata{}) {
-				return MdID{}, errors.New(
-					"Unmerged put with rmd.BID() == NullBranchID but a non-empty merged journal")
-			}
-
-			// Need a new branch ID.
-			bid, err := j.crypto.MakeRandomBranchID()
-			if err != nil {
-				return MdID{}, err
-			}
-
-			j.log.CDebugf(ctx, "Using new branch ID %s", bid)
-
-			lastBranchID = bid
-			j.branchID = bid
-			// Revert j.branchID if we run into an error.
-			defer func() {
-				if err != nil {
-					j.branchID = NullBranchID
-				}
-			}()
+			return MdID{}, errors.New(
+				"Unmerged put with rmd.BID() == j.branchID == NullBranchID")
 		}
+
 		j.log.CDebugf(
 			ctx, "Changing branch ID to %s and prev root to %s for MD for TLF=%s with rev=%s",
 			lastBranchID, lastMdID, rmd.TlfID(), rmd.Revision())

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -653,9 +653,32 @@ func (j *mdJournal) put(
 	mStatus := rmd.MergedStatus()
 
 	if (mStatus == Unmerged) && (rmd.BID() == NullBranchID) {
+		if lastBranchID == NullBranchID {
+			if (head != ImmutableBareRootMetadata{}) {
+				return MdID{}, errors.New(
+					"Unmerged put with rmd.BID() == NullBranchID but a non-empty merged journal")
+			}
+
+			// Need a new branch ID.
+			bid, err := j.crypto.MakeRandomBranchID()
+			if err != nil {
+				return MdID{}, err
+			}
+
+			j.log.CDebugf(ctx, "Using new branch ID %s", bid)
+
+			lastBranchID = bid
+			j.branchID = bid
+			// Revert j.branchID if we run into an error.
+			defer func() {
+				if err != nil {
+					j.branchID = NullBranchID
+				}
+			}()
+		}
 		j.log.CDebugf(
 			ctx, "Changing branch ID to %s and prev root to %s for MD for TLF=%s with rev=%s",
-			lastBranchID, lastMdID, rmd.TlfID(), rmd.Revision(), rmd.BID())
+			lastBranchID, lastMdID, rmd.TlfID(), rmd.Revision())
 		rmd.SetBranchID(lastBranchID)
 		rmd.SetPrevRoot(lastMdID)
 	}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -176,6 +176,21 @@ func TestMDJournalBasic(t *testing.T) {
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 }
 
+func TestMDJournalPutCase1Empty(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+
+	head, err := j.getHead(uid, verifyingKey)
+	require.NoError(t, err)
+	require.Equal(t, md.bareMd, head.BareRootMetadata)
+}
+
 func TestMDJournalReplaceHead(t *testing.T) {
 	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -346,6 +346,31 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+
+	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	require.NoError(t, err)
+
+	// Flush.
+	mdID, rmds, err := j.getNextEntryToFlush(ctx, uid, verifyingKey, signer)
+	require.NoError(t, err)
+	j.removeFlushedEntry(ctx, uid, verifyingKey, mdID, rmds)
+
+	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, mdID)
+	md2.SetUnmerged()
+	md2.SetBranchID(j.branchID)
+	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md2)
+	require.NoError(t, err)
+}
+
 func TestMDJournalBranchConversion(t *testing.T) {
 	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -301,6 +301,51 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+
+	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	require.NoError(t, err)
+
+	head, err := j.getHead(uid, verifyingKey)
+	require.NoError(t, err)
+
+	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, head.mdID)
+	md2.SetUnmerged()
+	md2.SetBranchID(head.BID())
+	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md2)
+	require.NoError(t, err)
+}
+
+func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+
+	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	require.NoError(t, err)
+
+	head, err := j.getHead(uid, verifyingKey)
+	require.NoError(t, err)
+
+	md.SetUnmerged()
+	md.SetBranchID(head.BID())
+	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+}
+
 func TestMDJournalBranchConversion(t *testing.T) {
 	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -240,7 +240,7 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	require.Equal(t, md.DiskUsage(), head.DiskUsage())
 }
 
-func TestMDJournalPutCase2NonEmptyNoReplace(t *testing.T) {
+func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
 	uid, verifyingKey, _, _, id, signer, ekg,
 		bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
@@ -255,7 +255,7 @@ func TestMDJournalPutCase2NonEmptyNoReplace(t *testing.T) {
 
 	md.SetUnmerged()
 	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
-	require.Error(t, err, "Replacing revision 10 disallowed")
+	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -191,6 +191,23 @@ func TestMDJournalPutCase1Empty(t *testing.T) {
 	require.Equal(t, md.bareMd, head.BareRootMetadata)
 }
 
+func TestMDJournalPutCase1Conflict(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+
+	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	require.NoError(t, err)
+
+	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.Equal(t, MDJournalConflictError{}, err)
+}
+
 func TestMDJournalReplaceHead(t *testing.T) {
 	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -208,7 +208,9 @@ func TestMDJournalPutCase1Conflict(t *testing.T) {
 	require.Equal(t, MDJournalConflictError{}, err)
 }
 
-func TestMDJournalReplaceHead(t *testing.T) {
+// The append portion of case 1 is covered by TestMDJournalBasic.
+
+func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
@@ -236,6 +238,24 @@ func TestMDJournalReplaceHead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, md.Revision(), head.RevisionNumber())
 	require.Equal(t, md.DiskUsage(), head.DiskUsage())
+}
+
+func TestMDJournalPutCase2NonEmpty(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+
+	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	require.NoError(t, err)
+
+	md.SetUnmerged()
+	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
 }
 
 func TestMDJournalBranchConversion(t *testing.T) {

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -371,6 +371,19 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestMDJournalPutCase4(t *testing.T) {
+	uid, verifyingKey, _, _, id, signer, ekg,
+		bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	ctx := context.Background()
+	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	md.SetUnmerged()
+	md.SetBranchID(FakeBranchID(1))
+	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	require.NoError(t, err)
+}
+
 func TestMDJournalBranchConversion(t *testing.T) {
 	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)


### PR DESCRIPTION
Enumerate in detail the cases the mdJournal.put expects
to handle, and have journalMDOps.PutUnmerged simply forward
to mdJournal.put.

Add test coverage for all cases in mdJournal.put. Add more
test coverage for journalMDOps.PutUnmerged.