### PR TITLE
folder_branch_ops: SyncFromServer should wait for md flush calls

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3341,11 +3341,9 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// reference them without re-uploading them).  If any new unmerged
 	// puts happen, our context will get cancelled and we'll try
 	// again.
-	if jServer, jErr := GetJournalServer(cr.config); jErr == nil {
-		cr.log.CDebugf(ctx, "Waiting for journal to flush")
-		if err = jServer.Wait(ctx, cr.fbo.id()); err != nil {
-			return
-		}
+	if err = WaitForTLFJournal(ctx, cr.config, cr.fbo.id(),
+		cr.log); err != nil {
+		return
 	}
 
 	// Step 1: Build the chains for each branch, as well as the paths

--- a/libkbfs/journal_server_util.go
+++ b/libkbfs/journal_server_util.go
@@ -4,7 +4,12 @@
 
 package libkbfs
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
+)
 
 // GetJournalServer returns the JournalServer tied to a particular
 // config.
@@ -25,4 +30,17 @@ func TLFJournalEnabled(config Config, tlfID TlfID) bool {
 		return err == nil
 	}
 	return false
+}
+
+// WaitForTLFJournal waits for the corresponding journal to flush, if
+// one exists.
+func WaitForTLFJournal(ctx context.Context, config Config, tlfID TlfID,
+	log logger.Logger) error {
+	if jServer, err := GetJournalServer(config); err == nil {
+		log.CDebugf(ctx, "Waiting for journal to flush")
+		if err := jServer.Wait(ctx, tlfID); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -647,5 +647,5 @@ func (fs *KBFSOpsStandard) onTLFBranchChange(tlfID TlfID, newBID BranchID) {
 func (fs *KBFSOpsStandard) onMDFlush(tlfID TlfID, bid BranchID,
 	rev MetadataRevision) {
 	ops := fs.getOpsNoAdd(FolderBranch{Tlf: tlfID, Branch: MasterBranch})
-	go ops.onMDFlush(bid, rev)
+	ops.onMDFlush(bid, rev) // folderBranchOps makes a goroutine
 }


### PR DESCRIPTION
This changes the onMDFlush code to make sure that we handle all
archive events before shutting down in tests.