### PR TITLE
Remove dependency on IRMD from crChains

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2505,12 +2505,8 @@ func (rmd rootMetadataWithTimestamp) LocalTimestamp() time.Time {
 func (cr *ConflictResolver) makePostResolutionPaths(ctx context.Context,
 	md *RootMetadata, unmergedChains, mergedChains *crChains,
 	mergedPaths map[BlockPointer]path) (map[BlockPointer]path, error) {
-	// No need to run any identifies on these chains, since we have
-	// already finished all actions.  It is an ugly hack that we fake
-	// out the metadata ID here, but we can't calculate the true ID
-	// yet since the private metadata isn't yet set.  newCRChains
-	// doesn't use it; it only inspects the MD itself and the
-	// timestamp.
+	// No need to run any identifies on these chains, since we
+	// have already finished all actions.
 	resolvedChains, err := newCRChains(ctx, cr.config,
 		[]chainMetadata{rootMetadataWithTimestamp{md,
 			cr.config.Clock().Now()}},

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -302,14 +302,14 @@ func (cr *ConflictResolver) updateCurrInput(ctx context.Context,
 func (cr *ConflictResolver) makeChains(ctx context.Context,
 	unmerged, merged []ImmutableRootMetadata) (
 	unmergedChains, mergedChains *crChains, err error) {
-	unmergedChains, err =
-		newCRChains(ctx, cr.config, unmerged, &cr.fbo.blocks, true)
+	unmergedChains, err = newCRChainsForIRMDs(
+		ctx, cr.config, unmerged, &cr.fbo.blocks, true)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	mergedChains, err =
-		newCRChains(ctx, cr.config, merged, &cr.fbo.blocks, true)
+	mergedChains, err = newCRChainsForIRMDs(
+		ctx, cr.config, merged, &cr.fbo.blocks, true)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2502,7 +2502,7 @@ func (cr *ConflictResolver) makePostResolutionPaths(ctx context.Context,
 	// doesn't use it; it only inspects the MD itself and the
 	// timestamp.
 	resolvedChains, err := newCRChains(ctx, cr.config,
-		[]ImmutableRootMetadata{MakeImmutableRootMetadata(md, fakeMdID(1),
+		[]chainMetadata{MakeImmutableRootMetadata(md, fakeMdID(1),
 			cr.config.Clock().Now())},
 		&cr.fbo.blocks, false)
 	if err != nil {

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -957,8 +957,7 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 // buildChainsAndPaths make crChains for both the unmerged and merged
 // branches since the branch point, the corresponding full paths for
 // those changes, any new recreate ops, and returns the MDs used to
-// compute all this.  Note that even if err is nil, the merged MD list
-// might be non-nil to allow for better error handling.
+// compute all this.
 func (cr *ConflictResolver) buildChainsAndPaths(
 	ctx context.Context, lState *lockState, writerLocked bool) (
 	unmergedChains, mergedChains *crChains, unmergedPaths []path,

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -538,7 +538,7 @@ func (cr *ConflictResolver) addChildBlocksIfIndirectFile(ctx context.Context,
 	// For files with indirect pointers, and all child blocks
 	// as refblocks for the re-created file.
 	fblock, err := cr.fbo.blocks.GetFileBlockForReading(ctx, lState,
-		unmergedChains.mostRecentMDInfo.kmd,
+		unmergedChains.mostRecentCMDInfo.kmd,
 		mostRecent, currPath.Branch, currPath)
 	if err != nil {
 		return err
@@ -657,7 +657,7 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 		}
 
 		de, err := cr.fbo.blocks.GetDirtyEntry(ctx, lState,
-			unmergedChains.mostRecentMDInfo.kmd,
+			unmergedChains.mostRecentCMDInfo.kmd,
 			currPath)
 		if err != nil {
 			return path{}, BlockPointer{}, nil, err
@@ -913,8 +913,8 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
-		mergedChains.mostRecentMDInfo.kmd,
-		mergedChains.mostRecentMDInfo.rootPtr)
+		mergedChains.mostRecentCMDInfo.kmd,
+		mergedChains.mostRecentCMDInfo.rootPtr)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1334,7 +1334,7 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 				newChains.byOriginal[c.original] = newChain
 				newChains.byMostRecent[c.mostRecent] = newChain
 			}
-			newChains.mostRecentMDInfo = unmergedChains.mostRecentMDInfo
+			newChains.mostRecentCMDInfo = unmergedChains.mostRecentCMDInfo
 			unmergedPaths, err := newChains.getPaths(ctx, &cr.fbo.blocks,
 				cr.log, cr.fbo.nodeCache, false)
 			if err != nil {
@@ -1446,8 +1446,8 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
-		mergedChains.mostRecentMDInfo.kmd,
-		mergedChains.mostRecentMDInfo.rootPtr)
+		mergedChains.mostRecentCMDInfo.kmd,
+		mergedChains.mostRecentCMDInfo.rootPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -1840,7 +1840,7 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	lState *lockState, chains *crChains, mergedMostRecent BlockPointer, parentPath path,
 	name string, ptr BlockPointer, blocks fileBlockMap) (
 	BlockPointer, error) {
-	kmd := chains.mostRecentMDInfo.kmd
+	kmd := chains.mostRecentCMDInfo.kmd
 	fblock, err := cr.fbo.blocks.GetFileBlockForReading(
 		ctx, lState, kmd, ptr, parentPath.Branch,
 		parentPath.ChildPath(name, ptr))
@@ -1967,7 +1967,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 		actions := actionMap[mergedPath.tailPointer()]
 		// Now get the directory blocks.
 		unmergedBlock, err := cr.fetchDirBlockCopy(ctx, lState,
-			unmergedChains.mostRecentMDInfo.kmd,
+			unmergedChains.mostRecentCMDInfo.kmd,
 			unmergedPath, lbc)
 		if err != nil {
 			return err
@@ -1983,7 +1983,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 			lbc[mergedPath.tailPointer()] = mergedBlock
 		} else {
 			mergedBlock, err = cr.fetchDirBlockCopy(ctx, lState,
-				mergedChains.mostRecentMDInfo.kmd,
+				mergedChains.mostRecentCMDInfo.kmd,
 				mergedPath, lbc)
 			if err != nil {
 				return err
@@ -2029,7 +2029,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 						// a copy since this will just be a source
 						// block.
 						dBlock, err := cr.fbo.blocks.GetDirBlockForReading(ctx, lState,
-							mergedChains.mostRecentMDInfo.kmd, newPtr,
+							mergedChains.mostRecentCMDInfo.kmd, newPtr,
 							mergedPath.Branch, path{})
 						if err != nil {
 							return err
@@ -2257,7 +2257,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 					path:         []pathNode{{BlockPointer: ptr}},
 				}
 				fblock, err := cr.fbo.blocks.GetFileBlockForReading(ctx, lState,
-					unmergedChains.mostRecentMDInfo.kmd, ptr, file.Branch, file)
+					unmergedChains.mostRecentCMDInfo.kmd, ptr, file.Branch, file)
 				if err != nil {
 					return nil, err
 				}
@@ -2422,8 +2422,8 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 
 			nodeMap, cache, err := cr.fbo.blocks.SearchForNodes(
 				ctx, cr.fbo.nodeCache, ptrs, newPtrs,
-				unmergedChains.mostRecentMDInfo.kmd,
-				unmergedChains.mostRecentMDInfo.rootPtr)
+				unmergedChains.mostRecentCMDInfo.kmd,
+				unmergedChains.mostRecentCMDInfo.rootPtr)
 			if err != nil {
 				return path{}, err
 			}
@@ -2597,7 +2597,7 @@ func (cr *ConflictResolver) syncTree(ctx context.Context, lState *lockState,
 						iptr.BlockPointer)
 					childBlock, err := cr.fbo.blocks.GetFileBlockForReading(
 						ctx, lState,
-						unmergedChains.mostRecentMDInfo.kmd,
+						unmergedChains.mostRecentCMDInfo.kmd,
 						iptr.BlockPointer, node.mergedPath.Branch,
 						node.mergedPath)
 					if err != nil {

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -957,7 +957,8 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 // buildChainsAndPaths make crChains for both the unmerged and merged
 // branches since the branch point, the corresponding full paths for
 // those changes, any new recreate ops, and returns the MDs used to
-// compute all this.
+// compute all this. Note that even if err is nil, the merged MD list
+// might be non-nil to allow for better error handling.
 func (cr *ConflictResolver) buildChainsAndPaths(
 	ctx context.Context, lState *lockState, writerLocked bool) (
 	unmergedChains, mergedChains *crChains, unmergedPaths []path,

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3438,11 +3438,11 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	if err != nil {
 		return
 	}
-	var mostRecentMergedMD ImmutableRootMetadata
-	if len(mergedMDs) > 0 {
-		mostRecentMergedMD = mergedMDs[len(mergedMDs)-1]
-	}
 	if len(mergedPaths) == 0 {
+		var mostRecentMergedMD ImmutableRootMetadata
+		if len(mergedMDs) > 0 {
+			mostRecentMergedMD = mergedMDs[len(mergedMDs)-1]
+		}
 		// TODO: All the other variables returned by
 		// buildChainsAndPaths may also be nil, in which case
 		// completeResolution will deref a nil pointer. Fix
@@ -3475,6 +3475,8 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		}
 	}
 	cr.log.CDebugf(ctx, "Recreate ops: %s", recOps)
+
+	mostRecentMergedMD := mergedMDs[len(mergedMDs)-1]
 
 	mostRecentMergedWriterInfo, err := newWriterInfo(ctx, cr.config,
 		mostRecentMergedMD.LastModifyingWriter(),

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2489,6 +2489,15 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 	return resolvedPath, nil
 }
 
+type rootMetadataWithTimestamp struct {
+	*RootMetadata
+	localTimestamp time.Time
+}
+
+func (rmd rootMetadataWithTimestamp) LocalTimestamp() time.Time {
+	return rmd.localTimestamp
+}
+
 // makePostResolutionPaths returns the full paths to each unmerged
 // pointer, taking into account any rename operations that occurred in
 // the merged branch.
@@ -2502,8 +2511,8 @@ func (cr *ConflictResolver) makePostResolutionPaths(ctx context.Context,
 	// doesn't use it; it only inspects the MD itself and the
 	// timestamp.
 	resolvedChains, err := newCRChains(ctx, cr.config,
-		[]chainMetadata{MakeImmutableRootMetadata(md, fakeMdID(1),
-			cr.config.Clock().Now())},
+		[]chainMetadata{rootMetadataWithTimestamp{md,
+			cr.config.Clock().Now()}},
 		&cr.fbo.blocks, false)
 	if err != nil {
 		return nil, err

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -907,9 +907,10 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 	}
 
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
+	md := mergedChains.mostRecentMD
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
-		mergedChains.mostRecentMD.ReadOnly())
+		md, md.data.Dir.BlockPointer)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1435,9 +1436,10 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 	}
 
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
+	md := mergedChains.mostRecentMD
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
-		mergedChains.mostRecentMD.ReadOnly())
+		md, md.data.Dir.BlockPointer)
 	if err != nil {
 		return nil, err
 	}
@@ -2417,9 +2419,10 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 				newPtrs[ptr] = true
 			}
 
+			md := unmergedChains.mostRecentMD
 			nodeMap, cache, err := cr.fbo.blocks.SearchForNodes(
 				ctx, cr.fbo.nodeCache, ptrs, newPtrs,
-				unmergedChains.mostRecentMD.ReadOnly())
+				md, md.data.Dir.BlockPointer)
 			if err != nil {
 				return path{}, err
 			}
@@ -3177,7 +3180,8 @@ func (cr *ConflictResolver) getOpsForLocalNotification(ctx context.Context,
 	// that we can correctly order the chains from the root outward.
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
-		ctx, mergedNodeCache, ptrs, newPtrs, md.ReadOnly())
+		ctx, mergedNodeCache, ptrs, newPtrs,
+		md, md.data.Dir.BlockPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3443,6 +3443,11 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		mostRecentMergedMD = mergedMDs[len(mergedMDs)-1]
 	}
 	if len(mergedPaths) == 0 {
+		// TODO: All the other variables returned by
+		// buildChainsAndPaths may also be nil, in which case
+		// completeResolution will deref a nil pointer. Fix
+		// this!
+		//
 		// nothing to do
 		cr.log.CDebugf(ctx, "No updates to resolve, so finishing")
 		lbc := make(localBcache)

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1022,19 +1022,19 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	kbpki := cr.config.KBPKI()
 	_, uid, err := kbpki.GetCurrentUserInfo(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, nil, ImmutableRootMetadata{}, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	key, err := kbpki.GetCurrentVerifyingKey(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, nil, ImmutableRootMetadata{}, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	currUnmergedWriterInfo, err := newWriterInfo(
 		ctx, cr.config, uid, key.KID(),
 		unmerged[len(unmerged)-1].Revision())
 	if err != nil {
-		return nil, nil, nil, nil, nil, ImmutableRootMetadata{}, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Find the corresponding path in the merged branch for each of

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -571,7 +571,8 @@ func (cr *ConflictResolver) addChildBlocksIfIndirectFile(ctx context.Context,
 // have been completely removed from the merged path.  In this case,
 // they need to be recreated.  So this function also returns a slice
 // of create ops that will need to be replayed in the merged branch
-// for the conflicts to be resolved.
+// for the conflicts to be resolved; all of these ops have their
+// writer info set to the given one.
 func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 	lState *lockState, unmergedPath path, unmergedChains *crChains,
 	mergedChains *crChains, currUnmergedWriterInfo writerInfo) (

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -537,7 +537,7 @@ func (cr *ConflictResolver) addChildBlocksIfIndirectFile(ctx context.Context,
 	// For files with indirect pointers, and all child blocks
 	// as refblocks for the re-created file.
 	fblock, err := cr.fbo.blocks.GetFileBlockForReading(ctx, lState,
-		unmergedChains.mostRecentCMDInfo.kmd,
+		unmergedChains.mostRecentChainMDInfo.kmd,
 		mostRecent, currPath.Branch, currPath)
 	if err != nil {
 		return err
@@ -657,7 +657,7 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 		}
 
 		de, err := cr.fbo.blocks.GetDirtyEntry(ctx, lState,
-			unmergedChains.mostRecentCMDInfo.kmd,
+			unmergedChains.mostRecentChainMDInfo.kmd,
 			currPath)
 		if err != nil {
 			return path{}, BlockPointer{}, nil, err
@@ -913,8 +913,8 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
-		mergedChains.mostRecentCMDInfo.kmd,
-		mergedChains.mostRecentCMDInfo.rootPtr)
+		mergedChains.mostRecentChainMDInfo.kmd,
+		mergedChains.mostRecentChainMDInfo.rootPtr)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1335,7 +1335,7 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 				newChains.byOriginal[c.original] = newChain
 				newChains.byMostRecent[c.mostRecent] = newChain
 			}
-			newChains.mostRecentCMDInfo = unmergedChains.mostRecentCMDInfo
+			newChains.mostRecentChainMDInfo = unmergedChains.mostRecentChainMDInfo
 			unmergedPaths, err := newChains.getPaths(ctx, &cr.fbo.blocks,
 				cr.log, cr.fbo.nodeCache, false)
 			if err != nil {
@@ -1447,8 +1447,8 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 	mergedNodeCache := newNodeCacheStandard(cr.fbo.folderBranch)
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
-		mergedChains.mostRecentCMDInfo.kmd,
-		mergedChains.mostRecentCMDInfo.rootPtr)
+		mergedChains.mostRecentChainMDInfo.kmd,
+		mergedChains.mostRecentChainMDInfo.rootPtr)
 	if err != nil {
 		return nil, err
 	}
@@ -1841,7 +1841,7 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	lState *lockState, chains *crChains, mergedMostRecent BlockPointer, parentPath path,
 	name string, ptr BlockPointer, blocks fileBlockMap) (
 	BlockPointer, error) {
-	kmd := chains.mostRecentCMDInfo.kmd
+	kmd := chains.mostRecentChainMDInfo.kmd
 	fblock, err := cr.fbo.blocks.GetFileBlockForReading(
 		ctx, lState, kmd, ptr, parentPath.Branch,
 		parentPath.ChildPath(name, ptr))
@@ -1968,7 +1968,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 		actions := actionMap[mergedPath.tailPointer()]
 		// Now get the directory blocks.
 		unmergedBlock, err := cr.fetchDirBlockCopy(ctx, lState,
-			unmergedChains.mostRecentCMDInfo.kmd,
+			unmergedChains.mostRecentChainMDInfo.kmd,
 			unmergedPath, lbc)
 		if err != nil {
 			return err
@@ -1984,7 +1984,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 			lbc[mergedPath.tailPointer()] = mergedBlock
 		} else {
 			mergedBlock, err = cr.fetchDirBlockCopy(ctx, lState,
-				mergedChains.mostRecentCMDInfo.kmd,
+				mergedChains.mostRecentChainMDInfo.kmd,
 				mergedPath, lbc)
 			if err != nil {
 				return err
@@ -2030,7 +2030,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 						// a copy since this will just be a source
 						// block.
 						dBlock, err := cr.fbo.blocks.GetDirBlockForReading(ctx, lState,
-							mergedChains.mostRecentCMDInfo.kmd, newPtr,
+							mergedChains.mostRecentChainMDInfo.kmd, newPtr,
 							mergedPath.Branch, path{})
 						if err != nil {
 							return err
@@ -2258,7 +2258,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 					path:         []pathNode{{BlockPointer: ptr}},
 				}
 				fblock, err := cr.fbo.blocks.GetFileBlockForReading(ctx, lState,
-					unmergedChains.mostRecentCMDInfo.kmd, ptr, file.Branch, file)
+					unmergedChains.mostRecentChainMDInfo.kmd, ptr, file.Branch, file)
 				if err != nil {
 					return nil, err
 				}
@@ -2423,8 +2423,8 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 
 			nodeMap, cache, err := cr.fbo.blocks.SearchForNodes(
 				ctx, cr.fbo.nodeCache, ptrs, newPtrs,
-				unmergedChains.mostRecentCMDInfo.kmd,
-				unmergedChains.mostRecentCMDInfo.rootPtr)
+				unmergedChains.mostRecentChainMDInfo.kmd,
+				unmergedChains.mostRecentChainMDInfo.rootPtr)
 			if err != nil {
 				return path{}, err
 			}
@@ -2607,7 +2607,7 @@ func (cr *ConflictResolver) syncTree(ctx context.Context, lState *lockState,
 						iptr.BlockPointer)
 					childBlock, err := cr.fbo.blocks.GetFileBlockForReading(
 						ctx, lState,
-						unmergedChains.mostRecentCMDInfo.kmd,
+						unmergedChains.mostRecentChainMDInfo.kmd,
 						iptr.BlockPointer, node.mergedPath.Branch,
 						node.mergedPath)
 					if err != nil {

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -339,8 +339,9 @@ func testCRCheckPathsAndActions(t *testing.T, cr *ConflictResolver,
 	}
 
 	// Now for step 2 -- check the actions
-	actionMap, _, err := cr.computeActions(ctx, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, recreateOps)
+	actionMap, _, err := cr.computeActions(
+		ctx, unmergedChains, mergedChains,
+		unmergedPaths, mergedPaths, recreateOps, writerInfo{})
 	if err != nil {
 		t.Fatalf("Couldn't compute actions: %v", err)
 	}
@@ -1191,7 +1192,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 	}
 
 	actionMap, _, err := cr2.computeActions(ctx, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, recreateOps)
+		unmergedPaths, mergedPaths, recreateOps, writerInfo{})
 	if err != nil {
 		t.Fatalf("Couldn't compute actions: %v", err)
 	}
@@ -1307,7 +1308,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	}
 
 	actionMap, _, err := cr2.computeActions(ctx, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, recreateOps)
+		unmergedPaths, mergedPaths, recreateOps, writerInfo{})
 	if err != nil {
 		t.Fatalf("Couldn't compute actions: %v", err)
 	}

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -23,6 +23,7 @@ func crTestInit(t *testing.T) (mockCtrl *gomock.Controller, config *ConfigMock,
 	mockCtrl = gomock.NewController(ctr)
 	config = NewConfigMock(mockCtrl, ctr)
 	config.SetCodec(kbfscodec.NewMsgpack())
+	config.SetClock(wallClock{})
 	id := FakeTlfID(1, false)
 	fbo := newFolderBranchOps(config, FolderBranch{id, MasterBranch}, standard)
 	// usernames don't matter for these tests
@@ -40,6 +41,14 @@ func crTestShutdown(mockCtrl *gomock.Controller, config *ConfigMock,
 	config.ctr.CheckForFailures()
 	cr.fbo.Shutdown()
 	mockCtrl.Finish()
+}
+
+type failingCodec struct {
+	kbfscodec.Codec
+}
+
+func (fc failingCodec) Encode(interface{}) ([]byte, error) {
+	return nil, errors.New("Stopping resolution process early")
 }
 
 func TestCRInput(t *testing.T) {
@@ -113,8 +122,7 @@ func TestCRInput(t *testing.T) {
 
 	// CR doesn't see any operations and so it does resolution early.
 	// Just cause an error so it doesn't bother the mocks too much.
-	config.mockCrypto.EXPECT().MakeMdID(gomock.Any()).Return(MdID{},
-		errors.New("Stopping resolution process early"))
+	config.SetCodec(failingCodec{config.Codec()})
 	config.mockRep.EXPECT().ReportErr(gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any())
 
@@ -219,8 +227,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 
 	// CR doesn't see any operations and so it does resolution early.
 	// Just cause an error so it doesn't bother the mocks too much.
-	config.mockCrypto.EXPECT().MakeMdID(gomock.Any()).Return(MdID{},
-		errors.New("Stopping resolution process early"))
+	config.SetCodec(failingCodec{config.Codec()})
 	config.mockRep.EXPECT().ReportErr(gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any(), gomock.Any())
 
@@ -288,7 +295,7 @@ func testCRCheckPathsAndActions(t *testing.T, cr *ConflictResolver,
 
 	// Step 1 -- check the chains and paths
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, _, err := cr.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, err := cr.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1178,7 +1185,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1294,7 +1301,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -248,12 +248,12 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 }
 
 func (cc *crChain) remove(ctx context.Context, log logger.Logger,
-	rmd ImmutableRootMetadata) bool {
+	revision MetadataRevision) bool {
 	anyRemoved := false
 	var newOps []op
 	for i, currOp := range cc.ops {
 		info := currOp.getWriterInfo()
-		if info.revision == rmd.Revision() {
+		if info.revision == revision {
 			log.CDebugf(ctx, "Removing op %s from chain with mostRecent=%v",
 				currOp, cc.mostRecent)
 			if !anyRemoved {
@@ -965,15 +965,15 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 	return paths, nil
 }
 
-// remove deletes all operations associated with `rmd` from the chains.
-// It leaves original block pointers in place though, even when
-// removing operations from the head of the chain.  It returns the set
-// of chains with at least one operation removed.
+// remove deletes all operations associated with the given revision
+// from the chains.  It leaves original block pointers in place
+// though, even when removing operations from the head of the chain.
+// It returns the set of chains with at least one operation removed.
 func (ccs *crChains) remove(ctx context.Context, log logger.Logger,
-	rmd ImmutableRootMetadata) []*crChain {
+	revision MetadataRevision) []*crChain {
 	var chainsWithRemovals []*crChain
 	for _, chain := range ccs.byOriginal {
-		if chain.remove(ctx, log, rmd) {
+		if chain.remove(ctx, log, revision) {
 			chainsWithRemovals = append(chainsWithRemovals, chain)
 		}
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -667,7 +667,7 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 	privateMD PrivateMetadata, winfo writerInfo,
 	localTimestamp time.Time) error {
 	// Copy the ops since CR will change them.
-	var ops opsList
+	ops := make(opsList, len(privateMD.Changes.Ops))
 	err := kbfscodec.Update(codec, &ops, privateMD.Changes.Ops)
 	if err != nil {
 		return err

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -161,7 +161,7 @@ func (cc *crChain) isFile() bool {
 // state, but setAttr(mtime) can apply to either type; in that case,
 // we need to fetch the block to figure out the type.
 func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
-	md ImmutableRootMetadata, chains *crChains) error {
+	kmd KeyMetadata, chains *crChains) error {
 	if len(cc.ops) == 0 {
 		return nil
 	}
@@ -209,8 +209,7 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 	// If we get down here, we have an ambiguity, and need to fetch
 	// the block to figure out the file type.
 	dblock, err := fbo.GetDirBlockForReading(ctx, makeFBOLockState(),
-		md.ReadOnly(),
-		parentMostRecent, fbo.folderBranch.Branch, path{})
+		kmd, parentMostRecent, fbo.folderBranch.Branch, path{})
 	if err != nil {
 		return err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/logger"
-	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"golang.org/x/net/context"
 )
@@ -289,22 +288,14 @@ func (ri renameInfo) String() string {
 // crChainsMDInfo contains the subset of information from
 // BareRootMetadata that is needed for crChains.
 type crChainsMDInfo struct {
-	kmd                    KeyMetadata
-	rootPtr                BlockPointer
-	revision               MetadataRevision
-	lastModifyingWriter    keybase1.UID
-	lastModifyingWriterKID keybase1.KID
-	mdID                   MdID
+	kmd     KeyMetadata
+	rootPtr BlockPointer
 }
 
 func crChainsMDInfoFromIRMD(md ImmutableRootMetadata) crChainsMDInfo {
 	return crChainsMDInfo{
-		kmd:                    md,
-		rootPtr:                md.Data().Dir.BlockPointer,
-		revision:               md.Revision(),
-		lastModifyingWriter:    md.LastModifyingWriter(),
-		lastModifyingWriterKID: md.LastModifyingWriterKID(),
-		mdID: md.MdID(),
+		kmd:     md,
+		rootPtr: md.Data().Dir.BlockPointer,
 	}
 
 }

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -318,9 +318,9 @@ type crChains struct {
 	// Pointers that should be explicitly cleaned up in the resolution.
 	toUnrefPointers map[BlockPointer]bool
 
-	// Also keep the info for the most recent CMD used to build
-	// these chains.
-	mostRecentCMDInfo mostRecentChainMetadataInfo
+	// Also keep the info for the most recent chain MD used to
+	// build these chains.
+	mostRecentChainMDInfo mostRecentChainMetadataInfo
 
 	// We need to be able to track ANY BlockPointer, at any point in
 	// the chain, back to its original.
@@ -772,7 +772,7 @@ func newCRChains(ctx context.Context, cfg Config, cmds []chainMetadata,
 		}
 	}
 
-	ccs.mostRecentCMDInfo = mostRecentChainMetadataInfo{
+	ccs.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
 		kmd:     mostRecentMD,
 		rootPtr: mostRecentMD.Data().Dir.BlockPointer,
 	}
@@ -940,8 +940,8 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 	}
 
 	pathMap, err := blocks.SearchForPaths(ctx, nodeCache, ptrs,
-		newPtrs, ccs.mostRecentCMDInfo.kmd,
-		ccs.mostRecentCMDInfo.rootPtr)
+		newPtrs, ccs.mostRecentChainMDInfo.kmd,
+		ccs.mostRecentChainMDInfo.rootPtr)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -318,8 +318,8 @@ type crChains struct {
 	// Pointers that should be explicitly cleaned up in the resolution.
 	toUnrefPointers map[BlockPointer]bool
 
-	// Also keep the info for the most recent MD that's part of
-	// this chain.
+	// Also keep the info for the most recent CMD used to build
+	// these chains.
 	mostRecentCMDInfo mostRecentChainMetadataInfo
 
 	// We need to be able to track ANY BlockPointer, at any point in
@@ -684,14 +684,18 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 	return nil
 }
 
+// chainMetadata is the interface for metadata objects that can be
+// used in building crChains. It is implemented by
+// ImmutableRootMetadata, but is mostly implemented by RootMetadata
+// (just need LocalTimestamp).
 type chainMetadata interface {
 	KeyMetadata
-	LocalTimestamp() time.Time
 	IsWriterMetadataCopiedSet() bool
 	LastModifyingWriter() keybase1.UID
 	LastModifyingWriterKID() keybase1.KID
 	Revision() MetadataRevision
 	Data() *PrivateMetadata
+	LocalTimestamp() time.Time
 }
 
 // newCRChains builds a new crChains object from the given list of

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -686,8 +686,8 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 
 // chainMetadata is the interface for metadata objects that can be
 // used in building crChains. It is implemented by
-// ImmutableRootMetadata, but is mostly implemented by RootMetadata
-// (just need LocalTimestamp).
+// ImmutableRootMetadata, but is also mostly implemented by
+// RootMetadata (just need LocalTimestamp).
 type chainMetadata interface {
 	KeyMetadata
 	IsWriterMetadataCopiedSet() bool

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -297,7 +297,6 @@ func crChainsMDInfoFromIRMD(md ImmutableRootMetadata) crChainsMDInfo {
 		kmd:     md,
 		rootPtr: md.Data().Dir.BlockPointer,
 	}
-
 }
 
 // crChains contains a crChain for every KBFS node affected by the

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -713,9 +713,11 @@ func newCRChains(ctx context.Context, cfg Config, irmds []ImmutableRootMetadata,
 			return nil, err
 		}
 
-		err = ccs.addOps(cfg.Codec(), irmd.data, winfo, irmd.localTimestamp)
+		data := *irmd.Data()
 
-		if ptr := irmd.data.cachedChanges.Info.BlockPointer; ptr != zeroPtr {
+		err = ccs.addOps(cfg.Codec(), data, winfo, irmd.localTimestamp)
+
+		if ptr := data.cachedChanges.Info.BlockPointer; ptr != zeroPtr {
 			ccs.blockChangePointers[ptr] = true
 
 			// Any child block change pointers?
@@ -736,7 +738,7 @@ func newCRChains(ctx context.Context, cfg Config, irmds []ImmutableRootMetadata,
 		if !ccs.originalRoot.IsInitialized() {
 			// Find the original pointer for the root directory
 			if rootChain, ok :=
-				ccs.byMostRecent[irmd.data.Dir.BlockPointer]; ok {
+				ccs.byMostRecent[data.Dir.BlockPointer]; ok {
 				ccs.originalRoot = rootChain.original
 			}
 		}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -897,8 +897,9 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 		}
 	}
 
+	md := ccs.mostRecentMD
 	pathMap, err := blocks.SearchForPaths(ctx, nodeCache, ptrs,
-		newPtrs, ccs.mostRecentMD.ReadOnly())
+		newPtrs, md, md.data.Dir.BlockPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -286,18 +286,11 @@ func (ri renameInfo) String() string {
 		ri.originalNewParent, ri.newName)
 }
 
-// crChainsMDInfo contains the subset of information from
-// BareRootMetadata that is needed for crChains.
-type crChainsMDInfo struct {
+// mostRecentChainMetadataInfo contains the subset of information for
+// the most recent chainMetadata that is needed for crChains.
+type mostRecentChainMetadataInfo struct {
 	kmd     KeyMetadata
 	rootPtr BlockPointer
-}
-
-func crChainsMDInfoFromCMD(md chainMetadata) crChainsMDInfo {
-	return crChainsMDInfo{
-		kmd:     md,
-		rootPtr: md.Data().Dir.BlockPointer,
-	}
 }
 
 // crChains contains a crChain for every KBFS node affected by the
@@ -327,7 +320,7 @@ type crChains struct {
 
 	// Also keep the info for the most recent MD that's part of
 	// this chain.
-	mostRecentMDInfo crChainsMDInfo
+	mostRecentCMDInfo mostRecentChainMetadataInfo
 
 	// We need to be able to track ANY BlockPointer, at any point in
 	// the chain, back to its original.
@@ -775,7 +768,10 @@ func newCRChains(ctx context.Context, cfg Config, irmds []chainMetadata,
 		}
 	}
 
-	ccs.mostRecentMDInfo = crChainsMDInfoFromCMD(mostRecentMD)
+	ccs.mostRecentCMDInfo = mostRecentChainMetadataInfo{
+		kmd:     mostRecentMD,
+		rootPtr: mostRecentMD.Data().Dir.BlockPointer,
+	}
 
 	return ccs, nil
 }
@@ -938,7 +934,8 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 	}
 
 	pathMap, err := blocks.SearchForPaths(ctx, nodeCache, ptrs,
-		newPtrs, ccs.mostRecentMDInfo.kmd, ccs.mostRecentMDInfo.rootPtr)
+		newPtrs, ccs.mostRecentCMDInfo.kmd,
+		ccs.mostRecentCMDInfo.rootPtr)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -673,7 +673,7 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 	privateMD PrivateMetadata, winfo writerInfo,
 	localTimestamp time.Time) error {
 	// Copy the ops since CR will change them.
-	ops := make(opsList, len(privateMD.Changes.Ops))
+	var ops opsList
 	err := kbfscodec.Update(codec, &ops, privateMD.Changes.Ops)
 	if err != nil {
 		return err

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -179,7 +179,8 @@ func TestCRChainsSingleOp(t *testing.T) {
 	rmds := []*RootMetadata{rmd}
 	config, irmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, irmds, nil, true)
+	cc, err := newCRChainsForIRMDs(
+		context.Background(), config, irmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -214,7 +215,8 @@ func TestCRChainsRenameOp(t *testing.T) {
 	rmds := []*RootMetadata{rmd}
 	config, irmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, irmds, nil, true)
+	cc, err := newCRChainsForIRMDs(
+		context.Background(), config, irmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -324,7 +326,8 @@ func testCRChainsMultiOps(t *testing.T) (
 	rmds := []*RootMetadata{bigRmd}
 	config, irmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, irmds, nil, true)
+	cc, err := newCRChainsForIRMDs(
+		context.Background(), config, irmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains for big RMD: %v", err)
 	}
@@ -356,7 +359,8 @@ func testCRChainsMultiOps(t *testing.T) (
 	// now make sure the chain of MDs gets the same answers
 	config, multiIrmds := testCRChainsFillInWriter(t, multiRmds)
 	defer config.Shutdown()
-	mcc, err := newCRChains(context.Background(), config, multiIrmds, nil, true)
+	mcc, err := newCRChainsForIRMDs(
+		context.Background(), config, multiIrmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains for multi RMDs: %v", err)
 	}
@@ -488,7 +492,8 @@ func TestCRChainsCollapse(t *testing.T) {
 	rmds := []*RootMetadata{rmd}
 	config, irmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(context.Background(), config, irmds, nil, true)
+	cc, err := newCRChainsForIRMDs(
+		context.Background(), config, irmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -522,7 +527,8 @@ func TestCRChainsRemove(t *testing.T) {
 
 	config := MakeTestConfigOrBust(t, "u1")
 	defer config.Shutdown()
-	ccs, err := newCRChains(context.Background(), config, irmds, nil, true)
+	ccs, err := newCRChainsForIRMDs(
+		context.Background(), config, irmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -535,7 +535,7 @@ func TestCRChainsRemove(t *testing.T) {
 
 	// This should remove the write operation.
 	removedChains := ccs.remove(context.Background(),
-		logger.NewTestLogger(t), irmds[3])
+		logger.NewTestLogger(t), irmds[3].Revision())
 	require.Len(t, removedChains, 1)
 	require.Equal(t, removedChains[0].original, writtenFileUnref)
 	require.Len(t, removedChains[0].ops, 0)

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -143,21 +143,20 @@ func testCRCheckOps(t *testing.T, cc *crChains, original BlockPointer,
 }
 
 func testCRChainsFillInWriter(t *testing.T, rmds []*RootMetadata) (
-	Config, []ImmutableRootMetadata) {
+	Config, []chainMetadata) {
 	config := MakeTestConfigOrBust(t, "u1")
 	kbpki := config.KBPKI()
 	_, uid, err := kbpki.GetCurrentUserInfo(context.Background())
 	if err != nil {
 		t.Fatalf("Couldn't get UID: %v", err)
 	}
-	immutableRmds := make([]ImmutableRootMetadata, len(rmds))
+	cmds := make([]chainMetadata, len(rmds))
 	for i, rmd := range rmds {
 		rmd.SetLastModifyingWriter(uid)
 		rmd.SetTlfID(FakeTlfID(1, false))
-		immutableRmds[i] = MakeImmutableRootMetadata(rmd,
-			fakeMdID(1), time.Unix(0, 0))
+		cmds[i] = rootMetadataWithTimestamp{rmd, time.Unix(0, 0)}
 	}
-	return config, immutableRmds
+	return config, cmds
 }
 
 func TestCRChainsSingleOp(t *testing.T) {
@@ -177,10 +176,10 @@ func TestCRChainsSingleOp(t *testing.T) {
 	rmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 
 	rmds := []*RootMetadata{rmd}
-	config, irmds := testCRChainsFillInWriter(t, rmds)
+	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChainsForIRMDs(
-		context.Background(), config, irmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -213,10 +212,10 @@ func TestCRChainsRenameOp(t *testing.T) {
 	rmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 
 	rmds := []*RootMetadata{rmd}
-	config, irmds := testCRChainsFillInWriter(t, rmds)
+	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChainsForIRMDs(
-		context.Background(), config, irmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -232,8 +231,7 @@ func TestCRChainsRenameOp(t *testing.T) {
 	testCRCheckOps(t, cc, dir1Unref, []op{rmo})
 }
 
-func testCRChainsMultiOps(t *testing.T) (
-	[]ImmutableRootMetadata, BlockPointer) {
+func testCRChainsMultiOps(t *testing.T) ([]chainMetadata, BlockPointer) {
 	// To start, we have: root/dir1/dir2/file1 and root/dir3/file2
 	// Sequence of operations:
 	// * setex root/dir3/file2
@@ -324,10 +322,10 @@ func testCRChainsMultiOps(t *testing.T) (
 
 	bigRmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	rmds := []*RootMetadata{bigRmd}
-	config, irmds := testCRChainsFillInWriter(t, rmds)
+	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChainsForIRMDs(
-		context.Background(), config, irmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains for big RMD: %v", err)
 	}
@@ -359,7 +357,7 @@ func testCRChainsMultiOps(t *testing.T) (
 	// now make sure the chain of MDs gets the same answers
 	config, multiIrmds := testCRChainsFillInWriter(t, multiRmds)
 	defer config.Shutdown()
-	mcc, err := newCRChainsForIRMDs(
+	mcc, err := newCRChains(
 		context.Background(), config, multiIrmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains for multi RMDs: %v", err)
@@ -490,10 +488,10 @@ func TestCRChainsCollapse(t *testing.T) {
 
 	rmd.data.Dir.BlockPointer = expected[rootPtrUnref]
 	rmds := []*RootMetadata{rmd}
-	config, irmds := testCRChainsFillInWriter(t, rmds)
+	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChainsForIRMDs(
-		context.Background(), config, irmds, nil, true)
+	cc, err := newCRChains(
+		context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -519,23 +517,24 @@ func TestCRChainsCollapse(t *testing.T) {
 }
 
 func TestCRChainsRemove(t *testing.T) {
-	irmds, writtenFileUnref := testCRChainsMultiOps(t)
+	cmds, writtenFileUnref := testCRChainsMultiOps(t)
 
-	for i, irmd := range irmds {
-		irmd.SetRevision(MetadataRevision(i))
+	for i := range cmds {
+		cmds[i].(rootMetadataWithTimestamp).RootMetadata.SetRevision(
+			MetadataRevision(i))
 	}
 
 	config := MakeTestConfigOrBust(t, "u1")
 	defer config.Shutdown()
-	ccs, err := newCRChainsForIRMDs(
-		context.Background(), config, irmds, nil, true)
+	ccs, err := newCRChains(
+		context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
 
 	// This should remove the write operation.
 	removedChains := ccs.remove(context.Background(),
-		logger.NewTestLogger(t), irmds[3].Revision())
+		logger.NewTestLogger(t), cmds[3].Revision())
 	require.Len(t, removedChains, 1)
 	require.Equal(t, removedChains[0].original, writtenFileUnref)
 	require.Len(t, removedChains[0].ops, 0)

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -178,8 +178,7 @@ func TestCRChainsSingleOp(t *testing.T) {
 	rmds := []*RootMetadata{rmd}
 	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(
-		context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -214,8 +213,7 @@ func TestCRChainsRenameOp(t *testing.T) {
 	rmds := []*RootMetadata{rmd}
 	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(
-		context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -324,8 +322,7 @@ func testCRChainsMultiOps(t *testing.T) ([]chainMetadata, BlockPointer) {
 	rmds := []*RootMetadata{bigRmd}
 	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(
-		context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains for big RMD: %v", err)
 	}
@@ -490,8 +487,7 @@ func TestCRChainsCollapse(t *testing.T) {
 	rmds := []*RootMetadata{rmd}
 	config, cmds := testCRChainsFillInWriter(t, rmds)
 	defer config.Shutdown()
-	cc, err := newCRChains(
-		context.Background(), config, cmds, nil, true)
+	cc, err := newCRChains(context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}
@@ -526,8 +522,7 @@ func TestCRChainsRemove(t *testing.T) {
 
 	config := MakeTestConfigOrBust(t, "u1")
 	defer config.Shutdown()
-	ccs, err := newCRChains(
-		context.Background(), config, cmds, nil, true)
+	ccs, err := newCRChains(context.Background(), config, cmds, nil, true)
 	if err != nil {
 		t.Fatalf("Error making chains: %v", err)
 	}

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -322,7 +322,7 @@ func (c CryptoCommon) encryptData(data []byte, key [32]byte) (encryptedData, err
 
 // EncryptPrivateMetadata implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) EncryptPrivateMetadata(
-	pmd *PrivateMetadata, key kbfscrypto.TLFCryptKey) (
+	pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (
 	encryptedPmd EncryptedPrivateMetadata, err error) {
 	encodedPmd, err := c.codec.Encode(pmd)
 	if err != nil {
@@ -360,19 +360,19 @@ func (c CryptoCommon) decryptData(encryptedData encryptedData, key [32]byte) ([]
 // DecryptPrivateMetadata implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) DecryptPrivateMetadata(
 	encryptedPmd EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (
-	*PrivateMetadata, error) {
+	PrivateMetadata, error) {
 	encodedPmd, err := c.decryptData(encryptedData(encryptedPmd), key.Data())
 	if err != nil {
-		return nil, err
+		return PrivateMetadata{}, err
 	}
 
 	var pmd PrivateMetadata
 	err = c.codec.Decode(encodedPmd, &pmd)
 	if err != nil {
-		return nil, err
+		return PrivateMetadata{}, err
 	}
 
-	return &pmd, nil
+	return pmd, nil
 }
 
 const minBlockSize = 256

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -452,7 +452,7 @@ func TestEncryptPrivateMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	encryptedPrivateMetadata, err := c.EncryptPrivateMetadata(&privateMetadata, cryptKey)
+	encryptedPrivateMetadata, err := c.EncryptPrivateMetadata(privateMetadata, cryptKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +536,7 @@ func TestDecryptEncryptedPrivateMetadata(t *testing.T) {
 		TLFPrivateKey: tlfPrivateKey,
 	}
 
-	encryptedPrivateMetadata, err := c.EncryptPrivateMetadata(&privateMetadata, cryptKey)
+	encryptedPrivateMetadata, err := c.EncryptPrivateMetadata(privateMetadata, cryptKey)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -615,7 +615,7 @@ func TestDecryptPrivateMetadataFailures(t *testing.T) {
 		TLFPrivateKey: tlfPrivateKey,
 	}
 
-	encryptedPrivateMetadata, err := c.EncryptPrivateMetadata(&privateMetadata, cryptKey)
+	encryptedPrivateMetadata, err := c.EncryptPrivateMetadata(privateMetadata, cryptKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3556,7 +3556,7 @@ func (fbo *folderBranchOps) searchForNode(ctx context.Context,
 	}
 
 	nodeMap, _, err := fbo.blocks.SearchForNodes(ctx, fbo.nodeCache,
-		[]BlockPointer{ptr}, newPtrs, md)
+		[]BlockPointer{ptr}, newPtrs, md, md.data.Dir.BlockPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -805,12 +805,12 @@ type cryptoPure interface {
 
 	// EncryptPrivateMetadata encrypts a PrivateMetadata object.
 	EncryptPrivateMetadata(
-		pmd *PrivateMetadata, key kbfscrypto.TLFCryptKey) (
+		pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (
 		EncryptedPrivateMetadata, error)
 	// DecryptPrivateMetadata decrypts a PrivateMetadata object.
 	DecryptPrivateMetadata(
 		encryptedPMD EncryptedPrivateMetadata,
-		key kbfscrypto.TLFCryptKey) (*PrivateMetadata, error)
+		key kbfscrypto.TLFCryptKey) (PrivateMetadata, error)
 
 	// EncryptBlocks encrypts a block. plainSize is the size of the encoded
 	// block; EncryptBlock() must guarantee that plainSize <=

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -7,6 +7,8 @@ package libkbfs
 import (
 	"fmt"
 
+	"github.com/keybase/client/go/protocol/keybase1"
+
 	"golang.org/x/net/context"
 )
 
@@ -96,11 +98,39 @@ func (j journalMDOps) getHeadFromJournal(
 		}
 	}
 
-	irmd, err := tlfJournal.convertImmutableBareRMDToIRMD(ctx, head, handle)
+	irmd, err := j.convertImmutableBareRMDToIRMD(
+		ctx, head, handle, tlfJournal.uid)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
 
+	return irmd, nil
+}
+
+// convertImmutableBareRMDToIRMD decrypts the MD in the given bare root
+// MD.  The caller must NOT hold `j.journalLock`, because blocks
+// from the journal may need to be read as part of the decryption.
+func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
+	ibrmd ImmutableBareRootMetadata, handle *TlfHandle, uid keybase1.UID) (
+	ImmutableRootMetadata, error) {
+	// TODO: Avoid having to do this type assertion.
+	brmd, ok := ibrmd.BareRootMetadata.(MutableBareRootMetadata)
+	if !ok {
+		return ImmutableRootMetadata{}, MutableBareRootMetadataNoImplError{}
+	}
+
+	rmd := MakeRootMetadata(brmd, ibrmd.extra, handle)
+
+	config := j.jServer.config
+	pmd, err := decryptMDPrivateData(ctx, config.Codec(), config.Crypto(),
+		config.BlockCache(), config.BlockOps(), config.KeyManager(),
+		uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd)
+	if err != nil {
+		return ImmutableRootMetadata{}, err
+	}
+
+	rmd.data = pmd
+	irmd := MakeImmutableRootMetadata(rmd, ibrmd.mdID, ibrmd.localTimestamp)
 	return irmd, nil
 }
 
@@ -149,8 +179,8 @@ func (j journalMDOps) getRangeFromJournal(
 	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
 
 	for _, ibrmd := range ibrmds {
-		irmd, err := tlfJournal.convertImmutableBareRMDToIRMD(
-			ctx, ibrmd, handle)
+		irmd, err := j.convertImmutableBareRMDToIRMD(
+			ctx, ibrmd, handle, tlfJournal.uid)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -107,9 +107,8 @@ func (j journalMDOps) getHeadFromJournal(
 	return irmd, nil
 }
 
-// convertImmutableBareRMDToIRMD decrypts the MD in the given bare root
-// MD.  The caller must NOT hold `j.journalLock`, because blocks
-// from the journal may need to be read as part of the decryption.
+// convertImmutableBareRMDToIRMD decrypts the bare MD into a
+// full-fledged RMD.
 func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	ibrmd ImmutableBareRootMetadata, handle *TlfHandle, uid keybase1.UID) (
 	ImmutableRootMetadata, error) {

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -710,13 +710,14 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// decryptMDPrivateData assumes that the MD is always encrypted
 	// using the latest key gen.
 	if !md.IsReadable() && len(md.GetSerializedPrivateMetadata()) > 0 {
-		err := decryptMDPrivateData(
+		pmd, err := decryptMDPrivateData(
 			ctx, km.config.Codec(), km.config.Crypto(),
 			km.config.BlockCache(), km.config.BlockOps(),
-			km, uid, md, md.ReadOnly())
+			km, uid, md.GetSerializedPrivateMetadata(), md, md)
 		if err != nil {
 			return false, nil, err
 		}
+		md.data = pmd
 	}
 
 	defer func() {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -187,12 +187,15 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	// Try to decrypt using the keys available in this md.  If that
 	// doesn't work, a future MD may contain more keys and will be
 	// tried later.
-	err = decryptMDPrivateData(
-		ctx, md.config.Codec(), md.config.Crypto(), md.config.BlockCache(),
-		md.config.BlockOps(), md.config.KeyManager(), uid, rmd, rmd.ReadOnly())
+	pmd, err := decryptMDPrivateData(
+		ctx, md.config.Codec(), md.config.Crypto(),
+		md.config.BlockCache(), md.config.BlockOps(),
+		md.config.KeyManager(), uid, rmd.GetSerializedPrivateMetadata(),
+		rmd, rmd)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
+	rmd.data = pmd
 
 	mdID, err := md.config.Crypto().MakeMdID(rmd.bareMd)
 	if err != nil {

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -170,7 +170,7 @@ func verifyMDForPrivateHelper(
 	var pmd PrivateMetadata
 	config.mockCrypto.EXPECT().DecryptPrivateMetadata(
 		gomock.Any(), kbfscrypto.TLFCryptKey{}).
-		MinTimes(minTimes).MaxTimes(maxTimes).Return(&pmd, nil)
+		MinTimes(minTimes).MaxTimes(maxTimes).Return(pmd, nil)
 
 	if rmds.MD.IsFinal() {
 		config.mockKbpki.EXPECT().HasUnverifiedVerifyingKey(gomock.Any(), gomock.Any(),
@@ -197,7 +197,7 @@ func verifyMDForPrivate(
 func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	expectGetTLFCryptKeyForEncryption(config, rmd)
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
-		&rmd.data, kbfscrypto.TLFCryptKey{}).Return(
+		rmd.data, kbfscrypto.TLFCryptKey{}).Return(
 		EncryptedPrivateMetadata{}, nil)
 	config.mockCrypto.EXPECT().Sign(
 		gomock.Any(), gomock.Any()).Times(2).Return(
@@ -700,7 +700,7 @@ func TestMDOpsPutFailEncode(t *testing.T) {
 
 	expectGetTLFCryptKeyForEncryption(config, rmd)
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
-		&rmd.data, kbfscrypto.TLFCryptKey{}).Return(
+		rmd.data, kbfscrypto.TLFCryptKey{}).Return(
 		EncryptedPrivateMetadata{}, nil)
 	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
 		Return(true)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -325,7 +325,7 @@ func encryptMDPrivateData(
 	}
 
 	brmd := rmd.bareMd
-	privateData := &rmd.data
+	privateData := rmd.data
 
 	if brmd.TlfID().IsPublic() || !brmd.IsWriterMetadataCopiedSet() {
 		// Record the last writer to modify this writer metadata
@@ -545,12 +545,11 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 				return PrivateMetadata{}, err
 			}
 		} else {
-			pmdPtr, err := crypto.DecryptPrivateMetadata(
+			pmd, err = crypto.DecryptPrivateMetadata(
 				encryptedPrivateMetadata, k)
 			if err != nil {
 				return PrivateMetadata{}, err
 			}
-			pmd = *pmdPtr
 		}
 	}
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1867,7 +1867,7 @@ func (_mr *_MockcryptoPureRecorder) EncryptTLFCryptKeyClientHalf(arg0, arg1, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptTLFCryptKeyClientHalf", arg0, arg1, arg2)
 }
 
-func (_m *MockcryptoPure) EncryptPrivateMetadata(pmd *PrivateMetadata, key kbfscrypto.TLFCryptKey) (EncryptedPrivateMetadata, error) {
+func (_m *MockcryptoPure) EncryptPrivateMetadata(pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (EncryptedPrivateMetadata, error) {
 	ret := _m.ctrl.Call(_m, "EncryptPrivateMetadata", pmd, key)
 	ret0, _ := ret[0].(EncryptedPrivateMetadata)
 	ret1, _ := ret[1].(error)
@@ -1878,9 +1878,9 @@ func (_mr *_MockcryptoPureRecorder) EncryptPrivateMetadata(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptPrivateMetadata", arg0, arg1)
 }
 
-func (_m *MockcryptoPure) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (*PrivateMetadata, error) {
+func (_m *MockcryptoPure) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (PrivateMetadata, error) {
 	ret := _m.ctrl.Call(_m, "DecryptPrivateMetadata", encryptedPMD, key)
-	ret0, _ := ret[0].(*PrivateMetadata)
+	ret0, _ := ret[0].(PrivateMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2240,7 +2240,7 @@ func (_mr *_MockCryptoRecorder) EncryptTLFCryptKeyClientHalf(arg0, arg1, arg2 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptTLFCryptKeyClientHalf", arg0, arg1, arg2)
 }
 
-func (_m *MockCrypto) EncryptPrivateMetadata(pmd *PrivateMetadata, key kbfscrypto.TLFCryptKey) (EncryptedPrivateMetadata, error) {
+func (_m *MockCrypto) EncryptPrivateMetadata(pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (EncryptedPrivateMetadata, error) {
 	ret := _m.ctrl.Call(_m, "EncryptPrivateMetadata", pmd, key)
 	ret0, _ := ret[0].(EncryptedPrivateMetadata)
 	ret1, _ := ret[1].(error)
@@ -2251,9 +2251,9 @@ func (_mr *_MockCryptoRecorder) EncryptPrivateMetadata(arg0, arg1 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EncryptPrivateMetadata", arg0, arg1)
 }
 
-func (_m *MockCrypto) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (*PrivateMetadata, error) {
+func (_m *MockCrypto) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (PrivateMetadata, error) {
 	ret := _m.ctrl.Call(_m, "DecryptPrivateMetadata", encryptedPMD, key)
-	ret0, _ := ret[0].(*PrivateMetadata)
+	ret0, _ := ret[0].(PrivateMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -803,6 +803,12 @@ func (irmd ImmutableRootMetadata) MdID() MdID {
 	return irmd.mdID
 }
 
+// LocalTimestamp returns the timestamp associated with this
+// RootMetadata object.
+func (irmd ImmutableRootMetadata) LocalTimestamp() time.Time {
+	return irmd.localTimestamp
+}
+
 // RootMetadataSigned is the top-level MD object stored in MD server
 type RootMetadataSigned struct {
 	// signature over the root metadata by the private signing key

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -231,7 +231,8 @@ func (teh *TlfEditHistory) updateRmds(rmds []ImmutableRootMetadata,
 
 func (teh *TlfEditHistory) calculateEditCounts(ctx context.Context,
 	rmds []ImmutableRootMetadata) (TlfWriterEdits, *crChains, error) {
-	chains, err := newCRChains(ctx, teh.config, rmds, &teh.fbo.blocks, false)
+	chains, err := newCRChainsForIRMDs(
+		ctx, teh.config, rmds, &teh.fbo.blocks, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -960,17 +960,13 @@ func (j *tlfJournal) batchConvertImmutables(ctx context.Context,
 	mdInfos := make([]unflushedPathMDInfo, 0, len(ibrmds))
 
 	for _, ibrmd := range ibrmds {
-		irmd, err := j.convertImmutableBareRMDToIRMD(ctx, ibrmd, handle)
+		mdInfo, err := j.convertImmutableBareRMDToMDInfo(
+			ctx, ibrmd, handle)
 		if err != nil {
 			return nil, err
 		}
 
-		mdInfos = append(mdInfos, unflushedPathMDInfo{
-			revision:       irmd.Revision(),
-			kmd:            irmd,
-			pmd:            *irmd.Data(),
-			localTimestamp: irmd.localTimestamp,
-		})
+		mdInfos = append(mdInfos, mdInfo)
 	}
 	return mdInfos, nil
 }
@@ -1279,6 +1275,21 @@ func (j *tlfJournal) convertImmutableBareRMDToIRMD(ctx context.Context,
 	}
 	irmd := MakeImmutableRootMetadata(rmd, ibrmd.mdID, ibrmd.localTimestamp)
 	return irmd, nil
+}
+
+func (j *tlfJournal) convertImmutableBareRMDToMDInfo(ctx context.Context,
+	ibrmd ImmutableBareRootMetadata, handle *TlfHandle) (
+	unflushedPathMDInfo, error) {
+	irmd, err := j.convertImmutableBareRMDToIRMD(ctx, ibrmd, handle)
+	if err != nil {
+		return unflushedPathMDInfo{}, err
+	}
+	return unflushedPathMDInfo{
+		revision:       irmd.Revision(),
+		kmd:            irmd,
+		pmd:            *irmd.Data(),
+		localTimestamp: irmd.localTimestamp,
+	}, nil
 }
 
 func (j *tlfJournal) getMDHead(

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1331,8 +1331,8 @@ func (j *tlfJournal) putMD(
 	ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	// Prepare the paths without holding the lock, as it might need to
-	// take the lock.  Note that the md ID and timestamp don't matter
-	// for the unflushed path cache.  This is a no-op if the unflushed
+	// take the lock.  Note that the timestamp doesn't matter for
+	// the unflushed path cache.  This is a no-op if the unflushed
 	// path cache is uninitialized.  TODO: avoid doing this if we can
 	// somehow be sure the cache won't be initialized by the time we
 	// finish this put.

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1028,11 +1028,6 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 			break
 		}
 
-		if len(ibrmds) == 0 {
-			// Nothing else to do.
-			return jStatus, nil
-		}
-
 		// We need to init it ourselves, or wait for someone else
 		// to do it.
 		doInit, err := j.unflushedPaths.startInitializeOrWait(ctx)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -902,7 +902,9 @@ func (j *tlfJournal) getJournalStatus() (TLFJournalStatus, error) {
 // non-nil unflushedPathsMap is returned, which can be used directly
 // to fill in UnflushedPaths, or a list of ImmutableBareRootMetadatas
 // is returned (along with a bool indicating whether that list is
-// complete), which can be used to build an unflushedPathsMap.
+// complete), which can be used to build an unflushedPathsMap. If
+// complete is true, then the list may be empty; otherwise, it is
+// guaranteed to not be empty.
 func (j *tlfJournal) getJournalStatusWithRange() (
 	jStatus TLFJournalStatus, unflushedPaths unflushedPathsMap,
 	ibrmds []ImmutableBareRootMetadata, complete bool, err error) {
@@ -1001,6 +1003,11 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 				return TLFJournalStatus{}, err
 			}
 			break
+		}
+
+		if len(ibrmds) == 0 {
+			// Nothing else to do.
+			return jStatus, nil
 		}
 
 		// We need to init it ourselves, or wait for someone else

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -154,7 +154,7 @@ func addUnflushedPaths(ctx context.Context,
 				"since it's already in the cache", mdInfo.revision)
 			continue
 		}
-		unflushedPaths[irmd.Revision()] = make(map[string]bool)
+		unflushedPaths[mdInfo.revision] = make(map[string]bool)
 
 		processedOne = true
 		err := chains.addOps(codec, mdInfo.pmd, winfo, mdInfo.localTimestamp)

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -129,6 +129,13 @@ func addUnflushedPaths(ctx context.Context,
 	chains := newCRChainsEmpty()
 	processedOne := false
 	for _, irmd := range irmds {
+		winfo := writerInfo{
+			uid:      uid,
+			kid:      kid,
+			revision: irmd.Revision(),
+			// There won't be any conflicts, so no need for the
+			// username/devicename.
+		}
 		if _, ok := unflushedPaths[irmd.Revision()]; ok {
 			if processedOne {
 				return fmt.Errorf("Couldn't skip revision %d after "+
@@ -142,13 +149,6 @@ func addUnflushedPaths(ctx context.Context,
 		unflushedPaths[irmd.Revision()] = make(map[string]bool)
 
 		processedOne = true
-		winfo := writerInfo{
-			uid:      uid,
-			kid:      kid,
-			revision: irmd.Revision(),
-			// There won't be any conflicts, so no need for the
-			// username/devicename.
-		}
 		err := chains.addOps(codec, irmd.data, winfo, irmd.localTimestamp)
 		if err != nil {
 			return err

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -34,7 +35,7 @@ type unflushedPathCache struct {
 	unflushedPaths  unflushedPathsMap
 	ready           chan struct{}
 	chainsPopulator chainsPathPopulator
-	appendQueue     []ImmutableRootMetadata
+	appendQueue     []unflushedPathMDInfo
 	removeQueue     []MetadataRevision
 }
 
@@ -118,38 +119,45 @@ func (upc *unflushedPathCache) abortInitialization() {
 	upc.ready = nil
 }
 
+type unflushedPathMDInfo struct {
+	revision       MetadataRevision
+	kmd            KeyMetadata
+	pmd            PrivateMetadata
+	localTimestamp time.Time
+}
+
 // addUnflushedPaths populates the given unflushed paths object.  The
 // caller should NOT be holding any locks, as it's possible that
 // blocks will need to be fetched.
 func addUnflushedPaths(ctx context.Context,
 	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
-	log logger.Logger, irmds []ImmutableRootMetadata, cpp chainsPathPopulator,
-	unflushedPaths unflushedPathsMap) error {
+	log logger.Logger, mdInfos []unflushedPathMDInfo,
+	cpp chainsPathPopulator, unflushedPaths unflushedPathsMap) error {
 	// Make chains over the entire range to get the unflushed files.
 	chains := newCRChainsEmpty()
 	processedOne := false
-	for _, irmd := range irmds {
+	for _, mdInfo := range mdInfos {
 		winfo := writerInfo{
 			uid:      uid,
 			kid:      kid,
-			revision: irmd.Revision(),
+			revision: mdInfo.revision,
 			// There won't be any conflicts, so no need for the
 			// username/devicename.
 		}
-		if _, ok := unflushedPaths[irmd.Revision()]; ok {
+		if _, ok := unflushedPaths[mdInfo.revision]; ok {
 			if processedOne {
 				return fmt.Errorf("Couldn't skip revision %d after "+
-					"already processing one", irmd.Revision())
+					"already processing one", mdInfo.revision)
 			}
 
 			log.CDebugf(ctx, "Skipping unflushed paths for revision %d "+
-				"since it's already in the cache", irmd.Revision())
+				"since it's already in the cache", mdInfo.revision)
 			continue
 		}
 		unflushedPaths[irmd.Revision()] = make(map[string]bool)
 
 		processedOne = true
-		err := chains.addOps(codec, irmd.data, winfo, irmd.localTimestamp)
+		err := chains.addOps(codec, mdInfo.pmd, winfo, mdInfo.localTimestamp)
 		if err != nil {
 			return err
 		}
@@ -158,7 +166,11 @@ func addUnflushedPaths(ctx context.Context,
 		return nil
 	}
 
-	chains.mostRecentMDInfo = crChainsMDInfoFromIRMD(irmds[len(irmds)-1])
+	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
+	chains.mostRecentMDInfo = crChainsMDInfo{
+		kmd:     mostRecentMDInfo.kmd,
+		rootPtr: mostRecentMDInfo.pmd.Dir.BlockPointer,
+	}
 
 	err := cpp.populateChainPaths(ctx, log, chains, true)
 	if err != nil {
@@ -182,7 +194,7 @@ func addUnflushedPaths(ctx context.Context,
 // given revision.
 func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
-	log logger.Logger, irmd ImmutableRootMetadata) (
+	log logger.Logger, mdInfo unflushedPathMDInfo) (
 	unflushedPathsPerRevMap, error) {
 	cpp := func() chainsPathPopulator {
 		upc.lock.Lock()
@@ -196,9 +208,9 @@ func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 	}
 
 	newUnflushedPaths := make(unflushedPathsMap)
-	irmds := []ImmutableRootMetadata{irmd}
+	mdInfos := []unflushedPathMDInfo{mdInfo}
 
-	err := addUnflushedPaths(ctx, uid, kid, codec, log, irmds, cpp,
+	err := addUnflushedPaths(ctx, uid, kid, codec, log, mdInfos, cpp,
 		newUnflushedPaths)
 	if err != nil {
 		return nil, err
@@ -208,10 +220,10 @@ func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 			len(newUnflushedPaths))
 	}
 
-	perRevMap, ok := newUnflushedPaths[irmd.Revision()]
+	perRevMap, ok := newUnflushedPaths[mdInfo.revision]
 	if !ok {
 		panic(fmt.Errorf("Cannot find per-revision map for revision %d",
-			irmd.Revision()))
+			mdInfo.revision))
 	}
 
 	return perRevMap, nil
@@ -219,7 +231,7 @@ func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 
 // appendToCache returns true when successful, and false if it needs
 // to be retried after the per-revision map is recomputed.
-func (upc *unflushedPathCache) appendToCache(irmd ImmutableRootMetadata,
+func (upc *unflushedPathCache) appendToCache(mdInfo unflushedPathMDInfo,
 	perRevMap unflushedPathsPerRevMap) bool {
 	upc.lock.Lock()
 	defer upc.lock.Unlock()
@@ -228,7 +240,7 @@ func (upc *unflushedPathCache) appendToCache(irmd ImmutableRootMetadata,
 		// Nothing to do.
 	case upcInitializing:
 		// Append to queue for processing at the end of initialization.
-		upc.appendQueue = append(upc.appendQueue, irmd)
+		upc.appendQueue = append(upc.appendQueue, mdInfo)
 	case upcInitialized:
 		if perRevMap == nil {
 			// This was prepared before `upc.chainsPopulator` was set,
@@ -236,7 +248,7 @@ func (upc *unflushedPathCache) appendToCache(irmd ImmutableRootMetadata,
 			return false
 		}
 		// Update the cache with the prepared paths.
-		upc.unflushedPaths[irmd.Revision()] = perRevMap
+		upc.unflushedPaths[mdInfo.revision] = perRevMap
 	default:
 		panic(fmt.Sprintf("Unknown unflushedPathsCache state: %v", upc.state))
 	}
@@ -260,7 +272,7 @@ func (upc *unflushedPathCache) removeFromCache(rev MetadataRevision) {
 }
 
 func (upc *unflushedPathCache) setCacheIfPossible(cache unflushedPathsMap,
-	cpp chainsPathPopulator) []ImmutableRootMetadata {
+	cpp chainsPathPopulator) []unflushedPathMDInfo {
 	upc.lock.Lock()
 	defer upc.lock.Unlock()
 	if len(upc.appendQueue) > 0 {
@@ -292,12 +304,12 @@ func (upc *unflushedPathCache) setCacheIfPossible(cache unflushedPathsMap,
 func (upc *unflushedPathCache) initialize(ctx context.Context,
 	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
 	log logger.Logger, cpp chainsPathPopulator,
-	irmds []ImmutableRootMetadata) (unflushedPathsMap, bool, error) {
+	mdInfos []unflushedPathMDInfo) (unflushedPathsMap, bool, error) {
 	// First get all the paths for the given range.  On the first try
 	unflushedPaths := make(unflushedPathsMap)
 	log.CDebugf(ctx, "Initializing unflushed path cache with %d revisions",
-		len(irmds))
-	err := addUnflushedPaths(ctx, uid, kid, codec, log, irmds, cpp,
+		len(mdInfos))
+	err := addUnflushedPaths(ctx, uid, kid, codec, log, mdInfos, cpp,
 		unflushedPaths)
 	if err != nil {
 		return nil, false, err

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -158,7 +158,7 @@ func addUnflushedPaths(ctx context.Context,
 		return nil
 	}
 
-	chains.mostRecentMD = irmds[len(irmds)-1]
+	chains.mostRecentMDInfo = crChainsMDInfoFromIRMD(irmds[len(irmds)-1])
 
 	err := cpp.populateChainPaths(ctx, log, chains, true)
 	if err != nil {

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -167,7 +167,7 @@ func addUnflushedPaths(ctx context.Context,
 	}
 
 	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
-	chains.mostRecentMDInfo = crChainsMDInfo{
+	chains.mostRecentCMDInfo = mostRecentChainMetadataInfo{
 		kmd:     mostRecentMDInfo.kmd,
 		rootPtr: mostRecentMDInfo.pmd.Dir.BlockPointer,
 	}

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -119,6 +119,8 @@ func (upc *unflushedPathCache) abortInitialization() {
 	upc.ready = nil
 }
 
+// unflushedPathMDInfo is the subset of metadata info needed by
+// unflushedPathCache.
 type unflushedPathMDInfo struct {
 	revision       MetadataRevision
 	kmd            KeyMetadata

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -169,7 +169,7 @@ func addUnflushedPaths(ctx context.Context,
 	}
 
 	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
-	chains.mostRecentCMDInfo = mostRecentChainMetadataInfo{
+	chains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
 		kmd:     mostRecentMDInfo.kmd,
 		rootPtr: mostRecentMDInfo.pmd.Dir.BlockPointer,
 	}


### PR DESCRIPTION
Define types with restricted interfaces instead.
This removes the need to create fake
IRMD objects to pass into crChains, and will
make a future PR easier.

Restrict some other interfaces also, in particular
in folderBlockOps, and remove
some spurious `md.ReadOnly()` calls.