### PR TITLE
folder_branch_ops: don't cancel onMDFlush context early

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -647,8 +647,7 @@ func (fs *KBFSOpsStandard) UnregisterFromChanges(
 
 func (fs *KBFSOpsStandard) onTLFBranchChange(tlfID TlfID, newBID BranchID) {
 	ops := fs.getOpsNoAdd(FolderBranch{Tlf: tlfID, Branch: MasterBranch})
-	// Launch in a new goroutine to avoid deadlocks.
-	go ops.onTLFBranchChange(newBID)
+	ops.onTLFBranchChange(newBID) // folderBranchOps makes a goroutine
 }
 
 func (fs *KBFSOpsStandard) onMDFlush(tlfID TlfID, bid BranchID,


### PR DESCRIPTION
Also, track branch changes more carefully and wait on them while
syncing.

This fixes a flaky journal test.

Issue: KBFS-1545