### PR TITLE
FSNotification filename should use canonical path

### DIFF
--- a/libkbfs/path.go
+++ b/libkbfs/path.go
@@ -7,6 +7,8 @@ package libkbfs
 import (
 	"fmt"
 	"strings"
+
+	"github.com/keybase/kbfs/tlf"
 )
 
 // PathType describes the types for different paths
@@ -51,6 +53,14 @@ func buildCanonicalPathForTlfName(public bool, tlfName CanonicalTlfName) string 
 		pathType = PublicPathType
 	}
 	return BuildCanonicalPath(pathType, string(tlfName))
+}
+
+func buildCanonicalPathForTlf(tlf tlf.ID, paths ...string) string {
+	pathType := PrivatePathType
+	if tlf.IsPublic() {
+		pathType = PublicPathType
+	}
+	return BuildCanonicalPath(pathType, paths...)
 }
 
 // path represents the full KBFS path to a particular location, so
@@ -111,6 +121,15 @@ func (p path) String() string {
 		names = append(names, node.Name)
 	}
 	return strings.Join(names, "/")
+}
+
+// CanonicalPathString returns canonical representation of the full path,
+// always prefaced by /keybase. This may require conversion to a platform
+// specific path, for example, by replacing /keybase with the appropriate drive
+// letter on Windows. It also, might need conversion if on a different run mode,
+// for example, /keybase.staging on Unix type platforms.
+func (p path) CanonicalPathString() string {
+	return buildCanonicalPathForTlf(p.Tlf, p.String())
 }
 
 // parentPath returns a new Path representing the parent subdirectory

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -311,7 +311,7 @@ func fileRenameNotification(oldFile path, newFile path, writer keybase1.UID,
 	localTime time.Time) *keybase1.FSNotification {
 	n := baseFileEditNotification(newFile, writer, localTime)
 	n.NotificationType = keybase1.FSNotificationType_FILE_RENAMED
-	n.Params = map[string]string{errorParamRenameOldFilename: oldFile.String()}
+	n.Params = map[string]string{errorParamRenameOldFilename: oldFile.CanonicalPathString()}
 	return n
 }
 
@@ -335,7 +335,7 @@ func baseNotification(file path, finish bool) *keybase1.FSNotification {
 
 	return &keybase1.FSNotification{
 		PublicTopLevelFolder: file.Tlf.IsPublic(),
-		Filename:             file.String(),
+		Filename:             file.CanonicalPathString(),
 		StatusCode:           code,
 	}
 }


### PR DESCRIPTION
Sends full canonical path for FSNotifications.

The desktop app has a fix to use this since it knowns FSNotification.Filename is always the full canonical path: https://github.com/keybase/client/issues/4833