### PR TITLE
keybase_daemon_rpc: keep the conn alive with CurrentSession calls

### DIFF
--- a/vendor/github.com/keybase/client/go/protocol/chat1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/extras.go
@@ -159,6 +159,13 @@ var ConversationStatusGregorMap = map[ConversationStatus]string{
 	ConversationStatus_BLOCKED:  "blocked",
 }
 
+var ConversationStatusGregorRevMap = map[string]ConversationStatus{
+	"unfiled":  ConversationStatus_UNFILED,
+	"favorite": ConversationStatus_FAVORITE,
+	"ignored":  ConversationStatus_IGNORED,
+	"blocked":  ConversationStatus_BLOCKED,
+}
+
 func (t ConversationIDTriple) Hash10B() []byte {
 	h := sha256.New()
 	h.Write(t.Tlfid)
@@ -181,4 +188,8 @@ func (t ConversationIDTriple) Derivable(cid ConversationID) bool {
 	}
 	h10 := t.Hash10B()
 	return bytes.Equal(h10[2:], []byte(cid[2:]))
+}
+
+func (o OutboxID) Eq(r OutboxID) bool {
+	return bytes.Equal(o, r)
 }

--- a/vendor/github.com/keybase/client/go/protocol/chat1/gregor.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/gregor.go
@@ -11,10 +11,40 @@ type GenericPayload struct {
 	Action string `codec:"Action" json:"Action"`
 }
 
+type NewConversationPayload struct {
+	Action       string         `codec:"Action" json:"Action"`
+	ConvID       ConversationID `codec:"convID" json:"convID"`
+	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
+}
+
 type NewMessagePayload struct {
-	Action  string         `codec:"Action" json:"Action"`
-	ConvID  ConversationID `codec:"convID" json:"convID"`
-	Message MessageBoxed   `codec:"message" json:"message"`
+	Action       string         `codec:"Action" json:"Action"`
+	ConvID       ConversationID `codec:"convID" json:"convID"`
+	Message      MessageBoxed   `codec:"message" json:"message"`
+	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
+}
+
+type ReadMessagePayload struct {
+	Action       string         `codec:"Action" json:"Action"`
+	ConvID       ConversationID `codec:"convID" json:"convID"`
+	MsgID        MessageID      `codec:"msgID" json:"msgID"`
+	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
+}
+
+type SetStatusPayload struct {
+	Action       string             `codec:"Action" json:"Action"`
+	ConvID       ConversationID     `codec:"convID" json:"convID"`
+	Status       ConversationStatus `codec:"status" json:"status"`
+	InboxVers    InboxVers          `codec:"inboxVers" json:"inboxVers"`
+	UnreadUpdate *UnreadUpdate      `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
+}
+
+type UnreadUpdate struct {
+	ConvID         ConversationID `codec:"convID" json:"convID"`
+	UnreadMessages int            `codec:"UnreadMessages" json:"UnreadMessages"`
 }
 
 type GregorInterface interface {

--- a/vendor/github.com/keybase/client/go/protocol/chat1/notify.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/notify.go
@@ -4,6 +4,7 @@
 package chat1
 
 import (
+	"errors"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
@@ -14,16 +15,25 @@ type ChatActivityType int
 const (
 	ChatActivityType_RESERVED         ChatActivityType = 0
 	ChatActivityType_INCOMING_MESSAGE ChatActivityType = 1
+	ChatActivityType_READ_MESSAGE     ChatActivityType = 2
+	ChatActivityType_NEW_CONVERSATION ChatActivityType = 3
+	ChatActivityType_SET_STATUS       ChatActivityType = 4
 )
 
 var ChatActivityTypeMap = map[string]ChatActivityType{
 	"RESERVED":         0,
 	"INCOMING_MESSAGE": 1,
+	"READ_MESSAGE":     2,
+	"NEW_CONVERSATION": 3,
+	"SET_STATUS":       4,
 }
 
 var ChatActivityTypeRevMap = map[ChatActivityType]string{
 	0: "RESERVED",
 	1: "INCOMING_MESSAGE",
+	2: "READ_MESSAGE",
+	3: "NEW_CONVERSATION",
+	4: "SET_STATUS",
 }
 
 type IncomingMessage struct {
@@ -31,9 +41,126 @@ type IncomingMessage struct {
 	ConvID  ConversationID `codec:"convID" json:"convID"`
 }
 
+type MessageSentInfo struct {
+	ConvID    ConversationID `codec:"convID" json:"convID"`
+	RateLimit RateLimit      `codec:"rateLimit" json:"rateLimit"`
+	OutboxID  OutboxID       `codec:"outboxID" json:"outboxID"`
+}
+
+type ReadMessageInfo struct {
+	ConvID ConversationID `codec:"convID" json:"convID"`
+	MsgID  MessageID      `codec:"msgID" json:"msgID"`
+}
+
+type NewConversationInfo struct {
+	Conv ConversationLocal `codec:"conv" json:"conv"`
+}
+
+type SetStatusInfo struct {
+	ConvID ConversationID     `codec:"convID" json:"convID"`
+	Status ConversationStatus `codec:"status" json:"status"`
+}
+
 type ChatActivity struct {
-	ActivityType    ChatActivityType `codec:"ActivityType" json:"ActivityType"`
-	IncomingMessage *IncomingMessage `codec:"IncomingMessage,omitempty" json:"IncomingMessage,omitempty"`
+	ActivityType__    ChatActivityType     `codec:"activityType" json:"activityType"`
+	IncomingMessage__ *IncomingMessage     `codec:"incomingMessage,omitempty" json:"incomingMessage,omitempty"`
+	ReadMessage__     *ReadMessageInfo     `codec:"readMessage,omitempty" json:"readMessage,omitempty"`
+	NewConversation__ *NewConversationInfo `codec:"newConversation,omitempty" json:"newConversation,omitempty"`
+	SetStatus__       *SetStatusInfo       `codec:"setStatus,omitempty" json:"setStatus,omitempty"`
+}
+
+func (o *ChatActivity) ActivityType() (ret ChatActivityType, err error) {
+	switch o.ActivityType__ {
+	case ChatActivityType_INCOMING_MESSAGE:
+		if o.IncomingMessage__ == nil {
+			err = errors.New("unexpected nil value for IncomingMessage__")
+			return ret, err
+		}
+	case ChatActivityType_READ_MESSAGE:
+		if o.ReadMessage__ == nil {
+			err = errors.New("unexpected nil value for ReadMessage__")
+			return ret, err
+		}
+	case ChatActivityType_NEW_CONVERSATION:
+		if o.NewConversation__ == nil {
+			err = errors.New("unexpected nil value for NewConversation__")
+			return ret, err
+		}
+	case ChatActivityType_SET_STATUS:
+		if o.SetStatus__ == nil {
+			err = errors.New("unexpected nil value for SetStatus__")
+			return ret, err
+		}
+	}
+	return o.ActivityType__, nil
+}
+
+func (o ChatActivity) IncomingMessage() IncomingMessage {
+	if o.ActivityType__ != ChatActivityType_INCOMING_MESSAGE {
+		panic("wrong case accessed")
+	}
+	if o.IncomingMessage__ == nil {
+		return IncomingMessage{}
+	}
+	return *o.IncomingMessage__
+}
+
+func (o ChatActivity) ReadMessage() ReadMessageInfo {
+	if o.ActivityType__ != ChatActivityType_READ_MESSAGE {
+		panic("wrong case accessed")
+	}
+	if o.ReadMessage__ == nil {
+		return ReadMessageInfo{}
+	}
+	return *o.ReadMessage__
+}
+
+func (o ChatActivity) NewConversation() NewConversationInfo {
+	if o.ActivityType__ != ChatActivityType_NEW_CONVERSATION {
+		panic("wrong case accessed")
+	}
+	if o.NewConversation__ == nil {
+		return NewConversationInfo{}
+	}
+	return *o.NewConversation__
+}
+
+func (o ChatActivity) SetStatus() SetStatusInfo {
+	if o.ActivityType__ != ChatActivityType_SET_STATUS {
+		panic("wrong case accessed")
+	}
+	if o.SetStatus__ == nil {
+		return SetStatusInfo{}
+	}
+	return *o.SetStatus__
+}
+
+func NewChatActivityWithIncomingMessage(v IncomingMessage) ChatActivity {
+	return ChatActivity{
+		ActivityType__:    ChatActivityType_INCOMING_MESSAGE,
+		IncomingMessage__: &v,
+	}
+}
+
+func NewChatActivityWithReadMessage(v ReadMessageInfo) ChatActivity {
+	return ChatActivity{
+		ActivityType__: ChatActivityType_READ_MESSAGE,
+		ReadMessage__:  &v,
+	}
+}
+
+func NewChatActivityWithNewConversation(v NewConversationInfo) ChatActivity {
+	return ChatActivity{
+		ActivityType__:    ChatActivityType_NEW_CONVERSATION,
+		NewConversation__: &v,
+	}
+}
+
+func NewChatActivityWithSetStatus(v SetStatusInfo) ChatActivity {
+	return ChatActivity{
+		ActivityType__: ChatActivityType_SET_STATUS,
+		SetStatus__:    &v,
+	}
 }
 
 type NewChatActivityArg struct {

--- a/vendor/github.com/keybase/client/go/protocol/chat1/remote.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/remote.go
@@ -64,6 +64,12 @@ type SetConversationStatusRes struct {
 	RateLimit *RateLimit `codec:"rateLimit,omitempty" json:"rateLimit,omitempty"`
 }
 
+type UnreadUpdateFull struct {
+	Ignore    bool           `codec:"ignore" json:"ignore"`
+	InboxVers InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	Updates   []UnreadUpdate `codec:"updates" json:"updates"`
+}
+
 type S3Params struct {
 	Bucket               string `codec:"bucket" json:"bucket"`
 	ObjectKey            string `codec:"objectKey" json:"objectKey"`
@@ -75,6 +81,7 @@ type S3Params struct {
 }
 
 type GetInboxRemoteArg struct {
+	Vers       InboxVers      `codec:"vers" json:"vers"`
 	Query      *GetInboxQuery `codec:"query,omitempty" json:"query,omitempty"`
 	Pagination *Pagination    `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
@@ -118,6 +125,10 @@ type TlfFinalizeArg struct {
 	TlfID TLFID `codec:"tlfID" json:"tlfID"`
 }
 
+type GetUnreadUpdateFullArg struct {
+	InboxVers InboxVers `codec:"inboxVers" json:"inboxVers"`
+}
+
 type GetS3ParamsArg struct {
 	ConversationID ConversationID `codec:"conversationID" json:"conversationID"`
 }
@@ -137,6 +148,7 @@ type RemoteInterface interface {
 	MarkAsRead(context.Context, MarkAsReadArg) (MarkAsReadRes, error)
 	SetConversationStatus(context.Context, SetConversationStatusArg) (SetConversationStatusRes, error)
 	TlfFinalize(context.Context, TLFID) error
+	GetUnreadUpdateFull(context.Context, InboxVers) (UnreadUpdateFull, error)
 	GetS3Params(context.Context, ConversationID) (S3Params, error)
 	S3Sign(context.Context, S3SignArg) ([]byte, error)
 }
@@ -289,6 +301,22 @@ func RemoteProtocol(i RemoteInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"GetUnreadUpdateFull": {
+				MakeArg: func() interface{} {
+					ret := make([]GetUnreadUpdateFullArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]GetUnreadUpdateFullArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]GetUnreadUpdateFullArg)(nil), args)
+						return
+					}
+					ret, err = i.GetUnreadUpdateFull(ctx, (*typedArgs)[0].InboxVers)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"getS3Params": {
 				MakeArg: func() interface{} {
 					ret := make([]GetS3ParamsArg, 1)
@@ -373,6 +401,12 @@ func (c RemoteClient) SetConversationStatus(ctx context.Context, __arg SetConver
 func (c RemoteClient) TlfFinalize(ctx context.Context, tlfID TLFID) (err error) {
 	__arg := TlfFinalizeArg{TlfID: tlfID}
 	err = c.Cli.Call(ctx, "chat.1.remote.tlfFinalize", []interface{}{__arg}, nil)
+	return
+}
+
+func (c RemoteClient) GetUnreadUpdateFull(ctx context.Context, inboxVers InboxVers) (res UnreadUpdateFull, err error) {
+	__arg := GetUnreadUpdateFullArg{InboxVers: inboxVers}
+	err = c.Cli.Call(ctx, "chat.1.remote.GetUnreadUpdateFull", []interface{}{__arg}, &res)
 	return
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/gregor1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/gregor1/extras.go
@@ -338,6 +338,22 @@ func FromTime(t Time) time.Time {
 	return time.Unix(0, int64(t)*1000000)
 }
 
+func (t Time) Time() time.Time {
+	return FromTime(t)
+}
+
+func (t Time) UnixSeconds() int64 {
+	return t.Time().Unix()
+}
+
+func (t Time) UnixMilliseconds() int64 {
+	return t.Time().UnixNano() / 1e6
+}
+
+func (t Time) UnixMicroseconds() int64 {
+	return t.Time().UnixNano() / 1e3
+}
+
 // copied from keybase/client/go/protocol/extras.go. Consider eventually a
 // refactor to allow this code to be shared.
 func ToTime(t time.Time) Time {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/constants.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/constants.go
@@ -91,6 +91,7 @@ const (
 	StatusCode_SCChatAlreadySuperseded  StatusCode = 2507
 	StatusCode_SCChatAlreadyDeleted     StatusCode = 2508
 	StatusCode_SCChatTLFFinalized       StatusCode = 2509
+	StatusCode_SCChatCollision          StatusCode = 2510
 )
 
 var StatusCodeMap = map[string]StatusCode{
@@ -175,6 +176,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCChatAlreadySuperseded":  2507,
 	"SCChatAlreadyDeleted":     2508,
 	"SCChatTLFFinalized":       2509,
+	"SCChatCollision":          2510,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -259,6 +261,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2507: "SCChatAlreadySuperseded",
 	2508: "SCChatAlreadyDeleted",
 	2509: "SCChatTLFFinalized",
+	2510: "SCChatCollision",
 }
 
 type ConstantsInterface interface {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/session.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/session.go
@@ -20,8 +20,12 @@ type CurrentSessionArg struct {
 	SessionID int `codec:"sessionID" json:"sessionID"`
 }
 
+type SessionPingArg struct {
+}
+
 type SessionInterface interface {
 	CurrentSession(context.Context, int) (Session, error)
+	SessionPing(context.Context) error
 }
 
 func SessionProtocol(i SessionInterface) rpc.Protocol {
@@ -44,6 +48,17 @@ func SessionProtocol(i SessionInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"sessionPing": {
+				MakeArg: func() interface{} {
+					ret := make([]SessionPingArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.SessionPing(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -55,5 +70,10 @@ type SessionClient struct {
 func (c SessionClient) CurrentSession(ctx context.Context, sessionID int) (res Session, err error) {
 	__arg := CurrentSessionArg{SessionID: sessionID}
 	err = c.Cli.Call(ctx, "keybase.1.session.currentSession", []interface{}{__arg}, &res)
+	return
+}
+
+func (c SessionClient) SessionPing(ctx context.Context) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.session.sessionPing", []interface{}{SessionPingArg{}}, nil)
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -180,26 +180,26 @@
 		{
 			"checksumSHA1": "O1Q0NBB6o1mj4A+1uk1xgf7nw+c=",
 			"path": "github.com/keybase/client/go/protocol",
-			"revision": "d735cc8a00ca5b38281a350c699a51f76ceb142b",
-			"revisionTime": "2016-10-03T19:50:03Z"
+			"revision": "6b243b4e55e618f6b6379eb8c76553e4fc25ebe4",
+			"revisionTime": "2016-11-18T17:50:54Z"
 		},
 		{
-			"checksumSHA1": "GaqDVb12btEzMNqvA5souhhb7ro=",
+			"checksumSHA1": "0B73QBKRhHTqia2nJGBdgqY1Q0s=",
 			"path": "github.com/keybase/client/go/protocol/chat1",
-			"revision": "10e3781124a2a9177c5907030b61e6258f488706",
-			"revisionTime": "2016-10-20T17:08:33-07:00"
+			"revision": "6b243b4e55e618f6b6379eb8c76553e4fc25ebe4",
+			"revisionTime": "2016-11-18T17:50:54Z"
 		},
 		{
-			"checksumSHA1": "q70K4x5RScr+P5wAI+uVxZxwhDg=",
+			"checksumSHA1": "M6GljYelFgHh11vwx4eqe62gDRQ=",
 			"path": "github.com/keybase/client/go/protocol/gregor1",
-			"revision": "d735cc8a00ca5b38281a350c699a51f76ceb142b",
-			"revisionTime": "2016-10-03T19:50:03Z"
+			"revision": "6b243b4e55e618f6b6379eb8c76553e4fc25ebe4",
+			"revisionTime": "2016-11-18T17:50:54Z"
 		},
 		{
-			"checksumSHA1": "qq2N9NYqH1o5pNh+j2dHGHq1Wt8=",
+			"checksumSHA1": "5TQHj4drLvzmsMwuWhV71UeS3Q4=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "466c0e5938005a7451cfc0b1f51fa0f16dfa99e4",
-			"revisionTime": "2016-11-07T21:01:43Z"
+			"revision": "6b243b4e55e618f6b6379eb8c76553e4fc25ebe4",
+			"revisionTime": "2016-11-18T17:50:54Z"
 		},
 		{
 			"checksumSHA1": "jnN+Jbtoeb/NFpIi1vdDwokZxgY=",


### PR DESCRIPTION
OnConnect is called lazily when a reconnection is triggered by an
outgoing RPC, and we need to send HelloIAm calls as soon as we can
after the connection is re-established.  So instead of waiting for
KBFS to make a call, have one going proactively in the background at
all times.

Issue: KBFS-1671