### PR TITLE
tlf_journal: expose unflushed paths in .kbfs_status

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3434,7 +3434,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		return
 	}
 
-	if status, _, err := cr.fbo.status.getStatus(ctx); err == nil {
+	if status, _, err := cr.fbo.status.getStatus(ctx, nil); err == nil {
 		if statusString, err := json.Marshal(status); err == nil {
 			ci := func() conflictInput {
 				cr.inputLock.Lock()

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2932,3 +2932,17 @@ func (fbo *folderBlockOps) UpdatePointers(lState *lockState, op op) {
 		fbo.nodeCache.UpdatePointer(oldRef, update.Ref)
 	}
 }
+
+type chainsPathPopulator interface {
+	populateChainPaths(context.Context, logger.Logger, *crChains, bool) error
+}
+
+// populateChainPaths updates all the paths in all the ops tracked by
+// `chains`, using the main nodeCache.
+func (fbo *folderBlockOps) populateChainPaths(ctx context.Context,
+	log logger.Logger, chains *crChains, includeCreates bool) error {
+	_, err := chains.getPaths(ctx, fbo, log, fbo.nodeCache, includeCreates)
+	return err
+}
+
+var _ chainsPathPopulator = (*folderBlockOps)(nil)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3375,7 +3375,7 @@ func (fbo *folderBranchOps) FolderStatus(
 			WrongOpsError{fbo.folderBranch, folderBranch}
 	}
 
-	return fbo.status.getStatus(ctx)
+	return fbo.status.getStatus(ctx, &fbo.blocks)
 }
 
 func (fbo *folderBranchOps) Status(

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -43,7 +43,7 @@ func TestFBStatusSignal(t *testing.T) {
 	defer fbStatusTestShutdown(mockCtrl, config)
 	ctx := context.Background()
 
-	_, c, err := fbsk.getStatus(ctx)
+	_, c, err := fbsk.getStatus(ctx, nil)
 	if err != nil {
 		t.Fatalf("Couldn't get status: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestFBStatusSignal(t *testing.T) {
 	fbsk.addDirtyNode(n)
 	<-c
 
-	_, c, err = fbsk.getStatus(ctx)
+	_, c, err = fbsk.getStatus(ctx, nil)
 	if err != nil {
 		t.Fatalf("Couldn't get status: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestFBStatusAllFields(t *testing.T) {
 	config.mockRekeyQueue.EXPECT().IsRekeyPending(id)
 
 	// check the returned status for accuracy
-	status, _, err := fbsk.getStatus(ctx)
+	status, _, err := fbsk.getStatus(ctx, nil)
 	if err != nil {
 		t.Fatalf("Couldn't get status: %v", err)
 	}

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -510,7 +510,7 @@ func (j *JournalServer) JournalStatus(tlfID TlfID) (
 // given TLF suitable for diagnostics, including paths for all the
 // unflushed entries.
 func (j *JournalServer) JournalStatusWithPaths(ctx context.Context, tlfID TlfID,
-	blocks *folderBlockOps) (
+	cpp chainsPathPopulator) (
 	TLFJournalStatus, error) {
 	tlfJournal, ok := j.getTLFJournal(tlfID)
 	if !ok {
@@ -519,7 +519,7 @@ func (j *JournalServer) JournalStatusWithPaths(ctx context.Context, tlfID TlfID,
 	}
 
 	return tlfJournal.getJournalStatusWithPaths(ctx, j.config, j.mdOps(),
-		blocks)
+		cpp)
 }
 
 // shutdownExistingJournalsLocked shuts down all write journals, sets

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -495,7 +495,8 @@ func (j *JournalServer) Status() JournalServerStatus {
 
 // JournalStatus returns a TLFServerStatus object for the given TLF
 // suitable for diagnostics.
-func (j *JournalServer) JournalStatus(tlfID TlfID) (TLFJournalStatus, error) {
+func (j *JournalServer) JournalStatus(tlfID TlfID) (
+	TLFJournalStatus, error) {
 	tlfJournal, ok := j.getTLFJournal(tlfID)
 	if !ok {
 		return TLFJournalStatus{},
@@ -503,6 +504,22 @@ func (j *JournalServer) JournalStatus(tlfID TlfID) (TLFJournalStatus, error) {
 	}
 
 	return tlfJournal.getJournalStatus()
+}
+
+// JournalStatusWithPaths returns a TLFServerStatus object for the
+// given TLF suitable for diagnostics, including paths for all the
+// unflushed entries.
+func (j *JournalServer) JournalStatusWithPaths(ctx context.Context, tlfID TlfID,
+	blocks *folderBlockOps) (
+	TLFJournalStatus, error) {
+	tlfJournal, ok := j.getTLFJournal(tlfID)
+	if !ok {
+		return TLFJournalStatus{},
+			fmt.Errorf("Journal not enabled for %s", tlfID)
+	}
+
+	return tlfJournal.getJournalStatusWithPaths(ctx, j.config, j.mdOps(),
+		blocks)
 }
 
 // shutdownExistingJournalsLocked shuts down all write journals, sets

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -506,20 +506,100 @@ func (j *JournalServer) JournalStatus(tlfID TlfID) (
 	return tlfJournal.getJournalStatus()
 }
 
+var errJournalStatusRetry = errors.New("Retry journal status")
+
+func (j *JournalServer) getUnflushedPaths(ctx context.Context, tlfID TlfID,
+	cpp chainsPathPopulator, branchStr string, start MetadataRevision,
+	end MetadataRevision) ([]string, error) {
+	// Get the range of revisions.  Note that since we're not doing
+	// this under lock, the journal could enter conflict mode, and we
+	// could end up fetching merged revisions from some other device.
+	// So we need to check that all the revisions were written by this
+	// device.  If not, retry.
+	var unflushedPaths []string
+	if end != MetadataRevisionUninitialized {
+		bid, err := ParseBranchID(branchStr)
+		if err != nil {
+			return nil, err
+		}
+
+		mStatus := Merged
+		if bid != NullBranchID {
+			mStatus = Unmerged
+		}
+		irmds, err := getMDRange(ctx, j.config, tlfID, bid, start, end, mStatus)
+		if err != nil {
+			return nil, err
+		}
+
+		// Make sure that all of them were signed by this device.
+		key, err := j.config.KBPKI().GetCurrentVerifyingKey(ctx)
+		if err != nil {
+			// TODO: if the error is that the branch ID no longer
+			// exists, we should retry, since the conflict was
+			// resolved since we fetched the status.
+			return nil, err
+		}
+		for _, irmd := range irmds {
+			if key.KID() != irmd.LastModifyingWriterKID() {
+				j.log.CDebugf(ctx, "Found an MD in our journal range "+
+					"signed by another device (%v); retrying",
+					irmd.LastModifyingWriterKID())
+				return nil, errJournalStatusRetry
+			}
+		}
+
+		// Make chains over the entire range to get the unflushed files.
+		// TODO: cache this chains object and update it when new revisions
+		// appear and when revisions are flushed, instead of rebuilding
+		// every time.
+		chains, err := newCRChains(ctx, j.config, irmds, nil, false)
+		if err != nil {
+			return nil, err
+		}
+		err = cpp.populateChainPaths(ctx, j.log, chains, true)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, chain := range chains.byOriginal {
+			if len(chain.ops) > 0 {
+				unflushedPaths = append(unflushedPaths,
+					chain.ops[0].getFinalPath().String())
+			}
+		}
+	}
+	return unflushedPaths, nil
+}
+
 // JournalStatusWithPaths returns a TLFServerStatus object for the
 // given TLF suitable for diagnostics, including paths for all the
 // unflushed entries.
 func (j *JournalServer) JournalStatusWithPaths(ctx context.Context, tlfID TlfID,
-	cpp chainsPathPopulator) (
-	TLFJournalStatus, error) {
+	cpp chainsPathPopulator) (TLFJournalStatus, error) {
 	tlfJournal, ok := j.getTLFJournal(tlfID)
 	if !ok {
 		return TLFJournalStatus{},
 			fmt.Errorf("Journal not enabled for %s", tlfID)
 	}
 
-	return tlfJournal.getJournalStatusWithPaths(ctx, j.config, j.mdOps(),
-		cpp)
+	for i := 0; i < 10; i++ {
+		status, err := tlfJournal.getJournalStatus()
+		if err != nil {
+			return TLFJournalStatus{}, err
+		}
+
+		status.UnflushedPaths, err = j.getUnflushedPaths(ctx, tlfID,
+			cpp, status.BranchID, status.RevisionStart,
+			status.RevisionEnd)
+		if err == errJournalStatusRetry {
+			continue
+		} else if err != nil {
+			return TLFJournalStatus{}, err
+		}
+		return status, nil
+	}
+	return TLFJournalStatus{}, errors.New("Couldn't get a consistent status")
 }
 
 // shutdownExistingJournalsLocked shuts down all write journals, sets

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -62,6 +62,7 @@ type TLFJournalStatus struct {
 	BranchID       string
 	BlockOpCount   uint64
 	UnflushedBytes int64 // (signed because os.FileInfo.Size() is signed)
+	UnflushedPaths []string
 }
 
 // TLFJournalBackgroundWorkStatus indicates whether a journal should
@@ -806,9 +807,7 @@ func (j *tlfJournal) getJournalEntryCounts() (
 	return blockEntryCount, mdEntryCount, nil
 }
 
-func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
-	j.journalLock.RLock()
-	defer j.journalLock.RUnlock()
+func (j *tlfJournal) getBaseJournalStatusLocked() (TLFJournalStatus, error) {
 	if err := j.checkEnabledLocked(); err != nil {
 		return TLFJournalStatus{}, err
 	}
@@ -833,6 +832,62 @@ func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 		BlockOpCount:   blockEntryCount,
 		UnflushedBytes: j.blockJournal.unflushedBytes,
 	}, nil
+}
+
+func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	return j.getBaseJournalStatusLocked()
+}
+
+func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
+	config Config, mdOps journalMDOps, blocks *folderBlockOps) (
+	TLFJournalStatus, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	status, err := j.getBaseJournalStatusLocked()
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
+
+	// Make chains over the entire range to get the unflushed files.
+	// TODO: cache this chains object and update it when new revisions
+	// appear and when revisions are flushed, instead of rebuilding
+	// every time.
+	if status.RevisionEnd != MetadataRevisionUninitialized {
+		var irmds []ImmutableRootMetadata
+		// These GetRange calls end up taking journalLock for reading
+		// again, but that's ok.  (Note we can't just
+		// j.mdJournal.getRange() directly because we need them as
+		// ImmutableRootMetadatas, not ImmutableBareRootMetadatas.)
+		if j.mdJournal.getBranchID() == NullBranchID {
+			irmds, err = mdOps.GetRange(ctx, j.tlfID,
+				status.RevisionStart, status.RevisionEnd)
+		} else {
+			irmds, err = mdOps.GetUnmergedRange(ctx, j.tlfID,
+				j.mdJournal.getBranchID(), status.RevisionStart,
+				status.RevisionEnd)
+		}
+		if err != nil {
+			return TLFJournalStatus{}, err
+		}
+		chains, err := newCRChains(ctx, config, irmds, nil, false)
+		if err != nil {
+			return TLFJournalStatus{}, err
+		}
+		_, err = chains.getPaths(ctx, blocks, j.log, blocks.nodeCache, true)
+		if err != nil {
+			return TLFJournalStatus{}, err
+		}
+
+		for _, chain := range chains.byOriginal {
+			if len(chain.ops) > 0 {
+				status.UnflushedPaths = append(status.UnflushedPaths,
+					chain.ops[0].getFinalPath().String())
+			}
+		}
+	}
+	return status, nil
 }
 
 func (j *tlfJournal) getUnflushedBytes() int64 {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -841,7 +841,7 @@ func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 }
 
 func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
-	config Config, mdOps journalMDOps, blocks *folderBlockOps) (
+	config Config, mdOps journalMDOps, cpp chainsPathPopulator) (
 	TLFJournalStatus, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
@@ -875,7 +875,7 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 		if err != nil {
 			return TLFJournalStatus{}, err
 		}
-		_, err = chains.getPaths(ctx, blocks, j.log, blocks.nodeCache, true)
+		err = cpp.populateChainPaths(ctx, j.log, chains, true)
 		if err != nil {
 			return TLFJournalStatus{}, err
 		}


### PR DESCRIPTION
I'm not totally happy with the callstack flow for this; let me know if you can think of a better way to organize it.

Issue: KBFS-1475