### PR TITLE
cr: check that branch point is really the unmerged successor

### DIFF
--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -281,7 +281,7 @@ func (j journalMDOps) getRange(
 	[]ImmutableRootMetadata, error) {
 	// Grab the range from the journal first.
 	jirmds, err := j.getRangeFromJournal(ctx, id, bid, mStatus, start, stop)
-	if err != nil {
+	if err != nil && err != errTLFJournalDisabled {
 		return nil, err
 	}
 


### PR DESCRIPTION
There might be a bug where the unmerged list of revisions is missing
the earliest revision; this is to help us find it.

Issue: KBFS-1664