### PR TITLE
[KBFS-1693] Have fewer blockRetrievalWorkers for tests

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -20,14 +20,14 @@ type BlockOpsStandard struct {
 var _ BlockOps = (*BlockOpsStandard)(nil)
 
 // NewBlockOpsStandard creates a new BlockOpsStandard
-func NewBlockOpsStandard(config Config) *BlockOpsStandard {
+func NewBlockOpsStandard(config Config, queueSize int) *BlockOpsStandard {
 	bops := &BlockOpsStandard{
 		config:  config,
-		queue:   newBlockRetrievalQueue(defaultBlockRetrievalWorkerQueueSize, config.Codec()),
-		workers: make([]*blockRetrievalWorker, 0, defaultBlockRetrievalWorkerQueueSize),
+		queue:   newBlockRetrievalQueue(queueSize, config.Codec()),
+		workers: make([]*blockRetrievalWorker, 0, queueSize),
 	}
 	bg := &realBlockGetter{config: config}
-	for i := 0; i < defaultBlockRetrievalWorkerQueueSize; i++ {
+	for i := 0; i < queueSize; i++ {
 		bops.workers = append(bops.workers, newBlockRetrievalWorker(bg, bops.queue))
 	}
 	return bops

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -93,7 +93,7 @@ func blockOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	ctr := NewSafeTestReporter(t)
 	mockCtrl = gomock.NewController(ctr)
 	config = NewConfigMock(mockCtrl, ctr)
-	bops := NewBlockOpsStandard(config)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	config.SetBlockOps(bops)
 	ctx = context.Background()
 	return

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	defaultBlockRetrievalWorkerQueueSize int = 100
+	testBlockRetrievalWorkerQueueSize    int = 5
 	defaultOnDemandRequestPriority       int = 100
 )
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -713,28 +713,6 @@ func (c *ConfigLocal) SetLoggerMaker(
 	c.loggerFn = loggerFn
 }
 
-// newConfigLocalWithCryptoForSigning initializes a local crypto
-// config w/a crypto interface, using the given signing key, that can
-// be used for non-PKI crypto.
-func newConfigLocalWithCryptoForSigning(
-	signingKey kbfscrypto.SigningKey) *ConfigLocal {
-	config := NewConfigLocal()
-	config.SetLoggerMaker(func(m string) logger.Logger {
-		return logger.NewNull()
-	})
-	cryptPrivateKey := MakeLocalUserCryptPrivateKeyOrBust("nobody")
-	crypto := NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey)
-	config.SetCrypto(crypto)
-	return config
-}
-
-// NewConfigLocalWithCrypto initializes a local crypto config w/a
-// crypto interface that can be used for non-PKI crypto.
-func NewConfigLocalWithCrypto() *ConfigLocal {
-	signingKey := MakeLocalUserSigningKeyOrBust("nobody")
-	return newConfigLocalWithCryptoForSigning(signingKey)
-}
-
 // MetricsRegistry implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) MetricsRegistry() metrics.Registry {
 	return c.registry

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -216,7 +216,7 @@ func NewConfigLocal() *ConfigLocal {
 	config.SetConflictRenamer(WriterDeviceDateConflictRenamer{config})
 	config.ResetCaches()
 	config.SetCodec(kbfscodec.NewMsgpack())
-	config.SetBlockOps(NewBlockOpsStandard(config))
+	config.SetBlockOps(NewBlockOpsStandard(config, defaultBlockRetrievalWorkerQueueSize))
 	config.SetKeyOps(&KeyOpsStandard{config})
 	config.SetRekeyQueue(NewRekeyQueueStandard(config))
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -208,7 +208,9 @@ func MakeLocalUsers(users []libkb.NormalizedUsername) []LocalUser {
 	return localUsers
 }
 
-// NewConfigLocal constructs a new ConfigLocal with default components.
+// NewConfigLocal constructs a new ConfigLocal with some default
+// components.  The caller will have to fill in the rest though,
+// namely BlockOps and BlockSplitter.
 func NewConfigLocal() *ConfigLocal {
 	config := &ConfigLocal{}
 	config.SetClock(wallClock{})
@@ -216,7 +218,6 @@ func NewConfigLocal() *ConfigLocal {
 	config.SetConflictRenamer(WriterDeviceDateConflictRenamer{config})
 	config.ResetCaches()
 	config.SetCodec(kbfscodec.NewMsgpack())
-	config.SetBlockOps(NewBlockOpsStandard(config, defaultBlockRetrievalWorkerQueueSize))
 	config.SetKeyOps(&KeyOpsStandard{config})
 	config.SetRekeyQueue(NewRekeyQueueStandard(config))
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -209,8 +209,8 @@ func MakeLocalUsers(users []libkb.NormalizedUsername) []LocalUser {
 }
 
 // NewConfigLocal constructs a new ConfigLocal with some default
-// components.  The caller will have to fill in the rest though,
-// namely BlockOps and BlockSplitter.
+// components that don't depend on a logger. The caller will have to
+// fill in the rest.
 func NewConfigLocal() *ConfigLocal {
 	config := &ConfigLocal{}
 	config.SetClock(wallClock{})

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -305,6 +305,8 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 
 	config := NewConfigLocal()
 
+	config.SetBlockOps(NewBlockOpsStandard(config, defaultBlockRetrievalWorkerQueueSize))
+
 	bsplitter, err := NewBlockSplitterSimple(MaxBlockSizeBytesDefault, 8*1024,
 		config.Codec())
 	if err != nil {

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -70,11 +70,23 @@ func setTestLogger(config Config, t logger.TestLogBackend) {
 	config.SetLoggerMaker(testLoggerMaker(t))
 }
 
+// NewConfigForTest returns a ConfigLocal object suitable for testing.
+//
+// TODO: Decouple this from NewConfigLocal.
+func NewConfigForTest() *ConfigLocal {
+	config := NewConfigLocal()
+
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	config.SetBlockOps(bops)
+
+	return config
+}
+
 // MakeTestConfigOrBust creates and returns a config suitable for
 // unit-testing with the given list of users.
 func MakeTestConfigOrBust(t logger.TestLogBackend,
 	users ...libkb.NormalizedUsername) *ConfigLocal {
-	config := NewConfigLocal()
+	config := NewConfigForTest()
 	setTestLogger(config, t)
 
 	kbfsOps := NewKBFSOpsStandard(config)
@@ -195,7 +207,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 // ConfigAsUser clones a test configuration, setting another user as
 // the logged in user
 func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *ConfigLocal {
-	c := NewConfigLocal()
+	c := NewConfigForTest()
 	c.SetLoggerMaker(config.loggerFn)
 
 	kbfsOps := NewKBFSOpsStandard(c)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -70,10 +70,11 @@ func setTestLogger(config Config, t logger.TestLogBackend) {
 	config.SetLoggerMaker(testLoggerMaker(t))
 }
 
-// NewConfigForTest returns a ConfigLocal object suitable for testing.
+// newConfigForTest returns a ConfigLocal object suitable for use by
+// MakeTestConfigOrBust or ConfigAsUser.
 //
-// TODO: Decouple this from NewConfigLocal.
-func NewConfigForTest() *ConfigLocal {
+// TODO: Move more common code here.
+func newConfigForTest() *ConfigLocal {
 	config := NewConfigLocal()
 
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
@@ -88,7 +89,7 @@ func NewConfigForTest() *ConfigLocal {
 // unit-testing with the given list of users.
 func MakeTestConfigOrBust(t logger.TestLogBackend,
 	users ...libkb.NormalizedUsername) *ConfigLocal {
-	config := NewConfigForTest()
+	config := newConfigForTest()
 	setTestLogger(config, t)
 
 	kbfsOps := NewKBFSOpsStandard(config)
@@ -208,7 +209,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 // ConfigAsUser clones a test configuration, setting another user as
 // the logged in user
 func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *ConfigLocal {
-	c := NewConfigForTest()
+	c := newConfigForTest()
 	c.SetLoggerMaker(config.loggerFn)
 
 	kbfsOps := NewKBFSOpsStandard(c)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -79,6 +79,8 @@ func NewConfigForTest() *ConfigLocal {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	config.SetBlockOps(bops)
 
+	config.SetBlockSplitter(&BlockSplitterSimple{64 * 1024, 8 * 1024})
+
 	return config
 }
 
@@ -93,7 +95,6 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 	config.SetKBFSOps(kbfsOps)
 	config.SetNotifier(kbfsOps)
 
-	config.SetBlockSplitter(&BlockSplitterSimple{64 * 1024, 8 * 1024})
 	config.SetKeyManager(NewKeyManagerStandard(config))
 	config.SetMDOps(NewMDOpsStandard(config))
 
@@ -214,7 +215,6 @@ func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *C
 	c.SetKBFSOps(kbfsOps)
 	c.SetNotifier(kbfsOps)
 
-	c.SetBlockSplitter(config.BlockSplitter())
 	c.SetKeyManager(NewKeyManagerStandard(c))
 	c.SetMDOps(NewMDOpsStandard(c))
 	c.SetClock(config.Clock())


### PR DESCRIPTION
This is to avoid cluttering up stack
traces, e.g. when a DSL test times out.

Also clean up ConfigLocal constructors a bit.