### PR TITLE
libkbfs: support rekeys when journaling is enabled

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1181,7 +1181,9 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	}
 
 	// Return early if the head is already set.  This avoids taking
-	// mdWriterLock for no reason.
+	// mdWriterLock for no reason, and it also avoids any side effects
+	// (e.g., calling `identifyOnce` and downloading the merged
+	// head) if head is already set.
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
 	if head != (ImmutableRootMetadata{}) && head.mdID == md.mdID {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4304,6 +4304,16 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 
 	lState := makeFBOLockState()
 
+	// A journal flush before CR, if needed.
+	if err := WaitForTLFJournal(ctx, fbo.config, fbo.id(),
+		fbo.log); err != nil {
+		return err
+	}
+
+	if err := fbo.mdFlushes.Wait(ctx); err != nil {
+		return err
+	}
+
 	if !fbo.isMasterBranch(lState) {
 		if err := fbo.cr.Wait(ctx); err != nil {
 			return err
@@ -4323,7 +4333,7 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 		return errors.New("Can't sync from server while dirty.")
 	}
 
-	// A journal flush, if needed.
+	// A journal flush after CR, if needed.
 	if err := WaitForTLFJournal(ctx, fbo.config, fbo.id(),
 		fbo.log); err != nil {
 		return err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2042,8 +2042,23 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 
 	oldPrevRoot := md.PrevRoot()
 
-	// finally, write out the new metadata
-	mdID, err := fbo.config.MDOps().Put(ctx, md)
+	// Write out the new metadata.  If journaling is enabled, we don't
+	// want the rekey to hit the journal and possibly end up on a
+	// conflict branch, so wait for the journal to flush and then push
+	// straight to the server.  TODO: we're holding the writer lock
+	// while flushing the journal here (just like for exclusive
+	// writes), which may end up blocking incoming writes for a long
+	// time.  Rekeys are pretty rare, but if this becomes an issue
+	// maybe we should consider letting these hit the journal and
+	// scrubbing them when converting it to a branch.
+	mdOps := fbo.config.MDOps()
+	if jServer, err := GetJournalServer(fbo.config); err == nil {
+		if err = jServer.Wait(ctx, fbo.id()); err != nil {
+			return err
+		}
+		mdOps = jServer.delegateMDOps
+	}
+	mdID, err := mdOps.Put(ctx, md)
 	isConflict := isRevisionConflict(err)
 	if err != nil && !isConflict {
 		return err

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -83,21 +83,17 @@ func (j journalMDOps) getHeadFromJournal(
 			return ImmutableRootMetadata{}, err
 		}
 	} else {
-		bareHandle, err := handle.ToBareHandle()
+		// Check for mutal handle resolution.
+		headHandle, err := MakeTlfHandle(ctx, headBareHandle,
+			j.jServer.config.KBPKI())
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
-		ok, err := CodecEqual(j.jServer.config.Codec(),
-			headBareHandle, bareHandle)
-		if err != nil {
+
+		if err := headHandle.MutuallyResolvesTo(ctx, j.jServer.config.Codec(),
+			j.jServer.config.KBPKI(), *handle, head.RevisionNumber(),
+			head.TlfID(), j.jServer.log); err != nil {
 			return ImmutableRootMetadata{}, err
-		}
-		// TODO: Figure out if either handle can be more
-		// resolved.
-		if !ok {
-			return ImmutableRootMetadata{},
-				fmt.Errorf("Expected bare handle %v, got %v",
-					bareHandle, headBareHandle)
 		}
 	}
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -83,7 +83,7 @@ func (j journalMDOps) getHeadFromJournal(
 			return ImmutableRootMetadata{}, err
 		}
 	} else {
-		// Check for mutal handle resolution.
+		// Check for mutual handle resolution.
 		headHandle, err := MakeTlfHandle(ctx, headBareHandle,
 			j.jServer.config.KBPKI())
 		if err != nil {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -233,7 +233,7 @@ func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
 
-	// Check for mutal handle resolution.
+	// Check for mutual handle resolution.
 	if err := mdHandle.MutuallyResolvesTo(ctx, md.config.Codec(),
 		md.config.KBPKI(), *handle, rmds.MD.RevisionNumber(), rmds.MD.TlfID(),
 		md.log); err != nil {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -233,40 +233,11 @@ func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
 
-	handleResolvesToMdHandle, partialResolvedHandle, err :=
-		handle.ResolvesTo(
-			ctx, md.config.Codec(), md.config.KBPKI(), *mdHandle)
-	if err != nil {
+	// Check for mutal handle resolution.
+	if err := mdHandle.MutuallyResolvesTo(ctx, md.config.Codec(),
+		md.config.KBPKI(), *handle, rmds.MD.RevisionNumber(), rmds.MD.TlfID(),
+		md.log); err != nil {
 		return TlfID{}, ImmutableRootMetadata{}, err
-	}
-
-	// TODO: If handle has conflict info, mdHandle should, too.
-	mdHandleResolvesToHandle, partialResolvedMdHandle, err :=
-		mdHandle.ResolvesTo(
-			ctx, md.config.Codec(), md.config.KBPKI(), *handle)
-	if err != nil {
-		return TlfID{}, ImmutableRootMetadata{}, err
-	}
-
-	handlePath := handle.GetCanonicalPath()
-	mdHandlePath := mdHandle.GetCanonicalPath()
-	if !handleResolvesToMdHandle && !mdHandleResolvesToHandle {
-		return TlfID{}, ImmutableRootMetadata{}, MDMismatchError{
-			rmds.MD.RevisionNumber(), handle.GetCanonicalPath(),
-			rmds.MD.TlfID(),
-			fmt.Errorf(
-				"MD contained unexpected handle path %s (%s -> %s) (%s -> %s)",
-				mdHandlePath,
-				handle.GetCanonicalPath(),
-				partialResolvedHandle.GetCanonicalPath(),
-				mdHandle.GetCanonicalPath(),
-				partialResolvedMdHandle.GetCanonicalPath()),
-		}
-	}
-
-	if handlePath != mdHandlePath {
-		md.log.CDebugf(ctx, "handle for %s resolved to %s",
-			handlePath, mdHandlePath)
 	}
 
 	// TODO: For now, use the mdHandle that came with rmds for

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -139,6 +139,18 @@ func (s *NaïveStaller) StallMDOp(stalledOp StallableMDOp, maxStalls int) {
 	onStalledCh := make(chan struct{}, maxStalls)
 	unstallCh := make(chan struct{})
 	oldMDOps := s.config.MDOps()
+	if jServer, err := GetJournalServer(s.config); err == nil {
+		// Stall the delegate server as well
+		jServer.delegateMDOps = &stallingMDOps{
+			stallOpName: stalledOp,
+			stallKey:    stallKeyStallEverything,
+			staller: staller{
+				stalled: onStalledCh,
+				unstall: unstallCh,
+			},
+			delegate: jServer.delegateMDOps,
+		}
+	}
 	s.config.SetMDOps(&stallingMDOps{
 		stallOpName: stalledOp,
 		stallKey:    stallKeyStallEverything,

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -40,10 +40,11 @@ const (
 const stallKeyStallEverything = ""
 
 type naïveStallInfo struct {
-	onStalled      <-chan struct{}
-	unstall        chan<- struct{}
-	oldBlockServer BlockServer
-	oldMDOps       MDOps
+	onStalled               <-chan struct{}
+	unstall                 chan<- struct{}
+	oldBlockServer          BlockServer
+	oldMDOps                MDOps
+	oldJournalDelegateMDOps MDOps
 }
 
 // NaïveStaller is used to stall certain ops in BlockServer or
@@ -129,7 +130,8 @@ func (s *NaïveStaller) StallBlockOp(stalledOp StallableBlockOp, maxStalls int) 
 
 // StallMDOp wraps the internal MDOps so that all subsequent stalledOp
 // will be stalled. This can be undone by calling UndoStallMDOp.
-func (s *NaïveStaller) StallMDOp(stalledOp StallableMDOp, maxStalls int) {
+func (s *NaïveStaller) StallMDOp(stalledOp StallableMDOp, maxStalls int,
+	stallDelegate bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mdStalled {
@@ -139,7 +141,9 @@ func (s *NaïveStaller) StallMDOp(stalledOp StallableMDOp, maxStalls int) {
 	onStalledCh := make(chan struct{}, maxStalls)
 	unstallCh := make(chan struct{})
 	oldMDOps := s.config.MDOps()
-	if jServer, err := GetJournalServer(s.config); err == nil {
+	var oldJDelegate MDOps
+	if jServer, err := GetJournalServer(s.config); err == nil && stallDelegate {
+		oldJDelegate = jServer.delegateMDOps
 		// Stall the delegate server as well
 		jServer.delegateMDOps = &stallingMDOps{
 			stallOpName: stalledOp,
@@ -150,21 +154,23 @@ func (s *NaïveStaller) StallMDOp(stalledOp StallableMDOp, maxStalls int) {
 			},
 			delegate: jServer.delegateMDOps,
 		}
+	} else {
+		s.config.SetMDOps(&stallingMDOps{
+			stallOpName: stalledOp,
+			stallKey:    stallKeyStallEverything,
+			staller: staller{
+				stalled: onStalledCh,
+				unstall: unstallCh,
+			},
+			delegate: oldMDOps,
+		})
 	}
-	s.config.SetMDOps(&stallingMDOps{
-		stallOpName: stalledOp,
-		stallKey:    stallKeyStallEverything,
-		staller: staller{
-			stalled: onStalledCh,
-			unstall: unstallCh,
-		},
-		delegate: oldMDOps,
-	})
 	s.mdStalled = true
 	s.mdOpsStalls[stalledOp] = &naïveStallInfo{
-		onStalled: onStalledCh,
-		unstall:   unstallCh,
-		oldMDOps:  oldMDOps,
+		onStalled:               onStalledCh,
+		unstall:                 unstallCh,
+		oldMDOps:                oldMDOps,
+		oldJournalDelegateMDOps: oldJDelegate,
 	}
 }
 
@@ -210,6 +216,10 @@ func (s *NaïveStaller) UndoStallBlockOp(stalledOp StallableBlockOp) {
 // should have been called upon stalledOp, otherwise this would panic.
 func (s *NaïveStaller) UndoStallMDOp(stalledOp StallableMDOp) {
 	ns := s.getNaïveStallInfoForMDOpOrBust(stalledOp)
+	if jServer, err := GetJournalServer(s.config); err == nil &&
+		ns.oldJournalDelegateMDOps != nil {
+		jServer.delegateMDOps = ns.oldJournalDelegateMDOps
+	}
 	s.config.SetMDOps(ns.oldMDOps)
 	close(ns.unstall)
 	s.mu.Lock()

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -357,7 +357,6 @@ func (j *tlfJournal) doBackgroundWorkLoop(bws TLFJournalBackgroundWorkStatus) {
 				j.tlfID)
 			select {
 			case <-j.needResumeCh:
-				j.wg.Resume()
 				j.log.CDebugf(ctx,
 					"Got resume signal for %s", j.tlfID)
 				bws = TLFJournalBackgroundWorkEnabled
@@ -408,6 +407,9 @@ func (j *tlfJournal) pauseBackgroundWork() {
 func (j *tlfJournal) resumeBackgroundWork() {
 	select {
 	case j.needResumeCh <- struct{}{}:
+		// Resume the wait group right away, so future callers will block
+		// even before the background goroutine picks up this signal.
+		j.wg.Resume()
 	default:
 	}
 }

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -242,15 +242,16 @@ func runFileOp(c *ctx, fop fileOp) (string, error) {
 	return "File operation", fop.operation(c)
 }
 
-func expectError(op fileOp, reason string) fileOp {
+func expectError(op fileOp, reasonPrefix string) fileOp {
 	return fileOp{func(c *ctx) error {
 		_, err := runFileOp(c, op)
 		if err == nil {
-			return fmt.Errorf("Didn't get expected error (success while expecting failure): %q", reason)
+			return fmt.Errorf("Didn't get expected error (success while expecting failure): %q", reasonPrefix)
 		}
 		// Real filesystems don't give us the exact errors we wish for.
-		if c.engine.Name() == "libkbfs" && err.Error() != reason {
-			return fmt.Errorf("Got the wrong error: expected %q, got %q", reason, err.Error())
+		if c.engine.Name() == "libkbfs" &&
+			!strings.HasPrefix(err.Error(), reasonPrefix) {
+			return fmt.Errorf("Got the wrong error: expected prefix %q, got %q", reasonPrefix, err.Error())
 		}
 		return nil
 	}, IsInit /* So that we can use expectError with e.g. initRoot(). */}

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -528,10 +528,18 @@ func disableUpdates() fileOp {
 	}, IsInit}
 }
 
+func stallDelegateOnMDPut() fileOp {
+	return fileOp{func(c *ctx) error {
+		// TODO: Allow test to pass in a more precise maxStalls limit.
+		c.staller.StallMDOp(libkbfs.StallableMDPut, 100, true)
+		return nil
+	}, Defaults}
+}
+
 func stallOnMDPut() fileOp {
 	return fileOp{func(c *ctx) error {
 		// TODO: Allow test to pass in a more precise maxStalls limit.
-		c.staller.StallMDOp(libkbfs.StallableMDPut, 100)
+		c.staller.StallMDOp(libkbfs.StallableMDPut, 100, false)
 		return nil
 	}, Defaults}
 }

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -450,6 +450,8 @@ func getRootNode(ctx context.Context, config libkbfs.Config, tlfName string,
 		return nil, err
 	}
 
+	// TODO: we should cache the root node, to more faithfully
+	// simulate real-world callers and avoid unnecessary work.
 	kbfsOps := config.KBFSOps()
 	dir, _, err := kbfsOps.GetOrCreateRootNode(ctx, h, libkbfs.MasterBranch)
 	if err != nil {

--- a/test/journal_test.go
+++ b/test/journal_test.go
@@ -198,7 +198,7 @@ func TestJournalRekeyErrorAfterConflict(t *testing.T) {
 			pauseJournal(),
 			mkfile("d", "hello4"),
 		),
-		as(bob, noSync(), stallOnMDPut()),
+		as(bob, noSync(), stallDelegateOnMDPut()),
 		addNewAssertion("charlie", "charlie@twitter"),
 		parallel(
 			as(bob, noSync(),


### PR DESCRIPTION
Rekeys need to go straight to the real MD server -- if it ends up in a conflict branch, our key cache will be wrong.

Also, `journalMDOps` needs to check for handle resolution the same way as `MDOpsStandard`.

To build the test, I needed to do two extra things:
1. Return early from `SetInitialHeadFromServer` if the head is already set.  `EngineLibkbfs` calls this function on every operation, and if it gets to the point where it takes `mdWriterLock`, it deadlocks with other stalled operations.
2. Stall delegate MD ops, if journaling is on.

Issue: KBFS-1497