### PR TITLE
md_journal: make sure entries match before replacing in cache

### DIFF
--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -681,11 +681,14 @@ func (j *mdJournal) convertToBranch(
 		prevID = newID
 
 		// If possible, replace the old RMD in the cache.  If it's not
-		// already in the cache, or if it's been replaced by the REAL
-		// commit from the master branch due to a race, don't bother
-		// adding it, as that will just evict something incorrectly.
-		// TODO: Don't replace the MD until we know for sure that the
-		// branch conversion succeeds.
+		// already in the cache, don't bother adding it, as that will
+		// just evict something incorrectly.  If it's been replaced by
+		// the REAL commit from the master branch due to a race, don't
+		// clobber that real commit. TODO: Don't replace the MD until
+		// we know for sure that the branch conversion succeeds
+		// (however, the Replace doesn't affect correctness since the
+		// original commit will be read from disk instead of the cache
+		// in the event of a conversion failure).
 		oldIrmd, err := mdcache.Get(
 			tlfID, brmd.RevisionNumber(), NullBranchID)
 		if err == nil && entry.ID == oldIrmd.mdID {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -681,13 +681,14 @@ func (j *mdJournal) convertToBranch(
 		prevID = newID
 
 		// If possible, replace the old RMD in the cache.  If it's not
-		// already in the cache, don't bother adding it, as that will
-		// just evict something incorrectly.  TODO: Don't replace the
-		// MD until we know for sure that the branch conversion
-		// succeeds.
+		// already in the cache, or if it's been replaced by the REAL
+		// commit from the master branch due to a race, don't bother
+		// adding it, as that will just evict something incorrectly.
+		// TODO: Don't replace the MD until we know for sure that the
+		// branch conversion succeeds.
 		oldIrmd, err := mdcache.Get(
 			tlfID, brmd.RevisionNumber(), NullBranchID)
-		if err == nil {
+		if err == nil && entry.ID == oldIrmd.mdID {
 			newRmd, err := oldIrmd.deepCopy(codec)
 			if err != nil {
 				return NullBranchID, err

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -475,8 +475,10 @@ func TestMDJournalBranchConversion(t *testing.T) {
 	mdcache := NewMDCacheStandard(10)
 	cachedMd := makeMDForTest(
 		t, id, firstRevision, j.uid, signer, firstPrevRoot)
-	err := mdcache.Put(MakeImmutableRootMetadata(cachedMd,
-		j.key, fakeMdID(1), time.Now()))
+	cachedMdID, _, _, _, err := j.getEarliestWithExtra(false)
+	require.NoError(t, err)
+	err = mdcache.Put(MakeImmutableRootMetadata(cachedMd,
+		j.key, cachedMdID, time.Now()))
 	require.NoError(t, err)
 
 	bid, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -48,6 +48,8 @@ func (md *MDCacheStandard) Get(tlf tlf.ID, rev MetadataRevision, bid BranchID) (
 
 // Put implements the MDCache interface for MDCacheStandard.
 func (md *MDCacheStandard) Put(rmd ImmutableRootMetadata) error {
+	// TODO: is it worth the extra lookup here to make sure if there's
+	// one already in the cache that it has the same MdID?
 	key := mdCacheKey{rmd.TlfID(), rmd.Revision(), rmd.BID()}
 	md.lru.Add(key, rmd)
 	return nil


### PR DESCRIPTION
I have a theory that the client in KBFS-1664 experienced a race where
it pulled in a revision from the master branch right before it
converted a local journal into a branch, overwriting the local
revision in the cache with the "master" MD and then replacing that
master MD into the cache under the branch ID.  This would royally
screw up conflict resolution, among other things.

Issue: KBFS-1664