### PR TITLE
libkbfs: use MDv3 in staging env

### DIFF
--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -32,14 +32,14 @@ To run against remote KBFS servers:
   kbfsfuse [-debug] [-cpuprofile=path/to/dir]
     [-bserver=%s] [-mdserver=%s]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file]]
+    [-log-to-file] [-log-file=path/to/file] [-md-version=version]
     %s/path/to/mountpoint
 
 To run in a local testing environment:
   kbfsfuse [-debug] [-cpuprofile=path/to/dir]
     [-server-in-memory|-server-root=path/to/dir] [-localuser=<user>]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file]]
+    [-log-to-file] [-log-file=path/to/file] [-md-version=version]
     %s/path/to/mountpoint
 
 `

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -353,9 +353,13 @@ func (md *BareRootMetadataV3) MakeSuccessorCopy(
 	extra ExtraMetadata, isReadableAndWriter bool) (
 	MutableBareRootMetadata, ExtraMetadata, bool, error) {
 
-	extraCopy, err := extra.DeepCopy(config.Codec())
-	if err != nil {
-		return nil, nil, false, err
+	var extraCopy ExtraMetadata
+	if extra != nil {
+		var err error
+		extraCopy, err = extra.DeepCopy(config.Codec())
+		if err != nil {
+			return nil, nil, false, err
+		}
 	}
 	mdCopy, err := md.DeepCopy(config.Codec())
 	if err != nil {

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -553,8 +553,8 @@ func (c *ConfigLocal) SetConflictRenamer(cr ConflictRenamer) {
 
 // MetadataVersion implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) MetadataVersion() MetadataVer {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	return c.metadataVersion
 }
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -553,7 +553,16 @@ func (c *ConfigLocal) SetConflictRenamer(cr ConflictRenamer) {
 
 // MetadataVersion implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) MetadataVersion() MetadataVer {
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	return c.metadataVersion
+}
+
+// SetMetadataVersion implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) SetMetadataVersion(mdVer MetadataVer) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.metadataVersion = mdVer
 }
 
 // DataVersion implements the Config interface for ConfigLocal.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1386,6 +1386,7 @@ type Config interface {
 	ConflictRenamer() ConflictRenamer
 	SetConflictRenamer(ConflictRenamer)
 	MetadataVersion() MetadataVer
+	SetMetadataVersion(MetadataVer)
 	DataVersion() DataVer
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)


### PR DESCRIPTION
This actually does 3 things:

* Fixes a bug where we were dereferencing nil `ExtraMetadata` for public folders.
* Adds a cmdline option for which metadata version to use
* Makes the default version of the above v3 when connecting to staging.