### PR TITLE
journal: add an MDOps.ResolveBranch function for squashing branches

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -121,7 +121,7 @@ type blockJournalEntry struct {
 	Contexts map[BlockID][]BlockContext `codec:",omitempty"`
 	// Only used for mdRevMarkerOps.
 	Revision MetadataRevision `codec:",omitempty"`
-	// Ignore this entry if flushing if this is true.
+	// Ignore this entry while flushing if this is true.
 	Ignore bool `codec:",omitempty"`
 
 	codec.UnknownFieldSetHandler

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -268,7 +268,7 @@ func (j *blockJournal) readJournal(ctx context.Context) (
 			// refs won't have to upload any new bytes.  (This might
 			// be wrong if all references to a block were deleted
 			// since the addref entry was appended.)
-			if e.Op == blockPutOp {
+			if e.Op == blockPutOp && !e.Ignore {
 				b, err := j.getDataSize(id)
 				// Ignore ENOENT errors, since users like
 				// BlockServerDisk can remove block data without

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -941,6 +941,13 @@ type MDOps interface {
 	// branch.
 	PruneBranch(ctx context.Context, id TlfID, bid BranchID) error
 
+	// ResolveBranch prunes all unmerged history for the given TLF
+	// branch, and also deletes any blocks in `blocksToDelete` that
+	// are still in the local journal.  It also appends the given MD
+	// to the journal.
+	ResolveBranch(ctx context.Context, id TlfID, bid BranchID,
+		blocksToDelete []BlockID, rmd *RootMetadata) (MdID, error)
+
 	// GetLatestHandleForTLF returns the server's idea of the latest handle for the TLF,
 	// which may not yet be reflected in the MD if the TLF hasn't been rekeyed since it
 	// entered into a conflicting state.

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -370,13 +370,11 @@ func (j journalMDOps) ResolveBranch(
 	ctx context.Context, id TlfID, bid BranchID,
 	blocksToDelete []BlockID, rmd *RootMetadata) (MdID, error) {
 	if tlfJournal, ok := j.jServer.getTLFJournal(id); ok {
-		// Prune the journal, too.
 		mdID, err := tlfJournal.resolveBranch(
 			ctx, bid, blocksToDelete, rmd, rmd.extra)
-		if err != nil && err != errTLFJournalDisabled {
-			return MdID{}, err
+		if err != errTLFJournalDisabled {
+			return mdID, err
 		}
-		return mdID, nil
 	}
 
 	return MdID{}, errors.New("ResolveBranch not supported outside of journal")

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1174,8 +1174,8 @@ func (j *mdJournal) clear(
 
 func (j *mdJournal) resolveAndClear(
 	ctx context.Context, signer cryptoSigner, ekg encryptionKeyGetter,
-	bsplit BlockSplitter, bid BranchID, rmd *RootMetadata,
-	extra ExtraMetadata) (mdID MdID, err error) {
+	bsplit BlockSplitter, bid BranchID, rmd *RootMetadata) (
+	mdID MdID, err error) {
 	j.log.CDebugf(ctx, "Resolve and clear, branch %s, resolve rev %d",
 		bid, rmd.Revision())
 	defer func() {
@@ -1225,7 +1225,7 @@ func (j *mdJournal) resolveAndClear(
 	}()
 
 	otherJournal.branchID = NullBranchID
-	mdID, err = otherJournal.put(ctx, signer, ekg, bsplit, rmd, extra)
+	mdID, err = otherJournal.put(ctx, signer, ekg, bsplit, rmd)
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -540,7 +540,7 @@ func TestMDJournalResolveAndClear(t *testing.T) {
 	require.NoError(t, err)
 
 	resolveRev := firstRevision
-	md := makeMDForTest(t, id, resolveRev, j.uid, firstPrevRoot)
+	md := makeMDForTest(t, id, resolveRev, j.uid, j.key, firstPrevRoot)
 	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, bid, md)
 	require.NoError(t, err)
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -541,7 +541,7 @@ func TestMDJournalResolveAndClear(t *testing.T) {
 
 	resolveRev := firstRevision
 	md := makeMDForTest(t, id, resolveRev, j.uid, firstPrevRoot)
-	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, bid, md, nil)
+	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, bid, md)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, getMDJournalLength(t, j))

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -594,6 +594,13 @@ func (md *MDOpsStandard) PruneBranch(
 	return md.config.MDServer().PruneBranch(ctx, id, bid)
 }
 
+// ResolveBranch implements the MDOps interface for MDOpsStandard.
+func (md *MDOpsStandard) ResolveBranch(
+	ctx context.Context, id TlfID, bid BranchID,
+	blocksToDelete []BlockID, rmd *RootMetadata) (MdID, error) {
+	return MdID{}, errors.New("ResolveBranch not supported by MDOpsStandard")
+}
+
 // GetLatestHandleForTLF implements the MDOps interface for MDOpsStandard.
 func (md *MDOpsStandard) GetLatestHandleForTLF(ctx context.Context, id TlfID) (
 	BareTlfHandle, error) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2533,6 +2533,17 @@ func (_mr *_MockMDOpsRecorder) PruneBranch(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PruneBranch", arg0, arg1, arg2)
 }
 
+func (_m *MockMDOps) ResolveBranch(ctx context.Context, id TlfID, bid BranchID, blocksToDelete []BlockID, rmd *RootMetadata) (MdID, error) {
+	ret := _m.ctrl.Call(_m, "ResolveBranch", ctx, id, bid, blocksToDelete, rmd)
+	ret0, _ := ret[0].(MdID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockMDOpsRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResolveBranch", arg0, arg1, arg2, arg3, arg4)
+}
+
 func (_m *MockMDOps) GetLatestHandleForTLF(ctx context.Context, id TlfID) (BareTlfHandle, error) {
 	ret := _m.ctrl.Call(_m, "GetLatestHandleForTLF", ctx, id)
 	ret0, _ := ret[0].(BareTlfHandle)

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -36,6 +36,7 @@ const (
 	StallableMDPutUnmerged           StallableMDOp = "PutUnmerged"
 	StallableMDAfterPutUnmerged      StallableMDOp = "AfterPutUnmerged"
 	StallableMDPruneBranch           StallableMDOp = "PruneBranch"
+	StallableMDResolveBranch         StallableMDOp = "ResolveBranch"
 )
 
 type stallKeyType uint64
@@ -497,4 +498,15 @@ func (m *stallingMDOps) PruneBranch(
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
 		return m.delegate.PruneBranch(ctx, id, bid)
 	})
+}
+
+func (m *stallingMDOps) ResolveBranch(
+	ctx context.Context, id TlfID, bid BranchID, blocksToDelete []BlockID,
+	rmd *RootMetadata) (mdID MdID, err error) {
+	m.maybeStall(ctx, StallableMDResolveBranch)
+	err = runWithContextCheck(ctx, func(ctx context.Context) error {
+		mdID, err = m.delegate.ResolveBranch(ctx, id, bid, blocksToDelete, rmd)
+		return err
+	})
+	return mdID, err
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1452,7 +1452,7 @@ func (j *tlfJournal) resolveBranch(ctx context.Context,
 		localTimestamp: time.Now(),
 	}
 	perRevMap, err := j.unflushedPaths.prepUnflushedPaths(
-		ctx, j.uid, j.key.KID(), j.config.Codec(), j.log, mdInfo)
+		ctx, j.uid, j.key, j.config.Codec(), j.log, mdInfo)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1465,7 +1465,7 @@ func (j *tlfJournal) resolveBranch(ctx context.Context,
 
 	if retry {
 		perRevMap, err = j.unflushedPaths.prepUnflushedPaths(
-			ctx, j.uid, j.key.KID(), j.config.Codec(), j.log, mdInfo)
+			ctx, j.uid, j.key, j.config.Codec(), j.log, mdInfo)
 		if err != nil {
 			return MdID{}, err
 		}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1432,7 +1432,6 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	// TODO: kick off a background goroutine that deletes ignored
 	// block data files before the flush gets to them.
 
-	// No need to signal work in this case.
 	return mdID, false, nil
 }
 
@@ -1440,9 +1439,9 @@ func (j *tlfJournal) resolveBranch(ctx context.Context,
 	bid BranchID, blocksToDelete []BlockID, rmd *RootMetadata,
 	extra ExtraMetadata) (MdID, error) {
 	// Prepare the paths without holding the lock, as it might need to
-	// take the lock.  Note that the md ID and timestamp don't matter
-	// for the unflushed path cache.  This is a no-op if the unflushed
-	// path cache is uninitialized.  TODO: avoid doing this if we can
+	// take the lock.  Note that the timestamp don't matter for the
+	// unflushed path cache.  This is a no-op if the unflushed path
+	// cache is uninitialized.  TODO: avoid doing this if we can
 	// somehow be sure the cache won't be initialized by the time we
 	// finish this put.
 	mdInfo := unflushedPathMDInfo{

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1410,7 +1410,7 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	// the existing branch, then clear the existing branch.
 	mdID, err = j.mdJournal.resolveAndClear(
 		ctx, j.config.Crypto(), j.config.encryptionKeyGetter(),
-		j.config.BlockSplitter(), bid, rmd, extra)
+		j.config.BlockSplitter(), bid, rmd)
 	if err != nil {
 		return MdID{}, false, err
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1093,7 +1093,7 @@ func TestTLFJournalResolveBranch(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := config.makeMD(revision, prevRoot)
-		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		mdID, err := tlfJournal.putMD(ctx, md)
 		require.NoError(t, err)
 		prevRoot = mdID
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1069,3 +1069,66 @@ func TestTLFJournalFlushRetry(t *testing.T) {
 	requireJournalEntryCounts(t, tlfJournal, 0, 0)
 	testMDJournalGCd(t, tlfJournal.mdJournal)
 }
+
+func TestTLFJournalResolveBranch(t *testing.T) {
+	tempdir, config, ctx, cancel, tlfJournal, delegate :=
+		setupTLFJournalTest(t, TLFJournalBackgroundWorkPaused)
+	defer teardownTLFJournalTest(
+		tempdir, config, ctx, cancel, tlfJournal, delegate)
+
+	var bids []BlockID
+	for i := 0; i < 3; i++ {
+		data := []byte{byte(i)}
+		bid, bCtx, serverHalf := config.makeBlock(data)
+		bids = append(bids, bid)
+		err := tlfJournal.putBlockData(ctx, bid, bCtx, data, serverHalf)
+		require.NoError(t, err)
+	}
+
+	firstRevision := MetadataRevision(10)
+	firstPrevRoot := fakeMdID(1)
+	mdCount := 3
+
+	prevRoot := firstPrevRoot
+	for i := 0; i < mdCount; i++ {
+		revision := firstRevision + MetadataRevision(i)
+		md := config.makeMD(revision, prevRoot)
+		mdID, err := tlfJournal.putMD(ctx, md, nil)
+		require.NoError(t, err)
+		prevRoot = mdID
+	}
+
+	var mdserver shimMDServer
+	mdserver.nextErr = MDServerErrorConflictRevision{}
+	config.mdserver = &mdserver
+
+	_, mdEnd, err := tlfJournal.getJournalEnds(ctx)
+	require.NoError(t, err)
+
+	// This will convert to a branch.
+	flushed, err := tlfJournal.flushOneMDOp(ctx, mdEnd, mdEnd)
+	require.NoError(t, err)
+	require.True(t, flushed)
+
+	// Resolve the branch.
+	resolveMD := config.makeMD(firstRevision, firstPrevRoot)
+	_, err = tlfJournal.resolveBranch(ctx,
+		tlfJournal.mdJournal.getBranchID(), []BlockID{bids[1]}, resolveMD, nil)
+	require.NoError(t, err)
+
+	blockEnd, newMDEnd, err := tlfJournal.getJournalEnds(ctx)
+	require.NoError(t, err)
+	require.Equal(t, firstRevision+1, newMDEnd)
+
+	blocks, maxMD, err := tlfJournal.getNextBlockEntriesToFlush(ctx, blockEnd)
+	require.NoError(t, err)
+	require.Equal(t, firstRevision, maxMD)
+	// 3 blocks, 3 old MD markers, 1 new MD marker
+	require.Equal(t, 7, blocks.length())
+	require.Len(t, blocks.puts.blockStates, 2)
+	require.Len(t, blocks.adds.blockStates, 0)
+	// 1 ignored block, 3 ignored MD markers, 1 real MD marker
+	require.Len(t, blocks.other, 5)
+	require.Equal(t, bids[0], blocks.puts.blockStates[0].blockPtr.ID)
+	require.Equal(t, bids[2], blocks.puts.blockStates[1].blockPtr.ID)
+}

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -353,3 +353,25 @@ func (upc *unflushedPathCache) initialize(ctx context.Context,
 	// abort the initialization.
 	return initialUnflushedPaths, false, nil
 }
+
+// reinitializeWithResolution returns true when successful, and false
+// if it needs to be retried after the per-revision map is recomputed.
+func (upc *unflushedPathCache) reinitializeWithResolution(
+	irmd ImmutableRootMetadata, perRevMap unflushedPathsPerRevMap) bool {
+	upc.lock.Lock()
+	defer upc.lock.Unlock()
+
+	if perRevMap == nil && upc.state != upcUninitialized {
+		return false
+	}
+
+	upc.unflushedPaths = unflushedPathsMap{irmd.Revision(): perRevMap}
+	upc.appendQueue = nil
+	upc.removeQueue = nil
+	if upc.ready != nil {
+		close(upc.ready)
+		upc.ready = nil
+	}
+	upc.state = upcInitialized
+	return true
+}

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -357,7 +357,7 @@ func (upc *unflushedPathCache) initialize(ctx context.Context,
 // reinitializeWithResolution returns true when successful, and false
 // if it needs to be retried after the per-revision map is recomputed.
 func (upc *unflushedPathCache) reinitializeWithResolution(
-	irmd ImmutableRootMetadata, perRevMap unflushedPathsPerRevMap) bool {
+	mdInfo unflushedPathMDInfo, perRevMap unflushedPathsPerRevMap) bool {
 	upc.lock.Lock()
 	defer upc.lock.Unlock()
 
@@ -365,7 +365,7 @@ func (upc *unflushedPathCache) reinitializeWithResolution(
 		return false
 	}
 
-	upc.unflushedPaths = unflushedPathsMap{irmd.Revision(): perRevMap}
+	upc.unflushedPaths = unflushedPathsMap{mdInfo.revision: perRevMap}
 	upc.appendQueue = nil
 	upc.removeQueue = nil
 	if upc.ready != nil {


### PR DESCRIPTION
This is Phase 1 in speeding up CR under journaling and coalescing journal entries together.  It allows the upper layers to specify a revision that completely replaces the current conflict branch, and avoid flushing blocks that have since been deleted.  This involves:

* Replace the current MD conflict branch with a journal that contains only one MD representing the resolution.
* Mark certain block journal entries as ignorable.

The next phase will use `ResolveBranch` from the conflict resolver, and turn off journal flushing when on a conflict branch.  This should significantly speed up CR since everything needed to run it is guaranteed to be locally available, and will also reduce the number of blocks we have to flush.

After that, the journal will start "faking" conflicts in order to occasionally coalesce MD journal entries together into a single entry, which should speed up flushing, reduce disk requirements, and hopefully reduce the size of conflict branches when they do happen.

Issue: KBFS-1637