### PR TITLE
Revert "[KBFS-1614] Pull writer signatures out of MDV3"

### DIFF
--- a/kbfscrypto/signature.go
+++ b/kbfscrypto/signature.go
@@ -5,7 +5,6 @@
 package kbfscrypto
 
 import (
-	"bytes"
 	"encoding"
 	"encoding/hex"
 	"encoding/json"
@@ -42,21 +41,6 @@ type SignatureInfo struct {
 // IsNil returns true if this SignatureInfo is nil.
 func (s SignatureInfo) IsNil() bool {
 	return s.Version.IsNil() && len(s.Signature) == 0 && s.VerifyingKey.IsNil()
-}
-
-// Equals returns true if this SignatureInfo matches the given one.
-func (s SignatureInfo) Equals(other SignatureInfo) bool {
-	if s.Version != other.Version {
-		return false
-	}
-	if !bytes.Equal(s.Signature, other.Signature) {
-		return false
-	}
-	if s.VerifyingKey != other.VerifyingKey {
-		return false
-	}
-
-	return true
 }
 
 // DeepCopy makes a complete copy of this SignatureInfo.

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
-	"golang.org/x/net/context"
 )
 
 // WriterMetadataV2 stores the metadata for a TLF that is
@@ -267,8 +266,9 @@ func (md *BareRootMetadataV2) Update(id TlfID, h BareTlfHandle) error {
 	return nil
 }
 
-func (md *BareRootMetadataV2) deepCopy(
-	codec kbfscodec.Codec) (*BareRootMetadataV2, error) {
+// DeepCopy implements the BareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) DeepCopy(
+	codec kbfscodec.Codec) (BareRootMetadata, error) {
 	var newMd BareRootMetadataV2
 	if err := kbfscodec.Update(codec, &newMd, md); err != nil {
 		return nil, err
@@ -276,25 +276,11 @@ func (md *BareRootMetadataV2) deepCopy(
 	return &newMd, nil
 }
 
-// DeepCopy implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) DeepCopy(
-	codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
-	return md.deepCopy(codec)
-}
-
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) MakeSuccessorCopy(
-	codec kbfscodec.Codec, isReadableAndWriter bool) (
-	MutableBareRootMetadata, error) {
+	codec kbfscodec.Codec) (BareRootMetadata, error) {
 	// MDv3 TODO: Make a v3 successor.
-	mdCopy, err := md.deepCopy(codec)
-	if err != nil {
-		return nil, err
-	}
-	if isReadableAndWriter {
-		mdCopy.WriterMetadataSigInfo = kbfscrypto.SignatureInfo{}
-	}
-	return mdCopy, nil
+	return md.DeepCopy(codec)
 }
 
 // CheckValidSuccessor implements the BareRootMetadata interface for BareRootMetadataV2.
@@ -667,6 +653,11 @@ func (md *BareRootMetadataV2) LastModifyingWriter() keybase1.UID {
 	return md.WriterMetadataV2.LastModifyingWriter
 }
 
+// LastModifyingWriterKID implements the BareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) LastModifyingWriterKID() keybase1.KID {
+	return md.WriterMetadataSigInfo.VerifyingKey.KID()
+}
+
 // GetLastModifyingUser implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) GetLastModifyingUser() keybase1.UID {
 	return md.LastModifyingUser
@@ -778,20 +769,15 @@ func (md *BareRootMetadataV2) GetSerializedWriterMetadata(
 	return codec.Encode(md.WriterMetadataV2)
 }
 
-// SignWriterMetadataInternally implements the MutableBareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) SignWriterMetadataInternally(
-	ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
-	buf, err := codec.Encode(md.WriterMetadataV2)
-	if err != nil {
-		return err
-	}
+// GetWriterMetadataSigInfo implements the BareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
+	return md.WriterMetadataSigInfo
+}
 
-	sigInfo, err := signer.Sign(ctx, buf)
-	if err != nil {
-		return err
-	}
+// SetWriterMetadataSigInfo implements the MutableBareRootMetadata interface for BareRootMetadataV2.
+func (md *BareRootMetadataV2) SetWriterMetadataSigInfo(
+	sigInfo kbfscrypto.SignatureInfo) {
 	md.WriterMetadataSigInfo = sigInfo
-	return nil
 }
 
 // SetLastModifyingWriter implements the MutableBareRootMetadata interface for BareRootMetadataV2.
@@ -1052,4 +1038,14 @@ func (md *BareRootMetadataV2) GetHistoricTLFCryptKey(
 	kbfscrypto.TLFCryptKey, error) {
 	return kbfscrypto.TLFCryptKey{}, errors.New(
 		"TLF crypt key not symmetrically encrypted")
+}
+
+// BareRootMetadataSignedV2 is the MD that is signed by the reader or
+// writer including the signature info. Unlike RootMetadataSigned,
+// it contains exactly the serializable metadata and signature info.
+type BareRootMetadataSignedV2 struct {
+	// signature over the root metadata by the private signing key
+	SigInfo kbfscrypto.SignatureInfo `codec:",omitempty"`
+	// all the metadata
+	MD BareRootMetadataV2
 }

--- a/libkbfs/conflict_renamer.go
+++ b/libkbfs/conflict_renamer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -61,8 +60,7 @@ func splitExtension(path string) (string, string) {
 }
 
 func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID,
-	key kbfscrypto.VerifyingKey,
-	revision MetadataRevision) (writerInfo, error) {
+	kid keybase1.KID, revision MetadataRevision) (writerInfo, error) {
 	ui, err := cfg.KeybaseService().LoadUserPlusKeys(ctx, uid)
 	if err != nil {
 		return writerInfo{}, err
@@ -71,7 +69,8 @@ func newWriterInfo(ctx context.Context, cfg Config, uid keybase1.UID,
 	return writerInfo{
 		name:       ui.Name,
 		uid:        uid,
-		deviceName: ui.KIDNames[key.KID()],
+		kid:        kid,
+		deviceName: ui.KIDNames[kid],
 		revision:   revision,
 	}, nil
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -740,6 +740,7 @@ type TLFUpdateHistory struct {
 type writerInfo struct {
 	name       libkb.NormalizedUsername
 	uid        keybase1.UID
+	kid        keybase1.KID
 	deviceName string
 	revision   MetadataRevision
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -74,7 +74,7 @@ func (si *syncInfo) DeepCopy(codec kbfscodec.Codec) (*syncInfo, error) {
 		// It might be overkill to deep-copy these MDs and bpses,
 		// which are probably immutable, but for now let's do the safe
 		// thing.
-		copyMd, err := toClean.md.deepCopy(codec)
+		copyMd, err := toClean.md.deepCopy(codec, false)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -93,7 +93,7 @@ func (fbsk *folderBranchStatusKeeper) signalChangeLocked() {
 func (fbsk *folderBranchStatusKeeper) setRootMetadata(md ImmutableRootMetadata) {
 	fbsk.dataMutex.Lock()
 	defer fbsk.dataMutex.Unlock()
-	if fbsk.md.MdID() == md.MdID() {
+	if fbsk.md == md {
 		return
 	}
 	fbsk.md = md

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"golang.org/x/net/context"
@@ -115,9 +116,8 @@ func TestFBStatusAllFields(t *testing.T) {
 	p2 := path{path: []pathNode{{Name: "a2"}, {Name: "b2"}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
-	key := MakeFakeVerifyingKeyOrBust("fake key")
-	fbsk.setRootMetadata(
-		makeImmutableRootMetadataForTest(t, md, key, fakeMdID(1)))
+	fbsk.setRootMetadata(MakeImmutableRootMetadata(md, fakeMdID(1),
+		time.Now()))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1563,12 +1563,11 @@ type BareRootMetadata interface {
 	// IsReader returns whether or not the user+device is an authorized reader.
 	IsReader(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool
 	// DeepCopy returns a deep copy of the underlying data structure.
-	DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error)
+	DeepCopy(codec kbfscodec.Codec) (BareRootMetadata, error)
 	// MakeSuccessorCopy returns a newly constructed successor copy to this metadata revision.
 	// It differs from DeepCopy in that it can perform an up conversion to a new metadata
 	// version.
-	MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (
-		MutableBareRootMetadata, error)
+	MakeSuccessorCopy(codec kbfscodec.Codec) (BareRootMetadata, error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.
 	CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error
@@ -1618,6 +1617,8 @@ type BareRootMetadata interface {
 	IsLastModifiedBy(uid keybase1.UID, key kbfscrypto.VerifyingKey) error
 	// LastModifyingWriter return the UID of the last user to modify the writer metadata.
 	LastModifyingWriter() keybase1.UID
+	// LastModifyingWriterKID returns the KID of the last device to modify the writer metadata.
+	LastModifyingWriterKID() keybase1.KID
 	// LastModifyingUser return the UID of the last user to modify the any of the metadata.
 	GetLastModifyingUser() keybase1.UID
 	// RefBytes returns the number of newly referenced bytes introduced by this revision of metadata.
@@ -1638,6 +1639,8 @@ type BareRootMetadata interface {
 	GetSerializedPrivateMetadata() []byte
 	// GetSerializedWriterMetadata serializes the underlying writer metadata and returns the result.
 	GetSerializedWriterMetadata(codec kbfscodec.Codec) ([]byte, error)
+	// GetWriterMetadataSigInfo returns the signature info associated with the the writer metadata.
+	GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo
 	// Version returns the metadata version.
 	Version() MetadataVer
 	// GetTLFPublicKey returns the TLF public key for the give key generation.
@@ -1694,10 +1697,8 @@ type MutableBareRootMetadata interface {
 	SetPrevRoot(mdID MdID)
 	// SetSerializedPrivateMetadata sets the serialized private metadata.
 	SetSerializedPrivateMetadata(spmd []byte)
-	// SignWriterMetadataInternally signs the writer metadata, for
-	// versions that store this signature inside the metadata.
-	SignWriterMetadataInternally(ctx context.Context,
-		codec kbfscodec.Codec, signer cryptoSigner) error
+	// SetWriterMetadataSigInfo sets the signature info associated with the the writer metadata.
+	SetWriterMetadataSigInfo(sigInfo kbfscrypto.SignatureInfo)
 	// SetLastModifyingWriter sets the UID of the last user to modify the writer metadata.
 	SetLastModifyingWriter(user keybase1.UID)
 	// SetLastModifyingUser sets the UID of the last user to modify any of the metadata.

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/kbfs/kbfscrypto"
 
 	"golang.org/x/net/context"
 )
@@ -39,8 +38,7 @@ var _ MDOps = journalMDOps{}
 // convertImmutableBareRMDToIRMD decrypts the bare MD into a
 // full-fledged RMD.
 func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
-	ibrmd ImmutableBareRootMetadata, handle *TlfHandle,
-	uid keybase1.UID, key kbfscrypto.VerifyingKey) (
+	ibrmd ImmutableBareRootMetadata, handle *TlfHandle, uid keybase1.UID) (
 	ImmutableRootMetadata, error) {
 	// TODO: Avoid having to do this type assertion.
 	brmd, ok := ibrmd.BareRootMetadata.(MutableBareRootMetadata)
@@ -59,8 +57,7 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	}
 
 	rmd.data = pmd
-	irmd := MakeImmutableRootMetadata(
-		rmd, key, ibrmd.mdID, ibrmd.localTimestamp)
+	irmd := MakeImmutableRootMetadata(rmd, ibrmd.mdID, ibrmd.localTimestamp)
 	return irmd, nil
 }
 
@@ -128,7 +125,7 @@ func (j journalMDOps) getHeadFromJournal(
 	}
 
 	irmd, err := j.convertImmutableBareRMDToIRMD(
-		ctx, head, handle, tlfJournal.uid, tlfJournal.key)
+		ctx, head, handle, tlfJournal.uid)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -182,7 +179,7 @@ func (j journalMDOps) getRangeFromJournal(
 
 	for _, ibrmd := range ibrmds {
 		irmd, err := j.convertImmutableBareRMDToIRMD(
-			ctx, ibrmd, handle, tlfJournal.uid, tlfJournal.key)
+			ctx, ibrmd, handle, tlfJournal.uid)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/kbpki_util_test.go
+++ b/libkbfs/kbpki_util_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -29,16 +28,6 @@ func (d *daemonKBPKI) GetCurrentUserInfo(ctx context.Context) (
 		return libkb.NormalizedUsername(""), keybase1.UID(""), err
 	}
 	return session.Name, session.UID, nil
-}
-
-func (d *daemonKBPKI) GetCurrentVerifyingKey(ctx context.Context) (
-	kbfscrypto.VerifyingKey, error) {
-	const sessionID = 0
-	session, err := d.daemon.CurrentSession(ctx, sessionID)
-	if err != nil {
-		return kbfscrypto.VerifyingKey{}, err
-	}
-	return session.VerifyingKey, nil
 }
 
 func (d *daemonKBPKI) Resolve(ctx context.Context, assertion string) (

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -22,29 +22,16 @@ import (
 type shimCrypto struct {
 	Crypto
 	pure cryptoPure
-	key  kbfscrypto.SigningKey
 }
 
 func (c shimCrypto) MakeMdID(md BareRootMetadata) (MdID, error) {
 	return c.pure.MakeMdID(md)
 }
 
-func (c shimCrypto) Sign(
-	ctx context.Context, data []byte) (kbfscrypto.SignatureInfo, error) {
-	return c.key.Sign(data), nil
-}
-
-func (c shimCrypto) Verify(
-	msg []byte, sigInfo kbfscrypto.SignatureInfo) (err error) {
-	return kbfscrypto.Verify(msg, sigInfo)
-}
-
 func injectShimCrypto(config Config) {
-	signingKey := MakeFakeSigningKeyOrBust("test key")
 	crypto := shimCrypto{
 		config.Crypto(),
 		MakeCryptoCommon(kbfscodec.NewMsgpack()),
-		signingKey,
 	}
 	config.SetCrypto(crypto)
 }
@@ -56,7 +43,6 @@ func mdOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config = NewConfigMock(mockCtrl, ctr)
 	mdops := NewMDOpsStandard(config)
 	config.SetMDOps(mdops)
-	config.SetCodec(kbfscodec.NewMsgpack())
 	config.mockMdserv.EXPECT().OffsetFromServerTime().
 		Return(time.Duration(0), true).AnyTimes()
 	h1, _ := kbfshash.DefaultHash([]byte{1})
@@ -76,24 +62,20 @@ func mdOpsShutdown(mockCtrl *gomock.Controller, config *ConfigMock) {
 	mockCtrl.Finish()
 }
 
-func addFakeBRMDData(t *testing.T,
-	codec kbfscodec.Codec, crypto cryptoPure, brmd *BareRootMetadataV2,
-	h *TlfHandle) ExtraMetadata {
-	brmd.SetRevision(MetadataRevision(1))
-	pmd := PrivateMetadata{}
-	// TODO: Will have to change this for private folders if we
-	// un-mock out those tests.
-	buf, err := codec.Encode(pmd)
-	require.NoError(t, err)
-	brmd.SetSerializedPrivateMetadata(buf)
-	brmd.SetLastModifyingWriter(h.FirstResolvedWriter())
-	brmd.SetLastModifyingUser(h.FirstResolvedWriter())
-	var extra ExtraMetadata
+func addFakeRMDData(crypto cryptoPure, rmd *RootMetadata, h *TlfHandle) {
+	rmd.SetRevision(MetadataRevision(1))
+	rmd.SetLastModifyingWriter(h.FirstResolvedWriter())
+	rmd.SetLastModifyingUser(h.FirstResolvedWriter())
+	fakeVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
+	rmd.SetWriterMetadataSigInfo(kbfscrypto.SignatureInfo{
+		Version:      kbfscrypto.SigED25519,
+		Signature:    []byte{41},
+		VerifyingKey: fakeVerifyingKey,
+	})
+
 	if !h.IsPublic() {
-		extra, err = brmd.FakeInitialRekey(crypto, h.ToBareHandleOrBust())
-		require.NoError(t, err)
+		rmd.FakeInitialRekey(crypto, h.ToBareHandleOrBust())
 	}
-	return extra
 }
 
 func newRMD(t *testing.T, config Config, public bool) (
@@ -101,43 +83,64 @@ func newRMD(t *testing.T, config Config, public bool) (
 	id := FakeTlfID(1, public)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", public)
-	var brmd BareRootMetadataV2
-	err := brmd.Update(id, h.ToBareHandleOrBust())
+	rmd := NewRootMetadata()
+	err := rmd.Update(id, h.ToBareHandleOrBust())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	extra := addFakeBRMDData(t, config.Codec(), config.Crypto(), &brmd, h)
+	addFakeRMDData(config.Crypto(), rmd, h)
 
-	return &RootMetadata{
-		bareMd: &brmd,
-		extra:  extra,
-	}, h
+	return rmd, h
 }
 
-// TODO: Add test coverage for MDv3.
+func addFakeRMDSData(crypto cryptoPure, rmds *RootMetadataSigned, h *TlfHandle) ExtraMetadata {
+	rmds.MD.SetRevision(MetadataRevision(1))
+	rmds.MD.SetSerializedPrivateMetadata([]byte{1})
+	rmds.MD.SetLastModifyingWriter(h.FirstResolvedWriter())
+	rmds.MD.SetLastModifyingUser(h.FirstResolvedWriter())
+	fakeVerifyingKey := MakeFakeVerifyingKeyOrBust("fake key")
+	rmds.MD.SetWriterMetadataSigInfo(kbfscrypto.SignatureInfo{
+		Version:      kbfscrypto.SigED25519,
+		Signature:    []byte{41},
+		VerifyingKey: fakeVerifyingKey,
+	})
+	rmds.SigInfo = kbfscrypto.SignatureInfo{
+		Version:      kbfscrypto.SigED25519,
+		Signature:    []byte{42},
+		VerifyingKey: fakeVerifyingKey,
+	}
+	rmds.untrustedServerTimestamp = time.Now()
 
-func newRMDS(t *testing.T, config Config, h *TlfHandle) (
-	*RootMetadataSigned, ExtraMetadata) {
-	id := FakeTlfID(1, h.IsPublic())
+	var extra ExtraMetadata
+	if !h.IsPublic() {
+		extra, _ = rmds.MD.FakeInitialRekey(crypto, h.ToBareHandleOrBust())
+	}
+	return extra
+}
 
-	var brmd BareRootMetadataV2
-	err := brmd.Update(id, h.ToBareHandleOrBust())
-	require.NoError(t, err)
-	extra := addFakeBRMDData(t, config.Codec(), config.Crypto(), &brmd, h)
-	ctx := context.Background()
+func newRMDS(t *testing.T, config Config, public bool) (
+	*RootMetadataSigned, *TlfHandle, ExtraMetadata) {
+	id := FakeTlfID(1, public)
 
-	// Encode and sign writer metadata.
-	err = brmd.SignWriterMetadataInternally(ctx, config.Codec(), config.Crypto())
-	require.NoError(t, err)
+	h := parseTlfHandleOrBust(t, config, "alice,bob", public)
+	rmds := NewRootMetadataSigned()
+	err := rmds.MD.Update(id, h.ToBareHandleOrBust())
+	if err != nil {
+		t.Fatal(err)
+	}
+	extra := addFakeRMDSData(config.Crypto(), rmds, h)
 
-	rmds, err := signMD(ctx, config.Codec(), config.Crypto(), &brmd, (wallClock{}).Now())
-	require.NoError(t, err)
-	return rmds, extra
+	return rmds, h, extra
 }
 
 func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	verifyErr, hasVerifyingKeyErr error) {
+	packedData := []byte{4, 3, 2, 1}
+	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(packedData, nil).AnyTimes()
+
+	config.mockCrypto.EXPECT().Verify(packedData, rmds.MD.GetWriterMetadataSigInfo()).Return(nil)
+	config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).Return(verifyErr)
 	if verifyErr != nil {
 		return
 	}
@@ -147,18 +150,23 @@ func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	if hasVerifyingKeyErr != nil {
 		return
 	}
+
+	config.mockCodec.EXPECT().Decode(
+		rmds.MD.GetSerializedPrivateMetadata(), gomock.Any()).Return(nil)
 }
 
 func verifyMDForPrivateHelper(
-	config *ConfigMock, rmds *RootMetadataSigned, minTimes, maxTimes int) {
-	mdCopy, err := rmds.MD.DeepCopy(config.Codec())
-	if err != nil {
-		panic(err)
-	}
-	fakeRMD := RootMetadata{
-		bareMd: mdCopy,
-	}
-	expectGetTLFCryptKeyForMDDecryptionAtMostOnce(config, &fakeRMD)
+	config *ConfigMock, rmds *RootMetadataSigned, h *TlfHandle,
+	minTimes int, maxTimes int) {
+	packedData := []byte{4, 3, 2, 1}
+	config.mockCodec.EXPECT().Encode(gomock.Any()).
+		Return(packedData, nil).AnyTimes()
+
+	config.mockCodec.EXPECT().
+		Decode(rmds.MD.GetSerializedPrivateMetadata(), gomock.Any()).
+		MinTimes(minTimes).MaxTimes(maxTimes).Return(nil)
+	fakeRMD := MakeRootMetadata(rmds.MD, nil, h)
+	expectGetTLFCryptKeyForMDDecryptionAtMostOnce(config, fakeRMD)
 	var pmd PrivateMetadata
 	config.mockCrypto.EXPECT().DecryptPrivateMetadata(
 		gomock.Any(), kbfscrypto.TLFCryptKey{}).
@@ -167,21 +175,23 @@ func verifyMDForPrivateHelper(
 	if rmds.MD.IsFinal() {
 		config.mockKbpki.EXPECT().HasUnverifiedVerifyingKey(gomock.Any(), gomock.Any(),
 			gomock.Any()).AnyTimes().Return(nil)
+		config.mockCodec.EXPECT().
+			Decode(gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	} else {
 		config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	}
 
-	config.mockCrypto.EXPECT().Verify(gomock.Any(), rmds.SigInfo).
+	config.mockCrypto.EXPECT().Verify(packedData, rmds.SigInfo).
 		MinTimes(minTimes).MaxTimes(maxTimes).Return(nil)
 	config.mockCrypto.EXPECT().
-		Verify(gomock.Any(), rmds.GetWriterMetadataSigInfo()).
+		Verify(packedData, rmds.MD.GetWriterMetadataSigInfo()).
 		MinTimes(minTimes).MaxTimes(maxTimes).Return(nil)
 }
 
 func verifyMDForPrivate(
-	config *ConfigMock, rmds *RootMetadataSigned) {
-	verifyMDForPrivateHelper(config, rmds, 1, 1)
+	config *ConfigMock, rmds *RootMetadataSigned, h *TlfHandle) {
+	verifyMDForPrivateHelper(config, rmds, h, 1, 1)
 }
 
 func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
@@ -189,6 +199,9 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
 		rmd.data, kbfscrypto.TLFCryptKey{}).Return(
 		EncryptedPrivateMetadata{}, nil)
+	config.mockCrypto.EXPECT().Sign(
+		gomock.Any(), gomock.Any()).Times(2).Return(
+		kbfscrypto.SignatureInfo{}, nil)
 	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
 		Return(true)
 	config.mockMdserv.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
@@ -198,18 +211,15 @@ func TestMDOpsGetForHandlePublicSuccess(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
-	rmds, _ := newRMDS(t, config, h)
+	rmds, h, _ := newRMDS(t, config, true)
 
 	verifyMDForPublic(config, rmds, nil, nil)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 
-	// Do this first, since rmds is consumed.
-	expectedMD := rmds.MD
 	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
-	require.Equal(t, expectedMD, rmd2.bareMd)
+	require.Equal(t, rmds.MD, rmd2.bareMd)
 }
 
 func expectGetKeyBundles(ctx context.Context, config *ConfigMock, extra ExtraMetadata) {
@@ -224,27 +234,23 @@ func TestMDOpsGetForHandlePrivateSuccess(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
-	rmds, extra := newRMDS(t, config, h)
+	rmds, h, extra := newRMDS(t, config, false)
 
-	verifyMDForPrivate(config, rmds)
+	verifyMDForPrivate(config, rmds, h)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
-	// Do this first, since rmds is consumed.
-	expectedMD := rmds.MD
 	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
-	require.Equal(t, expectedMD, rmd2.bareMd)
+	require.Equal(t, rmds.MD, rmd2.bareMd)
 }
 
 func TestMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
-	rmds, _ := newRMDS(t, config, h)
+	rmds, _, _ := newRMDS(t, config, true)
 
 	// Do this before setting tlfHandle to nil.
 	verifyMDForPublic(config, rmds, nil, nil)
@@ -276,6 +282,8 @@ func TestMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
+	id := FakeTlfID(1, true)
+
 	mdHandle1, err := ParseTlfHandle(ctx, config.KBPKI(),
 		"alice,dave@twitter", true)
 	require.NoError(t, err)
@@ -288,11 +296,20 @@ func TestMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T) {
 		"alice,bob@twitter,charlie@twitter", true)
 	require.NoError(t, err)
 
-	rmds1, _ := newRMDS(t, config, mdHandle1)
+	rmds1 := NewRootMetadataSigned()
+	err = rmds1.MD.Update(id, mdHandle1.ToBareHandleOrBust())
+	require.NoError(t, err)
+	addFakeRMDSData(config.Crypto(), rmds1, mdHandle1)
 
-	rmds2, _ := newRMDS(t, config, mdHandle2)
+	rmds2 := NewRootMetadataSigned()
+	err = rmds2.MD.Update(id, mdHandle2.ToBareHandleOrBust())
+	require.NoError(t, err)
+	addFakeRMDSData(config.Crypto(), rmds2, mdHandle2)
 
-	rmds3, _ := newRMDS(t, config, mdHandle3)
+	rmds3 := NewRootMetadataSigned()
+	err = rmds3.MD.Update(id, mdHandle3.ToBareHandleOrBust())
+	require.NoError(t, err)
+	addFakeRMDSData(config.Crypto(), rmds3, mdHandle3)
 
 	// Do this before setting tlfHandles to nil.
 	verifyMDForPublic(config, rmds2, nil, nil)
@@ -334,8 +351,7 @@ func TestMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
-	rmds, _ := newRMDS(t, config, h)
+	rmds, _, _ := newRMDS(t, config, true)
 
 	hUnresolved, err := ParseTlfHandle(ctx, config.KBPKI(),
 		"alice,bob@github,bob@twitter", true)
@@ -359,8 +375,7 @@ func TestMDOpsGetForHandlePublicFailFindKey(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
-	rmds, _ := newRMDS(t, config, h)
+	rmds, h, _ := newRMDS(t, config, true)
 
 	// Do this before setting tlfHandle to nil.
 	verifyMDForPublic(config, rmds, nil, KeyNotFoundError{})
@@ -373,27 +388,15 @@ func TestMDOpsGetForHandlePublicFailFindKey(t *testing.T) {
 	}
 }
 
-type failVerifyCrypto struct {
-	Crypto
-	err error
-}
-
-func (c failVerifyCrypto) Verify(msg []byte, sigInfo kbfscrypto.SignatureInfo) error {
-	return c.err
-}
-
 func TestMDOpsGetForHandlePublicFailVerify(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
-	rmds, _ := newRMDS(t, config, h)
+	rmds, h, _ := newRMDS(t, config, true)
 
 	// Do this before setting tlfHandle to nil.
 	expectedErr := libkb.VerificationError{}
 	verifyMDForPublic(config, rmds, expectedErr, nil)
-
-	config.SetCrypto(failVerifyCrypto{config.Crypto(), expectedErr})
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(NullTlfID, rmds, nil)
 
@@ -421,8 +424,7 @@ func TestMDOpsGetForHandleFailHandleCheck(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
-	rmds, extra := newRMDS(t, config, h)
+	rmds, _, extra := newRMDS(t, config, false)
 
 	// Make a different handle.
 	otherH := parseTlfHandleOrBust(t, config, "alice", false)
@@ -439,28 +441,24 @@ func TestMDOpsGetSuccess(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
-	rmds, extra := newRMDS(t, config, h)
+	rmds, h, extra := newRMDS(t, config, false)
 
 	// Do this before setting tlfHandle to nil.
-	verifyMDForPrivate(config, rmds)
+	verifyMDForPrivate(config, rmds, h)
 
 	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), NullBranchID, Merged).Return(rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
-	// Do this first, since rmds is consumed.
-	expectedMD := rmds.MD
 	rmd2, err := config.MDOps().GetForTLF(ctx, rmds.MD.TlfID())
 	require.NoError(t, err)
-	require.Equal(t, expectedMD, rmd2.bareMd)
+	require.Equal(t, rmds.MD, rmd2.bareMd)
 }
 
 func TestMDOpsGetBlankSigFailure(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
-	rmds, extra := newRMDS(t, config, h)
+	rmds, _, extra := newRMDS(t, config, false)
 	rmds.SigInfo = kbfscrypto.SignatureInfo{}
 
 	// only the get happens, no verify needed with a blank sig
@@ -491,8 +489,7 @@ func TestMDOpsGetFailIdCheck(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
-	rmds, extra := newRMDS(t, config, h)
+	rmds, _, extra := newRMDS(t, config, false)
 
 	id2 := FakeTlfID(2, true)
 
@@ -508,39 +505,28 @@ func TestMDOpsGetFailIdCheck(t *testing.T) {
 
 func makeRMDSRange(t *testing.T, config Config,
 	start MetadataRevision, count int, prevID MdID) (
-	rmdses []*RootMetadataSigned, extras []ExtraMetadata) {
-	id := FakeTlfID(1, false)
-	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
+	rmdses []*RootMetadataSigned, h *TlfHandle, extras []ExtraMetadata) {
 	for i := 0; i < count; i++ {
-		var brmd BareRootMetadataV2
-		err := brmd.Update(id, h.ToBareHandleOrBust())
-		require.NoError(t, err)
-		extra := addFakeBRMDData(t, config.Codec(), config.Crypto(), &brmd, h)
-		brmd.SetPrevRoot(prevID)
-		brmd.SetRevision(start + MetadataRevision(i))
-
-		ctx := context.Background()
-
-		// Encode and sign writer metadata.
-		err = brmd.SignWriterMetadataInternally(ctx, config.Codec(), config.Crypto())
-		require.NoError(t, err)
-
-		rmds, err := signMD(ctx, config.Codec(), config.Crypto(), &brmd, (wallClock{}).Now())
-		require.NoError(t, err)
+		rmds, rmdsH, extra := newRMDS(t, config, false)
+		if h == nil {
+			h = rmdsH
+		}
+		rmds.MD.SetPrevRoot(prevID)
+		rmds.MD.SetRevision(start + MetadataRevision(i))
 		currID, err := config.Crypto().MakeMdID(rmds.MD)
 		require.NoError(t, err)
 		prevID = currID
 		rmdses = append(rmdses, rmds)
 		extras = append(extras, extra)
 	}
-	return rmdses, extras
+	return rmdses, h, extras
 }
 
 func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	rmdses, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
+	rmdses, h, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
 
 	start := MetadataRevision(100)
 	stop := start + MetadataRevision(len(rmdses))
@@ -549,7 +535,7 @@ func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
 	}
 
 	for _, rmds := range rmdses {
-		verifyMDForPrivate(config, rmds)
+		verifyMDForPrivate(config, rmds, h)
 	}
 
 	config.mockMdserv.EXPECT().GetRange(ctx, rmdses[0].MD.TlfID(), NullBranchID, Merged, start,
@@ -558,16 +544,11 @@ func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
 		expectGetKeyBundles(ctx, config, e)
 	}
 
-	// Do this first since rmdses is consumed.
-	expectedMDs := make([]BareRootMetadata, len(rmdses))
-	for i, rmds := range rmdses {
-		expectedMDs[i] = rmds.MD
-	}
 	rmds, err := config.MDOps().GetRange(ctx, rmdses[0].MD.TlfID(), start, stop)
 	require.NoError(t, err)
 	require.Equal(t, len(rmdses), len(rmds))
 	for i := 0; i < len(rmdses); i++ {
-		require.Equal(t, expectedMDs[i], rmds[i].bareMd)
+		require.Equal(t, rmdses[i].MD, rmds[i].bareMd)
 	}
 }
 
@@ -583,9 +564,9 @@ func TestMDOpsGetRangeFailBadPrevRoot(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	rmdses, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
+	rmdses, h, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
 
-	rmdses[2].MD.(MutableBareRootMetadata).SetPrevRoot(fakeMdID(1))
+	rmdses[2].MD.SetPrevRoot(fakeMdID(1))
 
 	start := MetadataRevision(100)
 	stop := start + MetadataRevision(len(rmdses))
@@ -593,7 +574,7 @@ func TestMDOpsGetRangeFailBadPrevRoot(t *testing.T) {
 	// Verification is parallelized, so we have to expect at most one
 	// verification for each rmds.
 	for _, rmds := range rmdses {
-		verifyMDForPrivateHelper(config, rmds, 0, 1)
+		verifyMDForPrivateHelper(config, rmds, h, 0, 1)
 	}
 
 	config.mockMdserv.EXPECT().GetRange(ctx, rmdses[0].MD.TlfID(), NullBranchID, Merged, start,
@@ -643,7 +624,7 @@ func validatePutPublicRMDS(
 	// Verify signature of WriterMetadata.
 	buf, err := rmds.MD.GetSerializedWriterMetadata(config.Codec())
 	require.NoError(t, err)
-	err = config.Crypto().Verify(buf, rmds.GetWriterMetadataSigInfo())
+	err = config.Crypto().Verify(buf, rmds.MD.GetWriterMetadataSigInfo())
 	require.NoError(t, err)
 
 	// Verify encoded PrivateMetadata.
@@ -665,7 +646,7 @@ func validatePutPublicRMDS(
 	// Overwrite written fields.
 	expectedRmd.SetLastModifyingWriter(rmds.MD.LastModifyingWriter())
 	expectedRmd.SetLastModifyingUser(rmds.MD.GetLastModifyingUser())
-	expectedRmd.WriterMetadataSigInfo = rmds.MD.(*BareRootMetadataV2).WriterMetadataSigInfo
+	expectedRmd.SetWriterMetadataSigInfo(rmds.MD.GetWriterMetadataSigInfo())
 	expectedRmd.SetSerializedPrivateMetadata(rmds.MD.GetSerializedPrivateMetadata())
 
 	require.Equal(t, &expectedRmd, rmds.MD)
@@ -709,15 +690,6 @@ func TestMDOpsPutPrivateSuccess(t *testing.T) {
 	}
 }
 
-type failEncodeCodec struct {
-	kbfscodec.Codec
-	err error
-}
-
-func (c failEncodeCodec) Encode(obj interface{}) ([]byte, error) {
-	return nil, c.err
-}
-
 func TestMDOpsPutFailEncode(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
@@ -734,7 +706,7 @@ func TestMDOpsPutFailEncode(t *testing.T) {
 		Return(true)
 
 	err := errors.New("Fake fail")
-	config.SetCodec(failEncodeCodec{config.Codec(), err})
+	config.mockCodec.EXPECT().Encode(gomock.Any()).Return(nil, err)
 
 	if _, err2 := config.MDOps().Put(ctx, rmd); err2 != err {
 		t.Errorf("Got bad error on put: %v", err2)
@@ -745,9 +717,9 @@ func TestMDOpsGetRangeFailFinal(t *testing.T) {
 	mockCtrl, config, ctx := mdOpsInit(t)
 	defer mdOpsShutdown(mockCtrl, config)
 
-	rmdses, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
-	rmdses[2].MD.(MutableBareRootMetadata).SetFinalBit()
-	rmdses[2].MD.(MutableBareRootMetadata).SetPrevRoot(rmdses[1].MD.GetPrevRoot())
+	rmdses, h, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
+	rmdses[2].MD.SetFinalBit()
+	rmdses[2].MD.SetPrevRoot(rmdses[1].MD.GetPrevRoot())
 
 	start := MetadataRevision(100)
 	stop := start + MetadataRevision(len(rmdses))
@@ -755,7 +727,7 @@ func TestMDOpsGetRangeFailFinal(t *testing.T) {
 	// Verification is parallelized, so we have to expect at most one
 	// verification for each rmds.
 	for _, rmds := range rmdses {
-		verifyMDForPrivateHelper(config, rmds, 0, 1)
+		verifyMDForPrivateHelper(config, rmds, h, 0, 1)
 	}
 
 	config.mockMdserv.EXPECT().GetRange(

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -5,15 +5,12 @@
 package libkbfs
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
-	"github.com/keybase/kbfs/kbfscrypto"
-	"github.com/stretchr/testify/require"
 )
 
 func mdCacheInit(t *testing.T, cap int) (
@@ -34,20 +31,12 @@ func mdCacheShutdown(mockCtrl *gomock.Controller, config *ConfigMock) {
 
 func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	mStatus MergeStatus, bid BranchID, h *TlfHandle, config *ConfigMock) {
-	key, err := config.KBPKI().GetCurrentVerifyingKey(context.Background())
-	if err != nil {
-		t.Fatalf("Couldn't get verifying key: %v", err)
-	}
-
 	rmd := MakeRootMetadata(
 		&BareRootMetadataV2{
 			WriterMetadataV2: WriterMetadataV2{
 				ID:    tlf,
 				WKeys: make(TLFWriterKeyGenerations, 0, 1),
 				BID:   bid,
-			},
-			WriterMetadataSigInfo: kbfscrypto.SignatureInfo{
-				VerifyingKey: key,
 			},
 			Revision: rev,
 			RKeys:    make(TLFReaderKeyGenerations, 1, 1),
@@ -59,15 +48,17 @@ func testMdcachePut(t *testing.T, tlf TlfID, rev MetadataRevision,
 	}
 
 	// put the md
-	irmd := MakeImmutableRootMetadata(rmd, key, fakeMdID(1), time.Now())
+	irmd := MakeImmutableRootMetadata(rmd, fakeMdID(1), time.Now())
 	if err := config.MDCache().Put(irmd); err != nil {
 		t.Errorf("Got error on put on md %v: %v", tlf, err)
 	}
 
 	// make sure we can get it successfully
-	irmd2, err := config.MDCache().Get(tlf, rev, bid)
-	require.NoError(t, err)
-	require.Equal(t, irmd, irmd2)
+	if irmd2, err := config.MDCache().Get(tlf, rev, bid); err != nil {
+		t.Errorf("Got error on get for md %v: %v", tlf, err)
+	} else if irmd2 != irmd {
+		t.Errorf("Got back unexpected metadata: %v", irmd2)
+	}
 }
 
 func TestMdcachePut(t *testing.T) {
@@ -126,14 +117,14 @@ func TestMdcacheReplace(t *testing.T) {
 
 	// Change the BID
 	bid := FakeBranchID(1)
-	newRmd, err := irmd.deepCopy(kbfscodec.NewMsgpack())
+	newRmd, err := irmd.deepCopy(kbfscodec.NewMsgpack(), false)
 	if err != nil {
 		t.Fatalf("Deep-copy error: %v", err)
 	}
 
 	newRmd.SetBranchID(bid)
 	err = config.MDCache().Replace(MakeImmutableRootMetadata(newRmd,
-		irmd.LastModifyingWriterVerifyingKey(), fakeMdID(2), time.Now()), NullBranchID)
+		fakeMdID(2), time.Now()), NullBranchID)
 	if err != nil {
 		t.Fatalf("Replace error: %v", err)
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -135,8 +135,8 @@ func (md *MDServerDisk) getStorage(tlfID TlfID) (*mdServerTlfStorage, error) {
 
 	path := filepath.Join(md.dirPath, tlfID.String())
 	storage = makeMDServerTlfStorage(
-		tlfID, md.config.Codec(), md.config.cryptoPure(),
-		md.config.Clock(), md.config.MetadataVersion(), path)
+		md.config.Codec(), md.config.cryptoPure(),
+		md.config.Clock(), tlfID, md.config.MetadataVersion(), path)
 
 	md.tlfStorage[tlfID] = storage
 	return storage, nil

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -251,12 +251,11 @@ func (md *MDServerMemory) getHeadForTLF(ctx context.Context, id TlfID,
 	max := md.config.MetadataVersion()
 	ver := blocks[len(blocks)-1].version
 	buf := blocks[len(blocks)-1].encodedMd
-	timestamp := blocks[len(blocks)-1].timestamp
-	rmds, err := DecodeRootMetadataSigned(
-		md.config.Codec(), id, ver, max, buf, timestamp)
+	rmds, err := DecodeRootMetadataSigned(md.config.Codec(), id, ver, max, buf)
 	if err != nil {
 		return nil, err
 	}
+	rmds.untrustedServerTimestamp = blocks[len(blocks)-1].timestamp
 	return rmds, nil
 }
 
@@ -333,12 +332,11 @@ func (md *MDServerMemory) GetRange(ctx context.Context, id TlfID,
 	for i := startI; i < endI; i++ {
 		ver := blocks[i].version
 		buf := blocks[i].encodedMd
-		rmds, err := DecodeRootMetadataSigned(
-			md.config.Codec(), id, ver, max, buf,
-			blocks[i].timestamp)
+		rmds, err := DecodeRootMetadataSigned(md.config.Codec(), id, ver, max, buf)
 		if err != nil {
 			return nil, MDServerError{err}
 		}
+		rmds.untrustedServerTimestamp = blocks[i].timestamp
 		expectedRevision := blockList.initialRevision + MetadataRevision(i)
 		if expectedRevision != rmds.MD.RevisionNumber() {
 			panic(fmt.Errorf("expected revision %v, got %v",

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -424,12 +424,11 @@ func (md *MDServerRemote) get(ctx context.Context, id TlfID,
 	rmdses := make([]*RootMetadataSigned, len(response.MdBlocks))
 	for i, block := range response.MdBlocks {
 		ver, max := MetadataVer(block.Version), md.config.MetadataVersion()
-		rmds, err := DecodeRootMetadataSigned(
-			md.config.Codec(), id, ver, max, block.Block,
-			keybase1.FromTime(block.Timestamp))
+		rmds, err := DecodeRootMetadataSigned(md.config.Codec(), id, ver, max, block.Block)
 		if err != nil {
 			return id, nil, err
 		}
+		rmds.untrustedServerTimestamp = keybase1.FromTime(block.Timestamp)
 		rmdses[i] = rmds
 	}
 	return id, rmdses, nil

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -60,10 +60,10 @@ import (
 // separately in dir/wkbv3 (dir/rkbv3). The number of bundles is
 // small, so no need to splay them.
 type mdServerTlfStorage struct {
-	tlfID  TlfID
 	codec  kbfscodec.Codec
 	crypto cryptoPure
 	clock  Clock
+	tlfID  TlfID
 	mdVer  MetadataVer
 	dir    string
 
@@ -73,14 +73,14 @@ type mdServerTlfStorage struct {
 	branchJournals map[BranchID]mdIDJournal
 }
 
-func makeMDServerTlfStorage(tlfID TlfID, codec kbfscodec.Codec,
-	crypto cryptoPure, clock Clock, mdVer MetadataVer,
-	dir string) *mdServerTlfStorage {
+func makeMDServerTlfStorage(codec kbfscodec.Codec,
+	crypto cryptoPure, clock Clock, tlfID TlfID,
+	mdVer MetadataVer, dir string) *mdServerTlfStorage {
 	journal := &mdServerTlfStorage{
-		tlfID:          tlfID,
 		codec:          codec,
 		crypto:         crypto,
 		clock:          clock,
+		tlfID:          tlfID,
 		mdVer:          mdVer,
 		dir:            dir,
 		branchJournals: make(map[BranchID]mdIDJournal),
@@ -135,11 +135,13 @@ func (s *mdServerTlfStorage) getMDReadLocked(id MdID) (
 	}
 
 	rmds, err := DecodeRootMetadataSigned(
-		s.codec, s.tlfID, srmds.Version, s.mdVer, srmds.EncodedRMDS,
-		srmds.Timestamp)
+		s.codec, s.tlfID, srmds.Version, s.mdVer,
+		srmds.EncodedRMDS)
 	if err != nil {
 		return nil, err
 	}
+
+	rmds.untrustedServerTimestamp = srmds.Timestamp
 
 	// Check integrity.
 

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -38,7 +38,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	}()
 
 	tlfID := FakeTlfID(1, false)
-	s := makeMDServerTlfStorage(tlfID, codec, crypto, wallClock{},
+	s := makeMDServerTlfStorage(codec, crypto, wallClock{}, tlfID,
 		SegregatedKeyBundlesVer, tempdir)
 	defer s.shutdown()
 
@@ -61,8 +61,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot := MdID{}
 	middleRoot := MdID{}
 	for i := MetadataRevision(1); i <= 10; i++ {
-		brmd := makeBRMDForTest(t, crypto, tlfID, h, i, uid, prevRoot)
-		rmds := signRMDSForTest(t, codec, signer, brmd)
+		rmds := makeRMDSForTest(t, crypto, tlfID, h, i, uid, prevRoot)
+		signRMDSForTest(t, codec, signer, rmds)
 		// MDv3 TODO: pass extra metadata
 		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
 		require.NoError(t, err)
@@ -78,8 +78,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 
 	// (3) Trigger a conflict.
 
-	brmd := makeBRMDForTest(t, crypto, tlfID, h, 10, uid, prevRoot)
-	rmds := signRMDSForTest(t, codec, signer, brmd)
+	rmds := makeRMDSForTest(t, crypto, tlfID, h, 10, uid, prevRoot)
+	signRMDSForTest(t, codec, signer, rmds)
 	// MDv3 TODO: pass extra metadata
 	_, err = s.put(uid, verifyingKey, rmds, nil)
 	require.IsType(t, MDServerErrorConflictRevision{}, err)
@@ -92,10 +92,10 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	prevRoot = middleRoot
 	bid := FakeBranchID(1)
 	for i := MetadataRevision(6); i < 41; i++ {
-		brmd := makeBRMDForTest(t, crypto, tlfID, h, i, uid, prevRoot)
-		brmd.SetUnmerged()
-		brmd.SetBranchID(bid)
-		rmds := signRMDSForTest(t, codec, signer, brmd)
+		rmds := makeRMDSForTest(t, crypto, tlfID, h, i, uid, prevRoot)
+		rmds.MD.SetUnmerged()
+		rmds.MD.SetBranchID(bid)
+		signRMDSForTest(t, codec, signer, rmds)
 		// MDv3 TODO: pass extra metadata
 		recordBranchID, err := s.put(uid, verifyingKey, rmds, nil)
 		require.NoError(t, err)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4560,9 +4560,9 @@ func (_mr *_MockBareRootMetadataRecorder) IsReader(arg0, arg1, arg2 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1, arg2)
 }
 
-func (_m *MockBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
+func (_m *MockBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
 	ret := _m.ctrl.Call(_m, "DeepCopy", codec)
-	ret0, _ := ret[0].(MutableBareRootMetadata)
+	ret0, _ := ret[0].(BareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4571,15 +4571,15 @@ func (_mr *_MockBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
 }
 
-func (_m *MockBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (MutableBareRootMetadata, error) {
-	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec, isReadableAndWriter)
-	ret0, _ := ret[0].(MutableBareRootMetadata)
+func (_m *MockBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec)
+	ret0, _ := ret[0].(BareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) MakeSuccessorCopy(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) MakeSuccessorCopy(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0)
 }
 
 func (_m *MockBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
@@ -4688,6 +4688,16 @@ func (_mr *_MockBareRootMetadataRecorder) LastModifyingWriter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriter")
 }
 
+func (_m *MockBareRootMetadata) LastModifyingWriterKID() keybase1.KID {
+	ret := _m.ctrl.Call(_m, "LastModifyingWriterKID")
+	ret0, _ := ret[0].(keybase1.KID)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) LastModifyingWriterKID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriterKID")
+}
+
 func (_m *MockBareRootMetadata) GetLastModifyingUser() keybase1.UID {
 	ret := _m.ctrl.Call(_m, "GetLastModifyingUser")
 	ret0, _ := ret[0].(keybase1.UID)
@@ -4787,6 +4797,16 @@ func (_m *MockBareRootMetadata) GetSerializedWriterMetadata(codec kbfscodec.Code
 
 func (_mr *_MockBareRootMetadataRecorder) GetSerializedWriterMetadata(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedWriterMetadata", arg0)
+}
+
+func (_m *MockBareRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
+	ret := _m.ctrl.Call(_m, "GetWriterMetadataSigInfo")
+	ret0, _ := ret[0].(kbfscrypto.SignatureInfo)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetWriterMetadataSigInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriterMetadataSigInfo")
 }
 
 func (_m *MockBareRootMetadata) Version() MetadataVer {
@@ -4985,9 +5005,9 @@ func (_mr *_MockMutableBareRootMetadataRecorder) IsReader(arg0, arg1, arg2 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsReader", arg0, arg1, arg2)
 }
 
-func (_m *MockMutableBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error) {
+func (_m *MockMutableBareRootMetadata) DeepCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
 	ret := _m.ctrl.Call(_m, "DeepCopy", codec)
-	ret0, _ := ret[0].(MutableBareRootMetadata)
+	ret0, _ := ret[0].(BareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -4996,15 +5016,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec, isReadableAndWriter bool) (MutableBareRootMetadata, error) {
-	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec, isReadableAndWriter)
-	ret0, _ := ret[0].(MutableBareRootMetadata)
+func (_m *MockMutableBareRootMetadata) MakeSuccessorCopy(codec kbfscodec.Codec) (BareRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", codec)
+	ret0, _ := ret[0].(BareRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) MakeSuccessorCopy(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) MakeSuccessorCopy(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeSuccessorCopy", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error {
@@ -5113,6 +5133,16 @@ func (_mr *_MockMutableBareRootMetadataRecorder) LastModifyingWriter() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriter")
 }
 
+func (_m *MockMutableBareRootMetadata) LastModifyingWriterKID() keybase1.KID {
+	ret := _m.ctrl.Call(_m, "LastModifyingWriterKID")
+	ret0, _ := ret[0].(keybase1.KID)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) LastModifyingWriterKID() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LastModifyingWriterKID")
+}
+
 func (_m *MockMutableBareRootMetadata) GetLastModifyingUser() keybase1.UID {
 	ret := _m.ctrl.Call(_m, "GetLastModifyingUser")
 	ret0, _ := ret[0].(keybase1.UID)
@@ -5212,6 +5242,16 @@ func (_m *MockMutableBareRootMetadata) GetSerializedWriterMetadata(codec kbfscod
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetSerializedWriterMetadata(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetSerializedWriterMetadata", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) GetWriterMetadataSigInfo() kbfscrypto.SignatureInfo {
+	ret := _m.ctrl.Call(_m, "GetWriterMetadataSigInfo")
+	ret0, _ := ret[0].(kbfscrypto.SignatureInfo)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetWriterMetadataSigInfo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWriterMetadataSigInfo")
 }
 
 func (_m *MockMutableBareRootMetadata) Version() MetadataVer {
@@ -5402,14 +5442,12 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetSerializedPrivateMetadata(ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSerializedPrivateMetadata", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) SignWriterMetadataInternally(ctx context.Context, codec kbfscodec.Codec, signer cryptoSigner) error {
-	ret := _m.ctrl.Call(_m, "SignWriterMetadataInternally", ctx, codec, signer)
-	ret0, _ := ret[0].(error)
-	return ret0
+func (_m *MockMutableBareRootMetadata) SetWriterMetadataSigInfo(sigInfo kbfscrypto.SignatureInfo) {
+	_m.ctrl.Call(_m, "SetWriterMetadataSigInfo", sigInfo)
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) SignWriterMetadataInternally(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SignWriterMetadataInternally", arg0, arg1, arg2)
+func (_mr *_MockMutableBareRootMetadataRecorder) SetWriterMetadataSigInfo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetWriterMetadataSigInfo", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) SetLastModifyingWriter(user keybase1.UID) {

--- a/libkbfs/root_metadata_test_util.go
+++ b/libkbfs/root_metadata_test_util.go
@@ -4,41 +4,15 @@
 
 package libkbfs
 
-import (
-	"context"
-	"time"
-
-	"github.com/keybase/kbfs/kbfscodec"
-)
-
 // This file contains test functions related to RootMetadata that need
 // to be exported for use by other modules' tests.
 
-// NewRootMetadataSignedForTest returns a new RootMetadataSigned
-// object at the latest known version for testing.
-func NewRootMetadataSignedForTest(
-	id TlfID, h BareTlfHandle, codec kbfscodec.Codec,
-	signer cryptoSigner) (*RootMetadataSigned, error) {
-	var md BareRootMetadataV2
-	// MDv3 TODO: uncomment the below when we're ready for MDv3
-	// var md BareRootMetadataV3
-	err := md.Update(id, h)
+// NewRootMetadataSignedForTest returns a new RootMetadataSigned for testing.
+func NewRootMetadataSignedForTest(id TlfID, h BareTlfHandle) (*RootMetadataSigned, error) {
+	rmds := NewRootMetadataSigned()
+	err := rmds.MD.Update(id, h)
 	if err != nil {
 		return nil, err
 	}
-
-	ctx := context.Background()
-
-	// Encode and sign writer metadata.
-	err = md.SignWriterMetadataInternally(ctx, codec, signer)
-	if err != nil {
-		return nil, err
-	}
-
-	rmds, err := signMD(ctx, codec, signer, &md, time.Time{})
-	if err != nil {
-		return nil, err
-	}
-
 	return rmds, nil
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1019,7 +1019,7 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 			if err != nil {
 				return TLFJournalStatus{}, err
 			}
-			err = addUnflushedPaths(ctx, j.uid, j.key,
+			err = addUnflushedPaths(ctx, j.uid, j.key.KID(),
 				j.config.Codec(), j.log, mdInfos, cpp,
 				unflushedPaths)
 			if err != nil {
@@ -1046,7 +1046,7 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 				return TLFJournalStatus{}, err
 			}
 			unflushedPaths, initSuccess, err = j.unflushedPaths.initialize(
-				ctx, j.uid, j.key, j.config.Codec(),
+				ctx, j.uid, j.key.KID(), j.config.Codec(),
 				j.log, cpp, mdInfos)
 			if err != nil {
 				return TLFJournalStatus{}, err
@@ -1327,7 +1327,8 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	return mdID, false, nil
 }
 
-func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
+func (j *tlfJournal) putMD(
+	ctx context.Context, rmd *RootMetadata) (
 	MdID, error) {
 	// Prepare the paths without holding the lock, as it might need to
 	// take the lock.  Note that the timestamp doesn't matter for
@@ -1343,7 +1344,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		localTimestamp: time.Now(),
 	}
 	perRevMap, err := j.unflushedPaths.prepUnflushedPaths(
-		ctx, j.uid, j.key, j.config.Codec(), j.log, mdInfo)
+		ctx, j.uid, j.key.KID(), j.config.Codec(), j.log, mdInfo)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1357,7 +1358,7 @@ func (j *tlfJournal) putMD(ctx context.Context, rmd *RootMetadata) (
 		// The cache was initialized after the last time we tried to
 		// prepare the unflushed paths.
 		perRevMap, err = j.unflushedPaths.prepUnflushedPaths(
-			ctx, j.uid, j.key, j.config.Codec(), j.log,
+			ctx, j.uid, j.key.KID(), j.config.Codec(), j.log,
 			mdInfo)
 		if err != nil {
 			return MdID{}, err

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -66,20 +66,19 @@ func (d testBWDelegate) requireNextState(
 // testTLFJournalConfig is the config we pass to the tlfJournal, and
 // also contains some helper functions for testing.
 type testTLFJournalConfig struct {
-	t            *testing.T
-	tlfID        TlfID
-	splitter     BlockSplitter
-	codec        kbfscodec.Codec
-	crypto       CryptoLocal
-	bcache       BlockCache
-	bops         BlockOps
-	mdcache      MDCache
-	reporter     Reporter
-	uid          keybase1.UID
-	verifyingKey kbfscrypto.VerifyingKey
-	ekg          singleEncryptionKeyGetter
-	nug          normalizedUsernameGetter
-	mdserver     MDServer
+	t        *testing.T
+	tlfID    TlfID
+	splitter BlockSplitter
+	codec    kbfscodec.Codec
+	crypto   CryptoLocal
+	bcache   BlockCache
+	bops     BlockOps
+	mdcache  MDCache
+	reporter Reporter
+	uid      keybase1.UID
+	ekg      singleEncryptionKeyGetter
+	nug      normalizedUsernameGetter
+	mdserver MDServer
 }
 
 func (c testTLFJournalConfig) BlockSplitter() BlockSplitter {
@@ -154,7 +153,7 @@ func (c testTLFJournalConfig) makeBlock(data []byte) (
 
 func (c testTLFJournalConfig) makeMD(
 	revision MetadataRevision, prevRoot MdID) *RootMetadata {
-	return makeMDForTest(c.t, c.tlfID, revision, c.uid, c.verifyingKey, prevRoot)
+	return makeMDForTest(c.t, c.tlfID, revision, c.uid, prevRoot)
 }
 
 func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
@@ -212,7 +211,7 @@ func setupTLFJournalTest(
 	config = &testTLFJournalConfig{
 		t, FakeTlfID(1, false), bsplitter, codec, crypto,
 		nil, nil, NewMDCacheStandard(10),
-		NewReporterSimple(newTestClockNow(), 10), uid, verifyingKey, ekg, nil, mdserver,
+		NewReporterSimple(newTestClockNow(), 10), uid, ekg, nil, mdserver,
 	}
 
 	ctx, cancel = context.WithTimeout(

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -13,7 +13,6 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
@@ -133,7 +132,7 @@ type unflushedPathMDInfo struct {
 // caller should NOT be holding any locks, as it's possible that
 // blocks will need to be fetched.
 func addUnflushedPaths(ctx context.Context,
-	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
+	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
 	log logger.Logger, mdInfos []unflushedPathMDInfo,
 	cpp chainsPathPopulator, unflushedPaths unflushedPathsMap) error {
 	// Make chains over the entire range to get the unflushed files.
@@ -142,6 +141,7 @@ func addUnflushedPaths(ctx context.Context,
 	for _, mdInfo := range mdInfos {
 		winfo := writerInfo{
 			uid:      uid,
+			kid:      kid,
 			revision: mdInfo.revision,
 			// There won't be any conflicts, so no need for the
 			// username/devicename.
@@ -195,7 +195,7 @@ func addUnflushedPaths(ctx context.Context,
 // prepUnflushedPaths returns a set of paths that were updated in the
 // given revision.
 func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
-	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
+	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
 	log logger.Logger, mdInfo unflushedPathMDInfo) (
 	unflushedPathsPerRevMap, error) {
 	cpp := func() chainsPathPopulator {
@@ -212,7 +212,7 @@ func (upc *unflushedPathCache) prepUnflushedPaths(ctx context.Context,
 	newUnflushedPaths := make(unflushedPathsMap)
 	mdInfos := []unflushedPathMDInfo{mdInfo}
 
-	err := addUnflushedPaths(ctx, uid, key, codec, log, mdInfos, cpp,
+	err := addUnflushedPaths(ctx, uid, kid, codec, log, mdInfos, cpp,
 		newUnflushedPaths)
 	if err != nil {
 		return nil, err
@@ -304,14 +304,14 @@ func (upc *unflushedPathCache) setCacheIfPossible(cache unflushedPathsMap,
 // not modify any of the per-revision inner maps of the returned
 // unflushed path map.
 func (upc *unflushedPathCache) initialize(ctx context.Context,
-	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
+	uid keybase1.UID, kid keybase1.KID, codec kbfscodec.Codec,
 	log logger.Logger, cpp chainsPathPopulator,
 	mdInfos []unflushedPathMDInfo) (unflushedPathsMap, bool, error) {
 	// First get all the paths for the given range.  On the first try
 	unflushedPaths := make(unflushedPathsMap)
 	log.CDebugf(ctx, "Initializing unflushed path cache with %d revisions",
 		len(mdInfos))
-	err := addUnflushedPaths(ctx, uid, key, codec, log, mdInfos, cpp,
+	err := addUnflushedPaths(ctx, uid, kid, codec, log, mdInfos, cpp,
 		unflushedPaths)
 	if err != nil {
 		return nil, false, err
@@ -343,7 +343,7 @@ func (upc *unflushedPathCache) initialize(ctx context.Context,
 
 		log.CDebugf(ctx, "Processing unflushed paths for %d items in "+
 			"the append queue", len(queue))
-		err := addUnflushedPaths(ctx, uid, key, codec, log, queue, cpp,
+		err := addUnflushedPaths(ctx, uid, kid, codec, log, queue, cpp,
 			unflushedPaths)
 		if err != nil {
 			return nil, false, err


### PR DESCRIPTION
Reverts keybase/kbfs#439

CI failures on kbfs-server weren't flakes.