### PR TITLE
folder_block_ops: do lookups while holding blockLock

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1568,31 +1568,9 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 			return err
 		}
 
-		dirPath, err := fbo.pathFromNodeForRead(dir)
+		node, de, err = fbo.blocks.Lookup(ctx, lState, md.ReadOnly(), dir, name)
 		if err != nil {
 			return err
-		}
-
-		childPath := dirPath.ChildPathNoPtr(name)
-
-		de, err = fbo.blocks.GetDirtyEntry(
-			ctx, lState, md.ReadOnly(), childPath)
-		if err != nil {
-			return err
-		}
-
-		if de.Type == Sym {
-			node = nil
-		} else {
-			err = fbo.blocks.checkDataVersion(childPath, de.BlockPointer)
-			if err != nil {
-				return err
-			}
-
-			node, err = fbo.nodeCache.GetOrCreate(de.BlockPointer, name, dir)
-			if err != nil {
-				return err
-			}
 		}
 		return nil
 	})


### PR DESCRIPTION
Otherwise there can be a race where the lookup gets the path, and then
we hear about a change for that child node.  But since the child isn't
in the node cache yet, the change doesn't update the pointer.  Then
the lookup makes a new node for the child using the old pointer, and
the node never gets updated by subsequent changes.

Note that the new test, as is, won't repro the original problem
exactly, because it depends on locking behavior.  The first version of
the test I wrote does repro the problem, but due to different locking
behavior it would hang now.  The test is probably useful on its own
though, to make sure a concurrent Lookup and Sync work correctly.

Issue: KBFS-1717