### PR TITLE
libkbfs: child block support for change blocks

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2667,12 +2667,15 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	refs := make(map[BlockPointer]bool)
 	unrefs := make(map[BlockPointer]bool)
 	for _, op := range md.data.Changes.Ops {
-		for _, ptr := range op.Refs() {
+		refDeleted := 0
+		for i := range op.Refs() {
+			ptr := op.Refs()[i-refDeleted]
 			// Don't add usage if it's an unembedded block change
 			// pointer.  Also, we shouldn't be referencing this
 			// anymore!
-			if _, ok := unmergedChains.blockChangePointers[ptr]; ok {
+			if unmergedChains.blockChangePointers[ptr] {
 				op.DelRefBlock(ptr)
+				refDeleted++
 			} else {
 				refs[ptr] = true
 			}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2667,15 +2667,14 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	refs := make(map[BlockPointer]bool)
 	unrefs := make(map[BlockPointer]bool)
 	for _, op := range md.data.Changes.Ops {
-		refDeleted := 0
-		for i := range op.Refs() {
-			ptr := op.Refs()[i-refDeleted]
+		// Iterate in reverse since we may be deleting references as we go.
+		for i := len(op.Refs()) - 1; i >= 0; i-- {
+			ptr := op.Refs()[i]
 			// Don't add usage if it's an unembedded block change
 			// pointer.  Also, we shouldn't be referencing this
 			// anymore!
 			if unmergedChains.blockChangePointers[ptr] {
 				op.DelRefBlock(ptr)
-				refDeleted++
 			} else {
 				refs[ptr] = true
 			}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -677,6 +677,16 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 
 		if ptr := rmd.data.cachedChanges.Info.BlockPointer; ptr != zeroPtr {
 			ccs.blockChangePointers[ptr] = true
+
+			// Any child block change pointers?
+			fblock, err := fbo.GetFileBlockForReading(ctx, makeFBOLockState(),
+				rmd.ReadOnly(), ptr, MasterBranch, path{})
+			if err != nil {
+				return nil, err
+			}
+			for _, iptr := range fblock.IPtrs {
+				ccs.blockChangePointers[iptr.BlockPointer] = true
+			}
 		}
 
 		// Copy the ops since CR will change them.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -509,17 +509,6 @@ func (fbo *folderBranchOps) setBranchIDLocked(lState *lockState, bid BranchID) {
 	}
 }
 
-func (fbo *folderBranchOps) checkDataVersion(p path, ptr BlockPointer) error {
-	if ptr.DataVer < FirstValidDataVer {
-		return InvalidDataVersionError{ptr.DataVer}
-	}
-	// TODO: migrate back to fbo.config.DataVersion
-	if ptr.DataVer > FilesWithHolesDataVer {
-		return NewDataVersionError{p, ptr.DataVer}
-	}
-	return nil
-}
-
 func (fbo *folderBranchOps) setHeadLocked(
 	ctx context.Context, lState *lockState, md ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -1482,7 +1471,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 		if de.Type == Sym {
 			node = nil
 		} else {
-			err = fbo.checkDataVersion(childPath, de.BlockPointer)
+			err = fbo.blocks.checkDataVersion(childPath, de.BlockPointer)
 			if err != nil {
 				return err
 			}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5038,6 +5038,14 @@ func TestSyncDirtyWithBlockChangePointerSuccess(t *testing.T) {
 	config.mockBserv.EXPECT().Put(gomock.Any(), rmd.TlfID(), changeBlockID,
 		gomock.Any(), changeReadyBlockData.buf,
 		changeReadyBlockData.serverHalf).Return(nil)
+	// For now, fake the amount copied by using a large number, since
+	// we don't have easy access here to the actual encoded data.  The
+	// exact return value doesn't matter as long as it's large enough.
+	config.mockBsplit.EXPECT().CopyUntilSplit(
+		gomock.Any(), gomock.Any(), gomock.Any(), int64(0)).
+		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
+			block.Contents = data
+		}).Return(int64(100 * 1024 * 1024))
 
 	if err := config.KBFSOps().Sync(ctx, n); err != nil {
 		t.Errorf("Got unexpected error on sync: %v", err)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -381,10 +381,10 @@ func signMD(
 
 func getFileBlockForMD(ctx context.Context, config Config, ptr BlockPointer,
 	rmdToDecrypt *RootMetadata, rmdWithKeys KeyMetadata) (*FileBlock, error) {
-	//We don't have a convenient way to
-	// fetch the block from here via folderBlockOps, so just go
-	// directly via the BlockCache/BlockOps.  No locking around the
-	// blocks is needed since these change blocks are read-only.
+	// We don't have a convenient way to fetch the block from here via
+	// folderBlockOps, so just go directly via the
+	// BlockCache/BlockOps.  No locking around the blocks is needed
+	// since these change blocks are read-only.
 	block, err := config.BlockCache().Get(ptr)
 	if err != nil {
 		block = NewFileBlock()

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -374,10 +374,10 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
 	return nil
 }
 
-// swapCachedBlockChanges swaps any cached block changes so that
+// loadCachedBlockChanges swaps any cached block changes so that
 // future local accesses to this MD (from the cache) can directly
 // access the ops without needing to re-embed the block changes.
-func (md *RootMetadata) swapCachedBlockChanges(bps *blockPutState) {
+func (md *RootMetadata) loadCachedBlockChanges(bps *blockPutState) {
 	if md.data.Changes.Ops == nil {
 		md.data.Changes, md.data.cachedChanges =
 			md.data.cachedChanges, md.data.Changes

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -377,12 +377,31 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
 // swapCachedBlockChanges swaps any cached block changes so that
 // future local accesses to this MD (from the cache) can directly
 // access the ops without needing to re-embed the block changes.
-func (md *RootMetadata) swapCachedBlockChanges() {
+func (md *RootMetadata) swapCachedBlockChanges(bps *blockPutState) {
 	if md.data.Changes.Ops == nil {
 		md.data.Changes, md.data.cachedChanges =
 			md.data.cachedChanges, md.data.Changes
 		md.data.Changes.Ops[0].
 			AddRefBlock(md.data.cachedChanges.Info.BlockPointer)
+		// Find the block and ref any children, if any.
+		if bps == nil {
+			panic("Must provide blocks when changes are unembedded")
+		}
+		found := false
+		for _, bs := range bps.blockStates {
+			if bs.blockPtr != md.data.cachedChanges.Info.BlockPointer {
+				continue
+			}
+			found = true
+			for _, iptr := range bs.block.(*FileBlock).IPtrs {
+				md.data.Changes.Ops[0].AddRefBlock(iptr.BlockPointer)
+			}
+			break
+		}
+		if !found {
+			panic(fmt.Sprintf("Couldn't find top change block %v",
+				md.data.cachedChanges.Info.BlockPointer))
+		}
 	}
 }
 

--- a/test/cr_multi_blocks_test.go
+++ b/test/cr_multi_blocks_test.go
@@ -190,7 +190,7 @@ func TestCrUnmergedWriteMultiblockFileWithSmallBlockChangeSize(t *testing.T) {
 		as(alice,
 			write("a/foo", "hello"),
 		),
-		as(bob,
+		as(bob, noSync(),
 			write("a/b", ntimesString(15, "0123456789")),
 			reenableUpdates(),
 			lsdir("a/", m{"b": "FILE", "foo": "FILE"}),


### PR DESCRIPTION
If conflict resolution, for example, makes a large change block, we risk going over the block server maximum if we put it all in one block.

I was going to bump up the data version for this change, but unfortunately in older versions we only check the data version on lookup, which doesn't help for unembedded block changes (or the root pointer, for that matter).  Sigh.  So I added that check as part of this PR for the future.  Older clients will unfortunately see a cryptic error, and if they already have the folder cached they will simply fail to update, and keep showing the old version.

Issue: KBFS-787