### PR TITLE
cr: speed up while journaling by avoiding extraneous block uploads and downloads

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -394,6 +394,11 @@ func (j *blockJournal) putRefEntry(
 	return j.refs[id].put(refEntry.context, refEntry.status, ordinal)
 }
 
+func (j *blockJournal) exists(id BlockID) error {
+	_, err := os.Stat(j.blockDataPath(id))
+	return err
+}
+
 func (j *blockJournal) getDataSize(id BlockID) (int64, error) {
 	fi, err := os.Stat(j.blockDataPath(id))
 	if err != nil {

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -264,15 +264,12 @@ func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
 }
 
 func testBlockJournalGCd(t *testing.T, j *blockJournal) {
-	filepath.Walk(j.j.dir, func(path string, _ os.FileInfo, _ error) error {
-		// We should only find the root directory here.
-		require.Equal(t, path, j.j.dir)
-		return nil
-	})
-	filepath.Walk(j.blocksPath(),
+	filepath.Walk(j.dir,
 		func(path string, info os.FileInfo, _ error) error {
 			// We should only find the blocks directory here.
-			require.Equal(t, path, j.blocksPath())
+			if path != j.dir && path != j.blocksPath() && path != j.j.dir {
+				t.Errorf("Found unexpected block path: %s", path)
+			}
 			return nil
 		})
 }
@@ -609,4 +606,102 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.NoError(t, err)
 	err = j.checkInSync(ctx)
 	require.NoError(t, err)
+}
+
+func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
+	ctx, tempdir, j := setupBlockJournalTest(t)
+	defer teardownBlockJournalTest(t, tempdir, j)
+
+	// Put a few blocks
+	data1 := []byte{1, 2, 3, 4}
+	bID1, _, _ := putBlockData(ctx, t, j, data1)
+	data2 := []byte{5, 6, 7, 8}
+	bID2, _, _ := putBlockData(ctx, t, j, data2)
+
+	// Put a revision marker
+	rev := MetadataRevision(10)
+	err := j.markMDRevision(ctx, rev)
+	require.NoError(t, err)
+
+	data3 := []byte{9, 10, 11, 12}
+	bID3, _, _ := putBlockData(ctx, t, j, data3)
+	data4 := []byte{13, 14, 15, 16}
+	bID4, _, _ := putBlockData(ctx, t, j, data4)
+
+	// Put a revision marker
+	rev = MetadataRevision(11)
+	err = j.markMDRevision(ctx, rev)
+	require.NoError(t, err)
+
+	err = j.saveBlocksUntilNextMDFlush()
+	require.NoError(t, err)
+	savedBlocks := []BlockID{bID1, bID2, bID3, bID4}
+
+	blockServer := NewBlockServerMemory(newTestBlockServerLocalConfig(t))
+	tlfID := tlf.FakeID(1, false)
+	bcache := NewBlockCacheStandard(0, 0)
+	reporter := NewReporterSimple(nil, 0)
+
+	// Flush all the entries, but they should still remain accessible.
+	flushAll := func() {
+		last, err := j.j.readLatestOrdinal()
+		require.NoError(t, err)
+		entries, _, err := j.getNextEntriesToFlush(ctx, last+1,
+			maxJournalBlockFlushBatchSize)
+		require.NoError(t, err)
+		err = flushBlockEntries(ctx, j.log, blockServer,
+			bcache, reporter, tlfID, CanonicalTlfName("fake TLF"),
+			entries)
+		require.NoError(t, err)
+		err = j.removeFlushedEntries(ctx, entries, tlfID, reporter)
+		require.NoError(t, err)
+	}
+	flushAll()
+
+	// The blocks can still be fetched from the journal.
+	for _, bid := range savedBlocks {
+		err = j.exists(bid)
+		require.NoError(t, err)
+	}
+
+	// No more blocks to flush though.
+	end, err := j.end()
+	require.NoError(t, err)
+	entries, gotRev, err := j.getNextEntriesToFlush(ctx, end,
+		maxJournalBlockFlushBatchSize)
+	require.NoError(t, err)
+	require.Equal(t, 0, entries.length())
+	require.Equal(t, MetadataRevisionUninitialized, gotRev)
+
+	// Add a few more blocks and save those too.
+	data5 := []byte{17, 18, 19, 20}
+	bID5, _, _ := putBlockData(ctx, t, j, data5)
+	data6 := []byte{21, 22, 23, 24}
+	bID6, _, _ := putBlockData(ctx, t, j, data6)
+	err = j.saveBlocksUntilNextMDFlush()
+	require.NoError(t, err)
+	savedBlocks = append(savedBlocks, bID5, bID6)
+	flushAll()
+
+	// Make sure all the blocks still exist, including both the old
+	// and the new ones.
+	for _, bid := range savedBlocks {
+		err = j.exists(bid)
+		require.NoError(t, err)
+	}
+
+	// Now remove all the data.
+	err = j.onMDFlush()
+	require.NoError(t, err)
+
+	err = j.exists(bID1)
+	require.True(t, os.IsNotExist(err))
+	err = j.exists(bID2)
+	require.True(t, os.IsNotExist(err))
+	err = j.exists(bID3)
+	require.True(t, os.IsNotExist(err))
+	err = j.exists(bID4)
+	require.True(t, os.IsNotExist(err))
+
+	testBlockJournalGCd(t, j)
 }

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -690,6 +690,14 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	{
+		// Make sure the saved block journal persists after a restart.
+		jRestarted, err := makeBlockJournal(
+			ctx, j.codec, j.crypto, j.dir, j.log)
+		require.NoError(t, err)
+		require.NotNil(t, jRestarted.saveUntilMDFlush)
+	}
+
 	// Now remove all the data.
 	err = j.onMDFlush()
 	require.NoError(t, err)

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -305,6 +305,23 @@ func (b *BlockServerDisk) getAll(ctx context.Context, tlfID tlf.ID) (
 	return tlfStorage.journal.getAll()
 }
 
+// IsUnflushed implements the BlockServer interface for BlockServerDisk.
+func (b *BlockServerDisk) IsUnflushed(ctx context.Context, tlfID tlf.ID,
+	_ BlockID) (bool, error) {
+	tlfStorage, err := b.getStorage(ctx, tlfID)
+	if err != nil {
+		return false, err
+	}
+
+	tlfStorage.lock.RLock()
+	defer tlfStorage.lock.RUnlock()
+	if tlfStorage.journal == nil {
+		return false, errBlockServerDiskShutdown
+	}
+
+	return false, nil
+}
+
 // Shutdown implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) Shutdown() {
 	tlfStorage := func() map[tlf.ID]*blockServerDiskTlfStorage {

--- a/libkbfs/bserver_measured.go
+++ b/libkbfs/bserver_measured.go
@@ -20,6 +20,7 @@ type BlockServerMeasured struct {
 	addBlockReferenceTimer      metrics.Timer
 	removeBlockReferencesTimer  metrics.Timer
 	archiveBlockReferencesTimer metrics.Timer
+	isUnflushedTimer            metrics.Timer
 }
 
 var _ BlockServer = BlockServerMeasured{}
@@ -32,6 +33,7 @@ func NewBlockServerMeasured(delegate BlockServer, r metrics.Registry) BlockServe
 	addBlockReferenceTimer := metrics.GetOrRegisterTimer("BlockServer.AddBlockReference", r)
 	removeBlockReferencesTimer := metrics.GetOrRegisterTimer("BlockServer.RemoveBlockReferences", r)
 	archiveBlockReferencesTimer := metrics.GetOrRegisterTimer("BlockServer.ArchiveBlockReferences", r)
+	isUnflushedTimer := metrics.GetOrRegisterTimer("BlockServer.IsUnflushed", r)
 	return BlockServerMeasured{
 		delegate:                    delegate,
 		getTimer:                    getTimer,
@@ -39,6 +41,7 @@ func NewBlockServerMeasured(delegate BlockServer, r metrics.Registry) BlockServe
 		addBlockReferenceTimer:      addBlockReferenceTimer,
 		removeBlockReferencesTimer:  removeBlockReferencesTimer,
 		archiveBlockReferencesTimer: archiveBlockReferencesTimer,
+		isUnflushedTimer:            isUnflushedTimer,
 	}
 }
 
@@ -92,6 +95,16 @@ func (b BlockServerMeasured) ArchiveBlockReferences(ctx context.Context,
 		err = b.delegate.ArchiveBlockReferences(ctx, tlfID, contexts)
 	})
 	return err
+}
+
+// IsUnflushed implements the BlockServer interface for BlockServerMeasured.
+func (b BlockServerMeasured) IsUnflushed(ctx context.Context, tlfID tlf.ID,
+	id BlockID) (isUnflushed bool, err error) {
+	b.isUnflushedTimer.Time(func() {
+		isUnflushed, err = b.delegate.IsUnflushed(ctx, tlfID, id)
+	})
+	return isUnflushed, err
+
 }
 
 // Shutdown implements the BlockServer interface for

--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -339,6 +339,19 @@ func (b *BlockServerMemory) numBlocks() int {
 	return len(b.m)
 }
 
+// IsUnflushed implements the BlockServer interface for BlockServerMemory.
+func (b *BlockServerMemory) IsUnflushed(ctx context.Context, tlfID tlf.ID,
+	_ BlockID) (bool, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	if b.m == nil {
+		return false, errBlockServerMemoryShutdown
+	}
+
+	return false, nil
+}
+
 // Shutdown implements the BlockServer interface for BlockServerMemory.
 func (b *BlockServerMemory) Shutdown() {
 	b.lock.Lock()

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -413,6 +413,13 @@ func (b *BlockServerRemote) ArchiveBlockReferences(ctx context.Context,
 	return err
 }
 
+// IsUnflushed implements the BlockServer interface for BlockServerRemote.
+func (b *BlockServerRemote) IsUnflushed(
+	_ context.Context, _ tlf.ID, _ BlockID) (
+	bool, error) {
+	return false, nil
+}
+
 // batchDowngradeReferences archives or deletes a batch of references
 func (b *BlockServerRemote) batchDowngradeReferences(ctx context.Context,
 	tlfID tlf.ID, contexts map[BlockID][]BlockContext, archive bool) (

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -223,6 +223,18 @@ func (cr *ConflictResolver) Restart(baseCtx context.Context) {
 	cr.startProcessing(baseCtx)
 }
 
+// BeginNewBranch resets any internal state to be ready to accept
+// resolutions from a new branch.
+func (cr *ConflictResolver) BeginNewBranch() {
+	cr.inputLock.Lock()
+	defer cr.inputLock.Unlock()
+	// Reset the curr input so we don't ignore a future CR
+	// request that uses the same revision number (i.e.,
+	// because the previous CR failed to flush due to a
+	// conflict).
+	cr.currInput = conflictInput{}
+}
+
 func (cr *ConflictResolver) checkDone(ctx context.Context) error {
 	select {
 	case <-ctx.Done():

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2676,11 +2676,14 @@ func (cr *ConflictResolver) syncTree(ctx context.Context, lState *lockState,
 
 // calculateResolutionBytes figured out how many bytes are referenced
 // and unreferenced in the merged branch by this resolution.  It
-// should be called before the block changes are unembedded in md.
+// should be called before the block changes are unembedded in md.  It
+// returns the list of blocks that can be remove from the flushing
+// queue, if any.
 func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState,
 	unmergedChains, mergedChains *crChains,
-	mostRecentMergedMD ImmutableRootMetadata) error {
+	mostRecentMergedMD ImmutableRootMetadata) (
+	blocksToDelete []BlockID, err error) {
 	md.SetRefBytes(0)
 	md.SetUnrefBytes(0)
 	md.SetDiskUsage(mostRecentMergedMD.DiskUsage())
@@ -2722,7 +2725,6 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	}
 
 	// Add bytes for every ref'd block.
-	var err error
 	for ptr := range refs {
 		block, ok := localBlocks[ptr]
 		if !ok {
@@ -2739,7 +2741,7 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 			block, err = cr.fbo.blocks.GetBlockForReading(ctx, lState,
 				md.ReadOnly(), ptr, cr.fbo.branch())
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
@@ -2778,7 +2780,7 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 			mostRecentMergedMD, ptr, cr.fbo.branch())
 		if err != nil {
 			cr.log.CDebugf(ctx, "Got err reading %v", ptr)
-			return err
+			return nil, err
 		}
 
 		cr.log.CDebugf(ctx, "Unref'ing block %v", ptr)
@@ -2787,9 +2789,9 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 		md.SetDiskUsage(md.DiskUsage() - size)
 	}
 
-	// Any blocks that were created on the unmerged branch, but didn't
-	// survive the resolution, should be marked as unreferenced in the
-	// resolution.
+	// Any blocks that were created on the unmerged branch and have
+	// been flushed, but didn't survive the resolution, should be
+	// marked as unreferenced in the resolution.
 	toUnref := make(map[BlockPointer]bool)
 	for ptr := range unmergedChains.originals {
 		if !refs[ptr] && !unrefs[ptr] {
@@ -2806,6 +2808,17 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 		}
 	}
 	for ptr := range toUnref {
+		isUnflushed, err := cr.config.BlockServer().IsUnflushed(
+			ctx, cr.fbo.id(), ptr.ID)
+		if err != nil {
+			return nil, err
+		}
+		if isUnflushed {
+			blocksToDelete = append(blocksToDelete, ptr.ID)
+			// No need to unreference this since we haven't flushed it yet.
+			continue
+		}
+
 		// Put the unrefs on the final operations, to cancel out any
 		// stray refs in earlier ops.
 		cr.log.CDebugf(ctx, "Unreferencing dropped block %v", ptr)
@@ -2815,7 +2828,7 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	cr.log.CDebugf(ctx, "New md byte usage: %d ref, %d unref, %d total usage "+
 		"(previously %d)", md.RefBytes, md.UnrefBytes, md.DiskUsage,
 		mostRecentMergedMD.DiskUsage)
-	return nil
+	return blocksToDelete, nil
 }
 
 // syncBlocks takes in the complete set of paths affected by this
@@ -2823,13 +2836,15 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 // syncs using syncTree.  It returns a map describing how blocks were
 // updated in the merged branch, as well as the complete set of blocks
 // that need to be put to the server (and cached) to complete this
-// resolution.
+// resolution and a list of blocks that can be removed from the
+// flushing queue.
 func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	md *RootMetadata, unmergedChains, mergedChains *crChains,
 	mostRecentMergedMD ImmutableRootMetadata,
 	resolvedPaths map[BlockPointer]path, lbc localBcache,
 	newFileBlocks fileBlockMap) (
-	updates map[BlockPointer]BlockPointer, bps *blockPutState, err error) {
+	updates map[BlockPointer]BlockPointer, bps *blockPutState,
+	blocksToDelete []BlockID, err error) {
 	// Construct a tree out of the merged paths, and do a sync at each leaf.
 	var root *crPathTreeNode
 	for _, p := range resolvedPaths {
@@ -2905,12 +2920,12 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 
 	updates = make(map[BlockPointer]BlockPointer)
 	if root == nil {
-		return updates, newBlockPutState(0), nil
+		return updates, newBlockPutState(0), nil, nil
 	}
 
 	_, uid, err := cr.config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Now do a depth-first walk, and syncBlock back up to the fork on
@@ -2918,13 +2933,13 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	bps, err = cr.syncTree(ctx, lState, unmergedChains, md, uid, root,
 		BlockPointer{}, lbc, newFileBlocks)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	oldOps := md.data.Changes.Ops
 	resOp, ok := oldOps[len(oldOps)-1].(*resolutionOp)
 	if !ok {
-		return nil, nil, fmt.Errorf("dummy op is not gc: %s",
+		return nil, nil, nil, fmt.Errorf("dummy op is not gc: %s",
 			oldOps[len(oldOps)-1])
 	}
 
@@ -2951,14 +2966,14 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 			mergedMostRecent, err :=
 				mergedChains.mostRecentFromOriginalOrSame(chain.original)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			cr.log.CDebugf(ctx, "Fixing resOp update from unmerged most "+
 				"recent %v to merged most recent %v",
 				update.Unref, mergedMostRecent)
 			err = update.setUnref(mergedMostRecent)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			resOp.Updates[i] = update
 			updates[update.Unref] = update.Ref
@@ -3034,7 +3049,7 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	newOps, err := crFixOpPointers(oldOps[:len(oldOps)-1], updates,
 		unmergedChains)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Clean up any gc updates that don't refer to blocks that exist
@@ -3097,10 +3112,10 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 		}
 	}
 
-	err = cr.calculateResolutionUsage(ctx, lState, md, bps, unmergedChains,
-		mergedChains, mostRecentMergedMD)
+	blocksToDelete, err = cr.calculateResolutionUsage(ctx, lState, md, bps,
+		unmergedChains, mergedChains, mostRecentMergedMD)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// do the block changes need their own blocks?
@@ -3108,10 +3123,10 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	if !bsplit.ShouldEmbedBlockChanges(&md.data.Changes) {
 		err = cr.fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes, uid)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 	}
-	return updates, bps, nil
+	return updates, bps, blocksToDelete, nil
 }
 
 // getOpsForLocalNotification returns the set of operations that this
@@ -3235,7 +3250,7 @@ func (cr *ConflictResolver) finalizeResolution(ctx context.Context,
 	lState *lockState, md *RootMetadata,
 	unmergedChains, mergedChains *crChains,
 	updates map[BlockPointer]BlockPointer,
-	bps *blockPutState, writerLocked bool) error {
+	bps *blockPutState, blocksToDelete []BlockID, writerLocked bool) error {
 	// Fix up all the block pointers in the merged ops to work well
 	// for local notifications.  Make a dummy op at the beginning to
 	// convert all the merged most recent pointers into unmerged most
@@ -3251,9 +3266,10 @@ func (cr *ConflictResolver) finalizeResolution(ctx context.Context,
 
 	if writerLocked {
 		return cr.fbo.finalizeResolutionLocked(
-			ctx, lState, md, bps, newOps, nil)
+			ctx, lState, md, bps, newOps, blocksToDelete)
 	}
-	return cr.fbo.finalizeResolution(ctx, lState, md, bps, newOps, nil)
+	return cr.fbo.finalizeResolution(
+		ctx, lState, md, bps, newOps, blocksToDelete)
 }
 
 // completeResolution pushes all the resolved blocks to the servers,
@@ -3277,7 +3293,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 		return err
 	}
 
-	updates, bps, err := cr.syncBlocks(
+	updates, bps, blocksToDelete, err := cr.syncBlocks(
 		ctx, lState, md, unmergedChains, mergedChains,
 		mostRecentMergedMD, resolvedPaths, lbc, newFileBlocks)
 	if err != nil {
@@ -3307,7 +3323,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	}
 
 	err = cr.finalizeResolution(ctx, lState, md, unmergedChains,
-		mergedChains, updates, bps, writerLocked)
+		mergedChains, updates, bps, blocksToDelete, writerLocked)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -328,6 +328,9 @@ type crChains struct {
 	// We need to be able to track ANY BlockPointer, at any point in
 	// the chain, back to its original.
 	originals map[BlockPointer]BlockPointer
+
+	// All the resolution ops from the branch, in order.
+	resOps []*resolutionOp
 }
 
 func (ccs *crChains) addOp(ptr BlockPointer, op op) error {
@@ -517,7 +520,7 @@ func (ccs *crChains) makeChainForOp(op op) error {
 			return err
 		}
 	case *resolutionOp:
-		// ignore resolution op
+		ccs.resOps = append(ccs.resOps, realOp)
 	case *rekeyOp:
 		// ignore rekey op
 	case *GCOp:

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5064,6 +5064,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 
 	// Kick off conflict resolution and set the head to the correct branch.
 	fbo.setBranchIDLocked(lState, newBID)
+	fbo.cr.BeginNewBranch()
 	fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
 
 	fbo.headLock.Lock(lState)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4922,7 +4922,7 @@ func (fbo *folderBranchOps) unblockUnmergedWrites(lState *lockState) {
 
 func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState,
-	newOps []op) error {
+	newOps []op, blocksToDelete []BlockID) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	// Put the blocks into the cache so that, even if we fail below,
@@ -4939,32 +4939,13 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	default:
 	}
 
-	mdOps := fbo.config.MDOps()
-	if jServer, err := GetJournalServer(fbo.config); err == nil {
-		// Switch to the non-journaled MDOps after flushing all the
-		// resolution block writes -- resolutions must go straight
-		// through to the server or else the journal will get
-		// confused.
-		if err := fbo.waitForJournalLocked(ctx, lState, jServer); err != nil {
-			return err
-		}
-		mdOps = jServer.delegateMDOps
-	}
-
-	// Put the MD.  If there's a conflict, abort the whole process and
-	// let CR restart itself.
-	mdID, err := mdOps.Put(ctx, md)
+	mdID, err := fbo.config.MDOps().ResolveBranch(ctx, fbo.id(), fbo.bid,
+		blocksToDelete, md)
 	doUnmergedPut := isRevisionConflict(err)
 	if doUnmergedPut {
 		fbo.log.CDebugf(ctx, "Got a conflict after resolution; aborting CR")
 		return err
 	}
-	if err != nil {
-		return err
-	}
-
-	// Prune the branch via the journal, if there is one.
-	err = fbo.config.MDOps().PruneBranch(ctx, fbo.id(), fbo.bid)
 	if err != nil {
 		return err
 	}
@@ -4998,9 +4979,10 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	}
 	fbo.setBranchIDLocked(lState, NullBranchID)
 
-	// Archive the old, unref'd blocks (the revision went straight to
-	// the server, so we know it is merged).
-	fbo.fbm.archiveUnrefBlocks(irmd.ReadOnly())
+	// Archive the old, unref'd blocks if journaling is off.
+	if !TLFJournalEnabled(fbo.config, fbo.id()) {
+		fbo.fbm.archiveUnrefBlocks(irmd.ReadOnly())
+	}
 
 	// notifyOneOp for every fixed-up merged op.
 	for _, op := range newOps {
@@ -5016,11 +4998,12 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 // completing conflict resolution.
 func (fbo *folderBranchOps) finalizeResolution(ctx context.Context,
 	lState *lockState, md *RootMetadata, bps *blockPutState,
-	newOps []op) error {
+	newOps []op, blocksToDelete []BlockID) error {
 	// Take the writer lock.
 	fbo.mdWriterLock.Lock(lState)
 	defer fbo.mdWriterLock.Unlock(lState)
-	return fbo.finalizeResolutionLocked(ctx, lState, md, bps, newOps)
+	return fbo.finalizeResolutionLocked(
+		ctx, lState, md, bps, newOps, blocksToDelete)
 }
 
 func (fbo *folderBranchOps) unstageAfterFailedResolution(ctx context.Context,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1195,6 +1195,10 @@ type BlockServer interface {
 	ArchiveBlockReferences(ctx context.Context, tlfID tlf.ID,
 		contexts map[BlockID][]BlockContext) error
 
+	// IsUnflushed returns whether a given block is being queued
+	// locally for later flushing to another block server.
+	IsUnflushed(ctx context.Context, tlfID tlf.ID, id BlockID) (bool, error)
+
 	// Shutdown is called to shutdown a BlockServer connection.
 	Shutdown()
 

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -107,6 +107,18 @@ func (j journalBlockServer) ArchiveBlockReferences(
 	return j.BlockServer.ArchiveBlockReferences(ctx, tlfID, contexts)
 }
 
+func (j journalBlockServer) IsUnflushed(ctx context.Context, tlfID tlf.ID,
+	id BlockID) (isLocal bool, err error) {
+	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+		defer func() {
+			err = translateToBlockServerError(err)
+		}()
+		return tlfJournal.isBlockUnflushed(id)
+	}
+
+	return j.BlockServer.IsUnflushed(ctx, tlfID, id)
+}
+
 func (j journalBlockServer) Shutdown() {
 	j.jServer.shutdown()
 	j.BlockServer.Shutdown()

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -198,11 +198,17 @@ func (j journalMDOps) getRangeFromJournal(
 func (j journalMDOps) GetForHandle(
 	ctx context.Context, handle *TlfHandle, mStatus MergeStatus) (
 	tlf.ID, ImmutableRootMetadata, error) {
-	// Need to always consult the server to get the tlfID. No need
-	// to optimize this, since all subsequent lookups will be by
-	// TLF. Although if we did want to, we could store a handle ->
-	// TLF ID mapping with the journals.
-	tlfID, rmd, err := j.MDOps.GetForHandle(ctx, handle, mStatus)
+	// Need to always consult the server to get the tlfID. No need to
+	// optimize this, since all subsequent lookups will be by
+	// TLF. Although if we did want to, we could store a handle -> TLF
+	// ID mapping with the journals.  If we are looking for an
+	// unmerged head, that exists only in the journal, so check the
+	// remote server only to get the TLF ID.
+	remoteMStatus := mStatus
+	if mStatus == Unmerged {
+		remoteMStatus = Merged
+	}
+	tlfID, rmd, err := j.MDOps.GetForHandle(ctx, handle, remoteMStatus)
 	if err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
@@ -221,6 +227,9 @@ func (j journalMDOps) GetForHandle(
 	}
 	if irmd != (ImmutableRootMetadata{}) {
 		return tlf.ID{}, irmd, nil
+	}
+	if remoteMStatus != mStatus {
+		return tlfID, ImmutableRootMetadata{}, nil
 	}
 
 	// Otherwise, use the server's head.

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -5,7 +5,6 @@
 package libkbfs
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -379,5 +378,5 @@ func (j journalMDOps) ResolveBranch(
 		}
 	}
 
-	return MdID{}, errors.New("ResolveBranch not supported outside of journal")
+	return j.MDOps.ResolveBranch(ctx, id, bid, blocksToDelete, rmd)
 }

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1697,7 +1697,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	}
 
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(context.Background(), config2, StallableMDPut, 1)
+		StallMDOp(context.Background(), config2, StallableMDResolveBranch, 1)
 
 	var wg sync.WaitGroup
 	putCtx, cancel2 := context.WithCancel(putCtx)
@@ -1844,7 +1844,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// to it locking next time (since it has seen how many revisions
 	// are outstanding).
 	onPutStalledCh, putUnstallCh, putCtx :=
-		StallMDOp(context.Background(), config2, StallableMDPut, 1)
+		StallMDOp(context.Background(), config2, StallableMDResolveBranch, 1)
 
 	var wg sync.WaitGroup
 	firstPutCtx, cancel := context.WithCancel(putCtx)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -663,14 +663,6 @@ func (_mr *_MockKeybaseServiceRecorder) FlushUserUnverifiedKeysFromLocalCache(ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "FlushUserUnverifiedKeysFromLocalCache", arg0, arg1)
 }
 
-func (_m *MockKeybaseService) Shutdown() {
-	_m.ctrl.Call(_m, "Shutdown")
-}
-
-func (_mr *_MockKeybaseServiceRecorder) Shutdown() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
-}
-
 func (_m *MockKeybaseService) EstablishMountDir(ctx context.Context) (string, error) {
 	ret := _m.ctrl.Call(_m, "EstablishMountDir", ctx)
 	ret0, _ := ret[0].(string)
@@ -680,6 +672,14 @@ func (_m *MockKeybaseService) EstablishMountDir(ctx context.Context) (string, er
 
 func (_mr *_MockKeybaseServiceRecorder) EstablishMountDir(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "EstablishMountDir", arg0)
+}
+
+func (_m *MockKeybaseService) Shutdown() {
+	_m.ctrl.Call(_m, "Shutdown")
+}
+
+func (_mr *_MockKeybaseServiceRecorder) Shutdown() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
 }
 
 // Mock of KeybaseServiceCn interface
@@ -3165,6 +3165,17 @@ func (_mr *_MockBlockServerRecorder) ArchiveBlockReferences(arg0, arg1, arg2 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ArchiveBlockReferences", arg0, arg1, arg2)
 }
 
+func (_m *MockBlockServer) IsUnflushed(ctx context.Context, tlfID tlf.ID, id BlockID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsUnflushed", ctx, tlfID, id)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBlockServerRecorder) IsUnflushed(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsUnflushed", arg0, arg1, arg2)
+}
+
 func (_m *MockBlockServer) Shutdown() {
 	_m.ctrl.Call(_m, "Shutdown")
 }
@@ -3264,6 +3275,17 @@ func (_m *MockblockServerLocal) ArchiveBlockReferences(ctx context.Context, tlfI
 
 func (_mr *_MockblockServerLocalRecorder) ArchiveBlockReferences(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ArchiveBlockReferences", arg0, arg1, arg2)
+}
+
+func (_m *MockblockServerLocal) IsUnflushed(ctx context.Context, tlfID tlf.ID, id BlockID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsUnflushed", ctx, tlfID, id)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockblockServerLocalRecorder) IsUnflushed(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsUnflushed", arg0, arg1, arg2)
 }
 
 func (_m *MockblockServerLocal) Shutdown() {

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -21,6 +21,7 @@ type op interface {
 	AddRefBlock(ptr BlockPointer)
 	DelRefBlock(ptr BlockPointer)
 	AddUnrefBlock(ptr BlockPointer)
+	DelUnrefBlock(ptr BlockPointer)
 	AddUpdate(oldPtr BlockPointer, newPtr BlockPointer)
 	SizeExceptUpdates() uint64
 	allUpdates() []blockUpdate
@@ -162,6 +163,17 @@ func (oc *OpCommon) DelRefBlock(ptr BlockPointer) {
 // for this op.
 func (oc *OpCommon) AddUnrefBlock(ptr BlockPointer) {
 	oc.UnrefBlocks = append(oc.UnrefBlocks, ptr)
+}
+
+// DelUnrefBlock removes the first unreference of the given block from
+// the list of unreferenced blocks for this op.
+func (oc *OpCommon) DelUnrefBlock(ptr BlockPointer) {
+	for i, unref := range oc.UnrefBlocks {
+		if ptr == unref {
+			oc.UnrefBlocks = append(oc.UnrefBlocks[:i], oc.UnrefBlocks[i+1:]...)
+			break
+		}
+	}
 }
 
 // AddUpdate adds a mapping from an old block to the new version of

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -206,6 +206,11 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = kbfscodec.Update(
+		codec, &rmd.data.cachedChanges, md.data.cachedChanges)
+	if err != nil {
+		return nil, err
+	}
 
 	return rmd, nil
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -622,7 +622,7 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 	// block ops. See KBFS-1502.
 
 	for {
-		isConflict, err := j.isOnConflictBranchLocked()
+		isConflict, err := j.isOnConflictBranch()
 		if err != nil {
 			return err
 		}
@@ -881,18 +881,15 @@ func (j *tlfJournal) getJournalEntryCounts() (
 	return blockEntryCount, mdEntryCount, nil
 }
 
-func (j *tlfJournal) isOnConflictBranchLocked() (bool, error) {
+func (j *tlfJournal) isOnConflictBranch() (bool, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+
 	if err := j.checkEnabledLocked(); err != nil {
 		return false, err
 	}
 
 	return j.mdJournal.getBranchID() != NullBranchID, nil
-}
-
-func (j *tlfJournal) isOnConflictBranch() (bool, error) {
-	j.journalLock.RLock()
-	defer j.journalLock.RUnlock()
-	return j.isOnConflictBranchLocked()
 }
 
 func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -847,6 +847,11 @@ func (j *tlfJournal) flushOneMDOp(
 			rmds.MD.RevisionNumber())
 	}
 
+	err = j.blockJournal.onMDFlush()
+	if err != nil {
+		return false, err
+	}
+
 	err = j.removeFlushedMDEntry(ctx, mdID, rmds)
 	if err != nil {
 		return false, err
@@ -1483,6 +1488,10 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 
 	// Then go through and mark blocks and md rev markers for ignoring.
 	err = j.blockJournal.ignoreBlocksAndMDRevMarkers(ctx, blocksToDelete)
+	if err != nil {
+		return MdID{}, false, err
+	}
+	err = j.blockJournal.saveBlocksUntilNextMDFlush()
 	if err != nil {
 		return MdID{}, false, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1270,6 +1270,21 @@ func (j *tlfJournal) archiveBlockReferences(
 	return nil
 }
 
+func (j *tlfJournal) isBlockUnflushed(id BlockID) (bool, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return false, err
+	}
+
+	err := j.blockJournal.exists(id)
+	if err != nil {
+		// Might exist on the server
+		return false, nil
+	}
+	return true, nil
+}
+
 func (j *tlfJournal) getMDHead(
 	ctx context.Context) (ImmutableBareRootMetadata, error) {
 	j.journalLock.RLock()

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -640,6 +640,43 @@ func undoStallOnMDGetRange() fileOp {
 	}, IsInit}
 }
 
+func stallDelegateOnMDResolveBranch() fileOp {
+	return fileOp{func(c *ctx) error {
+		// TODO: Allow test to pass in a more precise maxStalls limit.
+		c.staller.StallMDOp(libkbfs.StallableMDResolveBranch, 100, true)
+		return nil
+	}, Defaults}
+}
+
+func stallOnMDResolveBranch() fileOp {
+	return fileOp{func(c *ctx) error {
+		// TODO: Allow test to pass in a more precise maxStalls limit.
+		c.staller.StallMDOp(libkbfs.StallableMDResolveBranch, 100, false)
+		return nil
+	}, Defaults}
+}
+
+func waitForStalledMDResolveBranch() fileOp {
+	return fileOp{func(c *ctx) error {
+		c.staller.WaitForStallMDOp(libkbfs.StallableMDResolveBranch)
+		return nil
+	}, IsInit}
+}
+
+func unstallOneMDResolveBranch() fileOp {
+	return fileOp{func(c *ctx) error {
+		c.staller.UnstallOneMDOp(libkbfs.StallableMDResolveBranch)
+		return nil
+	}, IsInit}
+}
+
+func undoStallOnMDResolveBranch() fileOp {
+	return fileOp{func(c *ctx) error {
+		c.staller.UndoStallMDOp(libkbfs.StallableMDResolveBranch)
+		return nil
+	}, IsInit}
+}
+
 func reenableUpdates() fileOp {
 	return fileOp{func(c *ctx) error {
 		err := c.engine.ReenableUpdates(c.user, c.tlfName, c.tlfIsPublic)


### PR DESCRIPTION
This PR enables a journaled TLF to use only local information during conflict resolution, and completely avoids creating a conflict branch on the servers.  Getting there required quite a few changes (let me know if you'd prefer them broken out into separate PRs):
- `tlfJournal` pauses flushing as soon as it notices a conflict.
- `conflictResolver` figures out which blocks don't need to be uploaded, and passes that to `MDOps.ResolveBranch` so the journal can ignore them.
- We now write the resolution MD to the journal, rather than directly to the server (due to the `ResolveBranch` semantics).
- Since the journal might have uploaded some blocks before discovering a conflict, `BlockServer` now has an `IsFlushed` method that the `conflictResolver` can use to tell which blocks have already been flushed.
- `blockJournal` now has a way to avoid removing the data for flushed blocks from disk, until the next successful MD flush.  This helps us avoid re-downloading blocks in the case where the resolution MD itself hits a conflict during flushing, and we have to re-do CR all over again.
  - (This is possible now because we are writing the resolution MD to the journal, and won't know if there's a conflict until later.)
- `conflictResolver` needed several tweaks to work correctly when the unmerged branch contains a `resolutionOp`, which wasn't possible before.
- `RootMetadata.deepCopy` needs to also copy the cached block changes -- otherwise when the journal converts a branch and replaces the cached MD entries, it could wind up forgetting the cached block change pointer.
  - This fixes a bug in master that we just didn't have test coverage for, but now we do.
