### PR TITLE
journaling: option to enable automatic journaling

### DIFF
--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -307,6 +307,11 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 			folder: &Folder{fs: f}, // fake Folder for logging, etc.
 			action: libfs.JournalEnableAuto,
 		})
+	case libfs.DisableAutoJournalsFileName == ps[0]:
+		return oc.returnFileNoCleanup(&JournalControlFile{
+			folder: &Folder{fs: f}, // fake Folder for logging, etc.
+			action: libfs.JournalDisableAuto,
+		})
 
 	case ".kbfs_unmount" == ps[0]:
 		os.Exit(0)

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -302,6 +302,12 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 			read: f.remoteStatus.NewSpecialReadFunc,
 			fs:   f})
 
+	case libfs.EnableAutoJournalsFileName == ps[0]:
+		return oc.returnFileNoCleanup(&JournalControlFile{
+			folder: &Folder{fs: f}, // fake Folder for logging, etc.
+			action: libfs.JournalEnableAuto,
+		})
+
 	case ".kbfs_unmount" == ps[0]:
 		os.Exit(0)
 	case ".kbfs_number_of_handles" == ps[0]:

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -65,6 +65,11 @@ const DisableJournalFileName = ".kbfs_disable_journal"
 // journal-enabling file.  It's accessible anywhere outside a TLF.
 const EnableAutoJournalsFileName = ".kbfs_enable_auto_journals"
 
+// DisableAutoJournalsFileName is the name of the KBFS-wide
+// auto-journal-disabling file.  It's accessible anywhere outside a
+// TLF.
+const DisableAutoJournalsFileName = ".kbfs_disable_auto_journals"
+
 // EditHistoryName is the name of the KBFS TLF edit history file --
 // it can be reached anywhere within a top-level folder.
 const EditHistoryName = ".kbfs_edit_history"

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -62,7 +62,7 @@ const ResumeJournalBackgroundWorkFileName = ".kbfs_resume_journal_background_wor
 const DisableJournalFileName = ".kbfs_disable_journal"
 
 // EnableAutoJournalsFileName is the name of the KBFS-wide
-// journal-enabling file.  It's accessible anywhere outside a TLF.
+// auto-journal-enabling file.  It's accessible anywhere outside a TLF.
 const EnableAutoJournalsFileName = ".kbfs_enable_auto_journals"
 
 // DisableAutoJournalsFileName is the name of the KBFS-wide

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -61,6 +61,10 @@ const ResumeJournalBackgroundWorkFileName = ".kbfs_resume_journal_background_wor
 // file. It can be reached anywhere within a top-level folder.
 const DisableJournalFileName = ".kbfs_disable_journal"
 
+// EnableAutoJournalsFileName is the name of the KBFS-wide
+// journal-enabling file.  It's accessible anywhere outside a TLF.
+const EnableAutoJournalsFileName = ".kbfs_enable_auto_journals"
+
 // EditHistoryName is the name of the KBFS TLF edit history file --
 // it can be reached anywhere within a top-level folder.
 const EditHistoryName = ".kbfs_edit_history"

--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -29,6 +29,8 @@ const (
 	JournalResumeBackgroundWork
 	// JournalDisable is to disable the journal.
 	JournalDisable
+	// JournalEnableAuto is to turn on journals for all TLFs, persistently.
+	JournalEnableAuto
 )
 
 func (a JournalAction) String() string {
@@ -43,6 +45,8 @@ func (a JournalAction) String() string {
 		return "Resume journal background work"
 	case JournalDisable:
 		return "Disable journal"
+	case JournalEnableAuto:
+		return "Enable auto-journals"
 	}
 	return fmt.Sprintf("JournalAction(%d)", int(a))
 }
@@ -52,7 +56,7 @@ func (a JournalAction) String() string {
 func (a JournalAction) Execute(
 	ctx context.Context, jServer *libkbfs.JournalServer,
 	tlf libkbfs.TlfID) error {
-	if tlf == (libkbfs.TlfID{}) {
+	if tlf == (libkbfs.TlfID{}) && a != JournalEnableAuto {
 		panic("zero TlfID in JournalAction.Execute")
 	}
 
@@ -78,6 +82,12 @@ func (a JournalAction) Execute(
 
 	case JournalDisable:
 		_, err := jServer.Disable(ctx, tlf)
+		if err != nil {
+			return err
+		}
+
+	case JournalEnableAuto:
+		err := jServer.EnableAuto(ctx)
 		if err != nil {
 			return err
 		}

--- a/libfuse/special_files.go
+++ b/libfuse/special_files.go
@@ -50,6 +50,11 @@ func handleNonTLFSpecialFile(
 			folder: &Folder{fs: fs}, // fake Folder for logging, etc.
 			action: libfs.JournalEnableAuto,
 		}
+	case libfs.DisableAutoJournalsFileName:
+		return &JournalControlFile{
+			folder: &Folder{fs: fs}, // fake Folder for logging, etc.
+			action: libfs.JournalDisableAuto,
+		}
 	}
 
 	return nil

--- a/libfuse/special_files.go
+++ b/libfuse/special_files.go
@@ -45,6 +45,11 @@ func handleNonTLFSpecialFile(
 	case libfs.HumanErrorFileName, libfs.HumanNoLoginFileName:
 		*entryValid = 0
 		return &SpecialReadFile{fs.remoteStatus.NewSpecialReadFunc}
+	case libfs.EnableAutoJournalsFileName:
+		return &JournalControlFile{
+			folder: &Folder{fs: fs}, // fake Folder for logging, etc.
+			action: libfs.JournalEnableAuto,
+		}
 	}
 
 	return nil

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -416,6 +416,22 @@ func (j *JournalServer) EnableAuto(ctx context.Context) error {
 	return j.writeConfig()
 }
 
+// DisableAuto turns off automatic write journal for any
+// newly-accessed TLFs.  Existing journaled TLFs need to be disabled
+// manually.
+func (j *JournalServer) DisableAuto(ctx context.Context) error {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	if !j.serverConfig.EnableAuto {
+		// Nothing to do.
+		return nil
+	}
+
+	j.log.CDebugf(ctx, "Disabling auto-journaling")
+	j.serverConfig.EnableAuto = false
+	return j.writeConfig()
+}
+
 func (j *JournalServer) dirtyOpStart(tlfID TlfID) {
 	j.lock.Lock()
 	defer j.lock.Unlock()


### PR DESCRIPTION
This PR lets you turn on journaling for all TLFs, in a way that survives restarts by writing to a journal server config file on disk.  After enabling auto-journaling, all future TLF accesses will go through a journal.

When disabling auto-journaling, newly-accessed TLFs will no longer create a journal; however, existing journaled TLFs need to be disabled one-by-one if desired.

Introduces control files `/keybase/.kbfs_enable_auto_journals` and `/keybase/.kbfs_disable_auto_journals`.

Issue: KBFS-1622