### PR TITLE
init: initialize journal directory using the env data dir

### DIFF
--- a/env/context.go
+++ b/env/context.go
@@ -37,6 +37,11 @@ func (c Context) GetLogDir() string {
 	return c.g.Env.GetLogDir()
 }
 
+// GetDataDir returns log dir
+func (c Context) GetDataDir() string {
+	return c.g.Env.GetDataDir()
+}
+
 // GetRunMode returns run mode
 func (c Context) GetRunMode() libkb.RunMode {
 	return c.g.GetRunMode()

--- a/libkbfs/context.go
+++ b/libkbfs/context.go
@@ -15,6 +15,7 @@ import (
 type Context interface {
 	GetRunMode() libkb.RunMode
 	GetLogDir() string
+	GetDataDir() string
 	ConfigureSocketInfo() (err error)
 	GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
 	NewRPCLogFactory() *libkb.RPCLogFactory

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -125,7 +125,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
 	// The default is to *DELETE* old log files for kbfs.
 	flags.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
-	flags.StringVar(&params.WriteJournalRoot, "write-journal-root-this-may-lose-data", "", "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
+	flags.StringVar(&params.WriteJournalRoot, "write-journal-root", filepath.Join(ctx.GetDataDir(), "kbfs_journal"), "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	return &params
 }
 


### PR DESCRIPTION
@akalin-keybase did you have something else in mind?  This seems like the simplest thing.  I think we can turn this on by default now, without the warning, since there's an extra step to enable it per-TLF.  What do you think?

----

Issue: KBFS-1362