### PR TITLE
cr: tags ops with revision, and allow op removal by revision

### DIFF
--- a/libkbfs/conflict_renamer.go
+++ b/libkbfs/conflict_renamer.go
@@ -59,7 +59,8 @@ func splitExtension(path string) (string, string) {
 	return path, ""
 }
 
-func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID, kid keybase1.KID) (writerInfo, error) {
+func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID,
+	kid keybase1.KID, revision MetadataRevision) (writerInfo, error) {
 	ui, err := cfg.KeybaseService().LoadUserPlusKeys(ctx, uid)
 	if err != nil {
 		return writerInfo{}, err
@@ -70,5 +71,6 @@ func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID, kid keybas
 		uid:        uid,
 		kid:        kid,
 		deviceName: ui.KIDNames[kid],
+		revision:   revision,
 	}, nil
 }

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1059,7 +1059,9 @@ func (cr *ConflictResolver) addRecreateOpsToUnmergedChains(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	winfo, err := newWriterInfo(ctx, cr.config, uid, unmergedChains.mostRecentMD.LastModifyingWriterKID())
+	winfo, err := newWriterInfo(ctx, cr.config, uid,
+		unmergedChains.mostRecentMD.LastModifyingWriterKID(),
+		unmergedChains.mostRecentMD.Revision())
 	if err != nil {
 		return nil, err
 	}
@@ -1602,7 +1604,8 @@ func (cr *ConflictResolver) addMergedRecreates(ctx context.Context,
 					co.AddRefBlock(c.mostRecent)
 					winfo, err := newWriterInfo(ctx, cr.config,
 						mergedChains.mostRecentMD.LastModifyingWriter(),
-						mergedChains.mostRecentMD.LastModifyingWriterKID())
+						mergedChains.mostRecentMD.LastModifyingWriterKID(),
+						mergedChains.mostRecentMD.Revision())
 					if err != nil {
 						return err
 					}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -902,7 +902,7 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 	return paths, nil
 }
 
-// remove delets all operations associated with `rmd` from the chains.
+// remove deletes all operations associated with `rmd` from the chains.
 // It leaves original block pointers in place though, even when
 // removing operations from the head of the chain.  It returns the set
 // of chains with at least one operation removed.

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -641,7 +641,7 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 		}
 
 		winfo, err := newWriterInfo(ctx, cfg, rmd.LastModifyingWriter(),
-			rmd.LastModifyingWriterKID())
+			rmd.LastModifyingWriterKID(), rmd.Revision())
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -740,6 +740,7 @@ type writerInfo struct {
 	uid        keybase1.UID
 	kid        keybase1.KID
 	deviceName string
+	revision   MetadataRevision
 }
 
 // ErrorModeType indicates what type of operation was being attempted


### PR DESCRIPTION
This will be used in a later PR when a `crChains` is used to track outstanding journal writes, in order to remove the operations corresponding to a given revision once it has been flushed.

Issue: KBFS-1473
Issue: KBFS-1474