### PR TITLE
[KBFS-1614] Pull writer signatures out of MDV3

### DIFF
--- a/kbfscrypto/signature.go
+++ b/kbfscrypto/signature.go
@@ -5,6 +5,7 @@
 package kbfscrypto
 
 import (
+	"bytes"
 	"encoding"
 	"encoding/hex"
 	"encoding/json"
@@ -41,6 +42,21 @@ type SignatureInfo struct {
 // IsNil returns true if this SignatureInfo is nil.
 func (s SignatureInfo) IsNil() bool {
 	return s.Version.IsNil() && len(s.Signature) == 0 && s.VerifyingKey.IsNil()
+}
+
+// Equals returns true if this SignatureInfo matches the given one.
+func (s SignatureInfo) Equals(other SignatureInfo) bool {
+	if s.Version != other.Version {
+		return false
+	}
+	if !bytes.Equal(s.Signature, other.Signature) {
+		return false
+	}
+	if s.VerifyingKey != other.VerifyingKey {
+		return false
+	}
+
+	return true
 }
 
 // DeepCopy makes a complete copy of this SignatureInfo.

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -245,7 +245,7 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 			return 1
 		}
 
-		if irmd == (libkbfs.ImmutableRootMetadata{}) {
+		if irmd.IsNil() {
 			fmt.Printf("No result found for %q\n\n", input)
 			continue
 		}

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -245,7 +245,7 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 			return 1
 		}
 
-		if irmd.IsNil() {
+		if irmd == (libkbfs.ImmutableRootMetadata{}) {
 			fmt.Printf("No result found for %q\n\n", input)
 			continue
 		}

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -60,7 +60,7 @@ outer:
 		return libkbfs.TlfID{}, err
 	}
 
-	if irmd == (libkbfs.ImmutableRootMetadata{}) {
+	if irmd.IsNil() {
 		return libkbfs.TlfID{}, fmt.Errorf(
 			"Could not get TLF ID for %q", tlfStr)
 	}
@@ -80,7 +80,7 @@ func getBranchID(ctx context.Context, config libkbfs.Config,
 		if err != nil {
 			return libkbfs.NullBranchID, err
 		}
-		if irmd == (libkbfs.ImmutableRootMetadata{}) {
+		if irmd.IsNil() {
 			return libkbfs.NullBranchID, nil
 		}
 		return irmd.BID(), nil

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -60,7 +60,7 @@ outer:
 		return libkbfs.TlfID{}, err
 	}
 
-	if irmd.IsNil() {
+	if irmd == (libkbfs.ImmutableRootMetadata{}) {
 		return libkbfs.TlfID{}, fmt.Errorf(
 			"Could not get TLF ID for %q", tlfStr)
 	}
@@ -80,7 +80,7 @@ func getBranchID(ctx context.Context, config libkbfs.Config,
 		if err != nil {
 			return libkbfs.NullBranchID, err
 		}
-		if irmd.IsNil() {
+		if irmd == (libkbfs.ImmutableRootMetadata{}) {
 			return libkbfs.NullBranchID, nil
 		}
 		return irmd.BID(), nil

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -127,7 +127,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 			return 1
 		}
 
-		if irmd.IsNil() {
+		if irmd == (libkbfs.ImmutableRootMetadata{}) {
 			fmt.Printf("No result found for %q\n\n", input)
 			continue
 		}

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -127,7 +127,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 			return 1
 		}
 
-		if irmd == (libkbfs.ImmutableRootMetadata{}) {
+		if irmd.IsNil() {
 			fmt.Printf("No result found for %q\n\n", input)
 			continue
 		}

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -653,11 +653,6 @@ func (md *BareRootMetadataV2) LastModifyingWriter() keybase1.UID {
 	return md.WriterMetadataV2.LastModifyingWriter
 }
 
-// LastModifyingWriterKID implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) LastModifyingWriterKID() keybase1.KID {
-	return md.WriterMetadataSigInfo.VerifyingKey.KID()
-}
-
 // GetLastModifyingUser implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) GetLastModifyingUser() keybase1.UID {
 	return md.LastModifyingUser

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"golang.org/x/net/context"
 )
 
 // WriterMetadataV2 stores the metadata for a TLF that is
@@ -767,6 +768,22 @@ func (md *BareRootMetadataV2) GetSerializedWriterMetadata(
 // GetWriterMetadataSigInfo implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
 	return md.WriterMetadataSigInfo
+}
+
+// MaybeSignWriterMetadata implements the MutableBareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) MaybeSignWriterMetadata(
+	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
+	buf, err := codec.Encode(md.WriterMetadataV2)
+	if err != nil {
+		return err
+	}
+
+	sigInfo, err := signer.Sign(ctx, buf)
+	if err != nil {
+		return err
+	}
+	md.WriterMetadataSigInfo = sigInfo
+	return nil
 }
 
 // SetWriterMetadataSigInfo implements the MutableBareRootMetadata interface for BareRootMetadataV2.

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -279,9 +279,20 @@ func (md *BareRootMetadataV2) DeepCopy(
 
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) MakeSuccessorCopy(
-	codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
+	codec kbfscodec.Codec, preserveWriterSig bool) (MutableBareRootMetadata, error) {
 	// MDv3 TODO: Make a v3 successor.
-	return md.DeepCopy(codec)
+	mdCopy, err := md.DeepCopy(codec)
+	if err != nil {
+		return nil, err
+	}
+	if !preserveWriterSig {
+		vk := mdCopy.(*BareRootMetadataV2).WriterMetadataSigInfo.VerifyingKey
+		mdCopy.(*BareRootMetadataV2).WriterMetadataSigInfo =
+			kbfscrypto.SignatureInfo{
+				VerifyingKey: vk,
+			}
+	}
+	return mdCopy, nil
 }
 
 // CheckValidSuccessor implements the BareRootMetadata interface for BareRootMetadataV2.

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -634,9 +634,9 @@ func (md *BareRootMetadataV2) IsLastModifiedBy(
 			return fmt.Errorf("Last writer %s != %s", writer, uid)
 		}
 		if md.WriterMetadataSigInfo.VerifyingKey != key {
-			return fmt.Errorf(
+			panic(fmt.Errorf(
 				"Last writer verifying key %v != %v",
-				md.WriterMetadataSigInfo.VerifyingKey, key)
+				md.WriterMetadataSigInfo.VerifyingKey, key))
 		}
 	}
 

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -286,11 +286,8 @@ func (md *BareRootMetadataV2) MakeSuccessorCopy(
 		return nil, err
 	}
 	if !preserveWriterSig {
-		vk := mdCopy.(*BareRootMetadataV2).WriterMetadataSigInfo.VerifyingKey
 		mdCopy.(*BareRootMetadataV2).WriterMetadataSigInfo =
-			kbfscrypto.SignatureInfo{
-				VerifyingKey: vk,
-			}
+			kbfscrypto.SignatureInfo{}
 	}
 	return mdCopy, nil
 }

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -634,9 +634,9 @@ func (md *BareRootMetadataV2) IsLastModifiedBy(
 			return fmt.Errorf("Last writer %s != %s", writer, uid)
 		}
 		if md.WriterMetadataSigInfo.VerifyingKey != key {
-			panic(fmt.Errorf(
+			return fmt.Errorf(
 				"Last writer verifying key %v != %v",
-				md.WriterMetadataSigInfo.VerifyingKey, key))
+				md.WriterMetadataSigInfo.VerifyingKey, key)
 		}
 	}
 

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -765,11 +765,6 @@ func (md *BareRootMetadataV2) GetSerializedWriterMetadata(
 	return codec.Encode(md.WriterMetadataV2)
 }
 
-// GetWriterMetadataSigInfo implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
-	return md.WriterMetadataSigInfo
-}
-
 // MaybeSignWriterMetadata implements the MutableBareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) MaybeSignWriterMetadata(
 	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
@@ -784,12 +779,6 @@ func (md *BareRootMetadataV2) MaybeSignWriterMetadata(
 	}
 	md.WriterMetadataSigInfo = sigInfo
 	return nil
-}
-
-// SetWriterMetadataSigInfo implements the MutableBareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) SetWriterMetadataSigInfo(
-	sigInfo kbfscrypto.SignatureInfo) {
-	md.WriterMetadataSigInfo = sigInfo
 }
 
 // SetLastModifyingWriter implements the MutableBareRootMetadata interface for BareRootMetadataV2.
@@ -1050,15 +1039,4 @@ func (md *BareRootMetadataV2) GetHistoricTLFCryptKey(
 	kbfscrypto.TLFCryptKey, error) {
 	return kbfscrypto.TLFCryptKey{}, errors.New(
 		"TLF crypt key not symmetrically encrypted")
-}
-
-// BareRootMetadataSignedV2 is the MD that is signed by the reader or
-// writer including the signature info. Unlike RootMetadataSigned,
-// it contains exactly the serializable metadata and signature info.
-type BareRootMetadataSignedV2 struct {
-	// signature over the root metadata by the private signing
-	// key. The writer signature is in MD.
-	SigInfo kbfscrypto.SignatureInfo
-	// all the metadata
-	MD BareRootMetadataV2
 }

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -1044,8 +1044,9 @@ func (md *BareRootMetadataV2) GetHistoricTLFCryptKey(
 // writer including the signature info. Unlike RootMetadataSigned,
 // it contains exactly the serializable metadata and signature info.
 type BareRootMetadataSignedV2 struct {
-	// signature over the root metadata by the private signing key
-	SigInfo kbfscrypto.SignatureInfo `codec:",omitempty"`
+	// signature over the root metadata by the private signing
+	// key. The writer signature is in MD.
+	SigInfo kbfscrypto.SignatureInfo
 	// all the metadata
 	MD BareRootMetadataV2
 }

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -778,8 +778,8 @@ func (md *BareRootMetadataV2) GetSerializedWriterMetadata(
 	return codec.Encode(md.WriterMetadataV2)
 }
 
-// MaybeSignWriterMetadata implements the MutableBareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) MaybeSignWriterMetadata(
+// SignWriterMetadataInternally implements the MutableBareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) SignWriterMetadataInternally(
 	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
 	buf, err := codec.Encode(md.WriterMetadataV2)
 	if err != nil {

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -267,9 +267,8 @@ func (md *BareRootMetadataV2) Update(id TlfID, h BareTlfHandle) error {
 	return nil
 }
 
-// DeepCopy implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) DeepCopy(
-	codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
+func (md *BareRootMetadataV2) deepCopy(
+	codec kbfscodec.Codec) (*BareRootMetadataV2, error) {
 	var newMd BareRootMetadataV2
 	if err := kbfscodec.Update(codec, &newMd, md); err != nil {
 		return nil, err
@@ -277,17 +276,23 @@ func (md *BareRootMetadataV2) DeepCopy(
 	return &newMd, nil
 }
 
+// DeepCopy implements the BareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) DeepCopy(
+	codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
+	return md.deepCopy(codec)
+}
+
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) MakeSuccessorCopy(
-	codec kbfscodec.Codec, preserveWriterSig bool) (MutableBareRootMetadata, error) {
+	codec kbfscodec.Codec, isReadableAndWriter bool) (
+	MutableBareRootMetadata, error) {
 	// MDv3 TODO: Make a v3 successor.
-	mdCopy, err := md.DeepCopy(codec)
+	mdCopy, err := md.deepCopy(codec)
 	if err != nil {
 		return nil, err
 	}
-	if !preserveWriterSig {
-		mdCopy.(*BareRootMetadataV2).WriterMetadataSigInfo =
-			kbfscrypto.SignatureInfo{}
+	if isReadableAndWriter {
+		mdCopy.WriterMetadataSigInfo = kbfscrypto.SignatureInfo{}
 	}
 	return mdCopy, nil
 }

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -334,7 +334,8 @@ func (md *BareRootMetadataV3) DeepCopy(
 
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) MakeSuccessorCopy(
-	codec kbfscodec.Codec, preserveWriterSig bool) (MutableBareRootMetadata, error) {
+	codec kbfscodec.Codec, isReadableAndWriter bool) (
+	MutableBareRootMetadata, error) {
 	// TODO: If there is ever a BareRootMetadataV4 this will need to perform the conversion.
 	return md.DeepCopy(codec)
 }

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -789,8 +789,8 @@ func (md *BareRootMetadataV3) GetSerializedWriterMetadata(
 	return codec.Encode(md.WriterMetadata)
 }
 
-// MaybeSignWriterMetadata implements the MutableBareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV3) MaybeSignWriterMetadata(
+// SignWriterMetadataInternally implements the MutableBareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV3) SignWriterMetadataInternally(
 	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
 	// Nothing to do.
 	return nil

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -793,6 +793,9 @@ func (md *BareRootMetadataV3) GetSerializedWriterMetadata(
 func (md *BareRootMetadataV3) SignWriterMetadataInternally(
 	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
 	// Nothing to do.
+	//
+	// TODO: Set a flag, and a way to check it so that we can
+	// verify that this is called before sending to the server.
 	return nil
 }
 

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1162,7 +1162,9 @@ func (md *BareRootMetadataV3) GetHistoricTLFCryptKey(crypto cryptoPure,
 // it contains exactly the serializable metadata and signature info.
 type BareRootMetadataSignedV3 struct {
 	// signature over the root metadata by the private signing key
-	SigInfo kbfscrypto.SignatureInfo `codec:",omitempty"`
+	SigInfo kbfscrypto.SignatureInfo
+	// signature over the writer metadata by the private signing key
+	WriterSigInfo kbfscrypto.SignatureInfo
 	// all the metadata
 	MD BareRootMetadataV3
 }

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -713,11 +713,6 @@ func (md *BareRootMetadataV3) LastModifyingWriter() keybase1.UID {
 	return md.WriterMetadata.LastModifyingWriter
 }
 
-// LastModifyingWriterKID implements the BareRootMetadata interface for BareRootMetadataV3.
-func (md *BareRootMetadataV3) LastModifyingWriterKID() keybase1.KID {
-	return md.WriterMetadataSigInfo.VerifyingKey.KID()
-}
-
 // GetLastModifyingUser implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) GetLastModifyingUser() keybase1.UID {
 	return md.LastModifyingUser

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"golang.org/x/net/context"
 )
 
 // WriterMetadataV3 stores the metadata for a TLF that is
@@ -827,6 +828,13 @@ func (md *BareRootMetadataV3) GetSerializedWriterMetadata(
 // GetWriterMetadataSigInfo implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
 	return md.WriterMetadataSigInfo
+}
+
+// MaybeSignWriterMetadata implements the MutableBareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV3) MaybeSignWriterMetadata(
+	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
+	// Nothing to do.
+	return nil
 }
 
 // SetWriterMetadataSigInfo implements the MutableBareRootMetadata interface for BareRootMetadataV3.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -334,7 +334,7 @@ func (md *BareRootMetadataV3) DeepCopy(
 
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) MakeSuccessorCopy(
-	codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
+	codec kbfscodec.Codec, preserveWriterSig bool) (MutableBareRootMetadata, error) {
 	// TODO: If there is ever a BareRootMetadataV4 this will need to perform the conversion.
 	return md.DeepCopy(codec)
 }

--- a/libkbfs/conflict_renamer.go
+++ b/libkbfs/conflict_renamer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -60,7 +61,8 @@ func splitExtension(path string) (string, string) {
 }
 
 func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID,
-	kid keybase1.KID, revision MetadataRevision) (writerInfo, error) {
+	key kbfscrypto.VerifyingKey,
+	revision MetadataRevision) (writerInfo, error) {
 	ui, err := cfg.KeybaseService().LoadUserPlusKeys(ctx, uid)
 	if err != nil {
 		return writerInfo{}, err
@@ -69,8 +71,8 @@ func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID,
 	return writerInfo{
 		name:       ui.Name,
 		uid:        uid,
-		kid:        kid,
-		deviceName: ui.KIDNames[kid],
+		key:        key,
+		deviceName: ui.KIDNames[key.KID()],
 		revision:   revision,
 	}, nil
 }

--- a/libkbfs/conflict_renamer.go
+++ b/libkbfs/conflict_renamer.go
@@ -71,7 +71,6 @@ func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID,
 	return writerInfo{
 		name:       ui.Name,
 		uid:        uid,
-		key:        key,
 		deviceName: ui.KIDNames[key.KID()],
 		revision:   revision,
 	}, nil

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1033,8 +1033,7 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	}
 
 	currUnmergedWriterInfo, err := newWriterInfo(
-		ctx, cr.config, uid, key.KID(),
-		unmerged[len(unmerged)-1].Revision())
+		ctx, cr.config, uid, key, unmerged[len(unmerged)-1].Revision())
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, err
 	}
@@ -2497,7 +2496,7 @@ type rootMetadataWithKeyAndTimestamp struct {
 	localTimestamp time.Time
 }
 
-func (rmd rootMetadataWithKeyAndTimestamp) LastWriterVerifyingKey() kbfscrypto.VerifyingKey {
+func (rmd rootMetadataWithKeyAndTimestamp) LastModifyingWriterVerifyingKey() kbfscrypto.VerifyingKey {
 	return rmd.key
 }
 
@@ -3488,7 +3487,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 
 	mostRecentMergedWriterInfo, err := newWriterInfo(ctx, cr.config,
 		mostRecentMergedMD.LastModifyingWriter(),
-		mostRecentMergedMD.LastWriterVerifyingKey().KID(),
+		mostRecentMergedMD.LastModifyingWriterVerifyingKey(),
 		mostRecentMergedMD.Revision())
 	if err != nil {
 		return

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfssync"
 	"golang.org/x/net/context"
 )
@@ -2490,12 +2491,17 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 	return resolvedPath, nil
 }
 
-type rootMetadataWithTimestamp struct {
+type rootMetadataWithKeyAndTimestamp struct {
 	*RootMetadata
+	key            kbfscrypto.VerifyingKey
 	localTimestamp time.Time
 }
 
-func (rmd rootMetadataWithTimestamp) LocalTimestamp() time.Time {
+func (rmd rootMetadataWithKeyAndTimestamp) LastModifyingWriterKID() keybase1.KID {
+	return rmd.key.KID()
+}
+
+func (rmd rootMetadataWithKeyAndTimestamp) LocalTimestamp() time.Time {
 	return rmd.localTimestamp
 }
 
@@ -2505,11 +2511,16 @@ func (rmd rootMetadataWithTimestamp) LocalTimestamp() time.Time {
 func (cr *ConflictResolver) makePostResolutionPaths(ctx context.Context,
 	md *RootMetadata, unmergedChains, mergedChains *crChains,
 	mergedPaths map[BlockPointer]path) (map[BlockPointer]path, error) {
+	key, err := cr.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	// No need to run any identifies on these chains, since we
 	// have already finished all actions.
 	resolvedChains, err := newCRChains(ctx, cr.config,
-		[]chainMetadata{rootMetadataWithTimestamp{md,
-			cr.config.Clock().Now()}},
+		[]chainMetadata{rootMetadataWithKeyAndTimestamp{md,
+			key, cr.config.Clock().Now()}},
 		&cr.fbo.blocks, false)
 	if err != nil {
 		return nil, err

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2497,8 +2497,8 @@ type rootMetadataWithKeyAndTimestamp struct {
 	localTimestamp time.Time
 }
 
-func (rmd rootMetadataWithKeyAndTimestamp) LastModifyingWriterKID() keybase1.KID {
-	return rmd.key.KID()
+func (rmd rootMetadataWithKeyAndTimestamp) LastWriterVerifyingKey() kbfscrypto.VerifyingKey {
+	return rmd.key
 }
 
 func (rmd rootMetadataWithKeyAndTimestamp) LocalTimestamp() time.Time {
@@ -3488,7 +3488,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 
 	mostRecentMergedWriterInfo, err := newWriterInfo(ctx, cr.config,
 		mostRecentMergedMD.LastModifyingWriter(),
-		mostRecentMergedMD.LastModifyingWriterKID(),
+		mostRecentMergedMD.LastWriterVerifyingKey().KID(),
 		mostRecentMergedMD.Revision())
 	if err != nil {
 		return

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,7 +78,7 @@ func TestCRInput(t *testing.T) {
 			Revision: unmergedHead,
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, fakeMdID(1), time.Now())
+	}, kbfscrypto.VerifyingKey{}, fakeMdID(1), time.Now())
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -92,7 +93,7 @@ func TestCRInput(t *testing.T) {
 					Revision: i,
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i)), time.Now()), nil)
+			}, kbfscrypto.VerifyingKey{}, fakeMdID(byte(i)), time.Now()), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
@@ -111,7 +112,7 @@ func TestCRInput(t *testing.T) {
 					Revision: i,
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i)), time.Now()), nil)
+			}, kbfscrypto.VerifyingKey{}, fakeMdID(byte(i)), time.Now()), nil)
 	}
 	for i := mergedHead + 1; i <= branchPoint+2*maxMDsAtATime; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
@@ -161,7 +162,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 			Revision: unmergedHead,
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, fakeMdID(1), time.Now())
+	}, kbfscrypto.VerifyingKey{}, fakeMdID(1), time.Now())
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -176,7 +177,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 					},
 				},
 				tlfHandle: &TlfHandle{name: "fake"},
-			}, fakeMdID(byte(i)), time.Now()), nil)
+			}, kbfscrypto.VerifyingKey{}, fakeMdID(byte(i)), time.Now()), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
@@ -200,7 +201,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 						Revision: i,
 					},
 					tlfHandle: &TlfHandle{name: "fake"},
-				}, fakeMdID(byte(i)), time.Now()), nil)
+				}, kbfscrypto.VerifyingKey{}, fakeMdID(byte(i)), time.Now()), nil)
 		} else {
 			config.mockMdcache.EXPECT().Get(cr.fbo.id(), i,
 				NullBranchID).Return(
@@ -217,7 +218,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 				Revision: skipCacheRevision,
 			},
 			tlfHandle: &TlfHandle{name: "fake"},
-		}, fakeMdID(byte(skipCacheRevision)), time.Now())}, nil)
+		}, kbfscrypto.VerifyingKey{}, fakeMdID(byte(skipCacheRevision)), time.Now())}, nil)
 	for i := mergedHead + 1; i <= branchPoint+2*maxMDsAtATime; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
 			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), i, NullBranchID})

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -692,7 +693,7 @@ type chainMetadata interface {
 	KeyMetadata
 	IsWriterMetadataCopiedSet() bool
 	LastModifyingWriter() keybase1.UID
-	LastModifyingWriterKID() keybase1.KID
+	LastWriterVerifyingKey() kbfscrypto.VerifyingKey
 	Revision() MetadataRevision
 	Data() *PrivateMetadata
 	LocalTimestamp() time.Time
@@ -714,9 +715,8 @@ func newCRChains(ctx context.Context, cfg Config, cmds []chainMetadata,
 			continue
 		}
 
-		winfo, err := newWriterInfo(
-			ctx, cfg, cmd.LastModifyingWriter(),
-			cmd.LastModifyingWriterKID(), cmd.Revision())
+		winfo, err := newWriterInfo(ctx, cfg, cmd.LastModifyingWriter(),
+			cmd.LastWriterVerifyingKey().KID(), cmd.Revision())
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -693,7 +693,7 @@ type chainMetadata interface {
 	KeyMetadata
 	IsWriterMetadataCopiedSet() bool
 	LastModifyingWriter() keybase1.UID
-	LastWriterVerifyingKey() kbfscrypto.VerifyingKey
+	LastModifyingWriterVerifyingKey() kbfscrypto.VerifyingKey
 	Revision() MetadataRevision
 	Data() *PrivateMetadata
 	LocalTimestamp() time.Time
@@ -716,7 +716,7 @@ func newCRChains(ctx context.Context, cfg Config, cmds []chainMetadata,
 		}
 
 		winfo, err := newWriterInfo(ctx, cfg, cmd.LastModifyingWriter(),
-			cmd.LastWriterVerifyingKey().KID(), cmd.Revision())
+			cmd.LastModifyingWriterVerifyingKey(), cmd.Revision())
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -688,7 +688,8 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 // chainMetadata is the interface for metadata objects that can be
 // used in building crChains. It is implemented by
 // ImmutableRootMetadata, but is also mostly implemented by
-// RootMetadata (just need LocalTimestamp).
+// RootMetadata (just need LastModifyingWriterVerifyingKey
+// LocalTimestamp).
 type chainMetadata interface {
 	KeyMetadata
 	IsWriterMetadataCopiedSet() bool

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -154,7 +155,9 @@ func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
 	for i, rmd := range rmds {
 		rmd.SetLastModifyingWriter(uid)
 		rmd.SetTlfID(FakeTlfID(1, false))
-		cmds[i] = rootMetadataWithTimestamp{rmd, time.Unix(0, 0)}
+		cmds[i] = rootMetadataWithKeyAndTimestamp{
+			rmd, kbfscrypto.VerifyingKey{}, time.Unix(0, 0),
+		}
 	}
 	return config, cmds
 }
@@ -516,7 +519,7 @@ func TestCRChainsRemove(t *testing.T) {
 	cmds, writtenFileUnref := testCRChainsMultiOps(t)
 
 	for i := range cmds {
-		cmds[i].(rootMetadataWithTimestamp).RootMetadata.SetRevision(
+		cmds[i].(rootMetadataWithKeyAndTimestamp).RootMetadata.SetRevision(
 			MetadataRevision(i))
 	}
 

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -155,15 +155,15 @@ func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
 	if err != nil {
 		t.Fatalf("Couldn't get verifying key: %v", err)
 	}
-	cmds := make([]chainMetadata, len(rmds))
+	chainMDs := make([]chainMetadata, len(rmds))
 	for i, rmd := range rmds {
 		rmd.SetLastModifyingWriter(uid)
 		rmd.SetTlfID(FakeTlfID(1, false))
-		cmds[i] = rootMetadataWithKeyAndTimestamp{
+		chainMDs[i] = rootMetadataWithKeyAndTimestamp{
 			rmd, key, time.Unix(0, 0),
 		}
 	}
-	return config, cmds
+	return config, chainMDs
 }
 
 func TestCRChainsSingleOp(t *testing.T) {
@@ -183,9 +183,10 @@ func TestCRChainsSingleOp(t *testing.T) {
 	rmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 
 	rmds := []*RootMetadata{rmd}
-	config, cmds := testCRChainsFillInWriter(t, rmds)
+	config, chainMDs := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, chainMDs, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -218,9 +219,10 @@ func TestCRChainsRenameOp(t *testing.T) {
 	rmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 
 	rmds := []*RootMetadata{rmd}
-	config, cmds := testCRChainsFillInWriter(t, rmds)
+	config, chainMDs := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, chainMDs, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -327,9 +329,10 @@ func testCRChainsMultiOps(t *testing.T) ([]chainMetadata, BlockPointer) {
 
 	bigRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	rmds := []*RootMetadata{bigRmd}
-	config, cmds := testCRChainsFillInWriter(t, rmds)
+	config, chainMDs := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, chainMDs, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains for big RMD: %v", err)
 	}
@@ -492,9 +495,10 @@ func TestCRChainsCollapse(t *testing.T) {
 
 	rmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	rmds := []*RootMetadata{rmd}
-	config, cmds := testCRChainsFillInWriter(t, rmds)
+	config, chainMDs := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, chainMDs, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -520,23 +524,24 @@ func TestCRChainsCollapse(t *testing.T) {
 }
 
 func TestCRChainsRemove(t *testing.T) {
-	cmds, writtenFileUnref := testCRChainsMultiOps(t)
+	chainMDs, writtenFileUnref := testCRChainsMultiOps(t)
 
-	for i := range cmds {
-		cmds[i].(rootMetadataWithKeyAndTimestamp).RootMetadata.SetRevision(
+	for i := range chainMDs {
+		chainMDs[i].(rootMetadataWithKeyAndTimestamp).RootMetadata.SetRevision(
 			MetadataRevision(i))
 	}
 
 	config := MakeTestConfigOrBust(t, "u1")
 	defer config.Shutdown()
-	ccs, err := newCRChains(context.Background(), config, cmds, nil, true)
+	ccs, err := newCRChains(
+		context.Background(), config, chainMDs, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
 
 	// This should remove the write operation.
 	removedChains := ccs.remove(context.Background(),
-		logger.NewTestLogger(t), cmds[3].Revision())
+		logger.NewTestLogger(t), chainMDs[3].Revision())
 	require.Len(t, removedChains, 1)
 	require.Equal(t, removedChains[0].original, writtenFileUnref)
 	require.Len(t, removedChains[0].ops, 0)

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfscodec"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -147,16 +146,21 @@ func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
 	Config, []chainMetadata) {
 	config := MakeTestConfigOrBust(t, "u1")
 	kbpki := config.KBPKI()
-	_, uid, err := kbpki.GetCurrentUserInfo(context.Background())
+	ctx := context.Background()
+	_, uid, err := kbpki.GetCurrentUserInfo(ctx)
 	if err != nil {
 		t.Fatalf("Couldn't get UID: %v", err)
+	}
+	key, err := kbpki.GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		t.Fatalf("Couldn't get verifying key: %v", err)
 	}
 	cmds := make([]chainMetadata, len(rmds))
 	for i, rmd := range rmds {
 		rmd.SetLastModifyingWriter(uid)
 		rmd.SetTlfID(FakeTlfID(1, false))
 		cmds[i] = rootMetadataWithKeyAndTimestamp{
-			rmd, kbfscrypto.VerifyingKey{}, time.Unix(0, 0),
+			rmd, key, time.Unix(0, 0),
 		}
 	}
 	return config, cmds

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -740,7 +740,7 @@ type TLFUpdateHistory struct {
 type writerInfo struct {
 	name       libkb.NormalizedUsername
 	uid        keybase1.UID
-	kid        keybase1.KID
+	key        kbfscrypto.VerifyingKey
 	deviceName string
 	revision   MetadataRevision
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -740,7 +740,6 @@ type TLFUpdateHistory struct {
 type writerInfo struct {
 	name       libkb.NormalizedUsername
 	uid        keybase1.UID
-	key        kbfscrypto.VerifyingKey
 	deviceName string
 	revision   MetadataRevision
 }

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -896,7 +896,7 @@ func (fbm *folderBlockManager) finalizeReclamation(ctx context.Context,
 func (fbm *folderBlockManager) isQRNecessary(head ImmutableRootMetadata) bool {
 	fbm.lastQRLock.Lock()
 	defer fbm.lastQRLock.Unlock()
-	if head.IsNil() {
+	if head == (ImmutableRootMetadata{}) {
 		return false
 	}
 
@@ -966,7 +966,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		fbm.lastQRLock.Lock()
 		defer fbm.lastQRLock.Unlock()
 		// Remember the QR we just performed.
-		if err == nil && !head.IsNil() {
+		if err == nil && (head != ImmutableRootMetadata{}) {
 			fbm.lastQRHeadRev = head.Revision()
 			fbm.lastQROldEnoughRev = mostRecentOldEnoughRev
 			fbm.wasLastQRComplete = complete

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -966,7 +966,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		fbm.lastQRLock.Lock()
 		defer fbm.lastQRLock.Unlock()
 		// Remember the QR we just performed.
-		if err == nil && (head != ImmutableRootMetadata{}) {
+		if err == nil && head != (ImmutableRootMetadata{}) {
 			fbm.lastQRHeadRev = head.Revision()
 			fbm.lastQROldEnoughRev = mostRecentOldEnoughRev
 			fbm.wasLastQRComplete = complete

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -74,7 +74,7 @@ func (si *syncInfo) DeepCopy(codec kbfscodec.Codec) (*syncInfo, error) {
 		// It might be overkill to deep-copy these MDs and bpses,
 		// which are probably immutable, but for now let's do the safe
 		// thing.
-		copyMd, err := toClean.md.deepCopy(codec, false)
+		copyMd, err := toClean.md.deepCopy(codec)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1035,39 +1035,41 @@ func (fbo *folderBranchOps) getMDForWriteLockedForFilename(
 }
 
 func (fbo *folderBranchOps) getMDForRekeyWriteLocked(
-	ctx context.Context, lState *lockState) (rmd *RootMetadata, wasRekeySet bool, err error) {
+	ctx context.Context, lState *lockState) (
+	rmd *RootMetadata, lastWriterVerifyingKey kbfscrypto.VerifyingKey,
+	wasRekeySet bool, err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	md, err := fbo.getMDLocked(ctx, lState, mdRekey)
 	if err != nil {
-		return nil, false, err
+		return nil, kbfscrypto.VerifyingKey{}, false, err
 	}
 
 	username, uid, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
-		return nil, false, err
+		return nil, kbfscrypto.VerifyingKey{}, false, err
 	}
 
 	handle := md.GetTlfHandle()
 
 	// must be a reader or writer (it checks both.)
 	if !handle.IsReader(uid) {
-		return nil, false,
+		return nil, kbfscrypto.VerifyingKey{}, false,
 			NewRekeyPermissionError(md.GetTlfHandle(), username)
 	}
 
 	newMd, err := md.MakeSuccessor(fbo.config.Codec(), md.mdID, handle.IsWriter(uid))
 	if err != nil {
-		return nil, false, err
+		return nil, kbfscrypto.VerifyingKey{}, false, err
 	}
 
 	// readers shouldn't modify writer metadata
 	if !handle.IsWriter(uid) && !newMd.IsWriterMetadataCopiedSet() {
-		return nil, false,
+		return nil, kbfscrypto.VerifyingKey{}, false,
 			NewRekeyPermissionError(handle, username)
 	}
 
-	return newMd, md.IsRekeySet(), nil
+	return newMd, md.LastWriterVerifyingKey(), md.IsRekeySet(), nil
 }
 
 func (fbo *folderBranchOps) nowUnixNano() int64 {
@@ -1202,8 +1204,14 @@ func (fbo *folderBranchOps) initMDLocked(
 			"%v: Unexpected MD ID during new MD initialization: %v",
 			md.TlfID(), fbo.head.mdID)
 	}
-	fbo.setNewInitialHeadLocked(ctx, lState,
-		MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now()))
+
+	key, err := fbo.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	fbo.setNewInitialHeadLocked(ctx, lState, MakeImmutableRootMetadata(
+		md, key, mdID, fbo.config.Clock().Now()))
 	if err != nil {
 		return err
 	}
@@ -2172,9 +2180,15 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 		fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
 	}
 
+	key, err := fbo.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return err
+	}
+
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	irmd := MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now())
+	irmd := MakeImmutableRootMetadata(
+		md, key, mdID, fbo.config.Clock().Now())
 	err = fbo.setHeadSuccessorLocked(ctx, lState, irmd, rebased)
 	if err != nil {
 		return err
@@ -2221,7 +2235,8 @@ func (fbo *folderBranchOps) waitForJournalLocked(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
-	lState *lockState, md *RootMetadata) (err error) {
+	lState *lockState, md *RootMetadata,
+	lastWriterVerifyingKey kbfscrypto.VerifyingKey) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	oldPrevRoot := md.PrevRoot()
@@ -2269,10 +2284,22 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 
 	md.loadCachedBlockChanges(nil)
 
+	var key kbfscrypto.VerifyingKey
+	if md.IsWriterMetadataCopiedSet() {
+		key = lastWriterVerifyingKey
+	} else {
+		var err error
+		key, err = fbo.config.KBPKI().GetCurrentVerifyingKey(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
 	return fbo.setHeadSuccessorLocked(ctx, lState,
-		MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now()), rebased)
+		MakeImmutableRootMetadata(md, key, mdID, fbo.config.Clock().Now()),
+		rebased)
 }
 
 func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
@@ -2320,7 +2347,12 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	irmd := MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now())
+	key, err := fbo.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return err
+	}
+	irmd := MakeImmutableRootMetadata(
+		md, key, mdID, fbo.config.Clock().Now())
 	err = fbo.setHeadSuccessorLocked(ctx, lState, irmd, rebased)
 	if err != nil {
 		return err
@@ -4254,7 +4286,8 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 		}
 	}
 
-	md, rekeyWasSet, err := fbo.getMDForRekeyWriteLocked(ctx, lState)
+	md, lastWriterVerifyingKey, rekeyWasSet, err :=
+		fbo.getMDForRekeyWriteLocked(ctx, lState)
 	if err != nil {
 		return err
 	}
@@ -4365,7 +4398,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 
 	// we still let readers push a new md block that we validate against reader
 	// permissions
-	err = fbo.finalizeMDRekeyWriteLocked(ctx, lState, md)
+	err = fbo.finalizeMDRekeyWriteLocked(ctx, lState, md, lastWriterVerifyingKey)
 	if err != nil {
 		return err
 	}
@@ -4921,7 +4954,12 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	// Set the head to the new MD.
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	irmd := MakeImmutableRootMetadata(md, mdID, fbo.config.Clock().Now())
+	key, err := fbo.config.KBPKI().GetCurrentVerifyingKey(ctx)
+	if err != nil {
+		return err
+	}
+	irmd := MakeImmutableRootMetadata(
+		md, key, mdID, fbo.config.Clock().Now())
 	err = fbo.setHeadConflictResolvedLocked(ctx, lState, irmd)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't set local MD head after a "+

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -628,7 +628,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 				if err != nil {
 					return err
 				}
-				if key != md.LastWriterVerifyingKey() {
+				if key != md.LastModifyingWriterVerifyingKey() {
 					fbo.setLatestMergedRevisionLocked(
 						ctx, lState, md.Revision(), false)
 				}
@@ -1069,7 +1069,7 @@ func (fbo *folderBranchOps) getMDForRekeyWriteLocked(
 			NewRekeyPermissionError(handle, username)
 	}
 
-	return newMd, md.LastWriterVerifyingKey(), md.IsRekeySet(), nil
+	return newMd, md.LastModifyingWriterVerifyingKey(), md.IsRekeySet(), nil
 }
 
 func (fbo *folderBranchOps) nowUnixNano() int64 {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -628,7 +628,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 				if err != nil {
 					return err
 				}
-				if key.KID() != md.LastModifyingWriterKID() {
+				if key != md.LastWriterVerifyingKey() {
 					fbo.setLatestMergedRevisionLocked(
 						ctx, lState, md.Revision(), false)
 				}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4398,7 +4398,8 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 
 	// we still let readers push a new md block that we validate against reader
 	// permissions
-	err = fbo.finalizeMDRekeyWriteLocked(ctx, lState, md, lastWriterVerifyingKey)
+	err = fbo.finalizeMDRekeyWriteLocked(
+		ctx, lState, md, lastWriterVerifyingKey)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -451,7 +451,7 @@ func (fbo *folderBranchOps) addToFavorites(ctx context.Context,
 	favorites *Favorites, created bool) (err error) {
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
-	if head.IsNil() {
+	if head == (ImmutableRootMetadata{}) {
 		return OpsCantHandleFavorite{"Can't add a favorite without a handle"}
 	}
 
@@ -478,7 +478,7 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
-	if head.IsNil() {
+	if head == (ImmutableRootMetadata{}) {
 		// This can happen when identifies fail and the head is never set.
 		return OpsCantHandleFavorite{"Can't delete a favorite without a handle"}
 	}
@@ -562,7 +562,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
 
-	isFirstHead := fbo.head.IsNil()
+	isFirstHead := fbo.head == ImmutableRootMetadata{}
 	wasReadable := false
 	if !isFirstHead {
 		wasReadable = fbo.head.IsReadable()
@@ -675,7 +675,7 @@ func (fbo *folderBranchOps) setInitialHeadUntrustedLocked(ctx context.Context,
 	lState *lockState, md ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-	if !fbo.head.IsNil() {
+	if fbo.head != (ImmutableRootMetadata{}) {
 		return errors.New("Unexpected non-nil head in setInitialHeadUntrustedLocked")
 	}
 	return fbo.setHeadLocked(ctx, lState, md)
@@ -686,7 +686,7 @@ func (fbo *folderBranchOps) setNewInitialHeadLocked(ctx context.Context,
 	lState *lockState, md ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-	if !fbo.head.IsNil() {
+	if fbo.head != (ImmutableRootMetadata{}) {
 		return errors.New("Unexpected non-nil head in setNewInitialHeadLocked")
 	}
 	if md.Revision() != MetadataRevisionInitial {
@@ -702,7 +702,7 @@ func (fbo *folderBranchOps) setInitialHeadTrustedLocked(ctx context.Context,
 	lState *lockState, md ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-	if !fbo.head.IsNil() {
+	if fbo.head != (ImmutableRootMetadata{}) {
 		return errors.New("Unexpected non-nil head in setInitialHeadUntrustedLocked")
 	}
 	return fbo.setHeadLocked(ctx, lState, md)
@@ -714,7 +714,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	lState *lockState, md ImmutableRootMetadata, rebased bool) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-	if fbo.head.IsNil() {
+	if fbo.head == (ImmutableRootMetadata{}) {
 		// This can happen in tests via SyncFromServerForTesting().
 		return fbo.setInitialHeadTrustedLocked(ctx, lState, md)
 	}
@@ -780,7 +780,7 @@ func (fbo *folderBranchOps) setHeadPredecessorLocked(ctx context.Context,
 	lState *lockState, md ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-	if fbo.head.IsNil() {
+	if fbo.head == (ImmutableRootMetadata{}) {
 		return errors.New("Unexpected nil head in setHeadPredecessorLocked")
 	}
 	if fbo.head.Revision() <= MetadataRevisionInitial {
@@ -875,7 +875,7 @@ func (fbo *folderBranchOps) getMDLocked(
 	}()
 
 	md = fbo.getHead(lState)
-	if !md.IsNil() {
+	if md != (ImmutableRootMetadata{}) {
 		return md, nil
 	}
 
@@ -909,11 +909,11 @@ func (fbo *folderBranchOps) getMDLocked(
 		return ImmutableRootMetadata{}, err
 	}
 
-	if mergedMD.IsNil() {
+	if mergedMD == (ImmutableRootMetadata{}) {
 		return ImmutableRootMetadata{}, fmt.Errorf("Got nil RMD for %s", fbo.id())
 	}
 
-	if md.IsNil() {
+	if md == (ImmutableRootMetadata{}) {
 		// There are no unmerged MDs for this device, so just use the current head.
 		md = mergedMD
 	} else {
@@ -1199,7 +1199,7 @@ func (fbo *folderBranchOps) initMDLocked(
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	if !fbo.head.IsNil() {
+	if fbo.head != (ImmutableRootMetadata{}) {
 		return fmt.Errorf(
 			"%v: Unexpected MD ID during new MD initialization: %v",
 			md.TlfID(), fbo.head.mdID)
@@ -1277,7 +1277,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	// head) if head is already set.
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
-	if !head.IsNil() && head.mdID == md.mdID {
+	if (head != ImmutableRootMetadata{}) && head.mdID == md.mdID {
 		fbo.log.CDebugf(ctx, "Head MD already set to revision %d (%s), no "+
 			"need to set initial head again", md.Revision(), md.MergedStatus())
 		return nil
@@ -1326,7 +1326,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 		// Only update the head the first time; later it will be
 		// updated either directly via writes or through the
 		// background update processor.
-		if fbo.head.IsNil() {
+		if fbo.head == (ImmutableRootMetadata{}) {
 			err = fbo.setInitialHeadTrustedLocked(ctx, lState, md)
 			if err != nil {
 				return err
@@ -3848,7 +3848,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 func (fbo *folderBranchOps) getCurrMDRevisionLocked(lState *lockState) MetadataRevision {
 	fbo.headLock.AssertAnyLocked(lState)
 
-	if !fbo.head.IsNil() {
+	if fbo.head != (ImmutableRootMetadata{}) {
 		return fbo.head.Revision()
 	}
 	return MetadataRevisionUninitialized
@@ -3890,7 +3890,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			fbo.setLatestMergedRevisionLocked(ctx, lState, rmds[len(rmds)-1].Revision(), false)
 
 			unmergedRev := MetadataRevisionUninitialized
-			if !fbo.head.IsNil() {
+			if fbo.head != (ImmutableRootMetadata{}) {
 				unmergedRev = fbo.head.Revision()
 			}
 			fbo.cr.Resolve(unmergedRev, rmds[len(rmds)-1].Revision())
@@ -4058,7 +4058,7 @@ func (fbo *folderBranchOps) getAndApplyNewestUnmergedHead(ctx context.Context,
 		return err
 	}
 
-	if md.IsNil() {
+	if md == (ImmutableRootMetadata{}) {
 		// There is no unmerged revision, oops!
 		return errors.New("Couldn't find an unmerged head")
 	}
@@ -4271,7 +4271,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	}
 
 	head := fbo.getHead(lState)
-	if !head.IsNil() {
+	if head != (ImmutableRootMetadata{}) {
 		// If we already have a cached revision, make sure we're
 		// up-to-date with the latest revision before inspecting the
 		// metadata, since Rekey doesn't let us go into CR mode, and
@@ -5035,7 +5035,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 		return
 	}
 
-	if md.IsNil() || md.MergedStatus() != Unmerged ||
+	if (md == ImmutableRootMetadata{}) || md.MergedStatus() != Unmerged ||
 		md.BID() != newBID {
 		// This can happen if CR got kicked off in some other way and
 		// completed before we took the lock to process this

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1277,7 +1277,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	// head) if head is already set.
 	lState := makeFBOLockState()
 	head := fbo.getHead(lState)
-	if (head != ImmutableRootMetadata{}) && head.mdID == md.mdID {
+	if head != (ImmutableRootMetadata{}) && head.mdID == md.mdID {
 		fbo.log.CDebugf(ctx, "Head MD already set to revision %d (%s), no "+
 			"need to set initial head again", md.Revision(), md.MergedStatus())
 		return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5036,7 +5036,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 		return
 	}
 
-	if (md == ImmutableRootMetadata{}) || md.MergedStatus() != Unmerged ||
+	if md == (ImmutableRootMetadata{}) || md.MergedStatus() != Unmerged ||
 		md.BID() != newBID {
 		// This can happen if CR got kicked off in some other way and
 		// completed before we took the lock to process this

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -169,7 +169,7 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context,
 
 	var fbs FolderBranchStatus
 
-	if !fbsk.md.IsNil() {
+	if fbsk.md != (ImmutableRootMetadata{}) {
 		fbs.Staged = fbsk.md.IsUnmergedSet()
 		fbs.BranchID = fbsk.md.BID().String()
 		name, err := fbsk.config.KBPKI().GetNormalizedUsername(ctx, fbsk.md.LastModifyingWriter())

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -105,7 +104,9 @@ func TestFBStatusAllFields(t *testing.T) {
 	id := FakeTlfID(1, false)
 	h := parseTlfHandleOrBust(t, config, "alice", false)
 	u := h.FirstResolvedWriter()
+	key := MakeFakeVerifyingKeyOrBust("fake key")
 	md := newRootMetadataOrBust(t, id, h)
+	md.bareMd.(*BareRootMetadataV2).WriterMetadataSigInfo.VerifyingKey = key
 	md.SetUnmerged()
 	md.SetLastModifyingWriter(u)
 
@@ -117,7 +118,7 @@ func TestFBStatusAllFields(t *testing.T) {
 	p2 := path{path: []pathNode{{Name: "a2"}, {Name: "b2"}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
-	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, kbfscrypto.VerifyingKey{}, fakeMdID(1),
+	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, key, fakeMdID(1),
 		time.Now()))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -116,7 +117,7 @@ func TestFBStatusAllFields(t *testing.T) {
 	p2 := path{path: []pathNode{{Name: "a2"}, {Name: "b2"}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
-	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, fakeMdID(1),
+	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, kbfscrypto.VerifyingKey{}, fakeMdID(1),
 		time.Now()))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -116,7 +116,8 @@ func TestFBStatusAllFields(t *testing.T) {
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
 	key := MakeFakeVerifyingKeyOrBust("fake key")
-	fbsk.setRootMetadata(makeImmutableRootMetadataForTest(md, key))
+	fbsk.setRootMetadata(
+		makeImmutableRootMetadataForTest(t, md, key, fakeMdID(1)))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -9,7 +9,6 @@ import (
 	"reflect"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"golang.org/x/net/context"
@@ -104,9 +103,7 @@ func TestFBStatusAllFields(t *testing.T) {
 	id := FakeTlfID(1, false)
 	h := parseTlfHandleOrBust(t, config, "alice", false)
 	u := h.FirstResolvedWriter()
-	key := MakeFakeVerifyingKeyOrBust("fake key")
 	md := newRootMetadataOrBust(t, id, h)
-	md.bareMd.(*BareRootMetadataV2).WriterMetadataSigInfo.VerifyingKey = key
 	md.SetUnmerged()
 	md.SetLastModifyingWriter(u)
 
@@ -118,8 +115,8 @@ func TestFBStatusAllFields(t *testing.T) {
 	p2 := path{path: []pathNode{{Name: "a2"}, {Name: "b2"}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
-	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, key, fakeMdID(1),
-		time.Now()))
+	key := MakeFakeVerifyingKeyOrBust("fake key")
+	fbsk.setRootMetadata(makeImmutableRootMetadataForTest(md, key))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1637,8 +1637,6 @@ type BareRootMetadata interface {
 	GetSerializedPrivateMetadata() []byte
 	// GetSerializedWriterMetadata serializes the underlying writer metadata and returns the result.
 	GetSerializedWriterMetadata(codec kbfscodec.Codec) ([]byte, error)
-	// GetWriterMetadataSigInfo returns the signature info associated with the the writer metadata.
-	GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo
 	// Version returns the metadata version.
 	Version() MetadataVer
 	// GetTLFPublicKey returns the TLF public key for the give key generation.
@@ -1699,8 +1697,6 @@ type MutableBareRootMetadata interface {
 	// versions that store this signature inside the metadata.
 	MaybeSignWriterMetadata(ctx context.Context,
 		codec kbfscodec.Codec, signer cryptoSigner) error
-	// SetWriterMetadataSigInfo sets the signature info associated with the the writer metadata.
-	SetWriterMetadataSigInfo(sigInfo kbfscrypto.SignatureInfo)
 	// SetLastModifyingWriter sets the UID of the last user to modify the writer metadata.
 	SetLastModifyingWriter(user keybase1.UID)
 	// SetLastModifyingUser sets the UID of the last user to modify any of the metadata.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1695,6 +1695,10 @@ type MutableBareRootMetadata interface {
 	SetPrevRoot(mdID MdID)
 	// SetSerializedPrivateMetadata sets the serialized private metadata.
 	SetSerializedPrivateMetadata(spmd []byte)
+	// MaybeSignWriterMetadata signs the writer metadata, for
+	// versions that store this signature inside the metadata.
+	MaybeSignWriterMetadata(ctx context.Context,
+		codec kbfscodec.Codec, signer cryptoSigner) error
 	// SetWriterMetadataSigInfo sets the signature info associated with the the writer metadata.
 	SetWriterMetadataSigInfo(sigInfo kbfscrypto.SignatureInfo)
 	// SetLastModifyingWriter sets the UID of the last user to modify the writer metadata.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1567,7 +1567,7 @@ type BareRootMetadata interface {
 	// MakeSuccessorCopy returns a newly constructed successor copy to this metadata revision.
 	// It differs from DeepCopy in that it can perform an up conversion to a new metadata
 	// version.
-	MakeSuccessorCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error)
+	MakeSuccessorCopy(codec kbfscodec.Codec, preserveWriterSig bool) (MutableBareRootMetadata, error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.
 	CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1617,8 +1617,6 @@ type BareRootMetadata interface {
 	IsLastModifiedBy(uid keybase1.UID, key kbfscrypto.VerifyingKey) error
 	// LastModifyingWriter return the UID of the last user to modify the writer metadata.
 	LastModifyingWriter() keybase1.UID
-	// LastModifyingWriterKID returns the KID of the last device to modify the writer metadata.
-	LastModifyingWriterKID() keybase1.KID
 	// LastModifyingUser return the UID of the last user to modify the any of the metadata.
 	GetLastModifyingUser() keybase1.UID
 	// RefBytes returns the number of newly referenced bytes introduced by this revision of metadata.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1567,7 +1567,8 @@ type BareRootMetadata interface {
 	// MakeSuccessorCopy returns a newly constructed successor copy to this metadata revision.
 	// It differs from DeepCopy in that it can perform an up conversion to a new metadata
 	// version.
-	MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (MutableBareRootMetadata, error)
+	MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (
+		MutableBareRootMetadata, error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.
 	CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1567,7 +1567,7 @@ type BareRootMetadata interface {
 	// MakeSuccessorCopy returns a newly constructed successor copy to this metadata revision.
 	// It differs from DeepCopy in that it can perform an up conversion to a new metadata
 	// version.
-	MakeSuccessorCopy(codec kbfscodec.Codec, preserveWriterSig bool) (MutableBareRootMetadata, error)
+	MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (MutableBareRootMetadata, error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.
 	CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1693,9 +1693,9 @@ type MutableBareRootMetadata interface {
 	SetPrevRoot(mdID MdID)
 	// SetSerializedPrivateMetadata sets the serialized private metadata.
 	SetSerializedPrivateMetadata(spmd []byte)
-	// MaybeSignWriterMetadata signs the writer metadata, for
+	// SignWriterMetadataInternally signs the writer metadata, for
 	// versions that store this signature inside the metadata.
-	MaybeSignWriterMetadata(ctx context.Context,
+	SignWriterMetadataInternally(ctx context.Context,
 		codec kbfscodec.Codec, signer cryptoSigner) error
 	// SetLastModifyingWriter sets the UID of the last user to modify the writer metadata.
 	SetLastModifyingWriter(user keybase1.UID)

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -205,7 +205,7 @@ func (j journalMDOps) GetForHandle(
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
 
-	if (rmd != ImmutableRootMetadata{}) && (rmd.TlfID() != tlfID) {
+	if rmd != (ImmutableRootMetadata{}) && (rmd.TlfID() != tlfID) {
 		return TlfID{}, ImmutableRootMetadata{},
 			fmt.Errorf("Expected RMD to have TLF ID %s, but got %s",
 				tlfID, rmd.TlfID())
@@ -217,7 +217,7 @@ func (j journalMDOps) GetForHandle(
 	if err != nil {
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
-	if (irmd != ImmutableRootMetadata{}) {
+	if irmd != (ImmutableRootMetadata{}) {
 		return TlfID{}, irmd, nil
 	}
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -205,7 +205,7 @@ func (j journalMDOps) GetForHandle(
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
 
-	if !rmd.IsNil() && (rmd.TlfID() != tlfID) {
+	if (rmd != ImmutableRootMetadata{}) && (rmd.TlfID() != tlfID) {
 		return TlfID{}, ImmutableRootMetadata{},
 			fmt.Errorf("Expected RMD to have TLF ID %s, but got %s",
 				tlfID, rmd.TlfID())
@@ -217,7 +217,7 @@ func (j journalMDOps) GetForHandle(
 	if err != nil {
 		return TlfID{}, ImmutableRootMetadata{}, err
 	}
-	if !irmd.IsNil() {
+	if (irmd != ImmutableRootMetadata{}) {
 		return TlfID{}, irmd, nil
 	}
 
@@ -236,7 +236,7 @@ func (j journalMDOps) getForTLF(
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
-	if !irmd.IsNil() {
+	if irmd != (ImmutableRootMetadata{}) {
 		return irmd, nil
 	}
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -361,7 +361,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 
 			return node, ei, nil
 		}
-		if !create && (md == ImmutableRootMetadata{}) {
+		if !create && md == (ImmutableRootMetadata{}) {
 			kbpki := fs.config.KBPKI()
 			err := identifyHandle(ctx, kbpki, kbpki, h)
 			if err != nil {

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -290,7 +290,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(
 	if err != nil {
 		return false, ImmutableRootMetadata{}, id, err
 	}
-	if !md.IsNil() {
+	if md != (ImmutableRootMetadata{}) {
 		return false, md, id, nil
 	}
 
@@ -337,7 +337,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		return nil, EntryInfo{}, err
 	}
 
-	if md.IsNil() {
+	if md == (ImmutableRootMetadata{}) {
 		var id TlfID
 		var initialized bool
 		initialized, md, id, err = fs.getOrInitializeNewMDMaster(ctx, mdops, h, create)
@@ -361,7 +361,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 
 			return node, ei, nil
 		}
-		if !create && md.IsNil() {
+		if !create && (md == ImmutableRootMetadata{}) {
 			kbpki := fs.config.KBPKI()
 			err := identifyHandle(ctx, kbpki, kbpki, h)
 			if err != nil {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1050,7 +1050,7 @@ func (s shimMDOps) Put(ctx context.Context, rmd *RootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.MaybeSignWriterMetadata(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
+	rmd.bareMd.SignWriterMetadataInternally(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 
@@ -1064,7 +1064,7 @@ func (s shimMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (MdID, er
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.MaybeSignWriterMetadata(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
+	rmd.bareMd.SignWriterMetadataInternally(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1064,7 +1064,7 @@ func (s shimMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (MdID, er
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.MaybeSignWriterMetadata(ctx, s.codec, kbfscrypto.SigningKeySigner{signingKey})
+	rmd.bareMd.MaybeSignWriterMetadata(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1032,7 +1032,8 @@ func (s shimMDOps) Put(ctx context.Context, rmd *RootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.SignWriterMetadataInternally(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
+	rmd.bareMd.SignWriterMetadataInternally(
+		ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 
@@ -1046,7 +1047,8 @@ func (s shimMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (MdID, er
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.SignWriterMetadataInternally(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
+	rmd.bareMd.SignWriterMetadataInternally(
+		ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 
@@ -1351,8 +1353,8 @@ func testCreateEntrySuccess(t *testing.T, entryType EntryType) {
 		expectSyncBlock(t, config, nil, uid, id, "b", p, rmd,
 			entryType != Sym, 0, 0, 0, &newRmd, blocks)
 
-	var err error
 	var newN Node
+	var err error
 	switch entryType {
 	case File:
 		newN, _, err = config.KBFSOps().CreateFile(ctx, n, "b", false, NoExcl)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5139,9 +5139,6 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
 
-	key, err := config.KBPKI().GetCurrentVerifyingKey(ctx)
-	require.NoError(t, err)
-
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
 
@@ -5151,7 +5148,7 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 	p := path{FolderBranch{Tlf: id}, []pathNode{node}}
 	n := nodeFromPath(t, ops, p)
 
-	_, err = config.KBFSOps().Stat(ctx, n)
+	_, err := config.KBFSOps().Stat(ctx, n)
 	if err != nil {
 		t.Errorf("Error on Stat: %v", err)
 	}
@@ -5162,9 +5159,6 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 	defer kbfsTestShutdown(mockCtrl, config, ctx, cancel)
 
 	id, h, rmd := createNewRMD(t, config, "alice", false)
-
-	key, err := config.KBPKI().GetCurrentVerifyingKey(ctx)
-	require.NoError(t, err)
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
@@ -5179,7 +5173,7 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 	// TODO: Make sure Read, Write, and Truncate fail also with
 	// InvalidPathError{}.
 
-	err = config.KBFSOps().SetEx(ctx, n, true)
+	err := config.KBFSOps().SetEx(ctx, n, true)
 	if _, ok := err.(InvalidParentPathError); !ok {
 		t.Errorf("Unexpected error on SetEx: %v", err)
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1050,7 +1050,7 @@ func (s shimMDOps) Put(ctx context.Context, rmd *RootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.MaybeSignWriterMetadata(ctx, s.codec, kbfscrypto.SigningKeySigner{signingKey})
+	rmd.bareMd.MaybeSignWriterMetadata(ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 

--- a/libkbfs/kbpki_util_test.go
+++ b/libkbfs/kbpki_util_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -28,6 +29,16 @@ func (d *daemonKBPKI) GetCurrentUserInfo(ctx context.Context) (
 		return libkb.NormalizedUsername(""), keybase1.UID(""), err
 	}
 	return session.Name, session.UID, nil
+}
+
+func (d *daemonKBPKI) GetCurrentVerifyingKey(ctx context.Context) (
+	kbfscrypto.VerifyingKey, error) {
+	const sessionID = 0
+	session, err := d.daemon.CurrentSession(ctx, sessionID)
+	if err != nil {
+		return kbfscrypto.VerifyingKey{}, err
+	}
+	return session.VerifyingKey, nil
 }
 
 func (d *daemonKBPKI) Resolve(ctx context.Context, assertion string) (

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -685,7 +685,7 @@ func (j *mdJournal) convertToBranch(
 			// Everything else is the same.
 			err = mdcache.Replace(
 				MakeImmutableRootMetadata(newRmd,
-					oldIrmd.LastWriterVerifyingKey(),
+					oldIrmd.LastModifyingWriterVerifyingKey(),
 					newID, ts),
 				NullBranchID)
 			if err != nil {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -676,12 +676,12 @@ func (j *mdJournal) convertToBranch(
 		oldIrmd, err := mdcache.Get(
 			tlfID, brmd.RevisionNumber(), NullBranchID)
 		if err == nil {
-			newRmd, err := oldIrmd.deepCopy(codec, false)
+			newRmd, err := oldIrmd.deepCopy(codec)
 			if err != nil {
 				return NullBranchID, err
 			}
 			newRmd.bareMd = brmd
-			// The extra is the same.
+			// Everything else is the same.
 			err = mdcache.Replace(
 				MakeImmutableRootMetadata(newRmd,
 					oldIrmd.LastWriterVerifyingKey(),

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1049,24 +1049,23 @@ func (j *mdJournal) put(
 			errors.New("MD has embedded block changes, but shouldn't")
 	}
 
-	brmd, err := encryptMDPrivateData(
-		ctx, j.codec, j.crypto, signer, ekg,
-		j.uid, rmd.ReadOnly())
+	err = encryptMDPrivateData(
+		ctx, j.codec, j.crypto, signer, ekg, j.uid, rmd)
 	if err != nil {
 		return MdID{}, err
 	}
 
-	err = brmd.IsValidAndSigned(j.codec, j.crypto, extra)
+	err = rmd.bareMd.IsValidAndSigned(j.codec, j.crypto, extra)
 	if err != nil {
 		return MdID{}, err
 	}
 
-	id, err := j.putMD(brmd)
+	id, err := j.putMD(rmd.bareMd)
 	if err != nil {
 		return MdID{}, err
 	}
 
-	err = j.putExtraMetadata(brmd, extra)
+	err = j.putExtraMetadata(rmd.bareMd, extra)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1086,8 +1085,7 @@ func (j *mdJournal) put(
 			return MdID{}, err
 		}
 	} else {
-		err = j.j.append(
-			brmd.RevisionNumber(), mdIDJournalEntry{ID: id})
+		err = j.j.append(rmd.Revision(), mdIDJournalEntry{ID: id})
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -632,16 +632,10 @@ func (j *mdJournal) convertToBranch(
 		brmd.SetBranchID(bid)
 
 		// Re-sign the writer metadata.
-		buf, err := brmd.GetSerializedWriterMetadata(j.codec)
+		err = brmd.MaybeSignWriterMetadata(ctx, j.codec, signer)
 		if err != nil {
 			return NullBranchID, err
 		}
-
-		sigInfo, err := signer.Sign(ctx, buf)
-		if err != nil {
-			return NullBranchID, err
-		}
-		brmd.SetWriterMetadataSigInfo(sigInfo)
 
 		j.log.CDebugf(ctx, "Old prev root of rev=%s is %s",
 			brmd.RevisionNumber(), brmd.GetPrevRoot())

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -683,7 +683,9 @@ func (j *mdJournal) convertToBranch(
 			newRmd.bareMd = brmd
 			// The extra is the same.
 			err = mdcache.Replace(
-				MakeImmutableRootMetadata(newRmd, newID, ts),
+				MakeImmutableRootMetadata(newRmd,
+					oldIrmd.LastWriterVerifyingKey(),
+					newID, ts),
 				NullBranchID)
 			if err != nil {
 				return NullBranchID, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -631,8 +631,9 @@ func (j *mdJournal) convertToBranch(
 		brmd.SetUnmerged()
 		brmd.SetBranchID(bid)
 
-		// Re-sign the writer metadata.
-		err = brmd.MaybeSignWriterMetadata(ctx, j.codec, signer)
+		// Re-sign the writer metadata internally, since we
+		// changed it.
+		err = brmd.SignWriterMetadataInternally(ctx, j.codec, signer)
 		if err != nil {
 			return NullBranchID, err
 		}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -203,14 +203,13 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		}
 	}
 
-	// TODO: Avoid the need for this copy (which is because MakeRootMetadata
-	// takes a MutableBareRootMetadata).
-	newMD, err := rmds.MD.DeepCopy(md.config.Codec())
-	if err != nil {
-		return ImmutableRootMetadata{}, err
+	// TODO: Avoid having to do this type assertion.
+	mmd, ok := rmds.MD.(MutableBareRootMetadata)
+	if !ok {
+		return ImmutableRootMetadata{}, MutableBareRootMetadataNoImplError{}
 	}
 
-	rmd := MakeRootMetadata(newMD, extra, handle)
+	rmd := MakeRootMetadata(mmd, extra, handle)
 	// Try to decrypt using the keys available in this md.  If that
 	// doesn't work, a future MD may contain more keys and will be
 	// tried later.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -528,15 +528,16 @@ func (md *MDOpsStandard) put(
 			errors.New("MD has embedded block changes, but shouldn't")
 	}
 
-	brmd, err := encryptMDPrivateData(
+	err = encryptMDPrivateData(
 		ctx, md.config.Codec(), md.config.Crypto(),
-		md.config.Crypto(), md.config.KeyManager(), me, rmd.ReadOnly())
+		md.config.Crypto(), md.config.KeyManager(), me, rmd)
 	if err != nil {
 		return MdID{}, err
 	}
 
 	rmds, err := signMD(
-		ctx, md.config.Codec(), md.config.Crypto(), brmd, time.Time{})
+		ctx, md.config.Codec(), md.config.Crypto(),
+		rmd.bareMd, time.Time{})
 	if err != nil {
 		return MdID{}, err
 	}
@@ -551,13 +552,6 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
-	// TODO: Avoid the need for this deep copy, too.
-	newMD, err := rmds.MD.DeepCopy(md.config.Codec())
-	if err != nil {
-		return MdID{}, err
-	}
-
-	rmd.bareMd = newMD
 	return mdID, nil
 }
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -222,7 +222,9 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		localTimestamp = localTimestamp.Add(offset)
 	}
 
-	return MakeImmutableRootMetadata(rmd, mdID, localTimestamp), nil
+	return MakeImmutableRootMetadata(rmd,
+		rmds.GetWriterMetadataSigInfo().VerifyingKey, mdID,
+		localTimestamp), nil
 }
 
 // GetForHandle implements the MDOps interface for MDOpsStandard.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -436,7 +436,7 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 			return nil, fmt.Errorf("Unexpected revision %d; expected "+
 				"something between %d and %d inclusive", irmd.Revision(),
 				startRev, startRev+numExpected-1)
-		} else if !irmds[i].IsNil() {
+		} else if (irmds[i] != ImmutableRootMetadata{}) {
 			return nil, fmt.Errorf("Got revision %d twice", irmd.Revision())
 		}
 		irmds[i] = irmd
@@ -446,7 +446,7 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 	// the given MD objects form a valid sequence.
 	var prevIRMD ImmutableRootMetadata
 	for _, irmd := range irmds {
-		if !prevIRMD.IsNil() {
+		if prevIRMD != (ImmutableRootMetadata{}) {
 			// Ideally, we'd call
 			// ReadOnlyRootMetadata.CheckValidSuccessor()
 			// instead. However, we only convert r.MD to

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -115,13 +115,12 @@ func (md *MDOpsStandard) verifyWriterKey(ctx context.Context,
 
 		for i := len(prevMDs) - 1; i >= 0; i-- {
 			if !prevMDs[i].IsWriterMetadataCopiedSet() {
-				// We want to compare the writer
-				// signature of rmds with that of
-				// prevMDs[i]. However, we've already
-				// dropped prevMDs[i] writer
-				// signature. We can just verify
-				// prevMDs[i]'s writer metadata with
-				// rmds's signature, though.
+				// We want to compare the writer signature of
+				// rmds with that of prevMDs[i]. However, we've
+				// already dropped prevMDs[i]'s writer
+				// signature. We can just verify prevMDs[i]'s
+				// writer metadata with rmds's signature,
+				// though.
 				buf, err := prevMDs[i].GetSerializedWriterMetadata(md.config.Codec())
 				if err != nil {
 					return err

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -204,12 +204,12 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	}
 
 	// TODO: Avoid having to do this type assertion.
-	mmd, ok := rmds.MD.(MutableBareRootMetadata)
+	brmd, ok := rmds.MD.(MutableBareRootMetadata)
 	if !ok {
 		return ImmutableRootMetadata{}, MutableBareRootMetadataNoImplError{}
 	}
 
-	rmd := MakeRootMetadata(mmd, extra, handle)
+	rmd := MakeRootMetadata(brmd, extra, handle)
 	// Try to decrypt using the keys available in this md.  If that
 	// doesn't work, a future MD may contain more keys and will be
 	// tried later.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -134,7 +134,14 @@ func (md *MDOpsStandard) verifyWriterKey(ctx context.Context,
 				err = md.config.Crypto().Verify(
 					buf, rmds.GetWriterMetadataSigInfo())
 				if err != nil {
-					return fmt.Errorf("Could not verify uncopied writer metadata from revision %d of folder %s with signature from revision %d: %v", prevMDs[i].Revision(), rmds.MD.TlfID(), rmds.MD.RevisionNumber(), err)
+					return fmt.Errorf("Could not verify "+
+						"uncopied writer metadata "+
+						"from revision %d of folder "+
+						"%s with signature from "+
+						"revision %d: %v",
+						prevMDs[i].Revision(),
+						rmds.MD.TlfID(),
+						rmds.MD.RevisionNumber(), err)
 				}
 
 				// The fact the fact that we were able to process this

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -191,7 +191,8 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		}
 	}
 
-	// TODO: Avoid the need for this.
+	// TODO: Avoid the need for this copy (which is because MakeRootMetadata
+	// takes a MutableBareRootMetadata).
 	newMD, err := rmds.MD.DeepCopy(md.config.Codec())
 	if err != nil {
 		return ImmutableRootMetadata{}, err
@@ -435,7 +436,7 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id TlfID,
 			return nil, fmt.Errorf("Unexpected revision %d; expected "+
 				"something between %d and %d inclusive", irmd.Revision(),
 				startRev, startRev+numExpected-1)
-		} else if (irmds[i] != ImmutableRootMetadata{}) {
+		} else if irmds[i] != (ImmutableRootMetadata{}) {
 			return nil, fmt.Errorf("Got revision %d twice", irmd.Revision())
 		}
 		irmds[i] = irmd
@@ -539,6 +540,7 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
+	// TODO: Avoid the need for this deep copy, too.
 	newMD, err := rmds.MD.DeepCopy(md.config.Codec())
 	if err != nil {
 		return MdID{}, err

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -530,7 +530,7 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
-	err = md.config.MDServer().Put(ctx, &rmds, rmd.NewExtra())
+	err = md.config.MDServer().Put(ctx, rmds, rmd.NewExtra())
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -115,38 +115,6 @@ func newRMD(t *testing.T, config Config, public bool) (
 	}, h
 }
 
-func addFakeRMDSData(t *testing.T, codec kbfscodec.Codec, crypto cryptoPure,
-	rmds *RootMetadataSigned, h *TlfHandle) ExtraMetadata {
-	mmd := rmds.MD.(MutableBareRootMetadata)
-	mmd.SetRevision(MetadataRevision(1))
-	pmd := PrivateMetadata{}
-	// TODO: Will have to change this for private folders if we
-	// un-mock out those tests.
-	buf, err := codec.Encode(pmd)
-	require.NoError(t, err)
-	mmd.SetSerializedPrivateMetadata(buf)
-	mmd.SetLastModifyingWriter(h.FirstResolvedWriter())
-	mmd.SetLastModifyingUser(h.FirstResolvedWriter())
-	fakeVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
-	mmd.(*BareRootMetadataV2).WriterMetadataSigInfo = kbfscrypto.SignatureInfo{
-		Version:      kbfscrypto.SigED25519,
-		Signature:    []byte{41},
-		VerifyingKey: fakeVerifyingKey,
-	}
-	rmds.SigInfo = kbfscrypto.SignatureInfo{
-		Version:      kbfscrypto.SigED25519,
-		Signature:    []byte{42},
-		VerifyingKey: fakeVerifyingKey,
-	}
-	rmds.untrustedServerTimestamp = time.Now()
-
-	var extra ExtraMetadata
-	if !h.IsPublic() {
-		extra, _ = mmd.FakeInitialRekey(crypto, h.ToBareHandleOrBust())
-	}
-	return extra
-}
-
 func newRMDS(t *testing.T, config Config, h *TlfHandle) (
 	*RootMetadataSigned, ExtraMetadata) {
 	id := FakeTlfID(1, h.IsPublic())

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -115,13 +115,13 @@ func newRMD(t *testing.T, config Config, public bool) (
 	}, h
 }
 
+// TODO: Add test coverage for MDv3.
+
 func newRMDS(t *testing.T, config Config, h *TlfHandle) (
 	*RootMetadataSigned, ExtraMetadata) {
 	id := FakeTlfID(1, h.IsPublic())
 
 	var brmd BareRootMetadataV2
-	// MDv3 TODO: uncomment the below when we're ready for MDv3
-	// var md BareRootMetadataV3
 	err := brmd.Update(id, h.ToBareHandleOrBust())
 	require.NoError(t, err)
 	extra := addFakeBRMDData(t, config.Codec(), config.Crypto(), &brmd, h)
@@ -513,8 +513,6 @@ func makeRMDSRange(t *testing.T, config Config,
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
 	for i := 0; i < count; i++ {
 		var brmd BareRootMetadataV2
-		// MDv3 TODO: uncomment the below when we're ready for MDv3
-		// var md BareRootMetadataV3
 		err := brmd.Update(id, h.ToBareHandleOrBust())
 		require.NoError(t, err)
 		extra := addFakeBRMDData(t, config.Codec(), config.Crypto(), &brmd, h)

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -397,6 +397,15 @@ func TestMDOpsGetForHandlePublicFailFindKey(t *testing.T) {
 	}
 }
 
+type failVerifyCrypto struct {
+	Crypto
+	err error
+}
+
+func (c failVerifyCrypto) Verify(msg []byte, sigInfo kbfscrypto.SignatureInfo) error {
+	return c.err
+}
+
 func TestMDOpsGetForHandlePublicFailVerify(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
@@ -407,6 +416,8 @@ func TestMDOpsGetForHandlePublicFailVerify(t *testing.T) {
 	// Do this before setting tlfHandle to nil.
 	expectedErr := libkb.VerificationError{}
 	verifyMDForPublic(config, rmds, expectedErr, nil)
+
+	config.SetCrypto(failVerifyCrypto{config.Crypto(), expectedErr})
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -160,7 +160,7 @@ func newRMDS(t *testing.T, config Config, h *TlfHandle) (
 	ctx := context.Background()
 
 	// Encode and sign writer metadata.
-	err = brmd.MaybeSignWriterMetadata(ctx, config.Codec(), config.Crypto())
+	err = brmd.SignWriterMetadataInternally(ctx, config.Codec(), config.Crypto())
 	require.NoError(t, err)
 
 	rmds, err := signMD(ctx, config.Codec(), config.Crypto(), &brmd, (wallClock{}).Now())
@@ -550,7 +550,7 @@ func makeRMDSRange(t *testing.T, config Config,
 		ctx := context.Background()
 
 		// Encode and sign writer metadata.
-		err = brmd.MaybeSignWriterMetadata(ctx, config.Codec(), config.Crypto())
+		err = brmd.SignWriterMetadataInternally(ctx, config.Codec(), config.Crypto())
 		require.NoError(t, err)
 
 		rmds, err := signMD(ctx, config.Codec(), config.Crypto(), &brmd, (wallClock{}).Now())

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -205,9 +205,11 @@ func TestMDOpsGetForHandlePublicSuccess(t *testing.T) {
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 
+	// Do this first, since rmds is consumed.
+	expectedMD := rmds.MD
 	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
-	require.Equal(t, rmds.MD, rmd2.bareMd)
+	require.Equal(t, expectedMD, rmd2.bareMd)
 }
 
 func expectGetKeyBundles(ctx context.Context, config *ConfigMock, extra ExtraMetadata) {
@@ -230,9 +232,11 @@ func TestMDOpsGetForHandlePrivateSuccess(t *testing.T) {
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
+	// Do this first, since rmds is consumed.
+	expectedMD := rmds.MD
 	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
-	require.Equal(t, rmds.MD, rmd2.bareMd)
+	require.Equal(t, expectedMD, rmd2.bareMd)
 }
 
 func TestMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T) {
@@ -444,9 +448,11 @@ func TestMDOpsGetSuccess(t *testing.T) {
 	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), NullBranchID, Merged).Return(rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
+	// Do this first, since rmds is consumed.
+	expectedMD := rmds.MD
 	rmd2, err := config.MDOps().GetForTLF(ctx, rmds.MD.TlfID())
 	require.NoError(t, err)
-	require.Equal(t, rmds.MD, rmd2.bareMd)
+	require.Equal(t, expectedMD, rmd2.bareMd)
 }
 
 func TestMDOpsGetBlankSigFailure(t *testing.T) {
@@ -554,11 +560,16 @@ func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
 		expectGetKeyBundles(ctx, config, e)
 	}
 
+	// Do this first since rmdses is consumed.
+	expectedMDs := make([]BareRootMetadata, len(rmdses))
+	for i, rmds := range rmdses {
+		expectedMDs[i] = rmds.MD
+	}
 	rmds, err := config.MDOps().GetRange(ctx, rmdses[0].MD.TlfID(), start, stop)
 	require.NoError(t, err)
 	require.Equal(t, len(rmdses), len(rmds))
 	for i := 0; i < len(rmdses); i++ {
-		require.Equal(t, rmdses[i].MD, rmds[i].bareMd)
+		require.Equal(t, expectedMDs[i], rmds[i].bareMd)
 	}
 }
 

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -246,7 +246,8 @@ func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 			rmdCopy.data = pmd
 
 			// Overwrite the cached copy with the new copy
-			irmdCopy := MakeImmutableRootMetadata(rmdCopy, rmd.mdID,
+			irmdCopy := MakeImmutableRootMetadata(rmdCopy,
+				rmd.LastWriterVerifyingKey(), rmd.mdID,
 				rmd.localTimestamp)
 			if err := config.MDCache().Put(irmdCopy); err != nil {
 				return nil, err

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -151,7 +151,7 @@ func getMDRange(ctx context.Context, config Config, id TlfID, bid BranchID,
 	rmds = rmds[minSlot : maxSlot+1]
 	// check to make sure there are no holes
 	for i, rmd := range rmds {
-		if rmd.IsNil() {
+		if rmd == (ImmutableRootMetadata{}) {
 			return nil, fmt.Errorf("No %s MD found for revision %d",
 				mStatus, int(start)+minSlot+i)
 		}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -239,7 +239,7 @@ func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 				return nil, err
 			}
 
-			rmdCopy, err := rmd.deepCopy(config.Codec(), true)
+			rmdCopy, err := rmd.deepCopy(config.Codec())
 			if err != nil {
 				return nil, err
 			}
@@ -247,8 +247,8 @@ func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 
 			// Overwrite the cached copy with the new copy
 			irmdCopy := MakeImmutableRootMetadata(rmdCopy,
-				rmd.LastWriterVerifyingKey(), rmd.mdID,
-				rmd.localTimestamp)
+				rmd.LastWriterVerifyingKey(), rmd.MdID(),
+				rmd.LocalTimestamp())
 			if err := config.MDCache().Put(irmdCopy); err != nil {
 				return nil, err
 			}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -356,10 +356,10 @@ func encryptMDPrivateData(
 			brmd.SetSerializedPrivateMetadata(encodedEncryptedPrivateMetadata)
 		}
 
-		// Sign the writer metadata if needed. This has to be
+		// Sign the writer metadata internally. This has to be
 		// done here, instead of in signMD, since the
 		// MetadataID may depend on it.
-		err := brmd.MaybeSignWriterMetadata(ctx, codec, signer)
+		err := brmd.SignWriterMetadataInternally(ctx, codec, signer)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -247,7 +247,7 @@ func getMergedMDUpdates(ctx context.Context, config Config, id TlfID,
 
 			// Overwrite the cached copy with the new copy
 			irmdCopy := MakeImmutableRootMetadata(rmdCopy,
-				rmd.LastWriterVerifyingKey(), rmd.MdID(),
+				rmd.LastModifyingWriterVerifyingKey(), rmd.MdID(),
 				rmd.LocalTimestamp())
 			if err := config.MDCache().Put(irmdCopy); err != nil {
 				return nil, err

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -355,19 +355,13 @@ func encryptMDPrivateData(
 			brmd.SetSerializedPrivateMetadata(encodedEncryptedPrivateMetadata)
 		}
 
-		// Sign the writer metadata. This has to be done here,
-		// instead of in signMD, since the MetadataID depends
-		// on it.
-		buf, err := brmd.GetSerializedWriterMetadata(codec)
+		// Sign the writer metadata if needed. This has to be
+		// done here, instead of in signMD, since the
+		// MetadataID may depend on it.
+		err := brmd.MaybeSignWriterMetadata(ctx, codec, signer)
 		if err != nil {
 			return nil, err
 		}
-
-		sigInfo, err := signer.Sign(ctx, buf)
-		if err != nil {
-			return nil, err
-		}
-		brmd.SetWriterMetadataSigInfo(sigInfo)
 	}
 
 	// Record the last user to modify this metadata

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -133,7 +133,7 @@ func TestMdcacheReplace(t *testing.T) {
 
 	newRmd.SetBranchID(bid)
 	err = config.MDCache().Replace(MakeImmutableRootMetadata(newRmd,
-		irmd.LastWriterVerifyingKey(), fakeMdID(2), time.Now()), NullBranchID)
+		irmd.LastModifyingWriterVerifyingKey(), fakeMdID(2), time.Now()), NullBranchID)
 	if err != nil {
 		t.Fatalf("Replace error: %v", err)
 	}

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -126,7 +126,7 @@ func TestMdcacheReplace(t *testing.T) {
 
 	// Change the BID
 	bid := FakeBranchID(1)
-	newRmd, err := irmd.deepCopy(kbfscodec.NewMsgpack(), false)
+	newRmd, err := irmd.deepCopy(kbfscodec.NewMsgpack())
 	if err != nil {
 		t.Fatalf("Deep-copy error: %v", err)
 	}

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,7 +50,8 @@ func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	}
 
 	// put the md
-	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
+	irmd := MakeImmutableRootMetadata(
+		rmd, kbfscrypto.VerifyingKey{}, fakeMdID(1), time.Now())
 	if err := config.MDCache().Put(irmd); err != nil {
 		t.Errorf("Got error on put on md %v: %v", tlf, err)
 	}
@@ -123,7 +125,7 @@ func TestMdcacheReplace(t *testing.T) {
 
 	newRmd.SetBranchID(bid)
 	err = config.MDCache().Replace(MakeImmutableRootMetadata(newRmd,
-		fakeMdID(2), time.Now()), NullBranchID)
+		kbfscrypto.VerifyingKey{}, fakeMdID(2), time.Now()), NullBranchID)
 	if err != nil {
 		t.Fatalf("Replace error: %v", err)
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -136,7 +136,7 @@ func (md *MDServerDisk) getStorage(tlfID TlfID) (*mdServerTlfStorage, error) {
 	path := filepath.Join(md.dirPath, tlfID.String())
 	storage = makeMDServerTlfStorage(
 		tlfID, md.config.Codec(), md.config.cryptoPure(),
-		md.config.Clock(), tlfID, md.config.MetadataVersion(), path)
+		md.config.Clock(), md.config.MetadataVersion(), path)
 
 	md.tlfStorage[tlfID] = storage
 	return storage, nil

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -36,7 +36,7 @@ func signRMDSForTest(t *testing.T, codec kbfscodec.Codec, signer cryptoSigner,
 	ctx := context.Background()
 
 	// Encode and sign writer metadata.
-	err := brmd.MaybeSignWriterMetadata(ctx, codec, signer)
+	err := brmd.SignWriterMetadataInternally(ctx, codec, signer)
 	require.NoError(t, err)
 
 	rmds, err := signMD(ctx, codec, signer, brmd, time.Time{})

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -14,39 +15,34 @@ import (
 	"golang.org/x/net/context"
 )
 
-func makeRMDSForTest(t *testing.T, crypto cryptoPure, id TlfID,
+func makeBRMDForTest(t *testing.T, crypto cryptoPure, id TlfID,
 	h BareTlfHandle, revision MetadataRevision, uid keybase1.UID,
-	prevRoot MdID) *RootMetadataSigned {
-	rmds, err := NewRootMetadataSignedForTest(id, h)
-	require.NoError(t, err)
-	rmds.MD.(MutableBareRootMetadata).SetSerializedPrivateMetadata([]byte{0x1})
-	rmds.MD.(MutableBareRootMetadata).SetRevision(revision)
-	rmds.MD.(MutableBareRootMetadata).SetLastModifyingWriter(uid)
-	rmds.MD.(MutableBareRootMetadata).SetLastModifyingUser(uid)
-	rmds.MD.(MutableBareRootMetadata).FakeInitialRekey(crypto, h)
-	rmds.MD.(MutableBareRootMetadata).SetPrevRoot(prevRoot)
-	return rmds
+	prevRoot MdID) *BareRootMetadataV2 {
+	var md BareRootMetadataV2
+	// MDv3 TODO: uncomment the below when we're ready for MDv3
+	// md := &BareRootMetadataV3{}
+	md.SetTlfID(id)
+	md.SetSerializedPrivateMetadata([]byte{0x1})
+	md.SetRevision(revision)
+	md.SetLastModifyingWriter(uid)
+	md.SetLastModifyingUser(uid)
+	md.FakeInitialRekey(crypto, h)
+	md.SetPrevRoot(prevRoot)
+	return &md
 }
 
 func signRMDSForTest(t *testing.T, codec kbfscodec.Codec, signer cryptoSigner,
-	rmds *RootMetadataSigned) {
+	brmd *BareRootMetadataV2) *RootMetadataSigned {
 	ctx := context.Background()
 
 	// Encode and sign writer metadata.
-	buf, err := rmds.MD.GetSerializedWriterMetadata(codec)
+	err := brmd.MaybeSignWriterMetadata(ctx, codec, signer)
 	require.NoError(t, err)
 
-	sigInfo, err := signer.Sign(ctx, buf)
-	require.NoError(t, err)
-	rmds.MD.(MutableBareRootMetadata).SetWriterMetadataSigInfo(sigInfo)
-
-	// Encode and sign root metadata.
-	buf, err = codec.Encode(rmds.MD)
+	rmds, err := signMD(ctx, codec, signer, brmd, time.Time{})
 	require.NoError(t, err)
 
-	sigInfo, err = signer.Sign(ctx, buf)
-	require.NoError(t, err)
-	rmds.SigInfo = sigInfo
+	return rmds
 }
 
 // This should pass for both local and remote servers.
@@ -72,8 +68,8 @@ func TestMDServerBasics(t *testing.T) {
 	prevRoot := MdID{}
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
-		rmds := makeRMDSForTest(t, config.Crypto(), id, h, i, uid, prevRoot)
-		signRMDSForTest(t, config.Codec(), config.Crypto(), rmds)
+		brmd := makeBRMDForTest(t, config.Crypto(), id, h, i, uid, prevRoot)
+		rmds := signRMDSForTest(t, config.Codec(), config.Crypto(), brmd)
 		// MDv3 TODO: pass actual key bundles
 		err = mdServer.Put(ctx, rmds, nil)
 		require.NoError(t, err)
@@ -85,8 +81,8 @@ func TestMDServerBasics(t *testing.T) {
 	}
 
 	// (3) trigger a conflict
-	rmds = makeRMDSForTest(t, config.Crypto(), id, h, 10, uid, prevRoot)
-	signRMDSForTest(t, config.Codec(), config.Crypto(), rmds)
+	brmd := makeBRMDForTest(t, config.Crypto(), id, h, 10, uid, prevRoot)
+	rmds = signRMDSForTest(t, config.Codec(), config.Crypto(), brmd)
 	// MDv3 TODO: pass actual key bundles
 	err = mdServer.Put(ctx, rmds, nil)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
@@ -97,10 +93,10 @@ func TestMDServerBasics(t *testing.T) {
 	bid, err := config.Crypto().MakeRandomBranchID()
 	require.NoError(t, err)
 	for i := MetadataRevision(6); i < 41; i++ {
-		rmds := makeRMDSForTest(t, config.Crypto(), id, h, i, uid, prevRoot)
-		rmds.MD.(MutableBareRootMetadata).SetUnmerged()
-		rmds.MD.(MutableBareRootMetadata).SetBranchID(bid)
-		signRMDSForTest(t, config.Codec(), config.Crypto(), rmds)
+		brmd := makeBRMDForTest(t, config.Crypto(), id, h, i, uid, prevRoot)
+		brmd.SetUnmerged()
+		brmd.SetBranchID(bid)
+		rmds := signRMDSForTest(t, config.Codec(), config.Crypto(), brmd)
 		// MDv3 TODO: pass actual key bundles
 		err = mdServer.Put(ctx, rmds, nil)
 		require.NoError(t, err)

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -74,8 +74,8 @@ type mdServerTlfStorage struct {
 }
 
 func makeMDServerTlfStorage(tlfID TlfID, codec kbfscodec.Codec,
-	crypto cryptoPure, clock Clock, tlfID TlfID,
-	mdVer MetadataVer, dir string) *mdServerTlfStorage {
+	crypto cryptoPure, clock Clock, mdVer MetadataVer,
+	dir string) *mdServerTlfStorage {
 	journal := &mdServerTlfStorage{
 		tlfID:          tlfID,
 		codec:          codec,
@@ -135,13 +135,11 @@ func (s *mdServerTlfStorage) getMDReadLocked(id MdID) (
 	}
 
 	rmds, err := DecodeRootMetadataSigned(
-		s.codec, s.tlfID, srmds.Version, s.mdVer,
-		srmds.EncodedRMDS)
+		s.codec, s.tlfID, srmds.Version, s.mdVer, srmds.EncodedRMDS,
+		srmds.Timestamp)
 	if err != nil {
 		return nil, err
 	}
-
-	rmds.untrustedServerTimestamp = srmds.Timestamp
 
 	// Check integrity.
 

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -61,8 +61,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot := MdID{}
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
-		rmds := makeRMDSForTest(t, crypto, tlfID, h, i, uid, prevRoot)
-		signRMDSForTest(t, codec, signer, rmds)
+		brmd := makeBRMDForTest(t, crypto, tlfID, h, i, uid, prevRoot)
+		rmds := signRMDSForTest(t, codec, signer, brmd)
 		// MDv3 TODO: pass extra metadata
 		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
 		require.NoError(t, err)
@@ -78,8 +78,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 
 	// (3) Trigger a conflict.
 
-	rmds := makeRMDSForTest(t, crypto, tlfID, h, 10, uid, prevRoot)
-	signRMDSForTest(t, codec, signer, rmds)
+	brmd := makeBRMDForTest(t, crypto, tlfID, h, 10, uid, prevRoot)
+	rmds := signRMDSForTest(t, codec, signer, brmd)
 	// MDv3 TODO: pass extra metadata
 	_, err = s.put(uid, verifyingKey, rmds, nil)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
@@ -92,10 +92,10 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot = middleRoot
 	bid := FakeBranchID(1)
 	for i := MetadataRevision(6); i < 41; i++ {
-		rmds := makeRMDSForTest(t, crypto, tlfID, h, i, uid, prevRoot)
-		rmds.MD.(MutableBareRootMetadata).SetUnmerged()
-		rmds.MD.(MutableBareRootMetadata).SetBranchID(bid)
-		signRMDSForTest(t, codec, signer, rmds)
+		brmd := makeBRMDForTest(t, crypto, tlfID, h, i, uid, prevRoot)
+		brmd.SetUnmerged()
+		brmd.SetBranchID(bid)
+		rmds := signRMDSForTest(t, codec, signer, brmd)
 		// MDv3 TODO: pass extra metadata
 		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
 		require.NoError(t, err)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5402,14 +5402,14 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetSerializedPrivateMetadata(ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSerializedPrivateMetadata", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) MaybeSignWriterMetadata(ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
-	ret := _m.ctrl.Call(_m, "MaybeSignWriterMetadata", ctx, codec, signer)
+func (_m *MockMutableBareRootMetadata) SignWriterMetadataInternally(ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
+	ret := _m.ctrl.Call(_m, "SignWriterMetadataInternally", ctx, codec, signer)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) MaybeSignWriterMetadata(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaybeSignWriterMetadata", arg0, arg1, arg2)
+func (_mr *_MockMutableBareRootMetadataRecorder) SignWriterMetadataInternally(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignWriterMetadataInternally", arg0, arg1, arg2)
 }
 
 func (_m *MockMutableBareRootMetadata) SetLastModifyingWriter(user keybase1.UID) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4560,9 +4560,9 @@ func (_mr *_MockBareRootMetadataRecorder) IsReader(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1, arg2)
 }
 
-func (_m *MockBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
+func (_m *MockBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
 	ret := _m.ctrl.Call(_m, "DeepCopy", codec)
-	ret0, _ := ret[0].(BareRootMetadata)
+	ret0, _ := ret[0].(MutableBareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4571,15 +4571,15 @@ func (_mr *_MockBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
 }
 
-func (_m *MockBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
-	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec)
-	ret0, _ := ret[0].(BareRootMetadata)
+func (_m *MockBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (MutableBareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec, isReadableAndWriter)
+	ret0, _ := ret[0].(MutableBareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) MakeSuccessorCopy(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0)
+func (_mr *_MockBareRootMetadataRecorder) MakeSuccessorCopy(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0, arg1)
 }
 
 func (_m *MockBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
@@ -4688,16 +4688,6 @@ func (_mr *_MockBareRootMetadataRecorder) LastModifyingWriter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriter")
 }
 
-func (_m *MockBareRootMetadata) LastModifyingWriterKID() keybase1.KID {
-	ret := _m.ctrl.Call(_m, "LastModifyingWriterKID")
-	ret0, _ := ret[0].(keybase1.KID)
-	return ret0
-}
-
-func (_mr *_MockBareRootMetadataRecorder) LastModifyingWriterKID() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriterKID")
-}
-
 func (_m *MockBareRootMetadata) GetLastModifyingUser() keybase1.UID {
 	ret := _m.ctrl.Call(_m, "GetLastModifyingUser")
 	ret0, _ := ret[0].(keybase1.UID)
@@ -4797,16 +4787,6 @@ func (_m *MockBareRootMetadata) GetSerializedWriterMetadata(codec kbfscodec.Code
 
 func (_mr *_MockBareRootMetadataRecorder) GetSerializedWriterMetadata(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedWriterMetadata", arg0)
-}
-
-func (_m *MockBareRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
-	ret := _m.ctrl.Call(_m, "GetWriterMetadataSigInfo")
-	ret0, _ := ret[0].(kbfscrypto.SignatureInfo)
-	return ret0
-}
-
-func (_mr *_MockBareRootMetadataRecorder) GetWriterMetadataSigInfo() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriterMetadataSigInfo")
 }
 
 func (_m *MockBareRootMetadata) Version() MetadataVer {
@@ -5005,9 +4985,9 @@ func (_mr *_MockMutableBareRootMetadataRecorder) IsReader(arg0, arg1, arg2 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1, arg2)
 }
 
-func (_m *MockMutableBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
+func (_m *MockMutableBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
 	ret := _m.ctrl.Call(_m, "DeepCopy", codec)
-	ret0, _ := ret[0].(BareRootMetadata)
+	ret0, _ := ret[0].(MutableBareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -5016,15 +4996,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
-	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec)
-	ret0, _ := ret[0].(BareRootMetadata)
+func (_m *MockMutableBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (MutableBareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec, isReadableAndWriter)
+	ret0, _ := ret[0].(MutableBareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) MakeSuccessorCopy(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0)
+func (_mr *_MockMutableBareRootMetadataRecorder) MakeSuccessorCopy(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
@@ -5133,16 +5113,6 @@ func (_mr *_MockMutableBareRootMetadataRecorder) LastModifyingWriter() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriter")
 }
 
-func (_m *MockMutableBareRootMetadata) LastModifyingWriterKID() keybase1.KID {
-	ret := _m.ctrl.Call(_m, "LastModifyingWriterKID")
-	ret0, _ := ret[0].(keybase1.KID)
-	return ret0
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) LastModifyingWriterKID() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriterKID")
-}
-
 func (_m *MockMutableBareRootMetadata) GetLastModifyingUser() keybase1.UID {
 	ret := _m.ctrl.Call(_m, "GetLastModifyingUser")
 	ret0, _ := ret[0].(keybase1.UID)
@@ -5242,16 +5212,6 @@ func (_m *MockMutableBareRootMetadata) GetSerializedWriterMetadata(codec kbfscod
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetSerializedWriterMetadata(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedWriterMetadata", arg0)
-}
-
-func (_m *MockMutableBareRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
-	ret := _m.ctrl.Call(_m, "GetWriterMetadataSigInfo")
-	ret0, _ := ret[0].(kbfscrypto.SignatureInfo)
-	return ret0
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) GetWriterMetadataSigInfo() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriterMetadataSigInfo")
 }
 
 func (_m *MockMutableBareRootMetadata) Version() MetadataVer {
@@ -5442,12 +5402,14 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetSerializedPrivateMetadata(ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSerializedPrivateMetadata", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) SetWriterMetadataSigInfo(sigInfo kbfscrypto.SignatureInfo) {
-	_m.ctrl.Call(_m, "SetWriterMetadataSigInfo", sigInfo)
+func (_m *MockMutableBareRootMetadata) MaybeSignWriterMetadata(ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
+	ret := _m.ctrl.Call(_m, "MaybeSignWriterMetadata", ctx, codec, signer)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) SetWriterMetadataSigInfo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriterMetadataSigInfo", arg0)
+func (_mr *_MockMutableBareRootMetadataRecorder) MaybeSignWriterMetadata(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaybeSignWriterMetadata", arg0, arg1, arg2)
 }
 
 func (_m *MockMutableBareRootMetadata) SetLastModifyingWriter(user keybase1.UID) {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -862,7 +862,7 @@ func (irmd ImmutableRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.Signatur
 // TODO: Use the BareRootMetadataSigned types on the server side.
 type RootMetadataSigned struct {
 	// signature over the root metadata by the private signing key
-	SigInfo       kbfscrypto.SignatureInfo `codec:",omitempty"`
+	SigInfo       kbfscrypto.SignatureInfo
 	WriterSigInfo kbfscrypto.SignatureInfo
 	// all the metadata
 	MD BareRootMetadata

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -1043,10 +1043,16 @@ func (rmds *RootMetadataSigned) IsLastModifiedBy(
 			rmds.SigInfo.VerifyingKey, key)
 	}
 
-	if rmds.WriterSigInfo.VerifyingKey != key {
-		return fmt.Errorf(
-			"Last writer verifying key %v != %v",
-			rmds.WriterSigInfo.VerifyingKey, key)
+	writer := rmds.MD.LastModifyingWriter()
+	if !rmds.MD.IsWriterMetadataCopiedSet() {
+		if writer != uid {
+			return fmt.Errorf("Last writer %s != %s", writer, uid)
+		}
+		if rmds.WriterSigInfo.VerifyingKey != key {
+			panic(fmt.Errorf(
+				"Last writer verifying key %v != %v",
+				rmds.WriterSigInfo.VerifyingKey, key))
+		}
 	}
 
 	return nil

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -906,7 +906,8 @@ func (rmds *RootMetadataSigned) Version() MetadataVer {
 
 // MakeFinalCopy returns a complete copy of this RootMetadataSigned
 // with the revision incremented and the final bit set.
-func (rmds *RootMetadataSigned) MakeFinalCopy(codec kbfscodec.Codec) (
+func (rmds *RootMetadataSigned) MakeFinalCopy(
+	codec kbfscodec.Codec, clock Clock) (
 	*RootMetadataSigned, error) {
 	if rmds.MD.IsFinal() {
 		return nil, MetadataIsFinalError{}
@@ -927,7 +928,7 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(codec kbfscodec.Codec) (
 	newBareMd.SetRevision(rmds.MD.RevisionNumber() + 1)
 	return MakeRootMetadataSigned(
 		rmds.SigInfo.DeepCopy(), rmds.WriterSigInfo.DeepCopy(),
-		newBareMd, time.Time{})
+		newBareMd, clock.Now())
 }
 
 // IsValidAndSigned verifies the RootMetadataSigned, checks the root

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -172,34 +172,29 @@ func (md *RootMetadata) clearLastRevision() {
 	md.clearWriterMetadataCopiedBit()
 }
 
-func (md *RootMetadata) deepCopy(
-	codec kbfscodec.Codec, copyHandle bool) (*RootMetadata, error) {
+func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 	var newMd RootMetadata
-
-	if err := kbfscodec.Update(codec, &newMd, md); err != nil {
-		return nil, err
-	}
-	if err := kbfscodec.Update(codec, &newMd.data, md.data); err != nil {
-		return nil, err
-	}
-	brmdCopy, err := md.bareMd.DeepCopy(codec)
+	err := kbfscodec.Update(codec, &newMd, md)
 	if err != nil {
 		return nil, err
 	}
-	newMd.bareMd = brmdCopy
+	err = kbfscodec.Update(codec, &newMd.data, md.data)
+	if err != nil {
+		return nil, err
+	}
+	newMd.bareMd, err = md.bareMd.DeepCopy(codec)
+	if err != nil {
+		return nil, err
+	}
 
 	if md.extra != nil {
-		extraCopy, err := md.extra.DeepCopy(codec)
+		newMd.extra, err = md.extra.DeepCopy(codec)
 		if err != nil {
 			return nil, err
 		}
-		newMd.extra = extraCopy
 	}
 
-	if copyHandle {
-		newMd.tlfHandle = md.tlfHandle.deepCopy()
-	}
-
+	newMd.tlfHandle = md.tlfHandle.deepCopy()
 	return &newMd, nil
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -821,6 +821,8 @@ func (irmd ImmutableRootMetadata) LocalTimestamp() time.Time {
 	return irmd.localTimestamp
 }
 
+// LastWriterVerifyingKey returns the VerifyingKey used by the last
+// writer of this MD.
 func (irmd ImmutableRootMetadata) LastWriterVerifyingKey() kbfscrypto.VerifyingKey {
 	return irmd.lastWriterVerifyingKey
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -819,12 +819,6 @@ func (irmd ImmutableRootMetadata) LastWriterVerifyingKey() kbfscrypto.VerifyingK
 	return irmd.lastWriterVerifyingKey
 }
 
-// LastModifyingWriterKID returns the KID of the last device to modify
-// the writer metadata.
-func (irmd ImmutableRootMetadata) LastModifyingWriterKID() keybase1.KID {
-	return irmd.lastWriterVerifyingKey.KID()
-}
-
 // RootMetadataSigned is the top-level MD object stored in MD server
 //
 // TODO: Have separate types for:

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -875,6 +875,7 @@ func signMD(
 	if mdv2, ok := brmd.(*BareRootMetadataV2); ok {
 		writerSigInfo = mdv2.WriterMetadataSigInfo
 	} else {
+		// TODO: Implement this!
 		panic("not implemented")
 	}
 	return MakeRootMetadataSigned(

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -797,6 +797,9 @@ func MakeImmutableRootMetadata(
 	}
 	if bareMDV2, ok := rmd.bareMd.(*BareRootMetadataV2); ok {
 		writerSig := bareMDV2.WriterMetadataSigInfo
+		if writerSig.IsNil() {
+			panic("MDV2 with nil writer signature")
+		}
 		if writerSig.VerifyingKey != writerVerifyingKey {
 			panic(fmt.Sprintf("key mismatch: sig has %s, expected %s",
 				writerSig.VerifyingKey, writerVerifyingKey))

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -841,12 +841,6 @@ func (irmd ImmutableRootMetadata) LocalTimestamp() time.Time {
 	return irmd.localTimestamp
 }
 
-// GetWriterMetadataSigInfo returns the signature of the writer
-// metadata.
-func (irmd ImmutableRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
-	return irmd.writerSig
-}
-
 // LastModifyingWriterKID returns the KID of the last device to modify
 // the writer metadata.
 func (irmd ImmutableRootMetadata) LastModifyingWriterKID() keybase1.KID {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -792,6 +792,9 @@ func MakeImmutableRootMetadata(
 	if localTimestamp == (time.Time{}) {
 		panic("zero localTimestamp passed to MakeImmutableRootMetadata")
 	}
+	if writerVerifyingKey == (kbfscrypto.VerifyingKey{}) {
+		panic("zero writerVerifyingKey passed to MakeImmutableRootMetadata")
+	}
 	if bareMDV2, ok := rmd.bareMd.(*BareRootMetadataV2); ok {
 		writerSig := bareMDV2.WriterMetadataSigInfo
 		if writerSig.VerifyingKey != writerVerifyingKey {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -810,9 +810,9 @@ func (irmd ImmutableRootMetadata) LocalTimestamp() time.Time {
 	return irmd.localTimestamp
 }
 
-// LastWriterVerifyingKey returns the VerifyingKey used by the last
+// LastModifyingWriterVerifyingKey returns the VerifyingKey used by the last
 // writer of this MD.
-func (irmd ImmutableRootMetadata) LastWriterVerifyingKey() kbfscrypto.VerifyingKey {
+func (irmd ImmutableRootMetadata) LastModifyingWriterVerifyingKey() kbfscrypto.VerifyingKey {
 	return irmd.lastWriterVerifyingKey
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -449,11 +449,6 @@ func (md *RootMetadata) TlfID() TlfID {
 	return md.bareMd.TlfID()
 }
 
-// LastModifyingWriterKID wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) LastModifyingWriterKID() keybase1.KID {
-	return md.bareMd.LastModifyingWriterKID()
-}
-
 // LastModifyingWriter wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) LastModifyingWriter() keybase1.UID {
 	return md.bareMd.LastModifyingWriter()
@@ -855,6 +850,12 @@ func (irmd ImmutableRootMetadata) LocalTimestamp() time.Time {
 // metadata.
 func (irmd ImmutableRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
 	return irmd.writerSig
+}
+
+// LastModifyingWriterKID returns the KID of the last device to modify
+// the writer metadata.
+func (irmd ImmutableRootMetadata) LastModifyingWriterKID() keybase1.KID {
+	return irmd.writerSig.VerifyingKey.KID()
 }
 
 // RootMetadataSigned is the top-level MD object stored in MD server

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -825,8 +825,11 @@ func (irmd ImmutableRootMetadata) LastModifyingWriterVerifyingKey() kbfscrypto.V
 // - the type stored in the journal;
 // - and the type stored in the MD server.
 type RootMetadataSigned struct {
-	// signature over the root metadata by the private signing key
-	SigInfo       kbfscrypto.SignatureInfo
+	// SigInfo is the signature over the root metadata by the
+	// last modifying user's private signing key.
+	SigInfo kbfscrypto.SignatureInfo
+	// WriterSigInfo is the signature over the writer metadata by
+	// the last modifying writer's private signing key.
 	WriterSigInfo kbfscrypto.SignatureInfo
 	// all the metadata
 	MD BareRootMetadata

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -821,6 +821,7 @@ func MakeImmutableRootMetadata(
 		rmd.ReadOnly(), mdID, writerSig, localTimestamp}
 }
 
+// IsNil returns if irmd is the same as ImmutableRootMetadata{}.
 func (irmd ImmutableRootMetadata) IsNil() bool {
 	return (irmd.ReadOnlyRootMetadata == ReadOnlyRootMetadata{}) &&
 		(irmd.mdID == MdID{}) &&

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -173,29 +173,29 @@ func (md *RootMetadata) clearLastRevision() {
 }
 
 func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
-	var newMd RootMetadata
-	err := kbfscodec.Update(codec, &newMd, md)
-	if err != nil {
-		return nil, err
-	}
-	err = kbfscodec.Update(codec, &newMd.data, md.data)
-	if err != nil {
-		return nil, err
-	}
-	newMd.bareMd, err = md.bareMd.DeepCopy(codec)
+	brmdCopy, err := md.bareMd.DeepCopy(codec)
 	if err != nil {
 		return nil, err
 	}
 
+	var extraCopy ExtraMetadata
 	if md.extra != nil {
-		newMd.extra, err = md.extra.DeepCopy(codec)
+		extraCopy, err = md.extra.DeepCopy(codec)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	newMd.tlfHandle = md.tlfHandle.deepCopy()
-	return &newMd, nil
+	handleCopy := md.tlfHandle.deepCopy()
+
+	rmd := MakeRootMetadata(brmdCopy, extraCopy, handleCopy)
+
+	err = kbfscodec.Update(codec, &rmd.data, md.data)
+	if err != nil {
+		return nil, err
+	}
+
+	return rmd, nil
 }
 
 // MakeSuccessor returns a complete copy of this RootMetadata (but

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -697,7 +697,7 @@ func TestRootMetadataFinalVerifyV3(t *testing.T) {
 	}
 
 	// make a final copy
-	rmds2, err := rmds.MakeFinalCopy(config.Codec())
+	rmds2, err := rmds.MakeFinalCopy(config.Codec(), config.Clock())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -5,7 +5,6 @@
 package libkbfs
 
 import (
-	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -121,16 +120,17 @@ func newRootMetadataV3OrBust(
 }
 
 func makeImmutableRootMetadataForTest(
-	rmd *RootMetadata, key kbfscrypto.VerifyingKey) ImmutableRootMetadata {
+	t *testing.T, rmd *RootMetadata, key kbfscrypto.VerifyingKey,
+	mdID MdID) ImmutableRootMetadata {
 	brmdv2 := rmd.bareMd.(*BareRootMetadataV2)
-	if !brmdv2.WriterMetadataSigInfo.IsNil() {
-		panic(fmt.Errorf("Already have non-nil signature %s",
-			brmdv2.WriterMetadataSigInfo))
-	}
+	vk := brmdv2.WriterMetadataSigInfo.VerifyingKey
+	require.True(t, vk == (kbfscrypto.VerifyingKey{}) || vk == key,
+		"Writer signature %s with unexpected non-nil verifying key != %s",
+		brmdv2.WriterMetadataSigInfo, key)
 	brmdv2.WriterMetadataSigInfo = kbfscrypto.SignatureInfo{
 		VerifyingKey: key,
 	}
-	return MakeImmutableRootMetadata(rmd, key, fakeMdID(1), time.Now())
+	return MakeImmutableRootMetadata(rmd, key, mdID, time.Now())
 }
 
 // Test that GetTlfHandle() and MakeBareTlfHandle() work properly for

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -481,7 +481,7 @@ func TestIsValidRekeyRequestBasicV2(t *testing.T) {
 	err := brmd.Update(tlfID, h.ToBareHandleOrBust())
 	require.NoError(t, err)
 
-	err = brmd.MaybeSignWriterMetadata(
+	err = brmd.SignWriterMetadataInternally(
 		context.Background(), config.Codec(), config.Crypto())
 	if err != nil {
 		t.Fatal(err)
@@ -507,7 +507,7 @@ func TestIsValidRekeyRequestBasicV2(t *testing.T) {
 	config2 := MakeTestConfigOrBust(t, "bob")
 	defer config2.Shutdown()
 
-	err = newBrmd.MaybeSignWriterMetadata(
+	err = newBrmd.SignWriterMetadataInternally(
 		context.Background(), config2.Codec(), config2.Crypto())
 	if err != nil {
 		t.Fatal(err)
@@ -678,7 +678,7 @@ func TestRootMetadataFinalVerifyV3(t *testing.T) {
 	md.SetLastModifyingWriter(h.Writers[0])
 	md.SetLastModifyingUser(h.Writers[0])
 	md.SetSerializedPrivateMetadata([]byte{42})
-	err = md.MaybeSignWriterMetadata(
+	err = md.SignWriterMetadataInternally(
 		context.Background(), config.Codec(), config.Crypto())
 	if err != nil {
 		t.Fatal(err)

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -117,6 +118,19 @@ func newRootMetadataV3OrBust(
 	require.NoError(t, err)
 	rmd.tlfHandle = h
 	return rmd
+}
+
+func makeImmutableRootMetadataForTest(
+	rmd *RootMetadata, key kbfscrypto.VerifyingKey) ImmutableRootMetadata {
+	brmdv2 := rmd.bareMd.(*BareRootMetadataV2)
+	if !brmdv2.WriterMetadataSigInfo.IsNil() {
+		panic(fmt.Errorf("Already have non-nil signature %s",
+			brmdv2.WriterMetadataSigInfo))
+	}
+	brmdv2.WriterMetadataSigInfo = kbfscrypto.SignatureInfo{
+		VerifyingKey: key,
+	}
+	return MakeImmutableRootMetadata(rmd, key, fakeMdID(1), time.Now())
 }
 
 // Test that GetTlfHandle() and MakeBareTlfHandle() work properly for

--- a/libkbfs/root_metadata_test_util.go
+++ b/libkbfs/root_metadata_test_util.go
@@ -30,7 +30,7 @@ func NewRootMetadataSignedForTest(
 	ctx := context.Background()
 
 	// Encode and sign writer metadata.
-	err = md.MaybeSignWriterMetadata(ctx, codec, signer)
+	err = md.SignWriterMetadataInternally(ctx, codec, signer)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/root_metadata_test_util.go
+++ b/libkbfs/root_metadata_test_util.go
@@ -18,7 +18,7 @@ import (
 func NewRootMetadataSignedForTest(id TlfID, h BareTlfHandle) (*RootMetadataSigned, error) {
 	md := &BareRootMetadataV2{}
 	// MDv3 TODO: uncomment the below when we're ready for MDv3
-	// md := &BareRootMetadataV#{}
+	// md := &BareRootMetadataV3{}
 	err := md.Update(id, h)
 	if err != nil {
 		return nil, err

--- a/libkbfs/root_metadata_test_util.go
+++ b/libkbfs/root_metadata_test_util.go
@@ -23,6 +23,7 @@ func NewRootMetadataSignedForTest(id TlfID, h BareTlfHandle) (*RootMetadataSigne
 	if err != nil {
 		return nil, err
 	}
-	rmds := MakeRootMetadataSigned(kbfscrypto.SignatureInfo{}, md, time.Time{})
-	return rmds, nil
+	return MakeRootMetadataSigned(
+		kbfscrypto.SignatureInfo{}, kbfscrypto.SignatureInfo{},
+		md, time.Time{})
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1019,7 +1019,7 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 			if err != nil {
 				return TLFJournalStatus{}, err
 			}
-			err = addUnflushedPaths(ctx, j.uid, j.key.KID(),
+			err = addUnflushedPaths(ctx, j.uid, j.key,
 				j.config.Codec(), j.log, mdInfos, cpp,
 				unflushedPaths)
 			if err != nil {
@@ -1046,7 +1046,7 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 				return TLFJournalStatus{}, err
 			}
 			unflushedPaths, initSuccess, err = j.unflushedPaths.initialize(
-				ctx, j.uid, j.key.KID(), j.config.Codec(),
+				ctx, j.uid, j.key, j.config.Codec(),
 				j.log, cpp, mdInfos)
 			if err != nil {
 				return TLFJournalStatus{}, err
@@ -1343,7 +1343,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		localTimestamp: time.Now(),
 	}
 	perRevMap, err := j.unflushedPaths.prepUnflushedPaths(
-		ctx, j.uid, j.key.KID(), j.config.Codec(), j.log, mdInfo)
+		ctx, j.uid, j.key, j.config.Codec(), j.log, mdInfo)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1357,7 +1357,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		// The cache was initialized after the last time we tried to
 		// prepare the unflushed paths.
 		perRevMap, err = j.unflushedPaths.prepUnflushedPaths(
-			ctx, j.uid, j.key.KID(), j.config.Codec(), j.log,
+			ctx, j.uid, j.key, j.config.Codec(), j.log,
 			mdInfo)
 		if err != nil {
 			return MdID{}, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1327,8 +1327,7 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	return mdID, false, nil
 }
 
-func (j *tlfJournal) putMD(
-	ctx context.Context, rmd *RootMetadata) (
+func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	// Prepare the paths without holding the lock, as it might need to
 	// take the lock.  Note that the timestamp doesn't matter for

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -66,19 +66,20 @@ func (d testBWDelegate) requireNextState(
 // testTLFJournalConfig is the config we pass to the tlfJournal, and
 // also contains some helper functions for testing.
 type testTLFJournalConfig struct {
-	t        *testing.T
-	tlfID    TlfID
-	splitter BlockSplitter
-	codec    kbfscodec.Codec
-	crypto   CryptoLocal
-	bcache   BlockCache
-	bops     BlockOps
-	mdcache  MDCache
-	reporter Reporter
-	uid      keybase1.UID
-	ekg      singleEncryptionKeyGetter
-	nug      normalizedUsernameGetter
-	mdserver MDServer
+	t            *testing.T
+	tlfID        TlfID
+	splitter     BlockSplitter
+	codec        kbfscodec.Codec
+	crypto       CryptoLocal
+	bcache       BlockCache
+	bops         BlockOps
+	mdcache      MDCache
+	reporter     Reporter
+	uid          keybase1.UID
+	verifyingKey kbfscrypto.VerifyingKey
+	ekg          singleEncryptionKeyGetter
+	nug          normalizedUsernameGetter
+	mdserver     MDServer
 }
 
 func (c testTLFJournalConfig) BlockSplitter() BlockSplitter {
@@ -153,7 +154,7 @@ func (c testTLFJournalConfig) makeBlock(data []byte) (
 
 func (c testTLFJournalConfig) makeMD(
 	revision MetadataRevision, prevRoot MdID) *RootMetadata {
-	return makeMDForTest(c.t, c.tlfID, revision, c.uid, prevRoot)
+	return makeMDForTest(c.t, c.tlfID, revision, c.uid, c.verifyingKey, prevRoot)
 }
 
 func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
@@ -211,7 +212,7 @@ func setupTLFJournalTest(
 	config = &testTLFJournalConfig{
 		t, FakeTlfID(1, false), bsplitter, codec, crypto,
 		nil, nil, NewMDCacheStandard(10),
-		NewReporterSimple(newTestClockNow(), 10), uid, ekg, nil, mdserver,
+		NewReporterSimple(newTestClockNow(), 10), uid, verifyingKey, ekg, nil, mdserver,
 	}
 
 	ctx, cancel = context.WithTimeout(

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -132,7 +133,7 @@ type unflushedPathMDInfo struct {
 // caller should NOT be holding any locks, as it's possible that
 // blocks will need to be fetched.
 func addUnflushedPaths(ctx context.Context,
-	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
+	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
 	log logger.Logger, mdInfos []unflushedPathMDInfo,
 	cpp chainsPathPopulator, unflushedPaths unflushedPathsMap) error {
 	// Make chains over the entire range to get the unflushed files.
@@ -141,7 +142,7 @@ func addUnflushedPaths(ctx context.Context,
 	for _, mdInfo := range mdInfos {
 		winfo := writerInfo{
 			uid:      uid,
-			kid:      kid,
+			key:      key,
 			revision: mdInfo.revision,
 			// There won't be any conflicts, so no need for the
 			// username/devicename.
@@ -195,7 +196,7 @@ func addUnflushedPaths(ctx context.Context,
 // prepUnflushedPaths returns a set of paths that were updated in the
 // given revision.
 func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
-	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
+	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
 	log logger.Logger, mdInfo unflushedPathMDInfo) (
 	unflushedPathsPerRevMap, error) {
 	cpp := func() chainsPathPopulator {
@@ -212,7 +213,7 @@ func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 	newUnflushedPaths := make(unflushedPathsMap)
 	mdInfos := []unflushedPathMDInfo{mdInfo}
 
-	err := addUnflushedPaths(ctx, uid, kid, codec, log, mdInfos, cpp,
+	err := addUnflushedPaths(ctx, uid, key, codec, log, mdInfos, cpp,
 		newUnflushedPaths)
 	if err != nil {
 		return nil, err
@@ -304,14 +305,14 @@ func (upc *unflushedPathCache) setCacheIfPossible(cache unflushedPathsMap,
 // not modify any of the per-revision inner maps of the returned
 // unflushed path map.
 func (upc *unflushedPathCache) initialize(ctx context.Context,
-	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
+	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
 	log logger.Logger, cpp chainsPathPopulator,
 	mdInfos []unflushedPathMDInfo) (unflushedPathsMap, bool, error) {
 	// First get all the paths for the given range.  On the first try
 	unflushedPaths := make(unflushedPathsMap)
 	log.CDebugf(ctx, "Initializing unflushed path cache with %d revisions",
 		len(mdInfos))
-	err := addUnflushedPaths(ctx, uid, kid, codec, log, mdInfos, cpp,
+	err := addUnflushedPaths(ctx, uid, key, codec, log, mdInfos, cpp,
 		unflushedPaths)
 	if err != nil {
 		return nil, false, err
@@ -343,7 +344,7 @@ func (upc *unflushedPathCache) initialize(ctx context.Context,
 
 		log.CDebugf(ctx, "Processing unflushed paths for %d items in "+
 			"the append queue", len(queue))
-		err := addUnflushedPaths(ctx, uid, kid, codec, log, queue, cpp,
+		err := addUnflushedPaths(ctx, uid, key, codec, log, queue, cpp,
 			unflushedPaths)
 		if err != nil {
 			return nil, false, err

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -142,7 +142,6 @@ func addUnflushedPaths(ctx context.Context,
 	for _, mdInfo := range mdInfos {
 		winfo := writerInfo{
 			uid:      uid,
-			key:      key,
 			revision: mdInfo.revision,
 			// There won't be any conflicts, so no need for the
 			// username/devicename.


### PR DESCRIPTION
...into RootMetadataSigned.

This is the first part, which does all the
plumbing, but panics when signing a V3
metadata. (The second part will implement that
and add unit tests.)