### PR TITLE
[KBFS-1720] Store only the current TLFPublicKey

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1043,13 +1043,15 @@ func (md *BareRootMetadataV2) Version() MetadataVer {
 	return PreExtraMetadataVer
 }
 
-// GetTLFPublicKey implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) GetTLFPublicKey(keyGen KeyGen, _ ExtraMetadata) (
-	kbfscrypto.TLFPublicKey, bool) {
-	if keyGen > md.LatestKeyGeneration() {
-		return kbfscrypto.TLFPublicKey{}, false
+// GetCurrentTLFPublicKey implements the BareRootMetadata interface
+// for BareRootMetadataV2.
+func (md *BareRootMetadataV2) GetCurrentTLFPublicKey(
+	_ ExtraMetadata) (kbfscrypto.TLFPublicKey, error) {
+	if len(md.WKeys) == 0 {
+		return kbfscrypto.TLFPublicKey{}, errors.New(
+			"No key generations in GetCurrentTLFPublicKey")
 	}
-	return md.WKeys[keyGen].TLFPublicKey, true
+	return md.WKeys[len(md.WKeys)-1].TLFPublicKey, nil
 }
 
 // AreKeyGenerationsEqual implements the BareRootMetadata interface for BareRootMetadataV2.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -868,7 +868,7 @@ func (md *BareRootMetadataV3) AddNewKeysForTesting(crypto cryptoPure,
 	}
 	if md.WriterMetadata.LatestKeyGen >= FirstValidKeyGen {
 		// TODO: Relax this if needed (but would have to
-		// retrieve the previous pubkeys below).
+		// retrieve the previous historical crypt keys below).
 		panic("Cannot add more than one key generation")
 	}
 	for _, dkim := range wDkim {

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1082,11 +1082,11 @@ func (md *BareRootMetadataV3) FinalizeRekey(
 	if !ok {
 		return errors.New("Invalid extra metadata")
 	}
-	if md.LatestKeyGeneration() < KeyGen(FirstValidKeyGen) {
+	if md.LatestKeyGeneration() < FirstValidKeyGen {
 		return fmt.Errorf("Invalid key generation %d", md.LatestKeyGeneration())
 	}
 	if (prevKey != kbfscrypto.TLFCryptKey{}) {
-		numKeys := int(md.LatestKeyGeneration() - KeyGen(FirstValidKeyGen))
+		numKeys := int(md.LatestKeyGeneration() - FirstValidKeyGen)
 		if numKeys == 0 {
 			return errors.New("Previous key non-nil for first key generation")
 		}
@@ -1129,7 +1129,7 @@ func (md *BareRootMetadataV3) GetHistoricTLFCryptKey(crypto cryptoPure,
 		return kbfscrypto.TLFCryptKey{}, errors.New(
 			"Invalid extra metadata")
 	}
-	if keyGen < KeyGen(FirstValidKeyGen) || keyGen >= md.LatestKeyGeneration() {
+	if keyGen < FirstValidKeyGen || keyGen >= md.LatestKeyGeneration() {
 		return kbfscrypto.TLFCryptKey{}, fmt.Errorf(
 			"Invalid key generation %d", keyGen)
 	}
@@ -1138,7 +1138,7 @@ func (md *BareRootMetadataV3) GetHistoricTLFCryptKey(crypto cryptoPure,
 	if err != nil {
 		return kbfscrypto.TLFCryptKey{}, err
 	}
-	index := int(keyGen - KeyGen(FirstValidKeyGen))
+	index := int(keyGen - FirstValidKeyGen)
 	if index >= len(oldKeys) || index < 0 {
 		return kbfscrypto.TLFCryptKey{}, fmt.Errorf(
 			"Index %d out of range (max: %d)", index, len(oldKeys))

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1679,7 +1679,6 @@ type BareRootMetadata interface {
 	// Version returns the metadata version.
 	Version() MetadataVer
 	// GetTLFPublicKey returns the TLF public key for the give key generation.
-	// Note the *TLFWriterKeyBundleV3 is expected to be nil for pre-v3 metadata.
 	GetTLFPublicKey(KeyGen, ExtraMetadata) (kbfscrypto.TLFPublicKey, bool)
 	// AreKeyGenerationsEqual returns true if all key generations in the passed metadata are equal to those
 	// in this revision.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1678,8 +1678,9 @@ type BareRootMetadata interface {
 	GetSerializedWriterMetadata(codec kbfscodec.Codec) ([]byte, error)
 	// Version returns the metadata version.
 	Version() MetadataVer
-	// GetTLFPublicKey returns the TLF public key for the give key generation.
-	GetTLFPublicKey(KeyGen, ExtraMetadata) (kbfscrypto.TLFPublicKey, bool)
+	// GetCurrentTLFPublicKey returns the TLF public key for the
+	// current key generation.
+	GetCurrentTLFPublicKey(ExtraMetadata) (kbfscrypto.TLFPublicKey, error)
 	// AreKeyGenerationsEqual returns true if all key generations in the passed metadata are equal to those
 	// in this revision.
 	AreKeyGenerationsEqual(kbfscodec.Codec, BareRootMetadata) (bool, error)

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -176,14 +176,14 @@ func (tkg TLFWriterKeyGenerations) ToTLFWriterKeyBundleV3(
 	*TLFWriterKeyBundleV3, error) {
 
 	keyGen := tkg.LatestKeyGeneration()
-	if keyGen < 1 {
+	if keyGen < FirstValidKeyGen {
 		return nil, errors.New("No key generations to convert")
 	}
 
 	wkbCopy := &TLFWriterKeyBundleV3{}
 
 	// Copy the latest UserDeviceKeyInfoMap.
-	wkb := tkg[keyGen-1]
+	wkb := tkg[keyGen-FirstValidKeyGen]
 	wkbCopy.Keys = wkb.WKeys.deepCopy()
 
 	// Copy all of the TLFEphemeralPublicKeys at this generation.
@@ -191,13 +191,10 @@ func (tkg TLFWriterKeyGenerations) ToTLFWriterKeyBundleV3(
 		make(kbfscrypto.TLFEphemeralPublicKeys, len(wkb.TLFEphemeralPublicKeys))
 	copy(wkbCopy.TLFEphemeralPublicKeys[:], wkb.TLFEphemeralPublicKeys)
 
-	// Copy all of the TLFPublicKeys.
-	wkbCopy.TLFPublicKeys = make([]kbfscrypto.TLFPublicKey, int(keyGen))
-	for i, wkb := range tkg {
-		wkbCopy.TLFPublicKeys[i] = wkb.TLFPublicKey
-	}
+	// Copy the current TLFPublicKey.
+	wkbCopy.TLFPublicKey = wkb.TLFPublicKey
 
-	if keyGen > 1 {
+	if keyGen > FirstValidKeyGen {
 		// Fetch all of the TLFCryptKeys.
 		keys, err := keyManager.GetTLFCryptKeyOfAllGenerations(ctx, kmd)
 		if err != nil {

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -33,9 +33,8 @@ type TLFWriterKeyBundleV3 struct {
 	TLFEphemeralPublicKeys kbfscrypto.TLFEphemeralPublicKeys `codec:"ePubKey"`
 
 	// M_f as described in 4.1.1 of
-	// https://keybase.io/blog/kbfs-crypto. Indexed by key
-	// generation.
-	TLFPublicKeys []kbfscrypto.TLFPublicKey `codec:"pubKey"`
+	// https://keybase.io/blog/kbfs-crypto.
+	TLFPublicKey kbfscrypto.TLFPublicKey `codec:"pubKey"`
 
 	// This is a time-ordered encrypted list of historic key generations.
 	// It is encrypted with the latest generation of the TLF crypt key.

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -60,7 +60,7 @@ func (km *KeyManagerStandard) GetTLFCryptKeyForBlockDecryption(
 func (km *KeyManagerStandard) GetTLFCryptKeyOfAllGenerations(
 	ctx context.Context, kmd KeyMetadata) (
 	keys []kbfscrypto.TLFCryptKey, err error) {
-	for g := KeyGen(FirstValidKeyGen); g <= kmd.LatestKeyGeneration(); g++ {
+	for g := FirstValidKeyGen; g <= kmd.LatestKeyGeneration(); g++ {
 		var key kbfscrypto.TLFCryptKey
 		key, err = km.getTLFCryptKeyUsingCurrentDevice(ctx, kmd, g, true)
 		if err != nil {
@@ -673,7 +673,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	// If there's at least one new device, add that device to every key bundle.
 	if addNewReaderDevice || addNewWriterDevice {
-		for keyGen := KeyGen(FirstValidKeyGen); keyGen <= currKeyGen; keyGen++ {
+		for keyGen := FirstValidKeyGen; keyGen <= currKeyGen; keyGen++ {
 			flags := getTLFCryptKeyAnyDevice
 			if promptPaper {
 				flags |= getTLFCryptKeyPromptPaper
@@ -762,7 +762,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// Save the previous TLF crypt key. It's symmetrically encrypted and appended to a list
 	// for MDv3 metadata.
 	var prevTlfCryptKey kbfscrypto.TLFCryptKey
-	if currKeyGen >= KeyGen(FirstValidKeyGen) && md.StoresHistoricTLFCryptKeys() {
+	if currKeyGen >= FirstValidKeyGen && md.StoresHistoricTLFCryptKeys() {
 		flags := getTLFCryptKeyAnyDevice
 		if promptPaper {
 			flags |= getTLFCryptKeyPromptPaper
@@ -783,7 +783,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	md.data.TLFPrivateKey = privKey
 
 	// Delete server-side key halves for any revoked devices.
-	for keygen := KeyGen(FirstValidKeyGen); keygen <= currKeyGen; keygen++ {
+	for keygen := FirstValidKeyGen; keygen <= currKeyGen; keygen++ {
 		rDkim, wDkim, err := md.getUserDeviceKeyInfoMaps(keygen)
 		if _, noDkim := err.(TLFCryptKeyNotPerDeviceEncrypted); noDkim {
 			// No DKIM for this generation. This is possible for MDv3.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -885,7 +885,7 @@ func TestKeyManagerRekeyAddAndRevokeDevice(t *testing.T) {
 	if !ok {
 		t.Fatal("Wrong kind of key manager for config2")
 	}
-	for keyGen := KeyGen(FirstValidKeyGen); keyGen <= currKeyGen; keyGen++ {
+	for keyGen := FirstValidKeyGen; keyGen <= currKeyGen; keyGen++ {
 		_, err = km2.getTLFCryptKeyUsingCurrentDevice(ctx, rmd.ReadOnly(), keyGen, true)
 		if err == nil {
 			t.Errorf("User 2 could still fetch a key for keygen %d", keyGen)

--- a/libkbfs/keycache_test.go
+++ b/libkbfs/keycache_test.go
@@ -16,7 +16,7 @@ func TestKeyCacheBasic(t *testing.T) {
 	cache := NewKeyCacheStandard(10)
 	id := tlf.FakeID(100, true)
 	key := kbfscrypto.MakeTLFCryptKey([32]byte{0xf})
-	keyGen := KeyGen(1)
+	keyGen := FirstValidKeyGen
 	_, err := cache.GetTLFCryptKey(id, keyGen)
 	if _, ok := err.(KeyCacheMissError); !ok {
 		t.Fatal(errors.New("expected KeyCacheMissError"))

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3370,15 +3370,15 @@ func (_mr *_MockblockServerLocalRecorder) GetUserQuotaInfo(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserQuotaInfo", arg0)
 }
 
-func (_m *MockblockServerLocal) getAllRefs(ctx context.Context, tlfID tlf.ID) (map[BlockID]blockRefMap, error) {
-	ret := _m.ctrl.Call(_m, "getAllRefs", ctx, tlfID)
+func (_m *MockblockServerLocal) getAllRefsForTest(ctx context.Context, tlfID tlf.ID) (map[BlockID]blockRefMap, error) {
+	ret := _m.ctrl.Call(_m, "getAllRefsForTest", ctx, tlfID)
 	ret0, _ := ret[0].(map[BlockID]blockRefMap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockblockServerLocalRecorder) getAllRefs(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "getAllRefs", arg0, arg1)
+func (_mr *_MockblockServerLocalRecorder) getAllRefsForTest(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "getAllRefsForTest", arg0, arg1)
 }
 
 // Mock of BlockSplitter interface
@@ -4875,15 +4875,15 @@ func (_mr *_MockBareRootMetadataRecorder) Version() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
 }
 
-func (_m *MockBareRootMetadata) GetTLFPublicKey(_param0 KeyGen, _param1 ExtraMetadata) (kbfscrypto.TLFPublicKey, bool) {
-	ret := _m.ctrl.Call(_m, "GetTLFPublicKey", _param0, _param1)
+func (_m *MockBareRootMetadata) GetCurrentTLFPublicKey(_param0 ExtraMetadata) (kbfscrypto.TLFPublicKey, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentTLFPublicKey", _param0)
 	ret0, _ := ret[0].(kbfscrypto.TLFPublicKey)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) GetTLFPublicKey(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFPublicKey", arg0, arg1)
+func (_mr *_MockBareRootMetadataRecorder) GetCurrentTLFPublicKey(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentTLFPublicKey", arg0)
 }
 
 func (_m *MockBareRootMetadata) AreKeyGenerationsEqual(_param0 kbfscodec.Codec, _param1 BareRootMetadata) (bool, error) {
@@ -5302,15 +5302,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) Version() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Version")
 }
 
-func (_m *MockMutableBareRootMetadata) GetTLFPublicKey(_param0 KeyGen, _param1 ExtraMetadata) (kbfscrypto.TLFPublicKey, bool) {
-	ret := _m.ctrl.Call(_m, "GetTLFPublicKey", _param0, _param1)
+func (_m *MockMutableBareRootMetadata) GetCurrentTLFPublicKey(_param0 ExtraMetadata) (kbfscrypto.TLFPublicKey, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentTLFPublicKey", _param0)
 	ret0, _ := ret[0].(kbfscrypto.TLFPublicKey)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFPublicKey(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFPublicKey", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) GetCurrentTLFPublicKey(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentTLFPublicKey", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) AreKeyGenerationsEqual(_param0 kbfscodec.Codec, _param1 BareRootMetadata) (bool, error) {

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -544,9 +544,9 @@ func TestRootMetadataFinalIsFinal(t *testing.T) {
 func getAllUsersKeysForTest(
 	t *testing.T, config Config, rmd *RootMetadata, un string) []kbfscrypto.TLFCryptKey {
 	var keys []kbfscrypto.TLFCryptKey
-	for i := 1; i <= int(rmd.LatestKeyGeneration()); i++ {
+	for keyGen := FirstValidKeyGen; keyGen <= rmd.LatestKeyGeneration(); keyGen++ {
 		key, err := config.KeyManager().(*KeyManagerStandard).getTLFCryptKeyUsingCurrentDevice(
-			context.Background(), rmd, KeyGen(i), true)
+			context.Background(), rmd, keyGen, true)
 		require.NoError(t, err)
 		keys = append(keys, key)
 	}


### PR DESCRIPTION
The Merkle tree builder only needs the
current one, and we weren't maintaining the
list properly, anyway.

Also fix some redundant KeyGen casts.