### PR TITLE
Fix gobuild to use local KBFS in Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,7 +35,7 @@ dependencies:
     - npm install
     - npm install -g react-native-cli
     - ln -s $HOME/kbfs $GOPATH/src/github.com/keybase/kbfs
-    - (cd $GOPATH/src/github.com/keybase/client/react-native; npm run gobuild-android)
+    - (cd $GOPATH/src/github.com/keybase/client/react-native; LOCAL_KBFS=1 npm run gobuild-android)
 test:
   override:
     # Just testing builds


### PR DESCRIPTION
This arg makes it use existing KBFS in go path.