### PR TITLE
[KBFS-1525] Preserve unknown fields in mdJournal

### DIFF
--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -25,7 +25,9 @@ type mdIDJournal struct {
 }
 
 // An mdIDJournalEntry is, for now, just an MdID. In the future, it
-// may contain more fields.
+// may contain more fields. However, make sure that new fields don't
+// depend on the ID, as the mdJournal may change the ID when
+// converting to a branch.
 type mdIDJournalEntry struct {
 	ID MdID
 

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -875,8 +875,10 @@ func (j *mdJournal) put(
 		j.log.CDebugf(
 			ctx, "Replacing head MD for TLF=%s with rev=%s bid=%s",
 			rmd.TlfID(), rmd.Revision(), rmd.BID())
-		// TODO: Try and preserve unknown fields from the old
-		// journal.
+		// Don't try and preserve unknown fields from the old
+		// head here -- the new head is in general a different
+		// MD, so the unknown fields from the old head won't
+		// make sense.
 		err = j.j.replaceHead(mdIDJournalEntry{ID: id})
 		if err != nil {
 			return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -498,10 +498,10 @@ func (j *mdJournal) convertToBranch(
 		}
 		mdsToRemove = append(mdsToRemove, newID)
 
-		// TODO: Try and preserve unknown fields from the old
-		// journal.
-		err = tempJournal.append(
-			brmd.RevisionNumber(), mdIDJournalEntry{ID: newID})
+		// Preserve unknown fields from the old journal.
+		newEntry := entry
+		newEntry.ID = newID
+		err = tempJournal.append(brmd.RevisionNumber(), newEntry)
 		if err != nil {
 			return NullBranchID, err
 		}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -554,7 +554,7 @@ func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
 			Extra: i,
 		}
 		var entry mdIDJournalEntry
-		err = CodecUpdate(codec, &entry, entryFuture)
+		err = kbfscodec.Update(codec, &entry, entryFuture)
 		require.NoError(t, err)
 		o, err := revisionToOrdinal(revision)
 		require.NoError(t, err)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -525,6 +525,57 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	flushAllMDs(t, ctx, signer, j)
 }
 
+func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
+	codec, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
+	defer teardownMDJournalTest(t, tempdir)
+
+	var expectedEntries []mdIDJournalEntry
+
+	firstRevision := MetadataRevision(5)
+	mdCount := 5
+	prevRoot := fakeMdID(1)
+	ctx := context.Background()
+	for i := 0; i < mdCount; i++ {
+		revision := firstRevision + MetadataRevision(i)
+		md := makeMDForTest(t, id, revision, j.uid, prevRoot)
+		mdID, err := j.put(ctx, signer, ekg, bsplit, md)
+		require.NoError(t, err)
+
+		// Add extra fields to the journal entry.
+		entryFuture := makeFakeMDIDJournalEntryFuture(t)
+		entryFuture.ID = mdID
+		var entry mdIDJournalEntry
+		err = CodecUpdate(codec, &entry, entryFuture)
+		require.NoError(t, err)
+		o, err := revisionToOrdinal(revision)
+		require.NoError(t, err)
+		j.j.j.writeJournalEntry(o, entry)
+
+		// Zero out the MdID, since branch conversion changes
+		// it.
+		entry.ID = MdID{}
+		expectedEntries = append(expectedEntries, entry)
+
+		prevRoot = mdID
+	}
+
+	_, err := j.convertToBranch(ctx, signer, id, NewMDCacheStandard(10))
+	require.NoError(t, err)
+
+	// Check that the extra fields are preserved.
+	_, entries, err := j.j.getEntryRange(
+		firstRevision, firstRevision+MetadataRevision(mdCount))
+	require.NoError(t, err)
+	// Zero out MdIDs for comparison.
+	for i, entry := range entries {
+		entry.ID = MdID{}
+		entries[i] = entry
+	}
+	require.Equal(t, expectedEntries, entries)
+
+	flushAllMDs(t, ctx, signer, j)
+}
+
 func TestMDJournalClear(t *testing.T) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -525,6 +525,11 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	flushAllMDs(t, ctx, signer, j)
 }
 
+type mdIDJournalEntryExtra struct {
+	mdIDJournalEntry
+	Extra int
+}
+
 func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
 	codec, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t)
 	defer teardownMDJournalTest(t, tempdir)
@@ -542,8 +547,12 @@ func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
 		require.NoError(t, err)
 
 		// Add extra fields to the journal entry.
-		entryFuture := makeFakeMDIDJournalEntryFuture(t)
-		entryFuture.ID = mdID
+		entryFuture := mdIDJournalEntryExtra{
+			mdIDJournalEntry: mdIDJournalEntry{
+				ID: mdID,
+			},
+			Extra: i,
+		}
 		var entry mdIDJournalEntry
 		err = CodecUpdate(codec, &entry, entryFuture)
 		require.NoError(t, err)


### PR DESCRIPTION
In particular, when converting to a branch.

Don't preserve unknown fields when replacing
the head, though, as that is semanitically a
brand-new entry.