### PR TITLE
TLF reidentification when needed related to rekey

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3771,7 +3771,11 @@ outer:
 		return err
 	}
 
-	handle := cr.fbo.getTrustedHead(lState).GetTlfHandle()
+	head := cr.fbo.getTrustedHead(lState)
+	if head == (ImmutableRootMetadata{}) {
+		panic("maybeUnstageAfterFailure: head is nil (should be impossible)")
+	}
+	handle := head.GetTlfHandle()
 	cr.config.Reporter().ReportErr(ctx,
 		handle.GetCanonicalName(), handle.IsPublic(),
 		WriteMode, reportedError)
@@ -3795,7 +3799,11 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	defer func() {
 		cr.log.CDebugf(ctx, "Finished conflict resolution: %v", err)
 		if err != nil {
-			handle := cr.fbo.getTrustedHead(lState).GetTlfHandle()
+			head := cr.fbo.getTrustedHead(lState)
+			if head == (ImmutableRootMetadata{}) {
+				panic("doResolve: head is nil (should be impossible)")
+			}
+			handle := head.GetTlfHandle()
 			cr.config.Reporter().ReportErr(ctx,
 				handle.GetCanonicalName(), handle.IsPublic(),
 				WriteMode, CRWrapError{err})

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3771,7 +3771,7 @@ outer:
 		return err
 	}
 
-	handle := cr.fbo.getHead(lState).GetTlfHandle()
+	handle := cr.fbo.getTrustedHead(lState).GetTlfHandle()
 	cr.config.Reporter().ReportErr(ctx,
 		handle.GetCanonicalName(), handle.IsPublic(),
 		WriteMode, reportedError)
@@ -3795,7 +3795,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	defer func() {
 		cr.log.CDebugf(ctx, "Finished conflict resolution: %v", err)
 		if err != nil {
-			handle := cr.fbo.getHead(lState).GetTlfHandle()
+			handle := cr.fbo.getTrustedHead(lState).GetTlfHandle()
 			cr.config.Reporter().ReportErr(ctx,
 				handle.GetCanonicalName(), handle.IsPublic(),
 				WriteMode, CRWrapError{err})

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -115,7 +115,7 @@ func TestCRInput(t *testing.T) {
 	mergedHead := MetadataRevision(15)
 
 	cr.fbo.head = crMakeFakeRMD(unmergedHead, cr.fbo.bid)
-	cr.fbo.headTrusted = true
+	cr.fbo.headStatus = headTrusted
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -171,7 +171,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 	mergedHead := MetadataRevision(15)
 
 	cr.fbo.head = crMakeFakeRMD(unmergedHead, cr.fbo.bid)
-	cr.fbo.headTrusted = true
+	cr.fbo.headStatus = headTrusted
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -115,6 +115,7 @@ func TestCRInput(t *testing.T) {
 	mergedHead := MetadataRevision(15)
 
 	cr.fbo.head = crMakeFakeRMD(unmergedHead, cr.fbo.bid)
+	cr.fbo.headTrusted = true
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
@@ -170,6 +171,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 	mergedHead := MetadataRevision(15)
 
 	cr.fbo.head = crMakeFakeRMD(unmergedHead, cr.fbo.bid)
+	cr.fbo.headTrusted = true
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -171,9 +171,8 @@ func (bl *blockLock) DoRUnlockedIfPossible(lState *lockState, f func(*lockState)
 }
 
 // headTrustStatus marks whether the head is from a trusted or
-// untrusted source. When rekeying we get the fbo by folder
-// id and do not check the tlf id, thus resulting in untrusted
-// fbo heads.
+// untrusted source. When rekeying we get the head MD by folder id
+// and do not check the tlf handle
 type headTrustStatus int
 
 const (
@@ -515,7 +514,7 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 }
 
 // getTrustedHead should not be called outside of folder_branch_ops.go.
-// Returns  ImmutableRootMetadata{} when the head is not trusted.
+// Returns ImmutableRootMetadata{} when the head is not trusted.
 // See the comment on headTrustedStatus for more information.
 func (fbo *folderBranchOps) getTrustedHead(lState *lockState) ImmutableRootMetadata {
 	fbo.headLock.RLock(lState)
@@ -945,7 +944,7 @@ func (fbo *folderBranchOps) identifyOnce(
 	return nil
 }
 
-// getMDForReadLocked returns an existing md for read
+// getMDForReadLocked returns an existing md for a read
 // operation. Note that mds will not be fetched here.
 func (fbo *folderBranchOps) getMDForReadLocked(
 	ctx context.Context, lState *lockState, rtype mdReadType) (
@@ -1029,7 +1028,7 @@ func (fbo *folderBranchOps) getMDForWriteOrRekeyLocked(
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-	var headStatus = headTrusted
+	headStatus := headTrusted
 	if mdType == mdRekey {
 		headStatus = headUntrusted
 	}
@@ -5722,7 +5721,7 @@ func (fbo *folderBranchOps) ClearPrivateFolderMD(ctx context.Context) {
 	}
 
 	fbo.head = ImmutableRootMetadata{}
-	fbo.headStatus = headTrusted
+	fbo.headStatus = headUntrusted
 	fbo.latestMergedRevision = MetadataRevisionUninitialized
 	fbo.hasBeenCleared = true
 }

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -623,7 +623,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 		t.Errorf("Couldn't sync: %v", syncErr)
 	}
 
-	md, err := fbo.getMDLocked(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		t.Errorf("Couldn't get MD: %v", err)
 	}
@@ -712,7 +712,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 		t.Fatalf("Timeout waiting for sync: %v", ctx.Err())
 	}
 
-	md, err := fbo.getMDLocked(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		t.Errorf("Couldn't get MD: %v", err)
 	}

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -623,7 +623,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 		t.Errorf("Couldn't sync: %v", syncErr)
 	}
 
-	md, err := fbo.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		t.Errorf("Couldn't get MD: %v", err)
 	}
@@ -712,7 +712,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 		t.Fatalf("Timeout waiting for sync: %v", ctx.Err())
 	}
 
-	md, err := fbo.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		t.Errorf("Couldn't get MD: %v", err)
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -390,7 +390,7 @@ func TestKBFSOpsGetRootNodeCacheSuccess(t *testing.T) {
 
 	// Trigger identify.
 	lState := makeFBOLockState()
-	_, err = ops.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
+	_, err = ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 }
@@ -419,7 +419,7 @@ func TestKBFSOpsGetRootNodeReIdentify(t *testing.T) {
 
 	// Trigger identify.
 	lState := makeFBOLockState()
-	_, err = ops.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
+	_, err = ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 
@@ -433,7 +433,7 @@ func TestKBFSOpsGetRootNodeReIdentify(t *testing.T) {
 
 	// Trigger new identify.
 	lState = makeFBOLockState()
-	_, err = ops.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
+	_, err = ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 }
@@ -470,7 +470,7 @@ func TestKBFSOpsGetRootNodeCacheIdentifyFail(t *testing.T) {
 
 	// Trigger identify.
 	lState := makeFBOLockState()
-	_, err := ops.getMDLockedForRead(ctx, lState, mdReadNeedIdentify)
+	_, err := ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
 	assert.Equal(t, expectedErr, err)
 	assert.False(t, fboIdentityDone(ops))
 }

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5627,6 +5627,9 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 	require.IsType(t, MDPrevRootMismatch{}, err)
 }
 
+// TODO: Test malicious mdserver and rekey flow against wrong
+// TLFs being introduced upon rekey.
+
 // Test that if GetTLFCryptKeys fails to create a TLF, the second
 // attempt will also fail with the same error.  Regression test for
 // KBFS-1929.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -357,7 +357,7 @@ func injectNewRMD(t *testing.T, config *ConfigMock) (
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(
 		t, config, rmd, fakeMdID(tlf.FakeIDByte(id)))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 	rmd.SetSerializedPrivateMetadata(make([]byte, 1))
 	config.Notifier().RegisterForChanges(
 		[]FolderBranch{{id, MasterBranch}}, config.observer)
@@ -593,7 +593,7 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 	assert.False(t, fboIdentityDone(ops))
 
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(2))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 	n, ei, err :=
 		config.KBFSOps().GetOrCreateRootNode(ctx, h, MasterBranch)
 	require.NoError(t, err)
@@ -775,7 +775,7 @@ func TestKBFSOpsGetBaseDirChildrenUncachedFailNonReader(t *testing.T) {
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, p)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 	expectedErr := NewReadAccessError(h, "alice", "/keybase/private/bob#alice")
 	if _, err := config.KBFSOps().GetDirChildren(ctx, n); err == nil {
 		t.Errorf("Got no expected error on getdir")
@@ -819,7 +819,7 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 
@@ -863,7 +863,7 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 
@@ -908,7 +908,7 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 	rootID := kbfsblock.FakeID(42)
@@ -948,7 +948,7 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 	rootID := kbfsblock.FakeID(42)
@@ -985,7 +985,7 @@ func TestKBFSOpsLookupNewDataVersionFail(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 	rootID := kbfsblock.FakeID(42)
@@ -1028,7 +1028,7 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 	rootID := kbfsblock.FakeID(42)
@@ -5166,7 +5166,7 @@ func TestKBFSOpsStatRootSuccess(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 	rootID := kbfsblock.FakeID(42)
@@ -5188,7 +5188,7 @@ func TestKBFSOpsFailingRootOps(t *testing.T) {
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(t, config, rmd, fakeMdID(1))
-	ops.headTrusted = true
+	ops.headStatus = headTrusted
 
 	u := h.FirstResolvedWriter()
 	rootID := kbfsblock.FakeID(42)


### PR DESCRIPTION
Rekey ends up calling getMDLocked and thus we add an identity if we didn't have the md already locally in memory.