### PR TITLE
cr: co-exist peacefully with journaling

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -777,8 +777,9 @@ func (c *ConfigLocal) EnableJournaling(journalRoot string) {
 	// it if it doesn't exist, make sure that it doesn't
 	// point to /keybase itself, etc.
 	log := c.MakeLogger("")
+	onBranchChange := c.KBFSOps().(*KBFSOpsStandard)
 	jServer := makeJournalServer(c, log, journalRoot, c.BlockCache(),
-		c.BlockServer(), c.MDOps())
+		c.BlockServer(), c.MDOps(), onBranchChange)
 	ctx := context.Background()
 	err := jServer.EnableExistingJournals(
 		ctx, TLFJournalBackgroundWorkEnabled)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -777,9 +777,9 @@ func (c *ConfigLocal) EnableJournaling(journalRoot string) {
 	// it if it doesn't exist, make sure that it doesn't
 	// point to /keybase itself, etc.
 	log := c.MakeLogger("")
-	onBranchChange := c.KBFSOps().(*KBFSOpsStandard)
+	listener := c.KBFSOps().(branchChangeListener)
 	jServer := makeJournalServer(c, log, journalRoot, c.BlockCache(),
-		c.BlockServer(), c.MDOps(), onBranchChange)
+		c.BlockServer(), c.MDOps(), listener)
 	ctx := context.Background()
 	err := jServer.EnableExistingJournals(
 		ctx, TLFJournalBackgroundWorkEnabled)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -356,10 +356,6 @@ func newFolderBranchOps(config Config, fb FolderBranch,
 		go fbo.backgroundFlusher(secondsBetweenBackgroundFlushes * time.Second)
 	}
 
-	if jServer, err := GetJournalServer(fbo.config); err == nil {
-		jServer.RegisterBranchChange(fbo.id(), fbo.journalBranchChange)
-	}
-
 	return fbo
 }
 
@@ -4609,7 +4605,7 @@ func (fbo *folderBranchOps) unstageAfterFailedResolution(ctx context.Context,
 	return fbo.unstageLocked(ctx, lState)
 }
 
-func (fbo *folderBranchOps) journalBranchChange(newBID BranchID) {
+func (fbo *folderBranchOps) onTLFBranchChange(newBID BranchID) {
 	if newBID == NullBranchID {
 		return
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4606,12 +4606,15 @@ func (fbo *folderBranchOps) unstageAfterFailedResolution(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) onTLFBranchChange(newBID BranchID) {
-	if newBID == NullBranchID {
-		return
-	}
-
 	ctx, cancelFunc := fbo.newCtxWithFBOID()
 	defer cancelFunc()
+
+	// This only happens on a `PruneBranch` call, in which case we
+	// would have already updated fbo's local view of the branch/head.
+	if newBID == NullBranchID {
+		fbo.log.CDebugf(ctx, "Ignoring branch change back to master")
+		return
+	}
 
 	lState := makeFBOLockState()
 	fbo.mdWriterLock.Lock(lState)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -561,6 +561,8 @@ type MDCache interface {
 	Get(tlf TlfID, rev MetadataRevision, bid BranchID) (ImmutableRootMetadata, error)
 	// Put stores the metadata object.
 	Put(md ImmutableRootMetadata) error
+	// Delete removes the given metadata object from the cache if it exists.
+	Delete(tlf TlfID, rev MetadataRevision, bid BranchID)
 }
 
 // KeyCache handles caching for both TLFCryptKeys and BlockCryptKeys.

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -22,7 +22,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
-		config.BlockServer(), config.MDOps())
+		config.BlockServer(), config.MDOps(), nil)
 	ctx := context.Background()
 	err = jServer.EnableExistingJournals(
 		ctx, TLFJournalBackgroundWorkPaused)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -35,7 +35,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
-		config.BlockServer(), config.MDOps())
+		config.BlockServer(), config.MDOps(), nil)
 
 	ctx := context.Background()
 	err = jServer.EnableExistingJournals(

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -119,6 +119,10 @@ func (j *JournalServer) EnableExistingJournals(
 	return nil
 }
 
+func (j *JournalServer) branchChange(tlfID TlfID, newBID BranchID) {
+
+}
+
 // Enable turns on the write journal for the given TLF.
 func (j *JournalServer) Enable(
 	ctx context.Context, tlfID TlfID,
@@ -139,9 +143,13 @@ func (j *JournalServer) Enable(
 		return nil
 	}
 
+	branchFn := func(bid BranchID) {
+		j.branchChange(tlfID, bid)
+	}
+
 	tlfJournal, err := makeTLFJournal(ctx, j.dir, tlfID,
 		tlfJournalConfigAdapter{j.config}, j.delegateBlockServer,
-		bws, nil)
+		bws, nil, branchFn)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -22,7 +22,7 @@ func setupJournalServerTest(t *testing.T) (
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
 		config, log, tempdir, config.BlockCache(),
-		config.BlockServer(), config.MDOps())
+		config.BlockServer(), config.MDOps(), nil)
 	ctx := context.Background()
 	err = jServer.EnableExistingJournals(
 		ctx, TLFJournalBackgroundWorkPaused)
@@ -95,7 +95,7 @@ func TestJournalServerRestart(t *testing.T) {
 
 	jServer = makeJournalServer(
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
-		jServer.delegateBlockServer, jServer.delegateMDOps)
+		jServer.delegateBlockServer, jServer.delegateMDOps, nil)
 	err = jServer.EnableExistingJournals(
 		ctx, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -637,3 +637,9 @@ func (fs *KBFSOpsStandard) UnregisterFromChanges(
 	}
 	return nil
 }
+
+func (fs *KBFSOpsStandard) onTLFBranchChange(tlfID TlfID, newBID BranchID) {
+	ops := fs.getOpsNoAdd(FolderBranch{Tlf: tlfID, Branch: MasterBranch})
+	// Launch in a new goroutine to avoid deadlocks.
+	go ops.onTLFBranchChange(newBID)
+}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -325,7 +325,8 @@ func (j mdJournal) checkGetParams(currentUID keybase1.UID,
 
 func (j *mdJournal) convertToBranch(
 	ctx context.Context, currentUID keybase1.UID,
-	currentVerifyingKey VerifyingKey, signer cryptoSigner) (
+	currentVerifyingKey VerifyingKey, signer cryptoSigner,
+	tlfID TlfID, mdcache MDCache) (
 	bid BranchID, err error) {
 	if j.branchID != NullBranchID {
 		return NullBranchID, fmt.Errorf(
@@ -388,6 +389,9 @@ func (j *mdJournal) convertToBranch(
 		}
 		brmd.SetUnmerged()
 		brmd.SetBranchID(bid)
+
+		// Delete the old "merged" version from the cache.
+		mdcache.Delete(tlfID, ibrmd.RevisionNumber(), NullBranchID)
 
 		// Re-sign the writer metadata.
 		buf, err := brmd.GetSerializedWriterMetadata(j.codec)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -230,7 +230,8 @@ func TestMDJournalPutCase1Conflict(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
@@ -279,7 +280,8 @@ func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	md.SetUnmerged()
@@ -297,7 +299,8 @@ func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {
 	mdID, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, mdID)
@@ -316,7 +319,8 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Flush.
@@ -341,7 +345,8 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	head, err := j.getHead(uid, verifyingKey)
@@ -364,7 +369,8 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	head, err := j.getHead(uid, verifyingKey)
@@ -386,7 +392,8 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Flush.
@@ -428,7 +435,8 @@ func TestMDJournalBranchConversion(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Branch conversion shouldn't leave old folders behind.
@@ -485,7 +493,8 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, &limitedSigner)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, &limitedSigner, id,
+		NewMDCacheStandard(10))
 	require.NotNil(t, err)
 
 	// All entries should remain unchanged, since the conversion
@@ -519,7 +528,8 @@ func TestMDJournalClear(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -606,7 +616,8 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer, id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Restart journal.

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -230,7 +230,7 @@ func TestMDJournalPutCase1Conflict(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
@@ -279,7 +279,7 @@ func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	md.SetUnmerged()
@@ -297,7 +297,7 @@ func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {
 	mdID, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, mdID)
@@ -316,7 +316,7 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	// Flush.
@@ -341,7 +341,7 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	head, err := j.getHead(uid, verifyingKey)
@@ -364,7 +364,7 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	head, err := j.getHead(uid, verifyingKey)
@@ -386,7 +386,7 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	err = j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	// Flush.
@@ -428,7 +428,7 @@ func TestMDJournalBranchConversion(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	// Branch conversion shouldn't leave old folders behind.
@@ -485,7 +485,7 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := j.convertToBranch(ctx, uid, verifyingKey, &limitedSigner)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, &limitedSigner)
 	require.NotNil(t, err)
 
 	// All entries should remain unchanged, since the conversion
@@ -519,7 +519,7 @@ func TestMDJournalClear(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -606,7 +606,7 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	ctx := context.Background()
 
-	err := j.convertToBranch(ctx, uid, verifyingKey, signer)
+	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer)
 	require.NoError(t, err)
 
 	// Restart journal.

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -49,3 +49,10 @@ func (md *MDCacheStandard) Put(rmd ImmutableRootMetadata) error {
 	md.lru.Add(key, rmd)
 	return nil
 }
+
+// Delete implements the MDCache interface for MDCacheStandard.
+func (md *MDCacheStandard) Delete(tlf TlfID, rev MetadataRevision,
+	bid BranchID) {
+	key := mdCacheKey{tlf, rev, bid}
+	md.lru.Remove(key)
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1354,6 +1354,14 @@ func (_mr *_MockMDCacheRecorder) Put(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0)
 }
 
+func (_m *MockMDCache) Delete(tlf TlfID, rev MetadataRevision, bid BranchID) {
+	_m.ctrl.Call(_m, "Delete", tlf, rev, bid)
+}
+
+func (_mr *_MockMDCacheRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+}
+
 // Mock of KeyCache interface
 type MockKeyCache struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -22,6 +22,7 @@ type tlfJournalConfig interface {
 	Codec() Codec
 	Crypto() Crypto
 	BlockCache() BlockCache
+	MDCache() MDCache
 	Reporter() Reporter
 	currentInfoGetter() currentInfoGetter
 	encryptionKeyGetter() encryptionKeyGetter
@@ -539,8 +540,9 @@ func (j *tlfJournal) convertMDsToBranchAndGetNextEntry(
 	nextEntryEnd MetadataRevision) (MdID, *RootMetadataSigned, error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	err := j.mdJournal.convertToBranch(
-		ctx, currentUID, currentVerifyingKey, j.config.Crypto())
+	bid, err := j.mdJournal.convertToBranch(
+		ctx, currentUID, currentVerifyingKey, j.config.Crypto(), j.tlfID,
+		j.config.MDCache())
 	if err != nil {
 		return MdID{}, nil, err
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -209,7 +209,7 @@ func setupTLFJournalTest(
 	delegateBlockServer := NewBlockServerMemory(config)
 
 	tlfJournal, err = makeTLFJournal(ctx, tempdir, config.tlfID, config,
-		delegateBlockServer, bwStatus, delegate)
+		delegateBlockServer, bwStatus, delegate, nil)
 	require.NoError(t, err)
 
 	switch bwStatus {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -69,6 +69,7 @@ type testTLFJournalConfig struct {
 	codec    Codec
 	crypto   CryptoLocal
 	bcache   BlockCache
+	mdcache  MDCache
 	reporter Reporter
 	cig      singleCurrentInfoGetter
 	ekg      singleEncryptionKeyGetter
@@ -89,6 +90,10 @@ func (c testTLFJournalConfig) Crypto() Crypto {
 
 func (c testTLFJournalConfig) BlockCache() BlockCache {
 	return c.bcache
+}
+
+func (c testTLFJournalConfig) MDCache() MDCache {
+	return c.mdcache
 }
 
 func (c testTLFJournalConfig) Reporter() Reporter {
@@ -181,7 +186,8 @@ func setupTLFJournalTest(
 
 	config = &testTLFJournalConfig{
 		t, FakeTlfID(1, false), bsplitter, codec, crypto,
-		nil, NewReporterSimple(newTestClockNow(), 10), cig, ekg, mdserver,
+		nil, NewMDCacheStandard(10), NewReporterSimple(newTestClockNow(), 10),
+		cig, ekg, mdserver,
 	}
 
 	// Time out individual tests after 10 seconds.

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -583,23 +583,25 @@ func rekey() fileOp {
 
 func enableJournal() fileOp {
 	return fileOp{func(c *ctx) error {
-		err := c.engine.EnableJournal(c.user, c.tlfName, c.tlfIsPublic)
-		if err != nil {
-			return err
-		}
-		return c.engine.SyncFromServerForTesting(c.user, c.tlfName,
-			c.tlfIsPublic)
+		return c.engine.EnableJournal(c.user, c.tlfName, c.tlfIsPublic)
+	}, IsInit}
+}
+
+func pauseJournal() fileOp {
+	return fileOp{func(c *ctx) error {
+		return c.engine.PauseJournal(c.user, c.tlfName, c.tlfIsPublic)
+	}, IsInit}
+}
+
+func resumeJournal() fileOp {
+	return fileOp{func(c *ctx) error {
+		return c.engine.ResumeJournal(c.user, c.tlfName, c.tlfIsPublic)
 	}, IsInit}
 }
 
 func flushJournal() fileOp {
 	return fileOp{func(c *ctx) error {
-		err := c.engine.FlushJournal(c.user, c.tlfName, c.tlfIsPublic)
-		if err != nil {
-			return err
-		}
-		return c.engine.SyncFromServerForTesting(c.user, c.tlfName,
-			c.tlfIsPublic)
+		return c.engine.FlushJournal(c.user, c.tlfName, c.tlfIsPublic)
 	}, IsInit}
 }
 

--- a/test/engine.go
+++ b/test/engine.go
@@ -121,6 +121,12 @@ type Engine interface {
 	// EnableJournal is called by the test harness as the given
 	// user to enable journaling.
 	EnableJournal(u User, tlfName string, isPublic bool) (err error)
+	// PauseJournal is called by the test harness as the given
+	// user to pause journaling.
+	PauseJournal(u User, tlfName string, isPublic bool) (err error)
+	// ResumeJournal is called by the test harness as the given
+	// user to resume journaling.
+	ResumeJournal(u User, tlfName string, isPublic bool) (err error)
 	// FlushJournal is called by the test harness as the given
 	// user to wait for the journal to flush, if enabled.
 	FlushJournal(u User, tlfName string, isPublic bool) (err error)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -323,6 +323,28 @@ func (*fsEngine) EnableJournal(user User, tlfName string,
 		[]byte("on"), 0644)
 }
 
+// PauseJournal is called by the test harness as the given user to
+// pause journaling.
+func (*fsEngine) PauseJournal(user User, tlfName string,
+	isPublic bool) (err error) {
+	u := user.(*fsUser)
+	path := buildTlfPath(u, tlfName, isPublic)
+	return ioutil.WriteFile(
+		filepath.Join(path, libfs.PauseJournalBackgroundWorkFileName),
+		[]byte("on"), 0644)
+}
+
+// ResumeJournal is called by the test harness as the given user to
+// resume journaling.
+func (*fsEngine) ResumeJournal(user User, tlfName string,
+	isPublic bool) (err error) {
+	u := user.(*fsUser)
+	path := buildTlfPath(u, tlfName, isPublic)
+	return ioutil.WriteFile(
+		filepath.Join(path, libfs.ResumeJournalBackgroundWorkFileName),
+		[]byte("on"), 0644)
+}
+
 // FlushJournal is called by the test harness as the given user to
 // wait for the journal to flush, if enabled.
 func (*fsEngine) FlushJournal(user User, tlfName string,

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -589,6 +589,46 @@ func (k *LibKBFS) EnableJournal(u User, tlfName string, isPublic bool) error {
 		libkbfs.TLFJournalBackgroundWorkEnabled)
 }
 
+// PauseJournal implements the Engine interface.
+func (k *LibKBFS) PauseJournal(u User, tlfName string, isPublic bool) error {
+	config := u.(*libkbfs.ConfigLocal)
+
+	ctx, cancel := k.newContext()
+	defer cancel()
+	dir, err := getRootNode(ctx, config, tlfName, isPublic)
+	if err != nil {
+		return err
+	}
+
+	jServer, err := libkbfs.GetJournalServer(config)
+	if err != nil {
+		return err
+	}
+
+	jServer.PauseBackgroundWork(ctx, dir.GetFolderBranch().Tlf)
+	return nil
+}
+
+// ResumeJournal implements the Engine interface.
+func (k *LibKBFS) ResumeJournal(u User, tlfName string, isPublic bool) error {
+	config := u.(*libkbfs.ConfigLocal)
+
+	ctx, cancel := k.newContext()
+	defer cancel()
+	dir, err := getRootNode(ctx, config, tlfName, isPublic)
+	if err != nil {
+		return err
+	}
+
+	jServer, err := libkbfs.GetJournalServer(config)
+	if err != nil {
+		return err
+	}
+
+	jServer.ResumeBackgroundWork(ctx, dir.GetFolderBranch().Tlf)
+	return nil
+}
+
 // FlushJournal implements the Engine interface.
 func (k *LibKBFS) FlushJournal(u User, tlfName string, isPublic bool) error {
 	config := u.(*libkbfs.ConfigLocal)


### PR DESCRIPTION
To get CR working with journaling, this PR:
* Pushes resolution ops directly to the KBFS server, bypassing the journal, since otherwise it will be treated as unmerged since the branch hasn't yet been pruned.
* Flushes the journal when CR starts, since the resolution op goes straight to the server.
* Fixes `mdJournal` to clear out converted-to-branch revisions, since otherwise they will prevent the client from fetching the actual merged revisions with those revision numbers from the server.
* `tlfJournal` now notifies the corresponding `folderBranchOps` when branch conversion happens, so that it can kick off conflict resolution immediately instead of waiting to hear about the next update.
* Allow the DSL tests to pause/resume journal syncing.