### PR TITLE
file_data: move all indirect pointer access out of folderBlockOps

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2814,7 +2814,8 @@ func (cr *ConflictResolver) syncTree(ctx context.Context, lState *lockState,
 						return nil, err
 					}
 					info, _, readyBlockData, err := ReadyBlock(
-						ctx, cr.config, newMD.ReadOnly(), childBlock, uid)
+						ctx, cr.config.BlockCache(), cr.config.BlockOps(),
+						cr.config.Crypto(), newMD.ReadOnly(), childBlock, uid)
 					if err != nil {
 						return nil, err
 					}

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -635,3 +635,22 @@ func (fd *fileData) ready(ctx context.Context, id tlf.ID, bcache BlockCache,
 	}
 	return oldPtrs, nil
 }
+
+func (fd *fileData) getIndirectFileBlockInfos(ctx context.Context) (
+	[]BlockInfo, error) {
+	// TODO: handle multiple levels of indirection.
+	topBlock, _, err := fd.getter(
+		ctx, fd.kmd, fd.file.tailPointer(), fd.file, blockRead)
+	if err != nil {
+		return nil, err
+	}
+
+	if !topBlock.IsInd {
+		return nil, nil
+	}
+	blockInfos := make([]BlockInfo, len(topBlock.IPtrs))
+	for i, ptr := range topBlock.IPtrs {
+		blockInfos[i] = ptr.BlockInfo
+	}
+	return blockInfos, nil
+}

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -10,7 +10,7 @@ import (
 )
 
 type fileBlockGetter func(context.Context, KeyMetadata, BlockPointer,
-	path, blockReqType) (*FileBlock, error)
+	path, blockReqType) (fblock *FileBlock, wasDirty bool, err error)
 type dirtyBlockCacher func(ptr BlockPointer, block Block) error
 
 // fileData is a helper struct for accessing and manipulating data
@@ -21,17 +21,19 @@ type fileData struct {
 	uid    keybase1.UID
 	crypto cryptoPure
 	kmd    KeyMetadata
+	bsplit BlockSplitter
 	getter fileBlockGetter
 	cacher dirtyBlockCacher
 }
 
 func newFileData(file path, uid keybase1.UID, crypto cryptoPure,
-	kmd KeyMetadata, getter fileBlockGetter,
+	bsplit BlockSplitter, kmd KeyMetadata, getter fileBlockGetter,
 	cacher dirtyBlockCacher) *fileData {
 	return &fileData{
 		file:   file,
 		uid:    uid,
 		crypto: crypto,
+		bsplit: bsplit,
 		kmd:    kmd,
 		getter: getter,
 		cacher: cacher,
@@ -50,7 +52,8 @@ type parentBlockAndChildIndex struct {
 func (fd *fileData) getFileBlockAtOffset(ctx context.Context,
 	topBlock *FileBlock, off int64, rtype blockReqType) (
 	ptr BlockPointer, parentBlocks []parentBlockAndChildIndex,
-	block *FileBlock, nextBlockStartOff, startOff int64, err error) {
+	block *FileBlock, nextBlockStartOff, startOff int64,
+	wasDirty bool, err error) {
 	// find the block matching the offset, if it exists
 	ptr = fd.file.tailPointer()
 	block = topBlock
@@ -81,13 +84,13 @@ func (fd *fileData) getFileBlockAtOffset(ctx context.Context,
 			nextBlockStartOff = block.IPtrs[nextIndex+1].Off
 		}
 		ptr = nextPtr.BlockPointer
-		block, err = fd.getter(ctx, fd.kmd, ptr, fd.file, rtype)
+		block, wasDirty, err = fd.getter(ctx, fd.kmd, ptr, fd.file, rtype)
 		if err != nil {
-			return zeroPtr, nil, nil, 0, 0, err
+			return zeroPtr, nil, nil, 0, 0, false, err
 		}
 	}
 
-	return ptr, parentBlocks, block, nextBlockStartOff, startOff, nil
+	return ptr, parentBlocks, block, nextBlockStartOff, startOff, wasDirty, nil
 }
 
 // createIndirectBlock creates a new indirect block and pick a new id
@@ -171,4 +174,154 @@ func (fd *fileData) newRightBlock(
 		return err
 	}
 	return nil
+}
+
+// write sets the given data and the given offset within the file,
+// making new blocks and new levels of indirection as needed. Return
+// params:
+// * newDe: a new directory entry with the EncodedSize cleared if the file
+//   was extended.
+// * dirtyPtrs: a slice of the BlockPointers that have been dirtied during
+//   the write.
+// * unrefs: a slice of BlockInfos that must be unreferenced as part of an
+//   eventual sync of this write.  May be non-nil even if err != nil.
+// * newlyDirtiedChildBytes is the total amount of block data dirtied by this
+//   write, including the entire size of blocks that have had at least one
+//   byte dirtied.  As above, it may be non-zero even if err != nil.
+// * bytesExtended is the number of bytes the length of the file has been
+//   extended as part of this write.
+func (fd *fileData) write(ctx context.Context, data []byte, off int64,
+	topBlock *FileBlock, oldDe DirEntry, df *dirtyFile) (
+	newDe DirEntry, dirtyPtrs []BlockPointer, unrefs []BlockInfo,
+	newlyDirtiedChildBytes int64, bytesExtended int64, err error) {
+	n := int64(len(data))
+	nCopied := int64(0)
+	oldSizeWithoutHoles := oldDe.Size
+	newDe = oldDe
+
+	for nCopied < n {
+		ptr, parentBlocks, block, nextBlockOff, startOff, wasDirty, err :=
+			fd.getFileBlockAtOffset(ctx, topBlock, off+nCopied, blockWrite)
+		if err != nil {
+			return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+		}
+
+		oldLen := len(block.Contents)
+
+		// Take care not to write past the beginning of the next block
+		// by using max.
+		max := len(data)
+		if nextBlockOff > 0 {
+			if room := int(nextBlockOff - off); room < max {
+				max = room
+			}
+		}
+		oldNCopied := nCopied
+		nCopied += fd.bsplit.CopyUntilSplit(
+			block, nextBlockOff < 0, data[nCopied:max], off+nCopied-startOff)
+
+		// TODO: support multiple levels of indirection.  Right now the
+		// code only does one but it should be straightforward to
+		// generalize, just annoying
+
+		// if we need another block but there are no more, then make one
+		switchToIndirect := false
+		if nCopied < n && nextBlockOff < 0 {
+			// If the block doesn't already have a parent block, make one.
+			if ptr == fd.file.tailPointer() {
+				topBlock, err = fd.createIndirectBlock(
+					df, DefaultNewBlockDataVersion(false))
+				if err != nil {
+					return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+				}
+				ptr = topBlock.IPtrs[0].BlockPointer
+				// The whole block needs to be re-uploaded as an
+				// indirect block, so track those dirty bytes and
+				// cache the block as dirty.
+				switchToIndirect = true
+			}
+
+			// Make a new right block and update the parent's
+			// indirect block list
+			err = fd.newRightBlock(ctx, fd.file.tailPointer(), topBlock,
+				startOff+int64(len(block.Contents)))
+			if err != nil {
+				return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+			}
+		} else if nCopied < n && off+nCopied < nextBlockOff {
+			// We need a new block to be inserted here
+			err = fd.newRightBlock(ctx, fd.file.tailPointer(), topBlock,
+				startOff+int64(len(block.Contents)))
+			if err != nil {
+				return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+			}
+			// And push the indirect pointers to right
+			newb := topBlock.IPtrs[len(topBlock.IPtrs)-1]
+			indexInParent := parentBlocks[0].childIndex
+			copy(topBlock.IPtrs[indexInParent+2:],
+				topBlock.IPtrs[indexInParent+1:])
+			topBlock.IPtrs[indexInParent+1] = newb
+			if oldSizeWithoutHoles == oldDe.Size {
+				// For the purposes of calculating the newly-dirtied
+				// bytes for the deferral calculation, disregard the
+				// existing "hole" in the file.
+				oldSizeWithoutHoles = uint64(newb.Off)
+			}
+		}
+
+		// Nothing was copied, no need to dirty anything.  This can
+		// happen when trying to append to the contents of the file
+		// (i.e., either to the end of the file or right before the
+		// "hole"), and the last block is already full.
+		if nCopied == oldNCopied && !switchToIndirect {
+			continue
+		}
+
+		// Only in the last block does the file size grow.
+		if oldLen != len(block.Contents) && nextBlockOff < 0 {
+			newDe.EncodedSize = 0
+			// update the file info
+			newDe.Size += uint64(len(block.Contents) - oldLen)
+		}
+
+		// Calculate the amount of bytes we've newly-dirtied as part
+		// of this write.
+		newlyDirtiedChildBytes += int64(len(block.Contents))
+		if wasDirty {
+			newlyDirtiedChildBytes -= int64(oldLen)
+		}
+
+		for _, pb := range parentBlocks {
+			// Remember how many bytes it was.
+			unrefs = append(unrefs, pb.pblock.IPtrs[pb.childIndex].BlockInfo)
+			pb.pblock.IPtrs[pb.childIndex].EncodedSize = 0
+		}
+
+		// keep the old block ID while it's dirty
+		if err = fd.cacher(ptr, block); err != nil {
+			return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+		}
+		dirtyPtrs = append(dirtyPtrs, ptr)
+	}
+
+	if topBlock.IsInd {
+		// Always make the top block dirty, so we will sync its
+		// indirect blocks.  This has the added benefit of ensuring
+		// that any write to a file while it's being sync'd will be
+		// deferred, even if it's to a block that's not currently
+		// being sync'd, since this top-most block will always be in
+		// the dirtyFiles map.
+		if err = fd.cacher(fd.file.tailPointer(), topBlock); err != nil {
+			return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+		}
+		dirtyPtrs = append(dirtyPtrs, fd.file.tailPointer())
+	}
+
+	lastByteWritten := off + int64(len(data)) // not counting holes
+	bytesExtended = 0
+	if lastByteWritten > int64(oldSizeWithoutHoles) {
+		bytesExtended = lastByteWritten - int64(oldSizeWithoutHoles)
+	}
+
+	return newDe, dirtyPtrs, unrefs, newlyDirtiedChildBytes, bytesExtended, nil
 }

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -654,3 +654,20 @@ func (fd *fileData) getIndirectFileBlockInfos(ctx context.Context) (
 	}
 	return blockInfos, nil
 }
+
+// findIPtrsAndClearSize looks for the given indirect pointer, and
+// returns whether it could be found.  As a side effect, it also
+// clears the encoded size for that indirect pointer.
+func (fd *fileData) findIPtrsAndClearSize(topBlock *FileBlock,
+	ptr BlockPointer) (found bool) {
+	// TODO: handle multiple levels of indirection.  To make that
+	// efficient, we may need to pass in more information about which
+	// internal indirect pointers may have dirty child blocks.
+	for i, iptr := range topBlock.IPtrs {
+		if iptr.BlockPointer == ptr {
+			topBlock.IPtrs[i].EncodedSize = 0
+			return true
+		}
+	}
+	return false
+}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1132,7 +1132,8 @@ func ResetRootBlock(ctx context.Context, config Config,
 	Block, BlockInfo, ReadyBlockData, error) {
 	newDblock := NewDirBlock()
 	info, plainSize, readyBlockData, err :=
-		ReadyBlock(ctx, config, rmd.ReadOnly(), newDblock, currentUID)
+		ReadyBlock(ctx, config.BlockCache(), config.BlockOps(), config.Crypto(),
+			rmd.ReadOnly(), newDblock, currentUID)
 	if err != nil {
 		return nil, BlockInfo{}, ReadyBlockData{}, err
 	}
@@ -1733,7 +1734,8 @@ func (fbo *folderBranchOps) readyBlockMultiple(ctx context.Context,
 	kmd KeyMetadata, currBlock Block, uid keybase1.UID,
 	bps *blockPutState) (info BlockInfo, plainSize int, err error) {
 	info, plainSize, readyBlockData, err :=
-		ReadyBlock(ctx, fbo.config, kmd, currBlock, uid)
+		ReadyBlock(ctx, fbo.config.BlockCache(), fbo.config.BlockOps(),
+			fbo.config.Crypto(), kmd, currBlock, uid)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This is just a refactor that moves everything related to indirect pointers out of `folderBlockOps` and into `fileData`.  There shouldn't be any behavioral changes.  This is in preparation for multiple levels of indirection, and by moving everything into one place, it'll make that easier to write and unit test.

Note there's a bit of weirdness below in that sometimes the `fileData` methods return data even when `err != nil`, and that data is used by the caller.  This is to preserve existing behavior in `folderBlockOps` whenever possible.  It's possible we might be able to eliminate some of these cases in the future but I didn't want to change behavior in this PR.

Issue: KBFS-35