### PR TITLE
md_journal: don't convert local squashes to new squash branch

### DIFF
--- a/libkbfs/branch_id.go
+++ b/libkbfs/branch_id.go
@@ -29,9 +29,9 @@ var _ encoding.BinaryUnmarshaler = (*BranchID)(nil)
 // NullBranchID is an empty BranchID
 var NullBranchID = BranchID{}
 
-// LocalSquashBranchID indicates a local branch that is not in known
-// conflict with the master branch, but just needs to be squashed.
-var LocalSquashBranchID = BranchID{
+// PendingLocalSquashBranchID indicates a local branch that is not in known
+// conflict with the master branch, but just needs to be squashed locally.
+var PendingLocalSquashBranchID = BranchID{
 	[BranchIDByteLen]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
 
 // Bytes returns the bytes of the BranchID.

--- a/libkbfs/branch_id.go
+++ b/libkbfs/branch_id.go
@@ -29,6 +29,11 @@ var _ encoding.BinaryUnmarshaler = (*BranchID)(nil)
 // NullBranchID is an empty BranchID
 var NullBranchID = BranchID{}
 
+// LocalSquashBranchID indicates a local branch that is not in known
+// conflict with the master branch, but just needs to be squashed.
+var LocalSquashBranchID = BranchID{
+	[BranchIDByteLen]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
+
 // Bytes returns the bytes of the BranchID.
 func (id BranchID) Bytes() []byte {
 	return id.id[:]

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2415,6 +2415,11 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 	lState *lockState, unmergedPaths []path,
 	unmergedChains, mergedChains *crChains,
 	mostRecentMergedMD ImmutableRootMetadata) (*RootMetadata, error) {
+	err := cr.checkDone(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	newMD, err := mostRecentMergedMD.MakeSuccessor(
 		ctx, cr.config, mostRecentMergedMD.MdID(), true)
 	if err != nil {
@@ -2706,6 +2711,11 @@ func (rmd rootMetadataWithKeyAndTimestamp) LocalTimestamp() time.Time {
 func (cr *ConflictResolver) makePostResolutionPaths(ctx context.Context,
 	md *RootMetadata, unmergedChains, mergedChains *crChains,
 	mergedPaths map[BlockPointer]path) (map[BlockPointer]path, error) {
+	err := cr.checkDone(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	key, err := cr.config.KBPKI().GetCurrentVerifyingKey(ctx)
 	if err != nil {
 		return nil, err
@@ -3145,6 +3155,11 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	newFileBlocks fileBlockMap) (
 	updates map[BlockPointer]BlockPointer, bps *blockPutState,
 	blocksToDelete []BlockID, err error) {
+	err = cr.checkDone(ctx)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	updates = make(map[BlockPointer]BlockPointer)
 
 	_, uid, err := cr.config.KBPKI().GetCurrentUserInfo(ctx)
@@ -3560,6 +3575,11 @@ func (cr *ConflictResolver) finalizeResolution(ctx context.Context,
 	unmergedChains, mergedChains *crChains,
 	updates map[BlockPointer]BlockPointer,
 	bps *blockPutState, blocksToDelete []BlockID, writerLocked bool) error {
+	err := cr.checkDone(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Fix up all the block pointers in the merged ops to work well
 	// for local notifications.  Make a dummy op at the beginning to
 	// convert all the merged most recent pointers into unmerged most
@@ -3622,6 +3642,11 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 				md.ReadOnly(), bps, blockDeleteOnMDFail)
 		}
 	}()
+
+	err = cr.checkDone(ctx)
+	if err != nil {
+		return err
+	}
 
 	// Put all the blocks.  TODO: deal with recoverable block errors?
 	_, err = doBlockPuts(ctx, cr.config.BlockServer(), cr.config.BlockCache(),

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -260,6 +260,11 @@ func (cr *ConflictResolver) getMDs(ctx context.Context, lState *lockState,
 		return nil, nil, err
 	}
 
+	if len(unmerged) > 0 && unmerged[0].BID() == LocalSquashBranchID {
+		cr.log.CDebugf(ctx, "Squashing local branch")
+		return unmerged, nil, nil
+	}
+
 	// Now get all the merged MDs, starting from after the branch
 	// point.  We fetch the branch point (if possible) to make sure
 	// it's the right predecessor of the unmerged branch.  TODO: stop
@@ -322,14 +327,22 @@ func (cr *ConflictResolver) updateCurrInput(ctx context.Context,
 	}
 	cr.currInput.unmerged = rev
 
-	rev = merged[len(merged)-1].bareMd.RevisionNumber()
-	if rev < cr.currInput.merged {
-		return fmt.Errorf("Merged revision %d is lower than the "+
-			"expected merged revision %d", rev, cr.currInput.merged)
+	if len(merged) > 0 {
+		rev = merged[len(merged)-1].bareMd.RevisionNumber()
+		if rev < cr.currInput.merged {
+			return fmt.Errorf("Merged revision %d is lower than the "+
+				"expected merged revision %d", rev, cr.currInput.merged)
+		}
+	} else {
+		rev = MetadataRevisionUninitialized
 	}
 	cr.currInput.merged = rev
 
-	if len(unmerged)+len(merged) > cr.maxRevsThreshold {
+	// Take the lock right away next time if either there are lots of
+	// revisions, or this is a local squash and we won't block for
+	// very long.
+	if (len(unmerged)+len(merged) > cr.maxRevsThreshold) ||
+		(len(unmerged) > 0 && unmerged[0].BID() == LocalSquashBranchID) {
 		cr.lockNextTime = true
 	}
 	return nil
@@ -342,6 +355,12 @@ func (cr *ConflictResolver) makeChains(ctx context.Context,
 		ctx, cr.config.Codec(), unmerged, &cr.fbo.blocks, true)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	// If there are no new merged changes, don't make any merged
+	// chains.
+	if len(merged) == 0 {
+		return unmergedChains, newCRChainsEmpty(), nil
 	}
 
 	mergedChains, err = newCRChainsForIRMDs(
@@ -953,7 +972,7 @@ func (cr *ConflictResolver) resolveMergedPaths(ctx context.Context,
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
 		mergedChains.mostRecentChainMDInfo.kmd,
-		mergedChains.mostRecentChainMDInfo.rootPtr)
+		mergedChains.mostRecentChainMDInfo.rootInfo.BlockPointer)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1002,36 +1021,35 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	ctx context.Context, lState *lockState, writerLocked bool) (
 	unmergedChains, mergedChains *crChains, unmergedPaths []path,
 	mergedPaths map[BlockPointer]path, recreateOps []*createOp,
-	merged []ImmutableRootMetadata, err error) {
+	unmerged, merged []ImmutableRootMetadata, err error) {
 	// Fetch the merged and unmerged MDs
-	unmerged, merged, err := cr.getMDs(ctx, lState, writerLocked)
+	unmerged, merged, err = cr.getMDs(ctx, lState, writerLocked)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
-	if u, m := len(unmerged), len(merged); u == 0 || m == 0 {
-		cr.log.CDebugf(ctx, "Skipping merge process due to empty MD list: "+
-			"%d unmerged, %d merged", u, m)
-		return nil, nil, nil, nil, nil, nil, nil
+	if len(unmerged) == 0 {
+		cr.log.CDebugf(ctx, "Skipping merge process due to empty MD list")
+		return nil, nil, nil, nil, nil, nil, nil, nil
 	}
 
 	// Update the current input to reflect the MDs we'll actually be
 	// working with.
 	err = cr.updateCurrInput(ctx, unmerged, merged)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Canceled before we start the heavy lifting?
 	err = cr.checkDone(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Make the chains
 	unmergedChains, mergedChains, err = cr.makeChains(ctx, unmerged, merged)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// TODO: if the root node didn't change in either chain, we can
@@ -1044,14 +1062,14 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	unmergedPaths, err = unmergedChains.getPaths(ctx, &cr.fbo.blocks,
 		cr.log, cr.fbo.nodeCache, false)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	// Add in any directory paths that were created in both branches.
 	newUnmergedPaths, err := cr.findCreatedDirsToMerge(ctx, unmergedPaths,
 		unmergedChains, mergedChains)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	unmergedPaths = append(unmergedPaths, newUnmergedPaths...)
 	if len(newUnmergedPaths) > 0 {
@@ -1062,12 +1080,12 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	kbpki := cr.config.KBPKI()
 	_, uid, err := kbpki.GetCurrentUserInfo(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	key, err := kbpki.GetCurrentVerifyingKey(ctx)
 	if err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 
 	currUnmergedWriterInfo := newWriterInfo(
@@ -1082,7 +1100,7 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	if err != nil {
 		// Return mergedChains in this error case, to allow the error
 		// handling code to unstage if necessary.
-		return nil, nil, nil, nil, nil, merged, err
+		return nil, nil, nil, nil, nil, nil, merged, err
 	}
 	unmergedPaths = append(unmergedPaths, newUnmergedPaths...)
 	if len(newUnmergedPaths) > 0 {
@@ -1090,7 +1108,7 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	}
 
 	return unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, merged, nil
+		recreateOps, unmerged, merged, nil
 }
 
 // addRecreateOpsToUnmergedChains inserts each recreateOp, into its
@@ -1614,7 +1632,7 @@ func (cr *ConflictResolver) fixRenameConflicts(ctx context.Context,
 	nodeMap, _, err := cr.fbo.blocks.SearchForNodes(
 		ctx, mergedNodeCache, ptrs, newPtrs,
 		mergedChains.mostRecentChainMDInfo.kmd,
-		mergedChains.mostRecentChainMDInfo.rootPtr)
+		mergedChains.mostRecentChainMDInfo.rootInfo.BlockPointer)
 	if err != nil {
 		return nil, err
 	}
@@ -2403,67 +2421,52 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 		return nil, err
 	}
 
-	// We also need to add in any creates that happened within
-	// newly-created directories (which aren't being merged with other
-	// newly-created directories), to ensure that the overall Refs are
-	// correct and that future CR processes can check those create ops
-	// for conflicts.
 	var newPaths []path
 	for original, chain := range unmergedChains.byOriginal {
-		if !unmergedChains.isCreated(original) ||
-			mergedChains.isCreated(original) {
-			continue
-		}
 		added := false
 		for i, op := range chain.ops {
 			if cop, ok := op.(*createOp); ok {
-				// Shallowly copy the create op and update its
-				// directory to the most recent pointer -- this won't
-				// work with the usual revert ops process because that
-				// skips chains which are newly-created within this
-				// branch.
-				newCreateOp := *cop
-				newCreateOp.Dir, err = makeBlockUpdate(
-					chain.mostRecent, chain.mostRecent)
-				if err != nil {
-					return nil, err
-				}
-				chain.ops[i] = &newCreateOp
-				if !added {
-					newPaths = append(newPaths, path{
-						FolderBranch: cr.fbo.folderBranch,
-						path: []pathNode{{
-							BlockPointer: chain.mostRecent}},
-					})
-					added = true
+				// We need to add in any creates that happened
+				// within newly-created directories (which aren't
+				// being merged with other newly-created directories),
+				// to ensure that the overall Refs are correct and
+				// that future CR processes can check those create ops
+				// for conflicts.
+				if unmergedChains.isCreated(original) &&
+					!mergedChains.isCreated(original) {
+					// Shallowly copy the create op and update its
+					// directory to the most recent pointer -- this won't
+					// work with the usual revert ops process because that
+					// skips chains which are newly-created within this
+					// branch.
+					newCreateOp := *cop
+					newCreateOp.Dir, err = makeBlockUpdate(
+						chain.mostRecent, chain.mostRecent)
+					if err != nil {
+						return nil, err
+					}
+					chain.ops[i] = &newCreateOp
+					if !added {
+						newPaths = append(newPaths, path{
+							FolderBranch: cr.fbo.folderBranch,
+							path: []pathNode{{
+								BlockPointer: chain.mostRecent}},
+						})
+						added = true
+					}
 				}
 				if cop.Type == Dir || len(cop.Refs()) == 0 {
 					continue
 				}
-				// Make sure to add any direct file blocks too,
-				// originating in later syncs.
+				// Add any direct file blocks too into each create op,
+				// which originated in later unmerged syncs.
 				ptr, err :=
 					unmergedChains.mostRecentFromOriginalOrSame(cop.Refs()[0])
 				if err != nil {
 					return nil, err
 				}
-				file := path{
-					FolderBranch: cr.fbo.folderBranch,
-					path:         []pathNode{{BlockPointer: ptr}},
-				}
-				fblock, err := cr.fbo.blocks.GetFileBlockForReading(ctx, lState,
-					unmergedChains.mostRecentChainMDInfo.kmd, ptr, file.Branch, file)
-				if err != nil {
-					return nil, err
-				}
-				if fblock.IsInd {
-					newCreateOp.RefBlocks = make([]BlockPointer,
-						len(fblock.IPtrs)+1)
-					newCreateOp.RefBlocks[0] = cop.Refs()[0]
-					for j, iptr := range fblock.IPtrs {
-						newCreateOp.RefBlocks[j+1] = iptr.BlockPointer
-					}
-				}
+				trackSyncPtrChangesInCreate(
+					ptr, chain, unmergedChains, cop.NewName)
 			}
 		}
 	}
@@ -2617,7 +2620,7 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 			nodeMap, cache, err := cr.fbo.blocks.SearchForNodes(
 				ctx, cr.fbo.nodeCache, ptrs, newPtrs,
 				unmergedChains.mostRecentChainMDInfo.kmd,
-				unmergedChains.mostRecentChainMDInfo.rootPtr)
+				unmergedChains.mostRecentChainMDInfo.rootInfo.BlockPointer)
 			if err != nil {
 				return path{}, err
 			}
@@ -3051,21 +3054,9 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	return blocksToDelete, nil
 }
 
-// syncBlocks takes in the complete set of paths affected by this
-// conflict resolution, and organizes them into a tree, which it then
-// syncs using syncTree.  It returns a map describing how blocks were
-// updated in the merged branch, as well as the complete set of blocks
-// that need to be put to the server (and cached) to complete this
-// resolution and a list of blocks that can be removed from the
-// flushing queue.
-func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
-	md *RootMetadata, unmergedChains, mergedChains *crChains,
-	mostRecentMergedMD ImmutableRootMetadata,
+func (cr *ConflictResolver) makeSyncTree(ctx context.Context,
 	resolvedPaths map[BlockPointer]path, lbc localBcache,
-	newFileBlocks fileBlockMap) (
-	updates map[BlockPointer]BlockPointer, bps *blockPutState,
-	blocksToDelete []BlockID, err error) {
-	// Construct a tree out of the merged paths, and do a sync at each leaf.
+	newFileBlocks fileBlockMap) *crPathTreeNode {
 	var root *crPathTreeNode
 	for _, p := range resolvedPaths {
 		cr.log.CDebugf(ctx, "Creating tree from merged path: %v", p.path)
@@ -3137,27 +3128,28 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 			}
 		}
 	}
+	return root
+}
 
+// syncBlocks takes in the complete set of paths affected by this
+// conflict resolution, and organizes them into a tree, which it then
+// syncs using syncTree.  It returns a map describing how blocks were
+// updated in the merged branch, as well as the complete set of blocks
+// that need to be put to the server (and cached) to complete this
+// resolution and a list of blocks that can be removed from the
+// flushing queue.
+func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
+	md *RootMetadata, unmergedChains, mergedChains *crChains,
+	mostRecentMergedMD ImmutableRootMetadata,
+	resolvedPaths map[BlockPointer]path, lbc localBcache,
+	newFileBlocks fileBlockMap) (
+	updates map[BlockPointer]BlockPointer, bps *blockPutState,
+	blocksToDelete []BlockID, err error) {
 	updates = make(map[BlockPointer]BlockPointer)
-	if root == nil && len(unmergedChains.toUnrefPointers) == 0 {
-		return updates, newBlockPutState(0), nil, nil
-	}
 
 	_, uid, err := cr.config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
 		return nil, nil, nil, err
-	}
-
-	if root != nil {
-		// Now do a depth-first walk, and syncBlock back up to the fork on
-		// every branch
-		bps, err = cr.syncTree(ctx, lState, unmergedChains, md, uid, root,
-			BlockPointer{}, lbc, newFileBlocks)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-	} else {
-		bps = newBlockPutState(0)
 	}
 
 	oldOps := md.data.Changes.Ops
@@ -3165,6 +3157,38 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 	if !ok {
 		return nil, nil, nil, fmt.Errorf("dummy op is not gc: %s",
 			oldOps[len(oldOps)-1])
+	}
+
+	isSquash := mostRecentMergedMD.data.Dir.BlockPointer !=
+		mergedChains.mostRecentChainMDInfo.rootInfo.BlockPointer
+	if isSquash {
+		// Squashes don't need to sync anything new.  Just set the
+		// root pointer to the most recent root pointer, and fill up
+		// the resolution op with all the known chain updates for this
+		// branch.
+		bps = newBlockPutState(0)
+		md.data.Dir.BlockInfo = unmergedChains.mostRecentChainMDInfo.rootInfo
+		for original, chain := range unmergedChains.byOriginal {
+			if unmergedChains.isCreated(original) ||
+				unmergedChains.isDeleted(original) ||
+				chain.original == chain.mostRecent {
+				continue
+			}
+			resOp.AddUpdate(original, chain.mostRecent)
+		}
+	} else {
+		// Construct a tree out of the merged paths, and do a sync at each leaf.
+		root := cr.makeSyncTree(ctx, resolvedPaths, lbc, newFileBlocks)
+
+		if root != nil {
+			bps, err = cr.syncTree(ctx, lState, unmergedChains, md, uid, root,
+				BlockPointer{}, lbc, newFileBlocks)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		} else {
+			bps = newBlockPutState(0)
+		}
 	}
 
 	// Create an update map, and fix up the gc ops.
@@ -3401,7 +3425,9 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 		// The child blocks should be referenced in the resolution op.
 		_, ok := md.data.Changes.Ops[len(md.data.Changes.Ops)-1].(*resolutionOp)
 		if !ok {
-			md.AddOp(newResolutionOp())
+			// Append directly to the ops list, rather than use AddOp,
+			// because the size estimate was already calculated.
+			md.data.Changes.Ops = append(md.data.Changes.Ops, newResolutionOp())
 		}
 
 		err = cr.fbo.unembedBlockChanges(ctx, bps, md, &md.data.Changes, uid)
@@ -3732,15 +3758,22 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	//     to recreate any directories that were modified in the unmerged
 	//     branch but removed in the merged branch.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths, recOps,
-		mergedMDs, err :=
+		unmergedMDs, mergedMDs, err :=
 		cr.buildChainsAndPaths(ctx, lState, doLock)
 	if err != nil {
 		return
 	}
-	if len(mergedPaths) == 0 {
+	if len(mergedPaths) == 0 || len(mergedMDs) == 0 {
 		var mostRecentMergedMD ImmutableRootMetadata
 		if len(mergedMDs) > 0 {
 			mostRecentMergedMD = mergedMDs[len(mergedMDs)-1]
+		} else {
+			branchPoint := unmergedMDs[0].Revision() - 1
+			mostRecentMergedMD, err = getSingleMD(ctx, cr.config, cr.fbo.id(),
+				NullBranchID, branchPoint, Merged)
+			if err != nil {
+				return
+			}
 		}
 		// TODO: All the other variables returned by
 		// buildChainsAndPaths may also be nil, in which case

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -260,7 +260,7 @@ func (cr *ConflictResolver) getMDs(ctx context.Context, lState *lockState,
 		return nil, nil, err
 	}
 
-	if len(unmerged) > 0 && unmerged[0].BID() == LocalSquashBranchID {
+	if len(unmerged) > 0 && unmerged[0].BID() == PendingLocalSquashBranchID {
 		cr.log.CDebugf(ctx, "Squashing local branch")
 		return unmerged, nil, nil
 	}
@@ -342,7 +342,7 @@ func (cr *ConflictResolver) updateCurrInput(ctx context.Context,
 	// revisions, or this is a local squash and we won't block for
 	// very long.
 	if (len(unmerged)+len(merged) > cr.maxRevsThreshold) ||
-		(len(unmerged) > 0 && unmerged[0].BID() == LocalSquashBranchID) {
+		(len(unmerged) > 0 && unmerged[0].BID() == PendingLocalSquashBranchID) {
 		cr.lockNextTime = true
 	}
 	return nil

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -256,7 +256,7 @@ func testCRCheckPathsAndActions(t *testing.T, cr *ConflictResolver,
 
 	// Step 1 -- check the chains and paths
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, err := cr.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, _, err := cr.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1147,7 +1147,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}
@@ -1263,7 +1263,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 
 	// Now run through conflict resolution manually for user2.
 	unmergedChains, mergedChains, unmergedPaths, mergedPaths,
-		recreateOps, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
+		recreateOps, _, _, err := cr2.buildChainsAndPaths(ctx, lState, false)
 	if err != nil {
 		t.Fatalf("Couldn't build chains and paths: %v", err)
 	}

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -251,9 +251,9 @@ func crActionConvertSymlink(unmergedMostRecent BlockPointer,
 // trackSyncPtrChangesInCreate makes sure the correct set of refs and
 // unrefs, from the syncOps on the unmerged branch, makes it into the
 // createOp for a new file.
-func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
+func trackSyncPtrChangesInCreate(
 	mostRecentTargetPtr BlockPointer, unmergedChain *crChain,
-	unmergedChains *crChains) {
+	unmergedChains *crChains, toName string) {
 	targetChain, ok := unmergedChains.byMostRecent[mostRecentTargetPtr]
 	var refs, unrefs []BlockPointer
 	if ok && targetChain.isFile() {
@@ -284,7 +284,7 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 	if len(refs) > 0 {
 		for _, uop := range unmergedChain.ops {
 			cop, ok := uop.(*createOp)
-			if !ok || cop.NewName != cuea.toName {
+			if !ok || cop.NewName != toName {
 				continue
 			}
 			for _, ref := range refs {
@@ -296,6 +296,13 @@ func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
 			break
 		}
 	}
+}
+
+func (cuea *copyUnmergedEntryAction) trackSyncPtrChangesInCreate(
+	mostRecentTargetPtr BlockPointer, unmergedChain *crChain,
+	unmergedChains *crChains) {
+	trackSyncPtrChangesInCreate(
+		mostRecentTargetPtr, unmergedChain, unmergedChains, cuea.toName)
 }
 
 func (cuea *copyUnmergedEntryAction) updateOps(unmergedMostRecent BlockPointer,

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -329,8 +329,8 @@ func (ri renameInfo) String() string {
 // mostRecentChainMetadataInfo contains the subset of information for
 // the most recent chainMetadata that is needed for crChains.
 type mostRecentChainMetadataInfo struct {
-	kmd     KeyMetadata
-	rootPtr BlockPointer
+	kmd      KeyMetadata
+	rootInfo BlockInfo
 }
 
 // crChains contains a crChain for every KBFS node affected by the
@@ -822,8 +822,8 @@ func newCRChains(
 	}
 
 	ccs.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		kmd:     mostRecentMD,
-		rootPtr: mostRecentMD.Data().Dir.BlockPointer,
+		kmd:      mostRecentMD,
+		rootInfo: mostRecentMD.Data().Dir.BlockInfo,
 	}
 
 	return ccs, nil
@@ -990,7 +990,7 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 
 	pathMap, err := blocks.SearchForPaths(ctx, nodeCache, ptrs,
 		newPtrs, ccs.mostRecentChainMDInfo.kmd,
-		ccs.mostRecentChainMDInfo.rootPtr)
+		ccs.mostRecentChainMDInfo.rootInfo.BlockPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -41,9 +41,13 @@ func (c CryptoCommon) MakeRandomTlfID(isPublic bool) (tlf.ID, error) {
 // MakeRandomBranchID implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) MakeRandomBranchID() (BranchID, error) {
 	var id BranchID
-	err := kbfscrypto.RandRead(id.id[:])
-	if err != nil {
-		return BranchID{}, err
+	// Loop just in case we randomly pick the null or local squash
+	// branch IDs.
+	for id == NullBranchID || id == LocalSquashBranchID {
+		err := kbfscrypto.RandRead(id.id[:])
+		if err != nil {
+			return BranchID{}, err
+		}
 	}
 	return id, nil
 }

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -43,7 +43,7 @@ func (c CryptoCommon) MakeRandomBranchID() (BranchID, error) {
 	var id BranchID
 	// Loop just in case we randomly pick the null or local squash
 	// branch IDs.
-	for id == NullBranchID || id == LocalSquashBranchID {
+	for id == NullBranchID || id == PendingLocalSquashBranchID {
 		err := kbfscrypto.RandRead(id.id[:])
 		if err != nil {
 			return BranchID{}, err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3907,14 +3907,16 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 
 	// If there's anything in the journal, don't apply these MDs.
 	// Wait for CR to happen.
-	mergedRev, err := fbo.getJournalPredecessorRevision(ctx)
-	if err != nil {
-		return err
-	}
-	if mergedRev != MetadataRevisionUninitialized {
-		fbo.log.CDebugf(ctx,
-			"Ignoring fetched revisions while MDs are in journal")
-		return nil
+	if fbo.isMasterBranchLocked(lState) {
+		mergedRev, err := fbo.getJournalPredecessorRevision(ctx)
+		if err != nil {
+			return err
+		}
+		if mergedRev != MetadataRevisionUninitialized {
+			fbo.log.CDebugf(ctx,
+				"Ignoring fetched revisions while MDs are in journal")
+			return nil
+		}
 	}
 
 	fbo.headLock.Lock(lState)
@@ -3924,14 +3926,30 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 	// resolution kicks in.  TODO: cache these for future use.
 	if !fbo.isMasterBranchLocked(lState) {
 		if len(rmds) > 0 {
+			latestMerged := rmds[len(rmds)-1]
+			// If we're running a journal, don't trust our own updates
+			// here because they might have come from our own journal
+			// before the conflict was detected.  Assume we'll hear
+			// about the conflict via callbacks from the journal.
+			if TLFJournalEnabled(fbo.config, fbo.id()) {
+				key, err := fbo.config.KBPKI().GetCurrentVerifyingKey(ctx)
+				if err != nil {
+					return err
+				}
+				if key == latestMerged.LastModifyingWriterVerifyingKey() {
+					return UnmergedError{}
+				}
+			}
+
 			// setHeadLocked takes care of merged case
-			fbo.setLatestMergedRevisionLocked(ctx, lState, rmds[len(rmds)-1].Revision(), false)
+			fbo.setLatestMergedRevisionLocked(
+				ctx, lState, latestMerged.Revision(), false)
 
 			unmergedRev := MetadataRevisionUninitialized
 			if fbo.head != (ImmutableRootMetadata{}) {
 				unmergedRev = fbo.head.Revision()
 			}
-			fbo.cr.Resolve(unmergedRev, rmds[len(rmds)-1].Revision())
+			fbo.cr.Resolve(unmergedRev, latestMerged.Revision())
 		}
 		return UnmergedError{}
 	}
@@ -4534,47 +4552,55 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 		return err
 	}
 
-	if !fbo.isMasterBranch(lState) {
-		if err := fbo.cr.Wait(ctx); err != nil {
-			return err
-		}
-		// If we are still staged after the wait, then we have a problem.
+	// Loop until we're fully updated on the master branch.
+	for {
 		if !fbo.isMasterBranch(lState) {
-			return fmt.Errorf("Conflict resolution didn't take us out of " +
-				"staging.")
-		}
-	}
-
-	dirtyRefs := fbo.blocks.GetDirtyRefs(lState)
-	if len(dirtyRefs) > 0 {
-		for _, ref := range dirtyRefs {
-			fbo.log.CDebugf(ctx, "DeCache entry left: %v", ref)
-		}
-		return errors.New("can't sync from server while dirty")
-	}
-
-	// A journal flush after CR, if needed.
-	if err := WaitForTLFJournal(ctx, fbo.config, fbo.id(),
-		fbo.log); err != nil {
-		return err
-	}
-
-	if err := fbo.mdFlushes.Wait(ctx); err != nil {
-		return err
-	}
-
-	if err := fbo.branchChanges.Wait(ctx); err != nil {
-		return err
-	}
-
-	if err := fbo.getAndApplyMDUpdates(ctx, lState, fbo.applyMDUpdates); err != nil {
-		if applyErr, ok := err.(MDRevisionMismatch); ok {
-			if applyErr.rev == applyErr.curr {
-				fbo.log.CDebugf(ctx, "Already up-to-date with server")
-				return nil
+			if err := fbo.cr.Wait(ctx); err != nil {
+				return err
+			}
+			// If we are still staged after the wait, then we have a problem.
+			if !fbo.isMasterBranch(lState) {
+				return fmt.Errorf("Conflict resolution didn't take us out of " +
+					"staging.")
 			}
 		}
-		return err
+
+		dirtyRefs := fbo.blocks.GetDirtyRefs(lState)
+		if len(dirtyRefs) > 0 {
+			for _, ref := range dirtyRefs {
+				fbo.log.CDebugf(ctx, "DeCache entry left: %v", ref)
+			}
+			return errors.New("can't sync from server while dirty")
+		}
+
+		// A journal flush after CR, if needed.
+		if err := WaitForTLFJournal(ctx, fbo.config, fbo.id(),
+			fbo.log); err != nil {
+			return err
+		}
+
+		if err := fbo.mdFlushes.Wait(ctx); err != nil {
+			return err
+		}
+
+		if err := fbo.branchChanges.Wait(ctx); err != nil {
+			return err
+		}
+
+		if err := fbo.getAndApplyMDUpdates(
+			ctx, lState, fbo.applyMDUpdates); err != nil {
+			if applyErr, ok := err.(MDRevisionMismatch); ok {
+				if applyErr.rev == applyErr.curr {
+					fbo.log.CDebugf(ctx, "Already up-to-date with server")
+					return nil
+				}
+			}
+			if _, isUnmerged := err.(UnmergedError); isUnmerged {
+				continue
+			}
+			return err
+		}
+		break
 	}
 
 	// Wait for all the asynchronous block archiving and quota

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -752,7 +752,9 @@ type cryptoPure interface {
 	// MakeRandomTlfID generates a dir ID using a CSPRNG.
 	MakeRandomTlfID(isPublic bool) (tlf.ID, error)
 
-	// MakeRandomBranchID generates a per-device branch ID using a CSPRNG.
+	// MakeRandomBranchID generates a per-device branch ID using a
+	// CSPRNG.  It will not return LocalSquashBranchID or
+	// NullBranchID.
 	MakeRandomBranchID() (BranchID, error)
 
 	// MakeMdID computes the MD ID of a RootMetadata object.

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -95,7 +95,7 @@ func (j journalMDOps) getHeadFromJournal(
 	// for a local squash branch, we might contain some non-branch
 	// entries before some branch entries.
 	if mStatus == Merged {
-		for head.BID() == LocalSquashBranchID {
+		for head.BID() == PendingLocalSquashBranchID {
 			newHead := head.RevisionNumber() - 1
 			if newHead < MetadataRevisionInitial {
 				break
@@ -184,7 +184,7 @@ func (j journalMDOps) getRangeFromJournal(
 	// for a local squash branch, we might contain some non-branch
 	// entries before some branch entries.
 	if mStatus == Merged {
-		for head.BID() == LocalSquashBranchID {
+		for head.BID() == PendingLocalSquashBranchID {
 			if headIndex == 0 {
 				break
 			}
@@ -217,7 +217,7 @@ func (j journalMDOps) getRangeFromJournal(
 	irmds := make([]ImmutableRootMetadata, 0, len(ibrmds))
 
 	for _, ibrmd := range ibrmds {
-		if bid == LocalSquashBranchID && ibrmd.BID() != bid {
+		if bid == PendingLocalSquashBranchID && ibrmd.BID() != bid {
 			// It's acceptable for the journal to contain non-branch
 			// local squashes if the branch is itself a local squash.
 			continue

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -218,6 +218,10 @@ func (j journalMDOps) getRangeFromJournal(
 
 	for _, ibrmd := range ibrmds {
 		if bid == PendingLocalSquashBranchID && ibrmd.BID() != bid {
+			if ibrmd.BID() != NullBranchID {
+				return nil, fmt.Errorf("Local squash on branch %s does not "+
+					"have a null branch ID, has %s", bid, ibrmd.BID())
+			}
 			// It's acceptable for the journal to contain non-branch
 			// local squashes if the branch is itself a local squash.
 			continue

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -303,3 +303,81 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	_, err = mdOps.PutUnmerged(ctx, rmd)
 	require.Error(t, err, "Unmerged put with rmd.BID() == j.branchID == NullBranchID")
 }
+
+func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
+	tempdir, config, _, jServer := setupJournalMDOpsTest(t)
+	defer teardownJournalMDOpsTest(t, tempdir, config)
+
+	ctx := context.Background()
+	_, uid, err := config.KBPKI().GetCurrentUserInfo(ctx)
+	require.NoError(t, err)
+
+	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	require.NoError(t, err)
+
+	mdOps := jServer.mdOps()
+	id, irmd, err := mdOps.GetForHandle(ctx, h, Merged)
+	require.NoError(t, err)
+	require.Equal(t, ImmutableRootMetadata{}, irmd)
+	err = jServer.Enable(ctx, id, TLFJournalBackgroundWorkPaused)
+	require.NoError(t, err)
+
+	tlfJournal, ok := jServer.getTLFJournal(id)
+	require.True(t, ok)
+
+	// Prepare the md journal to have a leading local squash revision.
+	firstRevision := MetadataRevision(1)
+	initialRmd := makeMDForJournalMDOpsTest(t, config, id, h, firstRevision)
+	j := tlfJournal.mdJournal
+	initialMdID, err := j.put(ctx, config.Crypto(), config.KeyManager(),
+		config.BlockSplitter(), initialRmd, true)
+	require.NoError(t, err)
+
+	mdCount := 10
+	rmd := initialRmd
+	mdID := initialMdID
+	// Put several MDs after a local squash
+	for i := 0; i < mdCount; i++ {
+		rmd, err = rmd.MakeSuccessor(ctx, config, mdID, true)
+		require.NoError(t, err)
+		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
+			config.BlockSplitter(), rmd, false)
+		require.NoError(t, err)
+	}
+
+	mdcache := NewMDCacheStandard(10)
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, config.Crypto(), config.Codec(), id, mdcache)
+	require.NoError(t, err)
+
+	// The merged head should still be the initial rmd, because we
+	// marked it as a squash and it shouldn't have gotten converted.
+	irmd, err = mdOps.GetForTLF(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, initialMdID, irmd.mdID)
+	require.Equal(t, firstRevision, irmd.Revision())
+
+	// The unmerged head should be the last MD we put, converted to a
+	// branch.
+	irmd, err = mdOps.GetUnmergedForTLF(ctx, id, LocalSquashBranchID)
+	require.NoError(t, err)
+	require.Equal(t, rmd.Revision(), irmd.Revision())
+	require.Equal(t, LocalSquashBranchID, irmd.BID())
+
+	// The merged range should just be the initial MD.
+	stopRevision := firstRevision + MetadataRevision(mdCount*2)
+	irmds, err := mdOps.GetRange(ctx, id, firstRevision, stopRevision)
+	require.NoError(t, err)
+	require.Len(t, irmds, 1)
+	require.Equal(t, initialMdID, irmds[0].mdID)
+	require.Equal(t, firstRevision, irmds[0].Revision())
+
+	irmds, err = mdOps.GetUnmergedRange(ctx, id, LocalSquashBranchID,
+		firstRevision, stopRevision)
+	require.NoError(t, err)
+	require.Len(t, irmds, mdCount)
+	require.Equal(t, firstRevision+MetadataRevision(1), irmds[0].Revision())
+}

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -350,7 +350,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 
 	mdcache := NewMDCacheStandard(10)
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, config.Crypto(), config.Codec(), id, mdcache)
+		ctx, PendingLocalSquashBranchID, config.Crypto(), config.Codec(), id, mdcache)
 	require.NoError(t, err)
 
 	// The merged head should still be the initial rmd, because we
@@ -362,10 +362,10 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 
 	// The unmerged head should be the last MD we put, converted to a
 	// branch.
-	irmd, err = mdOps.GetUnmergedForTLF(ctx, id, LocalSquashBranchID)
+	irmd, err = mdOps.GetUnmergedForTLF(ctx, id, PendingLocalSquashBranchID)
 	require.NoError(t, err)
 	require.Equal(t, rmd.Revision(), irmd.Revision())
-	require.Equal(t, LocalSquashBranchID, irmd.BID())
+	require.Equal(t, PendingLocalSquashBranchID, irmd.BID())
 
 	// The merged range should just be the initial MD.
 	stopRevision := firstRevision + MetadataRevision(mdCount*2)
@@ -375,7 +375,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	require.Equal(t, initialMdID, irmds[0].mdID)
 	require.Equal(t, firstRevision, irmds[0].Revision())
 
-	irmds, err = mdOps.GetUnmergedRange(ctx, id, LocalSquashBranchID,
+	irmds, err = mdOps.GetUnmergedRange(ctx, id, PendingLocalSquashBranchID,
 		firstRevision, stopRevision)
 	require.NoError(t, err)
 	require.Len(t, irmds, mdCount)

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -29,7 +29,8 @@ type mdIDJournal struct {
 // depend on the ID, as the mdJournal may change the ID when
 // converting to a branch.
 type mdIDJournalEntry struct {
-	ID MdID
+	ID            MdID
+	IsLocalSquash bool
 
 	codec.UnknownFieldSetHandler
 }

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -24,10 +24,13 @@ type mdIDJournal struct {
 	j diskJournal
 }
 
-// An mdIDJournalEntry is, for now, just an MdID. In the future, it
-// may contain more fields. However, make sure that new fields don't
-// depend on the ID, as the mdJournal may change the ID when
-// converting to a branch.
+// An mdIDJournalEntry is an MdID and a boolean describing whether
+// this entry was the result of a local squash. Make sure that new
+// fields don't depend on the ID or `isLocalSquash`, as the mdJournal
+// may change these when converting to a branch.  Note that
+// `isLocalSquash` may only be true for entries in a continuous prefix
+// of the id journal; once there is one entry with `isLocalSquash =
+// false`, it will be the same in all the remaining entries.
 type mdIDJournalEntry struct {
 	ID            MdID
 	IsLocalSquash bool

--- a/libkbfs/md_id_journal_test.go
+++ b/libkbfs/md_id_journal_test.go
@@ -28,6 +28,7 @@ func makeFakeMDIDJournalEntryFuture(t *testing.T) mdIDJournalEntryFuture {
 	ef := mdIDJournalEntryFuture{
 		mdIDJournalEntry{
 			fakeMdID(1),
+			false,
 			codec.UnknownFieldSetHandler{},
 		},
 		kbfscodec.MakeExtraOrBust("mdIDJournalEntry", t),

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -153,8 +153,8 @@ type mdJournal struct {
 }
 
 func makeMDJournalWithIDJournal(
-	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	crypto cryptoPure, clock Clock, tlfID tlf.ID,
+	ctx context.Context, uid keybase1.UID, key kbfscrypto.VerifyingKey,
+	codec kbfscodec.Codec, crypto cryptoPure, clock Clock, tlfID tlf.ID,
 	mdVer MetadataVer, dir string, idJournal mdIDJournal,
 	log logger.Logger) (*mdJournal, error) {
 	if uid == keybase1.UID("") {
@@ -203,7 +203,7 @@ func makeMDJournalWithIDJournal(
 				"earliest.BID=%s != latest.BID=%s",
 				earliest.BID(), latest.BID())
 		}
-		log.CDebugf(nil, "Initializing with branch ID %s", latest.BID())
+		log.CDebugf(ctx, "Initializing with branch ID %s", latest.BID())
 		journal.branchID = latest.BID()
 	}
 
@@ -211,13 +211,13 @@ func makeMDJournalWithIDJournal(
 }
 
 func makeMDJournal(
-	uid keybase1.UID, key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
-	crypto cryptoPure, clock Clock, tlfID tlf.ID,
+	ctx context.Context, uid keybase1.UID, key kbfscrypto.VerifyingKey,
+	codec kbfscodec.Codec, crypto cryptoPure, clock Clock, tlfID tlf.ID,
 	mdVer MetadataVer, dir string,
 	log logger.Logger) (*mdJournal, error) {
 	journalDir := filepath.Join(dir, "md_journal")
 	return makeMDJournalWithIDJournal(
-		uid, key, codec, crypto, clock, tlfID, mdVer, dir,
+		ctx, uid, key, codec, crypto, clock, tlfID, mdVer, dir,
 		makeMdIDJournal(codec, journalDir), log)
 }
 
@@ -1297,7 +1297,7 @@ func (j *mdJournal) resolveAndClear(
 	}()
 
 	otherJournal, err := makeMDJournalWithIDJournal(
-		j.uid, j.key, j.codec, j.crypto, j.clock, j.tlfID, j.mdVer, j.dir,
+		ctx, j.uid, j.key, j.codec, j.crypto, j.clock, j.tlfID, j.mdVer, j.dir,
 		otherIDJournal, j.log)
 	if err != nil {
 		return MdID{}, err

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -74,7 +74,8 @@ func setupMDJournalTest(t *testing.T) (
 	}()
 
 	log := logger.NewTestLogger(t)
-	j, err = makeMDJournal(uid, verifyingKey, codec, crypto, wallClock{},
+	ctx := context.Background()
+	j, err = makeMDJournal(ctx, uid, verifyingKey, codec, crypto, wallClock{},
 		tlfID, defaultClientMetadataVer, tempdir, log)
 	require.NoError(t, err)
 
@@ -804,7 +805,8 @@ func TestMDJournalRestart(t *testing.T) {
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	// Restart journal.
-	j, err := makeMDJournal(j.uid, j.key, codec, crypto, j.clock,
+	ctx := context.Background()
+	j, err := makeMDJournal(ctx, j.uid, j.key, codec, crypto, j.clock,
 		j.tlfID, j.mdVer, j.dir, j.log)
 	require.NoError(t, err)
 
@@ -845,7 +847,7 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	// Restart journal.
 
-	j, err = makeMDJournal(j.uid, j.key, codec, crypto, j.clock,
+	j, err = makeMDJournal(ctx, j.uid, j.key, codec, crypto, j.clock,
 		j.tlfID, j.mdVer, j.dir, j.log)
 	require.NoError(t, err)
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -248,7 +248,7 @@ func TestMDJournalPutCase1Conflict(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -296,7 +296,7 @@ func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -315,7 +315,7 @@ func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -335,7 +335,7 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -361,7 +361,7 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -385,7 +385,7 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -408,7 +408,7 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	require.NoError(t, err)
 
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -491,7 +491,7 @@ func TestMDJournalBranchConversion(t *testing.T) {
 		j.key, cachedMdID, time.Now()))
 	require.NoError(t, err)
 
-	bid := LocalSquashBranchID
+	bid := PendingLocalSquashBranchID
 	err = j.convertToBranch(ctx, bid, signer, kbfscodec.NewMsgpack(),
 		id, mdcache)
 	require.NoError(t, err)
@@ -570,7 +570,7 @@ func testMDJournalResolveAndClear(t *testing.T, bid BranchID) {
 	require.NoError(t, err)
 	numExpectedMDs := 1
 	prevRoot := firstPrevRoot
-	if bid == LocalSquashBranchID {
+	if bid == PendingLocalSquashBranchID {
 		numExpectedMDs++
 		resolveRev++
 		prevRoot = resolveMdID
@@ -589,8 +589,8 @@ func testMDJournalResolveAndClear(t *testing.T, bid BranchID) {
 func TestMDJournalResolveAndClear(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)
-	bid := LocalSquashBranchID
-	for bid == LocalSquashBranchID {
+	bid := PendingLocalSquashBranchID
+	for bid == PendingLocalSquashBranchID {
 		var err error
 		bid, err = crypto.MakeRandomBranchID()
 		require.NoError(t, err)
@@ -599,7 +599,7 @@ func TestMDJournalResolveAndClear(t *testing.T) {
 }
 
 func TestMDJournalResolveAndClearLocalSquash(t *testing.T) {
-	testMDJournalResolveAndClear(t, LocalSquashBranchID)
+	testMDJournalResolveAndClear(t, PendingLocalSquashBranchID)
 }
 
 type limitedCryptoSigner struct {
@@ -632,7 +632,7 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	ctx := context.Background()
 
 	err := j.convertToBranch(
-		ctx, LocalSquashBranchID, &limitedSigner, kbfscodec.NewMsgpack(), id,
+		ctx, PendingLocalSquashBranchID, &limitedSigner, kbfscodec.NewMsgpack(), id,
 		NewMDCacheStandard(10))
 	require.NotNil(t, err)
 
@@ -701,7 +701,7 @@ func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
 	}
 
 	err := j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
 		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -732,7 +732,7 @@ func TestMDJournalClear(t *testing.T) {
 	ctx := context.Background()
 
 	err := j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
 		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
@@ -776,7 +776,7 @@ func TestMDJournalClear(t *testing.T) {
 	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 	err = j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
 		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
@@ -841,7 +841,7 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 	ctx := context.Background()
 
 	err := j.convertToBranch(
-		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
+		ctx, PendingLocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -246,7 +246,8 @@ func TestMDJournalPutCase1Conflict(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -293,7 +294,8 @@ func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -311,7 +313,8 @@ func TestMDJournalPutCase2NonEmptyAppend(t *testing.T) {
 	mdID, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -330,7 +333,8 @@ func TestMDJournalPutCase2Empty(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -355,7 +359,8 @@ func TestMDJournalPutCase3NonEmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -378,7 +383,8 @@ func TestMDJournalPutCase3NonEmptyReplace(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -400,7 +406,8 @@ func TestMDJournalPutCase3EmptyAppend(t *testing.T) {
 	_, err := j.put(ctx, signer, ekg, bsplit, md)
 	require.NoError(t, err)
 
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 
@@ -483,7 +490,8 @@ func TestMDJournalBranchConversion(t *testing.T) {
 		j.key, cachedMdID, time.Now()))
 	require.NoError(t, err)
 
-	bid, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	bid := LocalSquashBranchID
+	err = j.convertToBranch(ctx, bid, signer, kbfscodec.NewMsgpack(),
 		id, mdcache)
 	require.NoError(t, err)
 
@@ -535,13 +543,15 @@ func TestMDJournalResolveAndClear(t *testing.T) {
 
 	ctx := context.Background()
 
-	bid, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(), id,
-		NewMDCacheStandard(10))
+	bid := LocalSquashBranchID
+	mdcache := NewMDCacheStandard(10)
+	err := j.convertToBranch(ctx, bid, signer, kbfscodec.NewMsgpack(), id,
+		mdcache)
 	require.NoError(t, err)
 
 	resolveRev := firstRevision
 	md := makeMDForTest(t, id, resolveRev, j.uid, signer, firstPrevRoot)
-	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, bid, md)
+	_, err = j.resolveAndClear(ctx, signer, ekg, bsplit, mdcache, bid, md)
 	require.NoError(t, err)
 
 	require.Equal(t, 1, getMDJournalLength(t, j))
@@ -581,8 +591,9 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(
-		ctx, &limitedSigner, kbfscodec.NewMsgpack(), id, NewMDCacheStandard(10))
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, &limitedSigner, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NotNil(t, err)
 
 	// All entries should remain unchanged, since the conversion
@@ -649,8 +660,9 @@ func TestMDJournalBranchConversionPreservesUnknownFields(t *testing.T) {
 		prevRoot = mdID
 	}
 
-	_, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
-		id, NewMDCacheStandard(10))
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 
 	// Check that the extra fields are preserved.
@@ -679,8 +691,9 @@ func TestMDJournalClear(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
-		id, NewMDCacheStandard(10))
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -722,8 +735,9 @@ func TestMDJournalClear(t *testing.T) {
 	// journal.
 	putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
-	_, err = j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
-		id, NewMDCacheStandard(10))
+	err = j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(), id,
+		NewMDCacheStandard(10))
 	require.NoError(t, err)
 	require.NotEqual(t, NullBranchID, j.branchID)
 
@@ -785,7 +799,8 @@ func TestMDJournalRestartAfterBranchConversion(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err := j.convertToBranch(ctx, signer, kbfscodec.NewMsgpack(),
+	err := j.convertToBranch(
+		ctx, LocalSquashBranchID, signer, kbfscodec.NewMsgpack(),
 		id, NewMDCacheStandard(10))
 	require.NoError(t, err)
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -299,7 +299,7 @@ func makeTLFJournal(
 	}
 
 	mdJournal, err := makeMDJournal(
-		uid, key, config.Codec(), config.Crypto(), config.Clock(),
+		ctx, uid, key, config.Codec(), config.Crypto(), config.Clock(),
 		tlfID, config.MetadataVersion(), dir, log)
 	if err != nil {
 		return nil, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1518,7 +1518,9 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 
 	// The set of unflushed paths could change as part of the
 	// resolution, and the revision numbers definitely change.
-	if !j.unflushedPaths.reinitializeWithResolution(mdInfo, perRevMap) {
+	isLocalSquash := bid == LocalSquashBranchID
+	if !j.unflushedPaths.reinitializeWithResolution(
+		mdInfo, perRevMap, isLocalSquash) {
 		return MdID{}, true, nil
 	}
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -811,7 +811,7 @@ func (j *tlfJournal) convertMDsToBranchIfOverThreshold(ctx context.Context) (
 	}
 
 	j.log.CDebugf(ctx, "Converting journal of length %d to branch", size)
-	err = j.convertMDsToBranchLocked(ctx, LocalSquashBranchID)
+	err = j.convertMDsToBranchLocked(ctx, PendingLocalSquashBranchID)
 	if err != nil {
 		return false, err
 	}
@@ -1516,9 +1516,9 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 
 	// The set of unflushed paths could change as part of the
 	// resolution, and the revision numbers definitely change.
-	isLocalSquash := bid == LocalSquashBranchID
+	isPendingLocalSquash := bid == PendingLocalSquashBranchID
 	if !j.unflushedPaths.reinitializeWithResolution(
-		mdInfo, perRevMap, isLocalSquash) {
+		mdInfo, perRevMap, isPendingLocalSquash) {
 		return MdID{}, true, nil
 	}
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -69,6 +69,10 @@ const (
 	// This will be the final entry for unflushed paths if there are
 	// too many revisions to process at once.
 	incompleteUnflushedPathsMarker = "..."
+	// ForcedBranchSquashThreshold is the minimum number of MD
+	// revisions in the journal that will trigger an automatic branch
+	// conversion (and subsequent resolution).
+	ForcedBranchSquashThreshold = 20
 )
 
 // TLFJournalStatus represents the status of a TLF's journal for
@@ -631,6 +635,16 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 			return nil
 		}
 
+		/*  Will uncomment when the rest of KBFS-1653 goes in.
+		converted, err := j.convertMDsToBranchIfOverThreshold(ctx)
+		if err != nil {
+			return err
+		}
+		if converted {
+			return nil
+		}
+		*/
+
 		blockEnd, mdEnd, err := j.getJournalEnds(ctx)
 		if err != nil {
 			return err
@@ -744,16 +758,11 @@ func (j *tlfJournal) getNextMDEntryToFlush(ctx context.Context,
 	return j.mdJournal.getNextEntryToFlush(ctx, end, j.config.Crypto())
 }
 
-func (j *tlfJournal) convertMDsToBranch(
-	ctx context.Context, nextEntryEnd MetadataRevision) error {
-	j.journalLock.Lock()
-	defer j.journalLock.Unlock()
-	if err := j.checkEnabledLocked(); err != nil {
-		return err
-	}
-
-	bid, err := j.mdJournal.convertToBranch(
-		ctx, j.config.Crypto(), j.config.Codec(), j.tlfID, j.config.MDCache())
+func (j *tlfJournal) convertMDsToBranchLocked(
+	ctx context.Context, bid BranchID) error {
+	err := j.mdJournal.convertToBranch(
+		ctx, bid, j.config.Crypto(), j.config.Codec(), j.tlfID,
+		j.config.MDCache())
 	if err != nil {
 		return err
 	}
@@ -763,6 +772,45 @@ func (j *tlfJournal) convertMDsToBranch(
 	}
 
 	return nil
+}
+
+func (j *tlfJournal) convertMDsToBranch(ctx context.Context) error {
+	bid, err := j.config.Crypto().MakeRandomBranchID()
+	if err != nil {
+		return err
+	}
+
+	j.journalLock.Lock()
+	defer j.journalLock.Unlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return err
+	}
+
+	return j.convertMDsToBranchLocked(ctx, bid)
+}
+
+func (j *tlfJournal) convertMDsToBranchIfOverThreshold(ctx context.Context) (
+	bool, error) {
+	j.journalLock.Lock()
+	defer j.journalLock.Unlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return false, err
+	}
+
+	size, err := j.mdJournal.length()
+	if err != nil {
+		return false, err
+	}
+	if size < ForcedBranchSquashThreshold {
+		return false, nil
+	}
+
+	j.log.CDebugf(ctx, "Converting journal of length %d to branch", size)
+	err = j.convertMDsToBranchLocked(ctx, LocalSquashBranchID)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (j *tlfJournal) removeFlushedMDEntry(ctx context.Context,
@@ -831,7 +879,7 @@ func (j *tlfJournal) flushOneMDOp(
 			j.log.CDebugf(ctx, "Conflict detected %v", pushErr)
 			// Convert MDs to a branch and return -- the journal
 			// pauses until the resolution is complete.
-			err = j.convertMDsToBranch(ctx, end)
+			err = j.convertMDsToBranch(ctx)
 			if err != nil {
 				return false, err
 			}
@@ -1471,7 +1519,7 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	// the existing branch, then clear the existing branch.
 	mdID, err = j.mdJournal.resolveAndClear(
 		ctx, j.config.Crypto(), j.config.encryptionKeyGetter(),
-		j.config.BlockSplitter(), bid, rmd)
+		j.config.BlockSplitter(), j.config.MDCache(), bid, rmd)
 	if err != nil {
 		return MdID{}, false, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -795,11 +795,6 @@ func (j *tlfJournal) convertMDsToBranchIfOverThreshold(ctx context.Context) (
 		return false, err
 	}
 
-	size, err := j.mdJournal.length()
-	if size < ForcedBranchSquashThreshold {
-		return false, nil
-	}
-
 	ok, err := j.mdJournal.atLeastNNonLocalSquashes(ForcedBranchSquashThreshold)
 	if err != nil {
 		return false, err
@@ -810,7 +805,8 @@ func (j *tlfJournal) convertMDsToBranchIfOverThreshold(ctx context.Context) (
 		return false, nil
 	}
 
-	j.log.CDebugf(ctx, "Converting journal of length %d to branch", size)
+	j.log.CDebugf(ctx, "Converting journal with more than %d "+
+		"non-local-squash entries to a branch", ForcedBranchSquashThreshold)
 	err = j.convertMDsToBranchLocked(ctx, PendingLocalSquashBranchID)
 	if err != nil {
 		return false, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -635,7 +635,6 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 			return nil
 		}
 
-		/*  Will uncomment when the rest of KBFS-1653 goes in.
 		converted, err := j.convertMDsToBranchIfOverThreshold(ctx)
 		if err != nil {
 			return err
@@ -643,7 +642,6 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 		if converted {
 			return nil
 		}
-		*/
 
 		blockEnd, mdEnd, err := j.getJournalEnds(ctx)
 		if err != nil {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1015,7 +1015,8 @@ func (j *tlfJournal) getJournalStatusWithRange() (
 	// It would be nice to avoid getting this range if we are not
 	// the initializer, but at this point we don't know if we'll
 	// need to initialize or not.
-	ibrmds, err = j.mdJournal.getRange(jStatus.RevisionStart, stop)
+	ibrmds, err = j.mdJournal.getRange(j.mdJournal.branchID,
+		jStatus.RevisionStart, stop)
 	if err != nil {
 		return TLFJournalStatus{}, nil, nil, false, err
 	}
@@ -1359,18 +1360,18 @@ func (j *tlfJournal) isBlockUnflushed(id BlockID) (bool, error) {
 }
 
 func (j *tlfJournal) getMDHead(
-	ctx context.Context) (ImmutableBareRootMetadata, error) {
+	ctx context.Context, bid BranchID) (ImmutableBareRootMetadata, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
 	if err := j.checkEnabledLocked(); err != nil {
 		return ImmutableBareRootMetadata{}, err
 	}
 
-	return j.mdJournal.getHead()
+	return j.mdJournal.getHead(bid)
 }
 
 func (j *tlfJournal) getMDRange(
-	ctx context.Context, start, stop MetadataRevision) (
+	ctx context.Context, bid BranchID, start, stop MetadataRevision) (
 	[]ImmutableBareRootMetadata, error) {
 	j.journalLock.RLock()
 	defer j.journalLock.RUnlock()
@@ -1378,7 +1379,7 @@ func (j *tlfJournal) getMDRange(
 		return nil, err
 	}
 
-	return j.mdJournal.getRange(start, stop)
+	return j.mdJournal.getRange(bid, start, stop)
 }
 
 func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -28,6 +28,21 @@ const (
 type unflushedPathsPerRevMap map[string]bool
 type unflushedPathsMap map[MetadataRevision]unflushedPathsPerRevMap
 
+type upcQueuedOpType int
+
+const (
+	upcOpAppend upcQueuedOpType = iota
+	upcOpRemove
+	upcOpReinit
+)
+
+type upcQueuedOp struct {
+	op            upcQueuedOpType
+	info          unflushedPathMDInfo
+	rev           MetadataRevision
+	isLocalSquash bool
+}
+
 // unflushedPathCache tracks the paths that have been modified by MD
 // updates that haven't yet been flushed from the journal.
 type unflushedPathCache struct {
@@ -36,8 +51,7 @@ type unflushedPathCache struct {
 	unflushedPaths  unflushedPathsMap
 	ready           chan struct{}
 	chainsPopulator chainsPathPopulator
-	appendQueue     []unflushedPathMDInfo
-	removeQueue     []MetadataRevision
+	queue           []upcQueuedOp
 }
 
 var errUPCNotInitialized = errors.New("The unflushed path cache is not yet initialized")
@@ -114,8 +128,7 @@ func (upc *unflushedPathCache) abortInitialization() {
 	upc.lock.Lock()
 	defer upc.lock.Unlock()
 	upc.state = upcUninitialized
-	upc.appendQueue = nil
-	upc.removeQueue = nil
+	upc.queue = nil
 	close(upc.ready)
 	upc.ready = nil
 }
@@ -237,7 +250,11 @@ func (upc *unflushedPathCache) appendToCache(mdInfo unflushedPathMDInfo,
 		// Nothing to do.
 	case upcInitializing:
 		// Append to queue for processing at the end of initialization.
-		upc.appendQueue = append(upc.appendQueue, mdInfo)
+		upc.queue = append(upc.queue, upcQueuedOp{
+			op:   upcOpAppend,
+			info: mdInfo,
+			rev:  mdInfo.revision,
+		})
 	case upcInitialized:
 		if perRevMap == nil {
 			// This was prepared before `upc.chainsPopulator` was set,
@@ -260,7 +277,10 @@ func (upc *unflushedPathCache) removeFromCache(rev MetadataRevision) {
 		// Nothing to do.
 	case upcInitializing:
 		// Append to queue for processing at the end of initialization.
-		upc.removeQueue = append(upc.removeQueue, rev)
+		upc.queue = append(upc.queue, upcQueuedOp{
+			op:  upcOpRemove,
+			rev: rev,
+		})
 	case upcInitialized:
 		delete(upc.unflushedPaths, rev)
 	default:
@@ -269,26 +289,38 @@ func (upc *unflushedPathCache) removeFromCache(rev MetadataRevision) {
 }
 
 func (upc *unflushedPathCache) setCacheIfPossible(cache unflushedPathsMap,
-	cpp chainsPathPopulator) []unflushedPathMDInfo {
+	cpp chainsPathPopulator) []upcQueuedOp {
 	upc.lock.Lock()
 	defer upc.lock.Unlock()
-	if len(upc.appendQueue) > 0 {
+	if len(upc.queue) > 0 {
 		// We need to process more appends!
-		queue := upc.appendQueue
-		upc.appendQueue = nil
+		queue := upc.queue
+		upc.queue = nil
 		return queue
 	}
 
-	for _, rev := range upc.removeQueue {
-		delete(cache, rev)
-	}
-	upc.removeQueue = nil
 	upc.unflushedPaths = cache
 	upc.chainsPopulator = cpp
 	close(upc.ready)
 	upc.ready = nil
 	upc.state = upcInitialized
 	return nil
+}
+
+func reinitUpcCache(revision MetadataRevision,
+	unflushedPaths unflushedPathsMap, perRevMap unflushedPathsPerRevMap,
+	isLocalSquash bool) {
+	// Remove all entries equal or bigger to this revision.  Keep
+	// earlier revisions (likely preserved local squashes).
+	for rev := range unflushedPaths {
+		// Keep the revision if this is a local squash and it's
+		// smaller than the squash revision.
+		if isLocalSquash && rev < revision {
+			continue
+		}
+		delete(unflushedPaths, rev)
+	}
+	unflushedPaths[revision] = perRevMap
 }
 
 // initialize should only be called when the caller saw a `true` value
@@ -336,13 +368,50 @@ func (upc *unflushedPathCache) initialize(ctx context.Context,
 		default:
 		}
 
-		log.CDebugf(ctx, "Processing unflushed paths for %d items in "+
-			"the append queue", len(queue))
-		err := addUnflushedPaths(ctx, uid, key, codec, log, queue, cpp,
-			unflushedPaths)
-		if err != nil {
-			return nil, false, err
+		// Do the queued appends up to the first reinitialization.
+		for len(queue) > 0 {
+			var appends []unflushedPathMDInfo
+			for _, op := range queue {
+				if op.op == upcOpAppend {
+					appends = append(appends, op.info)
+				} else if op.op == upcOpReinit {
+					break
+				}
+			}
+
+			log.CDebugf(ctx, "Processing unflushed paths for %d items in "+
+				"the append queue", len(appends))
+			err := addUnflushedPaths(ctx, uid, key, codec, log, appends, cpp,
+				unflushedPaths)
+			if err != nil {
+				return nil, false, err
+			}
+
+			// Do the queued removes up to the first reinitialization.
+			// Then to do the reinitialization and repeat using the
+			// remainder of the queue.
+			reinit := false
+			for i, op := range queue {
+				if op.op == upcOpRemove {
+					delete(unflushedPaths, op.rev)
+				} else if op.op == upcOpReinit {
+					perRevMap, err := upc.prepUnflushedPaths(ctx, uid, key,
+						codec, log, op.info)
+					if err != nil {
+						return nil, false, err
+					}
+					reinitUpcCache(
+						op.rev, unflushedPaths, perRevMap, op.isLocalSquash)
+					queue = queue[i+1:]
+					reinit = true
+					break
+				}
+			}
+			if !reinit {
+				queue = nil
+			}
 		}
+
 	}
 	// If we can't catch up to the queue, then instruct the caller to
 	// abort the initialization.
@@ -352,17 +421,39 @@ func (upc *unflushedPathCache) initialize(ctx context.Context,
 // reinitializeWithResolution returns true when successful, and false
 // if it needs to be retried after the per-revision map is recomputed.
 func (upc *unflushedPathCache) reinitializeWithResolution(
-	mdInfo unflushedPathMDInfo, perRevMap unflushedPathsPerRevMap) bool {
+	mdInfo unflushedPathMDInfo, perRevMap unflushedPathsPerRevMap,
+	isLocalSquash bool) bool {
 	upc.lock.Lock()
 	defer upc.lock.Unlock()
 
-	if perRevMap == nil && upc.state != upcUninitialized {
-		return false
+	if perRevMap == nil {
+		switch upc.state {
+		case upcInitialized:
+			// Initialization started since the perRevMap was created,
+			// so try again.
+			return false
+		case upcInitializing:
+			// Save this reinit for later.
+			upc.queue = append(upc.queue, upcQueuedOp{
+				op:            upcOpReinit,
+				info:          mdInfo,
+				rev:           mdInfo.revision,
+				isLocalSquash: isLocalSquash,
+			})
+			return true
+		default:
+			// We can't initialize with a nil revision map.
+			return true
+		}
 	}
 
-	upc.unflushedPaths = unflushedPathsMap{mdInfo.revision: perRevMap}
-	upc.appendQueue = nil
-	upc.removeQueue = nil
+	if upc.unflushedPaths != nil {
+		reinitUpcCache(
+			mdInfo.revision, upc.unflushedPaths, perRevMap, isLocalSquash)
+	} else {
+		upc.unflushedPaths = unflushedPathsMap{mdInfo.revision: perRevMap}
+	}
+	upc.queue = nil
 	if upc.ready != nil {
 		close(upc.ready)
 		upc.ready = nil

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -37,9 +37,15 @@ const (
 )
 
 type upcQueuedOp struct {
-	op            upcQueuedOpType
-	info          unflushedPathMDInfo
-	rev           MetadataRevision
+	op upcQueuedOpType
+
+	// Remove ops don't need an info.
+	info unflushedPathMDInfo
+
+	// All op types should set this.
+	rev MetadataRevision
+
+	// Only reinit ops need to set this explicitly.
 	isLocalSquash bool
 }
 

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -165,8 +165,8 @@ func addUnflushedPaths(ctx context.Context,
 
 	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
 	chains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		kmd:     mostRecentMDInfo.kmd,
-		rootPtr: mostRecentMDInfo.pmd.Dir.BlockPointer,
+		kmd:      mostRecentMDInfo.kmd,
+		rootInfo: mostRecentMDInfo.pmd.Dir.BlockInfo,
 	}
 
 	err := cpp.populateChainPaths(ctx, log, chains, true)


### PR DESCRIPTION
This avoids squashing previous squashes into new squashes, by skipping them during branch conversion.  This allows the journal to have a mix of merged and unmerged entries, which complicates some of the `journalMDOps` logic, but it doesn't seem too bad.

Also, the `unflushedPathCache` reinitialization logic had to change a bit since a branch resolve doesn't necessarily clear the whole branch, so we have to keep around the revisions that were earlier than resolution revision.

Issue: KBFS-1653