### PR TITLE
tlf_journal: lock over whole flush

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -694,7 +694,21 @@ func (j *blockJournal) getNextEntriesToFlush(
 	}
 
 	if first >= end {
-		return blockEntriesToFlush{}, nil
+		return blockEntriesToFlush{}, fmt.Errorf("Trying to flush past the "+
+			"start of the journal (first=%d, end=%d)", first, end)
+	}
+
+	realEnd, err := j.end()
+	if realEnd == 0 {
+		return blockEntriesToFlush{}, fmt.Errorf("There was an earliest "+
+			"ordinal %d, but no latest ordinal", first)
+	} else if err != nil {
+		return blockEntriesToFlush{}, err
+	}
+
+	if end > realEnd {
+		return blockEntriesToFlush{}, fmt.Errorf("Trying to flush past the "+
+			"end of the journal (realEnd=%d, end=%d)", realEnd, end)
 	}
 
 	entries.puts = newBlockPutState(int(end - first))

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -255,8 +255,11 @@ func TestBlockJournalFlush(t *testing.T) {
 		}
 
 		// Test that the end parameter is respected.
-		partialEntries, err := j.getNextEntriesToFlush(ctx, end-1)
-		require.NoError(t, err)
+		var partialEntries blockEntriesToFlush
+		if end > 1 {
+			partialEntries, err = j.getNextEntriesToFlush(ctx, end-1)
+			require.NoError(t, err)
+		}
 
 		entries, err := j.getNextEntriesToFlush(ctx, end)
 		require.NoError(t, err)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -420,6 +420,9 @@ func (j *tlfJournal) getJournalEnds(ctx context.Context) (
 }
 
 func (j *tlfJournal) flush(ctx context.Context) (err error) {
+	j.flushLock.Lock()
+	defer j.flushLock.Unlock()
+
 	flushedBlockEntries := 0
 	flushedMDEntries := 0
 	defer func() {
@@ -510,9 +513,6 @@ func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
 
 func (j *tlfJournal) flushBlockEntries(
 	ctx context.Context, end journalOrdinal) (int, error) {
-	j.flushLock.Lock()
-	defer j.flushLock.Unlock()
-
 	entries, err := j.getNextBlockEntriesToFlush(ctx, end)
 	if err != nil {
 		return 0, err
@@ -606,9 +606,6 @@ func (j *tlfJournal) flushOneMDOp(
 			j.deferLog.CDebugf(ctx, "Flush failed with %v", err)
 		}
 	}()
-
-	j.flushLock.Lock()
-	defer j.flushLock.Unlock()
 
 	mdServer := j.config.MDServer()
 


### PR DESCRIPTION
This allows us to treat inconsistent end parameters in the block
flushing code as errors.

Note: I tried to do a similar thing for `mdJournal` but the `tlfJournal` flushing code relies on getting a `nil` error when trying to read past the end of the log, so I left it as is for now.