### PR TITLE
kbfs_ops_test: fix ReIdentify test flake

### DIFF
--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -337,14 +337,15 @@ func TestKBFSOpsGetRootNodeReIdentify(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 
-	// The channel is not buffered, when the second value is received
-	// the first round of marking for reidentify will be done.
+	// Mark everything for reidentifying, and wait for it to finish
+	// before checking.
 	kop := config.KBFSOps().(*KBFSOpsStandard)
-	kop.reIdentifyControlChan <- struct{}{}
-	kop.reIdentifyControlChan <- struct{}{}
+	returnCh := make(chan struct{})
+	kop.reIdentifyControlChan <- returnCh
+	<-returnCh
 	assert.False(t, fboIdentityDone(ops))
 
-	// Trigger identify.
+	// Trigger new identify.
 	lState = makeFBOLockState()
 	_, err = ops.getMDLocked(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)


### PR DESCRIPTION
This test tried to get around the fact that reidentifies were
asynchronous by sending twice on the reidentify channel.
Unfortunately, that led to a race, where identifyDone could be set
back to false by the second send, after the final identify was done.

Instead, the reidentify loop can explicitly signal when it's finished.

Issue: KBFS-1553