### PR TITLE
folder_block_ops: clean up blocks based on policy of first failure 

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2419,7 +2419,7 @@ func (fbo *folderBlockOps) cleanUpUnusedBlocks(ctx context.Context,
 	// status is different (e.g., we ended up on a conflict branch),
 	// clean it up only if the original revision failed.  If the same
 	// block appears more than once, the one with a different merged
-	// status takes precedence (which will always come earlier ni the
+	// status takes precedence (which will always come earlier in the
 	// list of MDs).
 	blocksSeen := make(map[BlockPointer]bool)
 	for _, oldMD := range syncState.si.toCleanIfUnused {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2331,7 +2331,7 @@ func (fbo *folderBlockOps) CleanupSyncState(
 		// Save this MD for later, so we can clean up its
 		// newly-referenced block pointers if necessary.
 		result.si.toCleanIfUnused = append(result.si.toCleanIfUnused,
-			mdToCleanIfUnused{md, result.si.bps})
+			mdToCleanIfUnused{md, result.si.bps.DeepCopy()})
 	}
 	if isRecoverableBlockError(err) {
 		if df := fbo.dirtyFiles[file.tailPointer()]; df != nil {


### PR DESCRIPTION
Otherwise a block that carries over from one failed sync to another could get incorrectly deleted if the first failed sync actually succeeded on the master branch.

Also, deep-copy the bps when saving a MD to clean.  Otherwise if a future sync also fails, the blocks from that failed sync will also appear in the bps of the previous failed sync, and will get incorrectly cleaned up with the policy of the first failed sync.

Issue: KBFS-1569