### PR TITLE
[KBFS-1641] Add individual test timeouts for some tests

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -385,8 +385,8 @@ func testCRGetCROrBust(t *testing.T, config Config,
 // merged path.
 func TestCRMergedChainsSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -445,8 +445,8 @@ func TestCRMergedChainsSimple(t *testing.T) {
 // mostly original block pointers when constructing the merged path.
 func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -507,8 +507,8 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 // some recreateOps.
 func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -604,8 +604,8 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 // path across the rename.
 func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -684,8 +684,8 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 // directories, etc).
 func TestCRMergedChainsComplex(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -866,8 +866,8 @@ func TestCRMergedChainsComplex(t *testing.T) {
 // Tests that conflict resolution detects and can fix rename cycles.
 func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
@@ -955,8 +955,8 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 // Tests that conflict resolution detects and renames conflicts.
 func TestCRMergedChainsConflictSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1023,8 +1023,8 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 // Tests that conflict resolution detects and renames conflicts.
 func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1132,8 +1132,8 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 // files being created simultaneously in the same directory.
 func TestCRDoActionsSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1220,8 +1220,8 @@ func TestCRDoActionsSimple(t *testing.T) {
 // simultaneous writes to the same file.
 func TestCRDoActionsWriteConflict(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -386,10 +386,9 @@ func testCRGetCROrBust(t *testing.T, config Config,
 func TestCRMergedChainsSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -447,10 +446,9 @@ func TestCRMergedChainsSimple(t *testing.T) {
 func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -510,10 +508,9 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -608,10 +605,9 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -689,10 +685,9 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 func TestCRMergedChainsComplex(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -872,13 +867,12 @@ func TestCRMergedChainsComplex(t *testing.T) {
 func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -962,10 +956,9 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 func TestCRMergedChainsConflictSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -1031,10 +1024,9 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -1141,10 +1133,9 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 func TestCRDoActionsSimple(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
@@ -1230,10 +1221,9 @@ func TestCRDoActionsSimple(t *testing.T) {
 func TestCRDoActionsWriteConflict(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {

--- a/libkbfs/delayed_cancellation.go
+++ b/libkbfs/delayed_cancellation.go
@@ -140,7 +140,7 @@ func newCancellationDelayer() *cancellationDelayer {
 }
 
 // NewContextWithCancellationDelayer creates a new context out of ctx. All replay
-// functions attached to ctx are run on the new new context. In addition, the
+// functions attached to ctx are run on the new context. In addition, the
 // new context is made "cancellation delayable". That is, it disconnects the cancelFunc
 // from ctx, and watch for the cancellation. When cancellation happens, it
 // checks if delayed cancellation is enabled for the associated context. If so,
@@ -149,7 +149,7 @@ func newCancellationDelayer() *cancellationDelayer {
 //
 // Note that, it's important to call context.WithCancel (or its friends) before
 // this function if those cancellations need to be controllable ("cancellation
-// delayable"). Otherwise, the new cancelFunc is inheriently NOT ("cancellation
+// delayable"). Otherwise, the new cancelFunc is inherently NOT ("cancellation
 // delayable").
 //
 // If this function is called, it is caller's responsibility to either 1)

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -112,8 +112,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 func TestQuotaReclamationSimple(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config)
+	defer kbfsTestShutdownNoMocks(t, config, ctx)
 
 	testQuotaReclamation(t, ctx, config, userName)
 }
@@ -123,8 +122,7 @@ func TestQuotaReclamationSimple(t *testing.T) {
 func TestQuotaReclamationUnembedded(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config)
+	defer kbfsTestShutdownNoMocks(t, config, ctx)
 
 	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 32
 
@@ -146,8 +144,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config)
+	defer kbfsTestShutdownNoMocks(t, config, ctx)
 
 	now := time.Now()
 	var clock TestClock
@@ -224,8 +221,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsInitNoMocks(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsTestShutdownNoMocks(t, config1, ctx)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
@@ -537,8 +533,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
 	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config)
+	defer kbfsTestShutdownNoMocks(t, config, ctx)
 
 	clock := newTestClockNow()
 	config.SetClock(clock)

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -111,8 +111,8 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 
 func TestQuotaReclamationSimple(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
-	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	testQuotaReclamation(t, ctx, config, userName)
 }
@@ -121,8 +121,8 @@ func TestQuotaReclamationSimple(t *testing.T) {
 // of pointers correctly.
 func TestQuotaReclamationUnembedded(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
-	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 32
 
@@ -143,8 +143,8 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 // much quota at once.
 func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
-	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	now := time.Now()
 	var clock TestClock
@@ -220,8 +220,8 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 // Test that deleted blocks are correctly flushed from the user cache.
 func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsInitNoMocks(t, u1, u2)
-	defer kbfsTestShutdownNoMocks(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2)
+	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
@@ -453,8 +453,8 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 // requested rekey.
 func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
@@ -531,8 +531,8 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 // at least the minimum needed age.
 func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	var userName libkb.NormalizedUsername = "test_user"
-	config, _, ctx := kbfsOpsInitNoMocks(t, userName)
-	defer kbfsTestShutdownNoMocks(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	clock := newTestClockNow()
 	config.SetClock(clock)

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -454,12 +454,11 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -470,7 +469,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 	name := u1.String() + "," + u2.String()
 	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
 	// Now give u2 a new device.  The configs don't share a Keybase

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -73,8 +73,8 @@ func checkStatus(t *testing.T, ctx context.Context, kbfsOps KBFSOps,
 func TestBasicMDUpdate(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -126,8 +126,8 @@ func TestBasicMDUpdate(t *testing.T) {
 func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -202,8 +202,8 @@ func TestMultipleMDUpdatesUnembedChanges(t *testing.T) {
 func TestUnmergedAfterRestart(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -364,8 +364,8 @@ func TestUnmergedAfterRestart(t *testing.T) {
 func TestMultiUserWrite(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -430,8 +430,8 @@ func TestMultiUserWrite(t *testing.T) {
 func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -589,8 +589,8 @@ func (md mdServerLocalRecordingRegisterForUpdate) RegisterForUpdate(
 func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	mdServ, chForMdServer2 := newMDServerLocalRecordingRegisterForUpdate(
@@ -696,8 +696,8 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 func TestBasicCRFileConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -821,8 +821,8 @@ func TestBasicCRFileConflict(t *testing.T) {
 func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -931,8 +931,8 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 func TestCRDouble(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1104,8 +1104,8 @@ func waitForRekey(t *testing.T, config Config, id TlfID) {
 func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1296,8 +1296,8 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1475,8 +1475,8 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1623,8 +1623,8 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -1699,7 +1699,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 		StallMDOp(context.Background(), config2, StallableMDPut, 1)
 
 	var wg sync.WaitGroup
-	putCtx, cancel := context.WithCancel(putCtx)
+	putCtx, cancel2 := context.WithCancel(putCtx)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -1719,7 +1719,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 		}
 	}()
 	<-onPutStalledCh
-	cancel()
+	cancel2()
 	close(putUnstallCh)
 	wg.Wait()
 
@@ -1777,8 +1777,8 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1936,8 +1936,8 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
 	config2 := ConfigAsUser(config1, userName2)
@@ -2005,7 +2005,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 		StallMDOp(ctx, config2, StallableMDAfterPutUnmerged, 1)
 
 	var wg sync.WaitGroup
-	putCtx, cancel := context.WithCancel(putCtx)
+	putCtx, cancel2 := context.WithCancel(putCtx)
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -2015,7 +2015,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 		}
 	}()
 	<-onPutStalledCh
-	cancel()
+	cancel2()
 	close(putUnstallCh)
 	wg.Wait()
 

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -74,10 +74,9 @@ func TestBasicMDUpdate(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()
@@ -128,10 +127,9 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	if unembedChanges {
@@ -205,10 +203,9 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()
@@ -272,9 +269,9 @@ func TestUnmergedAfterRestart(t *testing.T) {
 
 	// now re-login the users, and make sure 1 can see the changes,
 	// but 2 can't
-	config1B := ConfigAsUser(config1.(*ConfigLocal), userName1)
+	config1B := ConfigAsUser(config1, userName1)
 	defer CheckConfigAndShutdown(t, config1B)
-	config2B := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2B := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2B)
 
 	DisableCRForTesting(config1B, rootNode1.GetFolderBranch())
@@ -368,10 +365,9 @@ func TestMultiUserWrite(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()
@@ -435,10 +431,9 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	if unembedChanges {
@@ -595,10 +590,9 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	mdServ, chForMdServer2 := newMDServerLocalRecordingRegisterForUpdate(
 		config2.MDServer().(mdServerLocal))
 	config2.SetMDServer(mdServ)
@@ -703,10 +697,9 @@ func TestBasicCRFileConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	clock, now := newTestClockAndTimeNow()
@@ -829,10 +822,9 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	config2.SetClock(newTestClockNow())
@@ -940,11 +932,10 @@ func TestCRDouble(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, _, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1114,11 +1105,10 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1156,7 +1146,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 		t.Fatalf("Couldn't lookup file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2Dev2 := ConfigAsUser(config1, userName2)
 	// we don't check the config because this device can't read all of the md blocks.
 	defer config2Dev2.Shutdown()
 	config2Dev2.MDServer().DisableRekeyUpdatesForTesting()
@@ -1307,11 +1297,10 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1344,7 +1333,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 		t.Fatalf("Couldn't lookup dir: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2Dev2 := ConfigAsUser(config1, userName2)
 	// we don't check the config because this device can't read all of the md blocks.
 	defer config2Dev2.Shutdown()
 	config2Dev2.MDServer().DisableRekeyUpdatesForTesting()
@@ -1487,11 +1476,10 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, _, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1636,11 +1624,10 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, _, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1791,10 +1778,9 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()
@@ -1951,11 +1937,10 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, _, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -46,27 +46,27 @@ func (cl *CounterLock) GetCount() int {
 }
 
 func kbfsOpsConcurInit(t *testing.T, users ...libkb.NormalizedUsername) (
-	*ConfigLocal, keybase1.UID, context.Context) {
+	*ConfigLocal, keybase1.UID, context.Context, context.CancelFunc) {
 	return kbfsOpsInitNoMocks(t, users...)
 }
 
-func kbfsConcurTestShutdown(
-	t *testing.T, config *ConfigLocal, ctx context.Context) {
-	kbfsTestShutdownNoMocks(t, config, ctx)
+func kbfsConcurTestShutdown(t *testing.T, config *ConfigLocal,
+	ctx context.Context, cancel context.CancelFunc) {
+	kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 }
 
 // TODO: Get rid of all users of this.
-func kbfsConcurTestShutdownNoCheck(
-	t *testing.T, config *ConfigLocal, ctx context.Context) {
-	kbfsTestShutdownNoMocksNoCheck(t, config, ctx)
+func kbfsConcurTestShutdownNoCheck(t *testing.T, config *ConfigLocal,
+	ctx context.Context, cancel context.CancelFunc) {
+	kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
 }
 
 // Test that only one of two concurrent GetRootMD requests can end up
 // fetching the MD from the server.  The second one should wait, and
 // then get it from the MD cache.
 func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onGetStalledCh, getUnstallCh, ctxStallGetForTLF :=
 		StallMDOp(ctx, config, StallableMDGetForTLF, 1)
@@ -110,8 +110,8 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 
 // Test that a read can happen concurrently with a sync
 func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -160,8 +160,8 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 // Test that writes can happen concurrently with a sync
 func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	initialWriteBytes int, nOneByteWrites int) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -295,8 +295,8 @@ func TestKBFSOpsConcurMultipleIndirectWritesDuringSync(t *testing.T) {
 // Test that writes that happen concurrently with a sync, which write
 // to the same block, work correctly.
 func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -415,9 +415,9 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 // Test that a block write can happen concurrently with a block
 // read. This is a regression test for KBFS-536.
 func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	// TODO: Use kbfsConcurTestShutdown.
-	defer kbfsConcurTestShutdownNoCheck(t, config, ctx)
+	defer kbfsConcurTestShutdownNoCheck(t, config, ctx, cancel)
 
 	// Turn off transient block caching.
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
@@ -536,9 +536,9 @@ func (km *mdRecordingKeyManager) Rekey(
 // Test that a sync can happen concurrently with a write. This is a
 // regression test for KBFS-558.
 func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	// TODO: Use kbfsConcurTestShutdown.
-	defer kbfsConcurTestShutdownNoCheck(t, config, ctx)
+	defer kbfsConcurTestShutdownNoCheck(t, config, ctx, cancel)
 
 	km := &mdRecordingKeyManager{delegate: config.KeyManager()}
 
@@ -624,8 +624,8 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 // Test that a sync can happen concurrently with a truncate. This is a
 // regression test for KBFS-558.
 func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	km := &mdRecordingKeyManager{delegate: config.KeyManager()}
 
@@ -713,8 +713,8 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 // up. This should pass with -race. This is a regression test for
 // KBFS-537.
 func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// Turn off block caching.
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
@@ -776,8 +776,8 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 
 // Test that a write can survive a folder BlockPointer update
 func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -816,8 +816,8 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 // Test that a write can happen concurrently with a sync when there
 // are multiple blocks in the file.
 func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -920,8 +920,8 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	if maxParallelBlockPuts <= 1 {
 		t.Skip("Skipping because we are not putting blocks in parallel.")
 	}
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// give it a remote block server with a fake client
 	fc := NewFakeBServerClient(config, nil, nil, nil)
@@ -966,7 +966,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	fc.finishChan = finishChan
 
 	prevNBlocks := fc.numBlocks()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel2 := context.WithCancel(ctx)
 	go func() {
 		// let the first initialBlocks blocks through.
 		for i := 0; i < initialBlocks; i++ {
@@ -993,7 +993,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 		default:
 		}
 
-		cancel()
+		cancel2()
 	}()
 
 	err = kbfsOps.Sync(ctx, fileNode)
@@ -1041,8 +1041,8 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 // Test that, when writing multiple blocks in parallel, one error will
 // cancel the remaining puts.
 func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// give it a mock'd block server
 	ctr := NewSafeTestReporter(t)
@@ -1138,8 +1138,8 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 // with a sync, which has to retry due to an archived block, works
 // correctly.  Regression test for KBFS-700.
 func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -1249,8 +1249,8 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 // error and a unretriable error leave the system in a clean state.
 // Regression test for KBFS-1508.
 func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// Use the smallest possible block size.
 	bsplitter, err := NewBlockSplitterSimple(20, 8*1024, config.Codec())
@@ -1263,7 +1263,7 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
 	defer config.SetBlockServer(oldBServer)
 	onSyncStalledCh, syncUnstallCh, ctxStallSync :=
 		StallBlockOp(ctx, config, StallableBlockPut, 7)
-	ctxStallSync, cancel := context.WithCancel(ctxStallSync)
+	ctxStallSync, cancel2 := context.WithCancel(ctxStallSync)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -1341,7 +1341,7 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
 
 	// Once the first block of the retry comes in, cancel everything.
 	<-onSyncStalledCh
-	cancel()
+	cancel2()
 
 	// Unstall the sync.
 	close(syncUnstallCh)
@@ -1387,15 +1387,15 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
 // already started, and cancellation is delayed. Since no extra delay greater
 // than the grace period in MD writes is introduced, Create should succeed.
 func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
-	config, _, ctxThrowaway := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctxThrowaway)
+	config, _, ctxThrowaway, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctxThrowaway, cancel)
 
 	ctx := context.Background()
 
 	onPutStalledCh, putUnstallCh, ctx :=
 		StallMDOp(ctx, config, StallableMDPut, 1)
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel2 := context.WithCancel(ctx)
 
 	ctx, err := NewContextWithCancellationDelayer(ctx)
 	if err != nil {
@@ -1414,7 +1414,7 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 	// Wait until Create gets stuck at MDOps.Put(). At this point, the delayed
 	// cancellation should have been enabled.
 	<-onPutStalledCh
-	cancel()
+	cancel2()
 	close(putUnstallCh)
 
 	// We expect no canceled error
@@ -1435,8 +1435,8 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 // period is introduced to MD write, so Create should fail. This is to ensure
 // Ctrl-C is able to interrupt the process eventually after the grace period.
 func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
-	config, _, ctxThrowaway := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctxThrowaway)
+	config, _, ctxThrowaway, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctxThrowaway, cancel)
 
 	// This essentially fast-forwards the grace period timer, making cancellation
 	// happen much faster. This way we can avoid time.Sleep.
@@ -1447,7 +1447,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 	onPutStalledCh, putUnstallCh, ctx :=
 		StallMDOp(ctx, config, StallableMDPut, 1)
 
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel2 := context.WithCancel(ctx)
 
 	ctx, err := NewContextWithCancellationDelayer(ctx)
 	if err != nil {
@@ -1466,7 +1466,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 	// Wait until Create gets stuck at MDOps.Put(). At this point, the delayed
 	// cancellation should have been enabled.
 	<-onPutStalledCh
-	cancel()
+	cancel2()
 
 	select {
 	case <-ctx.Done():
@@ -1499,8 +1499,8 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 
 // Test that a Sync that is canceled during a successful MD put works.
 func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -1592,8 +1592,8 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 // and finally a Sync succeeds (as a conflict), the TLF is left in a
 // reasonable state where CR can succeed.  Regression for KBFS-1569.
 func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
@@ -1686,8 +1686,8 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 // duplicate has previously been archived, works correctly after a
 // cancel.  Regression test for KBFS-727.
 func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -1781,8 +1781,8 @@ func (booq *blockOpsOverQuota) Put(ctx context.Context, tlfID TlfID,
 func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	t.Skip("Broken pending KBFS-1261")
 
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
@@ -1869,8 +1869,8 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 }
 
 func TestKBFSOpsCancelGetFavorites(t *testing.T) {
-	config, _, ctx := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctx)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	serverConn, conn := rpc.MakeConnectionForTest(t)
 	daemon := newKeybaseDaemonRPCWithClient(

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -50,7 +50,7 @@ const (
 )
 
 // Time out individual tests after 10 seconds.
-var individualTestTimeout time.Duration = 10 * time.Second
+var individualTestTimeout = 10 * time.Second
 
 func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config *ConfigMock, ctx context.Context, cancel context.CancelFunc) {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -49,6 +49,9 @@ const (
 	tCtxID tCtxIDType = iota
 )
 
+// Time out individual tests after 10 seconds.
+var individualTestTimeout time.Duration = 10 * time.Second
+
 func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config *ConfigMock, ctx context.Context, cancel context.CancelFunc) {
 	ctr := NewSafeTestReporter(t)
@@ -116,8 +119,8 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	interposeDaemonKBPKI(config, "alice", "bob", "charlie")
 
 	// Time out individual tests after 10 seconds.
-	timeoutCtx, cancel :=
-		context.WithTimeout(context.Background(), 10*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(
+		context.Background(), individualTestTimeout)
 
 	// make the context identifiable, to verify that it is passed
 	// correctly to the observer

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -665,8 +665,8 @@ func TestKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T) {
 
 func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
@@ -879,8 +879,8 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 
 func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	// Revoke user 3's device for now, to test the "other" rekey error.
 	_, uid3, err := config1.KBPKI().Resolve(ctx, u3.String())
@@ -971,8 +971,8 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 
 func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1052,8 +1052,8 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 
 func TestKeyManagerReaderRekey(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	_, uid1, err := config1.KBPKI().GetCurrentUserInfo(context.Background())
 
 	config2 := ConfigAsUser(config1, u2)
@@ -1133,8 +1133,8 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 
 func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
@@ -1222,11 +1222,11 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 // metadata and simply set the rekey bit. Then another participant rekeys the folder and they try to read.
 func TestKeyManagerRekeyBit(t *testing.T) {
 	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	doShutdown1 := true
 	defer func() {
 		if doShutdown1 {
-			kbfsConcurTestShutdown(t, config1, ctx)
+			kbfsConcurTestShutdown(t, config1, ctx, cancel)
 		}
 	}()
 
@@ -1383,7 +1383,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 
 	// Explicitly run the checks with config1 before the deferred shutdowns begin.
 	// This way the shared mdserver hasn't been shutdown.
-	kbfsConcurTestShutdown(t, config1, ctx)
+	kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	doShutdown1 = false
 }
 
@@ -1391,8 +1391,8 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 // Test that after this both can still read the latest version of the folder.
 func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
@@ -1521,8 +1521,8 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 
 func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1627,8 +1627,8 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 
 func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
@@ -1739,8 +1739,8 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 
 func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1517,7 +1517,11 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 	ctx context.Context,
 	keys []EncryptedTLFCryptKeyClientAndEphemeral, promptPaper bool) (
 	kbfscrypto.TLFCryptKeyClientHalf, int, error) {
-	clta.promptCh <- promptPaper
+	select {
+	case clta.promptCh <- promptPaper:
+	case <-ctx.Done():
+		return kbfscrypto.TLFCryptKeyClientHalf{}, 0, ctx.Err()
+	}
 	// Decrypt the key half with the given config object
 	return clta.cryptoToUse.DecryptTLFCryptKeyClientHalfAny(
 		ctx, keys, promptPaper)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -666,12 +666,11 @@ func TestKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T) {
 func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -701,7 +700,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
 	// Now give u2 a new device.  The configs don't share a Keybase
@@ -752,7 +751,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	}
 
 	// add a third device for user 2
-	config2Dev3 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev3 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev3)
 	defer config2Dev3.SetKeyCache(NewKeyCacheStandard(5000))
 	AddDeviceForLocalUserOrBust(t, config1, uid2)
@@ -881,8 +880,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
 	// Revoke user 3's device for now, to test the "other" rekey error.
 	_, uid3, err := config1.KBPKI().Resolve(ctx, u3.String())
@@ -891,7 +889,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	}
 	RevokeDeviceForLocalUserOrBust(t, config1, uid3, 0)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -911,10 +909,10 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
-	config3 := ConfigAsUser(config1.(*ConfigLocal), u3)
+	config3 := ConfigAsUser(config1, u3)
 	defer CheckConfigAndShutdown(t, config3)
 
 	// Now give u2 and u3 new devices.  The configs don't share a
@@ -974,10 +972,9 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1056,11 +1053,10 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 func TestKeyManagerReaderRekey(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	_, uid1, err := config1.KBPKI().GetCurrentUserInfo(context.Background())
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1138,12 +1134,11 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1231,13 +1226,11 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	doShutdown1 := true
 	defer func() {
 		if doShutdown1 {
-			CheckConfigAndShutdown(t, config1)
+			kbfsConcurTestShutdown(t, config1, ctx)
 		}
-		CleanupCancellationDelayer(ctx)
 	}()
-	config1.MDServer().DisableRekeyUpdatesForTesting()
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1245,7 +1238,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	}
 	config2.MDServer().DisableRekeyUpdatesForTesting()
 
-	config3 := ConfigAsUser(config1.(*ConfigLocal), u3)
+	config3 := ConfigAsUser(config1, u3)
 	defer CheckConfigAndShutdown(t, config3)
 	_, uid3, err := config3.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1266,7 +1259,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	// we don't check the config because this device can't read all of the md blocks.
 	defer config2Dev2.Shutdown()
 	config2Dev2.MDServer().DisableRekeyUpdatesForTesting()
@@ -1327,7 +1320,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 		t.Fatalf("Device 2 couldn't read a: %v", err)
 	}
 
-	config3Dev2 := ConfigAsUser(config1.(*ConfigLocal), u3)
+	config3Dev2 := ConfigAsUser(config1, u3)
 	// we don't check the config because this device can't read all of the md blocks.
 	defer config3Dev2.Shutdown()
 	config3Dev2.MDServer().DisableRekeyUpdatesForTesting()
@@ -1390,7 +1383,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 
 	// Explicitly run the checks with config1 before the deferred shutdowns begin.
 	// This way the shared mdserver hasn't been shutdown.
-	CheckConfigAndShutdown(t, config1)
+	kbfsConcurTestShutdown(t, config1, ctx)
 	doShutdown1 = false
 }
 
@@ -1399,12 +1392,11 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1424,7 +1416,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
 	// give user 2 a new device
@@ -1530,10 +1522,9 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1553,7 +1544,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
 	// Now give u2 a new device.  The configs don't share a Keybase
@@ -1637,12 +1628,11 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1662,7 +1652,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
 	// Now give u2 a new device.  The configs don't share a Keybase
@@ -1750,10 +1740,9 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -1764,7 +1753,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	name := u1.String() + "," + u2.String()
 
 	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
 	// Now give u2 a new device.  The configs don't share a Keybase

--- a/libkbfs/key_server_local_test.go
+++ b/libkbfs/key_server_local_test.go
@@ -17,8 +17,8 @@ import (
 func TestKeyServerLocalTLFCryptKeyServerHalves(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)

--- a/libkbfs/key_server_local_test.go
+++ b/libkbfs/key_server_local_test.go
@@ -18,10 +18,9 @@ func TestKeyServerLocalTLFCryptKeyServerHalves(t *testing.T) {
 	// simulate two users
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -372,8 +372,8 @@ func truncateNotificationTimestamps(
 
 func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -373,13 +373,12 @@ func truncateNotificationTimestamps(
 func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -15,24 +15,23 @@ import (
 func TestRekeyQueueBasic(t *testing.T) {
 	var u1, u2, u3, u4 libkb.NormalizedUsername = "u1", "u2", "u3", "u4"
 	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3, u4)
-	defer CleanupCancellationDelayer(ctx)
-	defer config1.Shutdown()
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2 := ConfigAsUser(config1, u2)
 	defer config2.Shutdown()
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	config3 := ConfigAsUser(config1.(*ConfigLocal), u3)
+	config3 := ConfigAsUser(config1, u3)
 	defer config3.Shutdown()
 	_, _, err = config3.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	config4 := ConfigAsUser(config1.(*ConfigLocal), u4)
+	config4 := ConfigAsUser(config1, u4)
 	defer config4.Shutdown()
 	_, _, err = config4.KBPKI().GetCurrentUserInfo(context.Background())
 	if err != nil {
@@ -63,7 +62,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 	}
 
 	// Create a new device for user 2
-	config2Dev2 := ConfigAsUser(config1.(*ConfigLocal), u2)
+	config2Dev2 := ConfigAsUser(config1, u2)
 	defer config2Dev2.Shutdown()
 	AddDeviceForLocalUserOrBust(t, config1, uid2)
 	AddDeviceForLocalUserOrBust(t, config2, uid2)

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -14,8 +14,8 @@ import (
 
 func TestRekeyQueueBasic(t *testing.T) {
 	var u1, u2, u3, u4 libkb.NormalizedUsername = "u1", "u2", "u3", "u4"
-	config1, _, ctx := kbfsOpsConcurInit(t, u1, u2, u3, u4)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3, u4)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer config2.Shutdown()

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -145,6 +145,20 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 func TestLongTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	// Need to increase the timeout, since this test takes longer
+	// than usual.
+	//
+	// TODO: Make this test not take so long.
+	timeoutCtx, cancel := context.WithTimeout(
+		context.Background(), 3*individualTestTimeout)
+	ctx, err := NewContextWithCancellationDelayer(NewContextReplayable(
+		timeoutCtx, func(c context.Context) context.Context {
+			return c
+		}))
+	if err != nil {
+		cancel()
+		panic(err)
+	}
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	clock, now := newTestClockAndTimeNow()

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -35,8 +35,8 @@ func truncateTLFWriterEditsTimestamps(edits TlfWriterEdits) TlfWriterEdits {
 
 func TestBasicTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
@@ -144,8 +144,8 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 
 func TestLongTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
-	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer kbfsConcurTestShutdown(t, config1, ctx)
+	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
+	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -36,13 +36,12 @@ func truncateTLFWriterEditsTimestamps(edits TlfWriterEdits) TlfWriterEdits {
 func TestBasicTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()
@@ -146,13 +145,12 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 func TestLongTlfEditHistory(t *testing.T) {
 	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx := kbfsOpsConcurInit(t, userName1, userName2)
-	defer CleanupCancellationDelayer(ctx)
-	defer CheckConfigAndShutdown(t, config1)
+	defer kbfsConcurTestShutdown(t, config1, ctx)
 
 	clock, now := newTestClockAndTimeNow()
 	config1.SetClock(clock)
 
-	config2 := ConfigAsUser(config1.(*ConfigLocal), userName2)
+	config2 := ConfigAsUser(config1, userName2)
 	defer CheckConfigAndShutdown(t, config2)
 
 	name := userName1.String() + "," + userName2.String()

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -214,8 +214,8 @@ func setupTLFJournalTest(
 		NewReporterSimple(newTestClockNow(), 10), uid, ekg, nil, mdserver,
 	}
 
-	// Time out individual tests after 10 seconds.
-	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(
+		context.Background(), individualTestTimeout)
 
 	// Clean up the context if the rest of the setup fails.
 	setupSucceeded := false


### PR DESCRIPTION
In particular, the ones that use the kbfsOpsInit,
kbfsOpsInitNoMocks, and kbfsOpsConcurInit functions.

Wait on ctx.Done() in key manager tests to avoid
hanging the whole test run.