### PR TITLE
journal: move unflushed paths logic into tlfJournal

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -656,7 +656,7 @@ func newCRChainsEmpty() *crChains {
 	}
 }
 
-func (ccs *crChains) addOpsToChains(codec kbfscodec.Codec,
+func (ccs *crChains) addOps(codec kbfscodec.Codec,
 	privateMD PrivateMetadata, winfo writerInfo,
 	localTimestamp time.Time) error {
 	// Copy the ops since CR will change them.
@@ -697,8 +697,7 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 			return nil, err
 		}
 
-		err = ccs.addOpsToChains(cfg.Codec(), rmd.data, winfo,
-			rmd.localTimestamp)
+		err = ccs.addOps(cfg.Codec(), rmd.data, winfo, rmd.localTimestamp)
 
 		if ptr := rmd.data.cachedChanges.Info.BlockPointer; ptr != zeroPtr {
 			ccs.blockChangePointers[ptr] = true

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -655,6 +656,27 @@ func newCRChainsEmpty() *crChains {
 	}
 }
 
+func (ccs *crChains) addOpsToChains(codec kbfscodec.Codec,
+	privateMD PrivateMetadata, winfo writerInfo,
+	localTimestamp time.Time) error {
+	// Copy the ops since CR will change them.
+	ops := make(opsList, len(privateMD.Changes.Ops))
+	err := kbfscodec.Update(codec, &ops, privateMD.Changes.Ops)
+	if err != nil {
+		return err
+	}
+
+	for _, op := range ops {
+		op.setWriterInfo(winfo)
+		op.setLocalTimestamp(localTimestamp)
+		err := ccs.makeChainForOp(op)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 	fbo *folderBlockOps, identifyTypes bool) (
 	ccs *crChains, err error) {
@@ -675,6 +697,9 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 			return nil, err
 		}
 
+		err = ccs.addOpsToChains(cfg.Codec(), rmd.data, winfo,
+			rmd.localTimestamp)
+
 		if ptr := rmd.data.cachedChanges.Info.BlockPointer; ptr != zeroPtr {
 			ccs.blockChangePointers[ptr] = true
 
@@ -689,20 +714,8 @@ func newCRChains(ctx context.Context, cfg Config, rmds []ImmutableRootMetadata,
 			}
 		}
 
-		// Copy the ops since CR will change them.
-		ops := make(opsList, len(rmd.data.Changes.Ops))
-		err = kbfscodec.Update(cfg.Codec(), &ops, rmd.data.Changes.Ops)
 		if err != nil {
 			return nil, err
-		}
-
-		for _, op := range ops {
-			op.setWriterInfo(winfo)
-			op.setLocalTimestamp(rmd.localTimestamp)
-			err := ccs.makeChainForOp(op)
-			if err != nil {
-				return nil, err
-			}
 		}
 
 		if !ccs.originalRoot.IsInitialized() {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -506,11 +506,7 @@ type encryptionKeyGetter interface {
 		kbfscrypto.TLFCryptKey, error)
 }
 
-// KeyManager fetches and constructs the keys needed for KBFS file
-// operations.
-type KeyManager interface {
-	encryptionKeyGetter
-
+type mdDecryptionKeyGetter interface {
 	// GetTLFCryptKeyForMDDecryption gets the crypt key to use for the
 	// TLF with the given metadata to decrypt the private portion of
 	// the metadata.  It finds the appropriate key from mdWithKeys
@@ -519,6 +515,13 @@ type KeyManager interface {
 	GetTLFCryptKeyForMDDecryption(ctx context.Context,
 		kmdToDecrypt, kmdWithKeys KeyMetadata) (
 		kbfscrypto.TLFCryptKey, error)
+}
+
+// KeyManager fetches and constructs the keys needed for KBFS file
+// operations.
+type KeyManager interface {
+	encryptionKeyGetter
+	mdDecryptionKeyGetter
 
 	// GetTLFCryptKeyForBlockDecryption gets the crypt key to use
 	// for the TLF with the given metadata to decrypt the block

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -97,12 +97,12 @@ func (j journalMDOps) getHeadFromJournal(
 		}
 	}
 
-	rmd, err := tlfJournal.convertImmutableBareRMDToRMD(ctx, head, handle)
+	irmd, err := tlfJournal.convertImmutableBareRMDToIRMD(ctx, head, handle)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
 
-	return MakeImmutableRootMetadata(rmd, head.mdID, head.localTimestamp), nil
+	return irmd, nil
 }
 
 func (j journalMDOps) getRangeFromJournal(
@@ -151,12 +151,12 @@ func (j journalMDOps) getRangeFromJournal(
 	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
 
 	for _, ibrmd := range ibrmds {
-		rmd, err := tlfJournal.convertImmutableBareRMDToRMD(ctx, ibrmd, handle)
+		irmd, err :=
+			tlfJournal.convertImmutableBareRMDToIRMD(ctx, ibrmd, handle)
 		if err != nil {
 			return nil, err
 		}
 
-		irmd := MakeImmutableRootMetadata(rmd, ibrmd.mdID, ibrmd.localTimestamp)
 		irmds = append(irmds, irmd)
 	}
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -107,8 +107,15 @@ func (j journalMDOps) getHeadFromJournal(
 		tlfHandle: handle,
 	}
 
+	_, uid, err := j.jServer.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return ImmutableRootMetadata{}, err
+	}
+
 	err = decryptMDPrivateData(
-		ctx, j.jServer.config, &rmd, rmd.ReadOnly())
+		ctx, j.jServer.config.Codec(), j.jServer.config.Crypto(),
+		j.jServer.config.BlockCache(), j.jServer.config.BlockOps(),
+		j.jServer.config.KeyManager(), uid, &rmd, rmd.ReadOnly())
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -162,6 +169,11 @@ func (j journalMDOps) getRangeFromJournal(
 
 	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
 
+	_, uid, err := j.jServer.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, ibrmd := range ibrmds {
 		brmd, ok := ibrmd.BareRootMetadata.(MutableBareRootMetadata)
 		if !ok {
@@ -173,7 +185,9 @@ func (j journalMDOps) getRangeFromJournal(
 		}
 
 		err = decryptMDPrivateData(
-			ctx, j.jServer.config, &rmd, rmd.ReadOnly())
+			ctx, j.jServer.config.Codec(), j.jServer.config.Crypto(),
+			j.jServer.config.BlockCache(), j.jServer.config.BlockOps(),
+			j.jServer.config.KeyManager(), uid, &rmd, rmd.ReadOnly())
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -508,65 +508,6 @@ func (j *JournalServer) JournalStatus(tlfID TlfID) (
 
 var errJournalStatusRetry = errors.New("Retry journal status")
 
-func (j *JournalServer) getUnflushedPaths(ctx context.Context, tlfID TlfID,
-	cpp chainsPathPopulator, branchStr string, start MetadataRevision,
-	end MetadataRevision, key kbfscrypto.VerifyingKey) ([]string, error) {
-	// Get the range of revisions.  Note that since we're not doing
-	// this under lock, the journal could enter conflict mode, and we
-	// could end up fetching merged revisions from some other device.
-	// So we need to check that all the revisions were written by this
-	// device.  If not, retry.
-	var unflushedPaths []string
-	if end != MetadataRevisionUninitialized {
-		bid, err := ParseBranchID(branchStr)
-		if err != nil {
-			return nil, err
-		}
-
-		mStatus := Merged
-		if bid != NullBranchID {
-			mStatus = Unmerged
-		}
-		irmds, err := getMDRange(ctx, j.config, tlfID, bid, start, end, mStatus)
-		if err != nil {
-			// TODO: if the error is that the branch ID no longer
-			// exists, we should retry, since the conflict was
-			// resolved since we fetched the status.
-			return nil, err
-		}
-
-		for _, irmd := range irmds {
-			if key.KID() != irmd.LastModifyingWriterKID() {
-				j.log.CDebugf(ctx, "Found an MD in our journal range "+
-					"signed by another device (%v); retrying",
-					irmd.LastModifyingWriterKID())
-				return nil, errJournalStatusRetry
-			}
-		}
-
-		// Make chains over the entire range to get the unflushed files.
-		// TODO: cache this chains object and update it when new revisions
-		// appear and when revisions are flushed, instead of rebuilding
-		// every time.
-		chains, err := newCRChains(ctx, j.config, irmds, nil, false)
-		if err != nil {
-			return nil, err
-		}
-		err = cpp.populateChainPaths(ctx, j.log, chains, true)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, chain := range chains.byOriginal {
-			if len(chain.ops) > 0 {
-				unflushedPaths = append(unflushedPaths,
-					chain.ops[0].getFinalPath().String())
-			}
-		}
-	}
-	return unflushedPaths, nil
-}
-
 // JournalStatusWithPaths returns a TLFServerStatus object for the
 // given TLF suitable for diagnostics, including paths for all the
 // unflushed entries.
@@ -578,23 +519,7 @@ func (j *JournalServer) JournalStatusWithPaths(ctx context.Context, tlfID TlfID,
 			fmt.Errorf("Journal not enabled for %s", tlfID)
 	}
 
-	for i := 0; i < 10; i++ {
-		status, err := tlfJournal.getJournalStatus()
-		if err != nil {
-			return TLFJournalStatus{}, err
-		}
-
-		status.UnflushedPaths, err = j.getUnflushedPaths(ctx, tlfID,
-			cpp, status.BranchID, status.RevisionStart,
-			status.RevisionEnd, tlfJournal.key)
-		if err == errJournalStatusRetry {
-			continue
-		} else if err != nil {
-			return TLFJournalStatus{}, err
-		}
-		return status, nil
-	}
-	return TLFJournalStatus{}, errors.New("Couldn't get a consistent status")
+	return tlfJournal.getJournalStatusWithPaths(ctx, cpp)
 }
 
 // shutdownExistingJournalsLocked shuts down all write journals, sets

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -710,7 +710,11 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// decryptMDPrivateData assumes that the MD is always encrypted
 	// using the latest key gen.
 	if !md.IsReadable() && len(md.GetSerializedPrivateMetadata()) > 0 {
-		if err := decryptMDPrivateData(ctx, km.config, md, md.ReadOnly()); err != nil {
+		err := decryptMDPrivateData(
+			ctx, km.config.Codec(), km.config.Crypto(),
+			km.config.BlockCache(), km.config.BlockOps(),
+			km, uid, md, md.ReadOnly())
+		if err != nil {
 			return false, nil, err
 		}
 	}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -31,6 +31,12 @@ func (g singleEncryptionKeyGetter) GetTLFCryptKeyForEncryption(
 	return g.k, nil
 }
 
+func (g singleEncryptionKeyGetter) GetTLFCryptKeyForMDDecryption(
+	ctx context.Context, kmdToDecrypt, kmdWithKeys KeyMetadata) (
+	kbfscrypto.TLFCryptKey, error) {
+	return g.k, nil
+}
+
 func getMDJournalLength(t *testing.T, j *mdJournal) int {
 	len, err := j.length()
 	require.NoError(t, err)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -30,10 +30,13 @@ type tlfJournalConfig interface {
 	Codec() kbfscodec.Codec
 	Crypto() Crypto
 	BlockCache() BlockCache
+	BlockOps() BlockOps
 	MDCache() MDCache
 	Reporter() Reporter
 	encryptionKeyGetter() encryptionKeyGetter
+	mdDecryptionKeyGetter() mdDecryptionKeyGetter
 	MDServer() MDServer
+	usernameGetter() normalizedUsernameGetter
 	MakeLogger(module string) logger.Logger
 }
 
@@ -45,6 +48,14 @@ type tlfJournalConfigAdapter struct {
 
 func (ca tlfJournalConfigAdapter) encryptionKeyGetter() encryptionKeyGetter {
 	return ca.Config.KeyManager()
+}
+
+func (ca tlfJournalConfigAdapter) mdDecryptionKeyGetter() mdDecryptionKeyGetter {
+	return ca.Config.KeyManager()
+}
+
+func (ca tlfJournalConfigAdapter) usernameGetter() normalizedUsernameGetter {
+	return ca.Config.KBPKI()
 }
 
 const (

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -844,9 +844,7 @@ func (j *tlfJournal) getJournalEntryCounts() (
 	return blockEntryCount, mdEntryCount, nil
 }
 
-func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
-	j.journalLock.RLock()
-	defer j.journalLock.RUnlock()
+func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 	if err := j.checkEnabledLocked(); err != nil {
 		return TLFJournalStatus{}, err
 	}
@@ -876,6 +874,101 @@ func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 		UnflushedBytes: j.blockJournal.unflushedBytes,
 		LastFlushErr:   lastFlushErr,
 	}, nil
+}
+
+func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	return j.getJournalStatusLocked()
+}
+
+func (j *tlfJournal) getJournalStatusWithRange() (
+	TLFJournalStatus, []ImmutableBareRootMetadata, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	jStatus, err := j.getJournalStatusLocked()
+	if err != nil {
+		return TLFJournalStatus{}, nil, err
+	}
+
+	if jStatus.RevisionEnd == MetadataRevisionUninitialized {
+		return jStatus, nil, nil
+	}
+
+	ibrmds, err := j.mdJournal.getRange(
+		jStatus.RevisionStart, jStatus.RevisionEnd)
+	if err != nil {
+		return TLFJournalStatus{}, nil, err
+	}
+	return jStatus, ibrmds, nil
+}
+
+func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
+	cpp chainsPathPopulator) (TLFJournalStatus, error) {
+	jStatus, ibrmds, err := j.getJournalStatusWithRange()
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
+
+	if len(ibrmds) == 0 {
+		return jStatus, nil
+	}
+
+	ibrmdBareHandle, err := ibrmds[0].MakeBareTlfHandle(nil)
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
+
+	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
+	handle, err := MakeTlfHandle(
+		ctx, ibrmdBareHandle, j.config.usernameGetter())
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
+
+	for _, ibrmd := range ibrmds {
+		rmd, err := j.convertImmutableBareRMDToRMD(ctx, ibrmd, handle)
+		if err != nil {
+			return TLFJournalStatus{}, err
+		}
+
+		irmds = append(irmds, MakeImmutableRootMetadata(
+			rmd, ibrmd.mdID, ibrmd.localTimestamp))
+	}
+
+	// Make chains over the entire range to get the unflushed files.
+	// TODO: cache this chains object and update it when new revisions
+	// appear and when revisions are flushed, instead of rebuilding
+	// every time.
+	chains := newCRChainsEmpty()
+	for _, irmd := range irmds {
+		winfo := writerInfo{
+			uid:      j.uid,
+			kid:      j.key.KID(),
+			revision: irmd.Revision(),
+			// There won't be any conflicts, so no need for the
+			// username/devicename.
+		}
+		err := chains.addOps(j.config.Codec(), irmd.data, winfo,
+			irmd.localTimestamp)
+		if err != nil {
+			return TLFJournalStatus{}, nil
+		}
+	}
+	chains.mostRecentMD = irmds[len(irmds)-1]
+
+	err = cpp.populateChainPaths(ctx, j.log, chains, true)
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
+
+	for _, chain := range chains.byOriginal {
+		if len(chain.ops) > 0 {
+			jStatus.UnflushedPaths = append(jStatus.UnflushedPaths,
+				chain.ops[0].getFinalPath().String())
+		}
+	}
+	return jStatus, nil
 }
 
 func (j *tlfJournal) getUnflushedBytes() int64 {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -72,10 +72,12 @@ type testTLFJournalConfig struct {
 	codec    kbfscodec.Codec
 	crypto   CryptoLocal
 	bcache   BlockCache
+	bops     BlockOps
 	mdcache  MDCache
 	reporter Reporter
 	uid      keybase1.UID
 	ekg      singleEncryptionKeyGetter
+	nug      normalizedUsernameGetter
 	mdserver MDServer
 }
 
@@ -95,6 +97,10 @@ func (c testTLFJournalConfig) BlockCache() BlockCache {
 	return c.bcache
 }
 
+func (c testTLFJournalConfig) BlockOps() BlockOps {
+	return c.bops
+}
+
 func (c testTLFJournalConfig) MDCache() MDCache {
 	return c.mdcache
 }
@@ -109,6 +115,14 @@ func (c testTLFJournalConfig) cryptoPure() cryptoPure {
 
 func (c testTLFJournalConfig) encryptionKeyGetter() encryptionKeyGetter {
 	return c.ekg
+}
+
+func (c testTLFJournalConfig) mdDecryptionKeyGetter() mdDecryptionKeyGetter {
+	return c.ekg
+}
+
+func (c testTLFJournalConfig) usernameGetter() normalizedUsernameGetter {
+	return c.nug
 }
 
 func (c testTLFJournalConfig) MDServer() MDServer {
@@ -188,8 +202,8 @@ func setupTLFJournalTest(
 
 	config = &testTLFJournalConfig{
 		t, FakeTlfID(1, false), bsplitter, codec, crypto,
-		nil, NewMDCacheStandard(10),
-		NewReporterSimple(newTestClockNow(), 10), uid, ekg, mdserver,
+		nil, nil, NewMDCacheStandard(10),
+		NewReporterSimple(newTestClockNow(), 10), uid, ekg, nil, mdserver,
 	}
 
 	// Time out individual tests after 10 seconds.


### PR DESCRIPTION
A future commit will need to cache the unflushed paths within the `tlfJournal` struct, and add/remove from it as the journal changes.  So this PR moves the logic to build the complete unflushed paths into tlfJournal, as a step in that direction.  However, since `tlfJournal` doesn't have access to a complete `Config`, this required a bunch of refactoring:

* Break one function off the `KeyManager` interface.
* Change `decryptMDPrivateData` to not rely on a full `Config`, but instead on individual interfaces.
* Refactor the code in `crChains` a bit to not rely on a full `Config` when just adding ops to the chains -- much of the stuff dependent on other parts of the config isn't needed for this use case.
* Add a way for `tlfJournal` to get a view of the journal MD range that guaranteed to be consistent with its status.

(If you find this PR too unwieldy, you can check out the individual commits since they're fairly tidy.  Or I can make each commit its own PR if that would help.)

Issue: KBFS-1477