### PR TITLE
cleanup cancellation delayer in tests

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -45,6 +45,7 @@ func TestCRInput(t *testing.T) {
 	mockCtrl, config, cr := crTestInit(t)
 	defer crTestShutdown(mockCtrl, config, cr)
 	ctx := BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx)
 
 	// First try a completely unknown revision
 	cr.Resolve(MetadataRevisionUninitialized, MetadataRevisionUninitialized)
@@ -135,6 +136,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 	mockCtrl, config, cr := crTestInit(t)
 	defer crTestShutdown(mockCtrl, config, cr)
 	ctx := BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx)
 
 	// Next, try resolving a few items
 	branchPoint := MetadataRevision(2)
@@ -238,6 +240,7 @@ func testCRSharedFolderForUsers(t *testing.T, name string, createAs keybase1.UID
 	kbfsOps := configs[createAs].KBFSOps()
 	rootNode := GetRootNodeOrBust(t, configs[createAs], name, false)
 	ctx := BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx)
 	dir := rootNode
 	for _, d := range dirs {
 		dirNext, _, err := kbfsOps.CreateDir(ctx, dir, d)
@@ -279,6 +282,7 @@ func testCRCheckPathsAndActions(t *testing.T, cr *ConflictResolver,
 	expectedRecreateOps []*createOp,
 	expectedActions map[BlockPointer]crActionList) {
 	ctx := BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx)
 	lState := makeFBOLockState()
 
 	// Step 1 -- check the chains and paths
@@ -381,6 +385,7 @@ func testCRGetCROrBust(t *testing.T, config Config,
 func TestCRMergedChainsSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -441,6 +446,7 @@ func TestCRMergedChainsSimple(t *testing.T) {
 func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -503,6 +509,7 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -600,6 +607,7 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -680,6 +688,7 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 func TestCRMergedChainsComplex(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -862,6 +871,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	clock, now := newTestClockAndTimeNow()
@@ -951,6 +961,7 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 func TestCRMergedChainsConflictSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -1019,6 +1030,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -1128,6 +1140,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 func TestCRDoActionsSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -1216,6 +1229,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 func TestCRDoActionsWriteConflict(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -112,6 +112,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 func TestQuotaReclamationSimple(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	testQuotaReclamation(t, ctx, config, userName)
@@ -122,6 +123,7 @@ func TestQuotaReclamationSimple(t *testing.T) {
 func TestQuotaReclamationUnembedded(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 32
@@ -144,6 +146,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	now := time.Now()
@@ -221,6 +224,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsInitNoMocks(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	clock, now := newTestClockAndTimeNow()
@@ -454,6 +458,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	clock := newTestClockNow()
 	config1.SetClock(clock)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -74,6 +74,7 @@ func TestBasicMDUpdate(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -127,6 +128,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -203,6 +205,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -365,6 +368,7 @@ func TestMultiUserWrite(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -431,6 +435,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -590,6 +595,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -697,6 +703,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -822,6 +829,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -932,6 +940,7 @@ func TestCRDouble(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
@@ -1105,6 +1114,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
@@ -1297,6 +1307,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
@@ -1476,6 +1487,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
@@ -1623,6 +1635,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
@@ -1777,6 +1790,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
@@ -1936,6 +1950,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -54,6 +54,7 @@ func kbfsOpsConcurInit(t *testing.T, users ...libkb.NormalizedUsername) (
 // then get it from the MD cache.
 func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	onGetStalledCh, getUnstallCh, ctxStallGetForTLF :=
@@ -99,6 +100,7 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 // Test that a read can happen concurrently with a sync
 func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
@@ -149,6 +151,7 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	initialWriteBytes int, nOneByteWrites int) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
@@ -284,6 +287,7 @@ func TestKBFSOpsConcurMultipleIndirectWritesDuringSync(t *testing.T) {
 // to the same block, work correctly.
 func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
@@ -404,6 +408,7 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 // read. This is a regression test for KBFS-536.
 func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	// Turn off transient block caching.
@@ -523,6 +528,7 @@ func (km *mdRecordingKeyManager) Rekey(
 // regression test for KBFS-558.
 func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	km := &mdRecordingKeyManager{delegate: config.KeyManager()}
@@ -610,6 +616,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 // regression test for KBFS-558.
 func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	km := &mdRecordingKeyManager{delegate: config.KeyManager()}
@@ -699,6 +706,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 // KBFS-537.
 func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	// Turn off block caching.
@@ -762,6 +770,7 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 // Test that a write can survive a folder BlockPointer update
 func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	// create and write to a file
@@ -802,6 +811,7 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 // are multiple blocks in the file.
 func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
@@ -906,6 +916,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 		t.Skip("Skipping because we are not putting blocks in parallel.")
 	}
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// give it a remote block server with a fake client
@@ -1010,6 +1021,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	fc.goChan = nil
 	fc.finishChan = nil
 	ctx = BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx)
 	if err := kbfsOps.Sync(ctx, fileNode); err != nil {
 		t.Fatalf("Second sync failed: %v", err)
 	}
@@ -1026,6 +1038,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 // cancel the remaining puts.
 func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// give it a mock'd block server
@@ -1123,6 +1136,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 // correctly.  Regression test for KBFS-700.
 func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// Use the smallest possible block size.
@@ -1233,7 +1247,8 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 // already started, and cancellation is delayed. Since no extra delay greater
 // than the grace period in MD writes is introduced, Create should succeed.
 func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
-	config, _, _ := kbfsOpsConcurInit(t, "test_user")
+	config, _, ctxThrowaway := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctxThrowaway)
 	defer CheckConfigAndShutdown(t, config)
 
 	ctx := context.Background()
@@ -1268,9 +1283,10 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
 	}
-
+	ctx2 := BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx2)
 	if _, _, err = kbfsOps.Lookup(
-		BackgroundContextWithCancellationDelayer(), rootNode, "a"); err != nil {
+		ctx2, rootNode, "a"); err != nil {
 		t.Fatalf("Lookup returned error: %v", err)
 	}
 }
@@ -1280,7 +1296,8 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 // period is introduced to MD write, so Create should fail. This is to ensure
 // Ctrl-C is able to interrupt the process eventually after the grace period.
 func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
-	config, _, _ := kbfsOpsConcurInit(t, "test_user")
+	config, _, ctxThrowaway := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctxThrowaway)
 	defer CheckConfigAndShutdown(t, config)
 
 	// This essentially fast-forwards the grace period timer, making cancellation
@@ -1332,9 +1349,11 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 			" Got %v; expecting context.Canceled", err)
 	}
 
+	ctx2 := BackgroundContextWithCancellationDelayer()
+	defer CleanupCancellationDelayer(ctx2)
 	// do another Op, which generates a new revision, to make sure
 	// CheckConfigAndShutdown doesn't get stuck
-	if _, _, err = kbfsOps.CreateFile(BackgroundContextWithCancellationDelayer(),
+	if _, _, err = kbfsOps.CreateFile(ctx2,
 		rootNode, "b", false, NoExcl); err != nil {
 		t.Fatalf("throwaway op failed: %v", err)
 	}
@@ -1343,6 +1362,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 // Test that a Sync that is canceled during a successful MD put works.
 func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
@@ -1435,6 +1455,7 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 // cancel.  Regression test for KBFS-727.
 func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// create and write to a file
@@ -1530,6 +1551,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	t.Skip("Broken pending KBFS-1261")
 
 	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// create and write to a file
@@ -1617,7 +1639,8 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 }
 
 func TestKBFSOpsCancelGetFavorites(t *testing.T) {
-	config, _, _ := kbfsOpsConcurInit(t, "test_user")
+	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	serverConn, conn := rpc.MakeConnectionForTest(t)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -170,6 +170,7 @@ func checkBlockCache(t *testing.T, config *ConfigMock,
 
 func TestKBFSOpsGetFavoritesSuccess(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "alice", "bob")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	handle1 := parseTlfHandleOrBust(t, config, "alice", false)
@@ -5168,6 +5169,7 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 
 func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	// create a file.
@@ -5213,6 +5215,7 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 
 func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer config.Shutdown()
 
 	// create a file.
@@ -5259,6 +5262,7 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 
 func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// create a file.
@@ -5293,6 +5297,7 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 
 func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// make blocks small
@@ -5366,6 +5371,7 @@ func (cbs corruptBlockServer) Get(ctx context.Context, tlfID TlfID, id BlockID,
 
 func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 	config.SetBlockServer(&corruptBlockServer{
 		BlockServer: config.BlockServer(),
@@ -5399,6 +5405,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 // test ever fails, consult max or strib before merging.
 func TestKBFSOpsEmptyTlfSize(t *testing.T) {
 	config, _, ctx := kbfsOpsInitNoMocks(t, "test_user")
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config)
 
 	// Create a TLF.
@@ -5427,6 +5434,7 @@ func (c cryptoFixedTlf) MakeRandomTlfID(isPublic bool) (TlfID, error) {
 // accepting bad MDs.
 func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	config1, _, ctx := kbfsOpsInitNoMocks(t, "alice", "mallory")
+	defer CleanupCancellationDelayer(ctx)
 	defer config1.Shutdown()
 
 	// Create alice's TLF.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -605,6 +605,7 @@ func TestKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T) {
 func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
@@ -819,6 +820,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	// Revoke user 3's device for now, to test the "other" rekey error.
@@ -911,6 +913,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
@@ -992,6 +995,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 func TestKeyManagerReaderRekey(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	_, uid1, err := config1.KBPKI().GetCurrentUserInfo(context.Background())
 
@@ -1073,6 +1077,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
@@ -1167,6 +1172,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 		if doShutdown1 {
 			CheckConfigAndShutdown(t, config1)
 		}
+		CleanupCancellationDelayer(ctx)
 	}()
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
@@ -1332,6 +1338,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
@@ -1458,6 +1465,7 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
@@ -1564,6 +1572,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
@@ -1676,6 +1685,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)

--- a/libkbfs/key_server_local_test.go
+++ b/libkbfs/key_server_local_test.go
@@ -17,6 +17,7 @@ func TestKeyServerLocalTLFCryptKeyServerHalves(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -356,6 +356,7 @@ func TestKeybaseDaemonUserCache(t *testing.T) {
 func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	clock, now := newTestClockAndTimeNow()

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -15,6 +15,7 @@ import (
 func TestRekeyQueueBasic(t *testing.T) {
 	var u1, u2, u3, u4 libkb.NormalizedUsername = "u1", "u2", "u3", "u4"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3, u4)
+	defer CleanupCancellationDelayer(ctx)
 	defer config1.Shutdown()
 
 	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -19,6 +19,7 @@ import (
 func TestBasicTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	clock, now := newTestClockAndTimeNow()
@@ -122,6 +123,7 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 func TestLongTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
+	defer CleanupCancellationDelayer(ctx)
 	defer CheckConfigAndShutdown(t, config1)
 
 	clock, now := newTestClockAndTimeNow()


### PR DESCRIPTION
CR contexts are still not cleaned as they are longer term runners