### PR TITLE
Bump Go version requirement to 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Currently, our server implementations are not open source.
 
 Prerequisites:
 
-* [Go 1.6](https://golang.org/dl/) or higher.
+* [Go 1.7](https://golang.org/dl/) or higher.
 * A running Keybase client service (see [instructions](https://github.com/keybase/client/tree/master/go)).
 * On OS X, you may have to [install FUSE yourself](https://osxfuse.github.io/).
   * You may need to pass the `--use-system-fuse` flag to `kbfsfuse` if


### PR DESCRIPTION
I'm not sure if much else requires 1.7, but context didn't get moved from golang.org/x/net/context to the stdlib as 'context' until 1.7, and it is used as such in the current source.

eg: https://github.com/keybase/kbfs/blob/master/libkbfs/ops.go#L8

ref: https://tip.golang.org/doc/go1.7#context