### PR TITLE
libkbfs: changes to support local use of MDv3

### DIFF
--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -993,6 +993,24 @@ func (md *BareRootMetadataV2) fillInDevices(crypto Crypto,
 	return newServerKeys, nil
 }
 
+// GetTLFWriterKeyBundleID implements the BareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) GetTLFWriterKeyBundleID() TLFWriterKeyBundleID {
+	// Since key bundles are stored internally, just return the zero value.
+	return TLFWriterKeyBundleID{}
+}
+
+// GetTLFReaderKeyBundleID implements the BareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) GetTLFReaderKeyBundleID() TLFReaderKeyBundleID {
+	// Since key bundles are stored internally, just return the zero value.
+	return TLFReaderKeyBundleID{}
+}
+
+// FinalizeRekey implements the MutableBareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) FinalizeRekey(_ Config, _ ExtraMetadata) error {
+	// No-op.
+	return nil
+}
+
 // BareRootMetadataSignedV2 is the MD that is signed by the reader or
 // writer including the signature info. Unlike RootMetadataSigned,
 // it contains exactly the serializable metadata and signature info.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1002,6 +1002,32 @@ func (md *BareRootMetadataV3) fillInDevices(crypto Crypto,
 	return newServerKeys, nil
 }
 
+// GetTLFWriterKeyBundleID implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetTLFWriterKeyBundleID() TLFWriterKeyBundleID {
+	return md.WriterMetadata.WKeyBundleID
+}
+
+// GetTLFReaderKeyBundleID implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) GetTLFReaderKeyBundleID() TLFReaderKeyBundleID {
+	return md.RKeyBundleID
+}
+
+// FinalizeRekey implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) FinalizeRekey(config Config, extra ExtraMetadata) error {
+	extraV3, ok := extra.(*ExtraMetadataV3)
+	if !ok {
+		return errors.New("Invalid extra metadata")
+	}
+	var err error
+	md.WriterMetadata.WKeyBundleID, err =
+		config.Crypto().MakeTLFWriterKeyBundleID(extraV3.wkb)
+	if err != nil {
+		return err
+	}
+	md.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(extraV3.rkb)
+	return err
+}
+
 // BareRootMetadataSignedV3 is the MD that is signed by the reader or
 // writer including the signature info. Unlike RootMetadataSigned,
 // it contains exactly the serializable metadata and signature info.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -522,6 +522,8 @@ func (c *ConfigLocal) SetConflictRenamer(cr ConflictRenamer) {
 // MetadataVersion implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) MetadataVersion() MetadataVer {
 	return InitialExtraMetadataVer
+	// MDv3 TODO: uncomment the below when ready for MDv3.
+	//return SegregatedKeyBundlesVer
 }
 
 // DataVersion implements the Config interface for ConfigLocal.

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -102,6 +102,34 @@ func (c CryptoCommon) MakeMerkleHash(md *RootMetadataSigned) (MerkleHash, error)
 	return MerkleHash{h}, nil
 }
 
+// MakeTLFWriterKeyBundleID implements the Crypto interface for CryptoCommon.
+func (c CryptoCommon) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (
+	TLFWriterKeyBundleID, error) {
+	buf, err := c.codec.Encode(wkb)
+	if err != nil {
+		return TLFWriterKeyBundleID{}, err
+	}
+	h, err := DefaultHash(buf)
+	if err != nil {
+		return TLFWriterKeyBundleID{}, err
+	}
+	return TLFWriterKeyBundleID{h}, nil
+}
+
+// MakeTLFReaderKeyBundleID implements the Crypto interface for CryptoCommon.
+func (c CryptoCommon) MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (
+	TLFReaderKeyBundleID, error) {
+	buf, err := c.codec.Encode(rkb)
+	if err != nil {
+		return TLFReaderKeyBundleID{}, err
+	}
+	h, err := DefaultHash(buf)
+	if err != nil {
+		return TLFReaderKeyBundleID{}, err
+	}
+	return TLFReaderKeyBundleID{h}, nil
+}
+
 // MakeTemporaryBlockID implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) MakeTemporaryBlockID() (BlockID, error) {
 	var dh RawDefaultHash

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -679,5 +679,9 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		}
 	}
 
+	if err := md.finalizeRekey(km.config); err != nil {
+		return false, nil, err
+	}
+
 	return true, &tlfCryptKey, nil
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -148,7 +148,7 @@ func TestMDJournalBasic(t *testing.T) {
 	// Should start off as empty.
 
 	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 	require.Equal(t, 0, getMDJournalLength(t, j))
@@ -164,17 +164,15 @@ func TestMDJournalBasic(t *testing.T) {
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
 	// Should now be non-empty.
-	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, j.uid, j.key, codec, crypto,
 		ibrmds, firstRevision, firstPrevRoot, Merged, NullBranchID)
 
-	// MDv3 TODO: pass actual key bundles
-	head, err = j.getHead(nil)
+	head, err = j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 }
@@ -213,8 +211,7 @@ func TestMDJournalPutCase1Empty(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	// MDv3 TODO: pass key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, md.bareMd, head.BareRootMetadata)
 }
@@ -259,8 +256,7 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, md.Revision(), head.RevisionNumber())
 	require.Equal(t, md.DiskUsage(), head.DiskUsage())
@@ -336,8 +332,7 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
-	// MDv3 TODO: pass key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 
 	md2 := makeMDForTest(t, id, MetadataRevision(11), j.uid, head.mdID)
@@ -359,8 +354,7 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	_, err = j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
-	// MDv3 TODO: pass key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 
 	md.SetUnmerged()
@@ -460,9 +454,8 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	require.Equal(t, "md_journal", fileInfos[0].Name())
 	require.Equal(t, "mds", fileInfos[1].Name())
 
-	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
@@ -471,8 +464,7 @@ func TestMDJournalBranchConversion(t *testing.T) {
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
-	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 
@@ -515,9 +507,8 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	// All entries should remain unchanged, since the conversion
 	// encountered an error.
 
-	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
@@ -526,8 +517,7 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	require.Equal(t, 10, getMDJournalLength(t, j))
 
-	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
 
@@ -554,41 +544,34 @@ func TestMDJournalClear(t *testing.T) {
 	bid := j.branchID
 
 	// Clearing the master branch shouldn't work.
-	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, NullBranchID, nil)
+	err = j.clear(ctx, NullBranchID)
 	require.Error(t, err)
 
 	// Clearing a different branch ID should do nothing.
-	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, FakeBranchID(1), nil)
+	err = j.clear(ctx, FakeBranchID(1))
 	require.NoError(t, err)
 	require.Equal(t, bid, j.branchID)
 
-	// MDv3 TODO: pass actual key bundles
-	head, err := j.getHead(nil)
+	head, err := j.getHead()
 	require.NoError(t, err)
 	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
 
 	// Clearing the correct branch ID should clear the entire
 	// journal, and reset the branch ID.
-	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, bid, nil)
+	err = j.clear(ctx, bid)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
-	// MDv3 TODO: pass actual key bundles
-	head, err = j.getHead(nil)
+	head, err = j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 
 	// Clearing twice should do nothing.
-	// MDv3 TODO: pass actual key bundles
-	err = j.clear(ctx, bid, nil)
+	err = j.clear(ctx, bid)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
-	// MDv3 TODO: pass actual key bundles
-	head, err = j.getHead(nil)
+	head, err = j.getHead()
 	require.NoError(t, err)
 	require.Equal(t, ImmutableBareRootMetadata{}, head)
 
@@ -603,7 +586,7 @@ func TestMDJournalClear(t *testing.T) {
 	bid = j.branchID
 	flushAllMDs(t, ctx, signer, j)
 	require.Equal(t, bid, j.branchID)
-	err = j.clear(ctx, bid, nil)
+	err = j.clear(ctx, bid)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
 
@@ -629,9 +612,8 @@ func TestMDJournalRestart(t *testing.T) {
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
-	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 
@@ -668,9 +650,8 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
-	// MDv3 TODO: pass actual key bundles
 	ibrmds, err := j.getRange(
-		nil, 1, firstRevision+MetadataRevision(2*mdCount))
+		1, firstRevision+MetadataRevision(2*mdCount))
 	require.NoError(t, err)
 	require.Equal(t, mdCount, len(ibrmds))
 

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -374,7 +374,7 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
 	}
 
 	recordBranchID, err := tlfStorage.put(
-		currentUID, currentVerifyingKey, rmds)
+		currentUID, currentVerifyingKey, rmds, extra)
 	if err != nil {
 		return err
 	}
@@ -620,4 +620,15 @@ func (md *MDServerDisk) GetLatestHandleForTLF(_ context.Context, id TlfID) (
 // MDServerDisk.
 func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
 	return 0, true
+}
+
+// GetKeyBundles implements the MDServer interface for MDServerDisk.
+func (md *MDServerDisk) GetKeyBundles(_ context.Context,
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	// MDv3 TODO: implement this
+	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
+		panic("Bundle IDs are unexpectedly set")
+	}
+	return nil, nil, nil
 }

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -28,9 +28,9 @@ func isReader(currentUID keybase1.UID, mergedMasterHead BareRootMetadata,
 // access TLF metadata. mergedMasterHead can be nil, in which case
 // true is returned.
 func isWriterOrValidRekey(codec kbfscodec.Codec, currentUID keybase1.UID,
-	mergedMasterHead, newMd BareRootMetadata) (bool, error) {
-	// MDv3 TODO: pass actual key bundles
-	h, err := mergedMasterHead.MakeBareTlfHandle(nil)
+	mergedMasterHead, newMd BareRootMetadata, prevExtra, extra ExtraMetadata) (
+	bool, error) {
+	h, err := mergedMasterHead.MakeBareTlfHandle(prevExtra)
 	if err != nil {
 		return false, err
 	}
@@ -41,9 +41,8 @@ func isWriterOrValidRekey(codec kbfscodec.Codec, currentUID keybase1.UID,
 	if h.IsReader(currentUID) {
 		// if this is a reader, are they acting within their
 		// restrictions?
-		// MDv3 TODO: pass actual key bundles
 		return newMd.IsValidRekeyRequest(
-			codec, mergedMasterHead, currentUID, nil, nil)
+			codec, mergedMasterHead, currentUID, prevExtra, extra)
 	}
 
 	return false, nil

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -818,3 +818,11 @@ func (md *MDServerRemote) backgroundRekeyChecker(ctx context.Context) {
 		}
 	}
 }
+
+// GetKeyBundles implements the MDServer interface for MDServerRemote.
+func (md *MDServerRemote) GetKeyBundles(_ context.Context,
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	// MDv3 TODO: implement this
+	return nil, nil, nil
+}

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -61,7 +61,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	for i := MetadataRevision(1); i <= 10; i++ {
 		rmds := makeRMDSForTest(t, id, h, i, uid, prevRoot)
 		signRMDSForTest(t, codec, signer, rmds)
-		recordBranchID, err := s.put(uid, verifyingKey, rmds)
+		// MDv3 TODO: pass extra metadata
+		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
 		require.NoError(t, err)
 		require.False(t, recordBranchID)
 		prevRoot, err = crypto.MakeMdID(rmds.MD)
@@ -77,7 +78,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 
 	rmds := makeRMDSForTest(t, id, h, 10, uid, prevRoot)
 	signRMDSForTest(t, codec, signer, rmds)
-	_, err = s.put(uid, verifyingKey, rmds)
+	// MDv3 TODO: pass extra metadata
+	_, err = s.put(uid, verifyingKey, rmds, nil)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
 
 	require.Equal(t, 10, getMDStorageLength(t, s, NullBranchID))
@@ -92,7 +94,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		rmds.MD.SetUnmerged()
 		rmds.MD.SetBranchID(bid)
 		signRMDSForTest(t, codec, signer, rmds)
-		recordBranchID, err := s.put(uid, verifyingKey, rmds)
+		// MDv3 TODO: pass extra metadata
+		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
 		require.NoError(t, err)
 		require.Equal(t, i == MetadataRevision(6), recordBranchID)
 		prevRoot, err = crypto.MakeMdID(rmds.MD)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1919,6 +1919,28 @@ func (_mr *_MockcryptoPureRecorder) DecryptMerkleLeaf(arg0, arg1, arg2, arg3 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptMerkleLeaf", arg0, arg1, arg2, arg3)
 }
 
+func (_m *MockcryptoPure) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
+	ret := _m.ctrl.Call(_m, "MakeTLFWriterKeyBundleID", wkb)
+	ret0, _ := ret[0].(TLFWriterKeyBundleID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeTLFWriterKeyBundleID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTLFWriterKeyBundleID", arg0)
+}
+
+func (_m *MockcryptoPure) MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
+	ret := _m.ctrl.Call(_m, "MakeTLFReaderKeyBundleID", rkb)
+	ret0, _ := ret[0].(TLFReaderKeyBundleID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockcryptoPureRecorder) MakeTLFReaderKeyBundleID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTLFReaderKeyBundleID", arg0)
+}
+
 // Mock of cryptoSigner interface
 type MockcryptoSigner struct {
 	ctrl     *gomock.Controller
@@ -2246,6 +2268,28 @@ func (_m *MockCrypto) DecryptMerkleLeaf(encryptedLeaf EncryptedMerkleLeaf, privK
 
 func (_mr *_MockCryptoRecorder) DecryptMerkleLeaf(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptMerkleLeaf", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockCrypto) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
+	ret := _m.ctrl.Call(_m, "MakeTLFWriterKeyBundleID", wkb)
+	ret0, _ := ret[0].(TLFWriterKeyBundleID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCryptoRecorder) MakeTLFWriterKeyBundleID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTLFWriterKeyBundleID", arg0)
+}
+
+func (_m *MockCrypto) MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
+	ret := _m.ctrl.Call(_m, "MakeTLFReaderKeyBundleID", rkb)
+	ret0, _ := ret[0].(TLFReaderKeyBundleID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockCryptoRecorder) MakeTLFReaderKeyBundleID(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTLFReaderKeyBundleID", arg0)
 }
 
 func (_m *MockCrypto) Sign(ctx context.Context, msg []byte) (SignatureInfo, error) {
@@ -2712,6 +2756,18 @@ func (_mr *_MockMDServerRecorder) OffsetFromServerTime() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "OffsetFromServerTime")
 }
 
+func (_m *MockMDServer) GetKeyBundles(ctx context.Context, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	ret := _m.ctrl.Call(_m, "GetKeyBundles", ctx, wkbID, rkbID)
+	ret0, _ := ret[0].(*TLFWriterKeyBundleV3)
+	ret1, _ := ret[1].(*TLFReaderKeyBundleV3)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockMDServerRecorder) GetKeyBundles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2)
+}
+
 // Mock of mdServerLocal interface
 type MockmdServerLocal struct {
 	ctrl     *gomock.Controller
@@ -2884,6 +2940,18 @@ func (_m *MockmdServerLocal) OffsetFromServerTime() (time.Duration, bool) {
 
 func (_mr *_MockmdServerLocalRecorder) OffsetFromServerTime() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "OffsetFromServerTime")
+}
+
+func (_m *MockmdServerLocal) GetKeyBundles(ctx context.Context, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	ret := _m.ctrl.Call(_m, "GetKeyBundles", ctx, wkbID, rkbID)
+	ret0, _ := ret[0].(*TLFWriterKeyBundleV3)
+	ret1, _ := ret[1].(*TLFReaderKeyBundleV3)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockmdServerLocalRecorder) GetKeyBundles(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2)
 }
 
 func (_m *MockmdServerLocal) addNewAssertionForTest(uid keybase1.UID, newAssertion keybase1.SocialAssertion) error {
@@ -4638,6 +4706,26 @@ func (_mr *_MockBareRootMetadataRecorder) GetUnresolvedParticipants() *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUnresolvedParticipants")
 }
 
+func (_m *MockBareRootMetadata) GetTLFWriterKeyBundleID() TLFWriterKeyBundleID {
+	ret := _m.ctrl.Call(_m, "GetTLFWriterKeyBundleID")
+	ret0, _ := ret[0].(TLFWriterKeyBundleID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetTLFWriterKeyBundleID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFWriterKeyBundleID")
+}
+
+func (_m *MockBareRootMetadata) GetTLFReaderKeyBundleID() TLFReaderKeyBundleID {
+	ret := _m.ctrl.Call(_m, "GetTLFReaderKeyBundleID")
+	ret0, _ := ret[0].(TLFReaderKeyBundleID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetTLFReaderKeyBundleID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFReaderKeyBundleID")
+}
+
 // Mock of MutableBareRootMetadata interface
 type MockMutableBareRootMetadata struct {
 	ctrl     *gomock.Controller
@@ -5042,6 +5130,26 @@ func (_mr *_MockMutableBareRootMetadataRecorder) GetUnresolvedParticipants() *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUnresolvedParticipants")
 }
 
+func (_m *MockMutableBareRootMetadata) GetTLFWriterKeyBundleID() TLFWriterKeyBundleID {
+	ret := _m.ctrl.Call(_m, "GetTLFWriterKeyBundleID")
+	ret0, _ := ret[0].(TLFWriterKeyBundleID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFWriterKeyBundleID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFWriterKeyBundleID")
+}
+
+func (_m *MockMutableBareRootMetadata) GetTLFReaderKeyBundleID() TLFReaderKeyBundleID {
+	ret := _m.ctrl.Call(_m, "GetTLFReaderKeyBundleID")
+	ret0, _ := ret[0].(TLFReaderKeyBundleID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFReaderKeyBundleID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFReaderKeyBundleID")
+}
+
 func (_m *MockMutableBareRootMetadata) SetRefBytes(refBytes uint64) {
 	_m.ctrl.Call(_m, "SetRefBytes", refBytes)
 }
@@ -5311,6 +5419,16 @@ func (_m *MockMutableBareRootMetadata) GetUserDeviceKeyInfoMaps(keyGen KeyGen, e
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetUserDeviceKeyInfoMaps(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDeviceKeyInfoMaps", arg0, arg1)
+}
+
+func (_m *MockMutableBareRootMetadata) FinalizeRekey(_param0 Config, _param1 ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "FinalizeRekey", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) FinalizeRekey(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FinalizeRekey", arg0, arg1)
 }
 
 // Mock of KeyBundleCache interface

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -124,6 +124,8 @@ var _ KeyMetadata = (*RootMetadata)(nil)
 // NewRootMetadata returns a new RootMetadata object at the latest known version.
 func NewRootMetadata() *RootMetadata {
 	return &RootMetadata{bareMd: &BareRootMetadataV2{}}
+	// MDv3 TODO: uncomment the below when we're ready for MDv3
+	//return &RootMetadata{bareMd: &BareRootMetadataV3{}}
 }
 
 // Data returns the private metadata of this RootMetadata.
@@ -654,6 +656,10 @@ func (md *RootMetadata) fillInDevices(crypto Crypto,
 	return serverKeyMap{}, errors.New("Unknown bare metadata version")
 }
 
+func (md *RootMetadata) finalizeRekey(config Config) error {
+	return md.bareMd.FinalizeRekey(config, md.extra)
+}
+
 // A ReadOnlyRootMetadata is a thin wrapper around a
 // *RootMetadata. Functions that take a ReadOnlyRootMetadata parameter
 // must not modify it, and therefore code that passes a
@@ -736,6 +742,8 @@ type RootMetadataSigned struct {
 // NewRootMetadataSigned returns a new RootMetadataSigned object at the latest known version.
 func NewRootMetadataSigned() *RootMetadataSigned {
 	return &RootMetadataSigned{MD: &BareRootMetadataV2{}}
+	// MDv3 TODO: uncomment the below when we're ready for MDv3
+	//return &RootMetadataSigned{MD: &BareRootMetadataV3{}}
 }
 
 // MerkleHash computes a hash of this RootMetadataSigned object for inclusion

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1006,8 +1006,7 @@ func (j *tlfJournal) getMDHead(
 		return ImmutableBareRootMetadata{}, err
 	}
 
-	// MDv3 TODO: pass actual key bundles
-	return j.mdJournal.getHead(nil)
+	return j.mdJournal.getHead()
 }
 
 func (j *tlfJournal) getMDRange(
@@ -1019,8 +1018,7 @@ func (j *tlfJournal) getMDRange(
 		return nil, err
 	}
 
-	// MDv3 TODO: pass actual key bundles
-	return j.mdJournal.getRange(nil, start, stop)
+	return j.mdJournal.getRange(start, stop)
 }
 
 func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
@@ -1054,8 +1052,7 @@ func (j *tlfJournal) clearMDs(ctx context.Context, bid BranchID) error {
 	}
 
 	// No need to signal work in this case.
-	// MDv3 TODO: pass actual key bundles
-	return j.mdJournal.clear(ctx, bid, nil)
+	return j.mdJournal.clear(ctx, bid)
 }
 
 func (j *tlfJournal) wait(ctx context.Context) error {


### PR DESCRIPTION
With this change I can get through most of the tests with MDv3 enabled. I think I'll need to put up 2 more PRs though. Currently the following tests fail with MDv3:

1. Rekey-specific tests
2. Journaling tests