### PR TITLE
folder_block_manager: use LastGCRevision instead of scanning

### DIFF
--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -28,6 +28,7 @@ func mdForceQROne(
 		LatestRev: irmd.Revision(),
 	}
 	rmdNext.AddOp(gco)
+	rmdNext.SetLastGCRevision(irmd.Revision())
 
 	fmt.Printf(
 		"Will put a forced QR op up to revision %d:\n", irmd.Revision())

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2331,7 +2331,7 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 	}
 
 	md.AddOp(gco)
-	md.data.LastGCRevision = gco.LatestRev
+	md.SetLastGCRevision(gco.LatestRev)
 
 	bps, err := fbo.maybeUnembedAndPutBlocks(ctx, md)
 	if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2331,6 +2331,7 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 	}
 
 	md.AddOp(gco)
+	md.data.LastGCRevision = gco.LatestRev
 
 	bps, err := fbo.maybeUnembedAndPutBlocks(ctx, md)
 	if err != nil {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -71,6 +71,10 @@ type PrivateMetadata struct {
 	// The block changes done as part of the update that created this MD
 	Changes BlockChanges
 
+	// The last revision up to and including which garbage collection
+	// was performed on this TLF.
+	LastGCRevision MetadataRevision `codec:"lgc"`
+
 	codec.UnknownFieldSetHandler
 
 	// When the above Changes field gets unembedded into its own

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -355,6 +355,12 @@ func (md *RootMetadata) ClearBlockChanges() {
 	md.data.Changes.Ops = nil
 }
 
+// SetLastGCRevision sets the last revision up to and including which
+// garbage collection was performed on this TLF.
+func (md *RootMetadata) SetLastGCRevision(rev MetadataRevision) {
+	md.data.LastGCRevision = rev
+}
+
 // updateFromTlfHandle updates the current RootMetadata's fields to
 // reflect the given handle, which must be the result of running the
 // current handle with ResolveAgain().

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -75,6 +75,7 @@ func makeFakePrivateMetadataFuture(t *testing.T) privateMetadataFuture {
 				},
 				0,
 			},
+			0,
 			codec.UnknownFieldSetHandler{},
 			BlockChanges{},
 		},


### PR DESCRIPTION
Instead of scanning backwards until we find the latest GC op, we
instead use a field embedded in the private metadata if it's
available.

Note that we still have to scan to find the most recent old-enough
revision, but we now limit that scan.  And that's much less of a
problem, since it's guaranteed that as soon as the client stops
writing for 5 minutes it will be able to find an old-enough revision.
And it /really/ shouldn't be a problem since clients won't even do QR
if the head is too recent anyway.

Issue: KBFS-1734