### PR TITLE
journal_server: aggregate the unflushed paths for overall status

### DIFF
--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -35,6 +35,7 @@ type JournalServerStatus struct {
 	EnableAuto          bool
 	JournalCount        int
 	UnflushedBytes      int64 // (signed because os.FileInfo.Size() is signed)
+	UnflushedPaths      []string
 
 	journalTlfIDs []TlfID
 }

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -36,8 +36,6 @@ type JournalServerStatus struct {
 	JournalCount        int
 	UnflushedBytes      int64 // (signed because os.FileInfo.Size() is signed)
 	UnflushedPaths      []string
-
-	journalTlfIDs []TlfID
 }
 
 // branchChangeListener describes a caller that will get updates via
@@ -568,8 +566,9 @@ func (j *JournalServer) mdOps() journalMDOps {
 }
 
 // Status returns a JournalServerStatus object suitable for
-// diagnostics.
-func (j *JournalServer) Status() JournalServerStatus {
+// diagnostics.  It also returns a list of TLF IDs which have journals
+// enabled.
+func (j *JournalServer) Status() (JournalServerStatus, []TlfID) {
 	j.lock.RLock()
 	defer j.lock.RUnlock()
 	var unflushedBytes int64
@@ -586,8 +585,7 @@ func (j *JournalServer) Status() JournalServerStatus {
 		EnableAuto:          j.serverConfig.EnableAuto,
 		JournalCount:        len(tlfIDs),
 		UnflushedBytes:      unflushedBytes,
-		journalTlfIDs:       tlfIDs,
-	}
+	}, tlfIDs
 }
 
 // JournalStatus returns a TLFServerStatus object for the given TLF

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -420,9 +420,10 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	err := jServer.EnableAuto(ctx)
 	require.NoError(t, err)
 
-	status := jServer.Status()
+	status, tlfIDs := jServer.Status()
 	require.True(t, status.EnableAuto)
 	require.Zero(t, status.JournalCount)
+	require.Len(t, tlfIDs, 0)
 
 	blockServer := config.BlockServer()
 	crypto := config.Crypto()
@@ -440,9 +441,10 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	err = blockServer.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
 
-	status = jServer.Status()
+	status, tlfIDs = jServer.Status()
 	require.True(t, status.EnableAuto)
 	require.Equal(t, status.JournalCount, 1)
+	require.Len(t, tlfIDs, 1)
 
 	// Simulate a restart.
 	jServer = makeJournalServer(
@@ -455,7 +457,8 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	err = jServer.EnableExistingJournals(
 		ctx, uid, verifyingKey, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
-	status = jServer.Status()
+	status, tlfIDs = jServer.Status()
 	require.True(t, status.EnableAuto)
 	require.Equal(t, status.JournalCount, 1)
+	require.Len(t, tlfIDs, 1)
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -581,9 +581,10 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	var jServerStatus *JournalServerStatus
 	jServer, jErr := GetJournalServer(fs.config)
 	if jErr == nil {
-		status := jServer.Status()
+		status, tlfIDs := jServer.Status()
 		jServerStatus = &status
-		err := fillInJournalStatusUnflushedPaths(ctx, fs.config, jServerStatus)
+		err := fillInJournalStatusUnflushedPaths(
+			ctx, fs.config, jServerStatus, tlfIDs)
 		if err != nil {
 			return KBFSStatus{}, nil, err
 		}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -552,7 +552,7 @@ func (fs *KBFSOpsStandard) Sync(ctx context.Context, file Node) error {
 func (fs *KBFSOpsStandard) FolderStatus(
 	ctx context.Context, folderBranch FolderBranch) (
 	FolderBranchStatus, <-chan StatusUpdate, error) {
-	ops := fs.getOps(ctx, folderBranch)
+	ops := fs.getOpsNoAdd(folderBranch)
 	return ops.FolderStatus(ctx, folderBranch)
 }
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -583,7 +583,12 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	if jErr == nil {
 		status := jServer.Status()
 		jServerStatus = &status
+		err := fillInJournalStatusUnflushedPaths(ctx, fs.config, jServerStatus)
+		if err != nil {
+			return KBFSStatus{}, nil, err
+		}
 	}
+
 	return KBFSStatus{
 		CurrentUser:     username.String(),
 		IsConnected:     fs.config.MDServer().IsConnected(),

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -596,7 +596,7 @@ func (k *KeybaseServiceBase) FSSyncStatusRequest(ctx context.Context,
 	// For now, just return the number of syncing bytes.
 	jServer, err := GetJournalServer(k.config)
 	if err == nil {
-		status := jServer.Status()
+		status, _ := jServer.Status()
 		resp.Status.TotalSyncingBytes = status.UnflushedBytes
 		k.log.CDebugf(ctx, "Sending sync status response with %d syncing bytes",
 			status.UnflushedBytes)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -63,6 +63,9 @@ const (
 	// by the journal.  TODO: make this configurable, so that users
 	// can choose how much bandwidth is used by the journal.
 	maxJournalBlockFlushBatchSize = 25
+	// This will be the final entry for unflushed paths if there are
+	// too many revisions to process at once.
+	incompleteUnflushedPathsMarker = "..."
 )
 
 // TLFJournalStatus represents the status of a TLF's journal for
@@ -975,7 +978,8 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 		}
 	}
 	if !complete {
-		jStatus.UnflushedPaths = append(jStatus.UnflushedPaths, "...")
+		jStatus.UnflushedPaths =
+			append(jStatus.UnflushedPaths, incompleteUnflushedPathsMarker)
 	}
 	return jStatus, nil
 }


### PR DESCRIPTION
This calculates the unflushed paths for all journals in parallel, and adds them together in the overall KBFS status.

Issue: KBFS-1630

