### PR TITLE
folder_block_manager: don't run QR if the head is too new

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -37,6 +37,8 @@ const (
 	qrPeriodDefault = 1 * time.Minute
 	// How long must something be unreferenced before we reclaim it?
 	qrUnrefAgeDefault = 1 * time.Minute
+	// How old must the most recent revision be before we run QR?
+	qrMinHeadAgeDefault = 1 * time.Minute
 	// tlfValidDurationDefault is the default for tlf validity before redoing identify.
 	tlfValidDurationDefault = 6 * time.Hour
 )
@@ -78,6 +80,7 @@ type ConfigLocal struct {
 
 	qrPeriod                       time.Duration
 	qrUnrefAge                     time.Duration
+	qrMinHeadAge                   time.Duration
 	delayedCancellationGracePeriod time.Duration
 
 	// allKnownConfigsForTesting is used for testing, and contains all created
@@ -212,6 +215,7 @@ func NewConfigLocal() *ConfigLocal {
 	config.delayedCancellationGracePeriod = delayedCancellationGracePeriodDefault
 	config.qrPeriod = qrPeriodDefault
 	config.qrUnrefAge = qrUnrefAgeDefault
+	config.qrMinHeadAge = qrMinHeadAgeDefault
 
 	// Don't bother creating the registry if UseNilMetrics is set.
 	if !metrics.UseNilMetrics {
@@ -569,6 +573,11 @@ func (c *ConfigLocal) QuotaReclamationPeriod() time.Duration {
 // QuotaReclamationMinUnrefAge implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) QuotaReclamationMinUnrefAge() time.Duration {
 	return c.qrUnrefAge
+}
+
+// QuotaReclamationMinHeadAge implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) QuotaReclamationMinHeadAge() time.Duration {
+	return c.qrMinHeadAge
 }
 
 // ReqsBufSize implements the Config interface for ConfigLocal.

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -531,3 +531,98 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 		t.Fatalf("Unexpected rekey error: %v", err)
 	}
 }
+
+// Test that quota reclamation doesn't run unless the current head is
+// at least the minimum needed age.
+func TestQuotaReclamationMinHeadAge(t *testing.T) {
+	var userName libkb.NormalizedUsername = "test_user"
+	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
+	defer CleanupCancellationDelayer(ctx)
+	defer CheckConfigAndShutdown(t, config)
+
+	clock := newTestClockNow()
+	config.SetClock(clock)
+
+	config.qrMinHeadAge = qrMinHeadAgeDefault
+
+	rootNode := GetRootNodeOrBust(t, config, userName.String(), false)
+	kbfsOps := config.KBFSOps()
+	_, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
+	if err != nil {
+		t.Fatalf("Couldn't create dir: %v", err)
+	}
+	err = kbfsOps.RemoveDir(ctx, rootNode, "a")
+	if err != nil {
+		t.Fatalf("Couldn't remove dir: %v", err)
+	}
+
+	// Increase the time and make a new revision, and make sure quota
+	// reclamation doesn't run.
+	clock.Add(2 * config.QuotaReclamationMinUnrefAge())
+	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "b")
+	if err != nil {
+		t.Fatalf("Couldn't create dir: %v", err)
+	}
+
+	// Wait for outstanding archives
+	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %v", err)
+	}
+
+	// Make sure no blocks are deleted before there's a new-enough update.
+	bserverLocal, ok := config.BlockServer().(blockServerLocal)
+	if !ok {
+		t.Fatalf("Bad block server")
+	}
+	preQR1Blocks, err := bserverLocal.getAll(
+		ctx, rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		t.Fatalf("Couldn't get blocks: %v", err)
+	}
+
+	ops := kbfsOps.(*KBFSOpsStandard).getOpsByNode(ctx, rootNode)
+	ops.fbm.forceQuotaReclamation()
+	err = ops.fbm.waitForQuotaReclamations(ctx)
+	if err != nil {
+		t.Fatalf("Couldn't wait for QR: %v", err)
+	}
+
+	postQR1Blocks, err := bserverLocal.getAll(
+		ctx, rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		t.Fatalf("Couldn't get blocks: %v", err)
+	}
+
+	if !reflect.DeepEqual(preQR1Blocks, postQR1Blocks) {
+		t.Fatalf("Blocks deleted too early (%v vs %v)!",
+			preQR1Blocks, postQR1Blocks)
+	}
+
+	// Increase the time again and make sure it does run.
+	clock.Add(2 * config.QuotaReclamationMinHeadAge())
+
+	preQR2Blocks, err := bserverLocal.getAll(
+		ctx, rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		t.Fatalf("Couldn't get blocks: %v", err)
+	}
+
+	ops.fbm.forceQuotaReclamation()
+	err = ops.fbm.waitForQuotaReclamations(ctx)
+	if err != nil {
+		t.Fatalf("Couldn't wait for QR: %v", err)
+	}
+
+	postQR2Blocks, err := bserverLocal.getAll(
+		ctx, rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		t.Fatalf("Couldn't get blocks: %v", err)
+	}
+
+	if pre, post := totalBlockRefs(preQR2Blocks),
+		totalBlockRefs(postQR2Blocks); post >= pre {
+		t.Errorf("Blocks didn't shrink after reclamation: pre: %d, post %d",
+			pre, post)
+	}
+}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1351,6 +1351,10 @@ type Config interface {
 	// QuotaReclamationMinUnrefAge indicates the minimum time a block
 	// must have been unreferenced before it can be reclaimed.
 	QuotaReclamationMinUnrefAge() time.Duration
+	// QuotaReclamationMinHeadAge indicates the minimum age of the
+	// most recently merged MD update before we can run reclamation,
+	// to avoid conflicting with a currently active writer.
+	QuotaReclamationMinHeadAge() time.Duration
 
 	// ResetCaches clears and re-initializes all data and key caches.
 	ResetCaches()

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4010,6 +4010,16 @@ func (_mr *_MockConfigRecorder) QuotaReclamationMinUnrefAge() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "QuotaReclamationMinUnrefAge")
 }
 
+func (_m *MockConfig) QuotaReclamationMinHeadAge() time.Duration {
+	ret := _m.ctrl.Call(_m, "QuotaReclamationMinHeadAge")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) QuotaReclamationMinHeadAge() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "QuotaReclamationMinHeadAge")
+}
+
 func (_m *MockConfig) ResetCaches() {
 	_m.ctrl.Call(_m, "ResetCaches")
 }

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -181,6 +181,9 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 	// no auto reclamation
 	config.qrPeriod = 0 * time.Second
 
+	// no min head age
+	config.qrMinHeadAge = 0 * time.Second
+
 	configs := []Config{config}
 	config.allKnownConfigsForTesting = &configs
 


### PR DESCRIPTION
To avoid causing conflicts for active writers on other devices.

Also, while we're in this code, we can use the true server timestamp to decide when a revision is old enough for QR, rather than resolving on the root directory mtime (which might not have been updated, see KBFS-821, KBFS-902).

Issue: KBFS-1429