### PR TITLE
Add "none" mount-types for kbfsfuse and kbfsdokan

### DIFF
--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -21,7 +21,7 @@ import (
 
 var runtimeDir = flag.String("runtime-dir", os.Getenv("KEYBASE_RUNTIME_DIR"), "runtime directory")
 var label = flag.String("label", os.Getenv("KEYBASE_LABEL"), "label to help identify if running as a service")
-var mountType = flag.String("mount-type", defaultMountType, "mount type: default, force")
+var mountType = flag.String("mount-type", defaultMountType, "mount type: default, force, none")
 var version = flag.Bool("version", false, "Print version")
 var mountFlags = flag.Int64("mount-flags", int64(libdokan.DefaultMountFlags), "Dokan mount flags")
 var dokandll = flag.String("dokan-dll", "", "Absolute path of dokan dll to load")
@@ -87,6 +87,8 @@ func start() *libfs.Error {
 	var mounter libdokan.Mounter
 	if *mountType == "force" {
 		mounter = libdokan.NewForceMounter(mountpoint)
+	} else if *mountType == "none" {
+		mounter = libdokan.NewNoopMounter()
 	} else {
 		mounter = libdokan.NewDefaultMounter(mountpoint)
 	}

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -22,7 +22,7 @@ import (
 
 var runtimeDir = flag.String("runtime-dir", os.Getenv("KEYBASE_RUNTIME_DIR"), "runtime directory")
 var label = flag.String("label", os.Getenv("KEYBASE_LABEL"), "label to help identify if running as a service")
-var mountType = flag.String("mount-type", defaultMountType, "mount type: default, force")
+var mountType = flag.String("mount-type", defaultMountType, "mount type: default, force, none")
 var version = flag.Bool("version", false, "Print version")
 
 const usageFormatStr = `Usage:
@@ -94,6 +94,8 @@ func start() *libfs.Error {
 	var mounter libfuse.Mounter
 	if *mountType == "force" {
 		mounter = libfuse.NewForceMounter(mountpoint, *platformParams)
+	} else if *mountType == "none" {
+		mounter = libfuse.NewNoopMounter()
 	} else {
 		mounter = libfuse.NewDefaultMounter(mountpoint, *platformParams)
 	}

--- a/libdokan/mounter.go
+++ b/libdokan/mounter.go
@@ -106,3 +106,31 @@ func volumeName(dir string) (string, error) {
 	}
 	return volName, nil
 }
+
+// NoopMounter is a mounter that does nothing.
+type NoopMounter struct {
+	c chan struct{}
+}
+
+// NewNoopMounter creates a mounter that does nothing.
+func NewNoopMounter() NoopMounter {
+	return NoopMounter{c: make(chan struct{}, 1)}
+}
+
+// Mount doesn't mount anything, it just blocks until Unmount is
+// called.
+func (m NoopMounter) Mount(_ *dokan.Config, _ logger.Logger) error {
+	<-m.c
+	return nil
+}
+
+// Unmount doesn't do anything.
+func (m NoopMounter) Unmount() error {
+	close(m.c)
+	return nil
+}
+
+// Dir returns an empty string.
+func (m NoopMounter) Dir() string {
+	return ""
+}

--- a/libfuse/mounter.go
+++ b/libfuse/mounter.go
@@ -122,3 +122,26 @@ func volumeName(dir string) (string, error) {
 	}
 	return volName, nil
 }
+
+// NoopMounter is a mounter that does nothing.
+type NoopMounter struct{}
+
+// NewNoopMounter creates a mounter that does nothing.
+func NewNoopMounter() NoopMounter {
+	return NoopMounter{}
+}
+
+// Mount doesn't mount anything, and returns a nil connection.
+func (m NoopMounter) Mount() (*fuse.Conn, error) {
+	return nil, nil
+}
+
+// Unmount doesn't do anything.
+func (m NoopMounter) Unmount() error {
+	return nil
+}
+
+// Dir returns an empty string.
+func (m NoopMounter) Dir() string {
+	return ""
+}

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -72,7 +72,11 @@ func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.
 		ch := make(chan struct{}, 1)
 		doneChan = ch
 		onInterruptFn = func() {
-			ch <- struct{}{}
+			select {
+			case ch <- struct{}{}:
+				libkbfs.Shutdown()
+			default:
+			}
 		}
 	}
 

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -42,24 +42,38 @@ func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.
 	if err != nil {
 		return libfs.MountError(err.Error())
 	}
-	defer c.Close()
+	var doneChan <-chan struct{}
+	var onInterruptFn func()
 
-	onInterruptFn := func() {
-		select {
-		case <-c.Ready:
-			// Was mounted, so try to unmount if it was successful.
-			if c.MountError == nil {
-				err = mounter.Unmount()
-				if err != nil {
-					return
+	if c != nil {
+		defer c.Close()
+
+		doneChan = c.Ready
+		onInterruptFn = func() {
+			select {
+			case <-c.Ready:
+				// Was mounted, so try to unmount if it was successful.
+				if c.MountError == nil {
+					err = mounter.Unmount()
+					if err != nil {
+						return
+					}
 				}
-			}
 
-		default:
-			// Was not mounted successfully yet, so do nothing. Note that the mount
-			// could still happen, but that's a rare enough edge case.
+			default:
+				// Was not mounted successfully yet, so do nothing. Note that the mount
+				// could still happen, but that's a rare enough edge case.
+			}
+			libkbfs.Shutdown()
 		}
-		libkbfs.Shutdown()
+	} else {
+		// When there's no mount, declare ourselves done when we get
+		// an interrupt.
+		ch := make(chan struct{}, 1)
+		doneChan = ch
+		onInterruptFn = func() {
+			ch <- struct{}{}
+		}
 	}
 
 	log.Debug("Initializing")
@@ -71,18 +85,22 @@ func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.
 
 	defer libkbfs.Shutdown()
 
-	log.Debug("Creating filesystem")
-	fs := NewFS(config, c, options.KbfsParams.Debug)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = context.WithValue(ctx, CtxAppIDKey, fs)
-	log.Debug("Serving filesystem")
-	fs.Serve(ctx)
+	if c != nil {
+		log.Debug("Creating filesystem")
+		fs := NewFS(config, c, options.KbfsParams.Debug)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ctx = context.WithValue(ctx, CtxAppIDKey, fs)
+		log.Debug("Serving filesystem")
+		fs.Serve(ctx)
+	}
 
-	<-c.Ready
-	err = c.MountError
-	if err != nil {
-		return libfs.MountError(err.Error())
+	<-doneChan
+	if c != nil {
+		err = c.MountError
+		if err != nil {
+			return libfs.MountError(err.Error())
+		}
 	}
 
 	log.Debug("Ending")


### PR DESCRIPTION
This will let us easily enable mountless KBFS daemons on systems where mounting isn't possible due to incompatibility, but we still want to run KBFS for rekey/chat purposes.

cc: @maxtaco 

Issue: KBFS-1560