### PR TITLE
folder_branch_ops: update latest merged revision on CR

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -828,7 +828,19 @@ func (fbo *folderBranchOps) setHeadConflictResolvedLocked(ctx context.Context,
 		return errors.New("Unexpected unmerged update in setHeadConflictResolvedLocked")
 	}
 
-	return fbo.setHeadLocked(ctx, lState, md)
+	err := fbo.setHeadLocked(ctx, lState, md)
+	if err != nil {
+		return err
+	}
+
+	// Since the CR head goes directly to the server, we can safely
+	// set the latest merged revision here.  (Normally self-commits
+	// don't update the latest merged revision since all non-CR
+	// updates go through the journal.)
+	if TLFJournalEnabled(fbo.config, fbo.id()) {
+		fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision(), false)
+	}
+	return nil
 }
 
 func (fbo *folderBranchOps) identifyOnce(

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -457,7 +457,7 @@ func (teh *TlfEditHistory) updateHistory(ctx context.Context,
 		return nil
 	}
 	teh.log.CDebugf(ctx, "Processing %d MDs for notifications "+
-		"(most recent revision: %d)", len(rmds), rmds[len(rmds)-1].Revision)
+		"(most recent revision: %d)", len(rmds), rmds[len(rmds)-1].Revision())
 
 	currEdits := teh.getEditsCopy()
 	if currEdits == nil {


### PR DESCRIPTION
Because CR goes directly to the server when journaling is on (until
KBFS-1637 is in), we can safely update the latest merged revision.  If
we don't, and the TLF isn't accessed through its handle before a
journal flush ends up triggering CR (e.g. because of QR), we could end
up in a situation where head is set, but the latest merged rev is not
(which eventually leads to a panic in the fast-forward code).

Issue: KBFS-1663