### PR TITLE
folder_branch_ops: don't set latest merged revision to 0 

### DIFF
--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -157,6 +157,7 @@ func (s *NaïveStaller) StallMDOp(stalledOp StallableMDOp, maxStalls int,
 			},
 			delegate: jServer.delegateMDOps,
 		}
+		s.config.SetMDOps(jServer.mdOps())
 	} else {
 		s.config.SetMDOps(&stallingMDOps{
 			stallOpName: stalledOp,


### PR DESCRIPTION
We did this under journaling when there was a branch change, because
it's hard to know the right merged revision number in that code.
However, this messes up the registration code, and can cause the
client to fetch ALL revisions for no good reason.

Instead, `handleMDFlush` should be in charge of setting the latest
revision number for MDs flushed by this device, and `setHeadLocked`
should only set them for other devices, when journaling is enabled.

Issue: KBFS-1590