### PR TITLE
Include filename in ReadAccessError

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -154,9 +154,10 @@ func (e ErrorFileAccessError) Error() string {
 // ReadAccessError indicates that the user tried to read from a
 // top-level folder without read permission.
 type ReadAccessError struct {
-	User   libkb.NormalizedUsername
-	Tlf    CanonicalTlfName
-	Public bool
+	User     libkb.NormalizedUsername
+	Filename string
+	Tlf      CanonicalTlfName
+	Public   bool
 }
 
 // Error implements the error interface for ReadAccessError
@@ -194,9 +195,14 @@ func (e WriteUnsupportedError) Error() string {
 
 // NewReadAccessError constructs a ReadAccessError for the given
 // directory and user.
-func NewReadAccessError(h *TlfHandle, username libkb.NormalizedUsername) error {
+func NewReadAccessError(h *TlfHandle, username libkb.NormalizedUsername, filename string) error {
 	tlfname := h.GetCanonicalName()
-	return ReadAccessError{username, tlfname, h.IsPublic()}
+	return ReadAccessError{
+		User:     username,
+		Filename: filename,
+		Tlf:      tlfname,
+		Public:   h.IsPublic(),
+	}
 }
 
 // NewWriteAccessError is an access error trying to write a file

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -953,7 +953,7 @@ func (fbo *folderBranchOps) getMDForReadHelper(
 			return ImmutableRootMetadata{}, err
 		}
 		if !md.GetTlfHandle().IsReader(uid) {
-			return ImmutableRootMetadata{}, NewReadAccessError(md.GetTlfHandle(), username)
+			return ImmutableRootMetadata{}, NewReadAccessError(md.GetTlfHandle(), username, md.GetTlfHandle().GetCanonicalPath())
 		}
 	}
 	return md, nil

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -729,7 +729,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 
 	// won't even try getting the block if the user isn't a reader
 	ops.head = MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
-	expectedErr := ReadAccessError{"alice", h.GetCanonicalName(), false}
+	expectedErr := NewReadAccessError(h, "alice", "/keybase/private/bob#alice")
 	if _, err := config.KBFSOps().GetDirChildren(ctx, n); err == nil {
 		t.Errorf("Got no expected error on getdir")
 	} else if err != expectedErr {

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -567,7 +567,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	if !isWriter && incKeyGen {
 		// Readers cannot create the first key generation
-		return false, nil, NewReadAccessError(resolvedHandle, username)
+		return false, nil, NewReadAccessError(resolvedHandle, username, resolvedHandle.GetCanonicalPath())
 	}
 
 	// All writer keys in the desired keyset

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -30,7 +30,7 @@ func makeRekeyReadErrorHelper(
 	// If the user is not a legitimate reader of the folder, this is a
 	// normal read access error.
 	if !resolvedHandle.IsReader(uid) {
-		return NewReadAccessError(resolvedHandle, username)
+		return NewReadAccessError(resolvedHandle, username, resolvedHandle.GetCanonicalPath())
 	}
 
 	// Otherwise, this folder needs to be rekeyed for this device.

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -102,6 +102,7 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 	case ReadAccessError:
 		code = keybase1.FSErrorType_ACCESS_DENIED
 		params[errorParamMode] = errorModeRead
+		filename = e.Filename
 	case WriteAccessError:
 		code = keybase1.FSErrorType_ACCESS_DENIED
 		params[errorParamUsername] = e.User.String()

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -602,7 +602,7 @@ func TestMakeRekeyReadError(t *testing.T) {
 	require.NoError(t, err)
 
 	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
-	require.Equal(t, NewReadAccessError(h, u), err)
+	require.Equal(t, NewReadAccessError(h, u, "/keybase/private/alice"), err)
 
 	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedSelfRekeyError{"alice"}, err)
@@ -628,7 +628,7 @@ func TestMakeRekeyReadErrorResolvedHandle(t *testing.T) {
 	require.NoError(t, err)
 
 	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
-	require.Equal(t, NewReadAccessError(h, u), err)
+	require.Equal(t, NewReadAccessError(h, u, "/keybase/private/alice,bob@twitter"), err)
 
 	config.KeybaseService().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
 		"bob", "bob@twitter")

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -958,7 +958,7 @@ func ParseTlfHandle(
 		}
 
 		if !h.IsReader(currentUID) {
-			return nil, ReadAccessError{currentUsername, h.GetCanonicalName(), public}
+			return nil, NewReadAccessError(h, currentUsername, h.GetCanonicalPath())
 		}
 	}
 

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -83,7 +83,7 @@ func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 	name := "u2,u3"
 	_, err := ParseTlfHandle(ctx, kbpki, name, false)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
-	assert.Equal(t, ReadAccessError{"u1", CanonicalTlfName(name), false}, err)
+	assert.Equal(t, ReadAccessError{User: "u1", Tlf: CanonicalTlfName(name), Public: false, Filename: "/keybase/private/u2,u3"}, err)
 }
 
 func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {


### PR DESCRIPTION
We show the path that failed to read in the notification. This includes it in the ReadAccessError.
