### PR TITLE
cr: ignore renames if the whole chain has been deleted

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1298,7 +1298,7 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 			// existed in both branches.
 			if !unmergedChains.isCreated(info.originalNewParent) {
 				// There should definitely be a merged path for this
-				// parent, since it has a create operation.
+				// parent, since it doesn't have a create operation.
 				return nil, fmt.Errorf("fixRenameConflicts: couldn't find "+
 					"merged path for %v", parent)
 			}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -45,9 +45,13 @@ func (cc *crChain) collapse() {
 		case *rmOp:
 			if prevCreateIndex, ok := createsSeen[realOp.OldName]; ok {
 				delete(createsSeen, realOp.OldName)
-				// The rm cancels out the create, so remove both.
+				// The rm cancels out the create, so remove it.
 				indicesToRemove[prevCreateIndex] = true
-				indicesToRemove[i] = true
+				// Also remove the rmOp if it was part of a rename
+				// (i.e., it wasn't a "real" rm).
+				if len(op.Unrefs()) == 0 {
+					indicesToRemove[i] = true
+				}
 			}
 		case *setAttrOp:
 			// TODO: Collapse opposite setex pairs

--- a/test/cr_multi_blocks_test.go
+++ b/test/cr_multi_blocks_test.go
@@ -204,3 +204,32 @@ func TestCrUnmergedWriteMultiblockFileWithSmallBlockChangeSize(t *testing.T) {
 		),
 	)
 }
+
+// bob moves a multi-block file, and then deletes its parents.
+func TestCrUnmergedMoveAndDeleteMultiblockFile(t *testing.T) {
+	test(t,
+		blockSize(20), users("alice", "bob"),
+		as(alice,
+			write("a/b/c/d", ntimesString(15, "0123456789")),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			write("foo", "bar"),
+		),
+		as(bob, noSync(),
+			rename("a/b/c/d", "a/b/c/e"),
+			rm("a/b/c/e"),
+			rmdir("a/b/c"),
+			rmdir("a/b"),
+			reenableUpdates(),
+			lsdir("a/", m{}),
+			read("foo", "bar"),
+		),
+		as(alice,
+			lsdir("a/", m{}),
+			read("foo", "bar"),
+		),
+	)
+}

--- a/test/cr_simple_test.go
+++ b/test/cr_simple_test.go
@@ -1085,6 +1085,35 @@ func TestCrUnmergedBothRmfile(t *testing.T) {
 	)
 }
 
+// bob moves a file, and then deletes its parents.
+func TestCrUnmergedMoveAndDelete(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			write("a/b/c/d", "hello"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			write("foo", "bar"),
+		),
+		as(bob, noSync(),
+			rename("a/b/c/d", "a/b/c/e"),
+			rm("a/b/c/e"),
+			rmdir("a/b/c"),
+			rmdir("a/b"),
+			reenableUpdates(),
+			lsdir("a/", m{}),
+			read("foo", "bar"),
+		),
+		as(alice,
+			lsdir("a/", m{}),
+			read("foo", "bar"),
+		),
+	)
+}
+
 // bob exclusively creates a file while on an unmerged branch.
 func TestCrCreateFileExclOnStaged(t *testing.T) {
 	test(t,


### PR DESCRIPTION
Also fix a bookkeeping issue exposed by this -- if a block has been overwritten already on the merged branch, it shouldn't be unreferenced again in the resolution.

Issue: KBFS-1603