### PR TITLE
run identify in cryptkeys and plumb through IdentifyTrackBreaks

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/keybase/client/go/libkb"
@@ -12,61 +13,131 @@ import (
 	"golang.org/x/net/context"
 )
 
-func identifyUID(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uid keybase1.UID, isPublic bool) error {
+func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, uid keybase1.UID, isPublic bool) error {
+	_, _, err := identifyUIDWithIdentifyBehavior(ctx,
+		nug, identifier, uid, isPublic, keybase1.TLFIdentifyBehavior_DEFAULT_KBFS)
+	return err
+}
+
+func identifyUIDWithIdentifyBehavior(ctx context.Context,
+	nug normalizedUsernameGetter, identifier identifier, uid keybase1.UID,
+	isPublic bool, identifyBehavior keybase1.TLFIdentifyBehavior) (
+	libkb.NormalizedUsername, *keybase1.IdentifyTrackBreaks, error) {
 	username, err := nug.GetNormalizedUsername(ctx, uid)
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 	var reason string
 	if isPublic {
 		reason = "You accessed a public folder."
 	} else {
-		reason = fmt.Sprintf("You accessed a private folder with %s.", username.String())
+		reason = fmt.Sprintf("You accessed a private folder with %s.",
+			username.String())
 	}
-	userInfo, err := identifier.Identify(ctx, username.String(), reason)
-	if err != nil {
-		// Convert libkb.NoSigChainError into one we can report.  (See
-		// KBFS-1252).
-		if _, ok := err.(libkb.NoSigChainError); ok {
-			return NoSigChainError{username}
+
+	var (
+		userInfo UserInfo
+		breaks   *keybase1.IdentifyTrackBreaks
+	)
+	switch identifyBehavior {
+	case keybase1.TLFIdentifyBehavior_DEFAULT_KBFS:
+		userInfo, err = identifier.Identify(ctx, username.String(), reason)
+		if err != nil {
+			// Convert libkb.NoSigChainError into one we can report.  (See
+			// KBFS-1252).
+			if _, ok := err.(libkb.NoSigChainError); ok {
+				return "", nil, NoSigChainError{username}
+			}
+			return "", nil, err
 		}
-		return err
+	case keybase1.TLFIdentifyBehavior_CHAT:
+		userInfo, breaks, err = identifier.IdentifyForChat(
+			ctx, username.String(), reason)
+		if err != nil {
+			// Convert libkb.NoSigChainError into one we can report.  (See
+			// KBFS-1252).
+			if _, ok := err.(libkb.NoSigChainError); ok {
+				return "", nil, NoSigChainError{username}
+			}
+			return "", nil, err
+		}
+	default:
+		return "", nil, errors.New("unknown identifyBehavior")
 	}
+
 	if userInfo.Name != username {
-		return fmt.Errorf("Identify returned name=%s, expected %s", userInfo.Name, username)
+		return "", nil, fmt.Errorf("Identify returned name=%s, expected %s",
+			userInfo.Name, username)
 	}
 	if userInfo.UID != uid {
-		return fmt.Errorf("Identify returned uid=%s, expected %s", userInfo.UID, uid)
+		return "", nil, fmt.Errorf("Identify returned uid=%s, expected %s",
+			userInfo.UID, uid)
 	}
-	return nil
+
+	return username, breaks, nil
 }
 
 // identifyUserList identifies the users in the given list.
-func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID, public bool) error {
+func identifyUserList(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, uids []keybase1.UID, public bool) error {
+	_, err := identifyUserListWithIdentifyBehavior(ctx,
+		nug, identifier, uids, public, keybase1.TLFIdentifyBehavior_DEFAULT_KBFS)
+	return err
+}
+
+func identifyUserListWithIdentifyBehavior(ctx context.Context,
+	nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID,
+	public bool, identifyBehavior keybase1.TLFIdentifyBehavior) (
+	map[libkb.NormalizedUsername]*keybase1.IdentifyTrackBreaks, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	errChan := make(chan error, len(uids))
+	type jobRes struct {
+		err      error
+		breaks   *keybase1.IdentifyTrackBreaks
+		username libkb.NormalizedUsername
+	}
+
+	errChan := make(chan jobRes, len(uids))
 	// TODO: limit the number of concurrent identifies?
 	for _, uid := range uids {
 		go func(uid keybase1.UID) {
-			err := identifyUID(ctx, nug, identifier, uid, public)
-			errChan <- err
+			username, breaks, err := identifyUIDWithIdentifyBehavior(
+				ctx, nug, identifier, uid, public, identifyBehavior)
+			errChan <- jobRes{
+				err:      err,
+				breaks:   breaks,
+				username: username,
+			}
 		}(uid)
 	}
 
+	breaksMap := make(map[libkb.NormalizedUsername]*keybase1.IdentifyTrackBreaks)
 	for i := 0; i < len(uids); i++ {
-		err := <-errChan
-		if err != nil {
-			return err
+		res := <-errChan
+		if res.err != nil {
+			return nil, res.err
 		}
+		breaksMap[res.username] = res.breaks
 	}
 
-	return nil
+	return breaksMap, nil
 }
 
 // identifyHandle identifies the canonical names in the given handle.
-func identifyHandle(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, h *TlfHandle) error {
+func identifyHandle(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, h *TlfHandle) error {
+	_, err := identifyHandleWithIdentifyBehavior(ctx, nug, identifier, h,
+		keybase1.TLFIdentifyBehavior_DEFAULT_KBFS)
+	return err
+}
+
+func identifyHandleWithIdentifyBehavior(
+	ctx context.Context, nug normalizedUsernameGetter, identifier identifier,
+	h *TlfHandle, identifyBehavior keybase1.TLFIdentifyBehavior) (
+	map[libkb.NormalizedUsername]*keybase1.IdentifyTrackBreaks, error) {
 	uids := append(h.ResolvedWriters(), h.ResolvedReaders()...)
-	return identifyUserList(ctx, nug, identifier, uids, h.IsPublic())
+	return identifyUserListWithIdentifyBehavior(
+		ctx, nug, identifier, uids, h.IsPublic(), identifyBehavior)
 }

--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -52,6 +53,11 @@ func (ti *testIdentifier) Identify(
 	}()
 
 	return userInfo, nil
+}
+
+func (ti *testIdentifier) IdentifyForChat(ctx context.Context,
+	assertion, reason string) (UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	return UserInfo{}, nil, errors.New("unimplemented")
 }
 
 func TestIdentify(t *testing.T) {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -298,6 +298,9 @@ type KeybaseService interface {
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (UserInfo, error)
 
+	IdentifyForChat(ctx context.Context, assertion, reason string) (
+		UserInfo, *keybase1.IdentifyTrackBreaks, error)
+
 	// LoadUserPlusKeys returns a UserInfo struct for a
 	// user with the specified UID.
 	// If you have the UID for a user and don't require Identify to
@@ -378,6 +381,8 @@ type identifier interface {
 	// necessary.  The reason string is displayed on any tracker
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (UserInfo, error)
+	IdentifyForChat(ctx context.Context, assertion, reason string) (
+		UserInfo, *keybase1.IdentifyTrackBreaks, error)
 }
 
 type normalizedUsernameGetter interface {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -83,6 +83,13 @@ func (k *KBPKIClient) Identify(ctx context.Context, assertion, reason string) (
 	return k.config.KeybaseService().Identify(ctx, assertion, reason)
 }
 
+// IdentifyForChat implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) IdentifyForChat(
+	ctx context.Context, assertion, reason string) (
+	UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	return k.config.KeybaseService().IdentifyForChat(ctx, assertion, reason)
+}
+
 // GetNormalizedUsername implements the KBPKI interface for
 // KBPKIClient.
 func (k *KBPKIClient) GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -218,6 +218,13 @@ func (k *KeybaseDaemonLocal) Identify(ctx context.Context, assertion, reason str
 	return infoCopy, nil
 }
 
+// IdentifyForChat implements KeybaseDaemon for KeybaseDaemonLocal.
+func (k *KeybaseDaemonLocal) IdentifyForChat(
+	ctx context.Context, assertion, reason string) (
+	UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	return UserInfo{}, nil, errors.New("unimplemented")
+}
+
 // LoadUserPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (UserInfo, error) {
 	k.lock.Lock()

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -280,9 +280,9 @@ func (k *KeybaseServiceBase) Resolve(ctx context.Context, assertion string) (
 	return libkb.NewNormalizedUsername(user.Username), user.Uid, nil
 }
 
-// Identify implements the KeybaseService interface for KeybaseServiceBase.
-func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason string) (
-	UserInfo, error) {
+func (k *KeybaseServiceBase) identify(
+	ctx context.Context, assertion string, reason string, chatGUIMode bool) (
+	UserInfo, *keybase1.IdentifyTrackBreaks, error) {
 	// setting UseDelegateUI to true here will cause daemon to use
 	// registered identify ui providers instead of terminal if any
 	// are available.  If not, then it will use the terminal UI.
@@ -290,6 +290,7 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 		UserAssertion: assertion,
 		UseDelegateUI: true,
 		Reason:        keybase1.IdentifyReason{Reason: reason},
+		ChatGUIMode:   chatGUIMode,
 	}
 	res, err := k.identifyClient.Identify2(ctx, arg)
 	// Identify2 still returns keybase1.UserPlusKeys data (sans keys),
@@ -301,10 +302,28 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 		k.log.CDebugf(ctx, "Ignoring error (%s) for user %s with no sigchain",
 			err, res.Upk.Username)
 	} else if err != nil {
-		return UserInfo{}, ConvertIdentifyError(assertion, err)
+		return UserInfo{}, nil, ConvertIdentifyError(assertion, err)
 	}
 
-	return k.processUserPlusKeys(res.Upk)
+	userInfo, err := k.processUserPlusKeys(res.Upk)
+	if err != nil {
+		return UserInfo{}, nil, err
+	}
+
+	return userInfo, res.TrackBreaks, nil
+}
+
+// Identify implements the KeybaseService interface for KeybaseServiceBase.
+func (k *KeybaseServiceBase) Identify(
+	ctx context.Context, assertion, reason string) (UserInfo, error) {
+	userInfo, _, err := k.identify(ctx, assertion, reason, false)
+	return userInfo, err
+}
+
+func (k *KeybaseServiceBase) IdentifyForChat(
+	ctx context.Context, assertion, reason string) (
+	UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	return k.identify(ctx, assertion, reason, true)
 }
 
 // LoadUserPlusKeys implements the KeybaseService interface for KeybaseServiceBase.
@@ -495,16 +514,17 @@ const (
 const CtxKeybaseServiceOpID = "KSID"
 
 func (k *KeybaseServiceBase) getHandleFromFolderName(ctx context.Context,
-	tlfName string, public bool) (*TlfHandle, error) {
+	tlfName string, public bool, identifyBehavior keybase1.TLFIdentifyBehavior) (
+	*TlfHandle, map[libkb.NormalizedUsername]*keybase1.IdentifyTrackBreaks, error) {
 	for {
-		tlfHandle, err := ParseTlfHandle(ctx, k.config.KBPKI(), tlfName, public)
+		tlfHandle, breaks, err := ParseTlfHandleWithIdentifyBehavior(ctx, k.config.KBPKI(), tlfName, public, identifyBehavior)
 		switch e := err.(type) {
 		case TlfNameNotCanonical:
 			tlfName = e.NameToTry
 		case nil:
-			return tlfHandle, nil
+			return tlfHandle, breaks, nil
 		default:
-			return nil, err
+			return nil, nil, err
 		}
 	}
 }
@@ -517,8 +537,8 @@ func (k *KeybaseServiceBase) FSEditListRequest(ctx context.Context,
 		k.log)
 	k.log.CDebugf(ctx, "Edit list request for %s (public: %t)",
 		req.Folder.Name, !req.Folder.Private)
-	tlfHandle, err := k.getHandleFromFolderName(ctx, req.Folder.Name,
-		!req.Folder.Private)
+	tlfHandle, _, err := k.getHandleFromFolderName(ctx, req.Folder.Name,
+		!req.Folder.Private, keybase1.TLFIdentifyBehavior_DEFAULT_KBFS)
 	if err != nil {
 		return err
 	}
@@ -592,10 +612,12 @@ func (k *KeybaseServiceBase) FSSyncStatusRequest(ctx context.Context,
 // GetTLFCryptKeys implements the TlfKeysInterface interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
-	tlfName string) (res keybase1.TLFCryptKeys, err error) {
-	ctx = ctxWithRandomIDReplayable(ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID,
-		k.log)
-	tlfHandle, err := k.getHandleFromFolderName(ctx, tlfName, false)
+	arg keybase1.GetTLFCryptKeysArg) (
+	res keybase1.GetTLFCryptKeysRes, err error) {
+	ctx = ctxWithRandomIDReplayable(
+		ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log)
+	tlfHandle, breaks, err := k.getHandleFromFolderName(
+		ctx, arg.TlfName, false, arg.IdentifyBehavior)
 	if err != nil {
 		return res, err
 	}
@@ -615,16 +637,27 @@ func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
 		})
 	}
 
+	for username, breaks := range breaks {
+		if breaks != nil {
+			res.Breaks = append(res.Breaks, keybase1.TLFBreak{
+				Username: string(username),
+				Breaks:   *breaks,
+			})
+		}
+	}
+
 	return res, nil
 }
 
 // GetPublicCanonicalTLFNameAndID implements the TlfKeysInterface interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(ctx context.Context,
-	tlfName string) (res keybase1.CanonicalTLFNameAndID, err error) {
-	ctx = ctxWithRandomIDReplayable(ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID,
-		k.log)
-	tlfHandle, err := k.getHandleFromFolderName(ctx, tlfName, true /* public */)
+	arg keybase1.GetPublicCanonicalTLFNameAndIDArg) (
+	res keybase1.CanonicalTLFNameAndIDWithBreaks, err error) {
+	ctx = ctxWithRandomIDReplayable(
+		ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log)
+	tlfHandle, breaks, err := k.getHandleFromFolderName(
+		ctx, arg.TlfName, true /* public */, arg.IdentifyBehavior)
 	if err != nil {
 		return res, err
 	}
@@ -636,6 +669,15 @@ func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(ctx context.Context,
 		return res, err
 	}
 	res.TlfID = keybase1.TLFID(id.String())
+
+	for username, breaks := range breaks {
+		if breaks != nil {
+			res.Breaks = append(res.Breaks, keybase1.TLFBreak{
+				Username: string(username),
+				Breaks:   *breaks,
+			})
+		}
+	}
 
 	return res, nil
 }

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -64,12 +64,22 @@ func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
 }
 
 // Identify implements the KeybaseService interface for KeybaseServiceMeasured.
-func (k KeybaseServiceMeasured) Identify(ctx context.Context, assertion, reason string) (
-	userInfo UserInfo, err error) {
+func (k KeybaseServiceMeasured) Identify(
+	ctx context.Context, assertion, reason string) (userInfo UserInfo, err error) {
 	k.identifyTimer.Time(func() {
 		userInfo, err = k.delegate.Identify(ctx, assertion, reason)
 	})
 	return userInfo, err
+}
+
+// IdentifyForChat implements KeybaseDaemon for KeybaseDaemonLocal.
+func (k KeybaseServiceMeasured) IdentifyForChat(
+	ctx context.Context, assertion, reason string) (
+	userInfo UserInfo, breaks *keybase1.IdentifyTrackBreaks, err error) {
+	k.identifyTimer.Time(func() {
+		userInfo, breaks, err = k.delegate.IdentifyForChat(ctx, assertion, reason)
+	})
+	return userInfo, breaks, err
 }
 
 // LoadUserPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -562,6 +562,18 @@ func (_mr *_MockKeybaseServiceRecorder) Identify(arg0, arg1, arg2 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Identify", arg0, arg1, arg2)
 }
 
+func (_m *MockKeybaseService) IdentifyForChat(ctx context.Context, assertion string, reason string) (UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	ret := _m.ctrl.Call(_m, "IdentifyForChat", ctx, assertion, reason)
+	ret0, _ := ret[0].(UserInfo)
+	ret1, _ := ret[1].(*keybase1.IdentifyTrackBreaks)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockKeybaseServiceRecorder) IdentifyForChat(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifyForChat", arg0, arg1, arg2)
+}
+
 func (_m *MockKeybaseService) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (UserInfo, error) {
 	ret := _m.ctrl.Call(_m, "LoadUserPlusKeys", ctx, uid)
 	ret0, _ := ret[0].(UserInfo)
@@ -778,6 +790,18 @@ func (_mr *_MockidentifierRecorder) Identify(arg0, arg1, arg2 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Identify", arg0, arg1, arg2)
 }
 
+func (_m *Mockidentifier) IdentifyForChat(ctx context.Context, assertion string, reason string) (UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	ret := _m.ctrl.Call(_m, "IdentifyForChat", ctx, assertion, reason)
+	ret0, _ := ret[0].(UserInfo)
+	ret1, _ := ret[1].(*keybase1.IdentifyTrackBreaks)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockidentifierRecorder) IdentifyForChat(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifyForChat", arg0, arg1, arg2)
+}
+
 // Mock of normalizedUsernameGetter interface
 type MocknormalizedUsernameGetter struct {
 	ctrl     *gomock.Controller
@@ -963,6 +987,18 @@ func (_m *MockKBPKI) Identify(ctx context.Context, assertion string, reason stri
 
 func (_mr *_MockKBPKIRecorder) Identify(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Identify", arg0, arg1, arg2)
+}
+
+func (_m *MockKBPKI) IdentifyForChat(ctx context.Context, assertion string, reason string) (UserInfo, *keybase1.IdentifyTrackBreaks, error) {
+	ret := _m.ctrl.Call(_m, "IdentifyForChat", ctx, assertion, reason)
+	ret0, _ := ret[0].(UserInfo)
+	ret1, _ := ret[1].(*keybase1.IdentifyTrackBreaks)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockKBPKIRecorder) IdentifyForChat(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IdentifyForChat", arg0, arg1, arg2)
 }
 
 func (_m *MockKBPKI) GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error) {
@@ -2619,32 +2655,32 @@ func (_mr *_MockBlockOpsRecorder) Archive(arg0, arg1, arg2 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Archive", arg0, arg1, arg2)
 }
 
-// Mock of AuthTokenRefreshHandler interface
-type MockAuthTokenRefreshHandler struct {
+// Mock of authTokenRefreshHandler interface
+type MockauthTokenRefreshHandler struct {
 	ctrl     *gomock.Controller
-	recorder *_MockAuthTokenRefreshHandlerRecorder
+	recorder *_MockauthTokenRefreshHandlerRecorder
 }
 
-// Recorder for MockAuthTokenRefreshHandler (not exported)
-type _MockAuthTokenRefreshHandlerRecorder struct {
-	mock *MockAuthTokenRefreshHandler
+// Recorder for MockauthTokenRefreshHandler (not exported)
+type _MockauthTokenRefreshHandlerRecorder struct {
+	mock *MockauthTokenRefreshHandler
 }
 
-func NewMockAuthTokenRefreshHandler(ctrl *gomock.Controller) *MockAuthTokenRefreshHandler {
-	mock := &MockAuthTokenRefreshHandler{ctrl: ctrl}
-	mock.recorder = &_MockAuthTokenRefreshHandlerRecorder{mock}
+func NewMockauthTokenRefreshHandler(ctrl *gomock.Controller) *MockauthTokenRefreshHandler {
+	mock := &MockauthTokenRefreshHandler{ctrl: ctrl}
+	mock.recorder = &_MockauthTokenRefreshHandlerRecorder{mock}
 	return mock
 }
 
-func (_m *MockAuthTokenRefreshHandler) EXPECT() *_MockAuthTokenRefreshHandlerRecorder {
+func (_m *MockauthTokenRefreshHandler) EXPECT() *_MockauthTokenRefreshHandlerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockAuthTokenRefreshHandler) RefreshAuthToken(_param0 context.Context) {
+func (_m *MockauthTokenRefreshHandler) RefreshAuthToken(_param0 context.Context) {
 	_m.ctrl.Call(_m, "RefreshAuthToken", _param0)
 }
 
-func (_mr *_MockAuthTokenRefreshHandlerRecorder) RefreshAuthToken(arg0 interface{}) *gomock.Call {
+func (_mr *_MockauthTokenRefreshHandlerRecorder) RefreshAuthToken(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RefreshAuthToken", arg0)
 }
 

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -875,7 +875,7 @@ func (ra resolvableAssertion) resolve(ctx context.Context) (
 
 func ParseTlfHandleWithIdentifyBehavior(ctx context.Context, kbpki KBPKI,
 	name string, public bool, identifyBehavior keybase1.TLFIdentifyBehavior) (
-	*TlfHandle, map[libkb.NormalizedUsername]*keybase1.IdentifyTrackBreaks, error) {
+	*TlfHandle, []keybase1.TLFBreak, error) {
 	// Before parsing the tlf handle (which results in identify
 	// calls that cause tracker popups), first see if there's any
 	// quick normalization of usernames we can do.  For example,
@@ -940,6 +940,8 @@ func ParseTlfHandleWithIdentifyBehavior(ctx context.Context, kbpki KBPKI,
 	}
 
 	switch identifyBehavior {
+	case keybase1.TLFIdentifyBehavior_CHAT_CLI:
+		fallthrough
 	case keybase1.TLFIdentifyBehavior_DEFAULT_KBFS:
 		if string(h.GetCanonicalName()) == name {
 			// Name is already canonical (i.e., all usernames and
@@ -955,9 +957,9 @@ func ParseTlfHandleWithIdentifyBehavior(ctx context.Context, kbpki KBPKI,
 		}
 
 		return nil, nil, TlfNameNotCanonical{name, string(h.GetCanonicalName())}
-	case keybase1.TLFIdentifyBehavior_CHAT:
+	case keybase1.TLFIdentifyBehavior_CHAT_GUI:
 		breaks, err := identifyHandleWithIdentifyBehavior(ctx, kbpki, kbpki, h,
-			keybase1.TLFIdentifyBehavior_CHAT)
+			keybase1.TLFIdentifyBehavior_CHAT_GUI)
 		if err != nil {
 			return nil, breaks, err
 		}

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -958,14 +958,14 @@ func ParseTlfHandleWithIdentifyBehavior(ctx context.Context, kbpki KBPKI,
 
 		return nil, nil, TlfNameNotCanonical{name, string(h.GetCanonicalName())}
 	case keybase1.TLFIdentifyBehavior_CHAT_GUI:
-		breaks, err := identifyHandleWithIdentifyBehavior(ctx, kbpki, kbpki, h,
+		breaks, err := identifyHandleWithBehavior(ctx, kbpki, kbpki, h,
 			keybase1.TLFIdentifyBehavior_CHAT_GUI)
 		if err != nil {
-			return nil, breaks, err
+			return nil, nil, err
 		}
 
 		if string(h.GetCanonicalName()) != name {
-			return nil, breaks, TlfNameNotCanonical{name, string(h.GetCanonicalName())}
+			return nil, nil, TlfNameNotCanonical{name, string(h.GetCanonicalName())}
 		}
 
 		return h, breaks, nil

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/tlf.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/tlf.go
@@ -9,24 +9,27 @@ import (
 )
 
 type CryptKeysArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	TlfName          string              `codec:"tlfName" json:"tlfName"`
+	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type PublicCanonicalTLFNameAndIDArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	TlfName          string              `codec:"tlfName" json:"tlfName"`
+	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type CompleteAndCanonicalizeTlfNameArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	TlfName          string              `codec:"tlfName" json:"tlfName"`
+	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 }
 
 type TlfInterface interface {
 	// CryptKeys returns TLF crypt keys from all generations.
-	CryptKeys(context.Context, string) (TLFCryptKeys, error)
+	CryptKeys(context.Context, CryptKeysArg) (GetTLFCryptKeysRes, error)
 	// * tlfCanonicalID returns the canonical name and TLFID for tlfName.
 	// * TLFID should not be cached or stored persistently.
-	PublicCanonicalTLFNameAndID(context.Context, string) (CanonicalTLFNameAndID, error)
-	CompleteAndCanonicalizeTlfName(context.Context, string) (CanonicalTlfName, error)
+	PublicCanonicalTLFNameAndID(context.Context, PublicCanonicalTLFNameAndIDArg) (CanonicalTLFNameAndIDWithBreaks, error)
+	CompleteAndCanonicalizeTlfName(context.Context, CompleteAndCanonicalizeTlfNameArg) (CanonicalTLFNameAndIDWithBreaks, error)
 }
 
 func TlfProtocol(i TlfInterface) rpc.Protocol {
@@ -44,7 +47,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]CryptKeysArg)(nil), args)
 						return
 					}
-					ret, err = i.CryptKeys(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.CryptKeys(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -60,7 +63,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]PublicCanonicalTLFNameAndIDArg)(nil), args)
 						return
 					}
-					ret, err = i.PublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.PublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -76,7 +79,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]CompleteAndCanonicalizeTlfNameArg)(nil), args)
 						return
 					}
-					ret, err = i.CompleteAndCanonicalizeTlfName(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.CompleteAndCanonicalizeTlfName(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -90,22 +93,19 @@ type TlfClient struct {
 }
 
 // CryptKeys returns TLF crypt keys from all generations.
-func (c TlfClient) CryptKeys(ctx context.Context, tlfName string) (res TLFCryptKeys, err error) {
-	__arg := CryptKeysArg{TlfName: tlfName}
+func (c TlfClient) CryptKeys(ctx context.Context, __arg CryptKeysArg) (res GetTLFCryptKeysRes, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.tlf.CryptKeys", []interface{}{__arg}, &res)
 	return
 }
 
 // * tlfCanonicalID returns the canonical name and TLFID for tlfName.
 // * TLFID should not be cached or stored persistently.
-func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (res CanonicalTLFNameAndID, err error) {
-	__arg := PublicCanonicalTLFNameAndIDArg{TlfName: tlfName}
+func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, __arg PublicCanonicalTLFNameAndIDArg) (res CanonicalTLFNameAndIDWithBreaks, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.tlf.publicCanonicalTLFNameAndID", []interface{}{__arg}, &res)
 	return
 }
 
-func (c TlfClient) CompleteAndCanonicalizeTlfName(ctx context.Context, tlfName string) (res CanonicalTlfName, err error) {
-	__arg := CompleteAndCanonicalizeTlfNameArg{TlfName: tlfName}
+func (c TlfClient) CompleteAndCanonicalizeTlfName(ctx context.Context, __arg CompleteAndCanonicalizeTlfNameArg) (res CanonicalTLFNameAndIDWithBreaks, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.tlf.completeAndCanonicalizeTlfName", []interface{}{__arg}, &res)
 	return
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/tlf.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/tlf.go
@@ -9,27 +9,24 @@ import (
 )
 
 type CryptKeysArg struct {
-	TlfName          string              `codec:"tlfName" json:"tlfName"`
-	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type PublicCanonicalTLFNameAndIDArg struct {
-	TlfName          string              `codec:"tlfName" json:"tlfName"`
-	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type CompleteAndCanonicalizeTlfNameArg struct {
-	TlfName          string              `codec:"tlfName" json:"tlfName"`
-	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type TlfInterface interface {
 	// CryptKeys returns TLF crypt keys from all generations.
-	CryptKeys(context.Context, CryptKeysArg) (GetTLFCryptKeysRes, error)
+	CryptKeys(context.Context, TLFQuery) (GetTLFCryptKeysRes, error)
 	// * tlfCanonicalID returns the canonical name and TLFID for tlfName.
 	// * TLFID should not be cached or stored persistently.
-	PublicCanonicalTLFNameAndID(context.Context, PublicCanonicalTLFNameAndIDArg) (CanonicalTLFNameAndIDWithBreaks, error)
-	CompleteAndCanonicalizeTlfName(context.Context, CompleteAndCanonicalizeTlfNameArg) (CanonicalTLFNameAndIDWithBreaks, error)
+	PublicCanonicalTLFNameAndID(context.Context, TLFQuery) (CanonicalTLFNameAndIDWithBreaks, error)
+	CompleteAndCanonicalizeTlfName(context.Context, TLFQuery) (CanonicalTLFNameAndIDWithBreaks, error)
 }
 
 func TlfProtocol(i TlfInterface) rpc.Protocol {
@@ -47,7 +44,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]CryptKeysArg)(nil), args)
 						return
 					}
-					ret, err = i.CryptKeys(ctx, (*typedArgs)[0])
+					ret, err = i.CryptKeys(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -63,7 +60,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]PublicCanonicalTLFNameAndIDArg)(nil), args)
 						return
 					}
-					ret, err = i.PublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0])
+					ret, err = i.PublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -79,7 +76,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]CompleteAndCanonicalizeTlfNameArg)(nil), args)
 						return
 					}
-					ret, err = i.CompleteAndCanonicalizeTlfName(ctx, (*typedArgs)[0])
+					ret, err = i.CompleteAndCanonicalizeTlfName(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -93,19 +90,22 @@ type TlfClient struct {
 }
 
 // CryptKeys returns TLF crypt keys from all generations.
-func (c TlfClient) CryptKeys(ctx context.Context, __arg CryptKeysArg) (res GetTLFCryptKeysRes, err error) {
+func (c TlfClient) CryptKeys(ctx context.Context, query TLFQuery) (res GetTLFCryptKeysRes, err error) {
+	__arg := CryptKeysArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlf.CryptKeys", []interface{}{__arg}, &res)
 	return
 }
 
 // * tlfCanonicalID returns the canonical name and TLFID for tlfName.
 // * TLFID should not be cached or stored persistently.
-func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, __arg PublicCanonicalTLFNameAndIDArg) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+	__arg := PublicCanonicalTLFNameAndIDArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlf.publicCanonicalTLFNameAndID", []interface{}{__arg}, &res)
 	return
 }
 
-func (c TlfClient) CompleteAndCanonicalizeTlfName(ctx context.Context, __arg CompleteAndCanonicalizeTlfNameArg) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+func (c TlfClient) CompleteAndCanonicalizeTlfName(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+	__arg := CompleteAndCanonicalizeTlfNameArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlf.completeAndCanonicalizeTlfName", []interface{}{__arg}, &res)
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,10 +196,10 @@
 			"revisionTime": "2016-10-03T19:50:03Z"
 		},
 		{
-			"checksumSHA1": "GnpjAHOD/Q/6xCrhSb/lZWzE5XE=",
+			"checksumSHA1": "3wdoMpm1cAr1Fc18hqX4lUL7rj0=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "d735cc8a00ca5b38281a350c699a51f76ceb142b",
-			"revisionTime": "2016-10-03T19:50:03Z"
+			"revision": "06c7ebe681113381745141d2e67e27919d0295ea",
+			"revisionTime": "2016-10-05T04:14:36Z"
 		},
 		{
 			"checksumSHA1": "jnN+Jbtoeb/NFpIi1vdDwokZxgY=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,10 +196,10 @@
 			"revisionTime": "2016-10-03T19:50:03Z"
 		},
 		{
-			"checksumSHA1": "3wdoMpm1cAr1Fc18hqX4lUL7rj0=",
+			"checksumSHA1": "ar5DJmmw5+zM3SEYUGzh6m0dQ9k=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "06c7ebe681113381745141d2e67e27919d0295ea",
-			"revisionTime": "2016-10-05T04:14:36Z"
+			"revision": "00544b5c0f48562049cc1bdc37e070fe46774269",
+			"revisionTime": "2016-10-05T21:54:38Z"
 		},
 		{
 			"checksumSHA1": "jnN+Jbtoeb/NFpIi1vdDwokZxgY=",


### PR DESCRIPTION
Hi there,

This PR is to:

1. make `GetTLFCryptKeys` to run identify;
2. support chat specific behavior of identify, i.e. not fail but plumb through the proof failures

There's virtually no tests for the new stuff yet, but I wanted to see how people feel about this. If this look good, I'll add some tests before merging!