### PR TITLE
Dokan be stricter about files vs directories

### DIFF
--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -87,7 +87,7 @@ func (cd *CreateData) ReturningFileAllowed() error {
 	return nil
 }
 
-// ReturningFileAllowed answers whether returning a directory is allowed by
+// ReturningDirAllowed answers whether returning a directory is allowed by
 // CreateOptions.
 func (cd *CreateData) ReturningDirAllowed() error {
 	if cd.CreateOptions&FileNonDirectoryFile != 0 {

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -78,6 +78,24 @@ type CreateData struct {
 	CreateOptions     uint32
 }
 
+// ReturningFileAllowed answers whether returning a file is allowed by
+// CreateOptions.
+func (cd *CreateData) ReturningFileAllowed() error {
+	if cd.CreateOptions&FileDirectoryFile != 0 {
+		return ErrNotADirectory
+	}
+	return nil
+}
+
+// ReturningFileAllowed answers whether returning a directory is allowed by
+// CreateOptions.
+func (cd *CreateData) ReturningDirAllowed() error {
+	if cd.CreateOptions&FileNonDirectoryFile != 0 {
+		return ErrFileIsADirectory
+	}
+	return nil
+}
+
 // CreateDisposition marks whether to create or open a file. Not a bitmask.
 type CreateDisposition uint32
 
@@ -257,6 +275,8 @@ const (
 	ErrFileIsADirectory = NtStatus(0xC00000BA)
 	// ErrDirectoryNotEmpty - wanted an empty dir - it is not empty.
 	ErrDirectoryNotEmpty = NtStatus(0xC0000101)
+	// ErrNotADirectory - wanted a directory - it is not a directory.
+	ErrNotADirectory = NtStatus(0xC0000103)
 	// ErrFileAlreadyExists - file already exists - fatal.
 	ErrFileAlreadyExists = NtStatus(0xC0000035)
 	// ErrNotSameDevice - MoveFile is denied, please use copy+delete.

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -118,6 +118,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 		if aliasTarget != "" {
 			fl.fs.log.CDebugf(ctx, "FL Lookup aliasCache hit: %q -> %q", name, aliasTarget)
 			if len(path) == 1 && oc.isOpenReparsePoint() {
+				// TODO handle dir/non-dir here, semantics?
 				return &Alias{canon: aliasTarget}, true, nil
 			}
 			path[0] = aliasTarget
@@ -144,6 +145,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			fl.mu.Unlock()
 
 			if len(path) == 1 && oc.isOpenReparsePoint() {
+				// TODO handle dir/non-dir here, semantics?
 				fl.fs.log.CDebugf(ctx, "FL Lookup ret alias, oc: %#v", oc.CreateData)
 				return &Alias{canon: aliasTarget}, true, nil
 			}

--- a/libdokan/profilelist.go
+++ b/libdokan/profilelist.go
@@ -37,7 +37,7 @@ func (pl ProfileList) open(ctx context.Context, oc *openContext, path []string) 
 	if f == nil {
 		return nil, false, dokan.ErrObjectNameNotFound
 	}
-	return &SpecialReadFile{read: f, fs: pl.fs}, false, nil
+	return oc.returnFileNoCleanup(&SpecialReadFile{read: f, fs: pl.fs})
 }
 
 // FindFiles does readdir for dokan.

--- a/libdokan/tlf.go
+++ b/libdokan/tlf.go
@@ -161,8 +161,8 @@ func (tlf *TLF) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (st 
 // open tries to open a file.
 func (tlf *TLF) open(ctx context.Context, oc *openContext, path []string) (dokan.File, bool, error) {
 	if len(path) == 0 {
-		if oc.mayNotBeDirectory() {
-			return nil, true, dokan.ErrFileIsADirectory
+		if err := oc.ReturningDirAllowed(); err != nil {
+			return nil, true, err
 		}
 		tlf.refcount.Increase()
 		return tlf, true, nil


### PR DESCRIPTION
+ Sometimes returning either a file or directory is ok
+ Sometimes returning only a file is ok
+ Sometimes returning only a directory is ok

Thus:
+ Add extra checks for debug builds
+ Add two helper methods to dokan
+ Add more checking to libdokan
