### PR TITLE
libkbfs: add a journaling-specific dirty block cache

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -798,6 +798,11 @@ func (c *ConfigLocal) EnableJournaling(journalRoot string) {
 		if ok {
 			syncCache.name = "sync"
 		}
+
+		// Make a dirty block cache specifically for the journal
+		// server.  Since this doesn't rely directly on the network,
+		// there's no need for an adaptive sync buffer size, so we
+		// always set the min and max to the same thing.
 		maxSyncBufferSize :=
 			int64(MaxBlockSizeBytesDefault * maxParallelBlockPuts * 2)
 		journalCache := NewDirtyBlockCacheStandard(c.clock, c.MakeLogger,

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -249,6 +249,14 @@ func (d *DirtyBlockCacheStandard) IsDirty(_ TlfID, ptr BlockPointer,
 	return
 }
 
+// IsAnyDirty implements the DirtyBlockCache interface for
+// DirtyBlockCacheStandard.
+func (d *DirtyBlockCacheStandard) IsAnyDirty(_ TlfID) bool {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	return len(d.cache) > 0 || d.syncBufBytes > 0 || d.waitBufBytes > 0
+}
+
 const backpressureSlack = 1 * time.Second
 
 // calcBackpressure returns how much longer a given request should be

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -181,8 +181,8 @@ func NewDirtyBlockCacheStandard(clock Clock,
 
 // Get implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) Get(ptr BlockPointer, branch BranchName) (
-	Block, error) {
+func (d *DirtyBlockCacheStandard) Get(_ TlfID, ptr BlockPointer,
+	branch BranchName) (Block, error) {
 	block := func() Block {
 		dirtyID := dirtyBlockID{
 			id:       ptr.ID,
@@ -202,8 +202,8 @@ func (d *DirtyBlockCacheStandard) Get(ptr BlockPointer, branch BranchName) (
 
 // Put implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) Put(ptr BlockPointer, branch BranchName,
-	block Block) error {
+func (d *DirtyBlockCacheStandard) Put(_ TlfID, ptr BlockPointer,
+	branch BranchName, block Block) error {
 	dirtyID := dirtyBlockID{
 		id:       ptr.ID,
 		refNonce: ptr.RefNonce,
@@ -218,7 +218,7 @@ func (d *DirtyBlockCacheStandard) Put(ptr BlockPointer, branch BranchName,
 
 // Delete implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) Delete(ptr BlockPointer,
+func (d *DirtyBlockCacheStandard) Delete(_ TlfID, ptr BlockPointer,
 	branch BranchName) error {
 	dirtyID := dirtyBlockID{
 		id:       ptr.ID,
@@ -234,8 +234,8 @@ func (d *DirtyBlockCacheStandard) Delete(ptr BlockPointer,
 
 // IsDirty implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) IsDirty(
-	ptr BlockPointer, branch BranchName) (isDirty bool) {
+func (d *DirtyBlockCacheStandard) IsDirty(_ TlfID, ptr BlockPointer,
+	branch BranchName) (isDirty bool) {
 	dirtyID := dirtyBlockID{
 		id:       ptr.ID,
 		refNonce: ptr.RefNonce,
@@ -479,7 +479,8 @@ func (d *DirtyBlockCacheStandard) processPermission() {
 // RequestPermissionToDirty implements the DirtyBlockCache interface
 // for DirtyBlockCacheStandard.
 func (d *DirtyBlockCacheStandard) RequestPermissionToDirty(
-	ctx context.Context, estimatedDirtyBytes int64) (DirtyPermChan, error) {
+	ctx context.Context, _ TlfID, estimatedDirtyBytes int64) (
+	DirtyPermChan, error) {
 	d.shutdownLock.RLock()
 	defer d.shutdownLock.RUnlock()
 	if d.isShutdown {
@@ -517,8 +518,8 @@ func (d *DirtyBlockCacheStandard) signalDecreasedBytes() {
 
 // UpdateUnsyncedBytes implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) UpdateUnsyncedBytes(newUnsyncedBytes int64,
-	wasSyncing bool) {
+func (d *DirtyBlockCacheStandard) UpdateUnsyncedBytes(_ TlfID,
+	newUnsyncedBytes int64, wasSyncing bool) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	if wasSyncing {
@@ -533,7 +534,7 @@ func (d *DirtyBlockCacheStandard) UpdateUnsyncedBytes(newUnsyncedBytes int64,
 
 // UpdateSyncingBytes implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) UpdateSyncingBytes(size int64) {
+func (d *DirtyBlockCacheStandard) UpdateSyncingBytes(_ TlfID, size int64) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	d.syncBufBytes += size
@@ -543,7 +544,7 @@ func (d *DirtyBlockCacheStandard) UpdateSyncingBytes(size int64) {
 
 // BlockSyncFinished implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) BlockSyncFinished(size int64) {
+func (d *DirtyBlockCacheStandard) BlockSyncFinished(_ TlfID, size int64) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	if size > 0 {
@@ -571,7 +572,7 @@ func (d *DirtyBlockCacheStandard) resetBufferCap() {
 
 // SyncFinished implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) SyncFinished(size int64) {
+func (d *DirtyBlockCacheStandard) SyncFinished(_ TlfID, size int64) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	if size <= 0 {
@@ -615,7 +616,7 @@ func (d *DirtyBlockCacheStandard) SyncFinished(size int64) {
 
 // ShouldForceSync implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) ShouldForceSync() bool {
+func (d *DirtyBlockCacheStandard) ShouldForceSync(_ TlfID) bool {
 	d.lock.RLock()
 	defer d.lock.RUnlock()
 	// TODO: Fill up to likely block boundaries?

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -112,6 +112,7 @@ type DirtyBlockCacheStandard struct {
 	makeLog func(string) logger.Logger
 	log     logger.Logger
 	reqWg   sync.WaitGroup
+	name    string
 
 	// requestsChan is a queue for channels that should be closed when
 	// permission is granted to dirty new data.
@@ -294,7 +295,7 @@ func (d *DirtyBlockCacheStandard) calcBackpressure(start time.Time,
 
 func (d *DirtyBlockCacheStandard) logLocked(fmt string, arg ...interface{}) {
 	if d.log == nil {
-		log := d.makeLog("")
+		log := d.makeLog(d.name)
 		if log != nil {
 			d.log = log.CloneWithAddedDepth(1)
 		}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -235,7 +235,8 @@ func (fbo *folderBlockOps) GetState(lState *lockState) overallBlockState {
 func (fbo *folderBlockOps) getBlockFromDirtyOrCleanCache(ptr BlockPointer,
 	branch BranchName) (Block, error) {
 	// Check the dirty cache first.
-	if block, err := fbo.config.DirtyBlockCache().Get(ptr, branch); err == nil {
+	if block, err := fbo.config.DirtyBlockCache().Get(
+		fbo.id(), ptr, branch); err == nil {
 		return block, nil
 	}
 
@@ -461,7 +462,7 @@ func (fbo *folderBlockOps) getFileBlockLocked(ctx context.Context,
 		// being sync'd and needs a copy even though it's
 		// already dirty.
 		df := fbo.dirtyFiles[file.tailPointer()]
-		if !fbo.config.DirtyBlockCache().IsDirty(ptr, file.Branch) ||
+		if !fbo.config.DirtyBlockCache().IsDirty(fbo.id(), ptr, file.Branch) ||
 			(df != nil && df.blockNeedsCopy(ptr)) {
 			fblock, err = fblock.DeepCopy(fbo.config.Codec())
 			if err != nil {
@@ -548,7 +549,7 @@ func (fbo *folderBlockOps) getDirLocked(ctx context.Context,
 	}
 
 	if rtype == blockWrite && !fbo.config.DirtyBlockCache().IsDirty(
-		dir.tailPointer(), dir.Branch) {
+		fbo.id(), dir.tailPointer(), dir.Branch) {
 		// Copy the block if it's for writing and the block is
 		// not yet dirty.
 		dblock, err = dblock.DeepCopy(fbo.config.Codec())
@@ -795,7 +796,8 @@ func (fbo *folderBlockOps) cacheBlockIfNotYetDirtyLocked(
 	needsCaching, isSyncing := df.setBlockDirty(ptr)
 
 	if needsCaching {
-		err := fbo.config.DirtyBlockCache().Put(ptr, file.Branch, block)
+		err := fbo.config.DirtyBlockCache().Put(fbo.id(), ptr, file.Branch,
+			block)
 		if err != nil {
 			return err
 		}
@@ -911,7 +913,7 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableErrorLocked(
 	}
 
 	dirtyBcache := fbo.config.DirtyBlockCache()
-	topBlock, err := dirtyBcache.Get(file.tailPointer(), fbo.branch())
+	topBlock, err := dirtyBcache.Get(fbo.id(), file.tailPointer(), fbo.branch())
 	fblock, ok := topBlock.(*FileBlock)
 	if err != nil || !ok {
 		fbo.log.CWarningf(ctx, "Couldn't find dirtied "+
@@ -946,7 +948,7 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableErrorLocked(
 		}
 		fbo.log.CDebugf(ctx, "Deleting dirty ptr %v after recoverable error",
 			oldPtr)
-		err = dirtyBcache.Delete(oldPtr, fbo.branch())
+		err = dirtyBcache.Delete(fbo.id(), oldPtr, fbo.branch())
 		if err != nil {
 			fbo.log.CDebugf(ctx, "Couldn't del-dirty %v: %v", oldPtr, err)
 		}
@@ -1274,7 +1276,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 		// even on an error, since the previously-dirty bytes stay in
 		// the cache.
 		df.updateNotYetSyncingBytes(newlyDirtiedChildBytes)
-		if dirtyBcache.ShouldForceSync() {
+		if dirtyBcache.ShouldForceSync(fbo.id()) {
 			select {
 			// If we can't send on the channel, that means a sync is
 			// already in progress.
@@ -1309,7 +1311,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 		}
 
 		oldLen := len(block.Contents)
-		wasDirty := dirtyBcache.IsDirty(ptr, file.Branch)
+		wasDirty := dirtyBcache.IsDirty(fbo.id(), ptr, file.Branch)
 
 		// Take care not to write past the beginning of the next block
 		// by using max.
@@ -1445,12 +1447,12 @@ func (fbo *folderBlockOps) Write(
 	// of it gets flush so our memory usage doesn't grow without
 	// bound.
 	c, err := fbo.config.DirtyBlockCache().RequestPermissionToDirty(ctx,
-		int64(len(data)))
+		fbo.id(), int64(len(data)))
 	if err != nil {
 		return err
 	}
-	defer fbo.config.DirtyBlockCache().UpdateUnsyncedBytes(-int64(len(data)),
-		false)
+	defer fbo.config.DirtyBlockCache().UpdateUnsyncedBytes(fbo.id(),
+		-int64(len(data)), false)
 	err = fbo.maybeWaitOnDeferredWrites(ctx, lState, file, c)
 	if err != nil {
 		return err
@@ -1592,7 +1594,7 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	dirtyPtrs = append(dirtyPtrs, file.tailPointer())
 	latestWrite := si.op.addTruncate(size)
 
-	if fbo.config.DirtyBlockCache().ShouldForceSync() {
+	if fbo.config.DirtyBlockCache().ShouldForceSync(fbo.id()) {
 		select {
 		// If we can't send on the channel, that means a sync is
 		// already in progress
@@ -1656,7 +1658,7 @@ func (fbo *folderBlockOps) truncateLocked(
 
 	oldLen := len(block.Contents)
 	dirtyBcache := fbo.config.DirtyBlockCache()
-	wasDirty := dirtyBcache.IsDirty(ptr, file.Branch)
+	wasDirty := dirtyBcache.IsDirty(fbo.id(), ptr, file.Branch)
 
 	// otherwise, we need to delete some data (and possibly entire blocks)
 	block.Contents = append([]byte(nil), block.Contents[:iSize-startOff]...)
@@ -1736,11 +1738,12 @@ func (fbo *folderBlockOps) Truncate(
 	// truncate.  TODO: try to figure out how many bytes actually will
 	// be dirtied ahead of time?
 	c, err := fbo.config.DirtyBlockCache().RequestPermissionToDirty(ctx,
-		int64(size))
+		fbo.id(), int64(size))
 	if err != nil {
 		return err
 	}
-	defer fbo.config.DirtyBlockCache().UpdateUnsyncedBytes(-int64(size), false)
+	defer fbo.config.DirtyBlockCache().UpdateUnsyncedBytes(fbo.id(),
+		-int64(size), false)
 	err = fbo.maybeWaitOnDeferredWrites(ctx, lState, file, c)
 	if err != nil {
 		return err
@@ -1800,7 +1803,8 @@ func (fbo *folderBlockOps) Truncate(
 func (fbo *folderBlockOps) IsDirty(lState *lockState, file path) bool {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	return fbo.config.DirtyBlockCache().IsDirty(file.tailPointer(), file.Branch)
+	return fbo.config.DirtyBlockCache().IsDirty(
+		fbo.id(), file.tailPointer(), file.Branch)
 }
 
 func (fbo *folderBlockOps) clearCacheInfoLocked(lState *lockState,
@@ -2049,7 +2053,8 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 		// the blocks are be dirty.
 		for i := 0; i < len(fblock.IPtrs); i++ {
 			ptr := fblock.IPtrs[i]
-			isDirty := dirtyBcache.IsDirty(ptr.BlockPointer, file.Branch)
+			isDirty := dirtyBcache.IsDirty(fbo.id(), ptr.BlockPointer,
+				file.Branch)
 			if (ptr.EncodedSize > 0) && isDirty {
 				return nil, nil, syncState, nil,
 					InconsistentEncodedSizeError{ptr.BlockInfo}
@@ -2141,7 +2146,7 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 
 		for i, ptr := range fblock.IPtrs {
 			localPtr := ptr.BlockPointer
-			isDirty := dirtyBcache.IsDirty(localPtr, file.Branch)
+			isDirty := dirtyBcache.IsDirty(fbo.id(), localPtr, file.Branch)
 			if (ptr.EncodedSize > 0) && isDirty {
 				return nil, nil, syncState, nil,
 					InconsistentEncodedSizeError{ptr.BlockInfo}
@@ -2406,7 +2411,7 @@ func (fbo *folderBlockOps) FinishSync(
 	dirtyBcache := fbo.config.DirtyBlockCache()
 	for _, ptr := range syncState.oldFileBlockPtrs {
 		fbo.log.CDebugf(ctx, "Deleting dirty ptr %v", ptr)
-		if err := dirtyBcache.Delete(ptr, fbo.branch()); err != nil {
+		if err := dirtyBcache.Delete(fbo.id(), ptr, fbo.branch()); err != nil {
 			return true, err
 		}
 	}
@@ -2432,7 +2437,7 @@ func (fbo *folderBlockOps) FinishSync(
 	// happening during the sync, since we're redoing them below.
 	for _, ptr := range deletes {
 		fbo.log.CDebugf(ctx, "Deleting deferred dirty ptr %v", ptr)
-		if err := dirtyBcache.Delete(ptr, fbo.branch()); err != nil {
+		if err := dirtyBcache.Delete(fbo.id(), ptr, fbo.branch()); err != nil {
 			return true, err
 		}
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4455,7 +4455,7 @@ func (fbo *folderBranchOps) backgroundFlusher(betweenFlushes time.Duration) {
 	for {
 		doSelect := true
 		if fbo.blocks.GetState(lState) == dirtyState &&
-			fbo.config.DirtyBlockCache().ShouldForceSync() {
+			fbo.config.DirtyBlockCache().ShouldForceSync(fbo.id()) {
 			// We have dirty files, and the system has a full buffer,
 			// so don't bother waiting for a signal, just get right to
 			// the main attraction.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -640,17 +640,17 @@ type DirtyPermChan <-chan struct{}
 type DirtyBlockCache interface {
 	// Get gets the block associated with the given block ID.  Returns
 	// the dirty block for the given ID, if one exists.
-	Get(ptr BlockPointer, branch BranchName) (Block, error)
+	Get(tlfID TlfID, ptr BlockPointer, branch BranchName) (Block, error)
 	// Put stores a dirty block currently identified by the
 	// given block pointer and branch name.
-	Put(ptr BlockPointer, branch BranchName, block Block) error
+	Put(tlfID TlfID, ptr BlockPointer, branch BranchName, block Block) error
 	// Delete removes the dirty block associated with the given block
 	// pointer and branch from the cache.  No error is returned if no
 	// block exists for the given ID.
-	Delete(ptr BlockPointer, branch BranchName) error
+	Delete(tlfID TlfID, ptr BlockPointer, branch BranchName) error
 	// IsDirty states whether or not the block associated with the
 	// given block pointer and branch name is dirty in this cache.
-	IsDirty(ptr BlockPointer, branch BranchName) bool
+	IsDirty(tlfID TlfID, ptr BlockPointer, branch BranchName) bool
 	// RequestPermissionToDirty is called whenever a user wants to
 	// write data to a file.  The caller provides an estimated number
 	// of bytes that will become dirty -- this is difficult to know
@@ -662,7 +662,7 @@ type DirtyBlockCache interface {
 	// `UpdateUnsyncedBytes(-estimatedDirtyBytes)` once it has
 	// completed its write and called `UpdateUnsyncedBytes` for all
 	// the exact dirty block sizes.
-	RequestPermissionToDirty(ctx context.Context,
+	RequestPermissionToDirty(ctx context.Context, tlfID TlfID,
 		estimatedDirtyBytes int64) (DirtyPermChan, error)
 	// UpdateUnsyncedBytes is called by a user, who has already been
 	// granted permission to write, with the delta in block sizes that
@@ -676,25 +676,25 @@ type DirtyBlockCache interface {
 	// requests, newUnsyncedBytes may be negative.  wasSyncing should
 	// be true if `BlockSyncStarted` has already been called for this
 	// block.
-	UpdateUnsyncedBytes(newUnsyncedBytes int64, wasSyncing bool)
+	UpdateUnsyncedBytes(tlfID TlfID, newUnsyncedBytes int64, wasSyncing bool)
 	// UpdateSyncingBytes is called when a particular block has
 	// started syncing, or with a negative number when a block is no
 	// longer syncing due to an error (and BlockSyncFinished will
 	// never be called).
-	UpdateSyncingBytes(size int64)
+	UpdateSyncingBytes(tlfID TlfID, size int64)
 	// BlockSyncFinished is called when a particular block has
 	// finished syncing, though the overall sync might not yet be
 	// complete.  This lets the cache know it might be able to grant
 	// more permission to writers.
-	BlockSyncFinished(size int64)
+	BlockSyncFinished(tlfID TlfID, size int64)
 	// SyncFinished is called when a complete sync has completed and
 	// its dirty blocks have been removed from the cache.  This lets
 	// the cache know it might be able to grant more permission to
 	// writers.
-	SyncFinished(size int64)
+	SyncFinished(tlfID TlfID, size int64)
 	// ShouldForceSync returns true if the sync buffer is full enough
 	// to force all callers to sync their data immediately.
-	ShouldForceSync() bool
+	ShouldForceSync(tlfID TlfID) bool
 
 	// Shutdown frees any resources associated with this instance.  It
 	// returns an error if there are any unsynced blocks.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -651,6 +651,9 @@ type DirtyBlockCache interface {
 	// IsDirty states whether or not the block associated with the
 	// given block pointer and branch name is dirty in this cache.
 	IsDirty(tlfID TlfID, ptr BlockPointer, branch BranchName) bool
+	// IsAnyDirty returns whether there are any dirty blocks in the
+	// cache. tlfID may be ignored.
+	IsAnyDirty(tlfID TlfID) bool
 	// RequestPermissionToDirty is called whenever a user wants to
 	// write data to a file.  The caller provides an estimated number
 	// of bytes that will become dirty -- this is difficult to know

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -21,7 +21,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 	config = MakeTestConfigOrBust(t, "test_user")
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
-		config, log, tempdir, config.BlockCache(),
+		config, log, tempdir, config.BlockCache(), config.DirtyBlockCache(),
 		config.BlockServer(), config.MDOps(), nil, nil)
 	ctx := context.Background()
 	err = jServer.EnableExistingJournals(

--- a/libkbfs/journal_dirty_bcache.go
+++ b/libkbfs/journal_dirty_bcache.go
@@ -54,6 +54,10 @@ func (j journalDirtyBlockCache) IsDirty(tlfID TlfID, ptr BlockPointer,
 	return j.syncCache.IsDirty(tlfID, ptr, branch)
 }
 
+func (j journalDirtyBlockCache) IsAnyDirty(tlfID TlfID) bool {
+	return j.journalCache.IsAnyDirty(tlfID) || j.syncCache.IsAnyDirty(tlfID)
+}
+
 func (j journalDirtyBlockCache) RequestPermissionToDirty(ctx context.Context,
 	tlfID TlfID, estimatedDirtyBytes int64) (DirtyPermChan, error) {
 	if _, ok := j.jServer.getTLFJournal(tlfID); ok {

--- a/libkbfs/journal_dirty_bcache.go
+++ b/libkbfs/journal_dirty_bcache.go
@@ -1,0 +1,118 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"fmt"
+
+	"golang.org/x/net/context"
+)
+
+type journalDirtyBlockCache struct {
+	jServer      *JournalServer
+	syncCache    DirtyBlockCache
+	journalCache DirtyBlockCache
+}
+
+var _ DirtyBlockCache = journalDirtyBlockCache{}
+
+func (j journalDirtyBlockCache) Get(tlfID TlfID, ptr BlockPointer,
+	branch BranchName) (Block, error) {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		return j.journalCache.Get(tlfID, ptr, branch)
+	}
+
+	return j.syncCache.Get(tlfID, ptr, branch)
+}
+
+func (j journalDirtyBlockCache) Put(tlfID TlfID, ptr BlockPointer,
+	branch BranchName, block Block) error {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		return j.journalCache.Put(tlfID, ptr, branch, block)
+	}
+
+	return j.syncCache.Put(tlfID, ptr, branch, block)
+}
+
+func (j journalDirtyBlockCache) Delete(tlfID TlfID, ptr BlockPointer,
+	branch BranchName) error {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		return j.journalCache.Delete(tlfID, ptr, branch)
+	}
+
+	return j.syncCache.Delete(tlfID, ptr, branch)
+}
+
+func (j journalDirtyBlockCache) IsDirty(tlfID TlfID, ptr BlockPointer,
+	branch BranchName) bool {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		return j.journalCache.IsDirty(tlfID, ptr, branch)
+	}
+
+	return j.syncCache.IsDirty(tlfID, ptr, branch)
+}
+
+func (j journalDirtyBlockCache) RequestPermissionToDirty(ctx context.Context,
+	tlfID TlfID, estimatedDirtyBytes int64) (DirtyPermChan, error) {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		return j.journalCache.RequestPermissionToDirty(ctx, tlfID,
+			estimatedDirtyBytes)
+	}
+
+	return j.syncCache.RequestPermissionToDirty(ctx, tlfID, estimatedDirtyBytes)
+}
+
+func (j journalDirtyBlockCache) UpdateUnsyncedBytes(tlfID TlfID,
+	newUnsyncedBytes int64, wasSyncing bool) {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		j.journalCache.UpdateUnsyncedBytes(tlfID, newUnsyncedBytes, wasSyncing)
+	} else {
+		j.syncCache.UpdateUnsyncedBytes(tlfID, newUnsyncedBytes, wasSyncing)
+	}
+}
+
+func (j journalDirtyBlockCache) UpdateSyncingBytes(tlfID TlfID, size int64) {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		j.journalCache.UpdateSyncingBytes(tlfID, size)
+	} else {
+		j.syncCache.UpdateSyncingBytes(tlfID, size)
+	}
+}
+
+func (j journalDirtyBlockCache) BlockSyncFinished(tlfID TlfID, size int64) {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		j.journalCache.BlockSyncFinished(tlfID, size)
+	} else {
+		j.syncCache.BlockSyncFinished(tlfID, size)
+	}
+}
+
+func (j journalDirtyBlockCache) SyncFinished(tlfID TlfID, size int64) {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		j.journalCache.SyncFinished(tlfID, size)
+	} else {
+		j.syncCache.SyncFinished(tlfID, size)
+	}
+}
+
+func (j journalDirtyBlockCache) ShouldForceSync(tlfID TlfID) bool {
+	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+		return j.journalCache.ShouldForceSync(tlfID)
+	}
+
+	return j.syncCache.ShouldForceSync(tlfID)
+}
+
+func (j journalDirtyBlockCache) Shutdown() error {
+	journalErr := j.journalCache.Shutdown()
+	syncErr := j.syncCache.Shutdown()
+	if journalErr == nil {
+		return syncErr
+	} else if syncErr == nil {
+		return journalErr
+	}
+	return fmt.Errorf("Multiple errors on dirty bcache shutdown: %v",
+		[]error{journalErr, syncErr})
+}

--- a/libkbfs/journal_dirty_bcache.go
+++ b/libkbfs/journal_dirty_bcache.go
@@ -20,7 +20,7 @@ var _ DirtyBlockCache = journalDirtyBlockCache{}
 
 func (j journalDirtyBlockCache) Get(tlfID TlfID, ptr BlockPointer,
 	branch BranchName) (Block, error) {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		return j.journalCache.Get(tlfID, ptr, branch)
 	}
 
@@ -29,7 +29,7 @@ func (j journalDirtyBlockCache) Get(tlfID TlfID, ptr BlockPointer,
 
 func (j journalDirtyBlockCache) Put(tlfID TlfID, ptr BlockPointer,
 	branch BranchName, block Block) error {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		return j.journalCache.Put(tlfID, ptr, branch, block)
 	}
 
@@ -38,7 +38,7 @@ func (j journalDirtyBlockCache) Put(tlfID TlfID, ptr BlockPointer,
 
 func (j journalDirtyBlockCache) Delete(tlfID TlfID, ptr BlockPointer,
 	branch BranchName) error {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		return j.journalCache.Delete(tlfID, ptr, branch)
 	}
 
@@ -47,7 +47,7 @@ func (j journalDirtyBlockCache) Delete(tlfID TlfID, ptr BlockPointer,
 
 func (j journalDirtyBlockCache) IsDirty(tlfID TlfID, ptr BlockPointer,
 	branch BranchName) bool {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		return j.journalCache.IsDirty(tlfID, ptr, branch)
 	}
 
@@ -60,7 +60,7 @@ func (j journalDirtyBlockCache) IsAnyDirty(tlfID TlfID) bool {
 
 func (j journalDirtyBlockCache) RequestPermissionToDirty(ctx context.Context,
 	tlfID TlfID, estimatedDirtyBytes int64) (DirtyPermChan, error) {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		return j.journalCache.RequestPermissionToDirty(ctx, tlfID,
 			estimatedDirtyBytes)
 	}
@@ -70,7 +70,7 @@ func (j journalDirtyBlockCache) RequestPermissionToDirty(ctx context.Context,
 
 func (j journalDirtyBlockCache) UpdateUnsyncedBytes(tlfID TlfID,
 	newUnsyncedBytes int64, wasSyncing bool) {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		j.journalCache.UpdateUnsyncedBytes(tlfID, newUnsyncedBytes, wasSyncing)
 	} else {
 		j.syncCache.UpdateUnsyncedBytes(tlfID, newUnsyncedBytes, wasSyncing)
@@ -78,7 +78,7 @@ func (j journalDirtyBlockCache) UpdateUnsyncedBytes(tlfID TlfID,
 }
 
 func (j journalDirtyBlockCache) UpdateSyncingBytes(tlfID TlfID, size int64) {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		j.journalCache.UpdateSyncingBytes(tlfID, size)
 	} else {
 		j.syncCache.UpdateSyncingBytes(tlfID, size)
@@ -86,7 +86,7 @@ func (j journalDirtyBlockCache) UpdateSyncingBytes(tlfID TlfID, size int64) {
 }
 
 func (j journalDirtyBlockCache) BlockSyncFinished(tlfID TlfID, size int64) {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		j.journalCache.BlockSyncFinished(tlfID, size)
 	} else {
 		j.syncCache.BlockSyncFinished(tlfID, size)
@@ -94,7 +94,7 @@ func (j journalDirtyBlockCache) BlockSyncFinished(tlfID TlfID, size int64) {
 }
 
 func (j journalDirtyBlockCache) SyncFinished(tlfID TlfID, size int64) {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		j.journalCache.SyncFinished(tlfID, size)
 	} else {
 		j.syncCache.SyncFinished(tlfID, size)
@@ -102,7 +102,7 @@ func (j journalDirtyBlockCache) SyncFinished(tlfID TlfID, size int64) {
 }
 
 func (j journalDirtyBlockCache) ShouldForceSync(tlfID TlfID) bool {
-	if _, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if j.jServer.hasTLFJournal(tlfID) {
 		return j.journalCache.ShouldForceSync(tlfID)
 	}
 

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -34,7 +34,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
-		config, log, tempdir, config.BlockCache(),
+		config, log, tempdir, config.BlockCache(), config.DirtyBlockCache(),
 		config.BlockServer(), config.MDOps(), nil, nil)
 
 	ctx := context.Background()

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -100,6 +100,13 @@ func (j *JournalServer) getTLFJournal(tlfID TlfID) (*tlfJournal, bool) {
 	return tlfJournal, ok
 }
 
+func (j *JournalServer) hasTLFJournal(tlfID TlfID) bool {
+	j.lock.RLock()
+	defer j.lock.RUnlock()
+	_, ok := j.tlfJournals[tlfID]
+	return ok
+}
+
 // EnableExistingJournals turns on the write journal for all TLFs with
 // an existing journal. This must be the first thing done to a
 // JournalServer. Any returned error is fatal, and means that the
@@ -288,11 +295,11 @@ func (j *JournalServer) Disable(ctx context.Context, tlfID TlfID) (
 	}
 
 	if j.dirtyOps > 0 {
-		return false, fmt.Errorf("Can't enable journal for %s while there "+
+		return false, fmt.Errorf("Can't disable journal for %s while there "+
 			"are outstanding dirty ops", tlfID)
 	}
 	if j.delegateDirtyBlockCache.IsAnyDirty(tlfID) {
-		return false, fmt.Errorf("Can't enable journal for %s while there "+
+		return false, fmt.Errorf("Can't disable journal for %s while there "+
 			"are any dirty blocks outstanding", tlfID)
 	}
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -21,7 +21,7 @@ func setupJournalServerTest(t *testing.T) (
 	config = MakeTestConfigOrBust(t, "test_user")
 	log := config.MakeLogger("")
 	jServer = makeJournalServer(
-		config, log, tempdir, config.BlockCache(),
+		config, log, tempdir, config.BlockCache(), config.DirtyBlockCache(),
 		config.BlockServer(), config.MDOps(), nil, nil)
 	ctx := context.Background()
 	err = jServer.EnableExistingJournals(
@@ -95,6 +95,7 @@ func TestJournalServerRestart(t *testing.T) {
 
 	jServer = makeJournalServer(
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
+		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil)
 	err = jServer.EnableExistingJournals(
 		ctx, TLFJournalBackgroundWorkPaused)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1549,6 +1549,16 @@ func (_mr *_MockDirtyBlockCacheRecorder) IsDirty(arg0, arg1, arg2 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsDirty", arg0, arg1, arg2)
 }
 
+func (_m *MockDirtyBlockCache) IsAnyDirty(tlfID TlfID) bool {
+	ret := _m.ctrl.Call(_m, "IsAnyDirty", tlfID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockDirtyBlockCacheRecorder) IsAnyDirty(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsAnyDirty", arg0)
+}
+
 func (_m *MockDirtyBlockCache) RequestPermissionToDirty(ctx context.Context, tlfID TlfID, estimatedDirtyBytes int64) (DirtyPermChan, error) {
 	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty", ctx, tlfID, estimatedDirtyBytes)
 	ret0, _ := ret[0].(DirtyPermChan)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1508,98 +1508,98 @@ func (_m *MockDirtyBlockCache) EXPECT() *_MockDirtyBlockCacheRecorder {
 	return _m.recorder
 }
 
-func (_m *MockDirtyBlockCache) Get(ptr BlockPointer, branch BranchName) (Block, error) {
-	ret := _m.ctrl.Call(_m, "Get", ptr, branch)
+func (_m *MockDirtyBlockCache) Get(tlfID TlfID, ptr BlockPointer, branch BranchName) (Block, error) {
+	ret := _m.ctrl.Call(_m, "Get", tlfID, ptr, branch)
 	ret0, _ := ret[0].(Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1)
+func (_mr *_MockDirtyBlockCacheRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
 }
 
-func (_m *MockDirtyBlockCache) Put(ptr BlockPointer, branch BranchName, block Block) error {
-	ret := _m.ctrl.Call(_m, "Put", ptr, branch, block)
+func (_m *MockDirtyBlockCache) Put(tlfID TlfID, ptr BlockPointer, branch BranchName, block Block) error {
+	ret := _m.ctrl.Call(_m, "Put", tlfID, ptr, branch, block)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) Put(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2)
+func (_mr *_MockDirtyBlockCacheRecorder) Put(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockDirtyBlockCache) Delete(ptr BlockPointer, branch BranchName) error {
-	ret := _m.ctrl.Call(_m, "Delete", ptr, branch)
+func (_m *MockDirtyBlockCache) Delete(tlfID TlfID, ptr BlockPointer, branch BranchName) error {
+	ret := _m.ctrl.Call(_m, "Delete", tlfID, ptr, branch)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+func (_mr *_MockDirtyBlockCacheRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
 }
 
-func (_m *MockDirtyBlockCache) IsDirty(ptr BlockPointer, branch BranchName) bool {
-	ret := _m.ctrl.Call(_m, "IsDirty", ptr, branch)
+func (_m *MockDirtyBlockCache) IsDirty(tlfID TlfID, ptr BlockPointer, branch BranchName) bool {
+	ret := _m.ctrl.Call(_m, "IsDirty", tlfID, ptr, branch)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) IsDirty(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsDirty", arg0, arg1)
+func (_mr *_MockDirtyBlockCacheRecorder) IsDirty(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsDirty", arg0, arg1, arg2)
 }
 
-func (_m *MockDirtyBlockCache) RequestPermissionToDirty(ctx context.Context, estimatedDirtyBytes int64) (DirtyPermChan, error) {
-	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty", ctx, estimatedDirtyBytes)
+func (_m *MockDirtyBlockCache) RequestPermissionToDirty(ctx context.Context, tlfID TlfID, estimatedDirtyBytes int64) (DirtyPermChan, error) {
+	ret := _m.ctrl.Call(_m, "RequestPermissionToDirty", ctx, tlfID, estimatedDirtyBytes)
 	ret0, _ := ret[0].(DirtyPermChan)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty", arg0, arg1)
+func (_mr *_MockDirtyBlockCacheRecorder) RequestPermissionToDirty(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "RequestPermissionToDirty", arg0, arg1, arg2)
 }
 
-func (_m *MockDirtyBlockCache) UpdateUnsyncedBytes(newUnsyncedBytes int64, wasSyncing bool) {
-	_m.ctrl.Call(_m, "UpdateUnsyncedBytes", newUnsyncedBytes, wasSyncing)
+func (_m *MockDirtyBlockCache) UpdateUnsyncedBytes(tlfID TlfID, newUnsyncedBytes int64, wasSyncing bool) {
+	_m.ctrl.Call(_m, "UpdateUnsyncedBytes", tlfID, newUnsyncedBytes, wasSyncing)
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) UpdateUnsyncedBytes(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUnsyncedBytes", arg0, arg1)
+func (_mr *_MockDirtyBlockCacheRecorder) UpdateUnsyncedBytes(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateUnsyncedBytes", arg0, arg1, arg2)
 }
 
-func (_m *MockDirtyBlockCache) UpdateSyncingBytes(size int64) {
-	_m.ctrl.Call(_m, "UpdateSyncingBytes", size)
+func (_m *MockDirtyBlockCache) UpdateSyncingBytes(tlfID TlfID, size int64) {
+	_m.ctrl.Call(_m, "UpdateSyncingBytes", tlfID, size)
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) UpdateSyncingBytes(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSyncingBytes", arg0)
+func (_mr *_MockDirtyBlockCacheRecorder) UpdateSyncingBytes(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateSyncingBytes", arg0, arg1)
 }
 
-func (_m *MockDirtyBlockCache) BlockSyncFinished(size int64) {
-	_m.ctrl.Call(_m, "BlockSyncFinished", size)
+func (_m *MockDirtyBlockCache) BlockSyncFinished(tlfID TlfID, size int64) {
+	_m.ctrl.Call(_m, "BlockSyncFinished", tlfID, size)
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) BlockSyncFinished(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockSyncFinished", arg0)
+func (_mr *_MockDirtyBlockCacheRecorder) BlockSyncFinished(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockSyncFinished", arg0, arg1)
 }
 
-func (_m *MockDirtyBlockCache) SyncFinished(size int64) {
-	_m.ctrl.Call(_m, "SyncFinished", size)
+func (_m *MockDirtyBlockCache) SyncFinished(tlfID TlfID, size int64) {
+	_m.ctrl.Call(_m, "SyncFinished", tlfID, size)
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) SyncFinished(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncFinished", arg0)
+func (_mr *_MockDirtyBlockCacheRecorder) SyncFinished(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncFinished", arg0, arg1)
 }
 
-func (_m *MockDirtyBlockCache) ShouldForceSync() bool {
-	ret := _m.ctrl.Call(_m, "ShouldForceSync")
+func (_m *MockDirtyBlockCache) ShouldForceSync(tlfID TlfID) bool {
+	ret := _m.ctrl.Call(_m, "ShouldForceSync", tlfID)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockDirtyBlockCacheRecorder) ShouldForceSync() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShouldForceSync")
+func (_mr *_MockDirtyBlockCacheRecorder) ShouldForceSync(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ShouldForceSync", arg0)
 }
 
 func (_m *MockDirtyBlockCache) Shutdown() error {


### PR DESCRIPTION
This will prevent journaled writes from messing up the buffer counts and backpressure for synchronous writes.

Most of the line changes are due to adding a new `TlfID` parameter to the `DirtyBlockCache` methods, so we can direct calls to the appropriate DirtyBlockCache.

We also need to prevent journal enabling/disabling while there is, or might be, dirty data coming in to the dirty block cache.  For now, if there are any outstanding operations that might dirty data on ANY TLF, or if there is any dirty data already, don't allow any TLF to switch its journaling status, because it will mess up the state of the DirtyBlockCache.

Issue: KBFS-1266