### PR TITLE
journal: fix race between flushing and disabling

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2208,11 +2208,6 @@ func (fbo *folderBranchOps) createEntryLocked(
 			NameTooLongError{name, fbo.config.MaxNameBytes()}
 	}
 
-	// Wait for any journal entries to flush first.  TODO: this opens
-	// us up to timeout issues, even when journaling is enabled;
-	// perhaps investigate how we can re-order file system operations
-	// easily without compromising semantics too much (i.e., to jump
-	// this operation to the front of the journal).
 	if excl == WithExcl {
 		if err := WaitForTLFJournal(ctx, fbo.config, fbo.id(),
 			fbo.log); err != nil {
@@ -2267,8 +2262,29 @@ func (fbo *folderBranchOps) createEntryLocked(
 	// Passthrough journal writes temporarily.
 	if excl == WithExcl {
 		if jServer, err := GetJournalServer(fbo.config); err == nil {
-			wasEnabled, err := jServer.Disable(ctx, fbo.id())
+			// Repeatedly flush and try to disable the journal. Since
+			// we hold the write lock, this shouldn't take more than
+			// one attempt very often (but could happen since block
+			// archives and removals don't take the write lock).
+			// TODO: this opens us up to timeout issues; perhaps
+			// investigate how we can re-order file system operations
+			// easily without compromising semantics too much (i.e.,
+			// to jump this operation to the front of the journal).
+			wasEnabled := false
+			for i := 0; i < 20; i++ {
+				err = WaitForTLFJournal(ctx, fbo.config, fbo.id(), fbo.log)
+				if err != nil {
+					return nil, DirEntry{}, err
+				}
+				wasEnabled, err = jServer.Disable(ctx, fbo.id())
+				if err == nil {
+					break
+				}
+				fbo.log.CDebugf(ctx, "Trying again after error "+
+					"disabling journal: %v", err)
+			}
 			if err != nil {
+				fbo.log.CDebugf(ctx, "Couldn't disable journal: %v", err)
 				return nil, DirEntry{}, err
 			}
 			if wasEnabled {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2278,6 +2278,13 @@ func (fbo *folderBranchOps) createEntryLocked(
 				}
 				wasEnabled, err = jServer.Disable(ctx, fbo.id())
 				if err == nil {
+					// TODO: there is a theoretical race here if a
+					// user re-enables the journal directly via the
+					// JournalServer through a file system interface.
+					// Maybe we should create a way to lock down
+					// enables except for the goroutine that called
+					// Disable (using a channel or function returned
+					// from Disable, for example).
 					break
 				}
 				fbo.log.CDebugf(ctx, "Trying again after error "+

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -48,7 +48,9 @@ func (j journalMDOps) getHeadFromJournal(
 	}
 
 	head, err := tlfJournal.getMDHead(ctx)
-	if err != nil {
+	if err == errTLFJournalDisabled {
+		return ImmutableRootMetadata{}, nil
+	} else if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
 
@@ -129,7 +131,9 @@ func (j journalMDOps) getRangeFromJournal(
 	}
 
 	ibrmds, err := tlfJournal.getMDRange(ctx, start, stop)
-	if err != nil {
+	if err == errTLFJournalDisabled {
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -207,10 +211,10 @@ func (j journalMDOps) GetForHandle(
 	// If the journal has a head, use that.
 	irmd, err := j.getHeadFromJournal(
 		ctx, tlfID, NullBranchID, mStatus, handle)
-	if err != nil && err != errTLFJournalDisabled {
+	if err != nil {
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
-	if err == nil && irmd != (ImmutableRootMetadata{}) {
+	if irmd != (ImmutableRootMetadata{}) {
 		return TlfID{}, irmd, nil
 	}
 
@@ -226,10 +230,10 @@ func (j journalMDOps) getForTLF(
 	ImmutableRootMetadata, error) {
 	// If the journal has a head, use that.
 	irmd, err := j.getHeadFromJournal(ctx, id, bid, mStatus, nil)
-	if err != nil && err != errTLFJournalDisabled {
+	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
-	if err == nil && irmd != (ImmutableRootMetadata{}) {
+	if irmd != (ImmutableRootMetadata{}) {
 		return irmd, nil
 	}
 
@@ -263,7 +267,7 @@ func (j journalMDOps) getRange(
 	[]ImmutableRootMetadata, error) {
 	// Grab the range from the journal first.
 	jirmds, err := j.getRangeFromJournal(ctx, id, bid, mStatus, start, stop)
-	if err != nil && err != errTLFJournalDisabled {
+	if err != nil {
 		return nil, err
 	}
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -291,6 +291,10 @@ func (j *JournalServer) Disable(ctx context.Context, tlfID TlfID) (
 			"are any dirty blocks outstanding", tlfID)
 	}
 
+	// Disable the journal.  Note that we don't bother deleting the
+	// journal from j.tlfJournals, to avoid cases where something
+	// keeps it around doing background work or re-enables it, at the
+	// same time JournalServer creates a new journal for the same TLF.
 	wasEnabled, err = tlfJournal.disable()
 	if err != nil {
 		return false, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -146,6 +146,7 @@ type tlfJournal struct {
 	// both of these are nil after shutdown() is called.
 	blockJournal *blockJournal
 	mdJournal    *mdJournal
+	disabled     bool
 
 	bwDelegate tlfJournalBWDelegate
 }
@@ -484,10 +485,15 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 }
 
 var errTLFJournalShutdown = errors.New("tlfJournal is shutdown")
+var errTLFJournalDisabled = errors.New("tlfJournal is disable")
+var errTLFJournalNotEmpty = errors.New("tlfJournal is not empty")
 
-func (j *tlfJournal) checkShutdownLocked() error {
+func (j *tlfJournal) checkEnabledLocked() error {
 	if j.blockJournal == nil || j.mdJournal == nil {
 		return errTLFJournalShutdown
+	}
+	if j.disabled {
+		return errTLFJournalDisabled
 	}
 	return nil
 }
@@ -497,7 +503,7 @@ func (j *tlfJournal) getNextBlockEntriesToFlush(
 	entries blockEntriesToFlush, err error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return blockEntriesToFlush{}, err
 	}
 
@@ -508,7 +514,7 @@ func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
 	entries blockEntriesToFlush) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
 
@@ -550,7 +556,7 @@ func (j *tlfJournal) getNextMDEntryToFlush(ctx context.Context,
 	MdID, *RootMetadataSigned, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return MdID{}, nil, err
 	}
 
@@ -564,7 +570,7 @@ func (j *tlfJournal) convertMDsToBranchAndGetNextEntry(
 	nextEntryEnd MetadataRevision) (MdID, *RootMetadataSigned, error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return MdID{}, nil, err
 	}
 
@@ -589,7 +595,7 @@ func (j *tlfJournal) removeFlushedMDEntry(ctx context.Context,
 	mdID MdID, rmds *RootMetadataSigned) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
 
@@ -678,7 +684,7 @@ func (j *tlfJournal) getJournalEntryCounts() (
 	blockEntryCount, mdEntryCount uint64, err error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return 0, 0, err
 	}
 
@@ -698,7 +704,7 @@ func (j *tlfJournal) getJournalEntryCounts() (
 func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return TLFJournalStatus{}, err
 	}
 
@@ -739,7 +745,7 @@ func (j *tlfJournal) shutdown() {
 	// but that's ok.
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		// Already shutdown.
 		return
 	}
@@ -754,6 +760,55 @@ func (j *tlfJournal) shutdown() {
 	j.mdJournal = nil
 }
 
+// disable prevents new operations from hitting the journal.  Will
+// fail unless the journal is completely empty.
+func (j *tlfJournal) disable(ctx context.Context) error {
+	j.journalLock.Lock()
+	defer j.journalLock.Unlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		// Already shutdown.
+		return err
+	}
+	if j.disabled {
+		return errTLFJournalDisabled
+	}
+
+	blockEntryCount, err := j.blockJournal.length()
+	if err != nil {
+		return err
+	}
+
+	mdEntryCount, err := j.mdJournal.length()
+	if err != nil {
+		return err
+	}
+
+	// You can only disable an empty journal.
+	if blockEntryCount > 0 || mdEntryCount > 0 {
+		return errTLFJournalNotEmpty
+	}
+
+	j.log.CDebugf(ctx, "Disabling the journal for %s", j.tlfID)
+	j.disabled = true
+	return nil
+}
+
+func (j *tlfJournal) reenable(ctx context.Context) error {
+	// This may happen before the background goroutine finishes,
+	// but that's ok.
+	j.journalLock.Lock()
+	defer j.journalLock.Unlock()
+	err := j.checkEnabledLocked()
+	if err == nil {
+		return errors.New("Cannot reenable a journal that's not disabled")
+	} else if err != errTLFJournalDisabled {
+		return err
+	}
+
+	j.disabled = false
+	return nil
+}
+
 // All the functions below just do the equivalent blockJournal or
 // mdJournal function under j.journalLock.
 
@@ -762,7 +817,7 @@ func (j *tlfJournal) getBlockDataWithContext(
 	[]byte, BlockCryptKeyServerHalf, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return nil, BlockCryptKeyServerHalf{}, err
 	}
 
@@ -774,7 +829,7 @@ func (j *tlfJournal) putBlockData(
 	serverHalf BlockCryptKeyServerHalf) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
 
@@ -801,7 +856,7 @@ func (j *tlfJournal) addBlockReference(
 	ctx context.Context, id BlockID, context BlockContext) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
 
@@ -820,7 +875,7 @@ func (j *tlfJournal) removeBlockReferences(
 	liveCounts map[BlockID]int, err error) {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return nil, err
 	}
 
@@ -844,7 +899,7 @@ func (j *tlfJournal) archiveBlockReferences(
 	ctx context.Context, contexts map[BlockID][]BlockContext) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
 
@@ -868,7 +923,7 @@ func (j *tlfJournal) getMDHead(
 
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return ImmutableBareRootMetadata{}, err
 	}
 
@@ -887,7 +942,7 @@ func (j *tlfJournal) getMDRange(
 
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return nil, err
 	}
 
@@ -905,7 +960,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return MdID{}, err
 	}
 
@@ -933,7 +988,7 @@ func (j *tlfJournal) clearMDs(ctx context.Context, bid BranchID) error {
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
-	if err := j.checkShutdownLocked(); err != nil {
+	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Exclusive writes need to flush the journal and then disable it to ensure they write directly to the servers. But between the flush and the disable, other operations (like block archives or deletes) can sneak in, causing the disable to fail.

To fix this, we need to somehow guarantee that they will flush all their current data before they are shutdown.  But since those are two separate calls, another write could sneak in between the flush and the shutdown, causing an error.  We can't prevent this with more locking in tlfJournal, because there might already be a reference to the tlfJournal floating around (e.g., in JournalServer), and if we blindly shut down, the code holding that reference will hit an error instead of being passed through to the real servers while the journal is disabled.

Instead, use a WaitGroup to implement a sort of reference counting, so we can prevent disabling the tlfJournal until all the references are dropped.  We can then add a way to disable+flush the journal atomically, and use that for exclusive writes.

Issue: KBFS-1520