### PR TITLE
Add exception for golint warnings about context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 lint:
-	golint ./... | grep -v ^vendor | grep -v mocks_test\.go | grep -v mock_codec\.go | grep -v "protocol\/" | grep -v "error should be the last type" || echo "Lint-free!"
+	golint ./... | grep -v ^vendor | grep -v mocks_test\.go | grep -v mock_codec\.go | grep -v "protocol\/" | grep -v "error should be the last type" | grep -v "_test\.go.*context\.Context should be the first parameter of a function" || echo "Lint-free!"
 
 .PHONY: lint


### PR DESCRIPTION
Specifically, allow context.Context to not be
the first argument in test files. Usually,
testing.T is a better first argument.