### PR TITLE
folder_branch_ops: unembedded block change fixes

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1210,6 +1210,11 @@ func (fbo *folderBranchOps) initMDLocked(
 
 	md.loadCachedBlockChanges(bps)
 
+	err = fbo.finalizeBlocks(bps)
+	if err != nil {
+		return err
+	}
+
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
 	if fbo.head != (ImmutableRootMetadata{}) {
@@ -2345,6 +2350,11 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 
 	fbo.setBranchIDLocked(lState, NullBranchID)
 	md.loadCachedBlockChanges(bps)
+
+	err = fbo.finalizeBlocks(bps)
+	if err != nil {
+		return err
+	}
 
 	rebased := (oldPrevRoot != md.PrevRoot())
 	if rebased {
@@ -4965,6 +4975,11 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	}
 
 	md.loadCachedBlockChanges(bps)
+
+	err = fbo.finalizeBlocks(bps)
+	if err != nil {
+		return err
+	}
 
 	// Set the head to the new MD.
 	fbo.headLock.Lock(lState)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2040,6 +2040,9 @@ func isRetriableError(err error, retries int) bool {
 }
 
 func (fbo *folderBranchOps) finalizeBlocks(bps *blockPutState) error {
+	if bps == nil {
+		return nil
+	}
 	bcache := fbo.config.BlockCache()
 	for _, blockState := range bps.blockStates {
 		newPtr := blockState.blockPtr
@@ -4216,7 +4219,13 @@ func (fbo *folderBranchOps) unstageLocked(ctx context.Context,
 		resOp.AddUnrefBlock(ptr)
 	}
 	md.AddOp(resOp)
-	return fbo.finalizeMDWriteLocked(ctx, lState, md, &blockPutState{}, NoExcl)
+
+	bps, err := fbo.maybeUnembedAndPutBlocks(ctx, md)
+	if err != nil {
+		return err
+	}
+
+	return fbo.finalizeMDWriteLocked(ctx, lState, md, bps, NoExcl)
 }
 
 // TODO: remove once we have automatic conflict resolution


### PR DESCRIPTION
We must always unembed block changes when unstaging, otherwise the resolution put will get rejected.

Also, I noticed we weren't caching put blocks in a few places (most notably after CR!), so this fixes that up too.

Issue: KBFS-1676