### PR TITLE
block_id: implement encoding.json.Marshaler

### DIFF
--- a/libkbfs/block_id.go
+++ b/libkbfs/block_id.go
@@ -4,7 +4,11 @@
 
 package libkbfs
 
-import "encoding"
+import (
+	"encoding"
+	"fmt"
+	"strings"
+)
 
 // BlockID is the (usually content-based) ID for a data block.
 type BlockID struct {
@@ -55,4 +59,22 @@ func (id BlockID) MarshalBinary() (data []byte, err error) {
 // the BlockID is invalid.
 func (id *BlockID) UnmarshalBinary(data []byte) error {
 	return id.h.UnmarshalBinary(data)
+}
+
+// MarshalJSON implements the encoding.json.Marshaler interface for
+// BlockID.
+func (id BlockID) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", id)), nil
+}
+
+// UnmarshalJSON implements the encoding.json.Unmarshaler interface
+// for BlockID.
+func (id BlockID) UnmarshalJSON(s []byte) error {
+	blockIDStr := strings.Trim(string(s), "\"")
+	newID, err := BlockIDFromString(blockIDStr)
+	if err != nil {
+		return err
+	}
+	id.h = newID.h
+	return nil
 }

--- a/libkbfs/block_id.go
+++ b/libkbfs/block_id.go
@@ -4,11 +4,7 @@
 
 package libkbfs
 
-import (
-	"encoding"
-	"fmt"
-	"strings"
-)
+import "encoding"
 
 // BlockID is the (usually content-based) ID for a data block.
 type BlockID struct {
@@ -64,17 +60,11 @@ func (id *BlockID) UnmarshalBinary(data []byte) error {
 // MarshalJSON implements the encoding.json.Marshaler interface for
 // BlockID.
 func (id BlockID) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", id)), nil
+	return id.h.MarshalJSON()
 }
 
 // UnmarshalJSON implements the encoding.json.Unmarshaler interface
 // for BlockID.
 func (id BlockID) UnmarshalJSON(s []byte) error {
-	blockIDStr := strings.Trim(string(s), "\"")
-	newID, err := BlockIDFromString(blockIDStr)
-	if err != nil {
-		return err
-	}
-	id.h = newID.h
-	return nil
+	return id.h.UnmarshalJSON(s)
 }

--- a/libkbfs/hash.go
+++ b/libkbfs/hash.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 )
 
@@ -210,6 +211,28 @@ func (h Hash) Verify(buf []byte) error {
 	if h != expectedH {
 		return HashMismatchError{expectedH, h}
 	}
+	return nil
+}
+
+// MarshalJSON implements the encoding.json.Marshaler interface for
+// Hash.
+func (h Hash) MarshalJSON() ([]byte, error) {
+	return json.Marshal(h.String())
+}
+
+// UnmarshalJSON implements the encoding.json.Unmarshaler interface
+// for Hash.
+func (h Hash) UnmarshalJSON(data []byte) error {
+	var s string
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+	newH, err := HashFromString(s)
+	if err != nil {
+		return err
+	}
+	h.h = newH.h
 	return nil
 }
 


### PR DESCRIPTION
This lets us output BlockIDs as JSON values in the new
.kbfs_fileinfo_$FILE virtual file.

Issue: KBFS-1513