### PR TITLE
[KBFS-1641] Plumb through ctx to GetRootNode{ForTest,OrBust}

### DIFF
--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -271,11 +271,12 @@ func TestReaddirPrivate(t *testing.T) {
 	defer cancelFn()
 
 	{
+		ctx := context.Background()
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", false)
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", true)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", false)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", true)
 	}
 
 	checkDir(t, filepath.Join(mnt.Dir, PrivateName), map[string]fileInfoCheck{
@@ -292,11 +293,12 @@ func TestReaddirPublic(t *testing.T) {
 	defer cancelFn()
 
 	{
+		ctx := context.Background()
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", false)
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", true)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", false)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", true)
 	}
 
 	checkDir(t, filepath.Join(mnt.Dir, PublicName), map[string]fileInfoCheck{
@@ -1376,11 +1378,12 @@ func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 	defer cancelFn()
 
 	{
+		ctx := context.Background()
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", false)
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", true)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", false)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", true)
 	}
 
 	err := os.Remove(filepath.Join(mnt.Dir, PrivateName, "jdoe,janedoe"))
@@ -1614,7 +1617,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 func syncFolderToServerHelper(t *testing.T, tlf string, public bool, fs *FS) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	defer libkbfs.CleanupCancellationDelayer(ctx)
-	root := libkbfs.GetRootNodeOrBust(t, fs.config, tlf, public)
+	root := libkbfs.GetRootNodeOrBust(ctx, t, fs.config, tlf, public)
 	err := fs.config.KBFSOps().SyncFromServerForTesting(ctx, root.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
@@ -1816,7 +1819,8 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 
 	const input2 = "second round of content"
 	{
-		jdoe := libkbfs.GetRootNodeOrBust(t, config, "jdoe", false)
+		ctx := context.Background()
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", false)
 
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
@@ -2073,7 +2077,8 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	// the whole page.
 	const input2 = "input round two"
 	{
-		jdoe := libkbfs.GetRootNodeOrBust(t, config1, "user1,user2", false)
+		ctx := context.Background()
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", false)
 
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
@@ -2184,10 +2189,11 @@ func TestStatusFile(t *testing.T) {
 	defer mnt.Close()
 	defer cancelFn()
 
-	jdoe := libkbfs.GetRootNodeOrBust(t, config, "jdoe", true)
-
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	defer libkbfs.CleanupCancellationDelayer(ctx)
+
+	jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", true)
+
 	ops := config.KBFSOps()
 	status, _, err := ops.FolderStatus(ctx, jdoe.GetFolderBranch())
 	if err != nil {
@@ -2236,7 +2242,8 @@ func TestUnstageFile(t *testing.T) {
 	checkDir(t, myroot2, map[string]fileInfoCheck{})
 
 	// turn updates off for user 2
-	rootNode2 := libkbfs.GetRootNodeOrBust(t, config2, "user1,user2", false)
+	ctx := context.Background()
+	rootNode2 := libkbfs.GetRootNodeOrBust(ctx, t, config2, "user1,user2", false)
 	_, err := libkbfs.DisableUpdatesForTesting(config2,
 		rootNode2.GetFolderBranch())
 	if err != nil {

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -1819,11 +1819,11 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 
 	const input2 = "second round of content"
 	{
-		ctx := context.Background()
-		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", false)
-
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
+
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", false)
+
 		ops := config.KBFSOps()
 		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
 		if err != nil {
@@ -2077,11 +2077,11 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	// the whole page.
 	const input2 = "input round two"
 	{
-		ctx := context.Background()
-		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", false)
-
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
+
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", false)
+
 		ops := config1.KBFSOps()
 		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
 		if err != nil {

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -333,11 +333,12 @@ func TestReaddirPrivate(t *testing.T) {
 	defer cancelFn()
 
 	{
+		ctx := context.Background()
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", false)
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", true)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", false)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", true)
 	}
 
 	checkDir(t, path.Join(mnt.Dir, PrivateName), map[string]fileInfoCheck{
@@ -360,11 +361,12 @@ func TestReaddirPrivateDeleteAndReaddFavorite(t *testing.T) {
 	defer cancelFn()
 
 	{
+		ctx := context.Background()
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", false)
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", true)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", false)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", true)
 	}
 
 	err := os.Remove(path.Join(mnt.Dir, PrivateName, "jdoe,janedoe"))
@@ -394,11 +396,12 @@ func TestReaddirPublic(t *testing.T) {
 	defer cancelFn()
 
 	{
+		ctx := context.Background()
 		// Force FakeMDServer to have some TlfIDs it can present to us
 		// as favorites. Don't go through VFS to avoid caching causing
 		// false positives.
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", false)
-		libkbfs.GetRootNodeOrBust(t, config, "janedoe,jdoe", true)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", false)
+		libkbfs.GetRootNodeOrBust(ctx, t, config, "janedoe,jdoe", true)
 	}
 
 	checkDir(t, path.Join(mnt.Dir, PublicName), map[string]fileInfoCheck{
@@ -1599,10 +1602,11 @@ func TestSetattrFileMtimeAfterWrite(t *testing.T) {
 
 	const input2 = "second round of content"
 	{
-		jdoe := libkbfs.GetRootNodeOrBust(t, config, "jdoe", false)
-
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
+
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", false)
+
 		ops := config.KBFSOps()
 		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
 		if err != nil {
@@ -2020,7 +2024,7 @@ func TestReaddirOtherFolderAsAnyone(t *testing.T) {
 func syncFolderToServerHelper(t *testing.T, tlf string, public bool, fs *FS) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	defer libkbfs.CleanupCancellationDelayer(ctx)
-	root := libkbfs.GetRootNodeOrBust(t, fs.config, tlf, public)
+	root := libkbfs.GetRootNodeOrBust(ctx, t, fs.config, tlf, public)
 	err := fs.config.KBFSOps().SyncFromServerForTesting(ctx, root.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
@@ -2236,10 +2240,10 @@ func TestInvalidateDataOnLocalWrite(t *testing.T) {
 
 	const input2 = "second round of content"
 	{
-		jdoe := libkbfs.GetRootNodeOrBust(t, config, "jdoe", false)
-
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
+
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", false)
 		ops := config.KBFSOps()
 		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
 		if err != nil {
@@ -2505,10 +2509,11 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 	// the whole page.
 	const input2 = "input round two"
 	{
-		jdoe := libkbfs.GetRootNodeOrBust(t, config1, "user1,user2", false)
-
 		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 		defer libkbfs.CleanupCancellationDelayer(ctx)
+
+		jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config1, "user1,user2", false)
+
 		ops := config1.KBFSOps()
 		myfile, _, err := ops.Lookup(ctx, jdoe, "myfile")
 		if err != nil {
@@ -2619,10 +2624,11 @@ func TestStatusFile(t *testing.T) {
 	defer mnt.Close()
 	defer cancelFn()
 
-	jdoe := libkbfs.GetRootNodeOrBust(t, config, "jdoe", true)
-
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	defer libkbfs.CleanupCancellationDelayer(ctx)
+
+	jdoe := libkbfs.GetRootNodeOrBust(ctx, t, config, "jdoe", true)
+
 	ops := config.KBFSOps()
 	status, _, err := ops.FolderStatus(ctx, jdoe.GetFolderBranch())
 	if err != nil {
@@ -2675,7 +2681,8 @@ func TestUnstageFile(t *testing.T) {
 	checkDir(t, myroot2, map[string]fileInfoCheck{})
 
 	// turn updates off for user 2
-	rootNode2 := libkbfs.GetRootNodeOrBust(t, config2, "user1,user2", false)
+	ctx := context.Background()
+	rootNode2 := libkbfs.GetRootNodeOrBust(ctx, t, config2, "user1,user2", false)
 	_, err := libkbfs.DisableUpdatesForTesting(config2,
 		rootNode2.GetFolderBranch())
 	if err != nil {

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -201,15 +202,14 @@ func TestCRInputFracturedRange(t *testing.T) {
 	}
 }
 
-func testCRSharedFolderForUsers(t *testing.T, name string, createAs keybase1.UID,
+func testCRSharedFolderForUsers(
+	t *testing.T, ctx context.Context, name string, createAs keybase1.UID,
 	configs map[keybase1.UID]Config, dirs []string) map[keybase1.UID]Node {
 	nodes := make(map[keybase1.UID]Node)
 
 	// create by the first user
 	kbfsOps := configs[createAs].KBFSOps()
-	rootNode := GetRootNodeOrBust(t, configs[createAs], name, false)
-	ctx := BackgroundContextWithCancellationDelayer()
-	defer CleanupCancellationDelayer(ctx)
+	rootNode := GetRootNodeOrBust(t, ctx, configs[createAs], name, false)
 	dir := rootNode
 	for _, d := range dirs {
 		dirNext, _, err := kbfsOps.CreateDir(ctx, dir, d)
@@ -232,7 +232,7 @@ func testCRSharedFolderForUsers(t *testing.T, name string, createAs keybase1.UID
 
 		kbfsOps := config.KBFSOps()
 		kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch())
-		rootNode := GetRootNodeOrBust(t, config, name, false)
+		rootNode := GetRootNodeOrBust(t, ctx, config, name, false)
 		dir := rootNode
 		for _, d := range dirs {
 			var err error
@@ -369,7 +369,7 @@ func TestCRMergedChainsSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodes := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dir"})
+	nodes := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dir"})
 	dir1 := nodes[uid1]
 	dir2 := nodes[uid2]
 	fb := dir1.GetFolderBranch()
@@ -429,9 +429,9 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
-	nodesB := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirB"})
+	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirB"})
 	dirB1 := nodesB[uid1]
 	dirB2 := nodesB[uid2]
 	fb := dirA1.GetFolderBranch()
@@ -491,7 +491,7 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
 	fb := dirA1.GetFolderBranch()
 
@@ -499,10 +499,10 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 	cr2 := testCRGetCROrBust(t, config2, fb)
 	cr2.Shutdown()
 
-	nodesB := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB"})
 	dirB1 := nodesB[uid1]
-	nodesC := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesC := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirC"})
 	dirC2 := nodesC[uid2]
 	dirAPtr := cr1.fbo.nodeCache.PathFromNode(dirA1).tailPointer()
@@ -588,7 +588,7 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
 	fb := dirA1.GetFolderBranch()
 
@@ -596,10 +596,10 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 	cr2 := testCRGetCROrBust(t, config2, fb)
 	cr2.Shutdown()
 
-	nodesB := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB"})
 	dirB1 := nodesB[uid1]
-	nodesC := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesC := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirC"})
 	dirC1 := nodesC[uid1]
 	dirC2 := nodesC[uid2]
@@ -674,7 +674,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesA := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirA"})
+	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirA"})
 	dirA1 := nodesA[uid1]
 	dirA2 := nodesA[uid2]
 	fb := dirA1.GetFolderBranch()
@@ -683,27 +683,27 @@ func TestCRMergedChainsComplex(t *testing.T) {
 	cr2 := testCRGetCROrBust(t, config2, fb)
 	cr2.Shutdown()
 
-	nodesB := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB"})
 	dirB1 := nodesB[uid1]
 	dirB2 := nodesB[uid2]
-	nodesC := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesC := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirC"})
 	dirC2 := nodesC[uid2]
-	nodesD := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesD := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirA", "dirB", "dirD"})
 	dirD1 := nodesD[uid1]
 	dirD2 := nodesD[uid2]
-	nodesE := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirE"})
+	nodesE := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirE"})
 	dirE1 := nodesE[uid1]
-	nodesF := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesF := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirE", "dirF"})
 	dirF2 := nodesF[uid2]
 	dirEPtr := cr2.fbo.nodeCache.PathFromNode(dirE1).tailPointer()
 	dirFPtr := cr2.fbo.nodeCache.PathFromNode(dirF2).tailPointer()
-	nodesG := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dirG"})
+	nodesG := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dirG"})
 	dirG1 := nodesG[uid1]
-	nodesH := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesH := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"dirG", "dirH"})
 	dirH1 := nodesH[uid1]
 	dirH2 := nodesH[uid2]
@@ -853,16 +853,16 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesRoot := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"root"})
+	nodesRoot := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"root"})
 	dirRoot1 := nodesRoot[uid1]
 	dirRoot2 := nodesRoot[uid2]
 	fb := dirRoot1.GetFolderBranch()
 
-	nodesA := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesA := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"root", "dirA"})
 	dirA1 := nodesA[uid1]
 
-	nodesB := testCRSharedFolderForUsers(t, name, uid1, configs,
+	nodesB := testCRSharedFolderForUsers(t, ctx, name, uid1, configs,
 		[]string{"root", "dirB"})
 	dirB1 := nodesB[uid1]
 	dirB2 := nodesB[uid2]
@@ -942,7 +942,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesRoot := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"root"})
+	nodesRoot := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"root"})
 	dirRoot1 := nodesRoot[uid1]
 	dirRoot2 := nodesRoot[uid2]
 	fb := dirRoot1.GetFolderBranch()
@@ -1010,7 +1010,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodesRoot := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"root"})
+	nodesRoot := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"root"})
 	dirRoot1 := nodesRoot[uid1]
 	dirRoot2 := nodesRoot[uid2]
 	fb := dirRoot1.GetFolderBranch()
@@ -1116,7 +1116,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodes := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dir"})
+	nodes := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dir"})
 	dir1 := nodes[uid1]
 	dir2 := nodes[uid2]
 	fb := dir1.GetFolderBranch()
@@ -1207,7 +1207,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	configs := make(map[keybase1.UID]Config)
 	configs[uid1] = config1
 	configs[uid2] = config2
-	nodes := testCRSharedFolderForUsers(t, name, uid1, configs, []string{"dir"})
+	nodes := testCRSharedFolderForUsers(t, ctx, name, uid1, configs, []string{"dir"})
 	dir1 := nodes[uid1]
 	dir2 := nodes[uid2]
 	fb := dir1.GetFolderBranch()

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -209,7 +209,7 @@ func testCRSharedFolderForUsers(
 
 	// create by the first user
 	kbfsOps := configs[createAs].KBFSOps()
-	rootNode := GetRootNodeOrBust(t, ctx, configs[createAs], name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, configs[createAs], name, false)
 	dir := rootNode
 	for _, d := range dirs {
 		dirNext, _, err := kbfsOps.CreateDir(ctx, dir, d)
@@ -232,7 +232,7 @@ func testCRSharedFolderForUsers(
 
 		kbfsOps := config.KBFSOps()
 		kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch())
-		rootNode := GetRootNodeOrBust(t, ctx, config, name, false)
+		rootNode := GetRootNodeOrBust(ctx, t, config, name, false)
 		dir := rootNode
 		for _, d := range dirs {
 			var err error

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -30,7 +30,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 	clock, now := newTestClockAndTimeNow()
 	config.SetClock(clock)
 
-	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, userName.String(), false)
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
 	if err != nil {
@@ -129,7 +129,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 	testQuotaReclamation(t, ctx, config, userName)
 
 	// Make sure the MD has an unembedded change block.
-	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, userName.String(), false)
 	md, err := config.MDOps().GetForTLF(ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get MD: %v", err)
@@ -155,7 +155,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	// block-checking logic.
 	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 16 << 20
 
-	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, userName.String(), false)
 	// Do a bunch of operations.
 	kbfsOps := config.KBFSOps()
 	for i := 0; i < numPointersPerGCThreshold; i++ {
@@ -232,7 +232,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	config2.SetClock(clock)
 
 	name := u1.String() + "," + u2.String()
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 	data := []byte{1, 2, 3, 4, 5}
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -267,7 +267,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	}
 
 	// u2 reads the file
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 	kbfsOps2 := config2.KBFSOps()
 	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
 	if err != nil {
@@ -467,7 +467,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 
 	// Create a shared folder.
 	name := u1.String() + "," + u2.String()
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
@@ -539,7 +539,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 
 	config.qrMinHeadAge = qrMinHeadAgeDefault
 
-	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, userName.String(), false)
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
 	if err != nil {

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -30,7 +30,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 	clock, now := newTestClockAndTimeNow()
 	config.SetClock(clock)
 
-	rootNode := GetRootNodeOrBust(t, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
 	if err != nil {
@@ -129,7 +129,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 	testQuotaReclamation(t, ctx, config, userName)
 
 	// Make sure the MD has an unembedded change block.
-	rootNode := GetRootNodeOrBust(t, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
 	md, err := config.MDOps().GetForTLF(ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get MD: %v", err)
@@ -155,7 +155,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 	// block-checking logic.
 	config.bsplit.(*BlockSplitterSimple).blockChangeEmbedMaxSize = 16 << 20
 
-	rootNode := GetRootNodeOrBust(t, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
 	// Do a bunch of operations.
 	kbfsOps := config.KBFSOps()
 	for i := 0; i < numPointersPerGCThreshold; i++ {
@@ -232,7 +232,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	config2.SetClock(clock)
 
 	name := u1.String() + "," + u2.String()
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 	data := []byte{1, 2, 3, 4, 5}
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -267,7 +267,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	}
 
 	// u2 reads the file
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 	kbfsOps2 := config2.KBFSOps()
 	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
 	if err != nil {
@@ -467,7 +467,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 
 	// Create a shared folder.
 	name := u1.String() + "," + u2.String()
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
@@ -539,7 +539,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 
 	config.qrMinHeadAge = qrMinHeadAgeDefault
 
-	rootNode := GetRootNodeOrBust(t, config, userName.String(), false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, userName.String(), false)
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
 	if err != nil {

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -481,7 +481,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 
 	// user 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1161,7 +1161,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 
 	// user2 device 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1348,7 +1348,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 
 	// user2 device 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -17,7 +17,7 @@ import (
 
 func readAndCompareData(t *testing.T, config Config, ctx context.Context,
 	name string, expectedData []byte, user libkb.NormalizedUsername) {
-	rootNode := GetRootNodeOrBust(t, config, name, false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, name, false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.Lookup(ctx, rootNode, "a")
@@ -82,8 +82,8 @@ func TestBasicMDUpdate(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, statusChan, err := kbfsOps2.FolderStatus(ctx, rootNode2.GetFolderBranch())
@@ -145,7 +145,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	// user 1 creates a file
@@ -155,7 +155,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	}
 
 	// user 2 looks up the directory (and sees the file)
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	// now user 1 renames the old file, and creates a new one
 	err = kbfsOps1.Rename(ctx, rootNode1, "a", rootNode1, "b")
@@ -212,7 +212,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	fileNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -227,7 +227,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	DisableCRForTesting(config1, rootNode1.GetFolderBranch())
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -279,7 +279,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 
 	// Keep the config1B node in memory, so it doesn't get garbage
 	// collected (preventing notifications)
-	rootNode1B := GetRootNodeOrBust(t, config1B, name, false)
+	rootNode1B := GetRootNodeOrBust(t, ctx, config1B, name, false)
 
 	kbfsOps1B := config1B.KBFSOps()
 	fileNode1B, _, err := kbfsOps1B.Lookup(ctx, rootNode1B, "a")
@@ -374,7 +374,7 @@ func TestMultiUserWrite(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -383,7 +383,7 @@ func TestMultiUserWrite(t *testing.T) {
 	}
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -452,7 +452,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -461,7 +461,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -602,7 +602,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -615,7 +615,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -709,7 +709,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -722,7 +722,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -833,7 +833,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -842,7 +842,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -948,7 +948,7 @@ func TestCRDouble(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config1, name, false)
+	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -956,7 +956,7 @@ func TestCRDouble(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1122,7 +1122,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1135,7 +1135,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1244,7 +1244,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
-	rootNode2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
 	if err != nil {
 		t.Fatalf("Couldn't lookup dir: %v", err)
@@ -1313,7 +1313,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1326,7 +1326,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1422,7 +1422,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
-	rootNode2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
 	if err != nil {
 		t.Fatalf("Couldn't lookup dir: %v", err)
@@ -1496,7 +1496,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	config1.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config1, name, false)
+	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -1504,7 +1504,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1641,7 +1641,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config1, name, false)
+	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -1658,7 +1658,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1787,7 +1787,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1800,7 +1800,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	ops2 := getOps(config2, rootNode2.GetFolderBranch().Tlf)
@@ -1952,7 +1952,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config1, name, false)
+	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -1969,7 +1969,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -17,7 +17,7 @@ import (
 
 func readAndCompareData(t *testing.T, config Config, ctx context.Context,
 	name string, expectedData []byte, user libkb.NormalizedUsername) {
-	rootNode := GetRootNodeOrBust(t, ctx, config, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, name, false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.Lookup(ctx, rootNode, "a")
@@ -82,8 +82,8 @@ func TestBasicMDUpdate(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, statusChan, err := kbfsOps2.FolderStatus(ctx, rootNode2.GetFolderBranch())
@@ -145,7 +145,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	// user 1 creates a file
@@ -155,7 +155,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	}
 
 	// user 2 looks up the directory (and sees the file)
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	// now user 1 renames the old file, and creates a new one
 	err = kbfsOps1.Rename(ctx, rootNode1, "a", rootNode1, "b")
@@ -212,7 +212,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	fileNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -227,7 +227,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	DisableCRForTesting(config1, rootNode1.GetFolderBranch())
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -279,7 +279,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 
 	// Keep the config1B node in memory, so it doesn't get garbage
 	// collected (preventing notifications)
-	rootNode1B := GetRootNodeOrBust(t, ctx, config1B, name, false)
+	rootNode1B := GetRootNodeOrBust(ctx, t, config1B, name, false)
 
 	kbfsOps1B := config1B.KBFSOps()
 	fileNode1B, _, err := kbfsOps1B.Lookup(ctx, rootNode1B, "a")
@@ -374,7 +374,7 @@ func TestMultiUserWrite(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -383,7 +383,7 @@ func TestMultiUserWrite(t *testing.T) {
 	}
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -452,7 +452,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -461,7 +461,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -602,7 +602,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -615,7 +615,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -709,7 +709,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -722,7 +722,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -833,7 +833,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -842,7 +842,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -948,7 +948,7 @@ func TestCRDouble(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -956,7 +956,7 @@ func TestCRDouble(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1122,7 +1122,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1135,7 +1135,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1244,7 +1244,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
-	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
 	if err != nil {
 		t.Fatalf("Couldn't lookup dir: %v", err)
@@ -1313,7 +1313,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1326,7 +1326,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1422,7 +1422,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
-	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
 	if err != nil {
 		t.Fatalf("Couldn't lookup dir: %v", err)
@@ -1496,7 +1496,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	config1.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -1504,7 +1504,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1641,7 +1641,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -1658,7 +1658,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1787,7 +1787,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1800,7 +1800,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	ops2 := getOps(config2, rootNode2.GetFolderBranch().Tlf)
@@ -1952,7 +1952,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	if err != nil {
@@ -1969,7 +1969,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	}
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -75,7 +75,7 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	// Initialize the MD using a different config
 	c2 := ConfigAsUser(config, "test_user")
 	defer CheckConfigAndShutdown(t, c2)
-	rootNode := GetRootNodeOrBust(t, ctx, c2, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, c2, "test_user", false)
 
 	n := 10
 	c := make(chan error, n)
@@ -118,7 +118,7 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -175,7 +175,7 @@ func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -310,7 +310,7 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -424,7 +424,7 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -549,7 +549,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -636,7 +636,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -728,7 +728,7 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -781,7 +781,7 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -827,7 +827,7 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = 5
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -935,7 +935,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1065,7 +1065,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1155,7 +1155,7 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 		StallBlockOp(ctx, config, StallableBlockPut, 1)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1267,7 +1267,7 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
 	ctxStallSync, cancel2 := context.WithCancel(ctxStallSync)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1401,7 +1401,7 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error)
@@ -1463,7 +1463,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error)
@@ -1536,7 +1536,7 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1629,7 +1629,7 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1713,7 +1713,7 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1808,7 +1808,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -75,7 +75,7 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	// Initialize the MD using a different config
 	c2 := ConfigAsUser(config, "test_user")
 	defer CheckConfigAndShutdown(t, c2)
-	rootNode := GetRootNodeOrBust(t, c2, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, c2, "test_user", false)
 
 	n := 10
 	c := make(chan error, n)
@@ -118,7 +118,7 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -175,7 +175,7 @@ func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -310,7 +310,7 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -424,7 +424,7 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -549,7 +549,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -636,7 +636,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -728,7 +728,7 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -781,7 +781,7 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -827,7 +827,7 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = 5
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -935,7 +935,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1065,7 +1065,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1155,7 +1155,7 @@ func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 		StallBlockOp(ctx, config, StallableBlockPut, 1)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1267,7 +1267,7 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
 	ctxStallSync, cancel2 := context.WithCancel(ctxStallSync)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1388,27 +1388,25 @@ func TestKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T) {
 // already started, and cancellation is delayed. Since no extra delay greater
 // than the grace period in MD writes is introduced, Create should succeed.
 func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
-	config, _, ctxThrowaway, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctxThrowaway, cancel)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
-	ctx := context.Background()
+	onPutStalledCh, putUnstallCh, putCtx :=
+		StallMDOp(context.Background(), config, StallableMDPut, 1)
 
-	onPutStalledCh, putUnstallCh, ctx :=
-		StallMDOp(ctx, config, StallableMDPut, 1)
+	putCtx, cancel2 := context.WithCancel(putCtx)
 
-	ctx, cancel2 := context.WithCancel(ctx)
-
-	ctx, err := NewContextWithCancellationDelayer(ctx)
+	putCtx, err := NewContextWithCancellationDelayer(putCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error)
 	go func() {
-		_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, WithExcl)
+		_, _, err := kbfsOps.CreateFile(putCtx, rootNode, "a", false, WithExcl)
 		errChan <- err
 	}()
 
@@ -1436,31 +1434,29 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 // period is introduced to MD write, so Create should fail. This is to ensure
 // Ctrl-C is able to interrupt the process eventually after the grace period.
 func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
-	config, _, ctxThrowaway, cancel := kbfsOpsConcurInit(t, "test_user")
-	defer kbfsConcurTestShutdown(t, config, ctxThrowaway, cancel)
+	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
+	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// This essentially fast-forwards the grace period timer, making cancellation
 	// happen much faster. This way we can avoid time.Sleep.
 	config.SetDelayedCancellationGracePeriod(0)
 
-	ctx := context.Background()
+	onPutStalledCh, putUnstallCh, putCtx :=
+		StallMDOp(context.Background(), config, StallableMDPut, 1)
 
-	onPutStalledCh, putUnstallCh, ctx :=
-		StallMDOp(ctx, config, StallableMDPut, 1)
+	putCtx, cancel2 := context.WithCancel(putCtx)
 
-	ctx, cancel2 := context.WithCancel(ctx)
-
-	ctx, err := NewContextWithCancellationDelayer(ctx)
+	putCtx, err := NewContextWithCancellationDelayer(putCtx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error)
 	go func() {
-		_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, WithExcl)
+		_, _, err := kbfsOps.CreateFile(putCtx, rootNode, "a", false, WithExcl)
 		errChan <- err
 	}()
 
@@ -1514,7 +1510,7 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1607,7 +1603,7 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1691,7 +1687,7 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1786,7 +1782,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5300,7 +5300,7 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5346,7 +5346,7 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5392,7 +5392,7 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5430,7 +5430,7 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5503,7 +5503,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	})
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5517,7 +5517,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	// Shutdown the mdserver explicitly before the state checker tries to run
 	defer config2.MDServer().Shutdown()
 
-	rootNode2 := GetRootNodeOrBust(t, config2, "test_user", false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, "test_user", false)
 	// Lookup the file, which should fail on block ID verification
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -5533,7 +5533,7 @@ func TestKBFSOpsEmptyTlfSize(t *testing.T) {
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	// Create a TLF.
-	rootNode := GetRootNodeOrBust(t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
 	status, _, err := config.KBFSOps().FolderStatus(ctx,
 		rootNode.GetFolderBranch())
 	if err != nil {
@@ -5562,7 +5562,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config1, ctx, cancel)
 
 	// Create alice's TLF.
-	rootNode1 := GetRootNodeOrBust(t, config1, "alice", false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, "alice", false)
 	fb1 := rootNode1.GetFolderBranch()
 
 	kbfsOps1 := config1.KBFSOps()
@@ -5580,7 +5580,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	config2.SetMDServer(mdserver2)
 	config2.SetMDCache(NewMDCacheStandard(1))
 
-	rootNode2 := GetRootNodeOrBust(t, config2, "alice,mallory", false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, "alice,mallory", false)
 	require.Equal(t, fb1.Tlf, rootNode2.GetFolderBranch().Tlf)
 
 	kbfsOps2 := config2.KBFSOps()

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5300,7 +5300,7 @@ func TestKBFSOpsWriteRenameStat(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5346,7 +5346,7 @@ func TestKBFSOpsWriteRenameGetDirChildren(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5392,7 +5392,7 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5430,7 +5430,7 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5503,7 +5503,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	})
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -5517,7 +5517,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	// Shutdown the mdserver explicitly before the state checker tries to run
 	defer config2.MDServer().Shutdown()
 
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, "test_user", false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, "test_user", false)
 	// Lookup the file, which should fail on block ID verification
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -5533,7 +5533,7 @@ func TestKBFSOpsEmptyTlfSize(t *testing.T) {
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
 	// Create a TLF.
-	rootNode := GetRootNodeOrBust(t, ctx, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
 	status, _, err := config.KBFSOps().FolderStatus(ctx,
 		rootNode.GetFolderBranch())
 	if err != nil {
@@ -5562,7 +5562,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	defer kbfsTestShutdownNoMocksNoCheck(t, config1, ctx, cancel)
 
 	// Create alice's TLF.
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, "alice", false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, "alice", false)
 	fb1 := rootNode1.GetFolderBranch()
 
 	kbfsOps1 := config1.KBFSOps()
@@ -5580,7 +5580,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	config2.SetMDServer(mdserver2)
 	config2.SetMDCache(NewMDCacheStandard(1))
 
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, "alice,mallory", false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, "alice,mallory", false)
 	require.Equal(t, fb1.Tlf, rootNode2.GetFolderBranch().Tlf)
 
 	kbfsOps2 := config2.KBFSOps()

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -696,7 +696,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -706,7 +706,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 
@@ -812,7 +812,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	root2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	root2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
 	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx, root2Dev2.GetFolderBranch())
@@ -821,7 +821,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	}
 
 	// device 2 should still work
-	rootNode2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	children, err := kbfsOps2Dev2.GetDirChildren(ctx, rootNode2Dev2)
 	if _, ok := children["d"]; !ok {
@@ -848,7 +848,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 
 	// meanwhile, device 3 should be able to read both the new and the
 	// old files
-	rootNode2Dev3 := GetRootNodeOrBust(t, config2Dev3, name, false)
+	rootNode2Dev3 := GetRootNodeOrBust(t, ctx, config2Dev3, name, false)
 
 	kbfsOps2Dev3 := config2Dev3.KBFSOps()
 	aNode, _, err := kbfsOps2Dev3.Lookup(ctx, rootNode2Dev3, "a")
@@ -915,7 +915,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String() + ReaderSep + u3.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -982,7 +982,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 		t.Fatalf("Got unexpected error after rekey: %v", err)
 	}
 
-	_ = GetRootNodeOrBust(t, config3, name, false)
+	_ = GetRootNodeOrBust(t, ctx, config3, name, false)
 }
 
 func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	t.Log("Create a shared folder")
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1029,7 +1029,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	}
 
 	t.Log("User 2 rekeys from device 1")
-	root2dev1 := GetRootNodeOrBust(t, config2, name, false)
+	root2dev1 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	err = kbfsOps2.Rekey(ctx, root2dev1.GetFolderBranch().Tlf)
@@ -1038,7 +1038,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	}
 
 	t.Log("User 2 device 2 should be able to read now")
-	root2dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	root2dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	t.Log("User 2 device 2 reads user 1's file")
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
@@ -1082,7 +1082,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	t.Log("Create a shared folder")
 	name := u1.String() + ReaderSep + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1123,7 +1123,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	}
 
 	t.Log("User 2 rekeys from device 1")
-	root2dev1 := GetRootNodeOrBust(t, config2, name, false)
+	root2dev1 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	err = kbfsOps2.Rekey(ctx, root2dev1.GetFolderBranch().Tlf)
@@ -1132,7 +1132,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	}
 
 	t.Log("User 2 device 2 should be able to read now")
-	root2dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	root2dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	t.Log("User 1 device 2 should still be unable to read")
 	_, err = GetRootNodeForTest(ctx, config1Dev2, name, false)
@@ -1170,7 +1170,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	t.Log("Create a shared folder")
 	name := u1.String() + ReaderSep + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1205,7 +1205,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	}
 
 	t.Log("User 2 rekeys from device 2")
-	root2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	root2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
 	err = kbfsOps2Dev2.Rekey(ctx, root2Dev2.GetFolderBranch().Tlf)
 	if err != nil {
@@ -1214,7 +1214,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	}
 
 	t.Log("User 2 device 3 should be able to read now")
-	GetRootNodeOrBust(t, config2Dev3, name, false)
+	GetRootNodeOrBust(t, ctx, config2Dev3, name, false)
 
 	// A second rekey by the same reader shouldn't change the
 	// revision, since the rekey bit is already set, even though a
@@ -1265,7 +1265,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	// 2 writers 1 reader
 	name := u1.String() + "," + u2.String() + "#" + u3.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1321,7 +1321,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	rootNode2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	// look for the file
 	aNode, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
@@ -1382,7 +1382,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	rootNode3Dev2 := GetRootNodeOrBust(t, config3Dev2, name, false)
+	rootNode3Dev2 := GetRootNodeOrBust(t, ctx, config3Dev2, name, false)
 
 	// look for the file
 	a2Node, _, err := kbfsOps3Dev2.Lookup(ctx, rootNode3Dev2, "a")
@@ -1422,7 +1422,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	// create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1456,7 +1456,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	root2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	root2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	// Now revoke the original user 2 device
 	clock.Add(1 * time.Minute)
@@ -1504,7 +1504,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
 
-	rootNode1 = GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 = GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	children, err := kbfsOps1.GetDirChildren(ctx, rootNode1)
 	if _, ok := children["b"]; !ok {
@@ -1550,7 +1550,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1627,7 +1627,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 
 	config2Dev2.SetCrypto(clta.Crypto)
 
-	rootNode2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
@@ -1668,7 +1668,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1759,7 +1759,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 
 	config2Dev2.SetCrypto(clta.Crypto)
 
-	rootNode2Dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
@@ -1788,7 +1788,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
@@ -1882,5 +1882,5 @@ func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	ops.mdWriterLock.Lock(lState)
 	ops.mdWriterLock.Unlock(lState)
 
-	GetRootNodeOrBust(t, config2Dev2, name, false)
+	GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 }

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -728,7 +728,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 
 	// user 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -946,11 +946,11 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	// Users 2 and 3 should be unable to read the data now since its
 	// device wasn't registered when the folder was originally
 	// created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
-	_, err = GetRootNodeForTest(config3, name, false)
+	_, err = GetRootNodeForTest(ctx, config3, name, false)
 	if _, ok := err.(NeedOtherRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -977,7 +977,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	}
 
 	// The new devices should be able to read now.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if err != nil {
 		t.Fatalf("Got unexpected error after rekey: %v", err)
 	}
@@ -1023,7 +1023,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	t.Log("Check that user 2 device 2 is unable to read the file")
 	// user 2 device 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1117,7 +1117,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	// user 2 device 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1135,7 +1135,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	root2dev2 := GetRootNodeOrBust(t, config2Dev2, name, false)
 
 	t.Log("User 1 device 2 should still be unable to read")
-	_, err = GetRootNodeForTest(config1Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config1Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1199,7 +1199,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	t.Log("Check that user 2 device 3 is unable to read the file")
 	// user 2 device 3 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev3, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev3, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1290,7 +1290,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 
 	// user 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1351,7 +1351,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 
 	// user 3 dev 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(config3Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config3Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1444,7 +1444,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	// user 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
-	_, err = GetRootNodeForTest(config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
 	if _, ok := err.(NeedSelfRekeyError); !ok {
 		t.Fatalf("Got unexpected error when reading with new key: %v", err)
 	}
@@ -1838,7 +1838,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	// Now cause a paper prompt unlock via a folder access
 	errCh := make(chan error)
 	go func() {
-		_, err := GetRootNodeForTest(config2Dev2, name, false)
+		_, err := GetRootNodeForTest(ctx, config2Dev2, name, false)
 		select {
 		case errCh <- err:
 		case <-ctx.Done():

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -696,7 +696,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -706,7 +706,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 		t.Fatalf("Couldn't create file: %v", err)
 	}
 
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 
@@ -812,7 +812,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	root2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	root2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
 	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx, root2Dev2.GetFolderBranch())
@@ -821,7 +821,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	}
 
 	// device 2 should still work
-	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	children, err := kbfsOps2Dev2.GetDirChildren(ctx, rootNode2Dev2)
 	if _, ok := children["d"]; !ok {
@@ -848,7 +848,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 
 	// meanwhile, device 3 should be able to read both the new and the
 	// old files
-	rootNode2Dev3 := GetRootNodeOrBust(t, ctx, config2Dev3, name, false)
+	rootNode2Dev3 := GetRootNodeOrBust(ctx, t, config2Dev3, name, false)
 
 	kbfsOps2Dev3 := config2Dev3.KBFSOps()
 	aNode, _, err := kbfsOps2Dev3.Lookup(ctx, rootNode2Dev3, "a")
@@ -915,7 +915,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String() + ReaderSep + u3.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -982,7 +982,7 @@ func TestKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T) {
 		t.Fatalf("Got unexpected error after rekey: %v", err)
 	}
 
-	_ = GetRootNodeOrBust(t, ctx, config3, name, false)
+	_ = GetRootNodeOrBust(ctx, t, config3, name, false)
 }
 
 func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
@@ -1000,7 +1000,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	t.Log("Create a shared folder")
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1029,7 +1029,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	}
 
 	t.Log("User 2 rekeys from device 1")
-	root2dev1 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	root2dev1 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	err = kbfsOps2.Rekey(ctx, root2dev1.GetFolderBranch().Tlf)
@@ -1038,7 +1038,7 @@ func TestKeyManagerSelfRekeyAcrossDevices(t *testing.T) {
 	}
 
 	t.Log("User 2 device 2 should be able to read now")
-	root2dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	root2dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	t.Log("User 2 device 2 reads user 1's file")
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
@@ -1082,7 +1082,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	t.Log("Create a shared folder")
 	name := u1.String() + ReaderSep + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1123,7 +1123,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	}
 
 	t.Log("User 2 rekeys from device 1")
-	root2dev1 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	root2dev1 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	kbfsOps2 := config2.KBFSOps()
 	err = kbfsOps2.Rekey(ctx, root2dev1.GetFolderBranch().Tlf)
@@ -1132,7 +1132,7 @@ func TestKeyManagerReaderRekey(t *testing.T) {
 	}
 
 	t.Log("User 2 device 2 should be able to read now")
-	root2dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	root2dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	t.Log("User 1 device 2 should still be unable to read")
 	_, err = GetRootNodeForTest(ctx, config1Dev2, name, false)
@@ -1170,7 +1170,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	t.Log("Create a shared folder")
 	name := u1.String() + ReaderSep + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1205,7 +1205,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	}
 
 	t.Log("User 2 rekeys from device 2")
-	root2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	root2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
 	err = kbfsOps2Dev2.Rekey(ctx, root2Dev2.GetFolderBranch().Tlf)
 	if err != nil {
@@ -1214,7 +1214,7 @@ func TestKeyManagerReaderRekeyAndRevoke(t *testing.T) {
 	}
 
 	t.Log("User 2 device 3 should be able to read now")
-	GetRootNodeOrBust(t, ctx, config2Dev3, name, false)
+	GetRootNodeOrBust(ctx, t, config2Dev3, name, false)
 
 	// A second rekey by the same reader shouldn't change the
 	// revision, since the rekey bit is already set, even though a
@@ -1265,7 +1265,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	// 2 writers 1 reader
 	name := u1.String() + "," + u2.String() + "#" + u3.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1321,7 +1321,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	// look for the file
 	aNode, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
@@ -1382,7 +1382,7 @@ func TestKeyManagerRekeyBit(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	rootNode3Dev2 := GetRootNodeOrBust(t, ctx, config3Dev2, name, false)
+	rootNode3Dev2 := GetRootNodeOrBust(ctx, t, config3Dev2, name, false)
 
 	// look for the file
 	a2Node, _, err := kbfsOps3Dev2.Lookup(ctx, rootNode3Dev2, "a")
@@ -1422,7 +1422,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	// create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1456,7 +1456,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 	}
 
 	// this device should be able to read now
-	root2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	root2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	// Now revoke the original user 2 device
 	clock.Add(1 * time.Minute)
@@ -1504,7 +1504,7 @@ func TestKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T) {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
 
-	rootNode1 = GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 = GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	children, err := kbfsOps1.GetDirChildren(ctx, rootNode1)
 	if _, ok := children["b"]; !ok {
@@ -1550,7 +1550,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1627,7 +1627,7 @@ func TestKeyManagerRekeyAddDeviceWithPrompt(t *testing.T) {
 
 	config2Dev2.SetCrypto(clta.Crypto)
 
-	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
@@ -1668,7 +1668,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 
 	kbfsOps1 := config1.KBFSOps()
 
@@ -1759,7 +1759,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T) {
 
 	config2Dev2.SetCrypto(clta.Crypto)
 
-	rootNode2Dev2 := GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 
 	kbfsOps2 := config2Dev2.KBFSOps()
 	children, err := kbfsOps2.GetDirChildren(ctx, rootNode2Dev2)
@@ -1788,7 +1788,7 @@ func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	// Create a shared folder
 	name := u1.String() + "," + u2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2Dev2)
 
@@ -1882,5 +1882,5 @@ func TestKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T) {
 	ops.mdWriterLock.Lock(lState)
 	ops.mdWriterLock.Unlock(lState)
 
-	GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+	GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 }

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -384,8 +384,8 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -384,8 +384,8 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -53,7 +53,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 		name := strings.Join(writers, ",")
 		names = append(names, name)
 		// user 1 creates the directory
-		rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+		rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 		// user 1 creates a file
 		_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 		if err != nil {
@@ -82,7 +82,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 
 	// now user 1 should rekey via its rekey worker
 	for _, name := range names {
-		rootNode1 := GetRootNodeOrBust(t, config1, name, false)
+		rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
 		// queue it for rekey
 		c := config1.RekeyQueue().Enqueue(rootNode1.GetFolderBranch().Tlf)
 		rekeyChannels = append(rekeyChannels, c)
@@ -97,6 +97,6 @@ func TestRekeyQueueBasic(t *testing.T) {
 
 	// user 2's new device should be able to read now
 	for _, name := range names {
-		_ = GetRootNodeOrBust(t, config2Dev2, name, false)
+		_ = GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
 	}
 }

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -72,7 +72,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 	// user 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
 	for _, name := range names {
-		_, err := GetRootNodeForTest(config2Dev2, name, false)
+		_, err := GetRootNodeForTest(ctx, config2Dev2, name, false)
 		if _, ok := err.(NeedSelfRekeyError); !ok {
 			t.Fatalf("Got unexpected error when reading with new key: %v", err)
 		}

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -53,7 +53,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 		name := strings.Join(writers, ",")
 		names = append(names, name)
 		// user 1 creates the directory
-		rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 		// user 1 creates a file
 		_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 		if err != nil {
@@ -82,7 +82,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 
 	// now user 1 should rekey via its rekey worker
 	for _, name := range names {
-		rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 		// queue it for rekey
 		c := config1.RekeyQueue().Enqueue(rootNode1.GetFolderBranch().Tlf)
 		rekeyChannels = append(rekeyChannels, c)
@@ -97,6 +97,6 @@ func TestRekeyQueueBasic(t *testing.T) {
 
 	// user 2's new device should be able to read now
 	for _, name := range names {
-		_ = GetRootNodeOrBust(t, ctx, config2Dev2, name, false)
+		_ = GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 	}
 }

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -545,8 +545,9 @@ func CheckConfigAndShutdown(t logger.TestLogBackend, config Config) {
 
 // GetRootNodeForTest gets the root node for the given TLF name, which
 // must be canonical, creating it if necessary.
-func GetRootNodeForTest(config Config, name string, public bool) (Node, error) {
-	ctx := context.Background()
+func GetRootNodeForTest(
+	ctx context.Context, config Config, name string,
+	public bool) (Node, error) {
 	h, err := ParseTlfHandle(ctx, config.KBPKI(), name, public)
 	if err != nil {
 		return nil, err
@@ -565,7 +566,8 @@ func GetRootNodeForTest(config Config, name string, public bool) (Node, error) {
 // an error.
 func GetRootNodeOrBust(
 	t logger.TestLogBackend, config Config, name string, public bool) Node {
-	n, err := GetRootNodeForTest(config, name, public)
+	ctx := context.Background()
+	n, err := GetRootNodeForTest(ctx, config, name, public)
 	if err != nil {
 		t.Fatalf("Couldn't get root node for %s (public=%t): %v",
 			name, public, err)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -565,8 +565,8 @@ func GetRootNodeForTest(
 // must be canonical, creating it if necessary, and failing if there's
 // an error.
 func GetRootNodeOrBust(
-	t logger.TestLogBackend, config Config, name string, public bool) Node {
-	ctx := context.Background()
+	t logger.TestLogBackend, ctx context.Context,
+	config Config, name string, public bool) Node {
 	n, err := GetRootNodeForTest(ctx, config, name, public)
 	if err != nil {
 		t.Fatalf("Couldn't get root node for %s (public=%t): %v",

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -565,7 +565,7 @@ func GetRootNodeForTest(
 // must be canonical, creating it if necessary, and failing if there's
 // an error.
 func GetRootNodeOrBust(
-	t logger.TestLogBackend, ctx context.Context,
+	ctx context.Context, t logger.TestLogBackend,
 	config Config, name string, public bool) Node {
 	n, err := GetRootNodeForTest(ctx, config, name, public)
 	if err != nil {

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -46,8 +46,8 @@ func TestBasicTlfEditHistory(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()
@@ -169,8 +169,8 @@ func TestLongTlfEditHistory(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	kbfsOps2 := config2.KBFSOps()
 

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -46,8 +46,8 @@ func TestBasicTlfEditHistory(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()
@@ -169,8 +169,8 @@ func TestLongTlfEditHistory(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(t, ctx, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(t, ctx, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 	kbfsOps1 := config1.KBFSOps()
 	kbfsOps2 := config2.KBFSOps()
 


### PR DESCRIPTION
This ensures that those functions obey the test timeout.