### PR TITLE
file_data: use for block changes, and supporting multiple levels of indirection in reads

### DIFF
--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -23,6 +23,11 @@ type IndirectDirPtr struct {
 
 // IndirectFilePtr pairs an indirect file block with the start of that
 // block's range of bytes (inclusive)
+//
+// If `Holes` is true, then this pointer is part of a list of pointers
+// that has non-continuous offsets; that is, the offset of ptr `i`
+// plus the length of the corresponding block contents is less than
+// the offset of ptr `i`+1.
 type IndirectFilePtr struct {
 	// When the EncodedSize field is non-zero, the block must not
 	// be dirty.

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -176,6 +176,14 @@ func NewDirtyBlockCacheStandard(clock Clock,
 	return d
 }
 
+// simpleDirtyBlockCacheStandard that can only handle block
+// put/get/delete requests; it cannot track dirty bytes.
+func simpleDirtyBlockCacheStandard() *DirtyBlockCacheStandard {
+	return &DirtyBlockCacheStandard{
+		cache: make(map[dirtyBlockID]Block),
+	}
+}
+
 // Get implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
 func (d *DirtyBlockCacheStandard) Get(_ tlf.ID, ptr BlockPointer,

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -137,7 +137,7 @@ func (fd *fileData) getFileBlockAtOffset(ctx context.Context,
 //     in the given range of offsets.
 //   * nextBlockOff is the offset of the block that follows the last
 //     block given in `pathsFromRoot`.  If `pathsFromRoot` contains
-//     the largest block among the children, nextBlockOff is -1.
+//     the last block among the children, nextBlockOff is -1.
 func (fd *fileData) getLeafBlocksForOffsetRange(ctx context.Context,
 	pblock *FileBlock, startOff int64, endOff int64,
 	prefixOk bool) (pathsFromRoot [][]parentBlockAndChildIndex,
@@ -259,7 +259,7 @@ outer:
 }
 
 // getByteSlicesInOffsetRange returns an ordered, continuous slice of
-// byte ranges for the data described by the half-inclusve offset
+// byte ranges for the data described by the half-inclusive offset
 // range `[startOff, endOff)`.  If `endOff` == -1, it returns data to
 // the end of the file.  The caller is responsible for concatenating
 // the data into a single buffer if desired. If `prefixOk` is true,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1774,11 +1774,6 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		}
 		return fblock, true, nil
 	}
-	goGetter := func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
-		p path) (*FileBlock, error) {
-		block, _, err := getter(ctx, kmd, ptr, p, blockRead)
-		return block, err
-	}
 	cacher := func(ptr BlockPointer, block Block) error {
 		return dirtyBcache.Put(fbo.id(), ptr, fbo.branch(), block)
 	}
@@ -1790,8 +1785,7 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 
 	df := newDirtyFile(file, dirtyBcache)
 	fd := newFileData(file, uid, fbo.config.Crypto(),
-		fbo.config.BlockSplitter(), md.ReadOnly(),
-		getter, goGetter, cacher, fbo.log)
+		fbo.config.BlockSplitter(), md.ReadOnly(), getter, cacher, fbo.log)
 
 	// Write all the data.
 	_, _, _, _, _, err = fd.write(ctx, buf, 0, block, DirEntry{}, df)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1755,7 +1755,8 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 			RefNonce: ZeroBlockRefNonce,
 		},
 	}
-	file := path{fbo.folderBranch, []pathNode{{ptr, ""}}}
+	file := path{fbo.folderBranch,
+		[]pathNode{{ptr, fmt.Sprintf("<MD rev %d>", md.Revision())}}}
 
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	// Simple dirty bcaches don't need to be shut down.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1773,6 +1773,11 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		}
 		return fblock, true, nil
 	}
+	goGetter := func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
+		p path) (*FileBlock, error) {
+		block, _, err := getter(ctx, kmd, ptr, p, blockRead)
+		return block, err
+	}
 	cacher := func(ptr BlockPointer, block Block) error {
 		return dirtyBcache.Put(fbo.id(), ptr, fbo.branch(), block)
 	}
@@ -1785,7 +1790,7 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 	df := newDirtyFile(file, dirtyBcache)
 	fd := newFileData(file, uid, fbo.config.Crypto(),
 		fbo.config.BlockSplitter(), md.ReadOnly(),
-		getter, cacher, fbo.log)
+		getter, goGetter, cacher, fbo.log)
 
 	// Write all the data.
 	_, _, _, _, _, err = fd.write(ctx, buf, 0, block, DirEntry{}, df)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1739,60 +1739,92 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		return err
 	}
 
+	// Treat the block change list as a file so we can reuse all the
+	// indirection code in fileData.
 	block := NewFileBlock().(*FileBlock)
-	copied := fbo.config.BlockSplitter().CopyUntilSplit(block, false, buf, 0)
-	info, _, err := fbo.readyBlockMultiple(ctx, md.ReadOnly(), block, uid, bps)
+	bid, err := fbo.config.Crypto().MakeTemporaryBlockID()
 	if err != nil {
 		return err
 	}
-	md.AddRefBytes(uint64(info.EncodedSize))
-	md.AddDiskUsage(uint64(info.EncodedSize))
+	ptr := BlockPointer{
+		ID:      bid,
+		KeyGen:  md.LatestKeyGeneration(),
+		DataVer: fbo.config.DataVersion(),
+		BlockContext: BlockContext{
+			Creator:  uid,
+			RefNonce: ZeroBlockRefNonce,
+		},
+	}
+	file := path{fbo.folderBranch, []pathNode{{ptr, ""}}}
 
-	// Everything fits in one block.
-	toCopy := int64(len(buf))
-	if copied >= toCopy {
-		changes.Info = info
-		md.data.cachedChanges = *changes
-		changes.Ops = nil
-		return nil
+	dirtyBcache := simpleDirtyBlockCacheStandard()
+	// Simple dirty bcaches don't need to be shut down.
+
+	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
+		_ path, _ blockReqType) (*FileBlock, bool, error) {
+		block, err := dirtyBcache.Get(fbo.id(), ptr, fbo.branch())
+		if err != nil {
+			return nil, false, err
+		}
+		fblock, ok := block.(*FileBlock)
+		if !ok {
+			return nil, false,
+				fmt.Errorf("Block for %s is not a file block", ptr)
+		}
+		return fblock, true, nil
+	}
+	cacher := func(ptr BlockPointer, block Block) error {
+		return dirtyBcache.Put(fbo.id(), ptr, fbo.branch(), block)
+	}
+	// Start off the cache with the new block
+	err = cacher(ptr, block)
+	if err != nil {
+		return err
 	}
 
-	// Otherwise make a top block and split up the remaining buffer.
-	topBlock := NewFileBlock().(*FileBlock)
-	topBlock.IsInd = true
-	topBlock.IPtrs = append(topBlock.IPtrs, IndirectFilePtr{
-		BlockInfo: info,
-		Off:       0,
-	})
-	copiedSize := copied
-	for copiedSize < toCopy {
-		block := NewFileBlock().(*FileBlock)
-		currOff := copiedSize
-		copied := fbo.config.BlockSplitter().CopyUntilSplit(block, false,
-			buf[currOff:], 0)
-		copiedSize += copied
-		info, _, err := fbo.readyBlockMultiple(
-			ctx, md.ReadOnly(), block, uid, bps)
-		if err != nil {
-			return err
-		}
+	df := newDirtyFile(file, dirtyBcache)
+	fd := newFileData(file, uid, fbo.config.Crypto(),
+		fbo.config.BlockSplitter(), md.ReadOnly(),
+		getter, cacher, fbo.log)
 
-		topBlock.IPtrs = append(topBlock.IPtrs, IndirectFilePtr{
-			BlockInfo: info,
-			Off:       currOff,
-		})
+	// Write all the data.
+	_, _, _, _, _, err = fd.write(ctx, buf, 0, block, DirEntry{}, df)
+	if err != nil {
+		return err
+	}
+
+	// There might be a new top block.
+	topBlock, err := dirtyBcache.Get(fbo.id(), ptr, fbo.branch())
+	if err != nil {
+		return err
+	}
+	block, ok := topBlock.(*FileBlock)
+	if !ok {
+		return errors.New("Top block change block no longer a file block")
+	}
+
+	// Ready all the child blocks.
+	infos, err := fd.ready(ctx, fbo.id(), fbo.config.BlockCache(),
+		dirtyBcache, fbo.config.BlockOps(), bps, block, df)
+	if err != nil {
+		return err
+	}
+	for info := range infos {
 		md.AddRefBytes(uint64(info.EncodedSize))
 		md.AddDiskUsage(uint64(info.EncodedSize))
 	}
+	fbo.log.CDebugf(ctx, "%d unembedded child blocks", len(infos))
 
-	info, _, err = fbo.readyBlockMultiple(
-		ctx, md.ReadOnly(), topBlock, uid, bps)
+	// Ready the top block.
+	info, _, err := fbo.readyBlockMultiple(
+		ctx, md.ReadOnly(), block, uid, bps)
 	if err != nil {
 		return err
 	}
-	changes.Info = info
+
 	md.AddRefBytes(uint64(info.EncodedSize))
 	md.AddDiskUsage(uint64(info.EncodedSize))
+	changes.Info = info
 	md.data.cachedChanges = *changes
 	changes.Ops = nil
 	return nil

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -55,7 +55,7 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	config := j.jServer.config
 	pmd, err := decryptMDPrivateData(ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(), config.KeyManager(),
-		uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd)
+		uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.jServer.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5112,6 +5112,8 @@ func TestSyncDirtyWithBlockChangePointerSuccess(t *testing.T) {
 	changeReadyBlockData := ReadyBlockData{
 		buf: changeBuf,
 	}
+	tempBCID := fakeBlockID(252)
+	config.mockCrypto.EXPECT().MakeTemporaryBlockID().Return(tempBCID, nil)
 	_ = config.mockBops.EXPECT().Ready(gomock.Any(), kmdMatcher{rmd},
 		gomock.Any()).Return(changeBlockID, changePlainSize,
 		changeReadyBlockData, nil).After(lastCall)

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -667,7 +667,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		pmd, err := decryptMDPrivateData(
 			ctx, km.config.Codec(), km.config.Crypto(),
 			km.config.BlockCache(), km.config.BlockOps(),
-			km, uid, md.GetSerializedPrivateMetadata(), md, md)
+			km, uid, md.GetSerializedPrivateMetadata(), md, md, km.log)
 		if err != nil {
 			return false, nil, err
 		}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -220,7 +220,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 		ctx, md.config.Codec(), md.config.Crypto(),
 		md.config.BlockCache(), md.config.BlockOps(),
 		md.config.KeyManager(), uid, rmd.GetSerializedPrivateMetadata(),
-		rmd, rmd)
+		rmd, rmd, md.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -419,10 +419,6 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 		}
 		return block, false, nil
 	}
-	goGetter := func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
-		p path) (*FileBlock, error) {
-		return getFileBlockForMD(ctx, bcache, bops, ptr, tlfID, kmd)
-	}
 	cacher := func(ptr BlockPointer, block Block) error {
 		return nil
 	}
@@ -430,8 +426,7 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	// just pass in nil.  Also, reading doesn't depend on the UID, so
 	// it's ok to be empty.
 	var uid keybase1.UID
-	fd := newFileData(file, uid, nil, nil, rmdWithKeys, getter, goGetter,
-		cacher, log)
+	fd := newFileData(file, uid, nil, nil, rmdWithKeys, getter, cacher, log)
 
 	buf, err := fd.getBytes(ctx, 0, -1)
 	if err != nil {

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
-	"golang.org/x/sync/errgroup"
 
 	"golang.org/x/net/context"
 )
@@ -236,7 +236,7 @@ func getMergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 				config.BlockCache(), config.BlockOps(),
 				config.KeyManager(), uid,
 				rmd.GetSerializedPrivateMetadata(),
-				rmd, latestRmd)
+				rmd, latestRmd, config.MakeLogger(""))
 			if err != nil {
 				return nil, err
 			}
@@ -399,88 +399,57 @@ func getFileBlockForMD(ctx context.Context, bcache BlockCache, bops BlockOps,
 
 func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	bcache BlockCache, bops BlockOps, tlfID tlf.ID, pmd *PrivateMetadata,
-	rmdWithKeys KeyMetadata) error {
+	rmdWithKeys KeyMetadata, log logger.Logger) error {
 	info := pmd.Changes.Info
 	if info.BlockPointer == zeroPtr {
 		return nil
 	}
 
-	// Fetch the top-level block.
-	fblock, err := getFileBlockForMD(
-		ctx, bcache, bops, info.BlockPointer, tlfID, rmdWithKeys)
+	// Treat the unembedded block change like a file so we can reuse
+	// the file reading code.
+	file := path{FolderBranch{tlfID, MasterBranch},
+		[]pathNode{{info.BlockPointer, ""}}}
+	getter := func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
+		p path, rtype blockReqType) (*FileBlock, bool, error) {
+		block, err := getFileBlockForMD(ctx, bcache, bops, ptr, tlfID, kmd)
+		if err != nil {
+			return nil, false, err
+		}
+		return block, false, nil
+	}
+	goGetter := func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
+		p path) (*FileBlock, error) {
+		return getFileBlockForMD(ctx, bcache, bops, ptr, tlfID, kmd)
+	}
+	cacher := func(ptr BlockPointer, block Block) error {
+		return nil
+	}
+	var uid keybase1.UID
+	// Reading doesn't use crypto or the block splitter, so for now
+	// just pass in nil.
+	fd := newFileData(file, uid, nil, nil, rmdWithKeys, getter, goGetter,
+		cacher, log)
+
+	buf, err := fd.getBytes(ctx, 0, -1)
 	if err != nil {
 		return err
-	}
-
-	buf := fblock.Contents
-	if fblock.IsInd {
-		numFetchers := len(fblock.IPtrs)
-		if numFetchers > maxParallelBlockGets {
-			numFetchers = maxParallelBlockGets
-		}
-
-		type iptrAndBlock struct {
-			ptr   IndirectFilePtr
-			block *FileBlock
-		}
-
-		// Fetch all the child blocks in parallel.
-		iptrsToFetch := make(chan IndirectFilePtr, len(fblock.IPtrs))
-		indirectBlocks := make(chan iptrAndBlock, len(fblock.IPtrs))
-		eg, groupCtx := errgroup.WithContext(ctx)
-		fetchFn := func() error {
-			for iptr := range iptrsToFetch {
-				select {
-				case <-groupCtx.Done():
-					return groupCtx.Err()
-				default:
-				}
-
-				fblock, err := getFileBlockForMD(groupCtx, bcache, bops,
-					iptr.BlockPointer, tlfID, rmdWithKeys)
-				if err != nil {
-					return err
-				}
-
-				indirectBlocks <- iptrAndBlock{iptr, fblock}
-			}
-			return nil
-		}
-		for i := 0; i < numFetchers; i++ {
-			eg.Go(fetchFn)
-		}
-		for _, iptr := range fblock.IPtrs {
-			iptrsToFetch <- iptr
-		}
-		close(iptrsToFetch)
-		if err := eg.Wait(); err != nil {
-			return err
-		}
-		close(indirectBlocks)
-
-		// Reconstruct the buffer by appending bytes in order of offset.
-		blocks := make(map[int64]*FileBlock)
-		for iab := range indirectBlocks {
-			blocks[iab.ptr.Off] = iab.block
-		}
-		lastOff := fblock.IPtrs[len(fblock.IPtrs)-1].Off
-		buf = make([]byte, lastOff+int64(len(blocks[lastOff].Contents)))
-		for _, iptr := range fblock.IPtrs {
-			block := blocks[iptr.Off]
-			blockSize := int64(len(block.Contents))
-			copy(buf[iptr.Off:iptr.Off+blockSize], block.Contents)
-		}
 	}
 
 	err = codec.Decode(buf, &pmd.Changes)
 	if err != nil {
 		return err
 	}
+
 	// The changes block pointers are implicit ref blocks.
 	pmd.Changes.Ops[0].AddRefBlock(info.BlockPointer)
-	for _, iptr := range fblock.IPtrs {
+	iptrs, err := fd.getIndirectFileBlockInfos(ctx)
+	if err != nil {
+		return err
+	}
+	for _, iptr := range iptrs {
 		pmd.Changes.Ops[0].AddRefBlock(iptr.BlockPointer)
 	}
+
 	pmd.cachedChanges.Info = info
 	return nil
 }
@@ -490,7 +459,8 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 	crypto Crypto, bcache BlockCache, bops BlockOps,
 	keyGetter mdDecryptionKeyGetter, uid keybase1.UID,
 	serializedPrivateMetadata []byte,
-	rmdToDecrypt, rmdWithKeys KeyMetadata) (PrivateMetadata, error) {
+	rmdToDecrypt, rmdWithKeys KeyMetadata, log logger.Logger) (
+	PrivateMetadata, error) {
 	handle := rmdToDecrypt.GetTlfHandle()
 
 	var pmd PrivateMetadata
@@ -533,7 +503,7 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 	// Re-embed the block changes if it's needed.
 	err := reembedBlockChanges(
 		ctx, codec, bcache, bops, rmdWithKeys.TlfID(),
-		&pmd, rmdWithKeys)
+		&pmd, rmdWithKeys, log)
 	if err != nil {
 		return PrivateMetadata{}, err
 	}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -408,7 +408,9 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	// Treat the unembedded block change like a file so we can reuse
 	// the file reading code.
 	file := path{FolderBranch{tlfID, MasterBranch},
-		[]pathNode{{info.BlockPointer, ""}}}
+		[]pathNode{{
+			info.BlockPointer, fmt.Sprintf("<MD with block change pointer %s>",
+				info.BlockPointer)}}}
 	getter := func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
 		p path, rtype blockReqType) (*FileBlock, bool, error) {
 		block, err := getFileBlockForMD(ctx, bcache, bops, ptr, tlfID, kmd)
@@ -424,9 +426,10 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	cacher := func(ptr BlockPointer, block Block) error {
 		return nil
 	}
-	var uid keybase1.UID
 	// Reading doesn't use crypto or the block splitter, so for now
-	// just pass in nil.
+	// just pass in nil.  Also, reading doesn't depend on the UID, so
+	// it's ok to be empty.
+	var uid keybase1.UID
 	fd := newFileData(file, uid, nil, nil, rmdWithKeys, getter, goGetter,
 		cacher, log)
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1060,7 +1060,7 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 			ctx, j.config.Codec(), j.config.Crypto(),
 			j.config.BlockCache(), j.config.BlockOps(),
 			j.config.mdDecryptionKeyGetter(), j.uid,
-			rmd.GetSerializedPrivateMetadata(), rmd, rmd)
+			rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.log)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR was to moves all of the unembedded block change work into `fileData`, for both creation and reading.

While I was working on reading data, I took the opportunity to combine the block change reads with the  `folderBlockOps.Read()` functionality, moved it all into `fileData`, and updated it to a) support multiple levels of indirection, and b) fetch blocks in parallel.

I plan to add a whole slew of `fileData` unit tests in a separate PR once it supports multiple levels of indirection everywhere.  For now, I think the existing tests cover it pretty well.

Issue: KBFS-35