### PR TITLE
use context for alternative identify behavior

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -774,9 +774,16 @@ func (fbo *folderBranchOps) identifyOnce(
 		return err
 	}
 
-	fbo.log.CDebugf(ctx, "Identify finished successfully")
-	fbo.identifyDone = true
-	fbo.identifyTime = fbo.config.Clock().Now()
+	ei := getExtendedIdentify(ctx)
+	if ei.behavior.WarningInsteadOfErrorOnBrokenTracks() &&
+		len(ei.getTlfBreakOrBust().Breaks) > 0 {
+		fbo.log.CDebugf(ctx,
+			"Identify finished with no error but broken proof warnings")
+	} else {
+		fbo.log.CDebugf(ctx, "Identify finished successfully")
+		fbo.identifyDone = true
+		fbo.identifyTime = fbo.config.Clock().Now()
+	}
 	return nil
 }
 

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -6,11 +6,110 @@ package libkbfs
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 )
+
+type extendedIdentify struct {
+	behavior   keybase1.TLFIdentifyBehavior
+	userBreaks chan keybase1.TLFUserBreak
+
+	tlfBreaksLock sync.Mutex
+	tlfBreaks     *keybase1.TLFBreak
+}
+
+func (ei *extendedIdentify) userBreak(username libkb.NormalizedUsername, uid keybase1.UID, breaks *keybase1.IdentifyTrackBreaks) {
+	if ei.userBreaks == nil {
+		return
+	}
+
+	ei.userBreaks <- keybase1.TLFUserBreak{
+		Breaks: breaks,
+		User: keybase1.User{
+			Uid:      uid,
+			Username: string(username),
+		},
+	}
+}
+
+func (ei *extendedIdentify) makeTlfBreaksIfNeeded(numUserInTlf int) {
+	if ei.userBreaks == nil {
+		return
+	}
+
+	b := &keybase1.TLFBreak{}
+	for i := 0; i < numUserInTlf; i++ {
+		ub := <-ei.userBreaks
+		if ub.Breaks != nil {
+			b.Breaks = append(b.Breaks, ub)
+		}
+	}
+
+	ei.tlfBreaksLock.Lock()
+	defer ei.tlfBreaksLock.Unlock()
+	ei.tlfBreaks = b
+}
+
+// getTlfBreakOrBust returns a keybase1.TLFBreak. This should only be called
+// for behavior.WarningInsteadOfErrorOnBrokenTracks() == true, and after
+// makeTlfBreaksIfNeeded is called. Otherwise it panics.
+func (ei *extendedIdentify) getTlfBreakOrBust() keybase1.TLFBreak {
+	ei.tlfBreaksLock.Lock()
+	defer ei.tlfBreaksLock.Unlock()
+	return *ei.tlfBreaks
+}
+
+// ctxExtendedIdentifyKeyType is a type for the context key for using
+// extendedIdentify
+type ctxExtendedIdentifyKeyType int
+
+const (
+	// ctxExtendedIdentifyKeyType is a context key for using extendedIdentify
+	ctxExtendedIdentifyKey ctxExtendedIdentifyKeyType = iota
+)
+
+// ExtendedIdentifyAlreadyExists is returned when makeExtendedIdentify is
+// called on a context already with extendedIdentify.
+type ExtendedIdentifyAlreadyExists struct{}
+
+func (e ExtendedIdentifyAlreadyExists) Error() string {
+	return "extendedIdentify already exists"
+}
+
+func makeExtendedIdentify(ctx context.Context,
+	behavior keybase1.TLFIdentifyBehavior) (context.Context, error) {
+	if _, ok := ctx.Value(ctxExtendedIdentifyKey).(*extendedIdentify); ok {
+		return nil, ExtendedIdentifyAlreadyExists{}
+	}
+
+	if !behavior.WarningInsteadOfErrorOnBrokenTracks() {
+		return NewContextReplayable(ctx, func(ctx context.Context) context.Context {
+			return context.WithValue(ctx, ctxExtendedIdentifyKey, &extendedIdentify{
+				behavior: behavior,
+			})
+		}), nil
+	}
+
+	return NewContextReplayable(ctx, func(ctx context.Context) context.Context {
+		return context.WithValue(ctx, ctxExtendedIdentifyKey, &extendedIdentify{
+			behavior:   behavior,
+			userBreaks: make(chan keybase1.TLFUserBreak),
+		})
+	}), nil
+}
+
+func getExtendedIdentify(ctx context.Context) (ei *extendedIdentify) {
+	if ei, ok := ctx.Value(ctxExtendedIdentifyKey).(*extendedIdentify); ok {
+		return ei
+	}
+	return &extendedIdentify{
+		behavior: keybase1.TLFIdentifyBehavior_DEFAULT_KBFS,
+	}
+}
 
 func identifyUID(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uid keybase1.UID, isPublic bool) error {
 	username, err := nug.GetNormalizedUsername(ctx, uid)
@@ -47,7 +146,8 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identif
 	defer cancel()
 
 	errChan := make(chan error, len(uids))
-	// TODO: limit the number of concurrent identifies?
+	// TODO: limit the number of concurrent identifies? Otherwise we can use
+	// errgroup.Group here.
 	for _, uid := range uids {
 		go func(uid keybase1.UID) {
 			err := identifyUID(ctx, nug, identifier, uid, public)
@@ -65,8 +165,24 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identif
 	return nil
 }
 
+func identifyUserListForTLF(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID, public bool) error {
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		ei := getExtendedIdentify(ctx)
+		ei.makeTlfBreaksIfNeeded(len(uids))
+		return nil
+	})
+
+	eg.Go(func() error {
+		return identifyUserList(ctx, nug, identifier, uids, public)
+	})
+
+	return eg.Wait()
+}
+
 // identifyHandle identifies the canonical names in the given handle.
 func identifyHandle(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, h *TlfHandle) error {
 	uids := append(h.ResolvedWriters(), h.ResolvedReaders()...)
-	return identifyUserList(ctx, nug, identifier, uids, h.IsPublic())
+	return identifyUserListForTLF(ctx, nug, identifier, uids, h.IsPublic())
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -271,6 +271,17 @@ func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context, tlfHandle *TlfHandle) (
 func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(
 	ctx context.Context, mdops MDOps, h *TlfHandle, create bool) (initialized bool,
 	md ImmutableRootMetadata, id TlfID, err error) {
+
+	defer func() {
+		if getExtendedIdentify(ctx).behavior.AlwaysRunIdentify() &&
+			!initialized && err == nil {
+			kbpki := fs.config.KBPKI()
+			// We are not runnign identify for existing TLFs in KBFS. This makes sure
+			// if requested, identify runs even for existing TLFs.
+			err = identifyHandle(ctx, kbpki, kbpki, h)
+		}
+	}()
+
 	id, md, err = mdops.GetForHandle(ctx, h, Merged)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, id, err

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -271,12 +271,11 @@ func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context, tlfHandle *TlfHandle) (
 func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(
 	ctx context.Context, mdops MDOps, h *TlfHandle, create bool) (initialized bool,
 	md ImmutableRootMetadata, id TlfID, err error) {
-
 	defer func() {
 		if getExtendedIdentify(ctx).behavior.AlwaysRunIdentify() &&
 			!initialized && err == nil {
 			kbpki := fs.config.KBPKI()
-			// We are not runnign identify for existing TLFs in KBFS. This makes sure
+			// We are not running identify for existing TLFs in KBFS. This makes sure
 			// if requested, identify runs even for existing TLFs.
 			err = identifyHandle(ctx, kbpki, kbpki, h)
 		}

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -291,6 +291,12 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 		UseDelegateUI: true,
 		Reason:        keybase1.IdentifyReason{Reason: reason},
 	}
+
+	ei := getExtendedIdentify(ctx)
+	if ei.behavior.WarningInsteadOfErrorOnBrokenTracks() {
+		arg.ChatGUIMode = true
+	}
+
 	res, err := k.identifyClient.Identify2(ctx, arg)
 	// Identify2 still returns keybase1.UserPlusKeys data (sans keys),
 	// even if it gives a NoSigChainError, and in KBFS it's fine if
@@ -304,7 +310,14 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 		return UserInfo{}, ConvertIdentifyError(assertion, err)
 	}
 
-	return k.processUserPlusKeys(res.Upk)
+	userInfo, err := k.processUserPlusKeys(res.Upk)
+	if err != nil {
+		return UserInfo{}, err
+	}
+
+	ei.userBreak(userInfo.Name, userInfo.UID, res.TrackBreaks)
+
+	return userInfo, nil
 }
 
 // LoadUserPlusKeys implements the KeybaseService interface for KeybaseServiceBase.
@@ -592,21 +605,28 @@ func (k *KeybaseServiceBase) FSSyncStatusRequest(ctx context.Context,
 // GetTLFCryptKeys implements the TlfKeysInterface interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
-	tlfName string) (res keybase1.TLFCryptKeys, err error) {
-	ctx = ctxWithRandomIDReplayable(ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID,
-		k.log)
-	tlfHandle, err := k.getHandleFromFolderName(ctx, tlfName, false)
+	query keybase1.TLFQuery) (res keybase1.GetTLFCryptKeysRes, err error) {
+	if ctx, err = makeExtendedIdentify(
+		ctxWithRandomIDReplayable(ctx,
+			CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log),
+		query.IdentifyBehavior,
+	); err != nil {
+		return keybase1.GetTLFCryptKeysRes{}, err
+	}
+
+	tlfHandle, err := k.getHandleFromFolderName(ctx, query.TlfName, false)
 	if err != nil {
 		return res, err
 	}
 
-	res.CanonicalName = keybase1.CanonicalTlfName(tlfHandle.GetCanonicalName())
+	res.NameIDBreaks.CanonicalName = keybase1.CanonicalTlfName(
+		tlfHandle.GetCanonicalName())
 
 	keys, id, err := k.config.KBFSOps().GetTLFCryptKeys(ctx, tlfHandle)
 	if err != nil {
 		return res, err
 	}
-	res.TlfID = keybase1.TLFID(id.String())
+	res.NameIDBreaks.TlfID = keybase1.TLFID(id.String())
 
 	for i, key := range keys {
 		res.CryptKeys = append(res.CryptKeys, keybase1.CryptKey{
@@ -615,27 +635,44 @@ func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
 		})
 	}
 
+	if query.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
+		res.NameIDBreaks.Breaks = getExtendedIdentify(ctx).getTlfBreakOrBust()
+	}
+
 	return res, nil
 }
 
 // GetPublicCanonicalTLFNameAndID implements the TlfKeysInterface interface for
 // KeybaseServiceBase.
-func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(ctx context.Context,
-	tlfName string) (res keybase1.CanonicalTLFNameAndID, err error) {
-	ctx = ctxWithRandomIDReplayable(ctx, CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID,
-		k.log)
-	tlfHandle, err := k.getHandleFromFolderName(ctx, tlfName, true /* public */)
+func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(
+	ctx context.Context, query keybase1.TLFQuery) (
+	res keybase1.CanonicalTLFNameAndIDWithBreaks, err error) {
+	if ctx, err = makeExtendedIdentify(
+		ctxWithRandomIDReplayable(ctx,
+			CtxKeybaseServiceIDKey, CtxKeybaseServiceOpID, k.log),
+		query.IdentifyBehavior,
+	); err != nil {
+		return keybase1.CanonicalTLFNameAndIDWithBreaks{}, err
+	}
+
+	tlfHandle, err := k.getHandleFromFolderName(
+		ctx, query.TlfName, true /* public */)
 	if err != nil {
 		return res, err
 	}
 
-	res.CanonicalName = keybase1.CanonicalTlfName(tlfHandle.GetCanonicalName())
+	res.CanonicalName = keybase1.CanonicalTlfName(
+		tlfHandle.GetCanonicalName())
 
 	id, err := k.config.KBFSOps().GetTLFID(ctx, tlfHandle)
 	if err != nil {
 		return res, err
 	}
 	res.TlfID = keybase1.TLFID(id.String())
+
+	if query.IdentifyBehavior.WarningInsteadOfErrorOnBrokenTracks() {
+		res.Breaks = getExtendedIdentify(ctx).getTlfBreakOrBust()
+	}
 
 	return res, nil
 }

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -315,6 +315,8 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 		return UserInfo{}, err
 	}
 
+	// This is required for every identify call. The userBreak function will take
+	// care of checking if res.TrackBreaks is nil or not.
 	ei.userBreak(userInfo.Name, userInfo.UID, res.TrackBreaks)
 
 	return userInfo, nil

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -729,3 +729,11 @@ func (t TLFID) ToBytes() []byte {
 	}
 	return b
 }
+
+func (b TLFIdentifyBehavior) AlwaysRunIdentify() bool {
+	return b == TLFIdentifyBehavior_CHAT_GUI || b == TLFIdentifyBehavior_CHAT_CLI
+}
+
+func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
+	return b == TLFIdentifyBehavior_CHAT_GUI
+}

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -406,6 +406,22 @@ func FromTime(t Time) time.Time {
 	return time.Unix(0, int64(t)*1000000)
 }
 
+func (t Time) Time() time.Time {
+	return FromTime(t)
+}
+
+func (t Time) UnixSeconds() int64 {
+	return t.Time().Unix()
+}
+
+func (t Time) UnixMilliseconds() int64 {
+	return t.Time().UnixNano() / 1e6
+}
+
+func (t Time) UnixMicroseconds() int64 {
+	return t.Time().UnixNano() / 1e3
+}
+
 func ToTime(t time.Time) Time {
 	// the result of calling UnixNano on the zero Time is undefined.
 	// https://golang.org/pkg/time/#Time.UnixNano

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/tlf.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/tlf.go
@@ -9,24 +9,24 @@ import (
 )
 
 type CryptKeysArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type PublicCanonicalTLFNameAndIDArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type CompleteAndCanonicalizeTlfNameArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type TlfInterface interface {
 	// CryptKeys returns TLF crypt keys from all generations.
-	CryptKeys(context.Context, string) (TLFCryptKeys, error)
+	CryptKeys(context.Context, TLFQuery) (GetTLFCryptKeysRes, error)
 	// * tlfCanonicalID returns the canonical name and TLFID for tlfName.
 	// * TLFID should not be cached or stored persistently.
-	PublicCanonicalTLFNameAndID(context.Context, string) (CanonicalTLFNameAndID, error)
-	CompleteAndCanonicalizeTlfName(context.Context, string) (CanonicalTlfName, error)
+	PublicCanonicalTLFNameAndID(context.Context, TLFQuery) (CanonicalTLFNameAndIDWithBreaks, error)
+	CompleteAndCanonicalizeTlfName(context.Context, TLFQuery) (CanonicalTLFNameAndIDWithBreaks, error)
 }
 
 func TlfProtocol(i TlfInterface) rpc.Protocol {
@@ -44,7 +44,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]CryptKeysArg)(nil), args)
 						return
 					}
-					ret, err = i.CryptKeys(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.CryptKeys(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -60,7 +60,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]PublicCanonicalTLFNameAndIDArg)(nil), args)
 						return
 					}
-					ret, err = i.PublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.PublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -76,7 +76,7 @@ func TlfProtocol(i TlfInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]CompleteAndCanonicalizeTlfNameArg)(nil), args)
 						return
 					}
-					ret, err = i.CompleteAndCanonicalizeTlfName(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.CompleteAndCanonicalizeTlfName(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -90,22 +90,22 @@ type TlfClient struct {
 }
 
 // CryptKeys returns TLF crypt keys from all generations.
-func (c TlfClient) CryptKeys(ctx context.Context, tlfName string) (res TLFCryptKeys, err error) {
-	__arg := CryptKeysArg{TlfName: tlfName}
+func (c TlfClient) CryptKeys(ctx context.Context, query TLFQuery) (res GetTLFCryptKeysRes, err error) {
+	__arg := CryptKeysArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlf.CryptKeys", []interface{}{__arg}, &res)
 	return
 }
 
 // * tlfCanonicalID returns the canonical name and TLFID for tlfName.
 // * TLFID should not be cached or stored persistently.
-func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (res CanonicalTLFNameAndID, err error) {
-	__arg := PublicCanonicalTLFNameAndIDArg{TlfName: tlfName}
+func (c TlfClient) PublicCanonicalTLFNameAndID(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+	__arg := PublicCanonicalTLFNameAndIDArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlf.publicCanonicalTLFNameAndID", []interface{}{__arg}, &res)
 	return
 }
 
-func (c TlfClient) CompleteAndCanonicalizeTlfName(ctx context.Context, tlfName string) (res CanonicalTlfName, err error) {
-	__arg := CompleteAndCanonicalizeTlfNameArg{TlfName: tlfName}
+func (c TlfClient) CompleteAndCanonicalizeTlfName(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+	__arg := CompleteAndCanonicalizeTlfNameArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlf.completeAndCanonicalizeTlfName", []interface{}{__arg}, &res)
 	return
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/tlf_keys.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/tlf_keys.go
@@ -8,38 +8,72 @@ import (
 	context "golang.org/x/net/context"
 )
 
+type TLFIdentifyBehavior int
+
+const (
+	TLFIdentifyBehavior_DEFAULT_KBFS TLFIdentifyBehavior = 0
+	TLFIdentifyBehavior_CHAT_CLI     TLFIdentifyBehavior = 1
+	TLFIdentifyBehavior_CHAT_GUI     TLFIdentifyBehavior = 2
+)
+
+var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
+	"DEFAULT_KBFS": 0,
+	"CHAT_CLI":     1,
+	"CHAT_GUI":     2,
+}
+
+var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
+	0: "DEFAULT_KBFS",
+	1: "CHAT_CLI",
+	2: "CHAT_GUI",
+}
+
 type CanonicalTlfName string
 type CryptKey struct {
 	KeyGeneration int     `codec:"KeyGeneration" json:"KeyGeneration"`
 	Key           Bytes32 `codec:"Key" json:"Key"`
 }
 
-type TLFCryptKeys struct {
-	TlfID         TLFID            `codec:"tlfID" json:"tlfID"`
-	CanonicalName CanonicalTlfName `codec:"CanonicalName" json:"CanonicalName"`
-	CryptKeys     []CryptKey       `codec:"CryptKeys" json:"CryptKeys"`
+type TLFBreak struct {
+	Breaks []TLFUserBreak `codec:"breaks" json:"breaks"`
 }
 
-type CanonicalTLFNameAndID struct {
+type TLFUserBreak struct {
+	User   User                 `codec:"user" json:"user"`
+	Breaks *IdentifyTrackBreaks `codec:"breaks,omitempty" json:"breaks,omitempty"`
+}
+
+type GetTLFCryptKeysRes struct {
+	NameIDBreaks CanonicalTLFNameAndIDWithBreaks `codec:"nameIDBreaks" json:"nameIDBreaks"`
+	CryptKeys    []CryptKey                      `codec:"CryptKeys" json:"CryptKeys"`
+}
+
+type TLFQuery struct {
+	TlfName          string              `codec:"tlfName" json:"tlfName"`
+	IdentifyBehavior TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
+}
+
+type CanonicalTLFNameAndIDWithBreaks struct {
 	TlfID         TLFID            `codec:"tlfID" json:"tlfID"`
 	CanonicalName CanonicalTlfName `codec:"CanonicalName" json:"CanonicalName"`
+	Breaks        TLFBreak         `codec:"breaks" json:"breaks"`
 }
 
 type GetTLFCryptKeysArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type GetPublicCanonicalTLFNameAndIDArg struct {
-	TlfName string `codec:"tlfName" json:"tlfName"`
+	Query TLFQuery `codec:"query" json:"query"`
 }
 
 type TlfKeysInterface interface {
 	// getTLFCryptKeys returns TLF crypt keys from all generations and the TLF ID.
 	// TLF ID should not be cached or stored persistently.
-	GetTLFCryptKeys(context.Context, string) (TLFCryptKeys, error)
+	GetTLFCryptKeys(context.Context, TLFQuery) (GetTLFCryptKeysRes, error)
 	// getPublicCanonicalTLFNameAndID return the canonical name and TLFID for tlfName.
 	// TLF ID should not be cached or stored persistently.
-	GetPublicCanonicalTLFNameAndID(context.Context, string) (CanonicalTLFNameAndID, error)
+	GetPublicCanonicalTLFNameAndID(context.Context, TLFQuery) (CanonicalTLFNameAndIDWithBreaks, error)
 }
 
 func TlfKeysProtocol(i TlfKeysInterface) rpc.Protocol {
@@ -57,7 +91,7 @@ func TlfKeysProtocol(i TlfKeysInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]GetTLFCryptKeysArg)(nil), args)
 						return
 					}
-					ret, err = i.GetTLFCryptKeys(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.GetTLFCryptKeys(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -73,7 +107,7 @@ func TlfKeysProtocol(i TlfKeysInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]GetPublicCanonicalTLFNameAndIDArg)(nil), args)
 						return
 					}
-					ret, err = i.GetPublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0].TlfName)
+					ret, err = i.GetPublicCanonicalTLFNameAndID(ctx, (*typedArgs)[0].Query)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -88,16 +122,16 @@ type TlfKeysClient struct {
 
 // getTLFCryptKeys returns TLF crypt keys from all generations and the TLF ID.
 // TLF ID should not be cached or stored persistently.
-func (c TlfKeysClient) GetTLFCryptKeys(ctx context.Context, tlfName string) (res TLFCryptKeys, err error) {
-	__arg := GetTLFCryptKeysArg{TlfName: tlfName}
+func (c TlfKeysClient) GetTLFCryptKeys(ctx context.Context, query TLFQuery) (res GetTLFCryptKeysRes, err error) {
+	__arg := GetTLFCryptKeysArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlfKeys.getTLFCryptKeys", []interface{}{__arg}, &res)
 	return
 }
 
 // getPublicCanonicalTLFNameAndID return the canonical name and TLFID for tlfName.
 // TLF ID should not be cached or stored persistently.
-func (c TlfKeysClient) GetPublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (res CanonicalTLFNameAndID, err error) {
-	__arg := GetPublicCanonicalTLFNameAndIDArg{TlfName: tlfName}
+func (c TlfKeysClient) GetPublicCanonicalTLFNameAndID(ctx context.Context, query TLFQuery) (res CanonicalTLFNameAndIDWithBreaks, err error) {
+	__arg := GetPublicCanonicalTLFNameAndIDArg{Query: query}
 	err = c.Cli.Call(ctx, "keybase.1.tlfKeys.getPublicCanonicalTLFNameAndID", []interface{}{__arg}, &res)
 	return
 }

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,67 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"sync"
+
+	"golang.org/x/net/context"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,10 +196,10 @@
 			"revisionTime": "2016-10-03T19:50:03Z"
 		},
 		{
-			"checksumSHA1": "GnpjAHOD/Q/6xCrhSb/lZWzE5XE=",
+			"checksumSHA1": "dIj0YcSA8RAfI1y3ca8YNwzETP0=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "d735cc8a00ca5b38281a350c699a51f76ceb142b",
-			"revisionTime": "2016-10-03T19:50:03Z"
+			"revision": "2f15e5b398089c9f85852ced44e6e7df5b1e970f",
+			"revisionTime": "2016-10-07T22:55:16Z"
 		},
 		{
 			"checksumSHA1": "jnN+Jbtoeb/NFpIi1vdDwokZxgY=",
@@ -511,6 +511,12 @@
 			"path": "golang.org/x/net/html/atom",
 			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
 			"revisionTime": "2016-08-26T20:58:34Z"
+		},
+		{
+			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
+			"path": "golang.org/x/sync/errgroup",
+			"revision": "1ae7c7b29e06598039be46c5083819ba6fd7a97e",
+			"revisionTime": "2016-10-04T22:49:57Z"
 		},
 		{
 			"path": "golang.org/x/sys/unix",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,10 +196,10 @@
 			"revisionTime": "2016-10-03T19:50:03Z"
 		},
 		{
-			"checksumSHA1": "dIj0YcSA8RAfI1y3ca8YNwzETP0=",
+			"checksumSHA1": "aovJhpamlO0X21t5XA6tls/mX74=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "2f15e5b398089c9f85852ced44e6e7df5b1e970f",
-			"revisionTime": "2016-10-07T22:55:16Z"
+			"revision": "9c314b4e3bafffd2fb2f91af502e1cb8bd021e13",
+			"revisionTime": "2016-10-07T23:45:30Z"
 		},
 		{
 			"checksumSHA1": "jnN+Jbtoeb/NFpIi1vdDwokZxgY=",


### PR DESCRIPTION
This is my 2nd take on https://github.com/keybase/kbfs/pull/406; I also added a simple test that practices part of the new code