### PR TITLE
journal_md_ops: fix GetForHandle(Unmerged) for journal branches

### DIFF
--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -80,6 +80,16 @@ func (j journalMDOps) getHeadFromJournal(
 		return ImmutableRootMetadata{}, nil
 	}
 
+	if mStatus == Unmerged && bid == NullBranchID {
+		// We need to look up the branch ID because the caller didn't
+		// know it.
+		var err error
+		bid, err = tlfJournal.getBranchID()
+		if err != nil {
+			return ImmutableRootMetadata{}, err
+		}
+	}
+
 	head, err := tlfJournal.getMDHead(ctx, bid)
 	if err == errTLFJournalDisabled {
 		return ImmutableRootMetadata{}, nil

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -181,6 +181,12 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.NotNil(t, head)
 	require.Equal(t, MetadataRevision(10), head.Revision())
 
+	_, head, err = mdOps.GetForHandle(ctx, h, Unmerged)
+	require.NoError(t, err)
+	require.NotNil(t, head)
+	require.Equal(t, MetadataRevision(10), head.Revision())
+	require.Equal(t, bid, head.BID())
+
 	// (4) push some new unmerged metadata blocks linking to the
 	//     middle merged block.
 	for i := MetadataRevision(11); i < 41; i++ {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1359,6 +1359,16 @@ func (j *tlfJournal) isBlockUnflushed(id BlockID) (bool, error) {
 	return true, nil
 }
 
+func (j *tlfJournal) getBranchID() (BranchID, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return NullBranchID, err
+	}
+
+	return j.mdJournal.branchID, nil
+}
+
 func (j *tlfJournal) getMDHead(
 	ctx context.Context, bid BranchID) (ImmutableBareRootMetadata, error) {
 	j.journalLock.RLock()


### PR DESCRIPTION
(@akalin-keybase this is a high priority review, should be pretty fast though.)

---

GetForHandle doesn't know the branch ID yet, so must pass in
NullBranchID.  So if there's a branch, we have to look up the right
branch ID first in that case, now that `getHead` requires it.

Issue: KBFS-1732