### PR TITLE
cr: fix situations where a conflicting file is renamed

### DIFF
--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -557,7 +557,7 @@ func (rua *renameUnmergedAction) updateOps(unmergedMostRecent BlockPointer,
 	}
 
 	if unmergedChain.isFile() {
-		// Replace the updates on all file operations
+		// Replace the updates on all file operations.
 		for _, op := range unmergedChain.ops {
 			switch realOp := op.(type) {
 			case *syncOp:

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -275,6 +275,24 @@ func (cc *crChain) remove(ctx context.Context, log logger.Logger,
 	return anyRemoved
 }
 
+func (cc *crChain) hasSyncOp() bool {
+	for _, op := range cc.ops {
+		if _, ok := op.(*syncOp); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (cc *crChain) hasSetAttrOp() bool {
+	for _, op := range cc.ops {
+		if _, ok := op.(*setAttrOp); ok {
+			return true
+		}
+	}
+	return false
+}
+
 type renameInfo struct {
 	originalOldParent BlockPointer
 	oldName           string

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1061,6 +1061,8 @@ func (fbo *folderBlockOps) Read(
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 
+	fbo.log.CDebugf(ctx, "Reading from %v", file.tailPointer())
+
 	// getFileLocked already checks read permissions
 	fblock, err := fbo.getFileLocked(ctx, lState, kmd, file, blockRead)
 	if err != nil {

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -340,6 +340,7 @@ func makeFakeSyncOpFuture(t *testing.T) syncOpFuture {
 			makeFakeOpCommon(t, true),
 			makeFakeBlockUpdate(t),
 			nil,
+			false,
 		},
 		[]writeRangeFuture{
 			makeFakeWriteRangeFuture(t),
@@ -375,6 +376,7 @@ func makeFakeSetAttrOpFuture(t *testing.T) setAttrOpFuture {
 			makeFakeBlockUpdate(t),
 			mtimeAttr,
 			makeFakeBlockPointer(t),
+			false,
 		},
 		makeExtraOrBust("setAttrOp", t),
 	}


### PR DESCRIPTION
Previously we didn't handle the situation where two users modify a
file (either by writing to it or modifying its attributes), but only
one of them renames it.  In that case, we've decided to keep both
versions of their files, under their names in their respective
branches.  E.g.:

* alice and bob have a shared folder with a file "foo"
* alice writes data into "foo"
* at the same time, bob writes different data into "foo" AND renames "foo" to "bar"
* after resolution, there will be both "foo" and "bar"

Issue: KBFS-1650