### PR TITLE
kbfstool: make a forceQR command for short-circuiting QR

### DIFF
--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -11,6 +11,7 @@ import (
 func mdForceQROne(
 	ctx context.Context, config libkbfs.Config, tlfPath string,
 	dryRun bool) error {
+	// Get the latest head, and add a QR record up to that point.
 	irmd, _, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
 		return err
@@ -78,8 +79,6 @@ func mdForceQR(ctx context.Context, config libkbfs.Config,
 		printError("md forceQR", err)
 		return 1
 	}
-
-	// Get the latest head, and add a QR record up to that point.
 
 	fmt.Print("\n")
 

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+func mdForceQROne(
+	ctx context.Context, config libkbfs.Config, tlfPath string,
+	dryRun bool) error {
+	irmd, _, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
+	if err != nil {
+		return err
+	}
+
+	rmdNext, err := irmd.MakeSuccessor(ctx, config, irmd.MdID(), true)
+	if err != nil {
+		return err
+	}
+
+	// Pretend like we've done quota reclamation up through the
+	// current head.
+	gco := &libkbfs.GCOp{
+		LatestRev: irmd.Revision(),
+	}
+	rmdNext.AddOp(gco)
+
+	fmt.Printf(
+		"Will put a forced QR op up to revision %d:\n", irmd.Revision())
+	err = mdDumpOneReadOnly(ctx, config, rmdNext.ReadOnly())
+	if err != nil {
+		return err
+	}
+
+	if dryRun {
+		fmt.Print("Dry-run set; not doing anything\n")
+		return nil
+	}
+
+	fmt.Printf("Putting revision %d...\n", rmdNext.Revision())
+
+	mdID, err := config.MDOps().Put(ctx, rmdNext)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("New MD has id %s\n", mdID)
+
+	return nil
+}
+
+const mdForceQRUsageStr = `Usage:
+  kbfstool md forceQR /keybase/[public|private]/user1,assertion2
+
+`
+
+func mdForceQR(ctx context.Context, config libkbfs.Config,
+	args []string) (exitStatus int) {
+	flags := flag.NewFlagSet("kbfs md forceQR", flag.ContinueOnError)
+	dryRun := flags.Bool("d", false, "Dry run: don't actually do anything.")
+	err := flags.Parse(args)
+	if err != nil {
+		printError("md forceQR", err)
+		return 1
+	}
+
+	inputs := flags.Args()
+	if len(inputs) != 1 {
+		fmt.Print(mdForceQRUsageStr)
+		return 1
+	}
+
+	err = mdForceQROne(ctx, config, inputs[0], *dryRun)
+	if err != nil {
+		printError("md forceQR", err)
+		return 1
+	}
+
+	// Get the latest head, and add a QR record up to that point.
+
+	fmt.Print("\n")
+
+	return 0
+}

--- a/kbfstool/md_main.go
+++ b/kbfstool/md_main.go
@@ -14,7 +14,7 @@ The possible subcommands are:
   dump	      Dump metadata objects
   check	      Check metadata objects and their associated blocks for errors
   reset	      Reset a broken top-level folder
-  forceQR     Append a fake quota reclamation record to the folder history
+  force-qr    Append a fake quota reclamation record to the folder history
 `
 
 func mdMain(ctx context.Context, config libkbfs.Config, args []string) (exitStatus int) {
@@ -33,7 +33,7 @@ func mdMain(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 		return mdCheck(ctx, config, args)
 	case "reset":
 		return mdReset(ctx, config, args)
-	case "forceQR":
+	case "force-qr":
 		return mdForceQR(ctx, config, args)
 	default:
 		printError("md", fmt.Errorf("unknown command '%s'", cmd))

--- a/kbfstool/md_main.go
+++ b/kbfstool/md_main.go
@@ -11,10 +11,10 @@ const mdUsageStr = `Usage:
   kbfstool md [<subcommand>] [<args>]
 
 The possible subcommands are:
-  dump		Dump metadata objects
-  check		Check metadata objects and their associated blocks for errors
-  reset		Reset a broken top-level folder
-
+  dump	      Dump metadata objects
+  check	      Check metadata objects and their associated blocks for errors
+  reset	      Reset a broken top-level folder
+  forceQR     Append a fake quota reclamation record to the folder history
 `
 
 func mdMain(ctx context.Context, config libkbfs.Config, args []string) (exitStatus int) {
@@ -33,6 +33,8 @@ func mdMain(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 		return mdCheck(ctx, config, args)
 	case "reset":
 		return mdReset(ctx, config, args)
+	case "forceQR":
+		return mdForceQR(ctx, config, args)
 	default:
 		printError("md", fmt.Errorf("unknown command '%s'", cmd))
 		return 1


### PR DESCRIPTION
Needed to repair throttle-causing TLFs that were broken due to the
lack of KBFS-1734.

Issue: KBFS-1735