### PR TITLE
[KBFS-1581] Don't archive GC ops

### DIFF
--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -305,6 +305,10 @@ func isArchivableOp(op op) bool {
 }
 
 func isArchivableMDOrError(md ReadOnlyRootMetadata) error {
+	if md.MergedStatus() != Merged {
+		return fmt.Errorf("md rev=%d is not merged", md.Revision())
+	}
+
 	for _, op := range md.data.Changes.Ops {
 		if !isArchivableOp(op) {
 			return fmt.Errorf(

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4788,7 +4788,7 @@ func (fbo *folderBranchOps) onTLFBranchChange(newBID BranchID) {
 
 func (fbo *folderBranchOps) handleMDFlush(ctx context.Context, bid BranchID,
 	rev MetadataRevision) {
-	fbo.log.CDebugf(ctx, "Archiving references for flushed MD revision %d", rev)
+	fbo.log.CDebugf(ctx, "Considering archiving references for flushed MD revision %d", rev)
 
 	// Get that revision.
 	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), NullBranchID,
@@ -4805,6 +4805,12 @@ func (fbo *folderBranchOps) handleMDFlush(ctx context.Context, bid BranchID,
 	lState := makeFBOLockState()
 	fbo.mdWriterLock.Lock(lState)
 	defer fbo.mdWriterLock.Unlock(lState)
+
+	if err := isArchivableMDOrError(rmd.ReadOnly()); err != nil {
+		fbo.log.CDebugf(
+			ctx, "Skipping archiving references for flushed MD revision %d: %s", rev, err)
+		return
+	}
 
 	fbo.fbm.archiveUnrefBlocks(rmd.ReadOnly())
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4799,18 +4799,18 @@ func (fbo *folderBranchOps) handleMDFlush(ctx context.Context, bid BranchID,
 		return
 	}
 
+	if err := isArchivableMDOrError(rmd.ReadOnly()); err != nil {
+		fbo.log.CDebugf(
+			ctx, "Skipping archiving references for flushed MD revision %d: %s", rev, err)
+		return
+	}
+
 	// We must take the lock so that other users, like exclusive file
 	// creation, can wait for the journal to flush while holding the
 	// lock, and be guaranteed it will stay flushed.
 	lState := makeFBOLockState()
 	fbo.mdWriterLock.Lock(lState)
 	defer fbo.mdWriterLock.Unlock(lState)
-
-	if err := isArchivableMDOrError(rmd.ReadOnly()); err != nil {
-		fbo.log.CDebugf(
-			ctx, "Skipping archiving references for flushed MD revision %d: %s", rev, err)
-		return
-	}
 
 	fbo.fbm.archiveUnrefBlocks(rmd.ReadOnly())
 }


### PR DESCRIPTION
This gets us into a bad state, since
the BlockServer rightly returns an error
that the blocks in question aren't
archivable.