### PR TITLE
libkbfs: add v3 metadata (WIP)

### DIFF
--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1,0 +1,1006 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
+)
+
+// WriterMetadataV3 stores the metadata for a TLF that is
+// only editable by users with writer permissions.
+type WriterMetadataV3 struct {
+	// Serialized, possibly encrypted, version of the PrivateMetadata
+	SerializedPrivateMetadata []byte `codec:"data"`
+
+	// The last KB user with writer permissions to this TLF
+	// who modified this WriterMetadata
+	LastModifyingWriter keybase1.UID `codec:"lmw"`
+
+	// For public TLFs (since those don't have any keys at all).
+	Writers []keybase1.UID `codec:",omitempty"`
+	// Writers identified by unresolved social assertions.
+	UnresolvedWriters []keybase1.SocialAssertion `codec:"uw,omitempty"`
+	// Pointer to the writer key bundle for private TLFs.
+	WKeyBundleID TLFWriterKeyBundleID `codec:"wkid,omitempty"`
+	// Latest key generation.
+	LatestKeyGen KeyGen `codec:"lkg"`
+
+	// The directory ID, signed over to make verification easier
+	ID TlfID
+	// The branch ID, currently only set if this is in unmerged per-device history.
+	BID BranchID
+	// Flags
+	WFlags WriterFlags
+
+	// Estimated disk usage at this revision
+	DiskUsage uint64
+	// The total number of bytes in new blocks
+	RefBytes uint64
+	// The total number of bytes in unreferenced blocks
+	UnrefBytes uint64
+
+	codec.UnknownFieldSetHandler
+}
+
+// BareRootMetadataV3 is the MD that is signed by the reader or
+// writer. Unlike RootMetadata, it contains exactly the serializable
+// metadata.
+type BareRootMetadataV3 struct {
+	// The metadata that is only editable by the writer.
+	WriterMetadata WriterMetadataV3 `codec:"wmd"`
+	// The signature for the writer metadata, to prove
+	// that it's only been changed by writers.
+	// MDv3 TODO: It would be better for journaling if we could move this
+	// to RootMetadataSigned since it references metadata by ID. We could
+	// then delay computing it until sending metadata to the server.
+	WriterMetadataSigInfo SignatureInfo `codec:"wmdsi"`
+
+	// The last KB user who modified this BareRootMetadata
+	LastModifyingUser keybase1.UID
+	// Flags
+	Flags MetadataFlags
+	// The revision number
+	Revision MetadataRevision
+	// Pointer to the previous root block ID
+	PrevRoot MdID
+
+	// For private TLFs. Any unresolved social assertions for readers.
+	UnresolvedReaders []keybase1.SocialAssertion `codec:"ur,omitempty"`
+	// Pointer to the reader key bundle for private TLFs.
+	RKeyBundleID TLFReaderKeyBundleID `codec:"rkid,omitempty"`
+
+	// ConflictInfo is set if there's a conflict for the given folder's
+	// handle after a social assertion resolution.
+	ConflictInfo *TlfHandleExtension `codec:"ci,omitempty"`
+	// FinalizedInfo is set if there are no more valid writer keys capable
+	// of writing to the given folder.
+	FinalizedInfo *TlfHandleExtension `codec:"fi,omitempty"`
+
+	codec.UnknownFieldSetHandler
+}
+
+// ExtraMetadataV3 contains references to key bundles stored outside of metadata
+// blocks.  This only ever exists in memory and is never serialized itself.
+type ExtraMetadataV3 struct {
+	wkb *TLFWriterKeyBundleV3
+	rkb *TLFReaderKeyBundleV3
+}
+
+// MetadataVersion implements the ExtraMetadata interface for ExtraMetadataV3.
+func (extra ExtraMetadataV3) MetadataVersion() MetadataVer {
+	return SegregatedKeyBundlesVer
+}
+
+// Helper function to extract key bundles for the ExtraMetadata interface.
+func getKeyBundlesV3(extra ExtraMetadata) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, bool) {
+	extraV3, ok := extra.(*ExtraMetadataV3)
+	if !ok {
+		return nil, nil, false
+	}
+	if extraV3.wkb == nil || extraV3.rkb == nil {
+		return nil, nil, false
+	}
+	return extraV3.wkb, extraV3.rkb, true
+}
+
+// TlfID implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) TlfID() TlfID {
+	return md.WriterMetadata.ID
+}
+
+// LatestKeyGeneration implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) LatestKeyGeneration() KeyGen {
+	if md.TlfID().IsPublic() {
+		return PublicKeyGen
+	}
+	return md.WriterMetadata.LatestKeyGen
+}
+
+func (md *BareRootMetadataV3) haveOnlyUserRKeysChanged(codec Codec, prevMD *BareRootMetadataV3,
+	user keybase1.UID, prevRkb, rkb TLFReaderKeyBundleV3) (bool, error) {
+	if len(rkb.RKeys) != len(prevRkb.RKeys) {
+		return false, nil
+	}
+	for u, keys := range rkb.RKeys {
+		if u != user {
+			prevKeys := prevRkb.RKeys[u]
+			keysEqual, err := CodecEqual(codec, keys, prevKeys)
+			if err != nil {
+				return false, err
+			}
+			if !keysEqual {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+// IsValidRekeyRequest implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsValidRekeyRequest(
+	codec Codec, prevBareMd BareRootMetadata, user keybase1.UID, prevExtra, extra ExtraMetadata) (
+	bool, error) {
+	if !md.IsWriterMetadataCopiedSet() {
+		// Not a copy.
+		return false, nil
+	}
+	prevMd, ok := prevBareMd.(*BareRootMetadataV3)
+	if !ok {
+		// Not the same type so not a copy.
+		return false, nil
+	}
+	prevExtraV3, ok := prevExtra.(*ExtraMetadataV3)
+	if !ok {
+		return false, errors.New("Invalid previous extra metadata")
+	}
+	extraV3, ok := extra.(*ExtraMetadataV3)
+	if !ok {
+		return false, errors.New("Invalid extra metadata")
+	}
+	writerEqual, err := CodecEqual(
+		codec, md.WriterMetadata, prevMd.WriterMetadata)
+	if err != nil {
+		return false, err
+	}
+	if !writerEqual {
+		// Copy mismatch.
+		return false, nil
+	}
+	writerSigInfoEqual, err := CodecEqual(codec,
+		md.WriterMetadataSigInfo, prevMd.WriterMetadataSigInfo)
+	if err != nil {
+		return false, err
+	}
+	if !writerSigInfoEqual {
+		// Signature/public key mismatch.
+		return false, nil
+	}
+	onlyUserRKeysChanged, err := md.haveOnlyUserRKeysChanged(
+		codec, prevMd, user, *prevExtraV3.rkb, *extraV3.rkb)
+	if err != nil {
+		return false, err
+	}
+	if !onlyUserRKeysChanged {
+		// Keys outside of this user's reader key set have changed.
+		return false, nil
+	}
+	return true, nil
+}
+
+// MergedStatus implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) MergedStatus() MergeStatus {
+	if md.WriterMetadata.WFlags&MetadataFlagUnmerged != 0 {
+		return Unmerged
+	}
+	return Merged
+}
+
+// IsRekeySet implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsRekeySet() bool {
+	return md.Flags&MetadataFlagRekey != 0
+}
+
+// IsWriterMetadataCopiedSet implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsWriterMetadataCopiedSet() bool {
+	return md.Flags&MetadataFlagWriterMetadataCopied != 0
+}
+
+// IsFinal implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsFinal() bool {
+	return md.Flags&MetadataFlagFinal != 0
+}
+
+// IsWriter implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsWriter(
+	user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	if md.TlfID().IsPublic() {
+		for _, w := range md.WriterMetadata.Writers {
+			if w == user {
+				return true
+			}
+		}
+		return false
+	}
+	wkb, _, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return false
+	}
+	return wkb.IsWriter(user, deviceKID)
+}
+
+// IsReader implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsReader(
+	user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	if md.TlfID().IsPublic() {
+		return true
+	}
+	_, rkb, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return false
+	}
+	return rkb.IsReader(user, deviceKID)
+}
+
+// Update implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) Update(id TlfID, h BareTlfHandle) error {
+	if id.IsPublic() != h.IsPublic() {
+		return errors.New("TlfID and TlfHandle disagree on public status")
+	}
+
+	var writers []keybase1.UID
+	if id.IsPublic() {
+		writers = make([]keybase1.UID, len(h.Writers))
+		copy(writers, h.Writers)
+	}
+	md.WriterMetadata = WriterMetadataV3{
+		Writers: writers,
+		ID:      id,
+	}
+	if len(h.UnresolvedWriters) > 0 {
+		md.WriterMetadata.UnresolvedWriters = make([]keybase1.SocialAssertion, len(h.UnresolvedWriters))
+		copy(md.WriterMetadata.UnresolvedWriters, h.UnresolvedWriters)
+	}
+	if len(h.UnresolvedReaders) > 0 {
+		md.UnresolvedReaders = make([]keybase1.SocialAssertion, len(h.UnresolvedReaders))
+		copy(md.UnresolvedReaders, h.UnresolvedReaders)
+	}
+	md.Revision = MetadataRevisionInitial
+	return nil
+}
+
+// DeepCopy implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) DeepCopy(codec Codec) (BareRootMetadata, error) {
+	var newMd BareRootMetadataV3
+	if err := CodecUpdate(codec, &newMd, md); err != nil {
+		return nil, err
+	}
+	return &newMd, nil
+}
+
+// MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) MakeSuccessorCopy(codec Codec) (BareRootMetadata, error) {
+	// TODO: If there is ever a BareRootMetadataV4 this will need to perform the conversion.
+	return md.DeepCopy(codec)
+}
+
+// CheckValidSuccessor implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) CheckValidSuccessor(
+	currID MdID, nextMd BareRootMetadata) error {
+	// (1) Verify current metadata is non-final.
+	if md.IsFinal() {
+		return MetadataIsFinalError{}
+	}
+
+	// (2) Check TLF ID.
+	if nextMd.TlfID() != md.TlfID() {
+		return MDTlfIDMismatch{
+			currID: md.TlfID(),
+			nextID: nextMd.TlfID(),
+		}
+	}
+
+	// (3) Check revision.
+	if nextMd.RevisionNumber() != md.RevisionNumber()+1 {
+		return MDRevisionMismatch{
+			rev:  nextMd.RevisionNumber(),
+			curr: md.RevisionNumber(),
+		}
+	}
+
+	// (4) Check PrevRoot pointer.
+	expectedPrevRoot := currID
+	if nextMd.IsFinal() {
+		expectedPrevRoot = md.GetPrevRoot()
+	}
+	if nextMd.GetPrevRoot() != expectedPrevRoot {
+		return MDPrevRootMismatch{
+			prevRoot:         nextMd.GetPrevRoot(),
+			expectedPrevRoot: expectedPrevRoot,
+		}
+	}
+
+	// (5) Check branch ID.
+	if md.MergedStatus() == nextMd.MergedStatus() && md.BID() != nextMd.BID() {
+		return fmt.Errorf("Unexpected branch ID on successor: %s vs. %s",
+			md.BID(), nextMd.BID())
+	} else if md.MergedStatus() == Unmerged && nextMd.MergedStatus() == Merged {
+		return errors.New("Merged MD can't follow unmerged MD.")
+	}
+
+	// (6) Check disk usage.
+	expectedUsage := md.DiskUsage()
+	if !nextMd.IsWriterMetadataCopiedSet() {
+		expectedUsage += nextMd.RefBytes() - nextMd.UnrefBytes()
+	}
+	if nextMd.DiskUsage() != expectedUsage {
+		return MDDiskUsageMismatch{
+			expectedDiskUsage: expectedUsage,
+			actualDiskUsage:   nextMd.DiskUsage(),
+		}
+	}
+
+	// TODO: Check that the successor (bare) TLF handle is the
+	// same or more resolved.
+
+	return nil
+}
+
+// CheckValidSuccessorForServer implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) CheckValidSuccessorForServer(
+	currID MdID, nextMd BareRootMetadata) error {
+	err := md.CheckValidSuccessor(currID, nextMd)
+	switch err := err.(type) {
+	case nil:
+		break
+
+	case MDRevisionMismatch:
+		return MDServerErrorConflictRevision{
+			Expected: err.curr + 1,
+			Actual:   err.rev,
+		}
+
+	case MDPrevRootMismatch:
+		return MDServerErrorConflictPrevRoot{
+			Expected: err.expectedPrevRoot,
+			Actual:   err.prevRoot,
+		}
+
+	case MDDiskUsageMismatch:
+		return MDServerErrorConflictDiskUsage{
+			Expected: err.expectedDiskUsage,
+			Actual:   err.actualDiskUsage,
+		}
+
+	default:
+		return MDServerError{Err: err}
+	}
+
+	return nil
+}
+
+// MakeBareTlfHandle implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) MakeBareTlfHandle(extra ExtraMetadata) (
+	BareTlfHandle, error) {
+	var writers, readers []keybase1.UID
+	if md.TlfID().IsPublic() {
+		writers = md.WriterMetadata.Writers
+		readers = []keybase1.UID{keybase1.PublicUID}
+	} else {
+		wkb, rkb, ok := getKeyBundlesV3(extra)
+		if !ok {
+			return BareTlfHandle{}, errors.New("Missing key bundles")
+		}
+		writers = make([]keybase1.UID, 0, len(wkb.Keys))
+		readers = make([]keybase1.UID, 0, len(rkb.RKeys))
+		for w := range wkb.Keys {
+			writers = append(writers, w)
+		}
+		for r := range rkb.RKeys {
+			// TODO: Return an error instead if r is
+			// PublicUID. Maybe return an error if r is in
+			// WKeys also. Or do all this in
+			// MakeBareTlfHandle.
+			if _, ok := wkb.Keys[r]; !ok &&
+				r != keybase1.PublicUID {
+				readers = append(readers, r)
+			}
+		}
+	}
+
+	return MakeBareTlfHandle(
+		writers, readers,
+		md.WriterMetadata.UnresolvedWriters, md.UnresolvedReaders,
+		md.TlfHandleExtensions())
+}
+
+// TlfHandleExtensions implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) TlfHandleExtensions() (
+	extensions []TlfHandleExtension) {
+	if md.ConflictInfo != nil {
+		extensions = append(extensions, *md.ConflictInfo)
+	}
+	if md.FinalizedInfo != nil {
+		extensions = append(extensions, *md.FinalizedInfo)
+	}
+	return extensions
+}
+
+// GetTLFKeyBundles implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetTLFKeyBundles(_ KeyGen) (
+	*TLFWriterKeyBundleV2, *TLFReaderKeyBundleV2, error) {
+	if md.TlfID().IsPublic() {
+		return nil, nil, InvalidPublicTLFOperation{md.TlfID(), "GetTLFKeyBundles"}
+	}
+	// v3 metadata contains no key bundles.
+	return nil, nil, errors.New("Not implemented")
+}
+
+// GetDeviceKIDs implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetDeviceKIDs(
+	keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) ([]keybase1.KID, error) {
+	wkb, rkb, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return nil, errors.New("Missing key bundles")
+	}
+	dkim := wkb.Keys[user]
+	if len(dkim) == 0 {
+		dkim = rkb.RKeys[user]
+		if len(dkim) == 0 {
+			return nil, nil
+		}
+	}
+
+	kids := make([]keybase1.KID, 0, len(dkim))
+	for kid := range dkim {
+		kids = append(kids, kid)
+	}
+
+	return kids, nil
+}
+
+// HasKeyForUser implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) HasKeyForUser(
+	keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) bool {
+	wkb, rkb, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return false
+	}
+	return (len(wkb.Keys[user]) > 0) || (len(rkb.RKeys[user]) > 0)
+}
+
+// GetTLFCryptKeyParams implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetTLFCryptKeyParams(
+	keyGen KeyGen, user keybase1.UID, key CryptPublicKey, extra ExtraMetadata) (
+	TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
+	TLFCryptKeyServerHalfID, bool, error) {
+	wkb, rkb, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return TLFEphemeralPublicKey{},
+			EncryptedTLFCryptKeyClientHalf{},
+			TLFCryptKeyServerHalfID{}, false, errors.New("Missing key bundles")
+	}
+	dkim := wkb.Keys[user]
+	if dkim == nil {
+		dkim = rkb.RKeys[user]
+		if dkim == nil {
+			return TLFEphemeralPublicKey{},
+				EncryptedTLFCryptKeyClientHalf{},
+				TLFCryptKeyServerHalfID{}, false, nil
+		}
+	}
+	info, ok := dkim[key.kid]
+	if !ok {
+		return TLFEphemeralPublicKey{},
+			EncryptedTLFCryptKeyClientHalf{},
+			TLFCryptKeyServerHalfID{}, false, nil
+	}
+
+	var index int
+	var publicKeys TLFEphemeralPublicKeys
+	var keyType string
+	if info.EPubKeyIndex >= 0 {
+		index = info.EPubKeyIndex
+		publicKeys = wkb.TLFEphemeralPublicKeys
+		keyType = "writer"
+	} else {
+		index = -1 - info.EPubKeyIndex
+		publicKeys = rkb.TLFReaderEphemeralPublicKeys
+		keyType = "reader"
+	}
+	keyCount := len(publicKeys)
+	if index >= keyCount {
+		return TLFEphemeralPublicKey{},
+			EncryptedTLFCryptKeyClientHalf{},
+			TLFCryptKeyServerHalfID{}, false,
+			fmt.Errorf("Invalid %s key index %d >= %d",
+				keyType, index, keyCount)
+	}
+	return publicKeys[index], info.ClientHalf, info.ServerHalfID, true, nil
+}
+
+// IsValidAndSigned implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsValidAndSigned(
+	codec Codec, crypto cryptoPure, extra ExtraMetadata) error {
+	// Optimization -- if the WriterMetadata signature is nil, it
+	// will fail verification.
+	if md.WriterMetadataSigInfo.IsNil() {
+		return errors.New("Missing WriterMetadata signature")
+	}
+	_, _, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return errors.New("Missing key bundles")
+	}
+
+	if md.IsFinal() {
+		if md.Revision < MetadataRevisionInitial+1 {
+			return fmt.Errorf("Invalid final revision %d", md.Revision)
+		}
+
+		if md.Revision == (MetadataRevisionInitial + 1) {
+			if md.PrevRoot != (MdID{}) {
+				return fmt.Errorf("Invalid PrevRoot %s for initial final revision", md.PrevRoot)
+			}
+		} else {
+			if md.PrevRoot == (MdID{}) {
+				return errors.New("No PrevRoot for non-initial final revision")
+			}
+		}
+	} else {
+		if md.Revision < MetadataRevisionInitial {
+			return fmt.Errorf("Invalid revision %d", md.Revision)
+		}
+
+		if md.Revision == MetadataRevisionInitial {
+			if md.PrevRoot != (MdID{}) {
+				return fmt.Errorf("Invalid PrevRoot %s for initial revision", md.PrevRoot)
+			}
+		} else {
+			if md.PrevRoot == (MdID{}) {
+				return errors.New("No PrevRoot for non-initial revision")
+			}
+		}
+	}
+
+	if len(md.WriterMetadata.SerializedPrivateMetadata) == 0 {
+		return errors.New("No private metadata")
+	}
+
+	if (md.MergedStatus() == Merged) != (md.BID() == NullBranchID) {
+		return fmt.Errorf("Branch ID %s doesn't match merged status %s",
+			md.BID(), md.MergedStatus())
+	}
+
+	handle, err := md.MakeBareTlfHandle(extra)
+	if err != nil {
+		return err
+	}
+
+	// Make sure the last writer is valid.
+	writer := md.LastModifyingWriter()
+	if !handle.IsWriter(writer) {
+		return fmt.Errorf("Invalid modifying writer %s", writer)
+	}
+
+	// Make sure the last modifier is valid.
+	user := md.LastModifyingUser
+	if !handle.IsReader(user) {
+		return fmt.Errorf("Invalid modifying user %s", user)
+	}
+
+	// Verify signature. We have to re-marshal the WriterMetadata,
+	// since it's embedded.
+	buf, err := codec.Encode(md.WriterMetadata)
+	if err != nil {
+		return err
+	}
+
+	err = crypto.Verify(buf, md.WriterMetadataSigInfo)
+	if err != nil {
+		return fmt.Errorf("Could not verify writer metadata: %v", err)
+	}
+
+	return nil
+}
+
+// IsLastModifiedBy implements the BareRootMetadata interface for
+// BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsLastModifiedBy(
+	uid keybase1.UID, key VerifyingKey) error {
+	// Verify the user and device are the writer.
+	writer := md.LastModifyingWriter()
+	if !md.IsWriterMetadataCopiedSet() {
+		if writer != uid {
+			return fmt.Errorf("Last writer %s != %s", writer, uid)
+		}
+		if md.WriterMetadataSigInfo.VerifyingKey != key {
+			return fmt.Errorf(
+				"Last writer verifying key %v != %v",
+				md.WriterMetadataSigInfo.VerifyingKey, key)
+		}
+	}
+
+	// Verify the user and device are the last modifier.
+	user := md.GetLastModifyingUser()
+	if user != uid {
+		return fmt.Errorf("Last modifier %s != %s", user, uid)
+	}
+
+	return nil
+}
+
+// LastModifyingWriter implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) LastModifyingWriter() keybase1.UID {
+	return md.WriterMetadata.LastModifyingWriter
+}
+
+// LastModifyingWriterKID implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) LastModifyingWriterKID() keybase1.KID {
+	return md.WriterMetadataSigInfo.VerifyingKey.KID()
+}
+
+// GetLastModifyingUser implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetLastModifyingUser() keybase1.UID {
+	return md.LastModifyingUser
+}
+
+// RefBytes implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) RefBytes() uint64 {
+	return md.WriterMetadata.RefBytes
+}
+
+// UnrefBytes implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) UnrefBytes() uint64 {
+	return md.WriterMetadata.UnrefBytes
+}
+
+// DiskUsage implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) DiskUsage() uint64 {
+	return md.WriterMetadata.DiskUsage
+}
+
+// SetRefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetRefBytes(refBytes uint64) {
+	md.WriterMetadata.RefBytes = refBytes
+}
+
+// SetUnrefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetUnrefBytes(unrefBytes uint64) {
+	md.WriterMetadata.UnrefBytes = unrefBytes
+}
+
+// SetDiskUsage implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetDiskUsage(diskUsage uint64) {
+	md.WriterMetadata.DiskUsage = diskUsage
+}
+
+// AddRefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AddRefBytes(refBytes uint64) {
+	md.WriterMetadata.RefBytes += refBytes
+}
+
+// AddUnrefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AddUnrefBytes(unrefBytes uint64) {
+	md.WriterMetadata.UnrefBytes += unrefBytes
+}
+
+// AddDiskUsage implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AddDiskUsage(diskUsage uint64) {
+	md.WriterMetadata.DiskUsage += diskUsage
+}
+
+// RevisionNumber implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) RevisionNumber() MetadataRevision {
+	return md.Revision
+}
+
+// BID implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) BID() BranchID {
+	return md.WriterMetadata.BID
+}
+
+// GetPrevRoot implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetPrevRoot() MdID {
+	return md.PrevRoot
+}
+
+// ClearRekeyBit implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) ClearRekeyBit() {
+	md.Flags &= ^MetadataFlagRekey
+}
+
+// ClearWriterMetadataCopiedBit implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) ClearWriterMetadataCopiedBit() {
+	md.Flags &= ^MetadataFlagWriterMetadataCopied
+}
+
+// IsUnmergedSet implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) IsUnmergedSet() bool {
+	return (md.WriterMetadata.WFlags & MetadataFlagUnmerged) != 0
+}
+
+// SetUnmerged implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetUnmerged() {
+	md.WriterMetadata.WFlags |= MetadataFlagUnmerged
+}
+
+// SetBranchID implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetBranchID(bid BranchID) {
+	md.WriterMetadata.BID = bid
+}
+
+// SetPrevRoot implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetPrevRoot(mdID MdID) {
+	md.PrevRoot = mdID
+}
+
+// GetSerializedPrivateMetadata implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetSerializedPrivateMetadata() []byte {
+	return md.WriterMetadata.SerializedPrivateMetadata
+}
+
+// SetSerializedPrivateMetadata implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetSerializedPrivateMetadata(spmd []byte) {
+	md.WriterMetadata.SerializedPrivateMetadata = spmd
+}
+
+// GetSerializedWriterMetadata implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetSerializedWriterMetadata(codec Codec) ([]byte, error) {
+	return codec.Encode(md.WriterMetadata)
+}
+
+// GetWriterMetadataSigInfo implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetWriterMetadataSigInfo() SignatureInfo {
+	return md.WriterMetadataSigInfo
+}
+
+// SetWriterMetadataSigInfo implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetWriterMetadataSigInfo(sigInfo SignatureInfo) {
+	md.WriterMetadataSigInfo = sigInfo
+}
+
+// SetLastModifyingWriter implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetLastModifyingWriter(user keybase1.UID) {
+	md.WriterMetadata.LastModifyingWriter = user
+}
+
+// SetLastModifyingUser implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetLastModifyingUser(user keybase1.UID) {
+	md.LastModifyingUser = user
+}
+
+// SetRekeyBit implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetRekeyBit() {
+	md.Flags |= MetadataFlagRekey
+}
+
+// SetFinalBit implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetFinalBit() {
+	md.Flags |= MetadataFlagFinal
+}
+
+// SetWriterMetadataCopiedBit implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetWriterMetadataCopiedBit() {
+	md.Flags |= MetadataFlagWriterMetadataCopied
+}
+
+// SetRevision implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetRevision(revision MetadataRevision) {
+	md.Revision = revision
+}
+
+// AddNewKeys implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AddNewKeys(wkb TLFWriterKeyBundleV2, rkb TLFReaderKeyBundleV2) {
+	// MDv3 TODO: set IDs
+}
+
+// NewKeyGeneration implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) NewKeyGeneration(pubKey TLFPublicKey) (
+	extra ExtraMetadata) {
+	newWriterKeys := &TLFWriterKeyBundleV3{
+		Keys: make(UserDeviceKeyInfoMap),
+	}
+	newReaderKeys := &TLFReaderKeyBundleV3{
+		TLFReaderKeyBundleV2: TLFReaderKeyBundleV2{
+			RKeys: make(UserDeviceKeyInfoMap),
+		},
+	}
+	newWriterKeys.TLFPublicKeys = []TLFPublicKey{pubKey}
+	md.WriterMetadata.LatestKeyGen++
+	return &ExtraMetadataV3{
+		rkb: newReaderKeys,
+		wkb: newWriterKeys,
+	}
+}
+
+// SetUnresolvedReaders implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetUnresolvedReaders(readers []keybase1.SocialAssertion) {
+	md.UnresolvedReaders = readers
+}
+
+// SetUnresolvedWriters implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetUnresolvedWriters(writers []keybase1.SocialAssertion) {
+	md.WriterMetadata.UnresolvedWriters = writers
+}
+
+// SetConflictInfo implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetConflictInfo(ci *TlfHandleExtension) {
+	md.ConflictInfo = ci
+}
+
+// SetFinalizedInfo implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetFinalizedInfo(fi *TlfHandleExtension) {
+	md.FinalizedInfo = fi
+}
+
+// SetWriters implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetWriters(writers []keybase1.UID) {
+	md.WriterMetadata.Writers = writers
+}
+
+// SetTlfID implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetTlfID(tlf TlfID) {
+	md.WriterMetadata.ID = tlf
+}
+
+// ClearFinalBit implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) ClearFinalBit() {
+	md.Flags &= ^MetadataFlagFinal
+}
+
+// Version implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) Version() MetadataVer {
+	return SegregatedKeyBundlesVer
+}
+
+// FakeInitialRekey implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) FakeInitialRekey(codec Codec, h BareTlfHandle) (
+	ExtraMetadata, error) {
+	if md.TlfID().IsPublic() {
+		panic("Called FakeInitialRekey on public TLF")
+	}
+	wkb := &TLFWriterKeyBundleV3{
+		Keys: make(UserDeviceKeyInfoMap),
+	}
+	for _, w := range h.Writers {
+		k := MakeFakeCryptPublicKeyOrBust(string(w))
+		wkb.Keys[w] = DeviceKeyInfoMap{
+			k.kid: TLFCryptKeyInfo{},
+		}
+	}
+	buf, err := codec.Encode(wkb)
+	if err != nil {
+		return nil, err
+	}
+	md.WriterMetadata.WKeyBundleID, err = TLFWriterKeyBundleIDFromBytes(buf)
+	if err != nil {
+		return nil, err
+	}
+	rkb := &TLFReaderKeyBundleV3{
+		TLFReaderKeyBundleV2: TLFReaderKeyBundleV2{
+			RKeys: make(UserDeviceKeyInfoMap),
+		},
+	}
+	for _, r := range h.Readers {
+		k := MakeFakeCryptPublicKeyOrBust(string(r))
+		rkb.RKeys[r] = DeviceKeyInfoMap{
+			k.kid: TLFCryptKeyInfo{},
+		}
+	}
+	buf, err = codec.Encode(rkb)
+	if err != nil {
+		return nil, err
+	}
+	md.RKeyBundleID, err = TLFReaderKeyBundleIDFromBytes(buf)
+	if err != nil {
+		return nil, err
+	}
+	md.WriterMetadata.LatestKeyGen++
+	return &ExtraMetadataV3{
+		rkb: rkb,
+		wkb: wkb,
+	}, nil
+}
+
+// GetTLFPublicKey implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetTLFPublicKey(keyGen KeyGen, extra ExtraMetadata) (
+	TLFPublicKey, bool) {
+	if keyGen > md.LatestKeyGeneration() {
+		return TLFPublicKey{}, false
+	}
+	wkb, _, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return TLFPublicKey{}, false
+	}
+	return wkb.TLFPublicKeys[keyGen], true
+}
+
+// AreKeyGenerationsEqual implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AreKeyGenerationsEqual(
+	codec Codec, other BareRootMetadata) (bool, error) {
+	md3, ok := other.(*BareRootMetadataV3)
+	if !ok {
+		// MDv3 TODO: handle comparisons across versions
+		return false, nil
+	}
+	rekey := md3.RKeyBundleID != md.RKeyBundleID ||
+		md3.WriterMetadata.WKeyBundleID != md.WriterMetadata.WKeyBundleID
+	return rekey, nil
+}
+
+// GetUnresolvedParticipants implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion) {
+	return md.UnresolvedReaders, md.WriterMetadata.UnresolvedWriters
+}
+
+// GetUserDeviceKeyInfoMaps implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetUserDeviceKeyInfoMaps(keyGen KeyGen, extra ExtraMetadata) (
+	readers, writers UserDeviceKeyInfoMap, err error) {
+	if md.TlfID().IsPublic() {
+		return nil, nil, InvalidPublicTLFOperation{md.TlfID(), "GetTLFKeyBundles"}
+	}
+	if keyGen != md.LatestKeyGeneration() {
+		return nil, nil, InvalidKeyGenerationError{md.TlfID(), keyGen}
+	}
+	wkb, rkb, ok := getKeyBundlesV3(extra)
+	if !ok {
+		return nil, nil, errors.New("Key bundles missing")
+	}
+	return rkb.RKeys, wkb.Keys, nil
+}
+
+// fillInDevices ensures that every device for every writer and reader
+// in the provided lists has complete TLF crypt key info, and uses the
+// new ephemeral key pair to generate the info if it doesn't yet
+// exist.
+func (md *BareRootMetadataV3) fillInDevices(crypto Crypto,
+	wkb *TLFWriterKeyBundleV3, rkb *TLFReaderKeyBundleV3,
+	wKeys map[keybase1.UID][]CryptPublicKey,
+	rKeys map[keybase1.UID][]CryptPublicKey, ePubKey TLFEphemeralPublicKey,
+	ePrivKey TLFEphemeralPrivateKey, tlfCryptKey TLFCryptKey) (
+	serverKeyMap, error) {
+	var newIndex int
+	if len(wKeys) == 0 {
+		// This is VERY ugly, but we need it in order to avoid having to
+		// version the metadata. The index will be strictly negative for reader
+		// ephemeral public keys
+		// MDv3 TODO: get rid of this hack after getting everything else working.
+		rkb.TLFReaderEphemeralPublicKeys =
+			append(rkb.TLFReaderEphemeralPublicKeys, ePubKey)
+		newIndex = -len(rkb.TLFReaderEphemeralPublicKeys)
+	} else {
+		wkb.TLFEphemeralPublicKeys =
+			append(wkb.TLFEphemeralPublicKeys, ePubKey)
+		newIndex = len(wkb.TLFEphemeralPublicKeys) - 1
+	}
+
+	// now fill in the secret keys as needed
+	newServerKeys := serverKeyMap{}
+	err := fillInDevicesAndServerMap(crypto, newIndex, wKeys, wkb.Keys,
+		ePubKey, ePrivKey, tlfCryptKey, newServerKeys)
+	if err != nil {
+		return nil, err
+	}
+	err = fillInDevicesAndServerMap(crypto, newIndex, rKeys, rkb.RKeys,
+		ePubKey, ePrivKey, tlfCryptKey, newServerKeys)
+	if err != nil {
+		return nil, err
+	}
+	return newServerKeys, nil
+}
+
+// BareRootMetadataSignedV3 is the MD that is signed by the reader or
+// writer including the signature info. Unlike RootMetadataSigned,
+// it contains exactly the serializable metadata and signature info.
+type BareRootMetadataSignedV3 struct {
+	// signature over the root metadata by the private signing key
+	SigInfo SignatureInfo `codec:",omitempty"`
+	// all the metadata
+	MD BareRootMetadataV3
+}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -175,6 +175,9 @@ const (
 	// InitialExtraMetadataVer is the first metadata version that did
 	// include support for extra MD fields.
 	InitialExtraMetadataVer = 2
+	// SegregatedKeyBundlesVer is the first metadata version to allow separate
+	// storage of key bundles.
+	SegregatedKeyBundlesVer = 3
 )
 
 // DataVer is the type of a version for marshalled KBFS data

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -68,7 +68,8 @@ func (j journalMDOps) getHeadFromJournal(
 				bid, head.BID())
 	}
 
-	headBareHandle, err := head.MakeBareTlfHandle()
+	// MDv3 TODO: pass key bundles when needed
+	headBareHandle, err := head.MakeBareTlfHandle(nil)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -149,7 +150,8 @@ func (j journalMDOps) getRangeFromJournal(
 			bid, head.BID())
 	}
 
-	bareHandle, err := head.MakeBareTlfHandle()
+	// MDv3 TODO: pass key bundles when needed
+	bareHandle, err := head.MakeBareTlfHandle(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -251,7 +251,7 @@ func injectNewRMD(t *testing.T, config *ConfigMock) (
 			EncodedSize: 1,
 		},
 	}
-	rmd.FakeInitialRekey(h.ToBareHandleOrBust())
+	rmd.FakeInitialRekey(config.Codec(), h.ToBareHandleOrBust())
 
 	ops := getOps(config, id)
 	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(fakeTlfIDByte(id)),
@@ -410,7 +410,7 @@ func (p ptrMatcher) String() string {
 
 func fillInNewMD(t *testing.T, config *ConfigMock, rmd *RootMetadata) {
 	if !rmd.TlfID().IsPublic() {
-		rmd.FakeInitialRekey(rmd.GetTlfHandle().ToBareHandleOrBust())
+		rmd.FakeInitialRekey(config.Codec(), rmd.GetTlfHandle().ToBareHandleOrBust())
 	}
 	rootPtr := BlockPointer{
 		ID:      fakeBlockID(42),

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -23,7 +23,7 @@ func (id TLFCryptKeyServerHalfID) String() string {
 }
 
 // TLFCryptKeyInfo is a per-device key half entry in the
-// TLFWriterKeyBundle/TLFReaderKeyBundle.
+// TLFWriterKeyBundleV2/TLFReaderKeyBundleV2.
 type TLFCryptKeyInfo struct {
 	ClientHalf   EncryptedTLFCryptKeyClientHalf
 	ServerHalfID TLFCryptKeyServerHalfID
@@ -102,9 +102,9 @@ func (kim DeviceKeyInfoMap) fillInDeviceInfo(crypto Crypto,
 // UserDeviceKeyInfoMap maps a user's keybase UID to their DeviceKeyInfoMap
 type UserDeviceKeyInfoMap map[keybase1.UID]DeviceKeyInfoMap
 
-// TLFWriterKeyBundle is a bundle of all the writer keys for a top-level
+// TLFWriterKeyBundleV2 is a bundle of all the writer keys for a top-level
 // folder.
-type TLFWriterKeyBundle struct {
+type TLFWriterKeyBundleV2 struct {
 	// Maps from each writer to their crypt key bundle.
 	WKeys UserDeviceKeyInfoMap
 
@@ -123,14 +123,14 @@ type TLFWriterKeyBundle struct {
 }
 
 // IsWriter returns true if the given user device is in the writer set.
-func (tkb TLFWriterKeyBundle) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
+func (tkb TLFWriterKeyBundleV2) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
 	_, ok := tkb.WKeys[user][deviceKID]
 	return ok
 }
 
-// TLFWriterKeyGenerations stores a slice of TLFWriterKeyBundle,
+// TLFWriterKeyGenerations stores a slice of TLFWriterKeyBundleV2,
 // where the last element is the current generation.
-type TLFWriterKeyGenerations []TLFWriterKeyBundle
+type TLFWriterKeyGenerations []TLFWriterKeyBundleV2
 
 // LatestKeyGeneration returns the current key generation for this TLF.
 func (tkg TLFWriterKeyGenerations) LatestKeyGeneration() KeyGen {
@@ -147,9 +147,9 @@ func (tkg TLFWriterKeyGenerations) IsWriter(user keybase1.UID, deviceKID keybase
 	return tkg[keyGen-1].IsWriter(user, deviceKID)
 }
 
-// TLFReaderKeyBundle stores all the user keys with reader
+// TLFReaderKeyBundleV2 stores all the user keys with reader
 // permissions on a TLF
-type TLFReaderKeyBundle struct {
+type TLFReaderKeyBundleV2 struct {
 	RKeys UserDeviceKeyInfoMap
 
 	// M_e as described in 4.1.1 of https://keybase.io/blog/kbfs-crypto.
@@ -166,14 +166,14 @@ type TLFReaderKeyBundle struct {
 }
 
 // IsReader returns true if the given user device is in the reader set.
-func (trb TLFReaderKeyBundle) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
+func (trb TLFReaderKeyBundleV2) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
 	_, ok := trb.RKeys[user][deviceKID]
 	return ok
 }
 
-// TLFReaderKeyGenerations stores a slice of TLFReaderKeyBundle,
+// TLFReaderKeyGenerations stores a slice of TLFReaderKeyBundleV2,
 // where the last element is the current generation.
-type TLFReaderKeyGenerations []TLFReaderKeyBundle
+type TLFReaderKeyGenerations []TLFReaderKeyBundleV2
 
 // LatestKeyGeneration returns the current key generation for this TLF.
 func (tkg TLFReaderKeyGenerations) LatestKeyGeneration() KeyGen {
@@ -218,8 +218,9 @@ func fillInDevicesAndServerMap(crypto Crypto, newIndex int,
 // in the provided lists has complete TLF crypt key info, and uses the
 // new ephemeral key pair to generate the info if it doesn't yet
 // exist.
+// MDv3 TODO: get rid of this as it's only used in tests right now.
 func fillInDevices(crypto Crypto,
-	wkb *TLFWriterKeyBundle, rkb *TLFReaderKeyBundle,
+	wkb *TLFWriterKeyBundleV2, rkb *TLFReaderKeyBundleV2,
 	wKeys map[keybase1.UID][]CryptPublicKey,
 	rKeys map[keybase1.UID][]CryptPublicKey, ePubKey TLFEphemeralPublicKey,
 	ePrivKey TLFEphemeralPrivateKey, tlfCryptKey TLFCryptKey) (

--- a/libkbfs/key_bundle_test.go
+++ b/libkbfs/key_bundle_test.go
@@ -60,7 +60,7 @@ func testKeyBundleGetKeysOrBust(t *testing.T, config Config, uid keybase1.UID,
 }
 
 func testKeyBundleCheckKeys(t *testing.T, config Config, uid keybase1.UID,
-	wkb TLFWriterKeyBundle, ePubKey TLFEphemeralPublicKey,
+	wkb TLFWriterKeyBundleV2, ePubKey TLFEphemeralPublicKey,
 	tlfCryptKey TLFCryptKey, serverMap serverKeyMap) {
 	ctx := context.Background()
 	// Check that every user can recover the crypt key
@@ -121,7 +121,7 @@ func TestKeyBundleFillInDevices(t *testing.T) {
 	}
 
 	// Make a wkb with empty writer key maps
-	wkb := TLFWriterKeyBundle{
+	wkb := TLFWriterKeyBundleV2{
 		WKeys: make(UserDeviceKeyInfoMap),
 		TLFEphemeralPublicKeys: make(TLFEphemeralPublicKeys, 1),
 	}
@@ -140,7 +140,7 @@ func TestKeyBundleFillInDevices(t *testing.T) {
 		t.Fatalf("Couldn't make keys: %v", err)
 	}
 	serverMap, err := fillInDevices(
-		config1.Crypto(), &wkb, &TLFReaderKeyBundle{},
+		config1.Crypto(), &wkb, &TLFReaderKeyBundleV2{},
 		wKeys, nil, ePubKey, ePrivKey, tlfCryptKey)
 	if err != nil {
 		t.Fatalf("Fill in devices failed: %v", err)
@@ -168,7 +168,7 @@ func TestKeyBundleFillInDevices(t *testing.T) {
 		t.Fatalf("Couldn't make keys: %v", err)
 	}
 	serverMap2, err := fillInDevices(
-		config1.Crypto(), &wkb, &TLFReaderKeyBundle{},
+		config1.Crypto(), &wkb, &TLFReaderKeyBundleV2{},
 		wKeys, nil, ePubKey2, ePrivKey2, tlfCryptKey)
 	if err != nil {
 		t.Fatalf("Fill in devices failed: %v", err)
@@ -205,14 +205,14 @@ func (udkimf userDeviceKeyInfoMapFuture) toCurrent() UserDeviceKeyInfoMap {
 }
 
 type tlfWriterKeyBundleFuture struct {
-	TLFWriterKeyBundle
-	// Override TLFWriterKeyBundle.WKeys.
+	TLFWriterKeyBundleV2
+	// Override TLFWriterKeyBundleV2.WKeys.
 	WKeys userDeviceKeyInfoMapFuture
 	extra
 }
 
-func (wkbf tlfWriterKeyBundleFuture) toCurrent() TLFWriterKeyBundle {
-	wkb := wkbf.TLFWriterKeyBundle
+func (wkbf tlfWriterKeyBundleFuture) toCurrent() TLFWriterKeyBundleV2 {
+	wkb := wkbf.TLFWriterKeyBundleV2
 	wkb.WKeys = wkbf.WKeys.toCurrent()
 	return wkb
 }
@@ -230,7 +230,7 @@ func makeFakeDeviceKeyInfoMapFuture(t *testing.T) userDeviceKeyInfoMapFuture {
 }
 
 func makeFakeTLFWriterKeyBundleFuture(t *testing.T) tlfWriterKeyBundleFuture {
-	wkb := TLFWriterKeyBundle{
+	wkb := TLFWriterKeyBundleV2{
 		nil,
 		MakeTLFPublicKey([32]byte{0xa}),
 		TLFEphemeralPublicKeys{
@@ -241,23 +241,23 @@ func makeFakeTLFWriterKeyBundleFuture(t *testing.T) tlfWriterKeyBundleFuture {
 	return tlfWriterKeyBundleFuture{
 		wkb,
 		makeFakeDeviceKeyInfoMapFuture(t),
-		makeExtraOrBust("TLFWriterKeyBundle", t),
+		makeExtraOrBust("TLFWriterKeyBundleV2", t),
 	}
 }
 
-func TestTLFWriterKeyBundleUnknownFields(t *testing.T) {
+func TestTLFWriterKeyBundleV2UnknownFields(t *testing.T) {
 	testStructUnknownFields(t, makeFakeTLFWriterKeyBundleFuture(t))
 }
 
 type tlfReaderKeyBundleFuture struct {
-	TLFReaderKeyBundle
-	// Override TLFReaderKeyBundle.WKeys.
+	TLFReaderKeyBundleV2
+	// Override TLFReaderKeyBundleV2.WKeys.
 	RKeys userDeviceKeyInfoMapFuture
 	extra
 }
 
-func (rkbf tlfReaderKeyBundleFuture) toCurrent() TLFReaderKeyBundle {
-	rkb := rkbf.TLFReaderKeyBundle
+func (rkbf tlfReaderKeyBundleFuture) toCurrent() TLFReaderKeyBundleV2 {
+	rkb := rkbf.TLFReaderKeyBundleV2
 	rkb.RKeys = rkbf.RKeys.toCurrent()
 	return rkb
 }
@@ -267,7 +267,7 @@ func (rkbf tlfReaderKeyBundleFuture) toCurrentStruct() currentStruct {
 }
 
 func makeFakeTLFReaderKeyBundleFuture(t *testing.T) tlfReaderKeyBundleFuture {
-	rkb := TLFReaderKeyBundle{
+	rkb := TLFReaderKeyBundleV2{
 		nil,
 		TLFEphemeralPublicKeys{
 			MakeTLFEphemeralPublicKey([32]byte{0xc}),
@@ -277,10 +277,10 @@ func makeFakeTLFReaderKeyBundleFuture(t *testing.T) tlfReaderKeyBundleFuture {
 	return tlfReaderKeyBundleFuture{
 		rkb,
 		makeFakeDeviceKeyInfoMapFuture(t),
-		makeExtraOrBust("TLFReaderKeyBundle", t),
+		makeExtraOrBust("TLFReaderKeyBundleV2", t),
 	}
 }
 
-func TestTLFReaderKeyBundleUnknownFields(t *testing.T) {
+func TestTLFReaderKeyBundleV2UnknownFields(t *testing.T) {
 	testStructUnknownFields(t, makeFakeTLFReaderKeyBundleFuture(t))
 }

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -1,0 +1,132 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"encoding"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
+)
+
+// TLFReaderKeyBundleV3 is an alias to a TLFReaderKeyBundleV2 for clarity.
+type TLFReaderKeyBundleV3 struct {
+	TLFReaderKeyBundleV2
+}
+
+// TLFWriterKeyBundleV3 is a bundle of writer keys and historic symmetric encryption
+// keys for a top-level folder.
+type TLFWriterKeyBundleV3 struct {
+	// Maps from each user to their crypt key bundle for the current generation.
+	Keys UserDeviceKeyInfoMap
+
+	// M_e as described in 4.1.1 of https://keybase.io/blog/kbfs-crypto.
+	// Because devices can be added into the key generation after it
+	// is initially created (so those devices can get access to
+	// existing data), we track multiple ephemeral public keys; the
+	// one used by a particular device is specified by EPubKeyIndex in
+	// its TLFCryptoKeyInfo struct.
+	TLFEphemeralPublicKeys TLFEphemeralPublicKeys `codec:"ePubKey"`
+
+	// M_f as described in 4.1.1 of https://keybase.io/blog/kbfs-crypto.
+	TLFPublicKeys []TLFPublicKey `codec:"pubKey"`
+
+	// This is a time-ordered, serialized, and encrypted list of historic key
+	// generations. It is encrypted with the latest generation of the TLF crypt
+	// key.
+	SerializedEncryptedHistoricTLFCryptKeys []byte `codec:"oldKeys"`
+
+	codec.UnknownFieldSetHandler
+}
+
+// IsWriter returns true if the given user device is in the device set.
+func (wkb TLFWriterKeyBundleV3) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
+	_, ok := wkb.Keys[user][deviceKID]
+	return ok
+}
+
+// TLFReaderKeyBundleID is the hash of a serialized TLFReaderKeyBundle.
+type TLFReaderKeyBundleID struct {
+	h Hash
+}
+
+var _ encoding.BinaryMarshaler = TLFReaderKeyBundleID{}
+var _ encoding.BinaryUnmarshaler = (*TLFReaderKeyBundleID)(nil)
+
+// TLFReaderKeyBundleIDFromBytes creates a new TLFReaderKeyBundleID from the given bytes.
+// If the returned error is nil, the returned TLFReaderKeyBundleID is valid.
+func TLFReaderKeyBundleIDFromBytes(data []byte) (TLFReaderKeyBundleID, error) {
+	h, err := HashFromBytes(data)
+	if err != nil {
+		return TLFReaderKeyBundleID{}, err
+	}
+	return TLFReaderKeyBundleID{h}, nil
+}
+
+// Bytes returns the bytes of the TLFReaderKeyBundleID.
+func (h TLFReaderKeyBundleID) Bytes() []byte {
+	return h.h.Bytes()
+}
+
+// String returns the string form of the TLFReaderKeyBundleID.
+func (h TLFReaderKeyBundleID) String() string {
+	return h.h.String()
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface for
+// TLFReaderKeyBundleID. Returns an error if the TLFReaderKeyBundleID is invalid and not the
+// zero TLFReaderKeyBundleID.
+func (h TLFReaderKeyBundleID) MarshalBinary() (data []byte, err error) {
+	return h.h.MarshalBinary()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+// for TLFReaderKeyBundleID. Returns an error if the given byte array is non-empty and
+// the TLFReaderKeyBundleID is invalid.
+func (h *TLFReaderKeyBundleID) UnmarshalBinary(data []byte) error {
+	return h.h.UnmarshalBinary(data)
+}
+
+// TLFWriterKeyBundleID is the hash of a serialized TLFWriterKeyBundle.
+type TLFWriterKeyBundleID struct {
+	h Hash
+}
+
+var _ encoding.BinaryMarshaler = TLFWriterKeyBundleID{}
+var _ encoding.BinaryUnmarshaler = (*TLFWriterKeyBundleID)(nil)
+
+// TLFWriterKeyBundleIDFromBytes creates a new TLFWriterKeyBundleID from the given bytes.
+// If the returned error is nil, the returned TLFWriterKeyBundleID is valid.
+func TLFWriterKeyBundleIDFromBytes(data []byte) (TLFWriterKeyBundleID, error) {
+	h, err := HashFromBytes(data)
+	if err != nil {
+		return TLFWriterKeyBundleID{}, err
+	}
+	return TLFWriterKeyBundleID{h}, nil
+}
+
+// Bytes returns the bytes of the TLFWriterKeyBundleID.
+func (h TLFWriterKeyBundleID) Bytes() []byte {
+	return h.h.Bytes()
+}
+
+// String returns the string form of the TLFWriterKeyBundleID.
+func (h TLFWriterKeyBundleID) String() string {
+	return h.h.String()
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface for
+// TLFWriterKeyBundleID. Returns an error if the TLFWriterKeyBundleID is invalid and not the
+// zero TLFWriterKeyBundleID.
+func (h TLFWriterKeyBundleID) MarshalBinary() (data []byte, err error) {
+	return h.h.MarshalBinary()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+// for TLFWriterKeyBundleID. Returns an error if the given byte array is non-empty and
+// the TLFWriterKeyBundleID is invalid.
+func (h *TLFWriterKeyBundleID) UnmarshalBinary(data []byte) error {
+	return h.h.UnmarshalBinary(data)
+}

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -193,8 +193,8 @@ func TestKeyManagerCachedSecretKeyForBlockDecryptionSuccess(t *testing.T) {
 }
 
 // makeDirRKeyBundle creates a new bundle with a reader key.
-func makeDirRKeyBundle(uid keybase1.UID, cryptPublicKey CryptPublicKey) TLFReaderKeyBundle {
-	return TLFReaderKeyBundle{
+func makeDirRKeyBundle(uid keybase1.UID, cryptPublicKey CryptPublicKey) TLFReaderKeyBundleV2 {
+	return TLFReaderKeyBundleV2{
 		RKeys: UserDeviceKeyInfoMap{
 			uid: {
 				cryptPublicKey.kid: TLFCryptKeyInfo{

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -83,7 +83,7 @@ func makeMDForTest(t *testing.T, tlfID TlfID, revision MetadataRevision,
 	err = md.Update(tlfID, h)
 	require.NoError(t, err)
 	md.SetRevision(revision)
-	md.FakeInitialRekey(h)
+	md.FakeInitialRekey(NewCodecMsgpack(), h)
 	md.SetPrevRoot(prevRoot)
 	md.SetDiskUsage(500)
 	return md
@@ -113,7 +113,8 @@ func checkBRMD(t *testing.T, uid keybase1.UID, verifyingKey VerifyingKey,
 	require.Equal(t, expectedRevision, brmd.RevisionNumber())
 	require.Equal(t, expectedPrevRoot, brmd.GetPrevRoot())
 	require.Equal(t, expectedMergeStatus, brmd.MergedStatus())
-	err := brmd.IsValidAndSigned(codec, crypto)
+	// MDv3 TODO: pass key bundles
+	err := brmd.IsValidAndSigned(codec, crypto, nil)
 	require.NoError(t, err)
 	err = brmd.IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(t, err)
@@ -146,7 +147,8 @@ func TestMDJournalBasic(t *testing.T) {
 
 	// Should start off as empty.
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 	require.Equal(t, 0, getMDJournalLength(t, j))
@@ -162,16 +164,17 @@ func TestMDJournalBasic(t *testing.T) {
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
 	// Should now be non-empty.
-
+	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
+		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 
-	head, err = j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err = j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 }
@@ -215,7 +218,8 @@ func TestMDJournalPutCase1Empty(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, md.bareMd, head.BareRootMetadata)
 }
@@ -264,7 +268,8 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 		ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, md.Revision(), head.RevisionNumber())
 	require.Equal(t, md.DiskUsage(), head.DiskUsage())
@@ -349,7 +354,8 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 
 	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, head.mdID)
@@ -373,7 +379,8 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 
 	md.SetUnmerged()
@@ -449,8 +456,9 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	require.Equal(t, "md_journal", fileInfos[0].Name())
 	require.Equal(t, "mds", fileInfos[1].Name())
 
+	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
+		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
@@ -459,7 +467,8 @@ func TestMDJournalBranchConversion(t *testing.T) {
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 }
@@ -500,8 +509,9 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	// All entries should remain unchanged, since the conversion
 	// encountered an error.
 
+	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
+		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
@@ -510,7 +520,8 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 }
@@ -536,37 +547,41 @@ func TestMDJournalClear(t *testing.T) {
 	bid := j.branchID
 
 	// Clearing the master branch shouldn't work.
-	err = j.clear(ctx, uid, verifyingKey, NullBranchID)
+	// MDv3 TODO: pass actual key bundles
+	err = j.clear(ctx, uid, verifyingKey, NullBranchID, nil)
 	require.Error(t, err)
 
 	// Clearing a different branch ID should do nothing.
-
-	err = j.clear(ctx, uid, verifyingKey, FakeBranchID(1))
+	// MDv3 TODO: pass actual key bundles
+	err = j.clear(ctx, uid, verifyingKey, FakeBranchID(1), nil)
 	require.NoError(t, err)
 	require.Equal(t, bid, j.branchID)
 
-	head, err := j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err := j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
 
 	// Clearing the correct branch ID should clear the entire
 	// journal, and reset the branch ID.
-
-	err = j.clear(ctx, uid, verifyingKey, bid)
+	// MDv3 TODO: pass actual key bundles
+	err = j.clear(ctx, uid, verifyingKey, bid, nil)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
-	head, err = j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err = j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 
 	// Clearing twice should do nothing.
-
-	err = j.clear(ctx, uid, verifyingKey, bid)
+	// MDv3 TODO: pass actual key bundles
+	err = j.clear(ctx, uid, verifyingKey, bid, nil)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
-	head, err = j.getHead(uid, verifyingKey)
+	// MDv3 TODO: pass actual key bundles
+	head, err = j.getHead(uid, verifyingKey, nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 }
@@ -590,8 +605,9 @@ func TestMDJournalRestart(t *testing.T) {
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
+	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
+		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
@@ -627,8 +643,9 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
+	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, 1, firstRevision+MetadataRevision(2*mdCount))
+		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -144,7 +144,8 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	handle *TlfHandle, rmds *RootMetadataSigned, getRangeLock *sync.Mutex) (
 	ImmutableRootMetadata, error) {
 	// First, verify validity and signatures.
-	err := rmds.IsValidAndSigned(md.config.Codec(), md.config.Crypto())
+	// MDv3 TODO: pass key bundles
+	err := rmds.IsValidAndSigned(md.config.Codec(), md.config.Crypto(), nil)
 	if err != nil {
 		return ImmutableRootMetadata{}, MDMismatchError{
 			rmds.MD.RevisionNumber(), handle.GetCanonicalPath(),
@@ -221,7 +222,8 @@ func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 		return id, ImmutableRootMetadata{}, nil
 	}
 
-	bareMdHandle, err := rmds.MD.MakeBareTlfHandle()
+	// MDv3 TODO: pass key bunldes when needed
+	bareMdHandle, err := rmds.MD.MakeBareTlfHandle(nil)
 	if err != nil {
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
@@ -313,7 +315,8 @@ func (md *MDOpsStandard) getForTLF(ctx context.Context, id TlfID,
 		// Possible if mStatus is Unmerged
 		return ImmutableRootMetadata{}, nil
 	}
-	bareHandle, err := rmds.MD.MakeBareTlfHandle()
+	// MDv3 TODO: pass key bundle when needed
+	bareHandle, err := rmds.MD.MakeBareTlfHandle(nil)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -364,7 +367,8 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 	worker := func() {
 		defer wg.Done()
 		for rmds := range rmdsChan {
-			bareHandle, err := rmds.MD.MakeBareTlfHandle()
+			// MDv3 TODO: pass key bundles when needed
+			bareHandle, err := rmds.MD.MakeBareTlfHandle(nil)
 			if err != nil {
 				select {
 				case errChan <- err:
@@ -520,7 +524,7 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
-	err = md.config.MDServer().Put(ctx, &rmds)
+	err = md.config.MDServer().Put(ctx, &rmds, rmd.extra)
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -65,7 +65,7 @@ func addFakeRMDData(rmd *RootMetadata, h *TlfHandle) {
 	})
 
 	if !h.IsPublic() {
-		rmd.FakeInitialRekey(h.ToBareHandleOrBust())
+		rmd.FakeInitialRekey(NewCodecMsgpack(), h.ToBareHandleOrBust())
 	}
 }
 
@@ -104,7 +104,7 @@ func addFakeRMDSData(rmds *RootMetadataSigned, h *TlfHandle) {
 	rmds.untrustedServerTimestamp = time.Now()
 
 	if !h.IsPublic() {
-		rmds.MD.FakeInitialRekey(h.ToBareHandleOrBust())
+		rmds.MD.FakeInitialRekey(NewCodecMsgpack(), h.ToBareHandleOrBust())
 	}
 }
 
@@ -191,7 +191,7 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	config.mockCrypto.EXPECT().Sign(gomock.Any(), gomock.Any()).Times(2).Return(SignatureInfo{}, nil)
 	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
 		Return(true)
-	config.mockMdserv.EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
+	config.mockMdserv.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 }
 
 func TestMDOpsGetForHandlePublicSuccess(t *testing.T) {
@@ -558,7 +558,8 @@ type fakeMDServerPut struct {
 	lastRmds     *RootMetadataSigned
 }
 
-func (s *fakeMDServerPut) Put(ctx context.Context, rmds *RootMetadataSigned) error {
+func (s *fakeMDServerPut) Put(ctx context.Context, rmds *RootMetadataSigned,
+	_ ExtraMetadata) error {
 	s.lastRmdsLock.Lock()
 	defer s.lastRmdsLock.Unlock()
 	s.lastRmds = rmds

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -41,7 +41,7 @@ func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 			RKeys:    make(TLFReaderKeyGenerations, 1, 1),
 		},
 	}
-	rmd.AddNewKeys(NewEmptyTLFWriterKeyBundle(), TLFReaderKeyBundle{})
+	rmd.AddNewKeys(NewEmptyTLFWriterKeyBundle(), TLFReaderKeyBundleV2{})
 	if mStatus == Unmerged {
 		rmd.SetUnmerged()
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -359,7 +359,9 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id TlfID,
 }
 
 // Put implements the MDServer interface for MDServerDisk.
-func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned) error {
+func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
+	extra ExtraMetadata) error {
+
 	currentUID, currentVerifyingKey, err :=
 		getCurrentUIDAndVerifyingKey(ctx, md.config.currentInfoGetter())
 	if err != nil {

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -14,9 +14,9 @@ import (
 // Helper to aid in enforcement that only specified public keys can
 // access TLF metadata. mergedMasterHead can be nil, in which case
 // true is returned.
-func isReader(currentUID keybase1.UID,
-	mergedMasterHead BareRootMetadata) (bool, error) {
-	h, err := mergedMasterHead.MakeBareTlfHandle()
+func isReader(currentUID keybase1.UID, mergedMasterHead BareRootMetadata,
+	extra ExtraMetadata) (bool, error) {
+	h, err := mergedMasterHead.MakeBareTlfHandle(extra)
 	if err != nil {
 		return false, err
 	}
@@ -28,7 +28,8 @@ func isReader(currentUID keybase1.UID,
 // true is returned.
 func isWriterOrValidRekey(codec Codec, currentUID keybase1.UID,
 	mergedMasterHead, newMd BareRootMetadata) (bool, error) {
-	h, err := mergedMasterHead.MakeBareTlfHandle()
+	// MDv3 TODO: pass actual key bundles
+	h, err := mergedMasterHead.MakeBareTlfHandle(nil)
 	if err != nil {
 		return false, err
 	}
@@ -39,8 +40,9 @@ func isWriterOrValidRekey(codec Codec, currentUID keybase1.UID,
 	if h.IsReader(currentUID) {
 		// if this is a reader, are they acting within their
 		// restrictions?
+		// MDv3 TODO: pass actual key bundles
 		return newMd.IsValidRekeyRequest(
-			codec, mergedMasterHead, currentUID)
+			codec, mergedMasterHead, currentUID, nil, nil)
 	}
 
 	return false, nil

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -459,7 +459,8 @@ func (md *MDServerRemote) GetRange(ctx context.Context, id TlfID,
 }
 
 // Put implements the MDServer interface for MDServerRemote.
-func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned) error {
+func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
+	extra ExtraMetadata) error {
 	// encode MD block
 	rmdsBytes, err := md.config.Codec().Encode(rmds)
 	if err != nil {

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -22,7 +22,7 @@ func makeRMDSForTest(t *testing.T, id TlfID, h BareTlfHandle,
 	rmds.MD.SetRevision(revision)
 	rmds.MD.SetLastModifyingWriter(uid)
 	rmds.MD.SetLastModifyingUser(uid)
-	rmds.MD.FakeInitialRekey(h)
+	rmds.MD.FakeInitialRekey(NewCodecMsgpack(), h)
 	rmds.MD.SetPrevRoot(prevRoot)
 	return rmds
 }
@@ -73,7 +73,8 @@ func TestMDServerBasics(t *testing.T) {
 	for i := MetadataRevision(1); i <= 10; i++ {
 		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
 		signRMDSForTest(t, config.Codec(), config.Crypto(), rmds)
-		err = mdServer.Put(ctx, rmds)
+		// MDv3 TODO: pass actual key bundles
+		err = mdServer.Put(ctx, rmds, nil)
 		require.NoError(t, err)
 		prevRoot, err = config.Crypto().MakeMdID(rmds.MD)
 		require.NoError(t, err)
@@ -85,7 +86,8 @@ func TestMDServerBasics(t *testing.T) {
 	// (3) trigger a conflict
 	rmds = makeRMDSForTest(t, id, h, 10, uid, prevRoot)
 	signRMDSForTest(t, config.Codec(), config.Crypto(), rmds)
-	err = mdServer.Put(ctx, rmds)
+	// MDv3 TODO: pass actual key bundles
+	err = mdServer.Put(ctx, rmds, nil)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 
 	// (4) push some new unmerged metadata blocks linking to the
@@ -98,7 +100,8 @@ func TestMDServerBasics(t *testing.T) {
 		rmds.MD.SetUnmerged()
 		rmds.MD.SetBranchID(bid)
 		signRMDSForTest(t, config.Codec(), config.Crypto(), rmds)
-		err = mdServer.Put(ctx, rmds)
+		// MDv3 TODO: pass actual key bundles
+		err = mdServer.Put(ctx, rmds, nil)
 		require.NoError(t, err)
 		prevRoot, err = config.Crypto().MakeMdID(rmds.MD)
 		require.NoError(t, err)

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -197,14 +197,14 @@ func (s *mdServerTlfStorage) getHeadForTLFReadLocked(bid BranchID) (
 }
 
 func (s *mdServerTlfStorage) checkGetParamsReadLocked(
-	currentUID keybase1.UID, bid BranchID) error {
+	currentUID keybase1.UID, bid BranchID, extra ExtraMetadata) error {
 	mergedMasterHead, err := s.getHeadForTLFReadLocked(NullBranchID)
 	if err != nil {
 		return MDServerError{err}
 	}
 
 	if mergedMasterHead != nil {
-		ok, err := isReader(currentUID, mergedMasterHead.MD)
+		ok, err := isReader(currentUID, mergedMasterHead.MD, extra)
 		if err != nil {
 			return MDServerError{err}
 		}
@@ -219,7 +219,8 @@ func (s *mdServerTlfStorage) checkGetParamsReadLocked(
 func (s *mdServerTlfStorage) getRangeReadLocked(
 	currentUID keybase1.UID, bid BranchID, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
-	err := s.checkGetParamsReadLocked(currentUID, bid)
+	// MDv3 TODO: pass actual key bundles
+	err := s.checkGetParamsReadLocked(currentUID, bid, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +284,8 @@ func (s *mdServerTlfStorage) getForTLF(
 		return nil, errMDServerTlfStorageShutdown
 	}
 
-	err := s.checkGetParamsReadLocked(currentUID, bid)
+	// MDv3 TODO: pass actual key bundles
+	err := s.checkGetParamsReadLocked(currentUID, bid, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +321,8 @@ func (s *mdServerTlfStorage) put(
 		return false, errMDServerTlfStorageShutdown
 	}
 
-	err = rmds.IsValidAndSigned(s.codec, s.crypto)
+	// MDv3 TODO: pass key bundles
+	err = rmds.IsValidAndSigned(s.codec, s.crypto, nil)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
 	}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2648,14 +2648,14 @@ func (_mr *_MockMDServerRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, arg5 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockMDServer) Put(ctx context.Context, rmds *RootMetadataSigned) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmds)
+func (_m *MockMDServer) Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMDServerRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1)
+func (_mr *_MockMDServerRecorder) Put(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2)
 }
 
 func (_m *MockMDServer) PruneBranch(ctx context.Context, id TlfID, bid BranchID) error {
@@ -2822,14 +2822,14 @@ func (_mr *_MockmdServerLocalRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockmdServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmds)
+func (_m *MockmdServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockmdServerLocalRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1)
+func (_mr *_MockmdServerLocalRecorder) Put(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2)
 }
 
 func (_m *MockmdServerLocal) PruneBranch(ctx context.Context, id TlfID, bid BranchID) error {
@@ -4322,15 +4322,15 @@ func (_mr *_MockBareRootMetadataRecorder) LatestKeyGeneration() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestKeyGeneration")
 }
 
-func (_m *MockBareRootMetadata) IsValidRekeyRequest(codec Codec, prevMd BareRootMetadata, user keybase1.UID) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsValidRekeyRequest", codec, prevMd, user)
+func (_m *MockBareRootMetadata) IsValidRekeyRequest(codec Codec, prevMd BareRootMetadata, user keybase1.UID, prevRkb *TLFReaderKeyBundleV2, rkb *TLFReaderKeyBundleV2) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsValidRekeyRequest", codec, prevMd, user, prevRkb, rkb)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsValidRekeyRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidRekeyRequest", arg0, arg1, arg2)
+func (_mr *_MockBareRootMetadataRecorder) IsValidRekeyRequest(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidRekeyRequest", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockBareRootMetadata) MergedStatus() MergeStatus {
@@ -4373,24 +4373,24 @@ func (_mr *_MockBareRootMetadataRecorder) IsFinal() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFinal")
 }
 
-func (_m *MockBareRootMetadata) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
-	ret := _m.ctrl.Call(_m, "IsWriter", user, deviceKID)
+func (_m *MockBareRootMetadata) IsWriter(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	ret := _m.ctrl.Call(_m, "IsWriter", user, deviceKID, extra)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsWriter(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2)
 }
 
-func (_m *MockBareRootMetadata) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
-	ret := _m.ctrl.Call(_m, "IsReader", user, deviceKID)
+func (_m *MockBareRootMetadata) IsReader(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	ret := _m.ctrl.Call(_m, "IsReader", user, deviceKID, extra)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsReader(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) IsReader(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1, arg2)
 }
 
 func (_m *MockBareRootMetadata) DeepCopy(codec Codec) (BareRootMetadata, error) {
@@ -4402,6 +4402,17 @@ func (_m *MockBareRootMetadata) DeepCopy(codec Codec) (BareRootMetadata, error) 
 
 func (_mr *_MockBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
+}
+
+func (_m *MockBareRootMetadata) MakeSuccessor(codec Codec) (BareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "MakeSuccessor", codec)
+	ret0, _ := ret[0].(BareRootMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBareRootMetadataRecorder) MakeSuccessor(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessor", arg0)
 }
 
 func (_m *MockBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
@@ -4424,15 +4435,15 @@ func (_mr *_MockBareRootMetadataRecorder) CheckValidSuccessorForServer(arg0, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckValidSuccessorForServer", arg0, arg1)
 }
 
-func (_m *MockBareRootMetadata) MakeBareTlfHandle() (BareTlfHandle, error) {
-	ret := _m.ctrl.Call(_m, "MakeBareTlfHandle")
+func (_m *MockBareRootMetadata) MakeBareTlfHandle(extra ExtraMetadata) (BareTlfHandle, error) {
+	ret := _m.ctrl.Call(_m, "MakeBareTlfHandle", extra)
 	ret0, _ := ret[0].(BareTlfHandle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) MakeBareTlfHandle() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle")
+func (_mr *_MockBareRootMetadataRecorder) MakeBareTlfHandle(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle", arg0)
 }
 
 func (_m *MockBareRootMetadata) TlfHandleExtensions() []TlfHandleExtension {
@@ -4445,29 +4456,29 @@ func (_mr *_MockBareRootMetadataRecorder) TlfHandleExtensions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfHandleExtensions")
 }
 
-func (_m *MockBareRootMetadata) GetDeviceKIDs(keyGen KeyGen, user keybase1.UID) ([]keybase1.KID, error) {
-	ret := _m.ctrl.Call(_m, "GetDeviceKIDs", keyGen, user)
+func (_m *MockBareRootMetadata) GetDeviceKIDs(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) ([]keybase1.KID, error) {
+	ret := _m.ctrl.Call(_m, "GetDeviceKIDs", keyGen, user, extra)
 	ret0, _ := ret[0].([]keybase1.KID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) GetDeviceKIDs(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDeviceKIDs", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) GetDeviceKIDs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDeviceKIDs", arg0, arg1, arg2)
 }
 
-func (_m *MockBareRootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID) bool {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user)
+func (_m *MockBareRootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) bool {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user, extra)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) HasKeyForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1, arg2)
 }
 
-func (_m *MockBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key)
+func (_m *MockBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key CryptPublicKey, extra ExtraMetadata) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key, extra)
 	ret0, _ := ret[0].(TLFEphemeralPublicKey)
 	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
 	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
@@ -4476,18 +4487,18 @@ func (_m *MockBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase
 	return ret0, ret1, ret2, ret3, ret4
 }
 
-func (_mr *_MockBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
+func (_mr *_MockBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure) error {
-	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto)
+func (_m *MockBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2)
 }
 
 func (_m *MockBareRootMetadata) IsLastModifiedBy(uid keybase1.UID, key VerifyingKey) error {
@@ -4641,15 +4652,15 @@ func (_mr *_MockBareRootMetadataRecorder) Version() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
 }
 
-func (_m *MockBareRootMetadata) GetTLFPublicKey(_param0 KeyGen) (TLFPublicKey, bool) {
-	ret := _m.ctrl.Call(_m, "GetTLFPublicKey", _param0)
+func (_m *MockBareRootMetadata) GetTLFPublicKey(_param0 KeyGen, _param1 ExtraMetadata) (TLFPublicKey, bool) {
+	ret := _m.ctrl.Call(_m, "GetTLFPublicKey", _param0, _param1)
 	ret0, _ := ret[0].(TLFPublicKey)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) GetTLFPublicKey(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFPublicKey", arg0)
+func (_mr *_MockBareRootMetadataRecorder) GetTLFPublicKey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFPublicKey", arg0, arg1)
 }
 
 func (_m *MockBareRootMetadata) AreKeyGenerationsEqual(_param0 Codec, _param1 BareRootMetadata) (bool, error) {
@@ -4715,15 +4726,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) LatestKeyGeneration() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LatestKeyGeneration")
 }
 
-func (_m *MockMutableBareRootMetadata) IsValidRekeyRequest(codec Codec, prevMd BareRootMetadata, user keybase1.UID) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsValidRekeyRequest", codec, prevMd, user)
+func (_m *MockMutableBareRootMetadata) IsValidRekeyRequest(codec Codec, prevMd BareRootMetadata, user keybase1.UID, prevRkb *TLFReaderKeyBundleV2, rkb *TLFReaderKeyBundleV2) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsValidRekeyRequest", codec, prevMd, user, prevRkb, rkb)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsValidRekeyRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidRekeyRequest", arg0, arg1, arg2)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsValidRekeyRequest(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidRekeyRequest", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockMutableBareRootMetadata) MergedStatus() MergeStatus {
@@ -4766,24 +4777,24 @@ func (_mr *_MockMutableBareRootMetadataRecorder) IsFinal() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFinal")
 }
 
-func (_m *MockMutableBareRootMetadata) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
-	ret := _m.ctrl.Call(_m, "IsWriter", user, deviceKID)
+func (_m *MockMutableBareRootMetadata) IsWriter(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	ret := _m.ctrl.Call(_m, "IsWriter", user, deviceKID, extra)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsWriter(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2)
 }
 
-func (_m *MockMutableBareRootMetadata) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
-	ret := _m.ctrl.Call(_m, "IsReader", user, deviceKID)
+func (_m *MockMutableBareRootMetadata) IsReader(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	ret := _m.ctrl.Call(_m, "IsReader", user, deviceKID, extra)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsReader(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsReader(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1, arg2)
 }
 
 func (_m *MockMutableBareRootMetadata) DeepCopy(codec Codec) (BareRootMetadata, error) {
@@ -4795,6 +4806,17 @@ func (_m *MockMutableBareRootMetadata) DeepCopy(codec Codec) (BareRootMetadata, 
 
 func (_mr *_MockMutableBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) MakeSuccessor(codec Codec) (BareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "MakeSuccessor", codec)
+	ret0, _ := ret[0].(BareRootMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) MakeSuccessor(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessor", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
@@ -4817,15 +4839,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) CheckValidSuccessorForServer(ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckValidSuccessorForServer", arg0, arg1)
 }
 
-func (_m *MockMutableBareRootMetadata) MakeBareTlfHandle() (BareTlfHandle, error) {
-	ret := _m.ctrl.Call(_m, "MakeBareTlfHandle")
+func (_m *MockMutableBareRootMetadata) MakeBareTlfHandle(extra ExtraMetadata) (BareTlfHandle, error) {
+	ret := _m.ctrl.Call(_m, "MakeBareTlfHandle", extra)
 	ret0, _ := ret[0].(BareTlfHandle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) MakeBareTlfHandle() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle")
+func (_mr *_MockMutableBareRootMetadataRecorder) MakeBareTlfHandle(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeBareTlfHandle", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) TlfHandleExtensions() []TlfHandleExtension {
@@ -4838,29 +4860,29 @@ func (_mr *_MockMutableBareRootMetadataRecorder) TlfHandleExtensions() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfHandleExtensions")
 }
 
-func (_m *MockMutableBareRootMetadata) GetDeviceKIDs(keyGen KeyGen, user keybase1.UID) ([]keybase1.KID, error) {
-	ret := _m.ctrl.Call(_m, "GetDeviceKIDs", keyGen, user)
+func (_m *MockMutableBareRootMetadata) GetDeviceKIDs(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) ([]keybase1.KID, error) {
+	ret := _m.ctrl.Call(_m, "GetDeviceKIDs", keyGen, user, extra)
 	ret0, _ := ret[0].([]keybase1.KID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) GetDeviceKIDs(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDeviceKIDs", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) GetDeviceKIDs(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDeviceKIDs", arg0, arg1, arg2)
 }
 
-func (_m *MockMutableBareRootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID) bool {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user)
+func (_m *MockMutableBareRootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) bool {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user, extra)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) HasKeyForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1, arg2)
 }
 
-func (_m *MockMutableBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
-	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key)
+func (_m *MockMutableBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key CryptPublicKey, extra ExtraMetadata) (TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key, extra)
 	ret0, _ := ret[0].(TLFEphemeralPublicKey)
 	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
 	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
@@ -4869,18 +4891,18 @@ func (_m *MockMutableBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user 
 	return ret0, ret1, ret2, ret3, ret4
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2)
+func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockMutableBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure) error {
-	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto)
+func (_m *MockMutableBareRootMetadata) IsValidAndSigned(codec Codec, crypto cryptoPure, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", codec, crypto, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2)
 }
 
 func (_m *MockMutableBareRootMetadata) IsLastModifiedBy(uid keybase1.UID, key VerifyingKey) error {
@@ -5034,15 +5056,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) Version() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
 }
 
-func (_m *MockMutableBareRootMetadata) GetTLFPublicKey(_param0 KeyGen) (TLFPublicKey, bool) {
-	ret := _m.ctrl.Call(_m, "GetTLFPublicKey", _param0)
+func (_m *MockMutableBareRootMetadata) GetTLFPublicKey(_param0 KeyGen, _param1 ExtraMetadata) (TLFPublicKey, bool) {
+	ret := _m.ctrl.Call(_m, "GetTLFPublicKey", _param0, _param1)
 	ret0, _ := ret[0].(TLFPublicKey)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFPublicKey(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFPublicKey", arg0)
+func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFPublicKey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFPublicKey", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) AreKeyGenerationsEqual(_param0 Codec, _param1 BareRootMetadata) (bool, error) {
@@ -5227,12 +5249,22 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetRevision(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRevision", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) AddNewKeys(wkb TLFWriterKeyBundle, rkb TLFReaderKeyBundle) {
+func (_m *MockMutableBareRootMetadata) AddNewKeys(wkb TLFWriterKeyBundleV2, rkb TLFReaderKeyBundleV2) {
 	_m.ctrl.Call(_m, "AddNewKeys", wkb, rkb)
 }
 
 func (_mr *_MockMutableBareRootMetadataRecorder) AddNewKeys(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddNewKeys", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) NewKeyGeneration(pubKey TLFPublicKey) ExtraMetadata {
+	ret := _m.ctrl.Call(_m, "NewKeyGeneration", pubKey)
+	ret0, _ := ret[0].(ExtraMetadata)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) NewKeyGeneration(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewKeyGeneration", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) SetUnresolvedReaders(readers []keybase1.SocialAssertion) {
@@ -5283,12 +5315,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetTlfID(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTlfID", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) FakeInitialRekey(h BareTlfHandle) {
-	_m.ctrl.Call(_m, "FakeInitialRekey", h)
+func (_m *MockMutableBareRootMetadata) FakeInitialRekey(c Codec, h BareTlfHandle) (ExtraMetadata, error) {
+	ret := _m.ctrl.Call(_m, "FakeInitialRekey", c, h)
+	ret0, _ := ret[0].(ExtraMetadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) FakeInitialRekey(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "FakeInitialRekey", arg0)
+func (_mr *_MockMutableBareRootMetadataRecorder) FakeInitialRekey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FakeInitialRekey", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) Update(tlf TlfID, h BareTlfHandle) error {
@@ -5301,14 +5336,96 @@ func (_mr *_MockMutableBareRootMetadataRecorder) Update(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Update", arg0, arg1)
 }
 
-func (_m *MockMutableBareRootMetadata) GetTLFKeyBundles(keyGen KeyGen) (*TLFWriterKeyBundle, *TLFReaderKeyBundle, error) {
+func (_m *MockMutableBareRootMetadata) GetTLFKeyBundles(keyGen KeyGen) (*TLFWriterKeyBundleV2, *TLFReaderKeyBundleV2, error) {
 	ret := _m.ctrl.Call(_m, "GetTLFKeyBundles", keyGen)
-	ret0, _ := ret[0].(*TLFWriterKeyBundle)
-	ret1, _ := ret[1].(*TLFReaderKeyBundle)
+	ret0, _ := ret[0].(*TLFWriterKeyBundleV2)
+	ret1, _ := ret[1].(*TLFReaderKeyBundleV2)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFKeyBundles(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFKeyBundles", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) GetUserDeviceKeyInfoMaps(keyGen KeyGen, extra ExtraMetadata) (UserDeviceKeyInfoMap, UserDeviceKeyInfoMap, error) {
+	ret := _m.ctrl.Call(_m, "GetUserDeviceKeyInfoMaps", keyGen, extra)
+	ret0, _ := ret[0].(UserDeviceKeyInfoMap)
+	ret1, _ := ret[1].(UserDeviceKeyInfoMap)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetUserDeviceKeyInfoMaps(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDeviceKeyInfoMaps", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) fillInDevices(crypto Crypto, wkb *TLFWriterKeyBundleV2, wkb2 *TLFWriterKeyBundleV3, rkb *TLFReaderKeyBundleV2, wKeys map[keybase1.UID][]CryptPublicKey, rKeys map[keybase1.UID][]CryptPublicKey, ePubKey TLFEphemeralPublicKey, ePrivKey TLFEphemeralPrivateKey, tlfCryptKey TLFCryptKey) (serverKeyMap, error) {
+	ret := _m.ctrl.Call(_m, "fillInDevices", crypto, wkb, wkb2, rkb, wKeys, rKeys, ePubKey, ePrivKey, tlfCryptKey)
+	ret0, _ := ret[0].(serverKeyMap)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) fillInDevices(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "fillInDevices", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+}
+
+// Mock of KeyBundleCache interface
+type MockKeyBundleCache struct {
+	ctrl     *gomock.Controller
+	recorder *_MockKeyBundleCacheRecorder
+}
+
+// Recorder for MockKeyBundleCache (not exported)
+type _MockKeyBundleCacheRecorder struct {
+	mock *MockKeyBundleCache
+}
+
+func NewMockKeyBundleCache(ctrl *gomock.Controller) *MockKeyBundleCache {
+	mock := &MockKeyBundleCache{ctrl: ctrl}
+	mock.recorder = &_MockKeyBundleCacheRecorder{mock}
+	return mock
+}
+
+func (_m *MockKeyBundleCache) EXPECT() *_MockKeyBundleCacheRecorder {
+	return _m.recorder
+}
+
+func (_m *MockKeyBundleCache) GetTLFReaderKeyBundleV2(_param0 TLFReaderKeyBundleID) (TLFReaderKeyBundleV2, bool) {
+	ret := _m.ctrl.Call(_m, "GetTLFReaderKeyBundleV2", _param0)
+	ret0, _ := ret[0].(TLFReaderKeyBundleV2)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+func (_mr *_MockKeyBundleCacheRecorder) GetTLFReaderKeyBundleV2(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFReaderKeyBundleV2", arg0)
+}
+
+func (_m *MockKeyBundleCache) GetTLFWriterKeyBundleV2(_param0 TLFWriterKeyBundleID) (TLFWriterKeyBundleV3, bool) {
+	ret := _m.ctrl.Call(_m, "GetTLFWriterKeyBundleV2", _param0)
+	ret0, _ := ret[0].(TLFWriterKeyBundleV3)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+func (_mr *_MockKeyBundleCacheRecorder) GetTLFWriterKeyBundleV2(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFWriterKeyBundleV2", arg0)
+}
+
+func (_m *MockKeyBundleCache) PutTLFReaderKeyBundleV2(_param0 TLFReaderKeyBundleV2) {
+	_m.ctrl.Call(_m, "PutTLFReaderKeyBundleV2", _param0)
+}
+
+func (_mr *_MockKeyBundleCacheRecorder) PutTLFReaderKeyBundleV2(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutTLFReaderKeyBundleV2", arg0)
+}
+
+func (_m *MockKeyBundleCache) PutTLFWriterKeyBundleV2(_param0 TLFWriterKeyBundleV3) {
+	_m.ctrl.Call(_m, "PutTLFWriterKeyBundleV2", _param0)
+}
+
+func (_mr *_MockKeyBundleCacheRecorder) PutTLFWriterKeyBundleV2(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutTLFWriterKeyBundleV2", arg0)
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -90,6 +90,12 @@ func (p PrivateMetadata) ChangesBlockInfo() BlockInfo {
 	return p.cachedChanges.Info
 }
 
+// ExtraMetadata is a per-version blob of extra metadata which may exist outside of the
+// given metadata block, e.g. key bundles for post-v2 metadata.
+type ExtraMetadata interface {
+	MetadataVersion() MetadataVer
+}
+
 // A RootMetadata is a BareRootMetadata but with a deserialized
 // PrivateMetadata. However, note that it is possible that the
 // PrivateMetadata has to be left serialized due to not having the
@@ -106,6 +112,10 @@ type RootMetadata struct {
 	// The TLF handle for this MD. May be nil if this object was
 	// deserialized (more common on the server side).
 	tlfHandle *TlfHandle
+
+	// ExtraMetadata currently contains key bundles for post-v2
+	// metadata.
+	extra ExtraMetadata
 }
 
 var _ KeyMetadata = (*RootMetadata)(nil)
@@ -131,15 +141,23 @@ func (md *RootMetadata) clearLastRevision() {
 	md.clearWriterMetadataCopiedBit()
 }
 
-func (md *RootMetadata) deepCopy(codec Codec, copyHandle bool) (*RootMetadata, error) {
+func (md *RootMetadata) makeSuccessor(codec Codec) (*RootMetadata, error) {
 	var newMd RootMetadata
-	if err := md.deepCopyInPlace(codec, copyHandle, &newMd); err != nil {
+	if err := md.deepCopyInPlace(codec, true, true, &newMd); err != nil {
 		return nil, err
 	}
 	return &newMd, nil
 }
 
-func (md *RootMetadata) deepCopyInPlace(codec Codec, copyHandle bool,
+func (md *RootMetadata) deepCopy(codec Codec, copyHandle bool) (*RootMetadata, error) {
+	var newMd RootMetadata
+	if err := md.deepCopyInPlace(codec, copyHandle, false, &newMd); err != nil {
+		return nil, err
+	}
+	return &newMd, nil
+}
+
+func (md *RootMetadata) deepCopyInPlace(codec Codec, copyHandle, successorCopy bool,
 	newMd *RootMetadata) error {
 	if err := CodecUpdate(codec, newMd, md); err != nil {
 		return err
@@ -147,8 +165,13 @@ func (md *RootMetadata) deepCopyInPlace(codec Codec, copyHandle bool,
 	if err := CodecUpdate(codec, &newMd.data, md.data); err != nil {
 		return err
 	}
-
-	brmdCopy, err := md.bareMd.DeepCopy(codec)
+	var err error
+	var brmdCopy BareRootMetadata
+	if successorCopy {
+		brmdCopy, err = md.bareMd.MakeSuccessorCopy(codec)
+	} else {
+		brmdCopy, err = md.bareMd.DeepCopy(codec)
+	}
 	if err != nil {
 		return err
 	}
@@ -179,7 +202,7 @@ func (md *RootMetadata) MakeSuccessor(
 	if md.IsFinal() {
 		return nil, MetadataIsFinalError{}
 	}
-	newMd, err := md.deepCopy(config.Codec(), true)
+	newMd, err := md.makeSuccessor(config.Codec())
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +230,7 @@ func (md *RootMetadata) MakeSuccessor(
 // AddNewKeys makes a new key generation for this RootMetadata using the
 // given TLF key bundles.
 func (md *RootMetadata) AddNewKeys(
-	wkb TLFWriterKeyBundle, rkb TLFReaderKeyBundle) error {
+	wkb TLFWriterKeyBundleV2, rkb TLFReaderKeyBundleV2) error {
 	if md.TlfID().IsPublic() {
 		return InvalidPublicTLFOperation{md.TlfID(), "AddNewKeys"}
 	}
@@ -231,7 +254,7 @@ func (md *RootMetadata) MakeBareTlfHandle() (BareTlfHandle, error) {
 		panic(errors.New("MakeBareTlfHandle called when md.tlfHandle exists"))
 	}
 
-	return md.bareMd.MakeBareTlfHandle()
+	return md.bareMd.MakeBareTlfHandle(md.extra)
 }
 
 // IsInitialized returns whether or not this RootMetadata has been initialized
@@ -311,7 +334,7 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
 	md.SetConflictInfo(newHandle.ConflictInfo())
 	md.SetFinalizedInfo(newHandle.FinalizedInfo())
 
-	bareHandle, err := md.bareMd.MakeBareTlfHandle()
+	bareHandle, err := md.bareMd.MakeBareTlfHandle(md.extra)
 	if err != nil {
 		return err
 	}
@@ -347,7 +370,7 @@ func (md *RootMetadata) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID, key CryptPublicKey) (
 	TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
 	TLFCryptKeyServerHalfID, bool, error) {
-	return md.bareMd.GetTLFCryptKeyParams(keyGen, user, key)
+	return md.bareMd.GetTLFCryptKeyParams(keyGen, user, key, md.extra)
 }
 
 // LatestKeyGeneration wraps the respective method of the underlying BareRootMetadata for convenience.
@@ -570,12 +593,14 @@ func (md *RootMetadata) SetTlfID(tlf TlfID) {
 
 // HasKeyForUser wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID) bool {
-	return md.bareMd.HasKeyForUser(keyGen, user)
+	return md.bareMd.HasKeyForUser(keyGen, user, md.extra)
 }
 
 // FakeInitialRekey wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) FakeInitialRekey(h BareTlfHandle) {
-	md.bareMd.FakeInitialRekey(h)
+func (md *RootMetadata) FakeInitialRekey(codec Codec, h BareTlfHandle) error {
+	var err error
+	md.extra, err = md.bareMd.FakeInitialRekey(codec, h)
+	return err
 }
 
 // Update wraps the respective method of the underlying BareRootMetadata for convenience.
@@ -586,6 +611,41 @@ func (md *RootMetadata) Update(id TlfID, h BareTlfHandle) error {
 // GetBareRootMetadata returns an interface to the underlying serializeable metadata.
 func (md *RootMetadata) GetBareRootMetadata() BareRootMetadata {
 	return md.bareMd
+}
+
+// NewKeyGeneration adds a new key generation to this revision of metadata.
+func (md *RootMetadata) NewKeyGeneration(pubKey TLFPublicKey) {
+	md.extra = md.bareMd.NewKeyGeneration(pubKey)
+}
+
+func (md *RootMetadata) fillInDevices(crypto Crypto,
+	keyGen KeyGen, wKeys map[keybase1.UID][]CryptPublicKey,
+	rKeys map[keybase1.UID][]CryptPublicKey, ePubKey TLFEphemeralPublicKey,
+	ePrivKey TLFEphemeralPrivateKey, tlfCryptKey TLFCryptKey) (serverKeyMap, error) {
+
+	if bareV3, ok := md.bareMd.(*BareRootMetadataV3); ok {
+		// v3 bundles aren't embedded.
+		wkb, rkb, ok := getKeyBundlesV3(md.extra)
+		if !ok {
+			return serverKeyMap{}, errors.New("Missing key bundles")
+		}
+		return bareV3.fillInDevices(crypto,
+			wkb, rkb, wKeys, rKeys,
+			ePubKey, ePrivKey, tlfCryptKey)
+	}
+
+	if bareV2, ok := md.bareMd.(*BareRootMetadataV2); ok {
+		// v1 & v2 bundles are embedded.
+		wkb, rkb, err := md.bareMd.GetTLFKeyBundles(keyGen)
+		if err != nil {
+			return serverKeyMap{}, err
+		}
+		return bareV2.fillInDevices(crypto,
+			wkb, rkb, wKeys, rKeys,
+			ePubKey, ePrivKey, tlfCryptKey)
+	}
+
+	return serverKeyMap{}, errors.New("Unknown bare metadata version")
 }
 
 // A ReadOnlyRootMetadata is a thin wrapper around a
@@ -724,14 +784,14 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(config Config) (
 // validated, either by comparing to the current device key (using
 // IsLastModifiedBy), or by checking with KBPKI.
 func (rmds *RootMetadataSigned) IsValidAndSigned(
-	codec Codec, crypto cryptoPure) error {
+	codec Codec, crypto cryptoPure, extra ExtraMetadata) error {
 	// Optimization -- if the RootMetadata signature is nil, it
 	// will fail verification.
 	if rmds.SigInfo.IsNil() {
 		return errors.New("Missing RootMetadata signature")
 	}
 
-	err := rmds.MD.IsValidAndSigned(codec, crypto)
+	err := rmds.MD.IsValidAndSigned(codec, crypto, extra)
 	if err != nil {
 		return err
 	}
@@ -795,12 +855,21 @@ func DecodeRootMetadataSigned(codec Codec, tlf TlfID, ver, max MetadataVer, buf 
 	} else if ver > max {
 		return nil, NewMetadataVersionError{tlf, ver}
 	}
-	// For now only v1 & v2 are supported (both by the same BareRootMetadataSignedV2 struct)
-	if ver > InitialExtraMetadataVer {
+	if ver > SegregatedKeyBundlesVer {
 		// Shouldn't be possible at the moment.
 		panic("Invalid metadata version")
 	}
-	var brmds BareRootMetadataSignedV2
+	if ver < SegregatedKeyBundlesVer {
+		var brmds BareRootMetadataSignedV2
+		if err := codec.Decode(buf, &brmds); err != nil {
+			return nil, err
+		}
+		return &RootMetadataSigned{
+			MD:      &brmds.MD,
+			SigInfo: brmds.SigInfo,
+		}, nil
+	}
+	var brmds BareRootMetadataSignedV3
 	if err := codec.Decode(buf, &brmds); err != nil {
 		return nil, err
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -280,22 +280,22 @@ func FakeBranchID(b byte) BranchID {
 	return BranchID{bytes}
 }
 
-// NewEmptyTLFWriterKeyBundle creates a new empty TLFWriterKeyBundle
-func NewEmptyTLFWriterKeyBundle() TLFWriterKeyBundle {
-	return TLFWriterKeyBundle{
+// NewEmptyTLFWriterKeyBundle creates a new empty TLFWriterKeyBundleV2
+func NewEmptyTLFWriterKeyBundle() TLFWriterKeyBundleV2 {
+	return TLFWriterKeyBundleV2{
 		WKeys: make(UserDeviceKeyInfoMap, 0),
 	}
 }
 
-// NewEmptyTLFReaderKeyBundle creates a new empty TLFReaderKeyBundle
-func NewEmptyTLFReaderKeyBundle() TLFReaderKeyBundle {
-	return TLFReaderKeyBundle{
+// NewEmptyTLFReaderKeyBundle creates a new empty TLFReaderKeyBundleV2
+func NewEmptyTLFReaderKeyBundle() TLFReaderKeyBundleV2 {
+	return TLFReaderKeyBundleV2{
 		RKeys: make(UserDeviceKeyInfoMap, 0),
 	}
 }
 
 // AddNewKeysOrBust adds new keys to root metadata and blows up on error.
-func AddNewKeysOrBust(t logger.TestLogBackend, rmd *RootMetadata, wkb TLFWriterKeyBundle, rkb TLFReaderKeyBundle) {
+func AddNewKeysOrBust(t logger.TestLogBackend, rmd *RootMetadata, wkb TLFWriterKeyBundleV2, rkb TLFReaderKeyBundleV2) {
 	if err := rmd.AddNewKeys(wkb, rkb); err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -624,7 +624,8 @@ func (j *tlfJournal) flushOneMDOp(
 
 	j.log.CDebugf(ctx, "Flushing MD for TLF=%s with id=%s, rev=%s, bid=%s",
 		rmds.MD.TlfID(), mdID, rmds.MD.RevisionNumber(), rmds.MD.BID())
-	pushErr := mdServer.Put(ctx, rmds)
+	// MDv3 TODO: pass actual key bundles
+	pushErr := mdServer.Put(ctx, rmds, nil)
 	if isRevisionConflict(pushErr) {
 		headMdID, err := getMdID(ctx, mdServer, j.mdJournal.crypto,
 			rmds.MD.TlfID(), rmds.MD.BID(), rmds.MD.MergedStatus(),
@@ -652,7 +653,8 @@ func (j *tlfJournal) flushOneMDOp(
 			}
 			j.log.CDebugf(ctx, "Flushing newly-unmerged MD for TLF=%s with id=%s, rev=%s, bid=%s",
 				rmds.MD.TlfID(), mdID, rmds.MD.RevisionNumber(), rmds.MD.BID())
-			pushErr = mdServer.Put(ctx, rmds)
+			// MDv3 TODO: pass actual key bundles
+			pushErr = mdServer.Put(ctx, rmds, nil)
 		}
 	}
 	if pushErr != nil {
@@ -870,7 +872,8 @@ func (j *tlfJournal) getMDHead(
 		return ImmutableBareRootMetadata{}, err
 	}
 
-	return j.mdJournal.getHead(uid, key)
+	// MDv3 TODO: pass actual key bundles
+	return j.mdJournal.getHead(uid, key, nil)
 }
 
 func (j *tlfJournal) getMDRange(
@@ -888,7 +891,8 @@ func (j *tlfJournal) getMDRange(
 		return nil, err
 	}
 
-	return j.mdJournal.getRange(uid, key, start, stop)
+	// MDv3 TODO: pass actual key bundles
+	return j.mdJournal.getRange(uid, key, nil, start, stop)
 }
 
 func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
@@ -934,7 +938,8 @@ func (j *tlfJournal) clearMDs(ctx context.Context, bid BranchID) error {
 	}
 
 	// No need to signal work in this case.
-	return j.mdJournal.clear(ctx, uid, key, bid)
+	// MDv3 TODO: pass actual key bundles
+	return j.mdJournal.clear(ctx, uid, key, bid, nil)
 }
 
 func (j *tlfJournal) wait(ctx context.Context) error {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -143,7 +143,8 @@ func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
 	checkBRMD(c.t, uid, verifyingKey, c.Codec(), c.Crypto(),
 		rmds.MD, expectedRevision, expectedPrevRoot,
 		expectedMergeStatus, expectedBranchID)
-	err := rmds.IsValidAndSigned(c.Codec(), c.Crypto())
+	// MDv3 TODO: pass key bundles
+	err := rmds.IsValidAndSigned(c.Codec(), c.Crypto(), nil)
 	require.NoError(c.t, err)
 	err = rmds.IsLastModifiedBy(uid, verifyingKey)
 	require.NoError(c.t, err)
@@ -428,7 +429,7 @@ type hangingMDServer struct {
 }
 
 func (md hangingMDServer) Put(
-	ctx context.Context, rmds *RootMetadataSigned) error {
+	ctx context.Context, rmds *RootMetadataSigned, _ ExtraMetadata) error {
 	close(md.onPutCh)
 	// Hang until the context is cancelled.
 	<-ctx.Done()
@@ -520,7 +521,7 @@ func (s *shimMDServer) GetRange(
 }
 
 func (s *shimMDServer) Put(
-	ctx context.Context, rmds *RootMetadataSigned) error {
+	ctx context.Context, rmds *RootMetadataSigned, _ ExtraMetadata) error {
 	if s.nextErr != nil {
 		err := s.nextErr
 		s.nextErr = nil
@@ -775,7 +776,7 @@ type orderedMDServer struct {
 }
 
 func (s *orderedMDServer) Put(
-	ctx context.Context, rmds *RootMetadataSigned) error {
+	ctx context.Context, rmds *RootMetadataSigned, _ ExtraMetadata) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	*s.puts = append(*s.puts, rmds.MD.RevisionNumber())


### PR DESCRIPTION
This is a WIP PR but I do intend to merge it. Having both metadata versions co-exist is going to span a couple more PRs. The motivation for this half-baked PR is that I want to both get some feedback earlier vs. later and spare myself some merge pain. MDv3 should not be active yet and only initial keying is partially working with no rekey support yet. The `BareRootMetadata` interface is most certainly still going to change. I literally dropped what I was doing and cleaned this up enough for review so it's not a complete thought.