### PR TITLE
[KBFS-1526] Plumb through ExtraMetadata some more

### DIFF
--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -70,7 +70,6 @@ func (j journalMDOps) getHeadFromJournal(
 				bid, head.BID())
 	}
 
-	// MDv3 TODO: pass key bundles when needed
 	headBareHandle, err := head.MakeBareTlfHandle(head.extra)
 	if err != nil {
 		return ImmutableRootMetadata{}, err

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -47,7 +47,7 @@ func (j journalMDOps) getHeadFromJournal(
 		return ImmutableRootMetadata{}, nil
 	}
 
-	head, extra, err := tlfJournal.getMDHead(ctx)
+	head, err := tlfJournal.getMDHead(ctx)
 	if err == errTLFJournalDisabled {
 		return ImmutableRootMetadata{}, nil
 	} else if err != nil {
@@ -71,7 +71,7 @@ func (j journalMDOps) getHeadFromJournal(
 	}
 
 	// MDv3 TODO: pass key bundles when needed
-	headBareHandle, err := head.MakeBareTlfHandle(extra)
+	headBareHandle, err := head.MakeBareTlfHandle(head.extra)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -97,8 +97,7 @@ func (j journalMDOps) getHeadFromJournal(
 		}
 	}
 
-	irmd, err := tlfJournal.convertImmutableBareRMDToIRMD(
-		ctx, head, extra, handle)
+	irmd, err := tlfJournal.convertImmutableBareRMDToIRMD(ctx, head, handle)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -128,18 +127,18 @@ func (j journalMDOps) getRangeFromJournal(
 
 	head := ibrmds[len(ibrmds)-1]
 
-	if head.ibrmd.MergedStatus() != mStatus {
+	if head.MergedStatus() != mStatus {
 		return nil, nil
 	}
 
-	if mStatus == Unmerged && bid != NullBranchID && bid != head.ibrmd.BID() {
+	if mStatus == Unmerged && bid != NullBranchID && bid != head.BID() {
 		// The given branch ID doesn't match the one in the
 		// journal, which can only be an error.
 		return nil, fmt.Errorf("Expected branch ID %s, got %s",
-			bid, head.ibrmd.BID())
+			bid, head.BID())
 	}
 
-	bareHandle, err := head.ibrmd.MakeBareTlfHandle(head.extra)
+	bareHandle, err := head.MakeBareTlfHandle(head.extra)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +152,7 @@ func (j journalMDOps) getRangeFromJournal(
 	for _, ibrmd := range ibrmds {
 		irmd, err :=
 			tlfJournal.convertImmutableBareRMDToIRMD(
-				ctx, ibrmd.ibrmd, ibrmd.extra, handle)
+				ctx, ibrmd, handle)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -70,7 +70,7 @@ func (j journalMDOps) getHeadFromJournal(
 				bid, head.BID())
 	}
 
-	headBareHandle, err := head.MakeBareTlfHandle(head.extra)
+	headBareHandle, err := head.MakeBareTlfHandleWithExtra()
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -137,7 +137,7 @@ func (j journalMDOps) getRangeFromJournal(
 			bid, head.BID())
 	}
 
-	bareHandle, err := head.MakeBareTlfHandle(head.extra)
+	bareHandle, err := head.MakeBareTlfHandleWithExtra()
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -71,7 +71,7 @@ func (j journalMDOps) getHeadFromJournal(
 	}
 
 	// MDv3 TODO: pass key bundles when needed
-	headBareHandle, err := head.MakeBareTlfHandle(nil)
+	headBareHandle, err := head.MakeBareTlfHandle(extra)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -299,7 +299,7 @@ func (j journalMDOps) Put(ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
 		// Just route to the journal.
-		mdID, err := tlfJournal.putMD(ctx, rmd, rmd.extra)
+		mdID, err := tlfJournal.putMD(ctx, rmd)
 		if err != errTLFJournalDisabled {
 			return mdID, err
 		}
@@ -312,7 +312,7 @@ func (j journalMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
 		rmd.SetUnmerged()
-		mdID, err := tlfJournal.putMD(ctx, rmd, rmd.extra)
+		mdID, err := tlfJournal.putMD(ctx, rmd)
 		if err != errTLFJournalDisabled {
 			return mdID, err
 		}

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -149,9 +149,8 @@ func (j journalMDOps) getRangeFromJournal(
 	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
 
 	for _, ibrmd := range ibrmds {
-		irmd, err :=
-			tlfJournal.convertImmutableBareRMDToIRMD(
-				ctx, ibrmd, handle)
+		irmd, err := tlfJournal.convertImmutableBareRMDToIRMD(
+			ctx, ibrmd, handle)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -54,6 +54,13 @@ func MakeImmutableBareRootMetadata(
 	return ImmutableBareRootMetadata{rmd, extra, mdID, localTimestamp}
 }
 
+// MakeBareTlfHandleWithExtra makes a BareTlfHandle for this
+// ImmutableBareRootMetadata. Should be used only by servers and MDOps.
+func (ibrmd ImmutableBareRootMetadata) MakeBareTlfHandleWithExtra() (
+	BareTlfHandle, error) {
+	return ibrmd.BareRootMetadata.MakeBareTlfHandle(ibrmd.extra)
+}
+
 // mdJournal stores a single ordered list of metadata IDs for a (TLF,
 // user, device) tuple, along with the associated metadata objects, in
 // flat files on disk.

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -930,8 +930,7 @@ func (e MDJournalConflictError) Error() string {
 // rmd becomes the initial entry.
 func (j *mdJournal) put(
 	ctx context.Context, signer cryptoSigner,
-	ekg encryptionKeyGetter, bsplit BlockSplitter, rmd *RootMetadata,
-	extra ExtraMetadata) (
+	ekg encryptionKeyGetter, bsplit BlockSplitter, rmd *RootMetadata) (
 	mdID MdID, err error) {
 	j.log.CDebugf(ctx, "Putting MD for TLF=%s with rev=%s bid=%s",
 		rmd.TlfID(), rmd.Revision(), rmd.BID())
@@ -943,6 +942,7 @@ func (j *mdJournal) put(
 		}
 	}()
 
+	extra := rmd.extra
 	if extra == nil {
 		// TODO: This could fail if the key bundle isn't part
 		// of the journal. Always mandate that the extra field

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -201,17 +201,18 @@ func TestMDJournalGetNextEntry(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md, nil)
 	require.NoError(t, err)
 
-	mdID, rmds, err := j.getNextEntryToFlush(ctx, md.Revision(), signer)
+	mdID, rmds, _, err := j.getNextEntryToFlush(ctx, md.Revision(), signer)
 	require.NoError(t, err)
 	require.Equal(t, MdID{}, mdID)
 	require.Nil(t, rmds)
 
-	mdID, rmds, err = j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
+	mdID, rmds, _, err = j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
 	require.NoError(t, err)
 	require.NotEqual(t, MdID{}, mdID)
 	require.Equal(t, md.bareMd, rmds.MD)
 
-	mdID, rmds, err = j.getNextEntryToFlush(ctx, md.Revision()+100, signer)
+	mdID, rmds, _, err = j.getNextEntryToFlush(
+		ctx, md.Revision()+100, signer)
 	require.NoError(t, err)
 	require.NotEqual(t, MdID{}, mdID)
 	require.Equal(t, md.bareMd, rmds.MD)
@@ -329,7 +330,8 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	require.NoError(t, err)
 
 	// Flush.
-	mdID, rmds, err := j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
+	mdID, rmds, _, err := j.getNextEntryToFlush(
+		ctx, md.Revision()+1, signer)
 	require.NoError(t, err)
 	j.removeFlushedEntry(ctx, mdID, rmds)
 
@@ -398,7 +400,8 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	require.NoError(t, err)
 
 	// Flush.
-	mdID, rmds, err := j.getNextEntryToFlush(ctx, md.Revision()+1, signer)
+	mdID, rmds, _, err := j.getNextEntryToFlush(
+		ctx, md.Revision()+1, signer)
 	require.NoError(t, err)
 	j.removeFlushedEntry(ctx, mdID, rmds)
 
@@ -440,7 +443,7 @@ func flushAllMDs(
 	end, err := j.end()
 	require.NoError(t, err)
 	for {
-		mdID, rmds, err := j.getNextEntryToFlush(ctx, end, signer)
+		mdID, rmds, _, err := j.getNextEntryToFlush(ctx, end, signer)
 		require.NoError(t, err)
 		if mdID == (MdID{}) {
 			break

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -172,12 +172,6 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		return ImmutableRootMetadata{}, md.convertVerifyingKeyError(ctx, rmds, handle, err)
 	}
 
-	rmd := RootMetadata{
-		bareMd:    rmds.MD,
-		tlfHandle: handle,
-		extra:     extra,
-	}
-
 	_, uid, err := md.config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
 		// If this is a public folder, it's ok to proceed if we have
@@ -189,12 +183,13 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		}
 	}
 
+	rmd := MakeRootMetadata(rmds.MD, extra, handle)
 	// Try to decrypt using the keys available in this md.  If that
 	// doesn't work, a future MD may contain more keys and will be
 	// tried later.
 	err = decryptMDPrivateData(
 		ctx, md.config.Codec(), md.config.Crypto(), md.config.BlockCache(),
-		md.config.BlockOps(), md.config.KeyManager(), uid, &rmd, rmd.ReadOnly())
+		md.config.BlockOps(), md.config.KeyManager(), uid, rmd, rmd.ReadOnly())
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -209,7 +204,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		localTimestamp = localTimestamp.Add(offset)
 	}
 
-	return MakeImmutableRootMetadata(&rmd, mdID, localTimestamp), nil
+	return MakeImmutableRootMetadata(rmd, mdID, localTimestamp), nil
 }
 
 // GetForHandle implements the MDOps interface for MDOpsStandard.

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -31,8 +31,8 @@ func mdCacheShutdown(mockCtrl *gomock.Controller, config *ConfigMock) {
 
 func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	mStatus MergeStatus, bid BranchID, h *TlfHandle, config *ConfigMock) {
-	rmd := &RootMetadata{
-		bareMd: &BareRootMetadataV2{
+	rmd := MakeRootMetadata(
+		&BareRootMetadataV2{
 			WriterMetadataV2: WriterMetadataV2{
 				ID:    tlf,
 				WKeys: make(TLFWriterKeyGenerations, 0, 1),
@@ -40,8 +40,7 @@ func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 			},
 			Revision: rev,
 			RKeys:    make(TLFReaderKeyGenerations, 1, 1),
-		},
-	}
+		}, nil, h)
 	rmd.AddNewKeysForTesting(config.Crypto(),
 		NewEmptyUserDeviceKeyInfoMap(), NewEmptyUserDeviceKeyInfoMap())
 	if mStatus == Unmerged {

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -781,8 +781,15 @@ func (md *MDServerMemory) putExtraMetadataLocked(rmds *RootMetadataSigned,
 func (md *MDServerMemory) getKeyBundles(
 	tlfID TlfID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	if wkbID == (TLFWriterKeyBundleID{}) ||
-		rkbID == (TLFReaderKeyBundleID{}) {
+	if (wkbID == TLFWriterKeyBundleID{}) !=
+		(rkbID == TLFReaderKeyBundleID{}) {
+		return nil, nil, fmt.Errorf(
+			"wkbID is empty (%t) != rkbID is empty (%t)",
+			wkbID == TLFWriterKeyBundleID{},
+			rkbID == TLFReaderKeyBundleID{})
+	}
+
+	if wkbID == (TLFWriterKeyBundleID{}) {
 		return nil, nil, nil
 	}
 

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -305,8 +305,15 @@ func (s *mdServerTlfStorage) getExtraMetadataReadLocked(
 func (s *mdServerTlfStorage) getKeyBundlesReadLocked(
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	if wkbID == (TLFWriterKeyBundleID{}) ||
-		rkbID == (TLFReaderKeyBundleID{}) {
+	if (wkbID == TLFWriterKeyBundleID{}) !=
+		(rkbID == TLFReaderKeyBundleID{}) {
+		return nil, nil, fmt.Errorf(
+			"wkbID is empty (%t) != rkbID is empty (%t)",
+			wkbID == TLFWriterKeyBundleID{},
+			rkbID == TLFReaderKeyBundleID{})
+	}
+
+	if wkbID == (TLFWriterKeyBundleID{}) {
 		return nil, nil, nil
 	}
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -920,7 +920,7 @@ func (rmds *RootMetadataSigned) IsLastModifiedBy(
 // versioned structure.
 func DecodeRootMetadata(
 	codec kbfscodec.Codec, tlf TlfID, ver, max MetadataVer, buf []byte) (
-	BareRootMetadata, error) {
+	MutableBareRootMetadata, error) {
 	if ver < FirstValidMetadataVer {
 		return nil, InvalidMetadataVersionError{tlf, ver}
 	} else if ver > max {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -126,6 +126,13 @@ var _ KeyMetadata = (*RootMetadata)(nil)
 // MakeRootMetadata makes a RootMetadata object from the given parameters.
 func MakeRootMetadata(bareMd MutableBareRootMetadata,
 	extra ExtraMetadata, handle *TlfHandle) *RootMetadata {
+	if bareMd == nil {
+		panic("nil MutableBareRootMetadata")
+	}
+	// extra can be nil.
+	if handle == nil {
+		panic("nil handle")
+	}
 	return &RootMetadata{
 		bareMd:    bareMd,
 		extra:     extra,

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -106,6 +106,10 @@ type ExtraMetadata interface {
 type RootMetadata struct {
 	bareMd MutableBareRootMetadata
 
+	// ExtraMetadata currently contains key bundles for post-v2
+	// metadata.
+	extra ExtraMetadata
+
 	// The plaintext, deserialized PrivateMetadata
 	//
 	// TODO: This should really be a pointer so that it's more
@@ -115,15 +119,24 @@ type RootMetadata struct {
 	// The TLF handle for this MD. May be nil if this object was
 	// deserialized (more common on the server side).
 	tlfHandle *TlfHandle
-
-	// ExtraMetadata currently contains key bundles for post-v2
-	// metadata.
-	extra ExtraMetadata
 }
 
 var _ KeyMetadata = (*RootMetadata)(nil)
 
-// NewRootMetadata returns a new RootMetadata object at the latest known version.
+// MakeRootMetadata makes a RootMetadata object from the given parameters.
+func MakeRootMetadata(bareMd MutableBareRootMetadata,
+	extra ExtraMetadata, handle *TlfHandle) *RootMetadata {
+	return &RootMetadata{
+		bareMd:    bareMd,
+		extra:     extra,
+		tlfHandle: handle,
+	}
+}
+
+// NewRootMetadata returns a new RootMetadata object at the latest
+// known version.
+//
+// TODO: This is used only for testing. Get rid of it.
 func NewRootMetadata() *RootMetadata {
 	return &RootMetadata{bareMd: &BareRootMetadataV2{}}
 	// MDv3 TODO: uncomment the below when we're ready for MDv3

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -945,7 +945,7 @@ func (j *tlfJournal) batchConvertImmutables(ctx context.Context,
 		return nil, nil
 	}
 
-	ibrmdBareHandle, err := ibrmds[0].MakeBareTlfHandle(ibrmds[0].extra)
+	ibrmdBareHandle, err := ibrmds[0].MakeBareTlfHandleWithExtra()
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -947,7 +947,8 @@ func (j *tlfJournal) batchConvertImmutables(ctx context.Context,
 		return nil, nil
 	}
 
-	ibrmdBareHandle, err := ibrmds[0].ibrmd.MakeBareTlfHandle(nil)
+	ibrmdBareHandle, err := ibrmds[0].ibrmd.MakeBareTlfHandle(
+		ibrmds[0].extra)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1295,8 +1295,7 @@ func (j *tlfJournal) getMDRange(
 }
 
 func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
-	extra ExtraMetadata, irmd ImmutableRootMetadata,
-	perRevMap unflushedPathsPerRevMap) (
+	irmd ImmutableRootMetadata, perRevMap unflushedPathsPerRevMap) (
 	mdID MdID, retryPut bool, err error) {
 	// Now take the lock and put the MD, merging in the unflushed
 	// paths while under the lock.
@@ -1314,7 +1313,7 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 
 	mdID, err = j.mdJournal.put(ctx, j.config.Crypto(),
 		j.config.encryptionKeyGetter(), j.config.BlockSplitter(),
-		rmd, extra)
+		rmd)
 	if err != nil {
 		return MdID{}, false, err
 	}
@@ -1330,7 +1329,7 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 }
 
 func (j *tlfJournal) putMD(
-	ctx context.Context, rmd *RootMetadata, extra ExtraMetadata) (
+	ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	// Prepare the paths without holding the lock, as it might need to
 	// take the lock.  Note that the md ID and timestamp don't matter
@@ -1345,7 +1344,7 @@ func (j *tlfJournal) putMD(
 		return MdID{}, err
 	}
 
-	mdID, retry, err := j.doPutMD(ctx, rmd, extra, irmd, perRevMap)
+	mdID, retry, err := j.doPutMD(ctx, rmd, irmd, perRevMap)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1359,7 +1358,7 @@ func (j *tlfJournal) putMD(
 			return MdID{}, err
 		}
 
-		mdID, retry, err = j.doPutMD(ctx, rmd, extra, irmd, perRevMap)
+		mdID, retry, err = j.doPutMD(ctx, rmd, irmd, perRevMap)
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -301,7 +301,7 @@ func teardownTLFJournalTest(
 func putOneMD(ctx context.Context, config *testTLFJournalConfig,
 	tlfJournal *tlfJournal) {
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md, nil)
+	_, err := tlfJournal.putMD(ctx, md)
 	require.NoError(config.t, err)
 }
 
@@ -489,7 +489,7 @@ func TestTLFJournalMDServerBusyPause(t *testing.T) {
 	config.mdserver = mdserver
 
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md, nil)
+	_, err := tlfJournal.putMD(ctx, md)
 	require.NoError(t, err)
 
 	mdserver.waitForPut(ctx, t)
@@ -511,7 +511,7 @@ func TestTLFJournalMDServerBusyShutdown(t *testing.T) {
 	config.mdserver = mdserver
 
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md, nil)
+	_, err := tlfJournal.putMD(ctx, md)
 	require.NoError(t, err)
 
 	mdserver.waitForPut(ctx, t)
@@ -530,7 +530,7 @@ func TestTLFJournalBlockOpWhileBusy(t *testing.T) {
 	config.mdserver = mdserver
 
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
-	_, err := tlfJournal.putMD(ctx, md, nil)
+	_, err := tlfJournal.putMD(ctx, md)
 	require.NoError(t, err)
 
 	mdserver.waitForPut(ctx, t)
@@ -600,7 +600,7 @@ func TestTLFJournalFlushMDBasic(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -645,7 +645,7 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 	for i := 0; i < mdCount/2; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -665,11 +665,11 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 
 		revision := firstRevision + MetadataRevision(mdCount/2)
 		md := config.makeMD(revision, prevRoot)
-		_, err = tlfJournal.putMD(ctx, md, nil)
+		_, err = tlfJournal.putMD(ctx, md)
 		require.IsType(t, MDJournalConflictError{}, err)
 
 		md.SetUnmerged()
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -678,7 +678,7 @@ func TestTLFJournalFlushMDConflict(t *testing.T) {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
 		md.SetUnmerged()
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -722,7 +722,7 @@ func TestTLFJournalPreservesBranchID(t *testing.T) {
 	for i := 0; i < mdCount-1; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}
@@ -752,11 +752,11 @@ func TestTLFJournalPreservesBranchID(t *testing.T) {
 	{
 		revision := firstRevision + MetadataRevision(mdCount-1)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.IsType(t, MDJournalConflictError{}, err)
 
 		md.SetUnmerged()
-		mdID, err = tlfJournal.putMD(ctx, md, nil)
+		mdID, err = tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 
@@ -867,7 +867,7 @@ func TestTLFJournalFlushOrdering(t *testing.T) {
 	err := tlfJournal.putBlockData(
 		ctx, bid1, bCtx1, []byte{1}, serverHalf1)
 	require.NoError(t, err)
-	prevRoot, err := tlfJournal.putMD(ctx, md1, nil)
+	prevRoot, err := tlfJournal.putMD(ctx, md1)
 	require.NoError(t, err)
 
 	bserver.onceOnPut = func() {
@@ -876,7 +876,7 @@ func TestTLFJournalFlushOrdering(t *testing.T) {
 			ctx, bid2, bCtx2, []byte{2}, serverHalf2)
 		require.NoError(t, err)
 		md2 := config.makeMD(MetadataRevision(11), prevRoot)
-		prevRoot, err = tlfJournal.putMD(ctx, md2, nil)
+		prevRoot, err = tlfJournal.putMD(ctx, md2)
 		require.NoError(t, err)
 	}
 
@@ -886,7 +886,7 @@ func TestTLFJournalFlushOrdering(t *testing.T) {
 			ctx, bid3, bCtx3, []byte{3}, serverHalf3)
 		require.NoError(t, err)
 		md3 := config.makeMD(MetadataRevision(12), prevRoot)
-		prevRoot, err = tlfJournal.putMD(ctx, md3, nil)
+		prevRoot, err = tlfJournal.putMD(ctx, md3)
 		require.NoError(t, err)
 	}
 
@@ -952,7 +952,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 		require.NoError(t, err)
 	}
 	md1 := config.makeMD(MetadataRevision(10), fakeMdID(1))
-	prevRoot, err := tlfJournal.putMD(ctx, md1, nil)
+	prevRoot, err := tlfJournal.putMD(ctx, md1)
 	require.NoError(t, err)
 
 	// Revision 2
@@ -965,7 +965,7 @@ func TestTLFJournalFlushInterleaving(t *testing.T) {
 		require.NoError(t, err)
 	}
 	md2 := config.makeMD(MetadataRevision(11), prevRoot)
-	prevRoot, err = tlfJournal.putMD(ctx, md2, nil)
+	prevRoot, err = tlfJournal.putMD(ctx, md2)
 	require.NoError(t, err)
 
 	err = tlfJournal.flush(ctx)
@@ -1046,7 +1046,7 @@ func TestTLFJournalFlushRetry(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}


### PR DESCRIPTION
I missed a few places in my last PR (#430).

Make ImmutableBareRootMetadata have an
ExtraMetadata field.

Add constructor for RootMetadata (to avoid
dropping fields).

Also add checks for wkbID and rkbID being either
both nil or both non-nil.