### PR TITLE
journal: coalesce updates together

### DIFF
--- a/libkbfs/branch_id.go
+++ b/libkbfs/branch_id.go
@@ -29,6 +29,11 @@ var _ encoding.BinaryUnmarshaler = (*BranchID)(nil)
 // NullBranchID is an empty BranchID
 var NullBranchID = BranchID{}
 
+// LocalSquashBranchID indicates a local branch that is not in known
+// conflict with the master branch, but just needs to be squashed.
+var LocalSquashBranchID = BranchID{
+	[BranchIDByteLen]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
+
 // Bytes returns the bytes of the BranchID.
 func (id BranchID) Bytes() []byte {
 	return id.id[:]

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3436,7 +3436,9 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 		// The child blocks should be referenced in the resolution op.
 		_, ok := md.data.Changes.Ops[len(md.data.Changes.Ops)-1].(*resolutionOp)
 		if !ok {
-			md.AddOp(newResolutionOp())
+			// Append directly to the ops list, rather than use AddOp,
+			// because the size estimate was already calculated.
+			md.data.Changes.Ops = append(md.data.Changes.Ops, newResolutionOp())
 		}
 
 		err = cr.fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes, uid)

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2434,7 +2434,6 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 				// for conflicts.
 				if unmergedChains.isCreated(original) &&
 					!mergedChains.isCreated(original) {
-
 					// Shallowly copy the create op and update its
 					// directory to the most recent pointer -- this won't
 					// work with the usual revert ops process because that
@@ -3162,7 +3161,10 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	isSquash := mostRecentMergedMD.data.Dir.BlockPointer !=
 		mergedChains.mostRecentChainMDInfo.rootInfo.BlockPointer
 	if isSquash {
-		// Squashes don't need to sync anything new.
+		// Squashes don't need to sync anything new.  Just set the
+		// root pointer to the most recent root pointer, and fill up
+		// the resolution op with all the known chain updates for this
+		// branch.
 		bps = newBlockPutState(0)
 		md.data.Dir.BlockInfo = unmergedChains.mostRecentChainMDInfo.rootInfo
 		for original, chain := range unmergedChains.byOriginal {
@@ -3778,8 +3780,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		// this!
 		//
 		// nothing to do
-		cr.log.CDebugf(ctx, "No updates to resolve, so complete resolution "+
-			"to follow revision %d", mostRecentMergedMD.Revision())
+		cr.log.CDebugf(ctx, "No updates to resolve, so finishing")
 		lbc := make(localBcache)
 		newFileBlocks := make(fileBlockMap)
 		err = cr.completeResolution(ctx, lState, unmergedChains,

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -256,7 +256,7 @@ func testCRCheckPathsAndActions(t *testing.T, cr *ConflictResolver,
 
 	// Step 1 -- check the chains and paths
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, err := cr.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, _, err := cr.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1147,7 +1147,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1263,7 +1263,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -251,9 +251,9 @@ func crActionConvertSymlink(unmergedMostRecent BlockPointer,
 // trackSyncPtrChangesInCreate makes sure the correct set of refs and
 // unrefs, from the syncOps on the unmerged branch, makes it into the
 // createOp for a new file.
-func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
+func trackSyncPtrChangesInCreate(
 	mostRecentTargetPtr BlockPointer, unmergedChain *crChain,
-	unmergedChains *crChains) {
+	unmergedChains *crChains, toName string) {
 	targetChain, ok := unmergedChains.byMostRecent[mostRecentTargetPtr]
 	var refs, unrefs []BlockPointer
 	if ok && targetChain.isFile() {
@@ -284,7 +284,7 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 	if len(refs) > 0 {
 		for _, uop := range unmergedChain.ops {
 			cop, ok := uop.(*createOp)
-			if !ok || cop.NewName != cuea.toName {
+			if !ok || cop.NewName != toName {
 				continue
 			}
 			for _, ref := range refs {
@@ -296,6 +296,13 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 			break
 		}
 	}
+}
+
+func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
+	mostRecentTargetPtr BlockPointer, unmergedChain *crChain,
+	unmergedChains *crChains) {
+	trackSyncPtrChangesInCreate(
+		mostRecentTargetPtr, unmergedChain, unmergedChains, cuea.toName)
 }
 
 func (cuea *copyUnmergedEntryAction) updateOps(unmergedMostRecent BlockPointer,

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -329,8 +329,8 @@ func (ri renameInfo) String() string {
 // mostRecentChainMetadataInfo contains the subset of information for
 // the most recent chainMetadata that is needed for crChains.
 type mostRecentChainMetadataInfo struct {
-	kmd     KeyMetadata
-	rootPtr BlockPointer
+	kmd      KeyMetadata
+	rootInfo BlockInfo
 }
 
 // crChains contains a crChain for every KBFS node affected by the
@@ -822,8 +822,8 @@ func newCRChains(
 	}
 
 	ccs.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		kmd:     mostRecentMD,
-		rootPtr: mostRecentMD.Data().Dir.BlockPointer,
+		kmd:      mostRecentMD,
+		rootInfo: mostRecentMD.Data().Dir.BlockInfo,
 	}
 
 	return ccs, nil
@@ -990,7 +990,7 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 
 	pathMap, err := blocks.SearchForPaths(ctx, nodeCache, ptrs,
 		newPtrs, ccs.mostRecentChainMDInfo.kmd,
-		ccs.mostRecentChainMDInfo.rootPtr)
+		ccs.mostRecentChainMDInfo.rootInfo.BlockPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -41,9 +41,13 @@ func (c CryptoCommon) MakeRandomTlfID(isPublic bool) (tlf.ID, error) {
 // MakeRandomBranchID implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) MakeRandomBranchID() (BranchID, error) {
 	var id BranchID
-	err := kbfscrypto.RandRead(id.id[:])
-	if err != nil {
-		return BranchID{}, err
+	// Loop just in case we randomly pick the null or local squash
+	// branch IDs.
+	for id == NullBranchID || id == LocalSquashBranchID {
+		err := kbfscrypto.RandRead(id.id[:])
+		if err != nil {
+			return BranchID{}, err
+		}
 	}
 	return id, nil
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4550,7 +4550,8 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 		return err
 	}
 
-	for true {
+	// Loop until we're fully updated on the master branch.
+	for {
 		if !fbo.isMasterBranch(lState) {
 			if err := fbo.cr.Wait(ctx); err != nil {
 				return err

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -752,7 +752,9 @@ type cryptoPure interface {
 	// MakeRandomTlfID generates a dir ID using a CSPRNG.
 	MakeRandomTlfID(isPublic bool) (tlf.ID, error)
 
-	// MakeRandomBranchID generates a per-device branch ID using a CSPRNG.
+	// MakeRandomBranchID generates a per-device branch ID using a
+	// CSPRNG.  It will not return LocalSquashBranchID or
+	// NullBranchID.
 	MakeRandomBranchID() (BranchID, error)
 
 	// MakeMdID computes the MD ID of a RootMetadata object.

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -572,7 +572,12 @@ func (j *mdJournal) convertToBranch(
 	ctx context.Context, bid BranchID, signer kbfscrypto.Signer,
 	codec kbfscodec.Codec, tlfID tlf.ID, mdcache MDCache) (err error) {
 	if j.branchID != NullBranchID {
-		return fmt.Errorf("convertToBranch called with BID=%s", j.branchID)
+		return fmt.Errorf(
+			"convertToBranch called with j.branchID=%s", j.branchID)
+	}
+	if bid == NullBranchID {
+		return fmt.Errorf(
+			"convertToBranch called with null branchID")
 	}
 
 	earliestRevision, err := j.j.readEarliestRevision()

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -246,7 +246,8 @@ func TestMDJournalPutCase1Conflict(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -293,7 +294,8 @@ func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -311,7 +313,8 @@ func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {
 	mdID, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -330,7 +333,8 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -355,7 +359,8 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -378,7 +383,8 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -400,7 +406,8 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -483,7 +490,8 @@ func TestMDJournalBranchConversion(t *testing.T) {
 		j.key, cachedMdID, time.Now()))
 	require.NoError(t, err)
 
-	bid, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	bid := LocalSquashBranchID
+	err = j.convertToBranch(ctx, bid, signer, kbfscodec.NewMsgpack(),
 		id, mdcache)
 	require.NoError(t, err)
 
@@ -535,7 +543,8 @@ func TestMDJournalResolveAndClear(t *testing.T) {
 
 	ctx := context.Background()
 
-	bid, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(), id,
+	bid := LocalSquashBranchID
+	err := j.convertToBranch(ctx, bid, signer, kbfscodec.NewMsgpack(), id,
 		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -581,8 +590,9 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(
-		ctx, &limitedSigner, kbfscodec.NewMsgpack(), id, NewMDCacheStandard(10))
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, &limitedSigner, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NotNil(t, err)
 
 	// All entries should remain unchanged, since the conversion
@@ -649,8 +659,9 @@ func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
 		prevRoot = mdID
 	}
 
-	_, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
-		id, NewMDCacheStandard(10))
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Check that the extra fields are preserved.
@@ -679,8 +690,9 @@ func TestMDJournalClear(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
-		id, NewMDCacheStandard(10))
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -722,8 +734,9 @@ func TestMDJournalClear(t *testing.T) {
 	// journal.
 	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
-		id, NewMDCacheStandard(10))
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -785,7 +798,8 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -544,13 +544,14 @@ func TestMDJournalResolveAndClear(t *testing.T) {
 	ctx := context.Background()
 
 	bid := LocalSquashBranchID
+	mdcache := NewMDCacheStandard(10)
 	err := j.convertToBranch(ctx, bid, signer, kbfscodec.NewMsgpack(), id,
-		NewMDCacheStandard(10))
+		mdcache)
 	require.NoError(t, err)
 
 	resolveRev := firstRevision
 	md := makeMDForTest(t, id, resolveRev, j.uid, signer, firstPrevRoot)
-	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, bid, md)
+	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, mdcache, bid, md)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, getMDJournalLength(t, j))

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1522,7 +1522,7 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	// the existing branch, then clear the existing branch.
 	mdID, err = j.mdJournal.resolveAndClear(
 		ctx, j.config.Crypto(), j.config.encryptionKeyGetter(),
-		j.config.BlockSplitter(), bid, rmd)
+		j.config.BlockSplitter(), j.config.MDCache(), bid, rmd)
 	if err != nil {
 		return MdID{}, false, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -69,6 +69,10 @@ const (
 	// This will be the final entry for unflushed paths if there are
 	// too many revisions to process at once.
 	incompleteUnflushedPathsMarker = "..."
+	// ForcedBranchSquashThreshold is the minimum number of MD
+	// revisions in the journal that will trigger an automatic branch
+	// conversion (and subsequent resolution).
+	ForcedBranchSquashThreshold = 20
 )
 
 // TLFJournalStatus represents the status of a TLF's journal for
@@ -631,6 +635,14 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 			return nil
 		}
 
+		converted, err := j.convertMDsToBranchIfOverThreshold(ctx)
+		if err != nil {
+			return err
+		}
+		if converted {
+			return nil
+		}
+
 		blockEnd, mdEnd, err := j.getJournalEnds(ctx)
 		if err != nil {
 			return err
@@ -744,14 +756,7 @@ func (j *tlfJournal) getNextMDEntryToFlush(ctx context.Context,
 	return j.mdJournal.getNextEntryToFlush(ctx, end, j.config.Crypto())
 }
 
-func (j *tlfJournal) convertMDsToBranch(
-	ctx context.Context, nextEntryEnd MetadataRevision) error {
-	j.journalLock.Lock()
-	defer j.journalLock.Unlock()
-	if err := j.checkEnabledLocked(); err != nil {
-		return err
-	}
-
+func (j *tlfJournal) convertMDsToBranchLocked(ctx context.Context) error {
 	bid, err := j.mdJournal.convertToBranch(
 		ctx, j.config.Crypto(), j.config.Codec(), j.tlfID, j.config.MDCache())
 	if err != nil {
@@ -763,6 +768,40 @@ func (j *tlfJournal) convertMDsToBranch(
 	}
 
 	return nil
+}
+
+func (j *tlfJournal) convertMDsToBranch(ctx context.Context) error {
+	j.journalLock.Lock()
+	defer j.journalLock.Unlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return err
+	}
+
+	return j.convertMDsToBranchLocked(ctx)
+}
+
+func (j *tlfJournal) convertMDsToBranchIfOverThreshold(ctx context.Context) (
+	bool, error) {
+	j.journalLock.Lock()
+	defer j.journalLock.Unlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return false, err
+	}
+
+	size, err := j.mdJournal.length()
+	if err != nil {
+		return false, err
+	}
+	if size < ForcedBranchSquashThreshold {
+		return false, nil
+	}
+
+	j.log.CDebugf(ctx, "Converting journal of length %d to branch", size)
+	err = j.convertMDsToBranchLocked(ctx)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (j *tlfJournal) removeFlushedMDEntry(ctx context.Context,
@@ -831,7 +870,7 @@ func (j *tlfJournal) flushOneMDOp(
 			j.log.CDebugf(ctx, "Conflict detected %v", pushErr)
 			// Convert MDs to a branch and return -- the journal
 			// pauses until the resolution is complete.
-			err = j.convertMDsToBranch(ctx, end)
+			err = j.convertMDsToBranch(ctx)
 			if err != nil {
 				return false, err
 			}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -635,6 +635,7 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 			return nil
 		}
 
+		/*  Will uncomment when the rest of KBFS-1653 goes in.
 		converted, err := j.convertMDsToBranchIfOverThreshold(ctx)
 		if err != nil {
 			return err
@@ -642,6 +643,7 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 		if converted {
 			return nil
 		}
+		*/
 
 		blockEnd, mdEnd, err := j.getJournalEnds(ctx)
 		if err != nil {
@@ -773,14 +775,9 @@ func (j *tlfJournal) convertMDsToBranchLocked(
 }
 
 func (j *tlfJournal) convertMDsToBranch(ctx context.Context) error {
-	bid := LocalSquashBranchID
-	// Loop just in case we randomly pick the local squash branch ID.
-	for bid == LocalSquashBranchID {
-		var err error
-		bid, err = j.config.Crypto().MakeRandomBranchID()
-		if err != nil {
-			return err
-		}
+	bid, err := j.config.Crypto().MakeRandomBranchID()
+	if err != nil {
+		return err
 	}
 
 	j.journalLock.Lock()

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -165,8 +165,8 @@ func addUnflushedPaths(ctx context.Context,
 
 	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
 	chains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		kmd:     mostRecentMDInfo.kmd,
-		rootPtr: mostRecentMDInfo.pmd.Dir.BlockPointer,
+		kmd:      mostRecentMDInfo.kmd,
+		rootInfo: mostRecentMDInfo.pmd.Dir.BlockInfo,
 	}
 
 	err := cpp.populateChainPaths(ctx, log, chains, true)


### PR DESCRIPTION
This PR squashes together a set of journal commits if the length of the journal exceeds some threshold ( hardcoded to 20 updates for now).  It does this by:

* Converting the journal to a branch, using a special reserved branch ID.
* CR handling an empty merged set and making sure pointers are all fixed up even when no explicit actions are involved.
* Making sure the branch updates are cleared from the MD cache after a resolution, since we can now re-use branch IDs.
* Tracking the most recent `BlockInfo` is `crChains` so we can get the encoded size of a root block during CR.

Note that I'll disable coalescing by default when I commit this because it currently does nothing to recognize if there are already squashes in the earliest journal slots, and thus too many updates can end up getting squashed into a single MD update over time.  A future PR will handle this better and then turn on coalescing for real.