### PR TITLE
journal: interleave blocks and MDs, and limit block parallelism

### DIFF
--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -45,6 +45,7 @@ func makeFakeBlockJournalEntryFuture(t *testing.T) blockJournalEntryFuture {
 					makeFakeBlockContext(t),
 				},
 			},
+			MetadataRevisionInitial,
 			codec.UnknownFieldSetHandler{},
 		},
 		makeExtraOrBust("blockJournalEntry", t),

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -314,11 +314,13 @@ func TestBlockJournalFlush(t *testing.T) {
 		// Test that the end parameter is respected.
 		var partialEntries blockEntriesToFlush
 		if end > 1 {
-			partialEntries, err = j.getNextEntriesToFlush(ctx, end-1)
+			partialEntries, _, err = j.getNextEntriesToFlush(ctx, end-1,
+				maxJournalParallelBlockFlushes)
 			require.NoError(t, err)
 		}
 
-		entries, err := j.getNextEntriesToFlush(ctx, end)
+		entries, _, err := j.getNextEntriesToFlush(ctx, end,
+			maxJournalParallelBlockFlushes)
 		require.NoError(t, err)
 		require.Equal(t, partialEntries.length()+1, entries.length())
 
@@ -405,7 +407,8 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 	flushOne := func() {
 		first, err := j.j.readEarliestOrdinal()
 		require.NoError(t, err)
-		entries, err := j.getNextEntriesToFlush(ctx, first+1)
+		entries, _, err := j.getNextEntriesToFlush(ctx, first+1,
+			maxJournalParallelBlockFlushes)
 		require.NoError(t, err)
 		require.Equal(t, 1, entries.length())
 		err = flushBlockEntries(ctx, j.log, blockServer,
@@ -500,7 +503,8 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 	end, err := j.end()
 	require.NoError(t, err)
-	entries, err := j.getNextEntriesToFlush(ctx, end)
+	entries, _, err := j.getNextEntriesToFlush(ctx, end,
+		maxJournalParallelBlockFlushes)
 	require.NoError(t, err)
 	require.Equal(t, 0, entries.length())
 

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -315,12 +315,12 @@ func TestBlockJournalFlush(t *testing.T) {
 		var partialEntries blockEntriesToFlush
 		if end > 1 {
 			partialEntries, _, err = j.getNextEntriesToFlush(ctx, end-1,
-				maxJournalParallelBlockFlushes)
+				maxJournalBlockFlushBatchSize)
 			require.NoError(t, err)
 		}
 
 		entries, _, err := j.getNextEntriesToFlush(ctx, end,
-			maxJournalParallelBlockFlushes)
+			maxJournalBlockFlushBatchSize)
 		require.NoError(t, err)
 		require.Equal(t, partialEntries.length()+1, entries.length())
 
@@ -408,7 +408,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 		first, err := j.j.readEarliestOrdinal()
 		require.NoError(t, err)
 		entries, _, err := j.getNextEntriesToFlush(ctx, first+1,
-			maxJournalParallelBlockFlushes)
+			maxJournalBlockFlushBatchSize)
 		require.NoError(t, err)
 		require.Equal(t, 1, entries.length())
 		err = flushBlockEntries(ctx, j.log, blockServer,
@@ -504,7 +504,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 	end, err := j.end()
 	require.NoError(t, err)
 	entries, _, err := j.getNextEntriesToFlush(ctx, end,
-		maxJournalParallelBlockFlushes)
+		maxJournalBlockFlushBatchSize)
 	require.NoError(t, err)
 	require.Equal(t, 0, entries.length())
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -46,10 +46,10 @@ func (ca tlfJournalConfigAdapter) encryptionKeyGetter() encryptionKeyGetter {
 }
 
 const (
-	// Maximum number of blocks that can be sent in parallel by the
-	// journal.  TODO: make this configurable, so that users can
-	// choose how much bandwidth is used by the journal.
-	maxJournalParallelBlockFlushes = 10
+	// Maximum number of blocks that can be flushed in a single batch
+	// by the journal.  TODO: make this configurable, so that users
+	// can choose how much bandwidth is used by the journal.
+	maxJournalBlockFlushBatchSize = 25
 )
 
 // TLFJournalStatus represents the status of a TLF's journal for
@@ -566,7 +566,7 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 		}
 		flushedBlockEntries += numFlushed
 
-		if maxMDRevToFlush == MetadataRevisionUninitialized && numFlushed == 0 {
+		if numFlushed == 0 {
 			// There were no blocks to flush, so we can flush all of
 			// the remaining MDs.
 			maxMDRevToFlush = mdEnd
@@ -615,7 +615,7 @@ func (j *tlfJournal) getNextBlockEntriesToFlush(
 	}
 
 	return j.blockJournal.getNextEntriesToFlush(ctx, end,
-		maxJournalParallelBlockFlushes)
+		maxJournalBlockFlushBatchSize)
 }
 
 func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1037,6 +1037,11 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		return MdID{}, err
 	}
 
+	err = j.blockJournal.markMDRevision(ctx, rmd.Revision())
+	if err != nil {
+		return MdID{}, err
+	}
+
 	j.signalWork()
 
 	return mdID, nil

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -920,7 +920,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 
 	// Revision 1
 	var bids []BlockID
-	rev1BlockEnd := maxJournalParallelBlockFlushes * 2
+	rev1BlockEnd := maxJournalBlockFlushBatchSize * 2
 	for i := 0; i < rev1BlockEnd; i++ {
 		data := []byte{byte(i)}
 		bid, bCtx, serverHalf := config.makeBlock(data)
@@ -933,7 +933,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 	require.NoError(t, err)
 
 	// Revision 2
-	rev2BlockEnd := rev1BlockEnd + maxJournalParallelBlockFlushes*2
+	rev2BlockEnd := rev1BlockEnd + maxJournalBlockFlushBatchSize*2
 	for i := rev1BlockEnd; i < rev2BlockEnd; i++ {
 		data := []byte{byte(i)}
 		bid, bCtx, serverHalf := config.makeBlock(data)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -954,6 +954,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 	// put; rev2 comes last; some blocks are put between the two.
 	bidsSeen := make(map[BlockID]bool)
 	md1Slot := 0
+	md2Slot := 0
 	for i, put := range puts {
 		if bid, ok := put.(BlockID); ok {
 			t.Logf("Saw bid %s at %d", bid, i)
@@ -970,9 +971,12 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 				require.True(t, bidsSeen[bids[j]])
 			}
 		} else if mdID == md2.Revision() {
+			md2Slot = i
 			require.NotZero(t, md1Slot)
 			require.True(t, md1Slot+1 < i)
 			require.Equal(t, i, len(puts)-1)
 		}
 	}
+	require.NotZero(t, md1Slot)
+	require.NotZero(t, md2Slot)
 }

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -596,7 +596,7 @@ func TestTLFJournalFlushMDBasic(t *testing.T) {
 	flushed, err := tlfJournal.flushOneMDOp(ctx, mdEnd)
 	require.NoError(t, err)
 	require.False(t, flushed)
-	requireJournalEntryCounts(t, tlfJournal, 0, 0)
+	requireJournalEntryCounts(t, tlfJournal, uint64(mdCount), 0)
 	testMDJournalGCd(t, tlfJournal.mdJournal)
 
 	// Check RMDSes on the server.
@@ -670,7 +670,7 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 	flushed, err := tlfJournal.flushOneMDOp(ctx, mdEnd)
 	require.NoError(t, err)
 	require.False(t, flushed)
-	requireJournalEntryCounts(t, tlfJournal, 0, 0)
+	requireJournalEntryCounts(t, tlfJournal, uint64(mdCount), 0)
 	testMDJournalGCd(t, tlfJournal.mdJournal)
 
 	// Check RMDSes on the server.
@@ -721,7 +721,7 @@ func TestTLFJournalPreservesBranchID(t *testing.T) {
 	flushed, err := tlfJournal.flushOneMDOp(ctx, mdEnd)
 	require.NoError(t, err)
 	require.False(t, flushed)
-	requireJournalEntryCounts(t, tlfJournal, 0, 0)
+	requireJournalEntryCounts(t, tlfJournal, uint64(mdCount)-1, 0)
 	testMDJournalGCd(t, tlfJournal.mdJournal)
 
 	// Put last revision and flush it.
@@ -745,7 +745,7 @@ func TestTLFJournalPreservesBranchID(t *testing.T) {
 		flushed, err = tlfJournal.flushOneMDOp(ctx, mdEnd)
 		require.NoError(t, err)
 		require.False(t, flushed)
-		requireJournalEntryCounts(t, tlfJournal, 0, 0)
+		requireJournalEntryCounts(t, tlfJournal, uint64(mdCount), 0)
 		testMDJournalGCd(t, tlfJournal.mdJournal)
 	}
 


### PR DESCRIPTION
Limit the number of blocks we process at once during a flush, and when that's done, move onto flushing whatever MDs we can.

Issue: KBFS-1564
Issue: KBFS-1575