### PR TITLE
[KBFS-1212] Make journal handle user switching

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -167,6 +167,8 @@ func (j *blockJournal) blocksPath() string {
 	return filepath.Join(j.dir, "blocks")
 }
 
+// TODO: Consider truncating the ID string to avoid running into path
+// limits while keeping the chance of collision negligible.
 func (j *blockJournal) blockPath(id BlockID) string {
 	idStr := id.String()
 	return filepath.Join(j.blocksPath(), idStr[:4], idStr[4:])

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,13 +28,14 @@ func setupBlockJournalTest(t *testing.T) (
 	ctx context.Context, tempdir string, j *blockJournal) {
 	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
 	require.NoError(t, err)
-	// Clean up the tempdir if anything in the setup fails/panics.
+
+	// Clean up the tempdir if anything in the rest of the setup
+	// fails.
+	setupSucceeded := false
 	defer func() {
-		if r := recover(); r != nil {
+		if !setupSucceeded {
 			err := os.RemoveAll(tempdir)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			assert.NoError(t, err)
 		}
 	}()
 
@@ -45,6 +47,7 @@ func setupBlockJournalTest(t *testing.T) (
 	require.NoError(t, err)
 	require.Equal(t, 0, getBlockJournalLength(t, j))
 
+	setupSucceeded = true
 	return ctx, tempdir, j
 }
 

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -34,8 +34,7 @@ func setupBlockJournalTest(t *testing.T) (
 	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
 	require.NoError(t, err)
 
-	// Clean up the tempdir if anything in the rest of the setup
-	// fails.
+	// Clean up the tempdir if the rest of the setup fails.
 	setupSucceeded := false
 	defer func() {
 		if !setupSucceeded {

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -26,6 +26,11 @@ func getBlockJournalLength(t *testing.T, j *blockJournal) int {
 
 func setupBlockJournalTest(t *testing.T) (
 	ctx context.Context, tempdir string, j *blockJournal) {
+	ctx = context.Background()
+	codec := NewCodecMsgpack()
+	crypto := MakeCryptoCommon(codec)
+	log := logger.NewTestLogger(t)
+
 	tempdir, err := ioutil.TempDir(os.TempDir(), "block_journal")
 	require.NoError(t, err)
 
@@ -39,10 +44,6 @@ func setupBlockJournalTest(t *testing.T) (
 		}
 	}()
 
-	ctx = context.Background()
-	codec := NewCodecMsgpack()
-	crypto := MakeCryptoCommon(codec)
-	log := logger.NewTestLogger(t)
 	j, err = makeBlockJournal(ctx, codec, crypto, tempdir, log)
 	require.NoError(t, err)
 	require.Equal(t, 0, getBlockJournalLength(t, j))
@@ -54,10 +55,10 @@ func setupBlockJournalTest(t *testing.T) (
 func teardownBlockJournalTest(t *testing.T, tempdir string, j *blockJournal) {
 	ctx := context.Background()
 	err := j.checkInSync(ctx)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	err = os.RemoveAll(tempdir)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func putBlockData(

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -842,20 +842,18 @@ func (c *ConfigLocal) EnableJournaling(journalRoot string) {
 		c.DirtyBlockCache(), c.BlockServer(), c.MDOps(), branchListener,
 		flushListener)
 	ctx := context.Background()
-	uid, key, err :=
-		getCurrentUIDAndVerifyingKey(ctx, c.KBPKI())
+	uid, key, err := getCurrentUIDAndVerifyingKey(ctx, c.KBPKI())
 	if err != nil {
-		log.Warning("Failed to enable existing journals: %v", err)
+		log.Warning("Failed to get current UID and key; not enabling existing journals: %v", err)
 		return
 	}
 	err = jServer.EnableExistingJournals(ctx, uid, key, TLFJournalBackgroundWorkEnabled)
-	if err == nil {
-		c.SetBlockServer(jServer.blockServer())
-		c.SetMDOps(jServer.mdOps())
-		if err := c.journalizeBcaches(); err != nil {
-			panic(err)
-		}
-	} else {
+	if err != nil {
 		log.Warning("Failed to enable existing journals: %v", err)
+	}
+	c.SetBlockServer(jServer.blockServer())
+	c.SetMDOps(jServer.mdOps())
+	if err := c.journalizeBcaches(); err != nil {
+		panic(err)
 	}
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -279,9 +279,17 @@ type KBFSOps interface {
 	PushConnectionStatusChange(service string, newStatus error)
 }
 
+type hasSession interface {
+	// CurrentSession returns a SessionInfo struct with all the
+	// information for the current session, or an error otherwise.
+	CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error)
+}
+
 // KeybaseService is an interface for communicating with the keybase
 // service.
 type KeybaseService interface {
+	hasSession
+
 	// Resolve, given an assertion, resolves it to a username/UID
 	// pair. The username <-> UID mapping is trusted and
 	// immutable, so it can be cached. If the assertion is just
@@ -312,10 +320,6 @@ type KeybaseService interface {
 	// keys currently part of the user's sigchain.
 	LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
 		[]keybase1.PublicKey, error)
-
-	// CurrentSession returns a SessionInfo struct with all the
-	// information for the current session, or an error otherwise.
-	CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error)
 
 	// FavoriteAdd adds the given folder to the list of favorites.
 	FavoriteAdd(ctx context.Context, folder keybase1.Folder) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -279,17 +279,9 @@ type KBFSOps interface {
 	PushConnectionStatusChange(service string, newStatus error)
 }
 
-type sessionGetter interface {
-	// CurrentSession returns a SessionInfo struct with all the
-	// information for the current session, or an error otherwise.
-	CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error)
-}
-
 // KeybaseService is an interface for communicating with the keybase
 // service.
 type KeybaseService interface {
-	sessionGetter
-
 	// Resolve, given an assertion, resolves it to a username/UID
 	// pair. The username <-> UID mapping is trusted and
 	// immutable, so it can be cached. If the assertion is just
@@ -320,6 +312,10 @@ type KeybaseService interface {
 	// keys currently part of the user's sigchain.
 	LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
 		[]keybase1.PublicKey, error)
+
+	// CurrentSession returns a SessionInfo struct with all the
+	// information for the current session, or an error otherwise.
+	CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error)
 
 	// FavoriteAdd adds the given folder to the list of favorites.
 	FavoriteAdd(ctx context.Context, folder keybase1.Folder) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -279,7 +279,7 @@ type KBFSOps interface {
 	PushConnectionStatusChange(service string, newStatus error)
 }
 
-type hasSession interface {
+type sessionGetter interface {
 	// CurrentSession returns a SessionInfo struct with all the
 	// information for the current session, or an error otherwise.
 	CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error)
@@ -288,7 +288,7 @@ type hasSession interface {
 // KeybaseService is an interface for communicating with the keybase
 // service.
 type KeybaseService interface {
-	hasSession
+	sessionGetter
 
 	// Resolve, given an assertion, resolves it to a username/UID
 	// pair. The username <-> UID mapping is trusted and

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -30,6 +30,14 @@ func setupJournalBlockServerTest(t *testing.T) (
 	}()
 
 	config = MakeTestConfigOrBust(t, "test_user")
+
+	// Clean up the config if the rest of the setup fails.
+	defer func() {
+		if !setupSucceeded {
+			CheckConfigAndShutdown(t, config)
+		}
+	}()
+
 	config.EnableJournaling(tempdir)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -20,8 +20,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_block_server")
 	require.NoError(t, err)
 
-	// Clean up the tempdir if anything in the rest of the setup
-	// fails.
+	// Clean up the tempdir if the rest of the setup fails.
 	setupSucceeded := false
 	defer func() {
 		if !setupSucceeded {

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -22,8 +22,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_md_ops")
 	require.NoError(t, err)
 
-	// Clean up the tempdir if anything in the rest of the setup
-	// fails.
+	// Clean up the tempdir if the rest of the setup fails.
 	setupSucceeded := false
 	defer func() {
 		if !setupSucceeded {

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -19,8 +19,6 @@ import (
 func setupJournalMDOpsTest(t *testing.T) (
 	tempdir string, config *ConfigLocal,
 	oldMDOps MDOps, jServer *JournalServer) {
-	config = MakeTestConfigOrBust(t, "test_user")
-
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_md_ops")
 	require.NoError(t, err)
 
@@ -34,6 +32,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 		}
 	}()
 
+	config = MakeTestConfigOrBust(t, "test_user")
 	oldMDOps = config.MDOps()
 	config.EnableJournaling(tempdir)
 	jServer, err = GetJournalServer(config)
@@ -49,7 +48,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 func teardownJournalMDOpsTest(t *testing.T, tempdir string, config Config) {
 	CheckConfigAndShutdown(t, config)
 	err := os.RemoveAll(tempdir)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func makeMDForJournalMDOpsTest(

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"golang.org/x/net/context"
@@ -22,14 +23,14 @@ func setupJournalMDOpsTest(t *testing.T) (
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_md_ops")
 	require.NoError(t, err)
-	// Clean up the tempdir if anything in the setup fails/panics.
+
+	// Clean up the tempdir if anything in the rest of the setup
+	// fails.
+	setupSucceeded := false
 	defer func() {
-		if r := recover(); r != nil {
-			CheckConfigAndShutdown(t, config)
+		if !setupSucceeded {
 			err := os.RemoveAll(tempdir)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			assert.NoError(t, err)
 		}
 	}()
 
@@ -40,6 +41,8 @@ func setupJournalMDOpsTest(t *testing.T) (
 	jServer.onBranchChange = nil
 	jServer.onMDFlush = nil
 	require.NoError(t, err)
+
+	setupSucceeded = true
 	return tempdir, config, oldMDOps, jServer
 }
 

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -32,6 +32,14 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	config = MakeTestConfigOrBust(t, "test_user")
+
+	// Clean up the config if the rest of the setup fails.
+	defer func() {
+		if !setupSucceeded {
+			CheckConfigAndShutdown(t, config)
+		}
+	}()
+
 	oldMDOps = config.MDOps()
 	config.EnableJournaling(tempdir)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -38,10 +38,12 @@ func setupJournalMDOpsTest(t *testing.T) (
 		config.BlockServer(), config.MDOps(), nil, nil)
 
 	ctx := context.Background()
-	currentUID := keybase1.MakeTestUID(1)
-	currentVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
+	_, uid, err := config.KBPKI().GetCurrentUserInfo(ctx)
+	require.NoError(t, err)
+	key, err := config.KBPKI().GetCurrentVerifyingKey(ctx)
+	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(
-		ctx, currentUID, currentVerifyingKey,
+		ctx, uid, key,
 		TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -36,6 +36,9 @@ func setupJournalMDOpsTest(t *testing.T) (
 	oldMDOps = config.MDOps()
 	config.EnableJournaling(tempdir)
 	jServer, err = GetJournalServer(config)
+	// Turn off listeners to avoid background MD pushes for CR.
+	jServer.onBranchChange = nil
+	jServer.onMDFlush = nil
 	require.NoError(t, err)
 	return tempdir, config, oldMDOps, jServer
 }

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -179,10 +179,12 @@ func (j *JournalServer) EnableExistingJournals(
 	// depend on it.
 	j.currentUID = currentUID
 	j.currentVerifyingKey = currentVerifyingKey
+
+	enableSucceeded := false
 	defer func() {
-		// Revert to a clean state if we panic or error.
-		r := recover()
-		if r != nil || err != nil {
+		// Revert to a clean state if the enable doesn't
+		// succeed, either due to a panic or error.
+		if !enableSucceeded {
 			j.shutdownExistingJournalsLocked(ctx)
 		}
 	}()
@@ -218,6 +220,7 @@ func (j *JournalServer) EnableExistingJournals(
 		}
 	}
 
+	enableSucceeded = true
 	return nil
 }
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -99,13 +99,12 @@ func makeJournalServer(
 }
 
 func (j *JournalServer) getDirLocked() string {
-	// TODO: This may end up making paths too long for some
-	// systems. We may end up having to drop the UID (since a
-	// device has only one associated UID) or even hashing the
-	// (UID, key, TLF) tuple.
-	return filepath.Join(
-		j.dir, "v1", j.currentUID.String(),
-		j.currentVerifyingKey.String())
+	// Device IDs and verifying keys are globally unique, so no
+	// need to have the uid in the path.
+	//
+	// TODO: Use the shorter device ID in the path instead of the
+	// verifying key.
+	return filepath.Join(j.dir, "v1", j.currentVerifyingKey.String())
 }
 
 func (j *JournalServer) getDir() string {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -195,7 +195,8 @@ func (j *JournalServer) Enable(
 			"are any dirty blocks outstanding", tlfID)
 	}
 
-	tlfJournal, err := makeTLFJournal(ctx, j.dir, tlfID,
+	tlfJournal, err := makeTLFJournal(
+		ctx, j.currentUID, j.currentVerifyingKey, j.dir, tlfID,
 		tlfJournalConfigAdapter{j.config}, j.delegateBlockServer,
 		bws, nil, j.onBranchChange, j.onMDFlush)
 	if err != nil {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -378,6 +378,15 @@ func (j *JournalServer) JournalStatus(tlfID TlfID) (TLFJournalStatus, error) {
 	return tlfJournal.getJournalStatus()
 }
 
+func (j *JournalServer) logIn(
+	ctx context.Context, currentUID keybase1.UID,
+	currentVerifyingKey VerifyingKey) {
+	j.log.CDebugf(context.Background(), "Logging in journal with %s", currentUID)
+	// TODO: Preserve background work status.
+	j.EnableExistingJournals(ctx, currentUID, currentVerifyingKey,
+		TLFJournalBackgroundWorkEnabled)
+}
+
 func (j *JournalServer) logOut(ctx context.Context) {
 	j.log.CDebugf(context.Background(), "Logging out journal")
 	j.lock.Lock()

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -205,8 +205,8 @@ func (j *JournalServer) EnableExistingJournals(
 			continue
 		}
 
-		// Force the enable, since any dirty writes in flight
-		// are most likely for another user.
+		// Allow enable even if dirty, since any dirty writes
+		// in flight are most likely for another user.
 		err = j.enableLocked(ctx, tlfID, bws, true)
 		if err != nil {
 			// Don't treat per-TLF errors as fatal.
@@ -221,8 +221,8 @@ func (j *JournalServer) EnableExistingJournals(
 }
 
 func (j *JournalServer) enableLocked(
-	ctx context.Context, tlfID TlfID,
-	bws TLFJournalBackgroundWorkStatus, force bool) (err error) {
+	ctx context.Context, tlfID TlfID, bws TLFJournalBackgroundWorkStatus,
+	allowEnableIfDirty bool) (err error) {
 	j.log.CDebugf(ctx, "Enabling journal for %s (%s)", tlfID, bws)
 	defer func() {
 		if err != nil {
@@ -248,7 +248,7 @@ func (j *JournalServer) enableLocked(
 		return nil
 	}()
 	if err != nil {
-		if !force {
+		if !allowEnableIfDirty {
 			return err
 		}
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -107,11 +107,12 @@ func makeJournalServer(
 
 func (j *JournalServer) getDirLocked() string {
 	// Device IDs and verifying keys are globally unique, so no
-	// need to have the uid in the path.
-	//
-	// TODO: Use the shorter device ID in the path instead of the
-	// verifying key.
-	return filepath.Join(j.dir, "v1", j.currentVerifyingKey.String())
+	// need to have the uid in the path. Furthermore, everything
+	// after the first two bytes (four characters) are randomly
+	// generated, so taking the first 36 characters gives ~1/2^64
+	// collision probability.
+	shortID := j.currentVerifyingKey.String()[0:36]
+	return filepath.Join(j.dir, "v1", shortID)
 }
 
 func (j *JournalServer) getDir() string {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -134,6 +134,13 @@ func (j *JournalServer) EnableExistingJournals(
 		return err
 	}
 
+	func() {
+		j.lock.Lock()
+		defer j.lock.Unlock()
+		j.currentUID = currentUID
+		j.currentVerifyingKey = currentVerifyingKey
+	}()
+
 	for _, fi := range fileInfos {
 		name := fi.Name()
 		if !fi.IsDir() {
@@ -384,6 +391,8 @@ func (j *JournalServer) logOut(ctx context.Context) {
 	}
 
 	j.tlfJournals = make(map[TlfID]*tlfJournal)
+	j.currentUID = keybase1.UID("")
+	j.currentVerifyingKey = VerifyingKey{}
 }
 
 func (j *JournalServer) shutdown() {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -489,22 +489,6 @@ func (j *JournalServer) shutdownExistingJournalsLocked(ctx context.Context) {
 		tlfJournal.shutdown()
 	}
 
-	// Shutting down atomically is more important than respecting
-	// context cancellation.
-	waitCtx := context.Background()
-	for tlfID, tlfJournal := range j.tlfJournals {
-		err := tlfJournal.wait(waitCtx)
-		if err != nil {
-			// This shouldn't really happen, since it only
-			// happens when wait's passed-in context is
-			// cancelled.
-			j.log.CDebugf(ctx,
-				"Got unexpected error when shutting down journal for %s: %v",
-				tlfID, err)
-
-		}
-	}
-
 	j.tlfJournals = make(map[TlfID]*tlfJournal)
 	j.currentUID = keybase1.UID("")
 	j.currentVerifyingKey = VerifyingKey{}

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -402,7 +402,7 @@ func (j *JournalServer) logOut(ctx context.Context) {
 		err := tlfJournal.wait(waitCtx)
 		if err != nil {
 			// This shouldn't really happen, since it only
-			// happens wait's passed-in context is
+			// happens when wait's passed-in context is
 			// cancelled.
 			j.log.CDebugf(ctx,
 				"Got unexpected error when shutting down journal for %s: %v",

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -242,7 +242,7 @@ func (j *JournalServer) enableLocked(
 		}
 
 		j.log.CWarningf(ctx,
-			"Got error on journal enable, but proceeding anyway: %v", err)
+			"Got ignorable error on journal enable, and proceeding anyway: %v", err)
 	}
 
 	tlfJournal, err := makeTLFJournal(
@@ -432,6 +432,8 @@ func (j *JournalServer) JournalStatus(tlfID TlfID) (TLFJournalStatus, error) {
 // again.
 func (j *JournalServer) shutdownExistingJournals(ctx context.Context) {
 	j.log.CDebugf(ctx, "Shutting down existing journals")
+
+	// TODO: Wait until dirtyOps reaches 0.
 
 	j.lock.Lock()
 	defer j.lock.Unlock()

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -104,7 +104,8 @@ func (j *JournalServer) getDirLocked() string {
 	// device has only one associated UID) or even hashing the
 	// (UID, key, TLF) tuple.
 	return filepath.Join(
-		j.dir, j.currentUID.String(), j.currentVerifyingKey.String())
+		j.dir, "v1", j.currentUID.String(),
+		j.currentVerifyingKey.String())
 }
 
 func (j *JournalServer) getDir() string {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -195,6 +195,7 @@ func (j *JournalServer) EnableExistingJournals(
 
 	fileInfos, err := ioutil.ReadDir(j.getDirLocked())
 	if os.IsNotExist(err) {
+		enableSucceeded = true
 		return nil
 	} else if err != nil {
 		return err

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -128,13 +128,6 @@ func (j *JournalServer) EnableExistingJournals(
 		}
 	}()
 
-	fileInfos, err := ioutil.ReadDir(j.dir)
-	if os.IsNotExist(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
 	err = func() error {
 		j.lock.Lock()
 		defer j.lock.Unlock()
@@ -149,6 +142,13 @@ func (j *JournalServer) EnableExistingJournals(
 		return nil
 	}()
 	if err != nil {
+		return err
+	}
+
+	fileInfos, err := ioutil.ReadDir(j.dir)
+	if os.IsNotExist(err) {
+		return nil
+	} else if err != nil {
 		return err
 	}
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -106,6 +106,10 @@ func makeJournalServer(
 }
 
 func (j *JournalServer) getDirLocked() string {
+	if j.currentVerifyingKey == (VerifyingKey{}) {
+		panic("currentVerifyingKey is zero")
+	}
+
 	// Device IDs and verifying keys are globally unique, so no
 	// need to have the uid in the path. Furthermore, everything
 	// after the first two bytes (four characters) are randomly
@@ -235,6 +239,13 @@ func (j *JournalServer) enableLocked(
 				tlfID, err)
 		}
 	}()
+
+	if j.currentUID == keybase1.UID("") {
+		return errors.New("Current UID is empty")
+	}
+	if j.currentVerifyingKey == (VerifyingKey{}) {
+		return errors.New("Current verifying key is empty")
+	}
 
 	if tlfJournal, ok := j.tlfJournals[tlfID]; ok {
 		return tlfJournal.enable()

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -459,7 +459,7 @@ func (j *JournalServer) Status() JournalServerStatus {
 		RootDir:             j.dir,
 		Version:             "v1",
 		CurrentUID:          currentUID.String(),
-		CurrentVerifyingKey: currentVerifyingKey.String(),x
+		CurrentVerifyingKey: currentVerifyingKey.String(),
 		JournalCount:        journalCount,
 		UnflushedBytes:      unflushedBytes,
 	}

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -29,6 +29,14 @@ func setupJournalServerTest(t *testing.T) (
 	}()
 
 	config = MakeTestConfigOrBust(t, "test_user1", "test_user2")
+
+	// Clean up the config if the rest of the setup fails.
+	defer func() {
+		if !setupSucceeded {
+			CheckConfigAndShutdown(t, config)
+		}
+	}()
+
 	config.EnableJournaling(tempdir)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -236,8 +236,8 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	serviceLoggedOut(ctx, config)
 
 	dirtyOps := func() uint {
-		jServer.journalsLock.RLock()
-		defer jServer.journalsLock.RUnlock()
+		jServer.lock.RLock()
+		defer jServer.lock.RUnlock()
 		return jServer.dirtyOps
 	}
 	require.NotEqual(t, 0, dirtyOps)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -84,16 +84,15 @@ func TestJournalServerRestart(t *testing.T) {
 
 	// Simulate a restart.
 
-	// TODO: Do under lock.
-	currentUID := jServer.currentUID
-	currentVerifyingKey := jServer.currentVerifyingKey
 	jServer = makeJournalServer(
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil)
+	uid, verifyingKey, err :=
+		getCurrentUIDAndVerifyingKey(ctx, config.KBPKI())
+	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(
-		ctx, currentUID, currentVerifyingKey,
-		TLFJournalBackgroundWorkPaused)
+		ctx, uid, verifyingKey, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())
 	config.SetBlockServer(jServer.blockServer())

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -231,6 +231,8 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 
 	// Should wait for the dirtyOpEnd call to happen and then
 	// finish.
+	//
+	// TODO: Ideally, this test would be deterministic.
 	serviceLoggedOut(ctx, config)
 
 	require.False(t, jServer.hasDirtyOps())

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -294,6 +294,15 @@ func TestJournalServerMultiUser(t *testing.T) {
 	err = jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
+	// None of user 1's changes should be visible.
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID1, bCtx1)
+	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	head, err := mdOps.GetForTLF(ctx, tlfID)
+	require.NoError(t, err)
+	require.Equal(t, ImmutableRootMetadata{}, head)
+
 	// Put a block under user 2.
 
 	bCtx2 := BlockContext{uid2, "", zeroBlockRefNonce}
@@ -332,7 +341,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	_, _, err = blockServer.Get(ctx, tlfID, bID2, bCtx2)
 	require.IsType(t, BServerErrorBlockNonExistent{}, err)
 
-	head, err := mdOps.GetForTLF(ctx, tlfID)
+	head, err = mdOps.GetForTLF(ctx, tlfID)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, head)
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -210,10 +210,16 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	tempdir, config, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, config)
 
-	// Time out this test after 10 seconds (although this may not
-	// work if we hang while waiting for an individual tlfJournal).
+	// Time out this test after 10 seconds.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	// Panic if timeout is hit, as shutdown code ignores context
+	// cancellation.
+	go func() {
+		<-ctx.Done()
+		panic("Timeout reached")
+	}()
 
 	tlfID := FakeTlfID(2, false)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -188,8 +188,8 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, head)
 
-	serviceLoggedIn(ctx, config, jServer.log, "test_user1",
-		TLFJournalBackgroundWorkPaused)
+	serviceLoggedIn(
+		ctx, config, "test_user1", TLFJournalBackgroundWorkPaused)
 
 	// Get the block.
 
@@ -266,8 +266,8 @@ func TestJournalServerMultiUser(t *testing.T) {
 	service.currentUID = uid2
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
-	serviceLoggedIn(ctx, config, jServer.log, "test_user2",
-		TLFJournalBackgroundWorkPaused)
+	serviceLoggedIn(
+		ctx, config, "test_user2", TLFJournalBackgroundWorkPaused)
 
 	err = jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -320,8 +320,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
-		ctx, config, jServer.log, "test_user1",
-		TLFJournalBackgroundWorkPaused)
+		ctx, config, "test_user1", TLFJournalBackgroundWorkPaused)
 
 	// Only user 1's block and MD should be visible.
 
@@ -345,8 +344,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
-		ctx, config, jServer.log, "test_user2",
-		TLFJournalBackgroundWorkPaused)
+		ctx, config, "test_user2", TLFJournalBackgroundWorkPaused)
 
 	// Only user 2's block and MD should be visible.
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -232,7 +232,9 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	// Should wait for the dirtyOpEnd call to happen and then
 	// finish.
 	//
-	// TODO: Ideally, this test would be deterministic.
+	// TODO: Ideally, this test would be deterministic, i.e. we
+	// detect when serviceLoggedOut blocks on waiting for
+	// dirtyOpEnd, and only then do we call dirtyOpEnd.
 	serviceLoggedOut(ctx, config)
 
 	dirtyOps := func() uint {

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -205,6 +205,23 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.Equal(t, rmd.Revision(), head.Revision())
 }
 
+func TestJournalServerLogOutDirtyOp(t *testing.T) {
+	tempdir, config, jServer := setupJournalServerTest(t)
+	defer teardownJournalServerTest(t, tempdir, config)
+
+	ctx := context.Background()
+
+	tlfID := FakeTlfID(2, false)
+	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
+	require.NoError(t, err)
+
+	jServer.dirtyOpStart(tlfID)
+	serviceLoggedOut(ctx, config)
+
+	// TODO: Use locking.
+	require.Equal(t, 0, jServer.dirtyOps)
+}
+
 func TestJournalServerMultiUser(t *testing.T) {
 	tempdir, config, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, config)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -222,7 +223,8 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			// Since we're in a goroutine, we can't use
-			// FailNow.
+			// require.FailNow().
+			assert.Fail(t, "Timeout reached")
 			panic("Timeout reached")
 		case <-testCtx.Done():
 		}

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -24,10 +24,12 @@ func setupJournalServerTest(t *testing.T) (
 		config, log, tempdir, config.BlockCache(), config.DirtyBlockCache(),
 		config.BlockServer(), config.MDOps(), nil, nil)
 	ctx := context.Background()
-	currentUID := keybase1.MakeTestUID(1)
-	currentVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
+	_, uid, err := config.KBPKI().GetCurrentUserInfo(ctx)
+	require.NoError(t, err)
+	key, err := config.KBPKI().GetCurrentVerifyingKey(ctx)
+	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(
-		ctx, currentUID, currentVerifyingKey,
+		ctx, uid, key,
 		TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	config.SetBlockCache(jServer.blockCache())

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -63,11 +62,11 @@ func TestJournalServerRestart(t *testing.T) {
 	mdOps := config.MDOps()
 	crypto := config.Crypto()
 
-	uid := keybase1.MakeTestUID(1)
-	bh, err := MakeBareTlfHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user", false)
 	require.NoError(t, err)
+	uid := h.ResolvedWriters()[0]
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	bh, err := h.ToBareHandle()
 	require.NoError(t, err)
 
 	bCtx := BlockContext{uid, "", zeroBlockRefNonce}

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -221,6 +221,8 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	go func() {
 		select {
 		case <-ctx.Done():
+			// Since we're in a goroutine, we can't use
+			// FailNow.
 			panic("Timeout reached")
 		case <-testCtx.Done():
 		}
@@ -234,11 +236,11 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	go func() {
 		jServer.dirtyOpEnd(tlfID)
 	}()
+	// Should wait for the dirtyOpEnd call to happen and then
+	// finish.
 	serviceLoggedOut(ctx, config)
 
-	jServer.dirtyOpsLock.RLock()
-	jServer.dirtyOpsLock.RUnlock()
-	require.Equal(t, uint(0), jServer.dirtyOps)
+	require.False(t, jServer.hasDirtyOps())
 }
 
 func TestJournalServerMultiUser(t *testing.T) {

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -235,7 +235,12 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	// TODO: Ideally, this test would be deterministic.
 	serviceLoggedOut(ctx, config)
 
-	require.False(t, jServer.hasDirtyOps())
+	dirtyOps := func() uint {
+		jServer.journalsLock.RLock()
+		defer jServer.journalsLock.RUnlock()
+		return jServer.dirtyOps
+	}
+	require.NotEqual(t, 0, dirtyOps)
 }
 
 func TestJournalServerMultiUser(t *testing.T) {

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -209,7 +210,10 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	tempdir, config, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, config)
 
-	ctx := context.Background()
+	// Time out this test after 10 seconds (although this may not
+	// work if we hang while waiting for an individual tlfJournal).
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
 	tlfID := FakeTlfID(2, false)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -188,8 +188,7 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, head)
 
-	serviceLoggedIn(
-		ctx, jServer.log, "test_user1", config.KeybaseService(), config,
+	serviceLoggedIn(ctx, config, jServer.log, "test_user1",
 		TLFJournalBackgroundWorkPaused)
 
 	// Get the block.
@@ -267,9 +266,8 @@ func TestJournalServerMultiUser(t *testing.T) {
 	service.currentUID = uid2
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
-	serviceLoggedIn(
-		ctx, jServer.log, "test_user2", config.KeybaseService(),
-		config, TLFJournalBackgroundWorkPaused)
+	serviceLoggedIn(ctx, config, jServer.log, "test_user2",
+		TLFJournalBackgroundWorkPaused)
 
 	err = jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -322,8 +320,8 @@ func TestJournalServerMultiUser(t *testing.T) {
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
-		ctx, jServer.log, "test_user1", config.KeybaseService(),
-		config, TLFJournalBackgroundWorkPaused)
+		ctx, config, jServer.log, "test_user1",
+		TLFJournalBackgroundWorkPaused)
 
 	// Only user 1's block and MD should be visible.
 
@@ -347,8 +345,8 @@ func TestJournalServerMultiUser(t *testing.T) {
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
-		ctx, jServer.log, "test_user2", config.KeybaseService(),
-		config, TLFJournalBackgroundWorkPaused)
+		ctx, config, jServer.log, "test_user2",
+		TLFJournalBackgroundWorkPaused)
 
 	// Only user 2's block and MD should be visible.
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -17,7 +17,7 @@ func setupJournalServerTest(t *testing.T) (
 	tempdir string, config *ConfigLocal, jServer *JournalServer) {
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
 	require.NoError(t, err)
-	config = MakeTestConfigOrBust(t, "test_user")
+	config = MakeTestConfigOrBust(t, "test_user1", "test_user2")
 	config.EnableJournaling(tempdir)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)
@@ -49,20 +49,19 @@ func TestJournalServerRestart(t *testing.T) {
 	mdOps := config.MDOps()
 	crypto := config.Crypto()
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user", false)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", false)
 	require.NoError(t, err)
 	uid := h.ResolvedWriters()[0]
 
 	bh, err := h.ToBareHandle()
 	require.NoError(t, err)
 
+	// Put a block.
+
 	bCtx := BlockContext{uid, "", zeroBlockRefNonce}
 	data := []byte{1, 2, 3, 4}
 	bID, err := crypto.MakePermanentBlockID(data)
 	require.NoError(t, err)
-
-	// Put a block.
-
 	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 	err = blockServer.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
@@ -130,20 +129,19 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	mdOps := config.MDOps()
 	crypto := config.Crypto()
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user", false)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", false)
 	require.NoError(t, err)
 	uid := h.ResolvedWriters()[0]
 
 	bh, err := h.ToBareHandle()
 	require.NoError(t, err)
 
+	// Put a block.
+
 	bCtx := BlockContext{uid, "", zeroBlockRefNonce}
 	data := []byte{1, 2, 3, 4}
 	bID, err := crypto.MakePermanentBlockID(data)
 	require.NoError(t, err)
-
-	// Put a block.
-
 	serverHalf, err := crypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 	err = blockServer.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
@@ -179,7 +177,7 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.Equal(t, ImmutableRootMetadata{}, head)
 
 	serviceLoggedIn(
-		ctx, jServer.log, "test_user", config.KeybaseService(), config,
+		ctx, jServer.log, "test_user1", config.KeybaseService(), config,
 		TLFJournalBackgroundWorkPaused)
 
 	// Get the block.
@@ -194,4 +192,163 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	head, err = mdOps.GetForTLF(ctx, tlfID)
 	require.NoError(t, err)
 	require.Equal(t, rmd.Revision(), head.Revision())
+}
+
+func TestJournalServerMultiUser(t *testing.T) {
+	tempdir, config, jServer := setupJournalServerTest(t)
+	defer teardownJournalServerTest(t, tempdir, config)
+
+	// Use a shutdown-only BlockServer so that it errors if the
+	// journal tries to access it.
+	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
+
+	ctx := context.Background()
+
+	tlfID := FakeTlfID(2, false)
+	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
+	require.NoError(t, err)
+
+	blockServer := config.BlockServer()
+	mdOps := config.MDOps()
+	crypto := config.Crypto()
+
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), "test_user1,test_user2", false)
+	require.NoError(t, err)
+	uid1 := h.ResolvedWriters()[0]
+	uid2 := h.ResolvedWriters()[1]
+
+	bh, err := h.ToBareHandle()
+	require.NoError(t, err)
+
+	// Put a block under user 1.
+
+	bCtx1 := BlockContext{uid1, "", zeroBlockRefNonce}
+	data1 := []byte{1, 2, 3, 4}
+	bID1, err := crypto.MakePermanentBlockID(data1)
+	require.NoError(t, err)
+	serverHalf1, err := crypto.MakeRandomBlockCryptKeyServerHalf()
+	require.NoError(t, err)
+	err = blockServer.Put(ctx, tlfID, bID1, bCtx1, data1, serverHalf1)
+	require.NoError(t, err)
+
+	// Put an MD under user 1.
+
+	rmd1 := NewRootMetadata()
+	err = rmd1.Update(tlfID, bh)
+	require.NoError(t, err)
+	rmd1.tlfHandle = h
+	rmd1.SetRevision(MetadataRevision(1))
+	rmd1.SetLastModifyingWriter(uid1)
+	rekeyDone, _, err := config.KeyManager().Rekey(ctx, rmd1, false)
+	require.NoError(t, err)
+	require.True(t, rekeyDone)
+
+	_, err = mdOps.Put(ctx, rmd1)
+	require.NoError(t, err)
+
+	// Log in user 2.
+
+	serviceLoggedOut(ctx, config)
+
+	service := config.KeybaseService().(*KeybaseDaemonLocal)
+	service.currentUID = uid2
+	SwitchDeviceForLocalUserOrBust(t, config, 0)
+
+	serviceLoggedIn(
+		ctx, jServer.log, "test_user2", config.KeybaseService(),
+		config, TLFJournalBackgroundWorkPaused)
+
+	err = jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
+	require.NoError(t, err)
+
+	// Put a block under user 2.
+
+	bCtx2 := BlockContext{uid2, "", zeroBlockRefNonce}
+	data2 := []byte{1, 2, 3, 4, 5}
+	bID2, err := crypto.MakePermanentBlockID(data2)
+	require.NoError(t, err)
+	serverHalf2, err := crypto.MakeRandomBlockCryptKeyServerHalf()
+	require.NoError(t, err)
+	err = blockServer.Put(ctx, tlfID, bID2, bCtx2, data2, serverHalf2)
+	require.NoError(t, err)
+
+	// Put an MD under user 2.
+
+	rmd2 := NewRootMetadata()
+	err = rmd2.Update(tlfID, bh)
+	require.NoError(t, err)
+	rmd2.tlfHandle = h
+	rmd2.SetRevision(MetadataRevision(1))
+	rmd2.SetLastModifyingWriter(uid2)
+	rekeyDone, _, err = config.KeyManager().Rekey(ctx, rmd2, false)
+	require.NoError(t, err)
+	require.True(t, rekeyDone)
+
+	_, err = mdOps.Put(ctx, rmd2)
+	require.NoError(t, err)
+
+	// Log out.
+
+	serviceLoggedOut(ctx, config)
+
+	// No block or MD should be visible.
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID1, bCtx1)
+	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID2, bCtx2)
+	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	head, err := mdOps.GetForTLF(ctx, tlfID)
+	require.NoError(t, err)
+	require.Equal(t, ImmutableRootMetadata{}, head)
+
+	// Log in user 1.
+
+	service.currentUID = uid1
+	SwitchDeviceForLocalUserOrBust(t, config, 0)
+
+	serviceLoggedIn(
+		ctx, jServer.log, "test_user1", config.KeybaseService(),
+		config, TLFJournalBackgroundWorkPaused)
+
+	// Only user 1's block and MD should be visible.
+
+	buf, key, err := blockServer.Get(ctx, tlfID, bID1, bCtx1)
+	require.NoError(t, err)
+	require.Equal(t, data1, buf)
+	require.Equal(t, serverHalf1, key)
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID2, bCtx2)
+	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	head, err = mdOps.GetForTLF(ctx, tlfID)
+	require.NoError(t, err)
+	require.Equal(t, uid1, head.LastModifyingWriter())
+
+	// Log in user 2.
+
+	serviceLoggedOut(ctx, config)
+
+	service.currentUID = uid2
+	SwitchDeviceForLocalUserOrBust(t, config, 0)
+
+	serviceLoggedIn(
+		ctx, jServer.log, "test_user2", config.KeybaseService(),
+		config, TLFJournalBackgroundWorkPaused)
+
+	// Only user 2's block and MD should be visible.
+
+	_, _, err = blockServer.Get(ctx, tlfID, bID1, bCtx1)
+	require.IsType(t, BServerErrorBlockNonExistent{}, err)
+
+	buf, key, err = blockServer.Get(ctx, tlfID, bID2, bCtx2)
+	require.NoError(t, err)
+	require.Equal(t, data2, buf)
+	require.Equal(t, serverHalf2, key)
+
+	head, err = mdOps.GetForTLF(ctx, tlfID)
+	require.NoError(t, err)
+	require.Equal(t, uid2, head.LastModifyingWriter())
 }

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -216,7 +216,7 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	// Time out this test after 10 seconds.
 	ctx, _ := context.WithTimeout(testCtx, 10*time.Second)
 
-	// Spawn a goroutine to check if the timeout is hit, as
+	// Spawn separate goroutine to check if timeout is hit, as
 	// shutdown code ignores context cancellation.
 	go func() {
 		select {
@@ -236,8 +236,9 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	}()
 	serviceLoggedOut(ctx, config)
 
-	// TODO: Use locking.
-	require.Equal(t, 0, jServer.dirtyOps)
+	jServer.dirtyOpsLock.RLock()
+	jServer.dirtyOpsLock.RUnlock()
+	require.Equal(t, uint(0), jServer.dirtyOps)
 }
 
 func TestJournalServerMultiUser(t *testing.T) {

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -203,8 +203,8 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	// Since we don't have the whole session, just clear the cache.
 	k.setCachedCurrentSession(SessionInfo{})
 	if k.config != nil {
-		serviceLoggedIn(ctx, k.config, k.log, name,
-			TLFJournalBackgroundWorkEnabled)
+		serviceLoggedIn(
+			ctx, k.config, name, TLFJournalBackgroundWorkEnabled)
 	}
 	return nil
 }

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -202,7 +202,15 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	k.log.CDebugf(ctx, "Current session logged in: %s", name)
 	// Since we don't have the whole session, just clear the cache.
 	k.setCachedCurrentSession(SessionInfo{})
+	const sessionID = 0
+	session, err := k.CurrentSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
 	if k.config != nil {
+		if jServer, err := GetJournalServer(k.config); err == nil {
+			jServer.logIn(ctx, session.UID, session.VerifyingKey)
+		}
 		k.config.MDServer().RefreshAuthToken(ctx)
 		k.config.BlockServer().RefreshAuthToken(ctx)
 		k.config.KBFSOps().RefreshCachedFavorites(ctx)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -209,7 +209,9 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	}
 	if k.config != nil {
 		if jServer, err := GetJournalServer(k.config); err == nil {
-			jServer.logIn(ctx, session.UID, session.VerifyingKey)
+			jServer.EnableExistingJournals(
+				ctx, session.UID, session.VerifyingKey,
+				TLFJournalBackgroundWorkEnabled)
 		}
 		k.config.MDServer().RefreshAuthToken(ctx)
 		k.config.BlockServer().RefreshAuthToken(ctx)
@@ -224,7 +226,7 @@ func (k *KeybaseServiceBase) LoggedOut(ctx context.Context) error {
 	k.setCachedCurrentSession(SessionInfo{})
 	if k.config != nil {
 		if jServer, err := GetJournalServer(k.config); err == nil {
-			jServer.logOut(ctx)
+			jServer.loggedOut(ctx)
 		}
 		k.config.ResetCaches()
 		k.config.MDServer().RefreshAuthToken(ctx)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -203,7 +203,8 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	// Since we don't have the whole session, just clear the cache.
 	k.setCachedCurrentSession(SessionInfo{})
 	if k.config != nil {
-		serviceLoggedIn(ctx, k.log, name, k, k.config)
+		serviceLoggedIn(ctx, k.log, name, k, k.config,
+			TLFJournalBackgroundWorkEnabled)
 	}
 	return nil
 }

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -226,7 +226,7 @@ func (k *KeybaseServiceBase) LoggedOut(ctx context.Context) error {
 	k.setCachedCurrentSession(SessionInfo{})
 	if k.config != nil {
 		if jServer, err := GetJournalServer(k.config); err == nil {
-			jServer.loggedOut(ctx)
+			jServer.shutdownExistingJournals(ctx)
 		}
 		k.config.ResetCaches()
 		k.config.MDServer().RefreshAuthToken(ctx)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -202,7 +202,9 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	k.log.CDebugf(ctx, "Current session logged in: %s", name)
 	// Since we don't have the whole session, just clear the cache.
 	k.setCachedCurrentSession(SessionInfo{})
-	serviceLoggedIn(ctx, k, k.config)
+	if k.config != nil {
+		serviceLoggedIn(ctx, k.log, name, k, k.config)
+	}
 	return nil
 }
 
@@ -210,7 +212,9 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 func (k *KeybaseServiceBase) LoggedOut(ctx context.Context) error {
 	k.log.CDebugf(ctx, "Current session logged out")
 	k.setCachedCurrentSession(SessionInfo{})
-	serviceLoggedOut(ctx, k.config)
+	if k.config != nil {
+		serviceLoggedOut(ctx, k.config)
+	}
 	return nil
 }
 

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -203,7 +203,7 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	// Since we don't have the whole session, just clear the cache.
 	k.setCachedCurrentSession(SessionInfo{})
 	if k.config != nil {
-		serviceLoggedIn(ctx, k.log, name, k, k.config,
+		serviceLoggedIn(ctx, k.config, k.log, name,
 			TLFJournalBackgroundWorkEnabled)
 	}
 	return nil

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -202,21 +202,7 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 	k.log.CDebugf(ctx, "Current session logged in: %s", name)
 	// Since we don't have the whole session, just clear the cache.
 	k.setCachedCurrentSession(SessionInfo{})
-	const sessionID = 0
-	session, err := k.CurrentSession(ctx, sessionID)
-	if err != nil {
-		return err
-	}
-	if k.config != nil {
-		if jServer, err := GetJournalServer(k.config); err == nil {
-			jServer.EnableExistingJournals(
-				ctx, session.UID, session.VerifyingKey,
-				TLFJournalBackgroundWorkEnabled)
-		}
-		k.config.MDServer().RefreshAuthToken(ctx)
-		k.config.BlockServer().RefreshAuthToken(ctx)
-		k.config.KBFSOps().RefreshCachedFavorites(ctx)
-	}
+	serviceLoggedIn(ctx, k, k.config)
 	return nil
 }
 
@@ -224,15 +210,7 @@ func (k *KeybaseServiceBase) LoggedIn(ctx context.Context, name string) error {
 func (k *KeybaseServiceBase) LoggedOut(ctx context.Context) error {
 	k.log.CDebugf(ctx, "Current session logged out")
 	k.setCachedCurrentSession(SessionInfo{})
-	if k.config != nil {
-		if jServer, err := GetJournalServer(k.config); err == nil {
-			jServer.shutdownExistingJournals(ctx)
-		}
-		k.config.ResetCaches()
-		k.config.MDServer().RefreshAuthToken(ctx)
-		k.config.BlockServer().RefreshAuthToken(ctx)
-		k.config.KBFSOps().RefreshCachedFavorites(ctx)
-	}
+	serviceLoggedOut(ctx, k.config)
 	return nil
 }
 

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import "golang.org/x/net/context"
+
+func serviceLoggedIn(
+	ctx context.Context, hasSession hasSession, config Config) {
+	const sessionID = 0
+	session, err := hasSession.CurrentSession(ctx, sessionID)
+	if err != nil {
+		// TODO: Log something.
+		serviceLoggedOut(ctx, config)
+		return
+	}
+	if jServer, err := GetJournalServer(config); err == nil {
+		jServer.EnableExistingJournals(
+			ctx, session.UID, session.VerifyingKey,
+			TLFJournalBackgroundWorkEnabled)
+	}
+	config.MDServer().RefreshAuthToken(ctx)
+	config.BlockServer().RefreshAuthToken(ctx)
+	config.KBFSOps().RefreshCachedFavorites(ctx)
+}
+
+func serviceLoggedOut(ctx context.Context, config Config) {
+	if config != nil {
+		if jServer, err := GetJournalServer(config); err == nil {
+			jServer.shutdownExistingJournals(ctx)
+		}
+		config.ResetCaches()
+		config.MDServer().RefreshAuthToken(ctx)
+		config.BlockServer().RefreshAuthToken(ctx)
+		config.KBFSOps().RefreshCachedFavorites(ctx)
+	}
+}

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -11,10 +11,10 @@ import (
 
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
-func serviceLoggedIn(ctx context.Context, log logger.Logger, name string,
-	sg sessionGetter, config Config, bws TLFJournalBackgroundWorkStatus) {
+func serviceLoggedIn(ctx context.Context, config Config, log logger.Logger,
+	name string, bws TLFJournalBackgroundWorkStatus) {
 	const sessionID = 0
-	session, err := sg.CurrentSession(ctx, sessionID)
+	session, err := config.KeybaseService().CurrentSession(ctx, sessionID)
 	if err != nil {
 		log.CDebugf(ctx, "Getting current session failed when %s is logged in, so pretending user has logged out: %v",
 			name, err)

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -17,16 +17,18 @@ func serviceLoggedIn(ctx context.Context, config Config, name string,
 		log.CDebugf(ctx, "Getting current session failed when %s is logged in, so pretending user has logged out: %v",
 			name, err)
 		serviceLoggedOut(ctx, config)
-	} else {
-		if jServer, err := GetJournalServer(config); err == nil {
-			err := jServer.EnableExistingJournals(
-				ctx, session.UID, session.VerifyingKey, bws)
-			if err != nil {
-				log.CWarningf(ctx,
-					"Failed to enable existing journals: %v", err)
-			}
+		return
+	}
+
+	if jServer, err := GetJournalServer(config); err == nil {
+		err := jServer.EnableExistingJournals(
+			ctx, session.UID, session.VerifyingKey, bws)
+		if err != nil {
+			log.CWarningf(ctx,
+				"Failed to enable existing journals: %v", err)
 		}
 	}
+
 	config.MDServer().RefreshAuthToken(ctx)
 	config.BlockServer().RefreshAuthToken(ctx)
 	config.KBFSOps().RefreshCachedFavorites(ctx)

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -4,14 +4,20 @@
 
 package libkbfs
 
-import "golang.org/x/net/context"
+import (
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
+)
 
-func serviceLoggedIn(
-	ctx context.Context, hasSession hasSession, config Config) {
+// serviceLoggedIn should be called when a new user logs in. It
+// shouldn't be called again until after serviceLoggedOut is called.
+func serviceLoggedIn(ctx context.Context, log logger.Logger, name string,
+	hasSession hasSession, config Config) {
 	const sessionID = 0
 	session, err := hasSession.CurrentSession(ctx, sessionID)
 	if err != nil {
-		// TODO: Log something.
+		log.CDebugf(ctx, "Getting current session failed when %s is logged in, so pretending user has logged out: %v",
+			name, err)
 		serviceLoggedOut(ctx, config)
 		return
 	}
@@ -25,14 +31,13 @@ func serviceLoggedIn(
 	config.KBFSOps().RefreshCachedFavorites(ctx)
 }
 
+// serviceLoggedIn should be called when the current user logs out.
 func serviceLoggedOut(ctx context.Context, config Config) {
-	if config != nil {
-		if jServer, err := GetJournalServer(config); err == nil {
-			jServer.shutdownExistingJournals(ctx)
-		}
-		config.ResetCaches()
-		config.MDServer().RefreshAuthToken(ctx)
-		config.BlockServer().RefreshAuthToken(ctx)
-		config.KBFSOps().RefreshCachedFavorites(ctx)
+	if jServer, err := GetJournalServer(config); err == nil {
+		jServer.shutdownExistingJournals(ctx)
 	}
+	config.ResetCaches()
+	config.MDServer().RefreshAuthToken(ctx)
+	config.BlockServer().RefreshAuthToken(ctx)
+	config.KBFSOps().RefreshCachedFavorites(ctx)
 }

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -20,11 +20,15 @@ func serviceLoggedIn(ctx context.Context, log logger.Logger, name string,
 		log.CDebugf(ctx, "Getting current session failed when %s is logged in, so pretending user has logged out: %v",
 			name, err)
 		serviceLoggedOut(ctx, config)
-		return
-	}
-	if jServer, err := GetJournalServer(config); err == nil {
-		jServer.EnableExistingJournals(
-			ctx, session.UID, session.VerifyingKey, bws)
+	} else {
+		if jServer, err := GetJournalServer(config); err == nil {
+			err := jServer.EnableExistingJournals(
+				ctx, session.UID, session.VerifyingKey, bws)
+			if err != nil {
+				log.CWarningf(ctx,
+					"Failed to enable existing journals: %v", err)
+			}
+		}
 	}
 	config.MDServer().RefreshAuthToken(ctx)
 	config.BlockServer().RefreshAuthToken(ctx)

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -12,7 +12,8 @@ import (
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
 func serviceLoggedIn(ctx context.Context, log logger.Logger, name string,
-	hasSession hasSession, config Config) {
+	hasSession hasSession, config Config,
+	bws TLFJournalBackgroundWorkStatus) {
 	const sessionID = 0
 	session, err := hasSession.CurrentSession(ctx, sessionID)
 	if err != nil {
@@ -23,8 +24,7 @@ func serviceLoggedIn(ctx context.Context, log logger.Logger, name string,
 	}
 	if jServer, err := GetJournalServer(config); err == nil {
 		jServer.EnableExistingJournals(
-			ctx, session.UID, session.VerifyingKey,
-			TLFJournalBackgroundWorkEnabled)
+			ctx, session.UID, session.VerifyingKey, bws)
 	}
 	config.MDServer().RefreshAuthToken(ctx)
 	config.BlockServer().RefreshAuthToken(ctx)

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -12,10 +12,9 @@ import (
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
 func serviceLoggedIn(ctx context.Context, log logger.Logger, name string,
-	hasSession hasSession, config Config,
-	bws TLFJournalBackgroundWorkStatus) {
+	sg sessionGetter, config Config, bws TLFJournalBackgroundWorkStatus) {
 	const sessionID = 0
-	session, err := hasSession.CurrentSession(ctx, sessionID)
+	session, err := sg.CurrentSession(ctx, sessionID)
 	if err != nil {
 		log.CDebugf(ctx, "Getting current session failed when %s is logged in, so pretending user has logged out: %v",
 			name, err)

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -4,15 +4,13 @@
 
 package libkbfs
 
-import (
-	"github.com/keybase/client/go/logger"
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
-func serviceLoggedIn(ctx context.Context, config Config, log logger.Logger,
-	name string, bws TLFJournalBackgroundWorkStatus) {
+func serviceLoggedIn(ctx context.Context, config Config, name string,
+	bws TLFJournalBackgroundWorkStatus) {
+	log := config.MakeLogger("")
 	const sessionID = 0
 	session, err := config.KeybaseService().CurrentSession(ctx, sessionID)
 	if err != nil {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -162,6 +162,8 @@ func (j mdJournal) mdsPath() string {
 	return filepath.Join(j.dir, "mds")
 }
 
+// TODO: Consider truncating the ID string to avoid running into path
+// limits while keeping the chance of collision negligible.
 func (j mdJournal) mdPath(id MdID) string {
 	idStr := id.String()
 	return filepath.Join(j.mdsPath(), idStr[:4], idStr[4:])

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -49,9 +49,9 @@ func MakeImmutableBareRootMetadata(
 	return ImmutableBareRootMetadata{rmd, mdID, localTimestamp}
 }
 
-// mdJournal stores a single ordered list of metadata IDs for a single
-// (TLF, user, device) tuple, along with the associated metadata
-// objects, in flat files on disk.
+// mdJournal stores a single ordered list of metadata IDs for a (TLF,
+// user, device) tuple, along with the associated metadata objects, in
+// flat files on disk.
 //
 // The directory layout looks like:
 //
@@ -106,6 +106,13 @@ type mdJournal struct {
 
 func makeMDJournal(uid keybase1.UID, key VerifyingKey, codec Codec,
 	crypto cryptoPure, dir string, log logger.Logger) (*mdJournal, error) {
+	if uid == keybase1.UID("") {
+		return nil, errors.New("Empty user")
+	}
+	if key == (VerifyingKey{}) {
+		return nil, errors.New("Empty verifying key")
+	}
+
 	journalDir := filepath.Join(dir, "md_journal")
 
 	deferLog := log.CloneWithAddedDepth(1)

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -49,9 +49,9 @@ func MakeImmutableBareRootMetadata(
 	return ImmutableBareRootMetadata{rmd, mdID, localTimestamp}
 }
 
-// mdJournal stores a single ordered list of metadata IDs for
-// a single TLF, along with the associated metadata objects, in flat
-// files on disk.
+// mdJournal stores a single ordered list of metadata IDs for a single
+// (TLF, user, device) tuple, along with the associated metadata
+// objects, in flat files on disk.
 //
 // The directory layout looks like:
 //
@@ -78,8 +78,9 @@ func MakeImmutableBareRootMetadata(
 // mdJournal is not goroutine-safe, so any code that uses it must
 // guarantee that only one goroutine at a time calls its functions.
 type mdJournal struct {
-	// uid and key are assumed constant for the lifetime of this
-	// object.
+	// key is assumed to be the VerifyingKey of a device owned by
+	// uid, and both uid and key are assumed constant for the
+	// lifetime of this object.
 	uid keybase1.UID
 	key VerifyingKey
 
@@ -109,11 +110,11 @@ func makeMDJournal(uid keybase1.UID, key VerifyingKey, codec Codec,
 
 	deferLog := log.CloneWithAddedDepth(1)
 	journal := mdJournal{
+		uid:      uid,
+		key:      key,
 		codec:    codec,
 		crypto:   crypto,
 		dir:      dir,
-		uid:      uid,
-		key:      key,
 		log:      log,
 		deferLog: deferLog,
 		j:        makeMdIDJournal(codec, journalDir),

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -61,8 +61,7 @@ func setupMDJournalTest(t *testing.T) (
 	}()
 
 	log := logger.NewTestLogger(t)
-	j, err = makeMDJournal(
-		uid, verifyingKey, codec, crypto, tempdir, log)
+	j, err = makeMDJournal(uid, verifyingKey, codec, crypto, tempdir, log)
 	require.NoError(t, err)
 
 	bsplit = &BlockSplitterSimple{64 * 1024, 8 * 1024}
@@ -105,7 +104,7 @@ func putMDRange(t *testing.T, tlfID TlfID, signer cryptoSigner,
 	return prevRoot
 }
 
-func checkBRMD(t *testing.T, uid keybase1.UID, verifyingKey VerifyingKey,
+func checkBRMD(t *testing.T, uid keybase1.UID, key VerifyingKey,
 	codec Codec, crypto cryptoPure, brmd BareRootMetadata,
 	expectedRevision MetadataRevision, expectedPrevRoot MdID,
 	expectedMergeStatus MergeStatus, expectedBranchID BranchID) {
@@ -115,7 +114,7 @@ func checkBRMD(t *testing.T, uid keybase1.UID, verifyingKey VerifyingKey,
 	// MDv3 TODO: pass key bundles
 	err := brmd.IsValidAndSigned(codec, crypto, nil)
 	require.NoError(t, err)
-	err = brmd.IsLastModifiedBy(uid, verifyingKey)
+	err = brmd.IsLastModifiedBy(uid, key)
 	require.NoError(t, err)
 
 	require.Equal(t, expectedMergeStatus == Merged,
@@ -124,15 +123,15 @@ func checkBRMD(t *testing.T, uid keybase1.UID, verifyingKey VerifyingKey,
 }
 
 func checkIBRMDRange(t *testing.T, uid keybase1.UID,
-	verifyingKey VerifyingKey, codec Codec, crypto cryptoPure,
+	key VerifyingKey, codec Codec, crypto cryptoPure,
 	ibrmds []ImmutableBareRootMetadata, firstRevision MetadataRevision,
 	firstPrevRoot MdID, mStatus MergeStatus, bid BranchID) {
-	checkBRMD(t, uid, verifyingKey, codec, crypto, ibrmds[0],
+	checkBRMD(t, uid, key, codec, crypto, ibrmds[0],
 		firstRevision, firstPrevRoot, mStatus, bid)
 
 	for i := 1; i < len(ibrmds); i++ {
 		prevID := ibrmds[i-1].mdID
-		checkBRMD(t, uid, verifyingKey, codec, crypto, ibrmds[i],
+		checkBRMD(t, uid, key, codec, crypto, ibrmds[i],
 			firstRevision+MetadataRevision(i), prevID, mStatus, bid)
 		err := ibrmds[i-1].CheckValidSuccessor(prevID, ibrmds[i])
 		require.NoError(t, err)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,13 +51,13 @@ func setupMDJournalTest(t *testing.T) (
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "md_journal")
 	require.NoError(t, err)
-	// Clean up the tempdir if anything in the setup fails/panics.
+
+	// Clean up the tempdir if the rest of the setup fails.
+	setupSucceeded := false
 	defer func() {
-		if r := recover(); r != nil {
+		if !setupSucceeded {
 			err := os.RemoveAll(tempdir)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			assert.NoError(t, err)
 		}
 	}()
 
@@ -71,7 +72,7 @@ func setupMDJournalTest(t *testing.T) (
 
 func teardownMDJournalTest(t *testing.T, tempdir string) {
 	err := os.RemoveAll(tempdir)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func makeMDForTest(t *testing.T, tlfID TlfID, revision MetadataRevision,

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -34,19 +34,18 @@ func getMDJournalLength(t *testing.T, j *mdJournal) int {
 }
 
 func setupMDJournalTest(t *testing.T) (
-	uid keybase1.UID, verifyingKey VerifyingKey, codec Codec,
-	crypto CryptoCommon, id TlfID, signer cryptoSigner,
+	codec Codec, crypto CryptoCommon, id TlfID, signer cryptoSigner,
 	ekg singleEncryptionKeyGetter, bsplit BlockSplitter, tempdir string,
 	j *mdJournal) {
 	codec = NewCodecMsgpack()
 	crypto = MakeCryptoCommon(codec)
 
-	uid = keybase1.MakeTestUID(1)
+	uid := keybase1.MakeTestUID(1)
 	id = FakeTlfID(1, false)
 
 	signingKey := MakeFakeSigningKeyOrBust("fake seed")
 	signer = cryptoSignerLocal{signingKey}
-	verifyingKey = signingKey.GetVerifyingKey()
+	verifyingKey := signingKey.GetVerifyingKey()
 	ekg = singleEncryptionKeyGetter{MakeTLFCryptKey([32]byte{0x1})}
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "md_journal")
@@ -62,13 +61,13 @@ func setupMDJournalTest(t *testing.T) (
 	}()
 
 	log := logger.NewTestLogger(t)
-	j, err = makeMDJournal(uid, verifyingKey, codec, crypto, tempdir, log)
+	j, err = makeMDJournal(
+		uid, verifyingKey, codec, crypto, tempdir, log)
 	require.NoError(t, err)
 
 	bsplit = &BlockSplitterSimple{64 * 1024, 8 * 1024}
 
-	return uid, verifyingKey, codec, crypto, id, signer, ekg,
-		bsplit, tempdir, j
+	return codec, crypto, id, signer, ekg, bsplit, tempdir, j
 }
 
 func teardownMDJournalTest(t *testing.T, tempdir string) {
@@ -90,17 +89,16 @@ func makeMDForTest(t *testing.T, tlfID TlfID, revision MetadataRevision,
 	return md
 }
 
-func putMDRange(t *testing.T, uid keybase1.UID, verifyingKey VerifyingKey,
-	tlfID TlfID, signer cryptoSigner, ekg singleEncryptionKeyGetter,
-	bsplit BlockSplitter, firstRevision MetadataRevision,
-	firstPrevRoot MdID, mdCount int, j *mdJournal) MdID {
+func putMDRange(t *testing.T, tlfID TlfID, signer cryptoSigner,
+	ekg singleEncryptionKeyGetter, bsplit BlockSplitter,
+	firstRevision MetadataRevision, firstPrevRoot MdID, mdCount int,
+	j *mdJournal) MdID {
 	prevRoot := firstPrevRoot
 	ctx := context.Background()
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
-		md := makeMDForTest(t, tlfID, revision, uid, prevRoot)
-		mdID, err := j.put(
-			ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+		md := makeMDForTest(t, tlfID, revision, j.uid, prevRoot)
+		mdID, err := j.put(ctx, signer, ekg, bsplit, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -142,14 +140,14 @@ func checkIBRMDRange(t *testing.T, uid keybase1.UID,
 }
 
 func TestMDJournalBasic(t *testing.T) {
-	uid, verifyingKey, codec, crypto, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
+		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	// Should start off as empty.
 
 	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 	require.Equal(t, 0, getMDJournalLength(t, j))
@@ -159,7 +157,7 @@ func TestMDJournalBasic(t *testing.T) {
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
@@ -167,87 +165,79 @@ func TestMDJournalBasic(t *testing.T) {
 	// Should now be non-empty.
 	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+	checkIBRMDRange(t, j.uid, j.key, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 
 	// MDv3 TODO: pass actual key bundles
-	head, err = j.getHead(uid, verifyingKey, nil)
+	head, err = j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 }
 
 func TestMDJournalGetNextEntry(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	mdID, rmds, err := j.getNextEntryToFlush(
-		ctx, uid, verifyingKey, md.Revision(), signer)
+	mdID, rmds, err := j.getNextEntryToFlush(ctx, md.Revision(), signer)
 	require.NoError(t, err)
 	require.Equal(t, MdID{}, mdID)
 	require.Nil(t, rmds)
 
-	mdID, rmds, err = j.getNextEntryToFlush(
-		ctx, uid, verifyingKey, md.Revision()+1, signer)
+	mdID, rmds, err = j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
 	require.NoError(t, err)
 	require.NotEqual(t, MdID{}, mdID)
 	require.Equal(t, md.bareMd, rmds.MD)
 
-	mdID, rmds, err = j.getNextEntryToFlush(
-		ctx, uid, verifyingKey, md.Revision()+100, signer)
+	mdID, rmds, err = j.getNextEntryToFlush(ctx, md.Revision()+100, signer)
 	require.NoError(t, err)
 	require.NotEqual(t, MdID{}, mdID)
 	require.Equal(t, md.bareMd, rmds.MD)
 }
 
 func TestMDJournalPutCase1Empty(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
 	// MDv3 TODO: pass key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, md.bareMd, head.BareRootMetadata)
 }
 
 func TestMDJournalPutCase1Conflict(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	_, err = j.put(ctx, signer, ekg, bsplit, md)
 	require.Equal(t, MDJournalConflictError{}, err)
 }
 
 // The append portion of case 1 is covered by TestMDJournalBasic.
 
 func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
-		setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	// Push some new metadata blocks.
@@ -255,7 +245,7 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 3
-	prevRoot := putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	prevRoot := putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	// Should just replace the head.
@@ -263,170 +253,154 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	ctx := context.Background()
 
 	revision := firstRevision + MetadataRevision(mdCount) - 1
-	md := makeMDForTest(t, id, revision, uid, prevRoot)
+	md := makeMDForTest(t, id, revision, j.uid, prevRoot)
 	md.SetDiskUsage(501)
-	_, err := j.put(
-		ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
 	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, md.Revision(), head.RevisionNumber())
 	require.Equal(t, md.DiskUsage(), head.DiskUsage())
 }
 
 func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	md.SetUnmerged()
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	_, err = j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	mdID, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	mdID, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
-	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, mdID)
+	md2 := makeMDForTest(t, id, MetadataRevision(11), j.uid, mdID)
 	md2.SetUnmerged()
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md2)
+	_, err = j.put(ctx, signer, ekg, bsplit, md2)
 	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase2Empty(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Flush.
-	mdID, rmds, err := j.getNextEntryToFlush(
-		ctx, uid, verifyingKey, md.Revision()+1, signer)
+	mdID, rmds, err := j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
 	require.NoError(t, err)
-	j.removeFlushedEntry(ctx, uid, verifyingKey, mdID, rmds)
+	j.removeFlushedEntry(ctx, mdID, rmds)
 
-	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, mdID)
+	md2 := makeMDForTest(t, id, MetadataRevision(11), j.uid, mdID)
 	md2.SetUnmerged()
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md2)
+	_, err = j.put(ctx, signer, ekg, bsplit, md2)
 	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// MDv3 TODO: pass key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 
-	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, head.mdID)
+	md2 := makeMDForTest(t, id, MetadataRevision(11), j.uid, head.mdID)
 	md2.SetUnmerged()
 	md2.SetBranchID(head.BID())
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md2)
+	_, err = j.put(ctx, signer, ekg, bsplit, md2)
 	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// MDv3 TODO: pass key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 
 	md.SetUnmerged()
 	md.SetBranchID(head.BID())
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	_, err = j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Flush.
-	mdID, rmds, err := j.getNextEntryToFlush(
-		ctx, uid, verifyingKey, md.Revision()+1, signer)
+	mdID, rmds, err := j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
 	require.NoError(t, err)
-	j.removeFlushedEntry(ctx, uid, verifyingKey, mdID, rmds)
+	j.removeFlushedEntry(ctx, mdID, rmds)
 
-	md2 := makeMDForTest(t, id, MetadataRevision(11), uid, mdID)
+	md2 := makeMDForTest(t, id, MetadataRevision(11), j.uid, mdID)
 	md2.SetUnmerged()
 	md2.SetBranchID(j.branchID)
-	_, err = j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md2)
+	_, err = j.put(ctx, signer, ekg, bsplit, md2)
 	require.NoError(t, err)
 }
 
 func TestMDJournalPutCase4(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	ctx := context.Background()
-	md := makeMDForTest(t, id, MetadataRevision(10), uid, fakeMdID(1))
+	md := makeMDForTest(t, id, MetadataRevision(10), j.uid, fakeMdID(1))
 	md.SetUnmerged()
 	md.SetBranchID(FakeBranchID(1))
-	_, err := j.put(ctx, uid, verifyingKey, signer, ekg, bsplit, md)
+	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 }
 
@@ -461,20 +435,19 @@ func flushAllMDs(t *testing.T, ctx context.Context, uid keybase1.UID,
 }
 
 func TestMDJournalBranchConversion(t *testing.T) {
-	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
+	codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err := j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Branch conversion shouldn't leave old folders behind.
@@ -489,17 +462,17 @@ func TestMDJournalBranchConversion(t *testing.T) {
 
 	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+	checkIBRMDRange(t, j.uid, j.key, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Unmerged, ibrmds[0].BID())
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
 	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 
@@ -521,22 +494,22 @@ func (s *limitedCryptoSigner) Sign(ctx context.Context, msg []byte) (
 }
 
 func TestMDJournalBranchConversionAtomic(t *testing.T) {
-	uid, verifyingKey, codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
+	codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	limitedSigner := limitedCryptoSigner{signer, 5}
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, &limitedSigner, id,
-		NewMDCacheStandard(10))
+	_, err := j.convertToBranch(
+		ctx, &limitedSigner, id, NewMDCacheStandard(10))
 	require.NotNil(t, err)
 
 	// All entries should remain unchanged, since the conversion
@@ -544,17 +517,17 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+	checkIBRMDRange(t, j.uid, j.key, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
 	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 
@@ -563,20 +536,18 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 }
 
 func TestMDJournalClear(t *testing.T) {
-	uid, verifyingKey, _, _, id, signer, ekg, bsplit, tempdir, j :=
-		setupMDJournalTest(t)
+	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err := j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -584,40 +555,40 @@ func TestMDJournalClear(t *testing.T) {
 
 	// Clearing the master branch shouldn't work.
 	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, uid, verifyingKey, NullBranchID, nil)
+	err = j.clear(ctx, NullBranchID, nil)
 	require.Error(t, err)
 
 	// Clearing a different branch ID should do nothing.
 	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, uid, verifyingKey, FakeBranchID(1), nil)
+	err = j.clear(ctx, FakeBranchID(1), nil)
 	require.NoError(t, err)
 	require.Equal(t, bid, j.branchID)
 
 	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(uid, verifyingKey, nil)
+	head, err := j.getHead(nil)
 	require.NoError(t, err)
 	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
 
 	// Clearing the correct branch ID should clear the entire
 	// journal, and reset the branch ID.
 	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, uid, verifyingKey, bid, nil)
+	err = j.clear(ctx, bid, nil)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
 	// MDv3 TODO: pass actual key bundles
-	head, err = j.getHead(uid, verifyingKey, nil)
+	head, err = j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 
 	// Clearing twice should do nothing.
 	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, uid, verifyingKey, bid, nil)
+	err = j.clear(ctx, bid, nil)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
 	// MDv3 TODO: pass actual key bundles
-	head, err = j.getHead(uid, verifyingKey, nil)
+	head, err = j.getHead(nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 
@@ -625,7 +596,7 @@ func TestMDJournalClear(t *testing.T) {
 }
 
 func TestMDJournalRestart(t *testing.T) {
-	uid, verifyingKey, codec, crypto, id, signer, ekg,
+	codec, crypto, id, signer, ekg,
 		bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -634,30 +605,30 @@ func TestMDJournalRestart(t *testing.T) {
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	// Restart journal.
-	j, err := makeMDJournal(uid, verifyingKey, codec, crypto, j.dir, j.log)
+	j, err := makeMDJournal(j.uid, j.key, codec, crypto, j.dir, j.log)
 	require.NoError(t, err)
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
 	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+	checkIBRMDRange(t, j.uid, j.key, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 
 	flushAllMDs(t, context.Background(), uid, verifyingKey, signer, j)
 }
 
 func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
-	uid, verifyingKey, codec, crypto, id, signer, ekg,
-		bsplit, tempdir, j := setupMDJournalTest(t)
+	codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
+		setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
 
 	// Push some new metadata blocks.
@@ -665,31 +636,30 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, uid, verifyingKey, id, signer, ekg, bsplit,
+	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	// Convert to branch.
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, uid, verifyingKey, signer, id,
-		NewMDCacheStandard(10))
+	_, err := j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Restart journal.
 
-	j, err = makeMDJournal(uid, verifyingKey, codec, crypto, j.dir, j.log)
+	j, err = makeMDJournal(j.uid, j.key, codec, crypto, j.dir, j.log)
 	require.NoError(t, err)
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
 	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		uid, verifyingKey, nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		nil, 1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
-	checkIBRMDRange(t, uid, verifyingKey, codec, crypto,
+	checkIBRMDRange(t, j.uid, j.key, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Unmerged, ibrmds[0].BID())
 
 	flushAllMDs(t, ctx, uid, verifyingKey, signer, j)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -164,11 +164,7 @@ func makeTLFJournal(
 
 	log := config.MakeLogger("TLFJ")
 
-	// TODO: This may end up making paths too long for some
-	// systems. We may end up having to drop the UID (since a
-	// device has only one associated UID) or even hashing the
-	// tuple.
-	tlfDir := filepath.Join(dir, uid.String(), key.String(), tlfID.String())
+	tlfDir := filepath.Join(dir, tlfID.String())
 
 	blockJournal, err := makeBlockJournal(
 		ctx, config.Codec(), config.Crypto(), tlfDir, log)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -215,7 +215,9 @@ func setupTLFJournalTest(
 
 	delegateBlockServer := NewBlockServerMemory(config)
 
-	tlfJournal, err = makeTLFJournal(ctx, tempdir, config.tlfID, config,
+	tlfJournal, err = makeTLFJournal(
+		ctx, config.cig.uid, config.cig.verifyingKey,
+		tempdir, config.tlfID, config,
 		delegateBlockServer, bwStatus, delegate, nil, nil)
 	require.NoError(t, err)
 

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -191,9 +191,11 @@ func setupTLFJournalTest(
 
 	// Time out individual tests after 10 seconds.
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
-	// Clean up the context if anything in the setup fails/panics.
+
+	// Clean up the context if the rest of the setup fails.
+	setupSucceeded := false
 	defer func() {
-		if r := recover(); r != nil {
+		if !setupSucceeded {
 			cancel()
 		}
 	}()
@@ -210,7 +212,6 @@ func setupTLFJournalTest(
 
 	// Clean up the tempdir if anything in the rest of the setup
 	// fails.
-	setupSucceeded := false
 	defer func() {
 		if !setupSucceeded {
 			err := os.RemoveAll(tempdir)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -207,8 +207,10 @@ func setupTLFJournalTest(
 
 	tempdir, err = ioutil.TempDir(os.TempDir(), "tlf_journal")
 	require.NoError(t, err)
+
+	// Clean up the tempdir if anything in the rest of the setup
+	// fails.
 	setupSucceeded := false
-	// Clean up the tempdir if anything in the setup fails/panics.
 	defer func() {
 		if !setupSucceeded {
 			err := os.RemoveAll(tempdir)
@@ -237,6 +239,7 @@ func setupTLFJournalTest(
 	default:
 		require.FailNow(t, "Unknown bwStatus %s", bwStatus)
 	}
+
 	setupSucceeded = true
 	return tempdir, config, ctx, cancel, tlfJournal, delegate
 }

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -191,6 +191,12 @@ func setupTLFJournalTest(
 
 	// Time out individual tests after 10 seconds.
 	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	// Clean up the context if anything in the setup fails/panics.
+	defer func() {
+		if r := recover(); r != nil {
+			cancel()
+		}
+	}()
 
 	delegate = testBWDelegate{
 		t:          t,

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -207,13 +207,12 @@ func setupTLFJournalTest(
 
 	tempdir, err = ioutil.TempDir(os.TempDir(), "tlf_journal")
 	require.NoError(t, err)
+	setupSucceeded := false
 	// Clean up the tempdir if anything in the setup fails/panics.
 	defer func() {
-		if r := recover(); r != nil {
+		if !setupSucceeded {
 			err := os.RemoveAll(tempdir)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
+			assert.NoError(t, err)
 		}
 	}()
 
@@ -238,6 +237,7 @@ func setupTLFJournalTest(
 	default:
 		require.FailNow(t, "Unknown bwStatus %s", bwStatus)
 	}
+	setupSucceeded = true
 	return tempdir, config, ctx, cancel, tlfJournal, delegate
 }
 
@@ -251,7 +251,7 @@ func teardownTLFJournalTest(
 	select {
 	case <-delegate.shutdownCh:
 	case <-ctx.Done():
-		require.FailNow(config.t, ctx.Err().Error())
+		assert.Fail(config.t, ctx.Err().Error())
 	}
 
 	cancel()
@@ -266,7 +266,7 @@ func teardownTLFJournalTest(
 	tlfJournal.delegateBlockServer.Shutdown()
 
 	err := os.RemoveAll(tempdir)
-	require.NoError(config.t, err)
+	assert.NoError(config.t, err)
 }
 
 func putOneMD(ctx context.Context, config *testTLFJournalConfig,


### PR DESCRIPTION
Store uid and verifying key (representing device)
in mdJournal. Handle user switching at the
JournalServer level.

Make uid and verifying key KID part of the path.

Add a "v1" path component. [KBFS-1524]

Clean up tests a bit.