### PR TITLE
libfs: fix RemoteStatus.ExtraFileNameAndSize

### DIFF
--- a/libfs/remote_status.go
+++ b/libfs/remote_status.go
@@ -121,7 +121,7 @@ func (r *RemoteStatus) ExtraFileNameAndSize() (string, int64) {
 	r.Lock()
 	defer r.Unlock()
 
-	if r.extraFileName == "" || time.Since(r.failingSince) > failureDisplayThreshold {
+	if r.extraFileName == "" || time.Since(r.failingSince) < failureDisplayThreshold {
 		return "", 0
 	}
 


### PR DESCRIPTION
* Make it behave like ExtraFileName
* It was reported on irc and traced the problem to this