### PR TITLE
folder_block_ops: fix dirty block accounting after double error sequence

### DIFF
--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -142,6 +142,12 @@ func (df *dirtyFile) isBlockDirty(ptr BlockPointer) bool {
 	return df.fileBlockStates[ptr].copy == blockAlreadyCopied
 }
 
+func (df *dirtyFile) isBlockOrphaned(ptr BlockPointer) bool {
+	df.lock.Lock()
+	defer df.lock.Unlock()
+	return df.fileBlockStates[ptr].orphaned
+}
+
 func (df *dirtyFile) setBlockSyncing(ptr BlockPointer) error {
 	df.lock.Lock()
 	defer df.lock.Unlock()

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -176,6 +176,7 @@ func (df *dirtyFile) resetSyncingBlocksToDirty() {
 	df.lock.Lock()
 	defer df.lock.Unlock()
 	// Reset all syncing blocks to just be dirty again
+	syncFinishedNeeded := false
 	for ptr, state := range df.fileBlockStates {
 		if state.orphaned {
 			// This block will never be sync'd again, so clear any
@@ -184,7 +185,9 @@ func (df *dirtyFile) resetSyncingBlocksToDirty() {
 				df.dirtyBcache.UpdateUnsyncedBytes(df.path.Tlf,
 					-state.syncSize, true)
 			} else if state.sync == blockSynced {
-				df.dirtyBcache.SyncFinished(df.path.Tlf, state.syncSize)
+				// Some blocks did finish, so we might be able to
+				// increase our buffer size.
+				syncFinishedNeeded = true
 			}
 			state.syncSize = 0
 			delete(df.fileBlockStates, ptr)
@@ -203,6 +206,9 @@ func (df *dirtyFile) resetSyncingBlocksToDirty() {
 			state.syncSize = 0
 			df.fileBlockStates[ptr] = state
 		}
+	}
+	if syncFinishedNeeded {
+		df.dirtyBcache.SyncFinished(df.path.Tlf, df.totalSyncBytes)
 	}
 	df.totalSyncBytes = 0 // all the blocks need to be re-synced.
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -198,6 +198,7 @@ type folderBlockOps struct {
 	// Blocks that need to be deleted from the dirty cache before any
 	// deferred writes are replayed.
 	deferredDirtyDeletes []BlockPointer
+	deferredWaitBytes    int64
 
 	// set to true if this write or truncate should be deferred
 	doDeferWrite bool
@@ -895,9 +896,6 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableErrorLocked(
 	redirtyOnRecoverableError map[BlockPointer]BlockPointer) {
 	fbo.blockLock.AssertLocked(lState)
 
-	// If a copy of the top indirect block was made, we need to
-	// redirty all the sync'd blocks under their new IDs, so that
-	// future syncs will know they failed.
 	df := fbo.dirtyFiles[file.tailPointer()]
 	if df != nil {
 		// Un-orphan old blocks, since we are reverting back to the
@@ -921,6 +919,9 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableErrorLocked(
 		return
 	}
 
+	// If a copy of the top indirect block was made, we need to
+	// redirty all the sync'd blocks under their new IDs, so that
+	// future syncs will know they failed.
 	for newPtr, oldPtr := range redirtyOnRecoverableError {
 		found := false
 		for i, iptr := range fblock.IPtrs {
@@ -1511,6 +1512,7 @@ func (fbo *folderBlockOps) Write(
 					ctx, lState, kmd, f, dataCopy, off)
 				return err
 			})
+		fbo.deferredWaitBytes += newlyDirtiedChildBytes
 	}
 
 	return nil
@@ -1803,6 +1805,7 @@ func (fbo *folderBlockOps) Truncate(
 					ctx, lState, kmd, f, size)
 				return err
 			})
+		fbo.deferredWaitBytes += newlyDirtiedChildBytes
 	}
 
 	return nil
@@ -2341,11 +2344,18 @@ func (fbo *folderBlockOps) CleanupSyncState(
 				result.redirtyOnRecoverableError)
 		}
 	} else {
+		// Since the sync has errored out unrecoverably, the deferred
+		// bytes are already accounted for.
+		if df := fbo.dirtyFiles[file.tailPointer()]; df != nil {
+			df.updateNotYetSyncingBytes(-fbo.deferredWaitBytes)
+		}
+
 		// On an unrecoverable error, the deferred writes aren't
 		// needed anymore since they're already part of the
 		// (still-)dirty blocks.
 		fbo.deferredDirtyDeletes = nil
 		fbo.deferredWrites = nil
+		fbo.deferredWaitBytes = 0
 	}
 
 	// The sync is over, due to an error, so reset the map so that we
@@ -2415,6 +2425,41 @@ func (fbo *folderBlockOps) cleanUpUnusedBlocks(ctx context.Context,
 	return nil
 }
 
+func (fbo *folderBlockOps) doDeferredWritesLocked(ctx context.Context,
+	lState *lockState, kmd KeyMetadata, newPath path) (
+	stillDirty bool, err error) {
+	fbo.blockLock.AssertLocked(lState)
+
+	// Redo any writes or truncates that happened to our file while
+	// the sync was happening.
+	deletes := fbo.deferredDirtyDeletes
+	writes := fbo.deferredWrites
+	stillDirty = len(fbo.deferredWrites) != 0
+	fbo.deferredDirtyDeletes = nil
+	fbo.deferredWrites = nil
+	fbo.deferredWaitBytes = 0
+
+	// Clear any dirty blocks that resulted from a write/truncate
+	// happening during the sync, since we're redoing them below.
+	dirtyBcache := fbo.config.DirtyBlockCache()
+	for _, ptr := range deletes {
+		fbo.log.CDebugf(ctx, "Deleting deferred dirty ptr %v", ptr)
+		if err := dirtyBcache.Delete(fbo.id(), ptr, fbo.branch()); err != nil {
+			return true, err
+		}
+	}
+
+	for _, f := range writes {
+		err = f(ctx, lState, kmd, newPath)
+		if err != nil {
+			// It's a little weird to return an error from a deferred
+			// write here. Hopefully that will never happen.
+			return true, err
+		}
+	}
+	return false, nil
+}
+
 // FinishSync finishes the sync process for a file, given the state
 // from StartSync. Specifically, it re-applies any writes that
 // happened since the call to StartSync.
@@ -2443,30 +2488,9 @@ func (fbo *folderBlockOps) FinishSync(
 		}
 	}
 
-	// Redo any writes or truncates that happened to our file while
-	// the sync was happening.
-	deletes := fbo.deferredDirtyDeletes
-	writes := fbo.deferredWrites
-	stillDirty = len(fbo.deferredWrites) != 0
-	fbo.deferredDirtyDeletes = nil
-	fbo.deferredWrites = nil
-
-	// Clear any dirty blocks that resulted from a write/truncate
-	// happening during the sync, since we're redoing them below.
-	for _, ptr := range deletes {
-		fbo.log.CDebugf(ctx, "Deleting deferred dirty ptr %v", ptr)
-		if err := dirtyBcache.Delete(fbo.id(), ptr, fbo.branch()); err != nil {
-			return true, err
-		}
-	}
-
-	for _, f := range writes {
-		err = f(ctx, lState, md, newPath)
-		if err != nil {
-			// It's a little weird to return an error from a deferred
-			// write here. Hopefully that will never happen.
-			return true, err
-		}
+	stillDirty, err = fbo.doDeferredWritesLocked(ctx, lState, md, newPath)
+	if err != nil {
+		return true, err
 	}
 
 	// Clear cached info for the old path.  We are guaranteed that any


### PR DESCRIPTION
Previously, this sequence of events left the dirty block cache in a bad state:
1. A Sync starts.
2. A block is dirtied.
3. The Sync fails with a recoverable block error.
4. The recovery Sync starts.
5. The recovery Sync fails due to an unrecoverable error (say a timeout or ctx cancel).
6. Later, another Sync completes successfully.

This left unaccounted bytes and dirty blocks in the dirty block cache.  This PR fixes it by:
* On an unrecoverable error, subtract newly-dirty child block bytes from the waitBuf count; they're not considered dirty anymore since the block has been finalized and the blocks are clean (but living in the bps, rather than the dirty block cache).
* On an unrecoverable error, delete these orphaned blocks from the dirty block cache as well.
* Move deferral work into a helper function for readability.
* Avoid double calls to SyncFinished on a recoverable error -- I think this was harmless but it made the logs harder to read.

Issue: KBFS-1508
Issue: keybase/client#4248