### PR TITLE
[KBFS-1526] Store MD version numbers and extra fields

### DIFF
--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -6,6 +6,9 @@ package kbfscodec
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
 )
 
@@ -69,5 +72,42 @@ func Update(c Codec, dst interface{}, src interface{}) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// SerializeToFile serializes the given object and writes it to the
+// given file, making its parent directory first if necessary.
+func SerializeToFile(c Codec, obj interface{}, path string) error {
+	err := os.MkdirAll(filepath.Dir(path), 0700)
+	if err != nil {
+		return err
+	}
+
+	buf, err := c.Encode(obj)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path, buf, 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeserializeFromFile deserializes the given file into the given
+// object.
+func DeserializeFromFile(codec Codec, path string, objPtr interface{}) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	err = c.Decode(data, objPtr)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -98,7 +98,7 @@ func SerializeToFile(c Codec, obj interface{}, path string) error {
 
 // DeserializeFromFile deserializes the given file into the given
 // object.
-func DeserializeFromFile(codec Codec, path string, objPtr interface{}) error {
+func DeserializeFromFile(c Codec, path string, objPtr interface{}) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err

--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -69,7 +69,7 @@ func Update(c Codec, dstPtr interface{}, src interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = c.Decode(buf, dst)
+	err = c.Decode(buf, dstPtr)
 	if err != nil {
 		return err
 	}

--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -62,8 +62,9 @@ func Equal(c Codec, x, y interface{}) (bool, error) {
 	return bytes.Equal(xBuf, yBuf), nil
 }
 
-// Update encodes src into a byte string, and then decode it into dst.
-func Update(c Codec, dst interface{}, src interface{}) error {
+// Update encodes src into a byte string, and then decode it into the
+// object pointed to by dstPtr.
+func Update(c Codec, dstPtr interface{}, src interface{}) error {
 	buf, err := c.Encode(src)
 	if err != nil {
 		return err
@@ -96,8 +97,8 @@ func SerializeToFile(c Codec, obj interface{}, path string) error {
 	return nil
 }
 
-// DeserializeFromFile deserializes the given file into the given
-// object.
+// DeserializeFromFile deserializes the given file into the object
+// pointed to by objPtr.
 func DeserializeFromFile(c Codec, path string, objPtr interface{}) error {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1102,9 +1102,8 @@ type MDServer interface {
 	OffsetFromServerTime() (time.Duration, bool)
 
 	// GetKeyBundles returns the key bundles for the given key bundle IDs.
-	GetKeyBundles(ctx context.Context,
-		wkbID TLFWriterKeyBundleID,
-		rkbID TLFReaderKeyBundleID) (
+	GetKeyBundles(ctx context.Context, tlfID TlfID,
+		wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 		*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
 }
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -300,7 +300,7 @@ func (j journalMDOps) Put(ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
 		// Just route to the journal.
-		mdID, err := tlfJournal.putMD(ctx, rmd)
+		mdID, err := tlfJournal.putMD(ctx, rmd, rmd.extra)
 		if err != errTLFJournalDisabled {
 			return mdID, err
 		}
@@ -313,7 +313,7 @@ func (j journalMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
 		rmd.SetUnmerged()
-		mdID, err := tlfJournal.putMD(ctx, rmd)
+		mdID, err := tlfJournal.putMD(ctx, rmd, rmd.extra)
 		if err != errTLFJournalDisabled {
 			return mdID, err
 		}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -239,6 +239,9 @@ func (j mdJournal) mdInfoPath(id MdID) string {
 }
 
 // mdInfo is the structure stored in mdInfoPath(id).
+//
+// TODO: Handle unknown fields? We'd have to build a handler for this,
+// since the Go JSON library doesn't support it natively.
 type mdInfo struct {
 	Timestamp time.Time
 	Version   MetadataVer

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -246,8 +246,13 @@ func (j mdJournal) getMD(id MdID, verifyBranchID bool) (
 		return nil, time.Time{}, err
 	}
 
-	// MDv3 TODO: pass key bundles when needed
-	err = rmd.IsValidAndSigned(j.codec, j.crypto, nil)
+	extra, err := j.getExtraMetadata(
+		rmd.GetTLFWriterKeyBundleID(), rmd.GetTLFReaderKeyBundleID())
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	err = rmd.IsValidAndSigned(j.codec, j.crypto, extra)
 	if err != nil {
 		return nil, time.Time{}, err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -96,6 +96,8 @@ func MakeImmutableBareRootMetadata(
 // separately in dir/wkbv3 (dir/rkbv3). The number of bundles is
 // small, so no need to splay them.
 //
+// TODO: Garbage-collect unreferenced key bundles.
+//
 // The maximum number of characters added to the root dir by an MD
 // journal is 50:
 //

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -746,14 +746,14 @@ func (j mdJournal) getExtraMetadata(
 	}
 
 	var wkb TLFWriterKeyBundleV3
-	err := deserializeFromFile(
+	err := kbfscodec.DeserializeFromFile(
 		j.codec, j.writerKeyBundleV3Path(wkbID), &wkb)
 	if err != nil {
 		return nil, err
 	}
 
 	var rkb TLFReaderKeyBundleV3
-	err = deserializeFromFile(
+	err = kbfscodec.DeserializeFromFile(
 		j.codec, j.readerKeyBundleV3Path(rkbID), &rkb)
 	if err != nil {
 		return nil, err
@@ -794,13 +794,13 @@ func (j mdJournal) putExtraMetadata(
 		return err
 	}
 
-	err = serializeToFile(
+	err = kbfscodec.SerializeToFile(
 		j.codec, extraV3.wkb, j.writerKeyBundleV3Path(wkbID))
 	if err != nil {
 		return err
 	}
 
-	err = serializeToFile(
+	err = kbfscodec.SerializeToFile(
 		j.codec, extraV3.rkb, j.readerKeyBundleV3Path(rkbID))
 	if err != nil {
 		return err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -119,12 +119,12 @@ type mdJournal struct {
 	uid keybase1.UID
 	key kbfscrypto.VerifyingKey
 
-	codec           kbfscodec.Codec
-	crypto          cryptoPure
-	clock           Clock
-	tlfID           TlfID
-	metadataVersion MetadataVer
-	dir             string
+	codec  kbfscodec.Codec
+	crypto cryptoPure
+	clock  Clock
+	tlfID  TlfID
+	mdVer  MetadataVer
+	dir    string
 
 	log      logger.Logger
 	deferLog logger.Logger
@@ -145,7 +145,7 @@ type mdJournal struct {
 func makeMDJournal(
 	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
 	crypto cryptoPure, clock Clock, tlfID TlfID,
-	metadataVersion MetadataVer, dir string,
+	mdVer MetadataVer, dir string,
 	log logger.Logger) (*mdJournal, error) {
 	if uid == keybase1.UID("") {
 		return nil, errors.New("Empty user")
@@ -158,17 +158,17 @@ func makeMDJournal(
 
 	deferLog := log.CloneWithAddedDepth(1)
 	journal := mdJournal{
-		uid:             uid,
-		key:             key,
-		codec:           codec,
-		crypto:          crypto,
-		clock:           clock,
-		tlfID:           tlfID,
-		metadataVersion: metadataVersion,
-		dir:             dir,
-		log:             log,
-		deferLog:        deferLog,
-		j:               makeMdIDJournal(codec, journalDir),
+		uid:      uid,
+		key:      key,
+		codec:    codec,
+		crypto:   crypto,
+		clock:    clock,
+		tlfID:    tlfID,
+		mdVer:    mdVer,
+		dir:      dir,
+		log:      log,
+		deferLog: deferLog,
+		j:        makeMdIDJournal(codec, journalDir),
 	}
 
 	earliest, err := journal.getEarliest(false)
@@ -297,7 +297,7 @@ func (j mdJournal) getMD(id MdID, verifyBranchID bool) (
 	}
 
 	rmd, err := DecodeRootMetadata(
-		j.codec, j.tlfID, version, j.metadataVersion, data)
+		j.codec, j.tlfID, version, j.mdVer, data)
 	if err != nil {
 		return nil, time.Time{}, err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -767,7 +767,7 @@ func (j mdJournal) getExtraMetadata(
 	return &ExtraMetadataV3{wkb: &wkb, rkb: &rkb}, nil
 }
 
-func (j mdJournal) setExtraMetadata(
+func (j mdJournal) putExtraMetadata(
 	rmd BareRootMetadata, extra ExtraMetadata) error {
 	if extra == nil {
 		return nil
@@ -1064,7 +1064,7 @@ func (j *mdJournal) put(
 		return MdID{}, err
 	}
 
-	err = j.setExtraMetadata(brmd, extra)
+	err = j.putExtraMetadata(brmd, extra)
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -759,6 +759,11 @@ func (j mdJournal) getExtraMetadata(
 		return nil, err
 	}
 
+	err = checkKeyBundlesV3(j.crypto, wkbID, rkbID, &wkb, &rkb)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ExtraMetadataV3{wkb: &wkb, rkb: &rkb}, nil
 }
 
@@ -783,7 +788,13 @@ func (j mdJournal) setExtraMetadata(
 		return errors.New("Invalid extra metadata")
 	}
 
-	err := serializeToFile(
+	err := checkKeyBundlesV3(
+		j.crypto, wkbID, rkbID, extraV3.wkb, extraV3.rkb)
+	if err != nil {
+		return err
+	}
+
+	err = serializeToFile(
 		j.codec, extraV3.wkb, j.writerKeyBundleV3Path(wkbID))
 	if err != nil {
 		return err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -262,15 +262,12 @@ func (j mdJournal) getMDInfo(id MdID) (time.Time, MetadataVer, error) {
 	return info.Timestamp, info.Version, nil
 }
 
+// putMDInfo assumes that the parent directory of j.mdInfoPath(id)
+// (which is j.mdPath(id)) has already been created.
 func (j mdJournal) putMDInfo(
 	id MdID, timestamp time.Time, version MetadataVer) error {
 	info := mdInfo{timestamp, version}
 	infoJSON, err := json.Marshal(info)
-	if err != nil {
-		return err
-	}
-
-	err = os.MkdirAll(j.mdPath(id), 0700)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -103,9 +103,12 @@ type mdJournal struct {
 	uid keybase1.UID
 	key kbfscrypto.VerifyingKey
 
-	codec  kbfscodec.Codec
-	crypto cryptoPure
-	dir    string
+	codec           kbfscodec.Codec
+	crypto          cryptoPure
+	clock           Clock
+	tlfID           TlfID
+	metadataVersion MetadataVer
+	dir             string
 
 	log      logger.Logger
 	deferLog logger.Logger
@@ -125,7 +128,9 @@ type mdJournal struct {
 
 func makeMDJournal(
 	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	crypto cryptoPure, dir string, log logger.Logger) (*mdJournal, error) {
+	crypto cryptoPure, clock Clock, tlfID TlfID,
+	metadataVersion MetadataVer, dir string,
+	log logger.Logger) (*mdJournal, error) {
 	if uid == keybase1.UID("") {
 		return nil, errors.New("Empty user")
 	}
@@ -137,14 +142,17 @@ func makeMDJournal(
 
 	deferLog := log.CloneWithAddedDepth(1)
 	journal := mdJournal{
-		uid:      uid,
-		key:      key,
-		codec:    codec,
-		crypto:   crypto,
-		dir:      dir,
-		log:      log,
-		deferLog: deferLog,
-		j:        makeMdIDJournal(codec, journalDir),
+		uid:             uid,
+		key:             key,
+		codec:           codec,
+		crypto:          crypto,
+		clock:           clock,
+		tlfID:           tlfID,
+		metadataVersion: metadataVersion,
+		dir:             dir,
+		log:             log,
+		deferLog:        deferLog,
+		j:               makeMdIDJournal(codec, journalDir),
 	}
 
 	earliest, err := journal.getEarliest(false)

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -929,6 +929,11 @@ func (j *mdJournal) put(
 	}()
 
 	if extra == nil {
+		// TODO: This could fail if the key bundle isn't part
+		// of the journal. Always mandate that the extra field
+		// be plumbed through with a RootMetadata, and keep
+		// around a flag as to whether it should be sent up to
+		// the remote MDServer.
 		var err error
 		extra, err = j.getExtraMetadata(
 			rmd.bareMd.GetTLFWriterKeyBundleID(),

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -353,8 +353,6 @@ func (j mdJournal) putMD(rmd BareRootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 
-	// TODO: Write version info.
-
 	err = ioutil.WriteFile(j.mdDataPath(id), buf, 0600)
 	if err != nil {
 		return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -64,8 +64,10 @@ func MakeImmutableBareRootMetadata(
 // dir/md_journal/0...002
 // dir/md_journal/0...fff
 // dir/mds/0100/0...01/data
+// dir/mds/0100/0...01/info.json
 // ...
 // dir/mds/01ff/f...ff/data
+// dir/mds/01ff/f...ff/info.json
 //
 // There's a single journal subdirectory; the journal ordinals are
 // just MetadataRevisions, and the journal entries are just MdIDs.
@@ -78,15 +80,16 @@ func MakeImmutableBareRootMetadata(
 // using the first four characters of the name to keep the number of
 // directories in dir itself to a manageable number, similar to git.
 // Each block directory has data, which is the raw MD data that should
-// hash to the MD ID. Future versions of the journal might add more
-// files to this directory; if any code is written to move MDs around,
-// it should be careful to preserve any unknown files in an MD
-// directory.
+// hash to the MD ID, and info.json, which contains the version and
+// timestamp info for that MD. Future versions of the journal might
+// add more files to this directory; if any code is written to move
+// MDs around, it should be careful to preserve any unknown files in
+// an MD directory.
 //
 // The maximum number of characters added to the root dir by an MD
-// journal is 45:
+// journal is 50:
 //
-//   /mds/01ff/f...(30 characters total)...ff/data
+//   /mds/01ff/f...(30 characters total)...ff/info.json
 //
 // This covers even the temporary files created in convertToBranch,
 // which create paths like

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -369,7 +369,7 @@ func (j mdJournal) checkGetParams() (
 	}
 
 	if head != (ImmutableBareRootMetadata{}) {
-		extra, err := j.getExtraMD(
+		extra, err := j.getExtraMetadata(
 			head.GetTLFWriterKeyBundleID(),
 			head.GetTLFReaderKeyBundleID())
 		if err != nil {
@@ -662,6 +662,16 @@ func getMdID(ctx context.Context, mdserver MDServer, crypto cryptoPure,
 	return crypto.MakeMdID(rmdses[0].MD)
 }
 
+func (j mdJournal) getExtraMetadata(
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	ExtraMetadata, error) {
+	// MDv3 TODO: implement this
+	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
+		panic("Bundle IDs are unexpectedly set")
+	}
+	return nil, nil
+}
+
 // All functions below are public functions.
 
 func (j mdJournal) readEarliestRevision() (MetadataRevision, error) {
@@ -853,7 +863,7 @@ func (j *mdJournal) put(
 
 	// Check permissions and consistency with head, if it exists.
 	if head != (ImmutableBareRootMetadata{}) {
-		prevExtra, err := j.getExtraMD(
+		prevExtra, err := j.getExtraMetadata(
 			head.GetTLFWriterKeyBundleID(),
 			head.GetTLFReaderKeyBundleID())
 		ok, err := isWriterOrValidRekey(
@@ -997,13 +1007,4 @@ func (j *mdJournal) clear(
 		}
 	}
 	return nil
-}
-
-func (j mdJournal) getExtraMD(wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
-	ExtraMetadata, error) {
-	// MDv3 TODO: implement this
-	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
-		panic("Bundle IDs are unexpectedly set")
-	}
-	return nil, nil
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -708,7 +708,7 @@ func TestMDJournalRestart(t *testing.T) {
 
 	// Restart journal.
 	j, err := makeMDJournal(j.uid, j.key, codec, crypto, j.clock,
-		j.tlfID, j.metadataVersion, j.dir, j.log)
+		j.tlfID, j.mdVer, j.dir, j.log)
 	require.NoError(t, err)
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
@@ -748,7 +748,7 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 	// Restart journal.
 
 	j, err = makeMDJournal(j.uid, j.key, codec, crypto, j.clock,
-		j.tlfID, j.metadataVersion, j.dir, j.log)
+		j.tlfID, j.mdVer, j.dir, j.log)
 	require.NoError(t, err)
 
 	require.Equal(t, mdCount, getMDJournalLength(t, j))

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -581,7 +581,7 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 		return nil, nil
 	}
 	mdserv := md.config.MDServer()
-	wkb, rkb, err := mdserv.GetKeyBundles(ctx, wkbID, rkbID)
+	wkb, rkb, err := mdserv.GetKeyBundles(ctx, brmd.TlfID(), wkbID, rkbID)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -225,7 +225,8 @@ func TestMDOpsGetForHandlePublicSuccess(t *testing.T) {
 
 func expectGetKeyBundles(ctx context.Context, config *ConfigMock, extra ExtraMetadata) {
 	if extraV3, ok := extra.(*ExtraMetadataV3); ok {
-		config.mockMdserv.EXPECT().GetKeyBundles(ctx, gomock.Any(), gomock.Any()).
+		config.mockMdserv.EXPECT().GetKeyBundles(
+			ctx, gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(extraV3.wkb, extraV3.rkb, nil)
 	}
 }

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -627,9 +627,17 @@ func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
 func (md *MDServerDisk) GetKeyBundles(_ context.Context,
 	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	// MDv3 TODO: implement this
-	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
-		panic("Bundle IDs are unexpectedly set")
+	md.lock.RLock()
+	defer md.lock.RUnlock()
+
+	if md.handleDb == nil {
+		return nil, nil, errMDServerDiskShutdown
 	}
-	return nil, nil, nil
+
+	tlfStorage, err := md.getStorage(tlfID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return tlfStorage.getKeyBundles(wkbID, rkbID)
 }

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -625,7 +625,7 @@ func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
 
 // GetKeyBundles implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetKeyBundles(_ context.Context,
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	// MDv3 TODO: implement this
 	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -136,7 +136,7 @@ func (md *MDServerDisk) getStorage(tlfID TlfID) (*mdServerTlfStorage, error) {
 	path := filepath.Join(md.dirPath, tlfID.String())
 	storage = makeMDServerTlfStorage(
 		md.config.Codec(), md.config.cryptoPure(),
-		md.config.Clock(), path)
+		md.config.Clock(), tlfID, md.config.MetadataVersion(), path)
 
 	md.tlfStorage[tlfID] = storage
 	return storage, nil

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -747,16 +747,24 @@ func (md *MDServerMemory) setExtraMetadataLocked(rmds *RootMetadataSigned,
 	if extra == nil {
 		return nil
 	}
+
+	tlfID := rmds.MD.TlfID()
+	wkbID := rmds.MD.GetTLFWriterKeyBundleID()
+	if wkbID == (TLFWriterKeyBundleID{}) {
+		panic("writer key bundle ID is empty")
+	}
+
+	rkbID := rmds.MD.GetTLFReaderKeyBundleID()
+	if rkbID == (TLFReaderKeyBundleID{}) {
+		panic("reader key bundle ID is empty")
+	}
+
 	extraV3, ok := extra.(*ExtraMetadataV3)
 	if !ok {
 		return errors.New("Invalid extra metadata")
 	}
-	md.writerKeyBundleDb[mdExtraWriterKey{
-		rmds.MD.TlfID(), rmds.MD.GetTLFWriterKeyBundleID(),
-	}] = extraV3.wkb
-	md.readerKeyBundleDb[mdExtraReaderKey{
-		rmds.MD.TlfID(), rmds.MD.GetTLFReaderKeyBundleID(),
-	}] = extraV3.rkb
+	md.writerKeyBundleDb[mdExtraWriterKey{tlfID, wkbID}] = extraV3.wkb
+	md.readerKeyBundleDb[mdExtraReaderKey{tlfID, rkbID}] = extraV3.rkb
 	return nil
 }
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -771,6 +771,11 @@ func (md *MDServerMemory) setExtraMetadataLocked(rmds *RootMetadataSigned,
 func (md *MDServerMemory) getKeyBundles(
 	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3) {
+	if wkbID == (TLFWriterKeyBundleID{}) ||
+		rkbID == (TLFReaderKeyBundleID{}) {
+		return nil, nil
+	}
+
 	md.lock.Lock()
 	defer md.lock.Unlock()
 	wkb := md.writerKeyBundleDb[mdExtraWriterKey{tlfID, wkbID}]

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -744,7 +744,6 @@ func (md *MDServerMemory) getExtraMetadata(
 
 func (md *MDServerMemory) setExtraMetadataLocked(rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
-	return nil
 	if extra == nil {
 		return nil
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -30,6 +30,16 @@ type mdBranchKey struct {
 	deviceKID keybase1.KID
 }
 
+type mdExtraWriterKey struct {
+	tlfID          TlfID
+	writerBundleID TLFWriterKeyBundleID
+}
+
+type mdExtraReaderKey struct {
+	tlfID          TlfID
+	readerBundleID TLFReaderKeyBundleID
+}
+
 type mdBlockMem struct {
 	// An encoded RootMetdataSigned.
 	encodedMd []byte
@@ -54,9 +64,9 @@ type mdServerMemShared struct {
 	// (TLF ID, branch ID) -> list of MDs
 	mdDb map[mdBlockKey]mdBlockMemList
 	// Writer key bundle ID -> writer key bundles
-	writerKeyBundleDb map[TLFWriterKeyBundleID]*TLFWriterKeyBundleV3
+	writerKeyBundleDb map[mdExtraWriterKey]*TLFWriterKeyBundleV3
 	// Reader key bundle ID -> reader key bundles
-	readerKeyBundleDb map[TLFReaderKeyBundleID]*TLFReaderKeyBundleV3
+	readerKeyBundleDb map[mdExtraReaderKey]*TLFReaderKeyBundleV3
 	// (TLF ID, device KID) -> branch ID
 	branchDb            map[mdBranchKey]BranchID
 	truncateLockManager *mdServerLocalTruncateLockManager
@@ -81,8 +91,8 @@ func NewMDServerMemory(config mdServerLocalConfig) (*MDServerMemory, error) {
 	latestHandleDb := make(map[TlfID]BareTlfHandle)
 	mdDb := make(map[mdBlockKey]mdBlockMemList)
 	branchDb := make(map[mdBranchKey]BranchID)
-	writerKeyBundleDb := make(map[TLFWriterKeyBundleID]*TLFWriterKeyBundleV3)
-	readerKeyBundleDb := make(map[TLFReaderKeyBundleID]*TLFReaderKeyBundleV3)
+	writerKeyBundleDb := make(map[mdExtraWriterKey]*TLFWriterKeyBundleV3)
+	readerKeyBundleDb := make(map[mdExtraReaderKey]*TLFReaderKeyBundleV3)
 	log := config.MakeLogger("MDSM")
 	truncateLockManager := newMDServerLocalTruncatedLockManager()
 	shared := mdServerMemShared{
@@ -181,7 +191,7 @@ func (md *MDServerMemory) checkGetParams(
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
 		extra, err := md.getExtraMetadata(
-			mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
+			id, mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
 			mergedMasterHead.MD.GetTLFReaderKeyBundleID())
 		if err != nil {
 			return NullBranchID, MDServerError{err}
@@ -351,7 +361,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	if extra == nil {
 		var err error
 		extra, err = md.getExtraMetadata(
-			rmds.MD.GetTLFWriterKeyBundleID(),
+			rmds.MD.TlfID(), rmds.MD.GetTLFWriterKeyBundleID(),
 			rmds.MD.GetTLFReaderKeyBundleID())
 		if err != nil {
 			return MDServerError{err}
@@ -381,6 +391,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
 		prevExtra, err := md.getExtraMetadata(
+			mergedMasterHead.MD.TlfID(),
 			mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
 			mergedMasterHead.MD.GetTLFReaderKeyBundleID())
 		if err != nil {
@@ -722,9 +733,9 @@ func (md *MDServerMemory) OffsetFromServerTime() (time.Duration, bool) {
 }
 
 func (md *MDServerMemory) getExtraMetadata(
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	ExtraMetadata, error) {
-	wkb, rkb := md.getKeyBundles(wkbID, rkbID)
+	wkb, rkb := md.getKeyBundles(tlfID, wkbID, rkbID)
 	if wkb == nil || rkb == nil {
 		return nil, nil
 	}
@@ -733,6 +744,7 @@ func (md *MDServerMemory) getExtraMetadata(
 
 func (md *MDServerMemory) setExtraMetadataLocked(rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
+	return nil
 	if extra == nil {
 		return nil
 	}
@@ -740,27 +752,29 @@ func (md *MDServerMemory) setExtraMetadataLocked(rmds *RootMetadataSigned,
 	if !ok {
 		return errors.New("Invalid extra metadata")
 	}
-	md.writerKeyBundleDb[rmds.MD.GetTLFWriterKeyBundleID()] =
-		extraV3.wkb
-	md.readerKeyBundleDb[rmds.MD.GetTLFReaderKeyBundleID()] =
-		extraV3.rkb
+	md.writerKeyBundleDb[mdExtraWriterKey{
+		rmds.MD.TlfID(), rmds.MD.GetTLFWriterKeyBundleID(),
+	}] = extraV3.wkb
+	md.readerKeyBundleDb[mdExtraReaderKey{
+		rmds.MD.TlfID(), rmds.MD.GetTLFReaderKeyBundleID(),
+	}] = extraV3.rkb
 	return nil
 }
 
 func (md *MDServerMemory) getKeyBundles(
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3) {
 	md.lock.Lock()
 	defer md.lock.Unlock()
-	wkb := md.writerKeyBundleDb[wkbID]
-	rkb := md.readerKeyBundleDb[rkbID]
+	wkb := md.writerKeyBundleDb[mdExtraWriterKey{tlfID, wkbID}]
+	rkb := md.readerKeyBundleDb[mdExtraReaderKey{tlfID, rkbID}]
 	return wkb, rkb
 }
 
 // GetKeyBundles implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetKeyBundles(_ context.Context,
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	wkb, rkb := md.getKeyBundles(wkbID, rkbID)
+	wkb, rkb := md.getKeyBundles(tlfID, wkbID, rkbID)
 	return wkb, rkb, nil
 }

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -497,7 +497,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 		}
 	}
 
-	if err := md.setExtraMetadataLocked(rmds, extra); err != nil {
+	if err := md.putExtraMetadataLocked(rmds, extra); err != nil {
 		return MDServerError{err}
 	}
 
@@ -745,7 +745,7 @@ func (md *MDServerMemory) getExtraMetadata(
 	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
 }
 
-func (md *MDServerMemory) setExtraMetadataLocked(rmds *RootMetadataSigned,
+func (md *MDServerMemory) putExtraMetadataLocked(rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
 	if extra == nil {
 		return nil

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -837,7 +837,7 @@ func (md *MDServerRemote) backgroundRekeyChecker(ctx context.Context) {
 
 // GetKeyBundles implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetKeyBundles(_ context.Context,
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	// MDv3 TODO: implement this
 	return nil, nil, nil

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -331,6 +331,16 @@ func (s *mdServerTlfStorage) put(
 		return false, errMDServerTlfStorageShutdown
 	}
 
+	if extra == nil {
+		var err error
+		extra, err = s.getExtraMetadata(
+			rmds.MD.GetTLFWriterKeyBundleID(),
+			rmds.MD.GetTLFReaderKeyBundleID())
+		if err != nil {
+			return false, MDServerError{err}
+		}
+	}
+
 	err = rmds.IsValidAndSigned(s.codec, s.crypto, extra)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
@@ -350,7 +360,7 @@ func (s *mdServerTlfStorage) put(
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		prevExtra, err := s.getExtraMD(
+		prevExtra, err := s.getExtraMetadata(
 			mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
 			mergedMasterHead.MD.GetTLFReaderKeyBundleID())
 		if err != nil {
@@ -430,7 +440,8 @@ func (s *mdServerTlfStorage) shutdown() {
 	s.branchJournals = nil
 }
 
-func (s *mdServerTlfStorage) getExtraMD(wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+func (s *mdServerTlfStorage) getExtraMetadata(
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	ExtraMetadata, error) {
 	// MDv3 TODO: implement this
 	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -135,8 +135,6 @@ func (s *mdServerTlfStorage) getMDReadLocked(id MdID) (
 		return nil, err
 	}
 
-	// Read file.
-
 	rmds, err := DecodeRootMetadataSigned(
 		s.codec, s.tlfID, srmds.Version, s.metadataVersion,
 		srmds.EncodedRMDS)

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -261,6 +261,43 @@ func (s *mdServerTlfStorage) getRangeReadLocked(
 	return rmdses, nil
 }
 
+func (s *mdServerTlfStorage) getExtraMetadataLocked(
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	ExtraMetadata, error) {
+	wkb, rkb, err := s.getKeyBundlesLocked(wkbID, rkbID)
+	if err != nil {
+		return nil, err
+	}
+	if wkb == nil || rkb == nil {
+		return nil, nil
+	}
+	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
+}
+
+func (s *mdServerTlfStorage) getKeyBundlesLocked(
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	// MDv3 TODO: implement this
+	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
+		panic("Bundle IDs are unexpectedly set")
+	}
+	return nil, nil, nil
+}
+
+func (s *mdServerTlfStorage) setExtraMetadataLocked(
+	rmds *RootMetadataSigned, extra ExtraMetadata) error {
+	if extra == nil {
+		return nil
+	}
+
+	_, ok := extra.(*ExtraMetadataV3)
+	if !ok {
+		return errors.New("Invalid extra metadata")
+	}
+	panic("Not implemented")
+	return nil
+}
+
 func (s *mdServerTlfStorage) isShutdownReadLocked() bool {
 	return s.branchJournals == nil
 }
@@ -439,32 +476,16 @@ func (s *mdServerTlfStorage) put(
 	return recordBranchID, nil
 }
 
+func (s *mdServerTlfStorage) getKeyBundles(
+	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.getKeyBundlesLocked(wkbID, rkbID)
+}
+
 func (s *mdServerTlfStorage) shutdown() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.branchJournals = nil
-}
-
-func (s *mdServerTlfStorage) getExtraMetadataLocked(
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
-	ExtraMetadata, error) {
-	// MDv3 TODO: implement this
-	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
-		panic("Bundle IDs are unexpectedly set")
-	}
-	return nil, nil
-}
-
-func (s *mdServerTlfStorage) setExtraMetadataLocked(
-	rmds *RootMetadataSigned, extra ExtraMetadata) error {
-	if extra == nil {
-		return nil
-	}
-
-	_, ok := extra.(*ExtraMetadataV3)
-	if !ok {
-		return errors.New("Invalid extra metadata")
-	}
-	panic("Not implemented")
-	return nil
 }

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -61,12 +61,12 @@ import (
 // separately in dir/wkbv3 (dir/rkbv3). The number of bundles is
 // small, so no need to splay them.
 type mdServerTlfStorage struct {
-	codec           kbfscodec.Codec
-	crypto          cryptoPure
-	clock           Clock
-	tlfID           TlfID
-	metadataVersion MetadataVer
-	dir             string
+	codec  kbfscodec.Codec
+	crypto cryptoPure
+	clock  Clock
+	tlfID  TlfID
+	mdVer  MetadataVer
+	dir    string
 
 	// Protects any IO operations in dir or any of its children,
 	// as well as branchJournals and its contents.
@@ -76,15 +76,15 @@ type mdServerTlfStorage struct {
 
 func makeMDServerTlfStorage(codec kbfscodec.Codec,
 	crypto cryptoPure, clock Clock, tlfID TlfID,
-	metadataVersion MetadataVer, dir string) *mdServerTlfStorage {
+	mdVer MetadataVer, dir string) *mdServerTlfStorage {
 	journal := &mdServerTlfStorage{
-		codec:           codec,
-		crypto:          crypto,
-		clock:           clock,
-		tlfID:           tlfID,
-		metadataVersion: metadataVersion,
-		dir:             dir,
-		branchJournals:  make(map[BranchID]mdIDJournal),
+		codec:          codec,
+		crypto:         crypto,
+		clock:          clock,
+		tlfID:          tlfID,
+		mdVer:          mdVer,
+		dir:            dir,
+		branchJournals: make(map[BranchID]mdIDJournal),
 	}
 	return journal
 }
@@ -136,7 +136,7 @@ func (s *mdServerTlfStorage) getMDReadLocked(id MdID) (
 	}
 
 	rmds, err := DecodeRootMetadataSigned(
-		s.codec, s.tlfID, srmds.Version, s.metadataVersion,
+		s.codec, s.tlfID, srmds.Version, s.mdVer,
 		srmds.EncodedRMDS)
 	if err != nil {
 		return nil, err

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -36,6 +36,12 @@ import (
 // dir/mds/0100/0...01
 // ...
 // dir/mds/01ff/f...ff
+// dir/wkbv3/0100...01
+// ...
+// dir/wkbv3/0100...ff
+// dir/rkbv3/0100...01
+// ...
+// dir/rkbv3/0100...ff
 //
 // Each branch has its own subdirectory with a journal; the journal
 // ordinals are just MetadataRevisions, and the journal entries are
@@ -49,6 +55,10 @@ import (
 // plus the first byte of the hash data -- using the first four
 // characters of the name to keep the number of directories in dir
 // itself to a manageable number, similar to git.
+//
+// Writer (reader) key bundles for V3 metadata objects are stored
+// separately in dir/wkbv3 (dir/rkbv3). The number of bundles is
+// small, so no need to splay them.
 type mdServerTlfStorage struct {
 	codec  kbfscodec.Codec
 	crypto cryptoPure

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -333,7 +333,7 @@ func (s *mdServerTlfStorage) put(
 
 	if extra == nil {
 		var err error
-		extra, err = s.getExtraMetadata(
+		extra, err = s.getExtraMetadataLocked(
 			rmds.MD.GetTLFWriterKeyBundleID(),
 			rmds.MD.GetTLFReaderKeyBundleID())
 		if err != nil {
@@ -360,7 +360,7 @@ func (s *mdServerTlfStorage) put(
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		prevExtra, err := s.getExtraMetadata(
+		prevExtra, err := s.getExtraMetadataLocked(
 			mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
 			mergedMasterHead.MD.GetTLFReaderKeyBundleID())
 		if err != nil {
@@ -421,6 +421,11 @@ func (s *mdServerTlfStorage) put(
 		return false, MDServerError{err}
 	}
 
+	err = s.setExtraMetadataLocked(rmds, extra)
+	if err != nil {
+		return false, MDServerError{err}
+	}
+
 	j, err := s.getOrCreateBranchJournalLocked(bid)
 	if err != nil {
 		return false, err
@@ -440,7 +445,7 @@ func (s *mdServerTlfStorage) shutdown() {
 	s.branchJournals = nil
 }
 
-func (s *mdServerTlfStorage) getExtraMetadata(
+func (s *mdServerTlfStorage) getExtraMetadataLocked(
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	ExtraMetadata, error) {
 	// MDv3 TODO: implement this
@@ -448,4 +453,18 @@ func (s *mdServerTlfStorage) getExtraMetadata(
 		panic("Bundle IDs are unexpectedly set")
 	}
 	return nil, nil
+}
+
+func (s *mdServerTlfStorage) setExtraMetadataLocked(
+	rmds *RootMetadataSigned, extra ExtraMetadata) error {
+	if extra == nil {
+		return nil
+	}
+
+	_, ok := extra.(*ExtraMetadataV3)
+	if !ok {
+		return errors.New("Invalid extra metadata")
+	}
+	panic("Not implemented")
+	return nil
 }

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -98,8 +98,8 @@ func (s *mdServerTlfStorage) mdPath(id MdID) string {
 	return filepath.Join(s.mdsPath(), idStr[:4], idStr[4:])
 }
 
-// getDataLocked verifies the MD data (but not the signature) for the
-// given ID and returns it.
+// getMDReadLocked verifies the MD data (but not the signature) for
+// the given ID and returns it.
 //
 // TODO: Verify signature?
 func (s *mdServerTlfStorage) getMDReadLocked(id MdID) (

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -104,16 +104,12 @@ func (s *mdServerTlfStorage) mdPath(id MdID) string {
 // TODO: Verify signature?
 func (s *mdServerTlfStorage) getMDReadLocked(id MdID) (
 	*RootMetadataSigned, error) {
+	path := s.mdPath(id)
+
 	// Read file.
 
-	path := s.mdPath(id)
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
 	rmds := RootMetadataSigned{MD: &BareRootMetadataV2{}}
-	err = s.codec.Decode(data, &rmds)
+	err := deserializeFromFile(s.codec, path, &rmds)
 	if err != nil {
 		return nil, err
 	}
@@ -161,6 +157,21 @@ func serializeToFile(codec kbfscodec.Codec, clock Clock,
 	err = os.Chtimes(path, now, now)
 	if err != nil {
 		return MdID{}, err
+	}
+
+	return nil
+}
+
+func deserializeFromFile(
+	codec kbfscodec.Codec, path string, objPtr interface{}) error {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	err = codec.Decode(data, objPtr)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -395,7 +395,7 @@ func checkKeyBundlesV3(
 	return nil
 }
 
-func (s *mdServerTlfStorage) setExtraMetadataLocked(
+func (s *mdServerTlfStorage) putExtraMetadataLocked(
 	rmds *RootMetadataSigned, extra ExtraMetadata) error {
 	if extra == nil {
 		return nil
@@ -596,7 +596,7 @@ func (s *mdServerTlfStorage) put(
 		return false, MDServerError{err}
 	}
 
-	err = s.setExtraMetadataLocked(rmds, extra)
+	err = s.putExtraMetadataLocked(rmds, extra)
 	if err != nil {
 		return false, MDServerError{err}
 	}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -156,7 +156,7 @@ func serializeToFile(codec kbfscodec.Codec, clock Clock,
 	now := clock.Now()
 	err = os.Chtimes(path, now, now)
 	if err != nil {
-		return MdID{}, err
+		return err
 	}
 
 	return nil
@@ -306,11 +306,26 @@ func (s *mdServerTlfStorage) getExtraMetadataLocked(
 func (s *mdServerTlfStorage) getKeyBundlesLocked(
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	// MDv3 TODO: implement this
-	if (wkbID != TLFWriterKeyBundleID{}) || (rkbID != TLFReaderKeyBundleID{}) {
-		panic("Bundle IDs are unexpectedly set")
+	if wkbID == (TLFWriterKeyBundleID{}) ||
+		rkbID == (TLFReaderKeyBundleID{}) {
+		return nil, nil, nil
 	}
-	return nil, nil, nil
+
+	var wkb TLFWriterKeyBundleV3
+	err := deserializeFromFile(
+		s.codec, s.writerKeyBundleV3Path(wkbID), &wkb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var rkb TLFReaderKeyBundleV3
+	err = deserializeFromFile(
+		s.codec, s.readerKeyBundleV3Path(rkbID), &rkb)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &wkb, &rkb, nil
 }
 
 func (s *mdServerTlfStorage) setExtraMetadataLocked(

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -38,10 +38,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	}()
 
 	tlfID := FakeTlfID(1, false)
-	// TODO: Test SegregatedKeyBundlesVer also.
-	s := makeMDServerTlfStorage(
-		codec, crypto, wallClock{}, tlfID,
-		InitialExtraMetadataVer, tempdir)
+	s := makeMDServerTlfStorage(codec, crypto, wallClock{}, tlfID,
+		SegregatedKeyBundlesVer, tempdir)
 	defer s.shutdown()
 
 	require.Equal(t, 0, getMDStorageLength(t, s, NullBranchID))

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -37,13 +37,16 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	s := makeMDServerTlfStorage(codec, crypto, wallClock{}, tempdir)
+	tlfID := FakeTlfID(1, false)
+	// TODO: Test SegregatedKeyBundlesVer also.
+	s := makeMDServerTlfStorage(
+		codec, crypto, wallClock{}, tlfID,
+		InitialExtraMetadataVer, tempdir)
 	defer s.shutdown()
 
 	require.Equal(t, 0, getMDStorageLength(t, s, NullBranchID))
 
 	uid := keybase1.MakeTestUID(1)
-	id := FakeTlfID(1, false)
 	h, err := MakeBareTlfHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
@@ -60,7 +63,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot := MdID{}
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
-		rmds := makeRMDSForTest(t, crypto, id, h, i, uid, prevRoot)
+		rmds := makeRMDSForTest(t, crypto, tlfID, h, i, uid, prevRoot)
 		signRMDSForTest(t, codec, signer, rmds)
 		// MDv3 TODO: pass extra metadata
 		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
@@ -77,7 +80,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 
 	// (3) Trigger a conflict.
 
-	rmds := makeRMDSForTest(t, crypto, id, h, 10, uid, prevRoot)
+	rmds := makeRMDSForTest(t, crypto, tlfID, h, 10, uid, prevRoot)
 	signRMDSForTest(t, codec, signer, rmds)
 	// MDv3 TODO: pass extra metadata
 	_, err = s.put(uid, verifyingKey, rmds, nil)
@@ -91,7 +94,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot = middleRoot
 	bid := FakeBranchID(1)
 	for i := MetadataRevision(6); i < 41; i++ {
-		rmds := makeRMDSForTest(t, crypto, id, h, i, uid, prevRoot)
+		rmds := makeRMDSForTest(t, crypto, tlfID, h, i, uid, prevRoot)
 		rmds.MD.SetUnmerged()
 		rmds.MD.SetBranchID(bid)
 		signRMDSForTest(t, codec, signer, rmds)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2832,16 +2832,16 @@ func (_mr *_MockMDServerRecorder) OffsetFromServerTime() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "OffsetFromServerTime")
 }
 
-func (_m *MockMDServer) GetKeyBundles(ctx context.Context, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	ret := _m.ctrl.Call(_m, "GetKeyBundles", ctx, wkbID, rkbID)
+func (_m *MockMDServer) GetKeyBundles(ctx context.Context, tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	ret := _m.ctrl.Call(_m, "GetKeyBundles", ctx, tlfID, wkbID, rkbID)
 	ret0, _ := ret[0].(*TLFWriterKeyBundleV3)
 	ret1, _ := ret[1].(*TLFReaderKeyBundleV3)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockMDServerRecorder) GetKeyBundles(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2)
+func (_mr *_MockMDServerRecorder) GetKeyBundles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2, arg3)
 }
 
 // Mock of mdServerLocal interface
@@ -3018,16 +3018,16 @@ func (_mr *_MockmdServerLocalRecorder) OffsetFromServerTime() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "OffsetFromServerTime")
 }
 
-func (_m *MockmdServerLocal) GetKeyBundles(ctx context.Context, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	ret := _m.ctrl.Call(_m, "GetKeyBundles", ctx, wkbID, rkbID)
+func (_m *MockmdServerLocal) GetKeyBundles(ctx context.Context, tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	ret := _m.ctrl.Call(_m, "GetKeyBundles", ctx, tlfID, wkbID, rkbID)
 	ret0, _ := ret[0].(*TLFWriterKeyBundleV3)
 	ret1, _ := ret[1].(*TLFReaderKeyBundleV3)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockmdServerLocalRecorder) GetKeyBundles(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2)
+func (_mr *_MockmdServerLocalRecorder) GetKeyBundles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockmdServerLocal) addNewAssertionForTest(uid keybase1.UID, newAssertion keybase1.SocialAssertion) error {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -916,7 +916,36 @@ func (rmds *RootMetadataSigned) IsLastModifiedBy(
 	return nil
 }
 
-// DecodeRootMetadataSigned deserializes a metaddata block into the specified versioned structure.
+// DecodeRootMetadata deserializes a metadata block into the specified
+// versioned structure.
+func DecodeRootMetadata(
+	codec kbfscodec.Codec, tlf TlfID, ver, max MetadataVer, buf []byte) (
+	BareRootMetadata, error) {
+	if ver < FirstValidMetadataVer {
+		return nil, InvalidMetadataVersionError{tlf, ver}
+	} else if ver > max {
+		return nil, NewMetadataVersionError{tlf, ver}
+	}
+	if ver > SegregatedKeyBundlesVer {
+		// Shouldn't be possible at the moment.
+		panic("Invalid metadata version")
+	}
+	if ver < SegregatedKeyBundlesVer {
+		var brmd BareRootMetadataV2
+		if err := codec.Decode(buf, &brmd); err != nil {
+			return nil, err
+		}
+		return &brmd, nil
+	}
+	var brmd BareRootMetadataV3
+	if err := codec.Decode(buf, &brmd); err != nil {
+		return nil, err
+	}
+	return &brmd, nil
+}
+
+// DecodeRootMetadataSigned deserializes a metadata block into the
+// specified versioned structure.
 func DecodeRootMetadataSigned(
 	codec kbfscodec.Codec, tlf TlfID, ver, max MetadataVer, buf []byte) (
 	*RootMetadataSigned, error) {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -197,6 +197,8 @@ func getTLFJournalInfoFilePath(dir string) string {
 	return filepath.Join(dir, "info.json")
 }
 
+// tlfJournalInfo is the structure stored in
+// getTLFJournalInfoFilePath(dir).
 type tlfJournalInfo struct {
 	UID          keybase1.UID
 	VerifyingKey kbfscrypto.VerifyingKey

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -27,11 +27,13 @@ import (
 // tlfJournal (for ease of testing).
 type tlfJournalConfig interface {
 	BlockSplitter() BlockSplitter
+	Clock() Clock
 	Codec() kbfscodec.Codec
 	Crypto() Crypto
 	BlockCache() BlockCache
 	BlockOps() BlockOps
 	MDCache() MDCache
+	MetadataVersion() MetadataVer
 	Reporter() Reporter
 	encryptionKeyGetter() encryptionKeyGetter
 	mdDecryptionKeyGetter() mdDecryptionKeyGetter
@@ -290,7 +292,8 @@ func makeTLFJournal(
 	}
 
 	mdJournal, err := makeMDJournal(
-		uid, key, config.Codec(), config.Crypto(), dir, log)
+		uid, key, config.Codec(), config.Crypto(), config.Clock(),
+		tlfID, config.MetadataVersion(), dir, log)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1283,7 +1283,8 @@ func (j *tlfJournal) getMDRange(
 }
 
 func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
-	irmd ImmutableRootMetadata, perRevMap unflushedPathsPerRevMap) (
+	extra ExtraMetadata, irmd ImmutableRootMetadata,
+	perRevMap unflushedPathsPerRevMap) (
 	mdID MdID, retryPut bool, err error) {
 	// Now take the lock and put the MD, merging in the unflushed
 	// paths while under the lock.
@@ -1299,8 +1300,9 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	// TODO: remove the revision from the cache on any errors below?
 	// Tricky when the append is only queued.
 
-	mdID, err = j.mdJournal.put(ctx, j.config.Crypto(),
-		j.config.encryptionKeyGetter(), j.config.BlockSplitter(), rmd)
+	mdID, err := j.mdJournal.put(ctx, j.config.Crypto(),
+		j.config.encryptionKeyGetter(), j.config.BlockSplitter(),
+		rmd, extra)
 	if err != nil {
 		return MdID{}, false, err
 	}
@@ -1330,7 +1332,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		return MdID{}, err
 	}
 
-	mdID, retry, err := j.doPutMD(ctx, rmd, irmd, perRevMap)
+	mdID, retry, err := j.doPutMD(ctx, irmd, perRevMap)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1344,7 +1346,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 			return MdID{}, err
 		}
 
-		mdID, retry, err = j.doPutMD(ctx, rmd, irmd, perRevMap)
+		mdID, retry, err = j.doPutMD(ctx, irmd, perRevMap)
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1305,7 +1305,7 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	// TODO: remove the revision from the cache on any errors below?
 	// Tricky when the append is only queued.
 
-	mdID, err := j.mdJournal.put(ctx, j.config.Crypto(),
+	mdID, err = j.mdJournal.put(ctx, j.config.Crypto(),
 		j.config.encryptionKeyGetter(), j.config.BlockSplitter(),
 		rmd, extra)
 	if err != nil {
@@ -1322,7 +1322,8 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	return mdID, false, nil
 }
 
-func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
+func (j *tlfJournal) putMD(
+	ctx context.Context, rmd *RootMetadata, extra ExtraMetadata) (
 	MdID, error) {
 	// Prepare the paths without holding the lock, as it might need to
 	// take the lock.  Note that the md ID and timestamp don't matter
@@ -1337,7 +1338,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		return MdID{}, err
 	}
 
-	mdID, retry, err := j.doPutMD(ctx, irmd, perRevMap)
+	mdID, retry, err := j.doPutMD(ctx, rmd, extra, irmd, perRevMap)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1351,7 +1352,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 			return MdID{}, err
 		}
 
-		mdID, retry, err = j.doPutMD(ctx, irmd, perRevMap)
+		mdID, retry, err = j.doPutMD(ctx, rmd, extra, irmd, perRevMap)
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -293,7 +293,7 @@ func teardownTLFJournalTest(
 func putOneMD(ctx context.Context, config *testTLFJournalConfig,
 	tlfJournal *tlfJournal) {
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md)
+	_, err := tlfJournal.putMD(ctx, md, nil)
 	require.NoError(config.t, err)
 }
 
@@ -481,7 +481,7 @@ func TestTLFJournalMDServerBusyPause(t *testing.T) {
 	config.mdserver = mdserver
 
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md)
+	_, err := tlfJournal.putMD(ctx, md, nil)
 	require.NoError(t, err)
 
 	mdserver.waitForPut(ctx, t)
@@ -503,7 +503,7 @@ func TestTLFJournalMDServerBusyShutdown(t *testing.T) {
 	config.mdserver = mdserver
 
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md)
+	_, err := tlfJournal.putMD(ctx, md, nil)
 	require.NoError(t, err)
 
 	mdserver.waitForPut(ctx, t)
@@ -522,7 +522,7 @@ func TestTLFJournalBlockOpWhileBusy(t *testing.T) {
 	config.mdserver = mdserver
 
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md)
+	_, err := tlfJournal.putMD(ctx, md, nil)
 	require.NoError(t, err)
 
 	mdserver.waitForPut(ctx, t)
@@ -592,7 +592,7 @@ func TestTLFJournalFlushMDBasic(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -637,7 +637,7 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 	for i := 0; i < mdCount/2; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -657,11 +657,11 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 
 		revision := firstRevision + MetadataRevision(mdCount/2)
 		md := config.makeMD(revision, prevRoot)
-		_, err = tlfJournal.putMD(ctx, md)
+		_, err = tlfJournal.putMD(ctx, md, nil)
 		require.IsType(t, MDJournalConflictError{}, err)
 
 		md.SetUnmerged()
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -670,7 +670,7 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
 		md.SetUnmerged()
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -714,7 +714,7 @@ func TestTLFJournalPreservesBranchID(t *testing.T) {
 	for i := 0; i < mdCount-1; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -744,11 +744,11 @@ func TestTLFJournalPreservesBranchID(t *testing.T) {
 	{
 		revision := firstRevision + MetadataRevision(mdCount-1)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.IsType(t, MDJournalConflictError{}, err)
 
 		md.SetUnmerged()
-		mdID, err = tlfJournal.putMD(ctx, md)
+		mdID, err = tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 
@@ -859,7 +859,7 @@ func TestTLFJournalFlushOrdering(t *testing.T) {
 	err := tlfJournal.putBlockData(
 		ctx, bid1, bCtx1, []byte{1}, serverHalf1)
 	require.NoError(t, err)
-	prevRoot, err := tlfJournal.putMD(ctx, md1)
+	prevRoot, err := tlfJournal.putMD(ctx, md1, nil)
 	require.NoError(t, err)
 
 	bserver.onceOnPut = func() {
@@ -868,7 +868,7 @@ func TestTLFJournalFlushOrdering(t *testing.T) {
 			ctx, bid2, bCtx2, []byte{2}, serverHalf2)
 		require.NoError(t, err)
 		md2 := config.makeMD(MetadataRevision(11), prevRoot)
-		prevRoot, err = tlfJournal.putMD(ctx, md2)
+		prevRoot, err = tlfJournal.putMD(ctx, md2, nil)
 		require.NoError(t, err)
 	}
 
@@ -878,7 +878,7 @@ func TestTLFJournalFlushOrdering(t *testing.T) {
 			ctx, bid3, bCtx3, []byte{3}, serverHalf3)
 		require.NoError(t, err)
 		md3 := config.makeMD(MetadataRevision(12), prevRoot)
-		prevRoot, err = tlfJournal.putMD(ctx, md3)
+		prevRoot, err = tlfJournal.putMD(ctx, md3, nil)
 		require.NoError(t, err)
 	}
 
@@ -944,7 +944,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 		require.NoError(t, err)
 	}
 	md1 := config.makeMD(MetadataRevision(10), fakeMdID(1))
-	prevRoot, err := tlfJournal.putMD(ctx, md1)
+	prevRoot, err := tlfJournal.putMD(ctx, md1, nil)
 	require.NoError(t, err)
 
 	// Revision 2
@@ -957,7 +957,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 		require.NoError(t, err)
 	}
 	md2 := config.makeMD(MetadataRevision(11), prevRoot)
-	prevRoot, err = tlfJournal.putMD(ctx, md2)
+	prevRoot, err = tlfJournal.putMD(ctx, md2, nil)
 	require.NoError(t, err)
 
 	err = tlfJournal.flush(ctx)
@@ -1038,7 +1038,7 @@ func TestTLFJournalFlushRetry(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -85,6 +85,10 @@ func (c testTLFJournalConfig) BlockSplitter() BlockSplitter {
 	return c.splitter
 }
 
+func (c testTLFJournalConfig) Clock() Clock {
+	return wallClock{}
+}
+
 func (c testTLFJournalConfig) Codec() kbfscodec.Codec {
 	return c.codec
 }
@@ -103,6 +107,10 @@ func (c testTLFJournalConfig) BlockOps() BlockOps {
 
 func (c testTLFJournalConfig) MDCache() MDCache {
 	return c.mdcache
+}
+
+func (c testTLFJournalConfig) MetadataVersion() MetadataVer {
+	return SegregatedKeyBundlesVer
 }
 
 func (c testTLFJournalConfig) Reporter() Reporter {


### PR DESCRIPTION
This makes it possible to store V3 MD objects in
MDServerMemory, MDServerDisk, and mdJournal.

Test coverage will be added in a future PR.