### PR TITLE
kbfs_ops_concur_test: unskip test

### DIFF
--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1794,8 +1794,6 @@ func (booq *blockOpsOverQuota) Put(ctx context.Context, tlfID tlf.ID,
 // Test that a quota error causes deferred writes to error.
 // Regression test for KBFS-751.
 func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
-	t.Skip("Broken pending KBFS-1261")
-
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 


### PR DESCRIPTION
KBFS-1261 was closed long ago and this test works now.