### PR TITLE
test_stallers: allow more than one stall to happen in a test

### DIFF
--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -384,7 +384,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	oldBServer := config2.BlockServer()
 	defer config2.SetBlockServer(oldBServer)
 	onWriteStalledCh, writeUnstallCh, ctxStall := StallBlockOp(
-		ctx, config2, StallableBlockPut)
+		ctx, config2, StallableBlockPut, 2)
 
 	// Start the sync and wait for it to stall twice only.
 	errChan := make(chan error)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -994,7 +994,7 @@ func TestCRDouble(t *testing.T) {
 	// Cancel this revision after the Put happens, to force the
 	// background block manager to try to clean up.
 	onSyncStalledCh, syncUnstallCh, syncCtx := StallMDOp(
-		syncCtx, config2, StallableMDPutUnmerged)
+		syncCtx, config2, StallableMDPutUnmerged, 1)
 
 	wg.Add(1)
 	go func() {
@@ -1695,7 +1695,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	}
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config2, StallableMDPut)
+		StallMDOp(ctx, config2, StallableMDPut, 1)
 
 	var wg sync.WaitGroup
 	putCtx, cancel := context.WithCancel(putCtx)
@@ -1842,7 +1842,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// to it locking next time (since it has seen how many revisions
 	// are outstanding).
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config2, StallableMDPut)
+		StallMDOp(ctx, config2, StallableMDPut, 1)
 
 	var wg sync.WaitGroup
 	firstPutCtx, cancel := context.WithCancel(putCtx)
@@ -2001,7 +2001,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	}
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config2, StallableMDAfterPutUnmerged)
+		StallMDOp(ctx, config2, StallableMDAfterPutUnmerged, 1)
 
 	var wg sync.WaitGroup
 	putCtx, cancel := context.WithCancel(putCtx)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1552,7 +1552,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// Now user 2 makes a big write where most of the blocks get canceled.
 	// We only need to know the first time we stall.
 	onSyncStalledCh, syncUnstallCh, syncCtx := StallBlockOp(
-		syncCtx, config2, StallableBlockPut)
+		syncCtx, config2, StallableBlockPut, 2)
 
 	var syncErr error
 	go func() {

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -57,7 +57,7 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	defer CheckConfigAndShutdown(t, config)
 
 	onGetStalledCh, getUnstallCh, ctxStallGetForTLF :=
-		StallMDOp(ctx, config, StallableMDGetForTLF)
+		StallMDOp(ctx, config, StallableMDGetForTLF, 1)
 
 	// Initialize the MD using a different config
 	c2 := ConfigAsUser(config.(*ConfigLocal), "test_user")
@@ -102,7 +102,7 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config, StallableMDAfterPut)
+		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -152,7 +152,7 @@ func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config, StallableMDAfterPut)
+		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -287,7 +287,7 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config, StallableMDAfterPut)
+		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -805,7 +805,7 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config, StallableMDAfterPut)
+		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// make blocks small
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = 5
@@ -1239,7 +1239,7 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 	ctx := context.Background()
 
 	onPutStalledCh, putUnstallCh, ctx :=
-		StallMDOp(ctx, config, StallableMDPut)
+		StallMDOp(ctx, config, StallableMDPut, 1)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -1290,7 +1290,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 	ctx := context.Background()
 
 	onPutStalledCh, putUnstallCh, ctx :=
-		StallMDOp(ctx, config, StallableMDPut)
+		StallMDOp(ctx, config, StallableMDPut, 1)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -1346,7 +1346,7 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config, StallableMDAfterPut)
+		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -419,9 +419,9 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	}
 
 	onReadStalledCh, readUnstallCh, ctxStallRead :=
-		StallBlockOp(ctx, config, StallableBlockGet)
+		StallBlockOp(ctx, config, StallableBlockGet, 1)
 	onWriteStalledCh, writeUnstallCh, ctxStallWrite :=
-		StallBlockOp(ctx, config, StallableBlockGet)
+		StallBlockOp(ctx, config, StallableBlockGet, 1)
 
 	var wg sync.WaitGroup
 
@@ -556,7 +556,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	}
 
 	onSyncStalledCh, syncUnstallCh, ctxStallSync :=
-		StallBlockOp(ctx, config, StallableBlockGet)
+		StallBlockOp(ctx, config, StallableBlockGet, 1)
 
 	var wg sync.WaitGroup
 
@@ -643,7 +643,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	}
 
 	onSyncStalledCh, syncUnstallCh, ctxStallSync :=
-		StallBlockOp(ctx, config, StallableBlockGet)
+		StallBlockOp(ctx, config, StallableBlockGet, 1)
 
 	var wg sync.WaitGroup
 
@@ -1135,7 +1135,7 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 	oldBServer := config.BlockServer()
 	defer config.SetBlockServer(oldBServer)
 	onSyncStalledCh, syncUnstallCh, ctxStallSync :=
-		StallBlockOp(ctx, config, StallableBlockPut)
+		StallBlockOp(ctx, config, StallableBlockPut, 1)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -1491,7 +1491,7 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	oldBServer := config.BlockServer()
 	defer config.SetBlockServer(oldBServer)
 	onSyncStalledCh, syncUnstallCh, ctxStallSync :=
-		StallBlockOp(cancelCtx, config, StallableBlockPut)
+		StallBlockOp(cancelCtx, config, StallableBlockPut, 1)
 
 	go func() {
 		errChan <- kbfsOps.Sync(ctxStallSync, fileNode2)
@@ -1555,7 +1555,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	config.SetBlockOps(&blockOpsOverQuota{BlockOps: config.BlockOps()})
 
 	onSyncStalledCh, syncUnstallCh, ctxStallSync :=
-		StallBlockOp(ctx, config, StallableBlockPut)
+		StallBlockOp(ctx, config, StallableBlockPut, 1)
 
 	// Block the Sync
 	// Sync the initial two data blocks

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1389,7 +1389,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 
 	// Stall user 1's rekey, to ensure a conflict.
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(ctx, config1, StallableMDPut)
+		StallMDOp(ctx, config1, StallableMDPut, 1)
 
 	// Have user 1 also try to rekey but fail due to conflict
 	errChan := make(chan error)

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -211,9 +211,10 @@ func (s *NaïveStaller) UndoStallMDOp(stalledOp StallableMDOp) {
 // for the stall to be effective. onStalled is a channel to notify the caller
 // when the stall has happened. unstall is a channel for caller to unstall an
 // Op.
-func StallBlockOp(ctx context.Context, config Config, stalledOp StallableBlockOp) (
+func StallBlockOp(ctx context.Context, config Config,
+	stalledOp StallableBlockOp, maxStalls int) (
 	onStalled <-chan struct{}, unstall chan<- struct{}, newCtx context.Context) {
-	onStalledCh := make(chan struct{}, 1)
+	onStalledCh := make(chan struct{}, maxStalls)
 	unstallCh := make(chan struct{})
 	stallKey := newStallKey()
 	config.SetBlockServer(&stallingBlockServer{

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -529,7 +529,8 @@ func disableUpdates() fileOp {
 
 func stallOnMDPut() fileOp {
 	return fileOp{func(c *ctx) error {
-		c.staller.StallMDOp(libkbfs.StallableMDPut)
+		// TODO: Allow test to pass in a more precise maxStalls limit.
+		c.staller.StallMDOp(libkbfs.StallableMDPut, 100)
 		return nil
 	}, Defaults}
 }


### PR DESCRIPTION
Otherwise if more than one expected `maybeStall` call happens at once, one of the sends onto stallCall could get dropped.

Note: Maybe a better solution is to not have a default case in the send in `maybeStall`?  But I can't remember if there's a good reason for doing that, so this seemed safer.  Happy to change it though if others disagree.

Issue: KBFS-1505
