### PR TITLE
[KBFS-1688] Avoid initial block journal scan

### DIFF
--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -312,8 +312,8 @@ func (s *blockDiskStore) getData(id BlockID) (
 
 // All functions below are public functions.
 
-// getUnflushedBytes returns the sum of the size of the data for each
-// stored block that needs to be flushed.
+// getUnflushedBytes returns the sum of data bytes that has been put,
+// but not removed or flushed.
 func (s *blockDiskStore) getUnflushedBytes() (int64, error) {
 	info, err := s.getAggregateInfo()
 	if err != nil {
@@ -510,7 +510,7 @@ func (s *blockDiskStore) put(id BlockID, context BlockContext, buf []byte,
 		return false, err
 	}
 
-	// Decremented in either flushPut() or remove().
+	// Decremented in either onPutFlush() or remove().
 	deltaUnflushedBytes := int64(len(buf))
 	err = s.adjustByteCounts(deltaUnflushedBytes)
 	if err != nil {
@@ -547,7 +547,7 @@ func (s *blockDiskStore) archiveReferences(
 	return nil
 }
 
-func (s *blockDiskStore) flushPut(id BlockID) error {
+func (s *blockDiskStore) onPutFlush(id BlockID) error {
 	size, err := s.getDataSize(id)
 	if err != nil {
 		return err

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -432,27 +432,27 @@ func (s *blockDiskStore) put(id BlockID, context BlockContext, buf []byte,
 				"key server half mismatch: expected %s, got %s",
 				existingServerHalf, serverHalf)
 		}
-	}
+	} else {
+		err = s.makeDir(id)
+		if err != nil {
+			return false, err
+		}
 
-	err = s.makeDir(id)
-	if err != nil {
-		return false, err
-	}
+		err = ioutil.WriteFile(s.dataPath(id), buf, 0600)
+		if err != nil {
+			return false, err
+		}
 
-	err = ioutil.WriteFile(s.dataPath(id), buf, 0600)
-	if err != nil {
-		return false, err
-	}
+		// TODO: Add integrity-checking for key server half?
 
-	// TODO: Add integrity-checking for key server half?
-
-	data, err := serverHalf.MarshalBinary()
-	if err != nil {
-		return false, err
-	}
-	err = ioutil.WriteFile(s.keyServerHalfPath(id), data, 0600)
-	if err != nil {
-		return false, err
+		data, err := serverHalf.MarshalBinary()
+		if err != nil {
+			return false, err
+		}
+		err = ioutil.WriteFile(s.keyServerHalfPath(id), data, 0600)
+		if err != nil {
+			return false, err
+		}
 	}
 
 	err = s.addRefs(id, []BlockContext{context}, liveBlockRef, tag)

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -297,7 +297,7 @@ func (s *blockDiskStore) getDataWithContext(id BlockID, context BlockContext) (
 	return s.getData(id)
 }
 
-func (s *blockDiskStore) getAllRefs() (map[BlockID]blockRefMap, error) {
+func (s *blockDiskStore) getAllRefsForTest() (map[BlockID]blockRefMap, error) {
 	res := make(map[BlockID]blockRefMap)
 
 	fileInfos, err := ioutil.ReadDir(s.dir)

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -51,7 +51,8 @@ import (
 //           May be missing.
 //   - key_server_half: The raw data for the associated key server half.
 //                      May be missing, but should be present when data is.
-//   - refs: The list of references to the block. May be missing.
+//   - refs: The list of references to the block, encoded as a serialized
+//           blockRefMap. May be missing.
 //
 // Future versions of the disk store might add more files to this
 // directory; if any code is written to move blocks around, it should

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -53,7 +53,7 @@ import (
 //   - ksh:  The raw data for the associated key server half.
 //           May be missing, but should be present when data is.
 //   - refs: The list of references to the block, encoded as a serialized
-//           blockRefMap. May be missing.
+//           blockRefInfo. May be missing.
 //
 // Future versions of the disk store might add more files to this
 // directory; if any code is written to move blocks around, it should

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -317,7 +317,9 @@ func (s *blockDiskStore) hasData(id BlockID) error {
 
 func (s *blockDiskStore) getDataSize(id BlockID) (int64, error) {
 	fi, err := os.Stat(s.dataPath(id))
-	if err != nil {
+	if os.IsNotExist(err) {
+		return 0, nil
+	} else if err != nil {
 		return 0, err
 	}
 	return fi.Size(), nil

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -280,6 +280,14 @@ func (s *blockDiskStore) hasContext(id BlockID, context BlockContext) (
 	return refs.checkExists(context)
 }
 
+func (s *blockDiskStore) getDataSize(id BlockID) (int64, error) {
+	fi, err := os.Stat(s.dataPath(id))
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}
+
 func (s *blockDiskStore) getDataWithContext(id BlockID, context BlockContext) (
 	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
 	hasContext, err := s.hasContext(id, context)

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -19,22 +19,22 @@ import (
 //
 // The directory layout looks like:
 //
-// /0100/0...01/data
-// /0100/0...01/id
-// /0100/0...01/key_server_half
-// /0100/0...01/refs
+// dir/0100/0...01/data
+// dir/0100/0...01/id
+// dir/0100/0...01/key_server_half
+// dir/0100/0...01/refs
 // ...
-// /01cc/5...55/id
-// /01cc/5...55/refs
+// dir/01cc/5...55/id
+// dir/01cc/5...55/refs
 // ...
-// /01dd/6...66/data
-// /01dd/6...66/id
-// /01dd/6...66/key_server_half
+// dir/01dd/6...66/data
+// dir/01dd/6...66/id
+// dir/01dd/6...66/key_server_half
 // ...
-// /01ff/f...ff/data
-// /01ff/f...ff/id
-// /01ff/f...ff/key_server_half
-// /01ff/f...ff/refs
+// dir/01ff/f...ff/data
+// dir/01ff/f...ff/id
+// dir/01ff/f...ff/key_server_half
+// dir/01ff/f...ff/refs
 //
 // Each block has its own subdirectory with its ID truncated to 17
 // bytes (34 characters) as a name. The block subdirectories are

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -348,9 +348,9 @@ func (s *blockDiskStore) walkBlockDirs(
 
 // All functions below are public functions.
 
-// getTotalDataSize returns the sum of the size of the data for each
-// stored block.
-func (s *blockDiskStore) getTotalDataSize() (int64, error) {
+// getUnflushedBytes returns the sum of the size of the data for each
+// stored block that needs to be flushed.
+func (s *blockDiskStore) getUnflushedBytes() (int64, error) {
 	var totalSize int64
 	err := s.walkBlockDirs(func(name, subName string) error {
 		dir := filepath.Join(s.dir, name, subName)

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -139,7 +139,7 @@ func (s *blockDiskStore) makeDir(id BlockID) error {
 
 // TODO: Support unknown fields.
 type blockFlags struct {
-	NeedsFlushing bool
+	NeedsFlush bool
 }
 
 func (s *blockDiskStore) getFlags(id BlockID) (blockFlags, error) {
@@ -502,6 +502,11 @@ func (s *blockDiskStore) put(id BlockID, context BlockContext, buf []byte,
 		if err != nil {
 			return false, err
 		}
+	}
+
+	err = s.setFlags(id, blockFlags{NeedsFlush: true})
+	if err != nil {
+		return false, err
 	}
 
 	err = s.addRefs(id, []BlockContext{context}, liveBlockRef, tag)

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -280,6 +280,11 @@ func (s *blockDiskStore) hasContext(id BlockID, context BlockContext) (
 	return refs.checkExists(context)
 }
 
+func (s *blockDiskStore) hasData(id BlockID) error {
+	_, err := os.Stat(s.dataPath(id))
+	return err
+}
+
 func (s *blockDiskStore) getDataSize(id BlockID) (int64, error) {
 	fi, err := os.Stat(s.dataPath(id))
 	if err != nil {

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -135,16 +135,11 @@ func (s *blockDiskStore) makeDir(id BlockID) error {
 
 // getRefs returns the references for the given ID.
 func (s *blockDiskStore) getRefs(id BlockID) (blockRefMap, error) {
-	data, err := ioutil.ReadFile(s.refsPath(id))
+	var refs blockRefMap
+	err := kbfscodec.DeserializeFromFile(s.codec, s.refsPath(id), &refs)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
-		return nil, err
-	}
-
-	var refs blockRefMap
-	err = s.codec.Decode(data, &refs)
-	if err != nil {
 		return nil, err
 	}
 
@@ -163,17 +158,7 @@ func (s *blockDiskStore) putRefs(id BlockID, refs blockRefMap) error {
 		return nil
 	}
 
-	buf, err := s.codec.Encode(refs)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile(s.refsPath(id), buf, 0600)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return kbfscodec.SerializeToFile(s.codec, refs, s.refsPath(id))
 }
 
 // addRefs adds references for the given contexts to the given ID, all

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -440,10 +440,10 @@ func (s *blockDiskStore) archiveReferences(
 	return nil
 }
 
-// removeReferences removes references for the given contexts from the
-// given ID. If tag is non-empty, then a reference will be removed
-// only if its most recent tag (passed in to addRefs) matches the
-// given one.
+// removeReferences removes references for the given contexts from
+// their respective IDs. If tag is non-empty, then a reference will be
+// removed only if its most recent tag (passed in to addRefs) matches
+// the given one.
 func (s *blockDiskStore) removeReferences(
 	id BlockID, contexts []BlockContext, tag string) (
 	liveCount int, err error) {

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -89,8 +89,10 @@ func makeBlockDiskStore(codec kbfscodec.Codec, crypto cryptoPure,
 
 // The functions below are for building various paths.
 
+const aggregateInfoFilename = "aggregate_info"
+
 func (s *blockDiskStore) aggregateInfoPath() string {
-	return filepath.Join(s.dir, "aggregate_info")
+	return filepath.Join(s.dir, aggregateInfoFilename)
 }
 
 func (s *blockDiskStore) blockPath(id BlockID) string {
@@ -104,16 +106,8 @@ func (s *blockDiskStore) blockPath(id BlockID) string {
 	return filepath.Join(s.dir, idStr[:4], idStr[4:34])
 }
 
-const dataFilename = "data"
-
 func (s *blockDiskStore) dataPath(id BlockID) string {
-	return filepath.Join(s.blockPath(id), dataFilename)
-}
-
-const flushInfoFilename = "flushInfo"
-
-func (s *blockDiskStore) flushInfoPath(id BlockID) string {
-	return filepath.Join(s.blockPath(id), flushInfoFilename)
+	return filepath.Join(s.blockPath(id), "data")
 }
 
 const idFilename = "id"
@@ -403,6 +397,9 @@ func (s *blockDiskStore) getAllRefsForTest() (map[BlockID]blockRefMap, error) {
 	for _, fi := range fileInfos {
 		name := fi.Name()
 		if !fi.IsDir() {
+			if name == aggregateInfoFilename {
+				continue
+			}
 			return nil, fmt.Errorf("Unexpected non-dir %q", name)
 		}
 

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -95,8 +95,10 @@ func (s *blockDiskStore) blockPath(id BlockID) string {
 	return filepath.Join(s.dir, idStr[:4], idStr[4:34])
 }
 
+const dataFilename = "data"
+
 func (s *blockDiskStore) dataPath(id BlockID) string {
-	return filepath.Join(s.blockPath(id), "data")
+	return filepath.Join(s.blockPath(id), dataFilename)
 }
 
 const idFilename = "id"
@@ -250,6 +252,26 @@ func (s *blockDiskStore) getData(id BlockID) (
 }
 
 // All functions below are public functions.
+
+// getTotalDataSize returns the sum of the size of the data for each
+// stored block.
+func (s *blockDiskStore) getTotalDataSize() (int64, error) {
+	var totalSize int64
+	err := filepath.Walk(s.dir,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if filepath.Base(path) == dataFilename {
+				totalSize += info.Size()
+			}
+			return nil
+		})
+	if err != nil {
+		return 0, err
+	}
+	return totalSize, nil
+}
 
 func (s *blockDiskStore) hasAnyRef(id BlockID) (bool, error) {
 	refs, err := s.getRefs(id)

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -131,6 +131,8 @@ func (s *blockDiskStore) makeDir(id BlockID) error {
 	return nil
 }
 
+// TODO: Add caching for refs.
+
 // getRefs returns the references for the given ID.
 func (s *blockDiskStore) getRefs(id BlockID) (blockRefMap, error) {
 	data, err := ioutil.ReadFile(s.refsPath(id))

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -259,6 +259,11 @@ func (s *blockDiskStore) getTotalDataSize() (int64, error) {
 	var totalSize int64
 	err := filepath.Walk(s.dir,
 		func(path string, info os.FileInfo, err error) error {
+			// The root directory doesn't exist, so just
+			// exit early and return 0.
+			if path == s.dir && os.IsNotExist(err) {
+				return nil
+			}
 			if err != nil {
 				return err
 			}

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -21,7 +21,7 @@ import (
 //
 // dir/0100/0...01/data
 // dir/0100/0...01/id
-// dir/0100/0...01/key_server_half
+// dir/0100/0...01/ksh
 // dir/0100/0...01/refs
 // ...
 // dir/01cc/5...55/id
@@ -29,11 +29,11 @@ import (
 // ...
 // dir/01dd/6...66/data
 // dir/01dd/6...66/id
-// dir/01dd/6...66/key_server_half
+// dir/01dd/6...66/ksh
 // ...
 // dir/01ff/f...ff/data
 // dir/01ff/f...ff/id
-// dir/01ff/f...ff/key_server_half
+// dir/01ff/f...ff/ksh
 // dir/01ff/f...ff/refs
 //
 // Each block has its own subdirectory with its ID truncated to 17
@@ -46,11 +46,11 @@ import (
 //
 // Each block directory has the following files:
 //
-//   - id: The full block ID in binary format. Always present.
+//   - id:   The full block ID in binary format. Always present.
 //   - data: The raw block data that should hash to the block ID.
 //           May be missing.
-//   - key_server_half: The raw data for the associated key server half.
-//                      May be missing, but should be present when data is.
+//   - ksh:  The raw data for the associated key server half.
+//           May be missing, but should be present when data is.
 //   - refs: The list of references to the block, encoded as a serialized
 //           blockRefMap. May be missing.
 //
@@ -59,9 +59,9 @@ import (
 // be careful to preserve any unknown files in a block directory.
 //
 // The maximum number of characters added to the root dir by a block
-// disk store is 52:
+// disk store is 44:
 //
-//   /01ff/f...(30 characters total)...ff/key_server_half
+//   /01ff/f...(30 characters total)...ff/data
 //
 // blockDiskStore is not goroutine-safe, so any code that uses it must
 // guarantee that only one goroutine at a time calls its functions.
@@ -114,7 +114,7 @@ func (s *blockDiskStore) idPath(id BlockID) string {
 }
 
 func (s *blockDiskStore) keyServerHalfPath(id BlockID) string {
-	return filepath.Join(s.blockPath(id), "key_server_half")
+	return filepath.Join(s.blockPath(id), "ksh")
 }
 
 func (s *blockDiskStore) refsPath(id BlockID) string {

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -183,7 +183,7 @@ func TestBlockDiskStoreRemoveReferences(t *testing.T) {
 
 	// Remove references.
 	liveCount, err := s.removeReferences(
-		bID, []BlockContext{bCtx, bCtx2}, "")
+		bID, []BlockContext{bCtx, bCtx2}, false /* forFlush */, "")
 	require.NoError(t, err)
 	require.Equal(t, 0, liveCount)
 
@@ -211,7 +211,8 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 	require.Error(t, err, "Trying to remove data")
 
 	// Remove reference.
-	liveCount, err := s.removeReferences(bID, []BlockContext{bCtx}, "")
+	liveCount, err := s.removeReferences(
+		bID, []BlockContext{bCtx}, false /* forFlush */, "")
 	require.NoError(t, err)
 	require.Equal(t, 0, liveCount)
 
@@ -271,13 +272,13 @@ func TestBlockDiskStoreTotalDataSize(t *testing.T) {
 	requireSize(expectedSize)
 
 	liveCount, err := s.removeReferences(
-		bID1, []BlockContext{bCtx1, bCtx1b}, "")
+		bID1, []BlockContext{bCtx1, bCtx1b}, false /* forFlush */, "")
 	require.NoError(t, err)
 	require.Equal(t, 0, liveCount)
 	requireSize(expectedSize)
 
 	liveCount, err = s.removeReferences(
-		bID2, []BlockContext{bCtx2, bCtx2}, "")
+		bID2, []BlockContext{bCtx2, bCtx2}, false /* forFlush */, "")
 	require.NoError(t, err)
 	require.Equal(t, 0, liveCount)
 	requireSize(expectedSize)

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -46,7 +46,7 @@ func teardownBlockDiskStoreTest(t *testing.T, tempdir string, s *blockDiskStore)
 
 func putBlockDisk(
 	t *testing.T, s *blockDiskStore, data []byte) (
-	BlockID, BlockContext, kbfscrypto.BlockCryptKeyServerHalf) {
+	bool, BlockID, BlockContext, kbfscrypto.BlockCryptKeyServerHalf) {
 	bID, err := s.crypto.MakePermanentBlockID(data)
 	require.NoError(t, err)
 
@@ -55,10 +55,10 @@ func putBlockDisk(
 	serverHalf, err := s.crypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
-	err = s.put(bID, bCtx, data, serverHalf, "")
+	didPut, err := s.put(bID, bCtx, data, serverHalf, "")
 	require.NoError(t, err)
 
-	return bID, bCtx, serverHalf
+	return didPut, bID, bCtx, serverHalf
 }
 
 func addBlockDiskRef(
@@ -89,7 +89,7 @@ func TestBlockDiskStoreBasic(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, s, data)
+	_, bID, bCtx, serverHalf := putBlockDisk(t, s, data)
 
 	// Make sure we get the same block back.
 	getAndCheckBlockDiskData(t, s, bID, bCtx, data, serverHalf)
@@ -131,7 +131,7 @@ func TestBlockDiskStoreArchiveReferences(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, s, data)
+	_, bID, bCtx, serverHalf := putBlockDisk(t, s, data)
 
 	// Add a reference.
 	bCtx2 := addBlockDiskRef(t, s, bID)
@@ -168,7 +168,7 @@ func TestBlockDiskStoreRemoveReferences(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, s, data)
+	_, bID, bCtx, serverHalf := putBlockDisk(t, s, data)
 
 	// Add a reference.
 	bCtx2 := addBlockDiskRef(t, s, bID)
@@ -196,7 +196,7 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 
 	// Put the block.
 	data := []byte{1, 2, 3, 4}
-	bID, bCtx, _ := putBlockDisk(t, s, data)
+	_, bID, bCtx, _ := putBlockDisk(t, s, data)
 
 	// Should not be removable.
 	err := s.remove(bID)
@@ -238,12 +238,12 @@ func TestBlockDiskStoreTotalDataSize(t *testing.T) {
 	requireSize(0)
 
 	data1 := []byte{1, 2, 3, 4}
-	bID1, bCtx1, _ := putBlockDisk(t, s, data1)
+	_, bID1, bCtx1, _ := putBlockDisk(t, s, data1)
 
 	requireSize(len(data1))
 
 	data2 := []byte{1, 2, 3, 4, 5}
-	bID2, bCtx2, _ := putBlockDisk(t, s, data2)
+	_, bID2, bCtx2, _ := putBlockDisk(t, s, data2)
 
 	expectedSize := len(data1) + len(data2)
 	requireSize(expectedSize)

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -48,10 +48,6 @@ func putBlockDisk(
 	require.NoError(t, err)
 	require.True(t, didPut)
 
-	info, err := s.getFlushInfo(bID)
-	require.NoError(t, err)
-	require.Equal(t, 1, info.UnflushedPutCount)
-
 	return bID, bCtx, serverHalf
 }
 
@@ -196,11 +192,6 @@ func TestBlockDiskStoreRemoveReferences(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, half)
-
-	// Should still need flushing.
-	info, err := s.getFlushInfo(bID)
-	require.NoError(t, err)
-	require.Equal(t, 1, info.UnflushedPutCount)
 }
 
 func TestBlockDiskStoreRemove(t *testing.T) {

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -48,6 +48,10 @@ func putBlockDisk(
 	require.NoError(t, err)
 	require.True(t, didPut)
 
+	flags, err := s.getFlags(bID)
+	require.NoError(t, err)
+	require.True(t, flags.NeedsFlush)
+
 	return bID, bCtx, serverHalf
 }
 

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -209,6 +210,16 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 	// Should now be removable.
 	err = s.remove(bID)
 	require.NoError(t, err)
+
 	_, _, err = s.getData(bID)
 	require.Equal(t, blockNonExistentError{bID}, err)
+
+	filepath.Walk(s.dir,
+		func(path string, info os.FileInfo, _ error) error {
+			// We should only find the blocks directory here.
+			if path != s.dir {
+				t.Errorf("Found unexpected block path: %s", path)
+			}
+			return nil
+		})
 }

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -44,9 +44,8 @@ func putBlockDisk(
 	serverHalf, err := s.crypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
-	didPut, err := s.put(bID, bCtx, data, serverHalf, "")
+	err = s.put(bID, bCtx, data, serverHalf, "")
 	require.NoError(t, err)
-	require.True(t, didPut)
 
 	return bID, bCtx, serverHalf
 }
@@ -97,20 +96,6 @@ func TestBlockDiskStoreBasic(t *testing.T) {
 
 	getAndCheckBlockDiskData(t, s, bID, bCtx, data, serverHalf)
 	getAndCheckBlockDiskData(t, s, bID, bCtx2, data, serverHalf)
-}
-
-func TestBlockDiskStorePutTwice(t *testing.T) {
-	tempdir, s := setupBlockDiskStoreTest(t)
-	defer teardownBlockDiskStoreTest(t, tempdir)
-
-	// Put the block.
-	data := []byte{1, 2, 3, 4}
-	bID, bCtx, serverHalf := putBlockDisk(t, s, data)
-
-	// Put the block again.
-	didPut, err := s.put(bID, bCtx, data, serverHalf, "")
-	require.NoError(t, err)
-	require.False(t, didPut)
 }
 
 func TestBlockDiskStoreAddReference(t *testing.T) {
@@ -284,9 +269,9 @@ func TestBlockDiskStoreUnflushedBytes(t *testing.T) {
 	require.NoError(t, err)
 	requireSize(len(data2))
 
-	// Removing blocks should also affect the size.
+	// Removing blocks shouldn't affect the size.
 
 	err = s.remove(bID2)
 	require.NoError(t, err)
-	requireSize(0)
+	requireSize(len(data2))
 }

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -214,7 +214,7 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 	_, _, err = s.getData(bID)
 	require.Equal(t, blockNonExistentError{bID}, err)
 
-	filepath.Walk(s.dir,
+	err = filepath.Walk(s.dir,
 		func(path string, info os.FileInfo, _ error) error {
 			// We should only find the blocks directory here.
 			if path != s.dir {
@@ -222,4 +222,5 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 			}
 			return nil
 		})
+	require.NoError(t, err)
 }

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -48,9 +48,9 @@ func putBlockDisk(
 	require.NoError(t, err)
 	require.True(t, didPut)
 
-	flags, err := s.getFlags(bID)
+	info, err := s.getFlushInfo(bID)
 	require.NoError(t, err)
-	require.True(t, flags.NeedsFlush)
+	require.Equal(t, 1, info.UnflushedPutCount)
 
 	return bID, bCtx, serverHalf
 }
@@ -198,9 +198,9 @@ func TestBlockDiskStoreRemoveReferences(t *testing.T) {
 	require.Equal(t, serverHalf, half)
 
 	// Should still need flushing.
-	flags, err := s.getFlags(bID)
+	info, err := s.getFlushInfo(bID)
 	require.NoError(t, err)
-	require.True(t, flags.NeedsFlush)
+	require.Equal(t, 1, info.UnflushedPutCount)
 }
 
 func TestBlockDiskStoreRemove(t *testing.T) {

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -229,8 +229,9 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 
 	err = filepath.Walk(s.dir,
 		func(path string, info os.FileInfo, _ error) error {
-			// We should only find the blocks directory here.
-			if path != s.dir {
+			// We should only find the blocks directory
+			// and the aggregate info file here.
+			if path != s.dir && path != s.aggregateInfoPath() {
 				t.Errorf("Found unexpected block path: %s", path)
 			}
 			return nil

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -196,6 +196,22 @@ func TestBlockDiskStoreRemoveReferences(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, half)
+
+	// Should still need flushing.
+	flags, err := s.getFlags(bID)
+	require.NoError(t, err)
+	require.True(t, flags.NeedsFlush)
+
+	// Simulate a flush.
+	liveCount, err = s.removeReferences(
+		bID, []BlockContext{bCtx, bCtx2},
+		true /* forFlush */, "some tag")
+	require.NoError(t, err)
+	require.Equal(t, 0, liveCount)
+
+	flags, err = s.getFlags(bID)
+	require.NoError(t, err)
+	require.False(t, flags.NeedsFlush)
 }
 
 func TestBlockDiskStoreRemove(t *testing.T) {

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -280,7 +280,7 @@ func TestBlockDiskStoreUnflushedBytes(t *testing.T) {
 
 	// Flushing a put should affect the size.
 
-	err = s.flushPut(bID1)
+	err = s.onPutFlush(bID1)
 	require.NoError(t, err)
 	requireSize(len(data2))
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -956,7 +956,7 @@ func (j *blockJournal) checkInSyncForTest() error {
 		return err
 	}
 
-	storeRefs, err := j.s.getAllRefs()
+	storeRefs, err := j.s.getAllRefsForTest()
 	if err != nil {
 		return err
 	}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -328,14 +328,9 @@ func (j *blockJournal) archiveReferences(
 		}
 	}()
 
-	var next journalOrdinal
-	lo, err := j.j.readLatestOrdinal()
-	if os.IsNotExist(err) {
-		next = 0
-	} else if err != nil {
+	next, err := j.end()
+	if err != nil {
 		return err
-	} else {
-		next = lo + 1
 	}
 
 	err = j.s.archiveReferences(contexts, next.String())

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -275,7 +275,7 @@ func (j *blockJournal) getDataWithContext(id BlockID, context BlockContext) (
 
 func (j *blockJournal) getUnflushedBytes() (int64, error) {
 	if j.cachedUnflushedBytes < 0 {
-		unflushedBytes, err := j.s.getTotalDataSize()
+		unflushedBytes, err := j.s.getUnflushedBytes()
 		if err != nil {
 			return 0, err
 		}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -27,6 +27,7 @@ import (
 //
 // The directory layout looks like:
 //
+// dir/aggregate_info
 // dir/block_journal/EARLIEST
 // dir/block_journal/LATEST
 // dir/block_journal/0...000
@@ -36,6 +37,9 @@ import (
 // dir/saved_block_journal/EARLIEST
 // dir/saved_block_journal/LATEST
 // dir/saved_block_journal/...
+//
+// aggregate_info holds aggregate info about the block journal;
+// currently it just holds the count of unflushed bytes.
 //
 // Each entry in the journal in dir/block_journal contains the
 // mutating operation and arguments for a single operation, except for
@@ -340,7 +344,8 @@ func (j *blockJournal) putData(
 		return err
 	}
 
-	// Decremented when the journal entry is ignored or flushed.
+	// Decremented when the put journal entry is ignored or
+	// flushed.
 	err = j.adjustUnflushedBytes(int64(len(buf)))
 	if err != nil {
 		return err

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -59,9 +59,16 @@ type blockJournal struct {
 	log      logger.Logger
 	deferLog logger.Logger
 
-	j                diskJournal
+	// j is the main journal.
+	j diskJournal
+
+	// saveUntilMDFlush, when non-nil, prevents garbage collection
+	// of blocks. When removed, all the referenced blocks are
+	// garbage-collected.
 	saveUntilMDFlush *diskJournal
 
+	// s stores all the block data. s should always reflect the
+	// state you get by replaying all the entries in j.
 	s *blockDiskStore
 }
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -633,6 +633,17 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 			ordinal, earliestOrdinal)
 	}
 
+	if entry.Op == blockPutOp && !entry.Ignore {
+		id, _, err := entry.getSingleContext()
+		if err != nil {
+			return 0, err
+		}
+		flushedBytes, err = j.s.getDataSize(id)
+		if err != nil {
+			return 0, err
+		}
+	}
+
 	_, err = j.j.removeEarliest()
 	if err != nil {
 		return 0, err

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -417,7 +417,8 @@ func (j *blockJournal) removeReferences(
 		// Remove the references unconditionally here (i.e.,
 		// with an empty tag), since j.s should reflect the
 		// most recent state.
-		liveCount, err := j.s.removeReferences(id, idContexts, "")
+		liveCount, err := j.s.removeReferences(
+			id, idContexts, false /* forFlush */, "")
 		if err != nil {
 			return nil, err
 		}
@@ -690,7 +691,8 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 	// references).
 	for id, idContexts := range entry.Contexts {
 		liveCount, err := j.s.removeReferences(
-			id, idContexts, earliestOrdinal.String())
+			id, idContexts, true, /* forFlush */
+			earliestOrdinal.String())
 		if err != nil {
 			return 0, err
 		}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -243,6 +243,12 @@ func (j *blockJournal) hasData(id BlockID) error {
 	return j.s.hasData(id)
 }
 
+func (j *blockJournal) remove(id BlockID) error {
+	// TODO: we'll eventually need a sweeper to clean up entries
+	// left behind if we crash here.
+	return j.s.remove(id)
+}
+
 // All functions below are public functions.
 
 func (j *blockJournal) getDataWithContext(id BlockID, context BlockContext) (
@@ -687,10 +693,7 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 		if j.saveUntilMDFlush == nil && liveCount == 0 {
 			// Garbage-collect the old entry if we are not
 			// saving blocks until the next MD flush.
-			// TODO: we'll eventually need a sweeper to
-			// clean up entries left behind if we crash
-			// here.
-			err = j.s.remove(id)
+			err = j.remove(id)
 			if err != nil {
 				return 0, err
 			}
@@ -857,10 +860,8 @@ func (j *blockJournal) onMDFlush() error {
 				return err
 			}
 			if !hasRef {
-				// Garbage-collect the old entry.  TODO: we'll
-				// eventually need a sweeper to clean up entries left
-				// behind if we crash here.
-				err = j.s.remove(id)
+				// Garbage-collect the old entry.
+				err = j.remove(id)
 				if err != nil {
 					return err
 				}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -45,9 +45,9 @@ import (
 // blockDiskStore comments for more details.
 //
 // The maximum number of characters added to the root dir by a block
-// journal is 59:
+// journal is 51:
 //
-//   /blocks/(max 52 characters)
+//   /blocks/(max 44 characters)
 //
 // blockJournal is not goroutine-safe, so any code that uses it must
 // guarantee that only one goroutine at a time calls its functions.

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -346,7 +346,7 @@ func (j *blockJournal) addReference(
 		return err
 	}
 
-	_, err = j.appendJournalEntry(blockJournalEntry{
+	_, err = j.appendJournalEntry(ctx, blockJournalEntry{
 		Op:       addRefOp,
 		Contexts: map[BlockID][]BlockContext{id: {context}},
 	})

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -682,6 +682,17 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 		return 0, err
 	}
 
+	if isPutFlush {
+		err := j.s.flushPut(putID)
+		if err != nil {
+			return 0, err
+		}
+
+		if j.cachedUnflushedBytes >= 0 {
+			j.cachedUnflushedBytes -= flushedBytes
+		}
+	}
+
 	// Remove any of the entry's refs that hasn't been modified by
 	// a subsequent block op (i.e., that has earliestOrdinal as a
 	// tag). Has no effect for removeRefsOp (since those are
@@ -702,17 +713,6 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 			if err != nil {
 				return 0, err
 			}
-		}
-	}
-
-	if isPutFlush {
-		err := j.s.flushPut(putID)
-		if err != nil {
-			return 0, err
-		}
-
-		if j.cachedUnflushedBytes >= 0 {
-			j.cachedUnflushedBytes -= flushedBytes
 		}
 	}
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -683,7 +683,7 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 	}
 
 	if isPutFlush {
-		err := j.s.flushPut(putID)
+		err := j.s.onPutFlush(putID)
 		if err != nil {
 			return 0, err
 		}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -657,9 +657,9 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 
 	// Remove any of the entry's refs that hasn't been modified by
 	// a subsequent block op (i.e., that has earliestOrdinal as a
-	// tag). Doesn't have an effect for removeRefsOp, since those
-	// are already removed, and mdRevMarkerOp, but doing this is
-	// harmless.
+	// tag). Has no effect for removeRefsOp (since those are
+	// already removed) or mdRevMarkerOp (which has no
+	// references).
 	for id, idContexts := range entry.Contexts {
 		liveCount, err := j.s.removeReferences(
 			id, idContexts, earliestOrdinal.String())

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -31,35 +31,23 @@ import (
 // dir/block_journal/0...000
 // dir/block_journal/0...001
 // dir/block_journal/0...fff
-// dir/blocks/0100/0...01/data
-// dir/blocks/0100/0...01/key_server_half
-// ...
-// dir/blocks/01ff/f...ff/data
-// dir/blocks/01ff/f...ff/key_server_half
+// dir/blocks/...
+// dir/saved_block_journal/EARLIEST
+// dir/saved_block_journal/LATEST
+// dir/saved_block_journal/...
 //
 // Each entry in the journal in dir/block_journal contains the
 // mutating operation and arguments for a single operation, except for
 // block data. (See diskJournal comments for more details about the
 // journal.)
 //
-// The block data is stored separately in dir/blocks. Each block has
-// its own subdirectory with its ID truncated to 17 bytes (34
-// characters) as a name. The block subdirectories are splayed over (#
-// of possible hash types) * 256 subdirectories -- one byte for the
-// hash type (currently only one) plus the first byte of the hash data
-// -- using the first four characters of the name to keep the number
-// of directories in dir itself to a manageable number, similar to
-// git. Each block directory has data, which is the raw block data
-// that should hash to the block ID, and key_server_half, which
-// contains the raw data for the associated key server half. Future
-// versions of the journal might add more files to this directory; if
-// any code is written to move blocks around, it should be careful to
-// preserve any unknown files in a block directory.
+// The block data is stored separately in dir/blocks. See
+// blockDiskStore comments for more details.
 //
 // The maximum number of characters added to the root dir by a block
 // journal is 59:
 //
-//   /blocks/01ff/f...(30 characters total)...ff/key_server_half
+//   /blocks/(max 52 characters)
 //
 // blockJournal is not goroutine-safe, so any code that uses it must
 // guarantee that only one goroutine at a time calls its functions.

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -245,9 +245,9 @@ func (j *blockJournal) getDataWithContext(id BlockID, context BlockContext) (
 	return j.s.getDataWithContext(id, context)
 }
 
-func (j *blockJournal) getUnflushedBytes() int64 {
+func (j *blockJournal) getUnflushedBytes() (int64, error) {
 	// TODO: Calculate this, and possibly cache it.
-	return 0
+	return 0, nil
 }
 
 func (j *blockJournal) putData(

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -257,9 +257,9 @@ func (j *blockJournal) remove(id BlockID) (int64, error) {
 	}
 
 	if j.cachedUnflushedBytes >= 0 {
-		// If we somehow get out of sync and dip below zero,
-		// then we'll just self-correct at the next call to
-		// getUnflushedBytes().
+		// If we somehow get out of sync such that we dip
+		// below zero, then we'll just self-correct at the
+		// next call to getUnflushedBytes().
 		j.cachedUnflushedBytes -= flushedBytes
 	}
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -65,6 +65,9 @@ type blockJournal struct {
 	// saveUntilMDFlush, when non-nil, prevents garbage collection
 	// of blocks. When removed, all the referenced blocks are
 	// garbage-collected.
+	//
+	// TODO: We only really need to save a list of IDs, and not a
+	// full journal.
 	saveUntilMDFlush *diskJournal
 
 	// s stores all the block data. s should always reflect the

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -754,6 +754,15 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkers(ctx context.Context,
 				return err
 			}
 
+			if e.Op == blockPutOp {
+				// Treat ignored blocks as flushed,
+				// for the purposes of accounting.
+				err := j.s.onPutFlush(id)
+				if err != nil {
+					return nil
+				}
+			}
+
 		case mdRevMarkerOp:
 			e.Ignore = true
 			err = j.j.writeJournalEntry(i, e)

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -234,9 +234,8 @@ func (j *blockJournal) end() (journalOrdinal, error) {
 	return last + 1, nil
 }
 
-func (j *blockJournal) exists(id BlockID) error {
-	_, err := os.Stat(j.s.dataPath(id))
-	return err
+func (j *blockJournal) hasData(id BlockID) error {
+	return j.s.hasData(id)
 }
 
 // All functions below are public functions.

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -237,7 +237,7 @@ func (j *blockJournal) getDataWithContext(id BlockID, context BlockContext) (
 }
 
 func (j *blockJournal) getUnflushedBytes() int64 {
-	// TODO: Figure out what to do here.
+	// TODO: Calculate this, and possibly cache it.
 	return 0
 }
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -280,7 +280,7 @@ func (j *blockJournal) putData(
 		return err
 	}
 
-	err = j.s.put(id, context, buf, serverHalf, next.String())
+	didPut, err := j.s.put(id, context, buf, serverHalf, next.String())
 	if err != nil {
 		return err
 	}
@@ -291,6 +291,10 @@ func (j *blockJournal) putData(
 	})
 	if err != nil {
 		return err
+	}
+
+	if j.cachedUnflushedBytes >= 0 && didPut {
+		j.cachedUnflushedBytes += int64(len(buf))
 	}
 
 	return nil

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -725,6 +725,13 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 
 	requireSize := func(expectedSize int) {
 		require.Equal(t, int64(expectedSize), j.getUnflushedBytes())
+		var info aggregateInfo
+		err := kbfscodec.DeserializeFromFile(
+			j.codec, aggregateInfoPath(j.dir), &info)
+		if !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+		require.Equal(t, int64(expectedSize), info.UnflushedBytes)
 	}
 
 	// Prime the cache.

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -748,7 +748,8 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 	bCtx1b := addBlockRef(ctx, t, j, bID1)
 	requireSize(expectedSize)
 
-	bID3, err := j.crypto.MakePermanentBlockID([]byte{1, 2, 3})
+	data3 := []byte{1, 2, 3}
+	bID3, err := j.crypto.MakePermanentBlockID(data3)
 	require.NoError(t, err)
 	_ = addBlockRef(ctx, t, j, bID3)
 	require.NoError(t, err)
@@ -792,7 +793,18 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 	flushOne()
 	requireSize(0)
 
-	// Flush the second add ref.
+	// Flush the second add ref, but push the block to the server
+	// first.
+
+	uid1 := keybase1.MakeTestUID(1)
+	bCtx3 := BlockContext{uid1, "", ZeroBlockRefNonce}
+	serverHalf3, err := j.crypto.MakeRandomBlockCryptKeyServerHalf()
+	require.NoError(t, err)
+
+	err = blockServer.Put(
+		context.Background(), tlfID, bID3, bCtx3, data3, serverHalf3)
+	require.NoError(t, err)
+
 	flushOne()
 	requireSize(0)
 

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -748,7 +748,12 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 	bCtx1b := addBlockRef(ctx, t, j, bID1)
 	requireSize(expectedSize)
 
-	err := j.archiveReferences(
+	bID3, err := j.crypto.MakePermanentBlockID([]byte{1, 2, 3})
+	require.NoError(t, err)
+	_ = addBlockRef(ctx, t, j, bID3)
+	require.NoError(t, err)
+
+	err = j.archiveReferences(
 		ctx, map[BlockID][]BlockContext{bID2: {bCtx2}})
 	require.NoError(t, err)
 	requireSize(expectedSize)
@@ -783,7 +788,11 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 	flushOne()
 	requireSize(0)
 
-	// Flush the add ref.
+	// Flush the first add ref.
+	flushOne()
+	requireSize(0)
+
+	// Flush the second add ref.
 	flushOne()
 	requireSize(0)
 

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -266,7 +266,7 @@ func testBlockJournalGCd(t *testing.T, j *blockJournal) {
 	err := filepath.Walk(j.dir,
 		func(path string, info os.FileInfo, _ error) error {
 			// We should only find the blocks directory here.
-			if path != j.dir && path != j.s.dir && path != j.j.dir {
+			if path != j.dir && path != j.s.dir && path != j.j.dir && path != j.s.aggregateInfoPath() {
 				t.Errorf("Found unexpected block path: %s", path)
 			}
 			return nil

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -658,7 +658,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 
 	// The blocks can still be fetched from the journal.
 	for _, bid := range savedBlocks {
-		err = j.exists(bid)
+		err = j.hasData(bid)
 		require.NoError(t, err)
 	}
 
@@ -682,7 +682,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	// Make sure all the blocks still exist, including both the old
 	// and the new ones.
 	for _, bid := range savedBlocks {
-		err = j.exists(bid)
+		err = j.hasData(bid)
 		require.NoError(t, err)
 	}
 
@@ -698,13 +698,13 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	err = j.onMDFlush()
 	require.NoError(t, err)
 
-	err = j.exists(bID1)
+	err = j.hasData(bID1)
 	require.True(t, os.IsNotExist(err))
-	err = j.exists(bID2)
+	err = j.hasData(bID2)
 	require.True(t, os.IsNotExist(err))
-	err = j.exists(bID3)
+	err = j.hasData(bID3)
 	require.True(t, os.IsNotExist(err))
-	err = j.exists(bID4)
+	err = j.hasData(bID4)
 	require.True(t, os.IsNotExist(err))
 
 	testBlockJournalGCd(t, j)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -774,23 +774,26 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 			ctx, t, j, blockServer, bcache, reporter, tlfID)
 	}
 
-	// Flush the puts.
+	// Flush the first put.
 	flushOne()
+	expectedSize = len(data2)
 	requireSize(expectedSize)
 
+	// Flush the second put.
 	flushOne()
-	requireSize(expectedSize)
+	requireSize(0)
 
-	// Flush the add and archive.
+	// Flush the add ref.
 	flushOne()
-	requireSize(expectedSize)
+	requireSize(0)
 
+	// Flush the add archive.
 	flushOne()
-	requireSize(expectedSize)
+	requireSize(0)
 
 	// Flush the first remove.
 	flushOne()
-	requireSize(len(data2))
+	requireSize(0)
 
 	// Flush the second remove.
 	flushOne()

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -267,7 +267,7 @@ func testBlockJournalGCd(t *testing.T, j *blockJournal) {
 		func(path string, info os.FileInfo, _ error) error {
 			// We should only find the blocks directories and
 			// aggregate info file here.
-			if path != j.dir && path != j.s.dir && path != j.j.dir && path != j.aggregateInfoPath() {
+			if path != j.dir && path != j.s.dir && path != j.j.dir && path != aggregateInfoPath(j.dir) {
 				t.Errorf("Found unexpected block path: %s", path)
 			}
 			return nil
@@ -724,9 +724,7 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 	defer teardownBlockJournalTest(t, tempdir, j)
 
 	requireSize := func(expectedSize int) {
-		totalSize, err := j.getUnflushedBytes()
-		require.NoError(t, err)
-		require.Equal(t, int64(expectedSize), totalSize)
+		require.Equal(t, int64(expectedSize), j.getUnflushedBytes())
 	}
 
 	// Prime the cache.
@@ -827,9 +825,7 @@ func TestBlockJournalUnflushedBytesIgnore(t *testing.T) {
 	defer teardownBlockJournalTest(t, tempdir, j)
 
 	requireSize := func(expectedSize int) {
-		totalSize, err := j.getUnflushedBytes()
-		require.NoError(t, err)
-		require.Equal(t, int64(expectedSize), totalSize)
+		require.Equal(t, int64(expectedSize), j.getUnflushedBytes())
 	}
 
 	// Prime the cache.

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -263,7 +263,7 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 }
 
 func testBlockJournalGCd(t *testing.T, j *blockJournal) {
-	filepath.Walk(j.dir,
+	err := filepath.Walk(j.dir,
 		func(path string, info os.FileInfo, _ error) error {
 			// We should only find the blocks directory here.
 			if path != j.dir && path != j.s.dir && path != j.j.dir {
@@ -271,6 +271,7 @@ func testBlockJournalGCd(t *testing.T, j *blockJournal) {
 			}
 			return nil
 		})
+	require.NoError(t, err)
 }
 
 func TestBlockJournalFlush(t *testing.T) {

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -746,16 +746,16 @@ func TestBlockJournalUnflushedBytes(t *testing.T) {
 	require.NoError(t, err)
 	requireSize(expectedSize)
 
-	liveCount, err := j.removeReferences(
+	liveCounts, err := j.removeReferences(
 		ctx, map[BlockID][]BlockContext{bID1: {bCtx1, bCtx1b}})
 	require.NoError(t, err)
-	require.Equal(t, 0, liveCount)
+	require.Equal(t, map[BlockID]int{bID1: 0}, liveCounts)
 	requireSize(expectedSize)
 
-	liveCount, err = j.removeReferences(
+	liveCounts, err = j.removeReferences(
 		ctx, map[BlockID][]BlockContext{bID2: {bCtx2}})
 	require.NoError(t, err)
-	require.Equal(t, 0, liveCount)
+	require.Equal(t, map[BlockID]int{bID2: 0}, liveCounts)
 	requireSize(expectedSize)
 
 	// TODO: Test flushing.

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -265,8 +265,9 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 func testBlockJournalGCd(t *testing.T, j *blockJournal) {
 	err := filepath.Walk(j.dir,
 		func(path string, info os.FileInfo, _ error) error {
-			// We should only find the blocks directory here.
-			if path != j.dir && path != j.s.dir && path != j.j.dir && path != j.s.aggregateInfoPath() {
+			// We should only find the blocks directories and
+			// aggregate info file here.
+			if path != j.dir && path != j.s.dir && path != j.j.dir && path != j.aggregateInfoPath() {
 				t.Errorf("Found unexpected block path: %s", path)
 			}
 			return nil

--- a/libkbfs/block_ref_map.go
+++ b/libkbfs/block_ref_map.go
@@ -22,6 +22,8 @@ func (e blockContextMismatchError) Error() string {
 		"Context mismatch: expected %s, got %s", e.expected, e.actual)
 }
 
+// TODO: Support unknown fields.
+
 type blockRefEntry struct {
 	Status  blockRefStatus
 	Context BlockContext
@@ -39,6 +41,8 @@ func (e blockRefEntry) checkContext(context BlockContext) error {
 }
 
 // blockRefMap is a map with additional checking methods.
+//
+// TODO: Make this into a struct type that supports unknown fields.
 type blockRefMap map[BlockRefNonce]blockRefEntry
 
 func (refs blockRefMap) hasNonArchivedRef() bool {

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -299,9 +299,9 @@ func (b *BlockServerDisk) ArchiveBlockReferences(ctx context.Context,
 	return tlfStorage.store.archiveReferences(contexts, "")
 }
 
-// getAllRefs implements the blockServerLocal interface for
+// getAllRefsForTest implements the blockServerLocal interface for
 // BlockServerDisk.
-func (b *BlockServerDisk) getAllRefs(ctx context.Context, tlfID tlf.ID) (
+func (b *BlockServerDisk) getAllRefsForTest(ctx context.Context, tlfID tlf.ID) (
 	map[BlockID]blockRefMap, error) {
 	tlfStorage, err := b.getStorage(tlfID)
 	if err != nil {
@@ -314,7 +314,7 @@ func (b *BlockServerDisk) getAllRefs(ctx context.Context, tlfID tlf.ID) (
 		return nil, errBlockServerDiskShutdown
 	}
 
-	return tlfStorage.store.getAllRefs()
+	return tlfStorage.store.getAllRefsForTest()
 }
 
 // IsUnflushed implements the BlockServer interface for BlockServerDisk.

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -247,7 +247,7 @@ func (b *BlockServerDisk) RemoveBlockReferences(ctx context.Context,
 	liveCounts = make(map[BlockID]int)
 	for id, idContexts := range contexts {
 		liveCount, err := tlfStorage.store.removeReferences(
-			id, idContexts, false /* forFlush */, "")
+			id, idContexts, "")
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -178,7 +178,7 @@ func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id BlockID,
 		return errBlockServerDiskShutdown
 	}
 
-	_, err = tlfStorage.store.put(id, context, buf, serverHalf, "")
+	err = tlfStorage.store.put(id, context, buf, serverHalf, "")
 	if err != nil {
 		return err
 	}

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -178,7 +178,12 @@ func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id BlockID,
 		return errBlockServerDiskShutdown
 	}
 
-	return tlfStorage.store.put(id, context, buf, serverHalf, "")
+	_, err = tlfStorage.store.put(id, context, buf, serverHalf, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // AddBlockReference implements the BlockServer interface for BlockServerDisk.

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -247,7 +247,7 @@ func (b *BlockServerDisk) RemoveBlockReferences(ctx context.Context,
 	liveCounts = make(map[BlockID]int)
 	for id, idContexts := range contexts {
 		liveCount, err := tlfStorage.store.removeReferences(
-			id, idContexts, "")
+			id, idContexts, false /* forFlush */, "")
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -317,9 +317,10 @@ func (b *BlockServerMemory) ArchiveBlockReferences(ctx context.Context,
 	return nil
 }
 
-// getAllRefs implements the blockServerLocal interface for
+// getAllRefsForTest implements the blockServerLocal interface for
 // BlockServerMemory.
-func (b *BlockServerMemory) getAllRefs(ctx context.Context, tlfID tlf.ID) (
+func (b *BlockServerMemory) getAllRefsForTest(
+	ctx context.Context, tlfID tlf.ID) (
 	map[BlockID]blockRefMap, error) {
 	res := make(map[BlockID]blockRefMap)
 	b.lock.RLock()

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -52,7 +52,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 	if !ok {
 		t.Fatalf("Bad block server")
 	}
-	preQR1Blocks, err := bserverLocal.getAllRefs(
+	preQR1Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -65,7 +65,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 		t.Fatalf("Couldn't wait for QR: %v", err)
 	}
 
-	postQR1Blocks, err := bserverLocal.getAllRefs(
+	postQR1Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -84,7 +84,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 		t.Fatalf("Couldn't create dir: %v", err)
 	}
 
-	preQR2Blocks, err := bserverLocal.getAllRefs(
+	preQR2Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -96,7 +96,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 		t.Fatalf("Couldn't wait for QR: %v", err)
 	}
 
-	postQR2Blocks, err := bserverLocal.getAllRefs(
+	postQR2Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -185,7 +185,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	if !ok {
 		t.Fatalf("Bad block server")
 	}
-	blocks, err := bserverLocal.getAllRefs(
+	blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -204,7 +204,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 			t.Fatalf("Couldn't wait for QR: %v", err)
 		}
 
-		blocks, err := bserverLocal.getAllRefs(
+		blocks, err := bserverLocal.getAllRefsForTest(
 			ctx, rootNode.GetFolderBranch().Tlf)
 		if err != nil {
 			t.Fatalf("Couldn't get blocks: %v", err)
@@ -316,7 +316,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	if !ok {
 		t.Fatalf("Bad block server")
 	}
-	preQRBlocks, err := bserverLocal.getAllRefs(
+	preQRBlocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode1.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -330,7 +330,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 		t.Fatalf("Couldn't wait for QR: %v", err)
 	}
 
-	postQRBlocks, err := bserverLocal.getAllRefs(
+	postQRBlocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode1.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -418,7 +418,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 		t.Fatalf("Couldn't wait for QR: %v", err)
 	}
 
-	endBlocks, err := bserverLocal.getAllRefs(
+	endBlocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode2.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -570,7 +570,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	if !ok {
 		t.Fatalf("Bad block server")
 	}
-	preQR1Blocks, err := bserverLocal.getAllRefs(
+	preQR1Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -583,7 +583,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 		t.Fatalf("Couldn't wait for QR: %v", err)
 	}
 
-	postQR1Blocks, err := bserverLocal.getAllRefs(
+	postQR1Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -597,7 +597,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	// Increase the time again and make sure it does run.
 	clock.Add(2 * config.QuotaReclamationMinHeadAge())
 
-	preQR2Blocks, err := bserverLocal.getAllRefs(
+	preQR2Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)
@@ -609,7 +609,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 		t.Fatalf("Couldn't wait for QR: %v", err)
 	}
 
-	postQR2Blocks, err := bserverLocal.getAllRefs(
+	postQR2Blocks, err := bserverLocal.getAllRefsForTest(
 		ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get blocks: %v", err)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1221,9 +1221,9 @@ type BlockServer interface {
 // that store data locally.
 type blockServerLocal interface {
 	BlockServer
-	// getAllRefs returns all the known block references for the
-	// given TLF, and should only be used during testing.
-	getAllRefs(ctx context.Context, tlfID tlf.ID) (
+	// getAllRefsForTest returns all the known block references
+	// for the given TLF, and should only be used during testing.
+	getAllRefsForTest(ctx context.Context, tlfID tlf.ID) (
 		map[BlockID]blockRefMap, error)
 }
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -69,7 +69,7 @@ type mdFlushListener interface {
 // MDOps.
 //
 // The maximum number of characters added to the root dir by a journal
-// server journal is 116: 59 for the TLF journal, and 57 for
+// server journal is 108: 51 for the TLF journal, and 57 for
 // everything else.
 //
 //   /v1/de...-...(53 characters total)...ff(/tlf journal)

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -569,13 +569,20 @@ func (j *JournalServer) mdOps() journalMDOps {
 // Status returns a JournalServerStatus object suitable for
 // diagnostics.  It also returns a list of TLF IDs which have journals
 // enabled.
-func (j *JournalServer) Status() (JournalServerStatus, []tlf.ID) {
+func (j *JournalServer) Status(
+	ctx context.Context) (JournalServerStatus, []tlf.ID) {
 	j.lock.RLock()
 	defer j.lock.RUnlock()
-	var unflushedBytes int64
+	var totalUnflushedBytes int64
 	tlfIDs := make([]tlf.ID, 0, len(j.tlfJournals))
 	for _, tlfJournal := range j.tlfJournals {
-		unflushedBytes += tlfJournal.getUnflushedBytes()
+		unflushedBytes, err := tlfJournal.getUnflushedBytes()
+		if err != nil {
+			j.log.CWarningf(ctx,
+				"Couldn't calculate unflushed bytes for %s: %v",
+				tlfJournal.tlfID, err)
+		}
+		totalUnflushedBytes += unflushedBytes
 		tlfIDs = append(tlfIDs, tlfJournal.tlfID)
 	}
 	return JournalServerStatus{
@@ -585,7 +592,7 @@ func (j *JournalServer) Status() (JournalServerStatus, []tlf.ID) {
 		CurrentVerifyingKey: j.currentVerifyingKey,
 		EnableAuto:          j.serverConfig.EnableAuto,
 		JournalCount:        len(tlfIDs),
-		UnflushedBytes:      unflushedBytes,
+		UnflushedBytes:      totalUnflushedBytes,
 	}, tlfIDs
 }
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -400,7 +400,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	err := jServer.EnableAuto(ctx)
 	require.NoError(t, err)
 
-	status, tlfIDs := jServer.Status()
+	status, tlfIDs := jServer.Status(ctx)
 	require.True(t, status.EnableAuto)
 	require.Zero(t, status.JournalCount)
 	require.Len(t, tlfIDs, 0)
@@ -421,7 +421,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	err = blockServer.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
 
-	status, tlfIDs = jServer.Status()
+	status, tlfIDs = jServer.Status(ctx)
 	require.True(t, status.EnableAuto)
 	require.Equal(t, 1, status.JournalCount)
 	require.Len(t, tlfIDs, 1)
@@ -442,7 +442,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	err = jServer.EnableExistingJournals(
 		ctx, uid, verifyingKey, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
-	status, tlfIDs = jServer.Status()
+	status, tlfIDs = jServer.Status(ctx)
 	require.True(t, status.EnableAuto)
 	require.Equal(t, 1, status.JournalCount)
 	require.Len(t, tlfIDs, 1)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -587,7 +587,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	var jServerStatus *JournalServerStatus
 	jServer, jErr := GetJournalServer(fs.config)
 	if jErr == nil {
-		status, tlfIDs := jServer.Status()
+		status, tlfIDs := jServer.Status(ctx)
 		jServerStatus = &status
 		err := fillInJournalStatusUnflushedPaths(
 			ctx, fs.config, jServerStatus, tlfIDs)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -599,7 +599,7 @@ func (k *KeybaseServiceBase) FSSyncStatusRequest(ctx context.Context,
 	// For now, just return the number of syncing bytes.
 	jServer, err := GetJournalServer(k.config)
 	if err == nil {
-		status, _ := jServer.Status()
+		status, _ := jServer.Status(ctx)
 		resp.Status.TotalSyncingBytes = status.UnflushedBytes
 		k.log.CDebugf(ctx, "Sending sync status response with %d syncing bytes",
 			status.UnflushedBytes)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -430,17 +430,19 @@ func TestMDJournalPutCase4(t *testing.T) {
 }
 
 func testMDJournalGCd(t *testing.T, j *mdJournal) {
-	filepath.Walk(j.j.j.dir, func(path string, _ os.FileInfo, _ error) error {
+	err := filepath.Walk(j.j.j.dir, func(path string, _ os.FileInfo, _ error) error {
 		// We should only find the root directory here.
 		require.Equal(t, path, j.j.j.dir)
 		return nil
 	})
-	filepath.Walk(j.mdsPath(),
+	require.NoError(t, err)
+	err = filepath.Walk(j.mdsPath(),
 		func(path string, info os.FileInfo, _ error) error {
 			// We should only find the MD directory here.
 			require.Equal(t, path, j.mdsPath())
 			return nil
 		})
+	require.NoError(t, err)
 }
 
 func flushAllMDs(

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -341,7 +341,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlf tlf.ID) error 
 		return errors.New("StateChecker only works against " +
 			"BlockServerLocal")
 	}
-	bserverKnownBlocks, err := bserverLocal.getAllRefs(ctx, tlf)
+	bserverKnownBlocks, err := bserverLocal.getAllRefsForTest(ctx, tlf)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -147,7 +147,7 @@ type tlfJournalBWDelegate interface {
 // servers.
 //
 // The maximum number of characters added to the root dir by a TLF
-// journal is 59, which just the max of the block journal and MD
+// journal is 51, which just the max of the block journal and MD
 // journal numbers.
 type tlfJournal struct {
 	uid                 keybase1.UID

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1300,7 +1300,7 @@ func (j *tlfJournal) isBlockUnflushed(id BlockID) (bool, error) {
 		return false, err
 	}
 
-	err := j.blockJournal.exists(id)
+	err := j.blockJournal.hasData(id)
 	if err != nil {
 		// Might exist on the server
 		return false, nil

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -919,7 +919,7 @@ func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 		RevisionStart:  earliestRevision,
 		RevisionEnd:    latestRevision,
 		BlockOpCount:   blockEntryCount,
-		UnflushedBytes: j.blockJournal.getUnflushedBytes(),
+		UnflushedBytes: j.getUnflushedBytes(),
 		LastFlushErr:   lastFlushErr,
 	}, nil
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -913,7 +913,7 @@ func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 	if j.lastFlushErr != nil {
 		lastFlushErr = j.lastFlushErr.Error()
 	}
-	unflushedBytes, err := j.getUnflushedBytes()
+	unflushedBytes, err := j.blockJournal.getUnflushedBytes()
 	if err != nil {
 		return TLFJournalStatus{}, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -913,13 +913,17 @@ func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 	if j.lastFlushErr != nil {
 		lastFlushErr = j.lastFlushErr.Error()
 	}
+	unflushedBytes, err := j.getUnflushedBytes()
+	if err != nil {
+		return TLFJournalStatus{}, err
+	}
 	return TLFJournalStatus{
 		Dir:            j.dir,
 		BranchID:       j.mdJournal.getBranchID().String(),
 		RevisionStart:  earliestRevision,
 		RevisionEnd:    latestRevision,
 		BlockOpCount:   blockEntryCount,
-		UnflushedBytes: j.getUnflushedBytes(),
+		UnflushedBytes: unflushedBytes,
 		LastFlushErr:   lastFlushErr,
 	}, nil
 }
@@ -1108,11 +1112,11 @@ func (j *tlfJournal) getJournalStatusWithPaths(ctx context.Context,
 	return jStatus, nil
 }
 
-func (j *tlfJournal) getUnflushedBytes() int64 {
+func (j *tlfJournal) getUnflushedBytes() (int64, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
 	if err := j.checkEnabledLocked(); err != nil {
-		return 0
+		return 0, err
 	}
 
 	return j.blockJournal.getUnflushedBytes()

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -913,10 +913,7 @@ func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 	if j.lastFlushErr != nil {
 		lastFlushErr = j.lastFlushErr.Error()
 	}
-	unflushedBytes, err := j.blockJournal.getUnflushedBytes()
-	if err != nil {
-		return TLFJournalStatus{}, err
-	}
+	unflushedBytes := j.blockJournal.getUnflushedBytes()
 	return TLFJournalStatus{
 		Dir:            j.dir,
 		BranchID:       j.mdJournal.getBranchID().String(),
@@ -1119,7 +1116,7 @@ func (j *tlfJournal) getUnflushedBytes() (int64, error) {
 		return 0, err
 	}
 
-	return j.blockJournal.getUnflushedBytes()
+	return j.blockJournal.getUnflushedBytes(), nil
 }
 
 func (j *tlfJournal) shutdown() {


### PR DESCRIPTION
Introduce a new blockDiskStore type to store
block data (including refs) on disk. Use it
in blockJournal and BlockServerDisk.

Remove the in-memory ref map from blockJournal,
and rely on blockDiskStore instead. This removes
the need for the scan on startup.

Track unflushed bytes via an aggregate_info file.