### PR TITLE
Taruti/kbfs 1466 number of open handles

### DIFF
--- a/dokan/dokan.go
+++ b/dokan/dokan.go
@@ -77,6 +77,12 @@ func (fi *FileInfo) IsRequestorUserSidEqualTo(sid *SID) bool {
 	return fi.isRequestorUserSidEqualTo(sid)
 }
 
+// NumberOfFileHandles returns the number of open file handles for
+// this filesystem.
+func (fi *FileInfo) NumberOfFileHandles() uint32 {
+	return fsTableGetFileCount(uint32(fi.ptr.DokanOptions.GlobalContext))
+}
+
 // CurrentProcessUserSid is a utility to get the
 // SID of the current user running the process.
 func CurrentProcessUserSid() (*SID, error) {

--- a/dokan/dummy.go
+++ b/dokan/dummy.go
@@ -20,6 +20,9 @@ func loadDokanDLL(fullpath string) error { return errNotWindows }
 type FileInfo struct {
 	ptr *struct {
 		DeleteOnClose int
+		DokanOptions  struct {
+			GlobalContext uint64
+		}
 	}
 	rawPath struct{}
 }

--- a/dokan/pointertable.go
+++ b/dokan/pointertable.go
@@ -68,6 +68,9 @@ func fsTableGetFileCount(slot uint32) uint32 {
 }
 
 func fiTableStoreFile(global uint32, fi File) uint32 {
+	fsTableLock.Lock()
+	fsTable[global].fileCount++
+	fsTableLock.Unlock()
 	fiTableLock.Lock()
 	defer fiTableLock.Unlock()
 	for {
@@ -83,9 +86,6 @@ func fiTableStoreFile(global uint32, fi File) uint32 {
 		if !exist {
 			debug("FID alloc", fiIdx, fi)
 			fiTable[fiIdx] = fi
-			fsTableLock.Lock()
-			defer fsTableLock.Unlock()
-			fsTable[global].fileCount++
 			return fiIdx
 		}
 	}
@@ -100,11 +100,11 @@ func fiTableGetFile(file uint32) File {
 }
 
 func fiTableFreeFile(global uint32, file uint32) {
+	fsTableLock.Lock()
+	fsTable[global].fileCount--
+	fsTableLock.Unlock()
 	fiTableLock.Lock()
 	defer fiTableLock.Unlock()
 	debug("FID free", global, file, "=>", fiTable[file], "# of open files:", len(fiTable)-1)
 	delete(fiTable, file)
-	fsTableLock.Lock()
-	defer fsTableLock.Unlock()
-	fsTable[global].fileCount--
 }

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -7,6 +7,7 @@ package libdokan
 import (
 	"errors"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -291,7 +292,8 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 
 	case ".kbfs_unmount" == ps[0]:
 		os.Exit(0)
-
+	case ".kbfs_number_of_handles" == ps[0]:
+		return f.stringReadFile(strconv.Itoa(int(oc.fi.NumberOfFileHandles())))
 	// TODO
 	// Unfortunately sometimes we end up in this case while using
 	// reparse points.
@@ -512,6 +514,15 @@ func (f *FS) logEnter(ctx context.Context, s string) {
 
 func (f *FS) logEnterf(ctx context.Context, fmt string, args ...interface{}) {
 	f.log.CDebugf(ctx, "=> "+fmt, args...)
+}
+
+func (f *FS) stringReadFile(contents string) (dokan.File, bool, error) {
+	return &SpecialReadFile{
+		read: func(context.Context) ([]byte, time.Time, error) {
+			return []byte(contents), time.Time{}, nil
+		},
+		fs: f,
+	}, false, nil
 }
 
 // Root represents the root of the KBFS file system.


### PR DESCRIPTION
* Add tracking of number of open files per mount to dokan
* Add a `K:\.kbfs_number_of_handles` that exposes it as an integer 