### PR TITLE
[KBFS-1525] Support unknown fields in journals

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -47,7 +47,10 @@ import (
 // of directories in dir itself to a manageable number, similar to
 // git. Each block directory has data, which is the raw block data
 // that should hash to the block ID, and key_server_half, which
-// contains the raw data for the associated key server half.
+// contains the raw data for the associated key server half. Future
+// versions of the journal might add more files to this directory; if
+// any code is written to move blocks around, it should be careful to
+// preserve any unknown files in a block directory.
 //
 // The maximum number of characters added to the root dir by a block
 // journal is 59:

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 	"golang.org/x/net/context"
 )
 
@@ -113,7 +114,7 @@ type blockJournalEntry struct {
 	// and addRefOp.
 	Contexts map[BlockID][]BlockContext
 
-	// TODO: Support unknown fields.
+	codec.UnknownFieldSetHandler
 }
 
 // Get the single context stored in this entry. Only applicable to

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -317,11 +317,6 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 	return refs, unflushedBytes, nil
 }
 
-func (j *blockJournal) writeJournalEntry(
-	ordinal journalOrdinal, entry blockJournalEntry) error {
-	return j.j.writeJournalEntry(ordinal, entry)
-}
-
 func (j *blockJournal) appendJournalEntry(
 	op blockOpType, contexts map[BlockID][]BlockContext) (
 	journalOrdinal, error) {

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -317,13 +317,9 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 	return refs, unflushedBytes, nil
 }
 
-func (j *blockJournal) appendJournalEntry(
-	op blockOpType, contexts map[BlockID][]BlockContext) (
+func (j *blockJournal) appendJournalEntry(entry blockJournalEntry) (
 	journalOrdinal, error) {
-	return j.j.appendJournalEntry(nil, blockJournalEntry{
-		Op:       op,
-		Contexts: contexts,
-	})
+	return j.j.appendJournalEntry(nil, entry)
 }
 
 func (j *blockJournal) length() (uint64, error) {
@@ -534,8 +530,10 @@ func (j *blockJournal) putData(
 		return err
 	}
 
-	ordinal, err := j.appendJournalEntry(blockPutOp,
-		map[BlockID][]BlockContext{id: {context}})
+	ordinal, err := j.appendJournalEntry(blockJournalEntry{
+		Op:       blockPutOp,
+		Contexts: map[BlockID][]BlockContext{id: {context}},
+	})
 	if err != nil {
 		return err
 	}
@@ -559,8 +557,10 @@ func (j *blockJournal) addReference(
 		}
 	}()
 
-	ordinal, err := j.appendJournalEntry(addRefOp,
-		map[BlockID][]BlockContext{id: {context}})
+	ordinal, err := j.appendJournalEntry(blockJournalEntry{
+		Op:       addRefOp,
+		Contexts: map[BlockID][]BlockContext{id: {context}},
+	})
 	if err != nil {
 		return err
 	}
@@ -610,7 +610,10 @@ func (j *blockJournal) removeReferences(
 		liveCounts[id] = count
 	}
 
-	_, err = j.appendJournalEntry(removeRefsOp, contexts)
+	_, err = j.appendJournalEntry(blockJournalEntry{
+		Op:       removeRefsOp,
+		Contexts: contexts,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -652,7 +655,10 @@ func (j *blockJournal) archiveReferences(
 		}
 	}()
 
-	ordinal, err := j.appendJournalEntry(archiveRefsOp, contexts)
+	ordinal, err := j.appendJournalEntry(blockJournalEntry{
+		Op:       archiveRefsOp,
+		Contexts: contexts,
+	})
 	if err != nil {
 		return err
 	}

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -18,6 +18,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type blockJournalEntryFuture struct {
+	blockJournalEntry
+	extra
+}
+
+func (ef blockJournalEntryFuture) toCurrent() blockJournalEntry {
+	return ef.blockJournalEntry
+}
+
+func (ef blockJournalEntryFuture) toCurrentStruct() currentStruct {
+	return ef.toCurrent()
+}
+
+func makeFakeBlockJournalEntryFuture(t *testing.T) blockJournalEntryFuture {
+	ef := blockJournalEntryFuture{
+		blockJournalEntry{
+			blockPutOp,
+			map[BlockID][]BlockContext{
+				fakeBlockID(1): []BlockContext{
+					makeFakeBlockContext(t),
+					makeFakeBlockContext(t),
+					makeFakeBlockContext(t),
+				},
+			},
+		},
+		makeExtraOrBust("blockJournalEntry", t),
+	}
+	return ef
+}
+
+func TestBlockJournalEntryUnknownFields(t *testing.T) {
+	testStructUnknownFields(t, makeFakeBlockJournalEntryFuture(t))
+}
+
 func getBlockJournalLength(t *testing.T, j *blockJournal) int {
 	len, err := j.length()
 	require.NoError(t, err)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,6 +43,7 @@ func makeFakeBlockJournalEntryFuture(t *testing.T) blockJournalEntryFuture {
 					makeFakeBlockContext(t),
 				},
 			},
+			codec.UnknownFieldSetHandler{},
 		},
 		makeExtraOrBust("blockJournalEntry", t),
 	}

--- a/libkbfs/block_types_test.go
+++ b/libkbfs/block_types_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeFakeBlockContext(t *testing.T) BlockContext {
+	return BlockContext{
+		"fake creator",
+		"fake writer",
+		BlockRefNonce{0xb},
+	}
+}
+
 func makeFakeBlockPointer(t *testing.T) BlockPointer {
 	h, err := DefaultHash([]byte("fake buf"))
 	require.NoError(t, err)
@@ -18,11 +26,7 @@ func makeFakeBlockPointer(t *testing.T) BlockPointer {
 		BlockID{h},
 		5,
 		1,
-		BlockContext{
-			"fake creator",
-			"fake writer",
-			BlockRefNonce{0xb},
-		},
+		makeFakeBlockContext(t),
 	}
 }
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -157,7 +157,7 @@ func (j mdIDJournal) getLatestEntry() (mdIDJournalEntry, bool, error) {
 	return entry, true, err
 }
 
-func (j mdIDJournal) getRange(start, stop MetadataRevision) (
+func (j mdIDJournal) getEntryRange(start, stop MetadataRevision) (
 	MetadataRevision, []mdIDJournalEntry, error) {
 	earliestRevision, err := j.readEarliestRevision()
 	if err != nil {

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -157,8 +157,8 @@ func (j mdIDJournal) getLatestEntry() (mdIDJournalEntry, bool, error) {
 	return entry, true, err
 }
 
-func (j mdIDJournal) getRange(
-	start, stop MetadataRevision) (MetadataRevision, []MdID, error) {
+func (j mdIDJournal) getRange(start, stop MetadataRevision) (
+	MetadataRevision, []mdIDJournalEntry, error) {
 	earliestRevision, err := j.readEarliestRevision()
 	if err != nil {
 		return MetadataRevisionUninitialized, nil, err
@@ -185,15 +185,15 @@ func (j mdIDJournal) getRange(
 		return MetadataRevisionUninitialized, nil, nil
 	}
 
-	var mdIDs []MdID
+	var entries []mdIDJournalEntry
 	for i := start; i <= stop; i++ {
 		entry, err := j.readJournalEntry(i)
 		if err != nil {
 			return MetadataRevisionUninitialized, nil, err
 		}
-		mdIDs = append(mdIDs, entry.ID)
+		entries = append(entries, entry)
 	}
-	return start, mdIDs, nil
+	return start, entries, nil
 }
 
 func (j mdIDJournal) replaceHead(mdID MdID) error {

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+
+	"github.com/keybase/go-codec/codec"
 )
 
 // An mdIDJournal wraps a diskJournal to provide a persistent list of
@@ -28,6 +30,8 @@ type mdIDJournal struct {
 // may contain more fields.
 type mdIDJournalEntry struct {
 	ID MdID
+
+	codec.UnknownFieldSetHandler
 }
 
 func makeMdIDJournal(codec Codec, dir string) mdIDJournal {
@@ -188,7 +192,7 @@ func (j mdIDJournal) replaceHead(mdID MdID) error {
 	if err != nil {
 		return err
 	}
-	return j.j.writeJournalEntry(o, mdIDJournalEntry{mdID})
+	return j.j.writeJournalEntry(o, mdIDJournalEntry{ID: mdID})
 }
 
 func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
@@ -196,7 +200,7 @@ func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
 	if err != nil {
 		return err
 	}
-	_, err = j.j.appendJournalEntry(&o, mdIDJournalEntry{mdID})
+	_, err = j.j.appendJournalEntry(&o, mdIDJournalEntry{ID: mdID})
 	return err
 }
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -24,8 +24,14 @@ type mdIDJournal struct {
 	j diskJournal
 }
 
+// An mdIDJournalEntry is, for now, just an MdID. In the future, it
+// may contain more fields.
+type mdIDJournalEntry struct {
+	ID MdID
+}
+
 func makeMdIDJournal(codec Codec, dir string) mdIDJournal {
-	j := makeDiskJournal(codec, dir, reflect.TypeOf(MdID{}))
+	j := makeDiskJournal(codec, dir, reflect.TypeOf(mdIDJournalEntry{}))
 	return mdIDJournal{j}
 }
 
@@ -97,7 +103,7 @@ func (j mdIDJournal) readMdID(r MetadataRevision) (MdID, error) {
 		return MdID{}, err
 	}
 
-	return e.(MdID), nil
+	return e.(mdIDJournalEntry).ID, nil
 }
 
 // All functions below are public functions.
@@ -182,7 +188,7 @@ func (j mdIDJournal) replaceHead(mdID MdID) error {
 	if err != nil {
 		return err
 	}
-	return j.j.writeJournalEntry(o, mdID)
+	return j.j.writeJournalEntry(o, mdIDJournalEntry{mdID})
 }
 
 func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
@@ -190,7 +196,7 @@ func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
 	if err != nil {
 		return err
 	}
-	_, err = j.j.appendJournalEntry(&o, mdID)
+	_, err = j.j.appendJournalEntry(&o, mdIDJournalEntry{mdID})
 	return err
 }
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -15,11 +15,6 @@ import (
 // An mdIDJournal wraps a diskJournal to provide a persistent list of
 // MdIDs with sequential MetadataRevisions for a single branch.
 //
-// TODO: Consider future-proofing this in case we want to journal
-// other stuff besides metadata puts. But doing so would be difficult,
-// since then we would require the ordinals to be something other than
-// MetadataRevisions.
-//
 // TODO: Write unit tests for this. For now, we're relying on
 // md_journal.go's unit tests.
 type mdIDJournal struct {

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -97,7 +97,6 @@ func (j mdIDJournal) readMdID(r MetadataRevision) (MdID, error) {
 		return MdID{}, err
 	}
 
-	// TODO: Validate MdID?
 	return e.(MdID), nil
 }
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -59,8 +59,7 @@ func revisionToOrdinal(r MetadataRevision) (journalOrdinal, error) {
 // TODO: Consider caching the values returned by the read functions
 // below in memory.
 
-func (j mdIDJournal) readEarliestRevision() (
-	MetadataRevision, error) {
+func (j mdIDJournal) readEarliestRevision() (MetadataRevision, error) {
 	o, err := j.j.readEarliestOrdinal()
 	if os.IsNotExist(err) {
 		return MetadataRevisionUninitialized, nil
@@ -78,8 +77,7 @@ func (j mdIDJournal) writeEarliestRevision(r MetadataRevision) error {
 	return j.j.writeEarliestOrdinal(o)
 }
 
-func (j mdIDJournal) readLatestRevision() (
-	MetadataRevision, error) {
+func (j mdIDJournal) readLatestRevision() (MetadataRevision, error) {
 	o, err := j.j.readLatestOrdinal()
 	if os.IsNotExist(err) {
 		return MetadataRevisionUninitialized, nil
@@ -129,28 +127,30 @@ func (j mdIDJournal) end() (MetadataRevision, error) {
 	return last + 1, nil
 }
 
-func (j mdIDJournal) getEarliestEntry() (mdIDJournalEntry, bool, error) {
+func (j mdIDJournal) getEarliestEntry() (
+	entry mdIDJournalEntry, exists bool, err error) {
 	earliestRevision, err := j.readEarliestRevision()
 	if err != nil {
 		return mdIDJournalEntry{}, false, err
 	} else if earliestRevision == MetadataRevisionUninitialized {
 		return mdIDJournalEntry{}, false, nil
 	}
-	entry, err := j.readJournalEntry(earliestRevision)
+	entry, err = j.readJournalEntry(earliestRevision)
 	if err != nil {
 		return mdIDJournalEntry{}, false, err
 	}
 	return entry, true, err
 }
 
-func (j mdIDJournal) getLatestEntry() (mdIDJournalEntry, bool, error) {
+func (j mdIDJournal) getLatestEntry() (
+	entry mdIDJournalEntry, exists bool, err error) {
 	latestRevision, err := j.readLatestRevision()
 	if err != nil {
 		return mdIDJournalEntry{}, false, err
 	} else if latestRevision == MetadataRevisionUninitialized {
 		return mdIDJournalEntry{}, false, nil
 	}
-	entry, err := j.readJournalEntry(latestRevision)
+	entry, err = j.readJournalEntry(latestRevision)
 	if err != nil {
 		return mdIDJournalEntry{}, false, err
 	}
@@ -196,12 +196,12 @@ func (j mdIDJournal) getEntryRange(start, stop MetadataRevision) (
 	return start, entries, nil
 }
 
-func (j mdIDJournal) replaceHead(mdID MdID) error {
+func (j mdIDJournal) replaceHead(entry mdIDJournalEntry) error {
 	o, err := j.j.readLatestOrdinal()
 	if err != nil {
 		return err
 	}
-	return j.j.writeJournalEntry(o, mdIDJournalEntry{ID: mdID})
+	return j.j.writeJournalEntry(o, entry)
 }
 
 func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -13,7 +13,8 @@ import (
 )
 
 // An mdIDJournal wraps a diskJournal to provide a persistent list of
-// MdIDs with sequential MetadataRevisions for a single branch.
+// MdIDs (with possible other fields in the future) with sequential
+// MetadataRevisions for a single branch.
 //
 // TODO: Write unit tests for this. For now, we're relying on
 // md_journal.go's unit tests.

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -204,12 +204,12 @@ func (j mdIDJournal) replaceHead(entry mdIDJournalEntry) error {
 	return j.j.writeJournalEntry(o, entry)
 }
 
-func (j mdIDJournal) append(r MetadataRevision, mdID MdID) error {
+func (j mdIDJournal) append(r MetadataRevision, entry mdIDJournalEntry) error {
 	o, err := revisionToOrdinal(r)
 	if err != nil {
 		return err
 	}
-	_, err = j.j.appendJournalEntry(&o, mdIDJournalEntry{ID: mdID})
+	_, err = j.j.appendJournalEntry(&o, entry)
 	return err
 }
 

--- a/libkbfs/md_id_journal_test.go
+++ b/libkbfs/md_id_journal_test.go
@@ -4,7 +4,11 @@
 
 package libkbfs
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/keybase/go-codec/codec"
+)
 
 type mdIDJournalEntryFuture struct {
 	mdIDJournalEntry
@@ -23,6 +27,7 @@ func makeFakeMDIDJournalEntryFuture(t *testing.T) mdIDJournalEntryFuture {
 	ef := mdIDJournalEntryFuture{
 		mdIDJournalEntry{
 			fakeMdID(1),
+			codec.UnknownFieldSetHandler{},
 		},
 		makeExtraOrBust("mdIDJournalEntry", t),
 	}

--- a/libkbfs/md_id_journal_test.go
+++ b/libkbfs/md_id_journal_test.go
@@ -1,0 +1,34 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import "testing"
+
+type mdIDJournalEntryFuture struct {
+	mdIDJournalEntry
+	extra
+}
+
+func (ef mdIDJournalEntryFuture) toCurrent() mdIDJournalEntry {
+	return ef.mdIDJournalEntry
+}
+
+func (ef mdIDJournalEntryFuture) toCurrentStruct() currentStruct {
+	return ef.toCurrent()
+}
+
+func makeFakeMDIDJournalEntryFuture(t *testing.T) mdIDJournalEntryFuture {
+	ef := mdIDJournalEntryFuture{
+		mdIDJournalEntry{
+			fakeMdID(1),
+		},
+		makeExtraOrBust("mdIDJournalEntry", t),
+	}
+	return ef
+}
+
+func TestMDIDJournalEntryUnknownFields(t *testing.T) {
+	testStructUnknownFields(t, makeFakeMDIDJournalEntryFuture(t))
+}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -482,7 +482,8 @@ func (j *mdJournal) convertToBranch(
 		}
 		mdsToRemove = append(mdsToRemove, newID)
 
-		err = tempJournal.append(brmd.RevisionNumber(), newID)
+		err = tempJournal.append(
+			brmd.RevisionNumber(), mdIDJournalEntry{ID: newID})
 		if err != nil {
 			return NullBranchID, err
 		}
@@ -857,7 +858,8 @@ func (j *mdJournal) put(
 			return MdID{}, err
 		}
 	} else {
-		err = j.j.append(brmd.RevisionNumber(), id)
+		err = j.j.append(
+			brmd.RevisionNumber(), mdIDJournalEntry{ID: id})
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -314,13 +314,14 @@ func (j *mdJournal) removeMD(id MdID) error {
 
 func (j mdJournal) getEarliest(verifyBranchID bool) (
 	ImmutableBareRootMetadata, error) {
-	earliestID, err := j.j.getEarliest()
+	entry, exists, err := j.j.getEarliestEntry()
 	if err != nil {
 		return ImmutableBareRootMetadata{}, err
 	}
-	if earliestID == (MdID{}) {
+	if !exists {
 		return ImmutableBareRootMetadata{}, nil
 	}
+	earliestID := entry.ID
 	earliest, ts, err := j.getMD(earliestID, verifyBranchID)
 	if err != nil {
 		return ImmutableBareRootMetadata{}, err
@@ -330,13 +331,14 @@ func (j mdJournal) getEarliest(verifyBranchID bool) (
 
 func (j mdJournal) getLatest(verifyBranchID bool) (
 	ImmutableBareRootMetadata, error) {
-	latestID, err := j.j.getLatest()
+	entry, exists, err := j.j.getLatestEntry()
 	if err != nil {
 		return ImmutableBareRootMetadata{}, err
 	}
-	if latestID == (MdID{}) {
+	if !exists {
 		return ImmutableBareRootMetadata{}, nil
 	}
+	latestID := entry.ID
 	latest, ts, err := j.getMD(latestID, verifyBranchID)
 	if err != nil {
 		return ImmutableBareRootMetadata{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -482,6 +482,9 @@ func (j *mdJournal) convertToBranch(
 		}
 		mdsToRemove = append(mdsToRemove, newID)
 
+		// No need to try and preserve unknown fields from the
+		// old journal; some of those fields may depend on the
+		// changed parts of the MD.
 		err = tempJournal.append(
 			brmd.RevisionNumber(), mdIDJournalEntry{ID: newID})
 		if err != nil {
@@ -853,6 +856,9 @@ func (j *mdJournal) put(
 		j.log.CDebugf(
 			ctx, "Replacing head MD for TLF=%s with rev=%s bid=%s",
 			rmd.TlfID(), rmd.Revision(), rmd.BID())
+		// No need to try and preserve unknown fields from the
+		// old head; some of those fields may depend on the
+		// changed parts of the head.
 		err = j.j.replaceHead(mdIDJournalEntry{ID: id})
 		if err != nil {
 			return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -490,9 +490,8 @@ func (j *mdJournal) convertToBranch(
 		}
 		mdsToRemove = append(mdsToRemove, newID)
 
-		// No need to try and preserve unknown fields from the
-		// old journal; some of those fields may depend on the
-		// changed parts of the MD.
+		// TODO: Try and preserve unknown fields from the old
+		// journal.
 		err = tempJournal.append(
 			brmd.RevisionNumber(), mdIDJournalEntry{ID: newID})
 		if err != nil {
@@ -864,9 +863,8 @@ func (j *mdJournal) put(
 		j.log.CDebugf(
 			ctx, "Replacing head MD for TLF=%s with rev=%s bid=%s",
 			rmd.TlfID(), rmd.Revision(), rmd.BID())
-		// No need to try and preserve unknown fields from the
-		// old head; some of those fields may depend on the
-		// changed parts of the head.
+		// TODO: Try and preserve unknown fields from the old
+		// journal.
 		err = j.j.replaceHead(mdIDJournalEntry{ID: id})
 		if err != nil {
 			return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -852,7 +852,7 @@ func (j *mdJournal) put(
 		j.log.CDebugf(
 			ctx, "Replacing head MD for TLF=%s with rev=%s bid=%s",
 			rmd.TlfID(), rmd.Revision(), rmd.BID())
-		err = j.j.replaceHead(id)
+		err = j.j.replaceHead(mdIDJournalEntry{ID: id})
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -60,9 +60,9 @@ func MakeImmutableBareRootMetadata(
 // dir/md_journal/0...001
 // dir/md_journal/0...002
 // dir/md_journal/0...fff
-// dir/mds/0100/0...01
+// dir/mds/0100/0...01/data
 // ...
-// dir/mds/01ff/f...ff
+// dir/mds/01ff/f...ff/data
 //
 // There's a single journal subdirectory; the journal ordinals are
 // just MetadataRevisions, and the journal entries are just MdIDs.
@@ -76,9 +76,9 @@ func MakeImmutableBareRootMetadata(
 // directories in dir itself to a manageable number, similar to git.
 //
 // The maximum number of characters added to the root dir by an MD
-// journal is 40:
+// journal is 45:
 //
-//   /mds/01ff/f...(30 characters total)...ff
+//   /mds/01ff/f...(30 characters total)...ff/data
 //
 // This covers even the temporary files created in convertToBranch,
 // which create paths like

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -67,13 +67,18 @@ func MakeImmutableBareRootMetadata(
 // There's a single journal subdirectory; the journal ordinals are
 // just MetadataRevisions, and the journal entries are just MdIDs.
 //
-// The Metadata objects are stored separately in dir/mds. Each block
-// has its own subdirectory with its ID truncated to 17 bytes (34
+// The Metadata objects are stored separately in dir/mds. Each MD has
+// its own subdirectory with its ID truncated to 17 bytes (34
 // characters) as a name. The MD subdirectories are splayed over (# of
 // possible hash types) * 256 subdirectories -- one byte for the hash
 // type (currently only one) plus the first byte of the hash data --
 // using the first four characters of the name to keep the number of
 // directories in dir itself to a manageable number, similar to git.
+// Each block directory has data, which is the raw MD data that should
+// hash to the MD ID. Future versions of the journal might add more
+// files to this directory; if any code is written to move MDs around,
+// it should be careful to preserve any unknown files in an MD
+// directory.
 //
 // The maximum number of characters added to the root dir by an MD
 // journal is 45:

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -389,7 +389,8 @@ func (j *mdJournal) convertToBranch(
 	j.log.CDebugf(
 		ctx, "rewriting MDs %s to %s", earliestRevision, latestRevision)
 
-	_, allEntries, err := j.j.getRange(earliestRevision, latestRevision)
+	_, allEntries, err := j.j.getEntryRange(
+		earliestRevision, latestRevision)
 	if err != nil {
 		return NullBranchID, err
 	}
@@ -650,7 +651,7 @@ func (j mdJournal) getRange(
 		return nil, err
 	}
 
-	realStart, entries, err := j.j.getRange(start, stop)
+	realStart, entries, err := j.j.getEntryRange(start, stop)
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +917,8 @@ func (j *mdJournal) clear(
 		return err
 	}
 
-	_, allEntries, err := j.j.getRange(earliestRevision, latestRevision)
+	_, allEntries, err := j.j.getEntryRange(
+		earliestRevision, latestRevision)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -230,14 +230,14 @@ func (s *mdServerTlfStorage) getRangeReadLocked(
 		return nil, nil
 	}
 
-	realStart, mdIDs, err := j.getRange(start, stop)
+	realStart, entries, err := j.getRange(start, stop)
 	if err != nil {
 		return nil, err
 	}
 	var rmdses []*RootMetadataSigned
-	for i, mdID := range mdIDs {
+	for i, entry := range entries {
 		expectedRevision := realStart + MetadataRevision(i)
-		rmds, err := s.getMDReadLocked(mdID)
+		rmds, err := s.getMDReadLocked(entry.ID)
 		if err != nil {
 			return nil, MDServerError{err}
 		}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -399,7 +399,7 @@ func (s *mdServerTlfStorage) put(
 		return false, err
 	}
 
-	err = j.append(rmds.MD.RevisionNumber(), id)
+	err = j.append(rmds.MD.RevisionNumber(), mdIDJournalEntry{ID: id})
 	if err != nil {
 		return false, MDServerError{err}
 	}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -186,14 +186,14 @@ func (s *mdServerTlfStorage) getHeadForTLFReadLocked(bid BranchID) (
 	if !ok {
 		return nil, nil
 	}
-	headID, err := j.getLatest()
+	entry, exists, err := j.getLatestEntry()
 	if err != nil {
 		return nil, err
 	}
-	if headID == (MdID{}) {
+	if !exists {
 		return nil, nil
 	}
-	return s.getMDReadLocked(headID)
+	return s.getMDReadLocked(entry.ID)
 }
 
 func (s *mdServerTlfStorage) checkGetParamsReadLocked(

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -230,7 +230,7 @@ func (s *mdServerTlfStorage) getRangeReadLocked(
 		return nil, nil
 	}
 
-	realStart, entries, err := j.getRange(start, stop)
+	realStart, entries, err := j.getEntryRange(start, stop)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Have blockJournalEntry support unknown fields.

Have mdIDJournal store a struct (with unknown
field support) instead of just an MdID.

Have mdJournal store MD data in a file in a
per-MD directory. In the future, the directory
might have other files (e.g. to store the
version).