### PR TITLE
folder_branch_ops: always set latest merged rev when initial head

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4581,12 +4581,11 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 func (fbo *folderBranchOps) registerForUpdates(ctx context.Context) (
 	updateChan <-chan error, err error) {
 	lState := makeFBOLockState()
-	currRev := fbo.getCurrMDRevision(lState)
+	currRev := fbo.getLatestMergedRevision(lState)
 	fbo.log.CDebugf(ctx, "Registering for updates (curr rev = %d)", currRev)
 	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
 	// RegisterForUpdate will itself retry on connectivity issues
-	return fbo.config.MDServer().RegisterForUpdate(ctx, fbo.id(),
-		fbo.getLatestMergedRevision(lState))
+	return fbo.config.MDServer().RegisterForUpdate(ctx, fbo.id(), currRev)
 }
 
 func (fbo *folderBranchOps) waitForAndProcessUpdates(


### PR DESCRIPTION
Otherwise, after a restart when journaling is on, if you were the last
writer to the folder, you will never set the revision and you'll keep
registering with a revision of 0.

Issue: KBFS-1638