### PR TITLE
fix a bug in cancellation delayer

### DIFF
--- a/libkbfs/delayed_cancellation_test.go
+++ b/libkbfs/delayed_cancellation_test.go
@@ -102,6 +102,25 @@ func TestDelayedCancellationCleanupWhileNotEnabled(t *testing.T) {
 	}
 }
 
+func TestDelayedCancellationSecondEnable(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := makeContextWithDelayedCancellation(t)
+	defer cancel()
+
+	err := EnableDelayedCancellationWithGracePeriod(ctx, 0)
+	if err != nil {
+		t.Fatalf("1st EnableDelayedCancellationWithGracePeriod failed: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond) // make sure async ops sorts out
+	// parent context is not canceled; second "enable" should succeed even it's
+	// after grace period
+	err = EnableDelayedCancellationWithGracePeriod(ctx, 0)
+	if err != nil {
+		t.Fatalf("2nd EnableDelayedCancellationWithGracePeriod failed: %v", err)
+	}
+}
+
 func TestDelayedCancellationEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/libkbfs/delayed_cancellation_test.go
+++ b/libkbfs/delayed_cancellation_test.go
@@ -112,12 +112,15 @@ func TestDelayedCancellationSecondEnable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("1st EnableDelayedCancellationWithGracePeriod failed: %v", err)
 	}
-	time.Sleep(5 * time.Millisecond) // make sure async ops sorts out
+	cancel()
+	<-ctx.Done()
 	// parent context is not canceled; second "enable" should succeed even it's
 	// after grace period
 	err = EnableDelayedCancellationWithGracePeriod(ctx, 0)
-	if err != nil {
-		t.Fatalf("2nd EnableDelayedCancellationWithGracePeriod failed: %v", err)
+	if err == nil {
+		t.Fatalf("2nd EnableDelayedCancellationWithGracePeriod succeeded even " +
+			"though more than grace period has passed since parent context was " +
+			"canceled")
 	}
 }
 


### PR DESCRIPTION
When calling `EnableDelayedCancellationWithGracePeriod` the second time, if it's already past grace period since last time `EnableDelayedCancellationWithGracePeriod` was called, a `context.Canceled` would be returned even if parent context has not been canceled yet.

This is an issue for e.g. `Flush()` since we enable the context delayer in `libfuse`, and the enable function is called again in `finalizeMDWriteLocked`. For a real server over network, this can cause a lot of cancellations for slow writes.

Resolves https://github.com/keybase/client/issues/4254 (hopefully)