### PR TITLE
coalescing_context: remove racy check in coalescing_context_test

### DIFF
--- a/libkbfs/coalescing_context_test.go
+++ b/libkbfs/coalescing_context_test.go
@@ -39,8 +39,6 @@ func TestCoalescingContext(t *testing.T) {
 	}
 	cf2()
 
-	require.NoError(t, cc.Err())
-
 	t.Log("Verify that the CoalescingContext is Done() only after its parent contexts have both been canceled.")
 	select {
 	case <-time.After(time.Second):


### PR DESCRIPTION
Fix for https://ci.keyba.se/job/kbfs/job/master/1219/execution/node/231/log/

We shouldn't have been checking here for `NoError`, since as soon as `cf2` is called, the `CoalescingContext` `cc.Done()` will begin racing to complete.

r? @strib
cc @maxtaco 