### PR TITLE
ops: inverting a rename needs to check for an empty newdir

### DIFF
--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -1194,7 +1194,11 @@ func invertOpForLocalNotifications(oldOp op) (newOp op, err error) {
 			return nil, err
 		}
 	case *renameOp:
-		newOp, err = newRenameOp(op.NewName, op.NewDir.Ref,
+		newDirRef := op.NewDir.Ref
+		if op.NewDir == (blockUpdate{}) {
+			newDirRef = op.OldDir.Ref
+		}
+		newOp, err = newRenameOp(op.NewName, newDirRef,
 			op.OldName, op.OldDir.Ref, op.Renamed, op.RenamedType)
 		if err != nil {
 			return nil, err

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -556,8 +556,8 @@ func TestOpInversion(t *testing.T) {
 
 	iop3, err := invertOpForLocalNotifications(rop)
 	require.NoError(t, err)
-	renameOp, ok := iop3.(*renameOp)
-	if !ok || !reflect.DeepEqual(*renameOp, *expectedIOp3) {
+	iRenameOp, ok := iop3.(*renameOp)
+	if !ok || !reflect.DeepEqual(*iRenameOp, *expectedIOp3) {
 		t.Errorf("renameOp didn't invert properly, expected %v, got %v",
 			expectedIOp3, iop3)
 	}
@@ -594,6 +594,22 @@ func TestOpInversion(t *testing.T) {
 	if !ok || !reflect.DeepEqual(*sao, *expectedIOp5) {
 		t.Errorf("setAttrOp didn't invert properly, expected %v, got %v",
 			expectedIOp5, iop5)
+	}
+
+	// rename (same dir)
+	rop, err = newRenameOp("old", oldPtr1, "new", oldPtr1, filePtr, File)
+	require.NoError(t, err)
+	rop.AddUpdate(oldPtr1, newPtr1)
+	expectedIOp6, err := newRenameOp("new", newPtr1, "old", newPtr1, filePtr, File)
+	require.NoError(t, err)
+	expectedIOp6.AddUpdate(newPtr1, oldPtr1)
+
+	iop6, err := invertOpForLocalNotifications(rop)
+	require.NoError(t, err)
+	iRenameOp, ok = iop6.(*renameOp)
+	if !ok || !reflect.DeepEqual(*iRenameOp, *expectedIOp6) {
+		t.Errorf("renameOp didn't invert properly, expected %v, got %v",
+			expectedIOp6, iop6)
 	}
 }
 


### PR DESCRIPTION
Otherwise the OldDir in the new renameOp will be very wrong.

Issue: KBFS-1676