### PR TITLE
Hide some spammy logs

### DIFF
--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -85,9 +85,8 @@ func start() *libfs.Error {
 	if kbfsParams.Debug {
 		fuseLog := logger.NewWithCallDepth("FUSE", 1)
 		fuseLog.Configure("", true, "")
-		fuse.Debug = func(msg interface{}) {
-			fuseLog.Debug("%s", msg)
-		}
+		fuse.Debug = libfuse.MakeFuseDebugFn(
+			fuseLog, false /* superVerbose */)
 	}
 
 	mountpoint := flag.Arg(0)

--- a/libfuse/debug.go
+++ b/libfuse/debug.go
@@ -19,6 +19,9 @@ func MakeFuseDebugFn(
 		str := fmt.Sprintf("%s", msg)
 		// If superVerbose is not set, filter out Statfs and
 		// Access messages, since they're spammy on OS X.
+		//
+		// Ideally, bazil would let us filter this better, and
+		// also pass in the ctx.
 		if !superVerbose &&
 			(strings.HasPrefix(str, "<- ") ||
 				strings.HasPrefix(str, "-> ")) &&

--- a/libfuse/debug.go
+++ b/libfuse/debug.go
@@ -6,10 +6,12 @@ package libfuse
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 
 	"github.com/keybase/client/go/logger"
 )
+
+var statfsOrAccessRegexp = regexp.MustCompile(`^(<-|->).* (Statfs|Access)`)
 
 // MakeFuseDebugFn returns a function that logs its argument to the
 // given log, suitable to assign to fuse.Debug.
@@ -22,11 +24,7 @@ func MakeFuseDebugFn(
 		//
 		// Ideally, bazil would let us filter this better, and
 		// also pass in the ctx.
-		if !superVerbose &&
-			(strings.HasPrefix(str, "<- ") ||
-				strings.HasPrefix(str, "-> ")) &&
-			(strings.Contains(str, " Statfs") ||
-				strings.Contains(str, " Access")) {
+		if !superVerbose && statfsOrAccessRegexp.MatchString(str) {
 			return
 		}
 		log.Debug("%s", str)

--- a/libfuse/debug.go
+++ b/libfuse/debug.go
@@ -11,8 +11,8 @@ import (
 	"github.com/keybase/client/go/logger"
 )
 
-// Returns a function that logs its argument to the given log,
-// suitable to assign to fuse.Debug.
+// MakeFuseDebugFn returns a function that logs its argument to the
+// given log, suitable to assign to fuse.Debug.
 func MakeFuseDebugFn(
 	log logger.Logger, superVerbose bool) func(msg interface{}) {
 	return func(msg interface{}) {

--- a/libfuse/debug.go
+++ b/libfuse/debug.go
@@ -1,0 +1,31 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/keybase/client/go/logger"
+)
+
+// Returns a function that logs its argument to the given log,
+// suitable to assign to fuse.Debug.
+func MakeFuseDebugFn(
+	log logger.Logger, superVerbose bool) func(msg interface{}) {
+	return func(msg interface{}) {
+		str := fmt.Sprintf("%s", msg)
+		// If superVerbose is not set, filter out Statfs and
+		// Access messages, since they're spammy on OS X.
+		if !superVerbose &&
+			(strings.HasPrefix(str, "<- ") ||
+				strings.HasPrefix(str, "-> ")) &&
+			(strings.Contains(str, " Statfs") ||
+				strings.Contains(str, " Access")) {
+			return
+		}
+		log.Debug("%s", str)
+	}
+}

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -34,9 +34,7 @@ func makeFS(t testing.TB, config *libkbfs.ConfigLocal) (
 	*fstestutil.Mount, *FS, func()) {
 	log := logger.NewTestLogger(t)
 	debugLog := log.CloneWithAddedDepth(1)
-	fuse.Debug = func(msg interface{}) {
-		debugLog.Debug("%s", msg)
-	}
+	fuse.Debug = MakeFuseDebugFn(debugLog, false /* superVerbose */)
 
 	// TODO duplicates main() in kbfsfuse/main.go too much
 	filesys := &FS{

--- a/test/run_fuse_test.go
+++ b/test/run_fuse_test.go
@@ -34,9 +34,7 @@ func createUserFuse(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser {
 	log := logger.NewTestLogger(t)
 	debugLog := log.CloneWithAddedDepth(1)
-	fuse.Debug = func(msg interface{}) {
-		debugLog.Debug("%s", msg)
-	}
+	fuse.Debug = libfuse.MakeFuseDebugFn(debugLog, false /* superVerbose */)
 
 	filesys := libfuse.NewFS(config, nil, false)
 	fn := func(mnt *fstestutil.Mount) fs.FS {


### PR DESCRIPTION
In particular, Statfs and Access calls, which
for some reason are called very frequently on
OS X.