### PR TITLE
Forbid encoding nil values

### DIFF
--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -26,7 +26,8 @@ const (
 type Codec interface {
 	// Decode unmarshals the given buffer into the given object, if possible.
 	Decode(buf []byte, obj interface{}) error
-	// Encode marshals the given object into a returned buffer.
+	// Encode marshals the given object (which must not be typed
+	// or untyped nil) into a returned buffer.
 	Encode(obj interface{}) ([]byte, error)
 	// RegisterType should be called for all types that are stored
 	// under ambiguous types (like interface{} or nil interface) in a

--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -49,9 +49,17 @@ type Codec interface {
 		typer func(interface{}) reflect.Value)
 }
 
-// Equal returns whether or not the given objects serialize to the
-// same byte string. x or y (or both) can be nil.
+// Equal returns whether or not the given objects, if both non-nil,
+// serialize to the same byte string. If either x or y is nil, then
+// Equal returns true if the other one is nil, too.
 func Equal(c Codec, x, y interface{}) (bool, error) {
+	if x == nil {
+		return y == nil, nil
+	}
+	if y == nil {
+		return x == nil, nil
+	}
+
 	xBuf, err := c.Encode(x)
 	if err != nil {
 		return false, err

--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -75,7 +75,7 @@ func Equal(c Codec, x, y interface{}) (bool, error) {
 		return isNil(y), nil
 	}
 	if isNil(y) {
-		return isNil(x), nil
+		return false, nil
 	}
 
 	xBuf, err := c.Encode(x)

--- a/kbfscodec/codec_msgpack.go
+++ b/kbfscodec/codec_msgpack.go
@@ -168,8 +168,13 @@ func (c *CodecMsgpack) Encode(obj interface{}) (buf []byte, err error) {
 	if obj == nil {
 		return nil, errors.New("Cannot encode untyped nil")
 	}
-	if reflect.ValueOf(obj).IsNil() {
-		return nil, fmt.Errorf("Cannot encode nil of type %T", obj)
+	v := reflect.ValueOf(obj)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		if v.IsNil() {
+			return nil, fmt.Errorf("Cannot encode nil of type %T", obj)
+		}
+	default:
 	}
 	err = codec.NewEncoderBytes(&buf, c.h).Encode(obj)
 	return

--- a/kbfscodec/codec_msgpack.go
+++ b/kbfscodec/codec_msgpack.go
@@ -168,13 +168,8 @@ func (c *CodecMsgpack) Encode(obj interface{}) (buf []byte, err error) {
 	if obj == nil {
 		return nil, errors.New("Cannot encode untyped nil")
 	}
-	v := reflect.ValueOf(obj)
-	switch v.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		if v.IsNil() {
-			return nil, fmt.Errorf("Cannot encode nil of type %T", obj)
-		}
-	default:
+	if isTypedNil(obj) {
+		return nil, fmt.Errorf("Cannot encode nil of type %T", obj)
 	}
 	err = codec.NewEncoderBytes(&buf, c.h).Encode(obj)
 	return

--- a/kbfscodec/codec_msgpack.go
+++ b/kbfscodec/codec_msgpack.go
@@ -5,6 +5,7 @@
 package kbfscodec
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -164,6 +165,12 @@ func (c *CodecMsgpack) Decode(buf []byte, obj interface{}) (err error) {
 
 // Encode implements the Codec interface for CodecMsgpack
 func (c *CodecMsgpack) Encode(obj interface{}) (buf []byte, err error) {
+	if obj == nil {
+		return nil, errors.New("Cannot encode untyped nil")
+	}
+	if reflect.ValueOf(obj).IsNil() {
+		return nil, fmt.Errorf("Cannot encode nil of type %T", obj)
+	}
 	err = codec.NewEncoderBytes(&buf, c.h).Encode(obj)
 	return
 }

--- a/kbfscodec/codec_msgpack_test.go
+++ b/kbfscodec/codec_msgpack_test.go
@@ -49,3 +49,9 @@ func TestCodecEncodeTypedNil(t *testing.T) {
 	_, err := codec.Encode((*int)(nil))
 	require.EqualError(t, err, "Cannot encode nil of type *int")
 }
+
+func TestCodecEncodeStruct(t *testing.T) {
+	codec := NewMsgpack()
+	_, err := codec.Encode(struct{}{})
+	require.NoError(t, err)
+}

--- a/kbfscodec/codec_msgpack_test.go
+++ b/kbfscodec/codec_msgpack_test.go
@@ -7,6 +7,8 @@ package kbfscodec
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestCodecEncodeMap tests that codec.Encode() isn't affected by map
@@ -34,4 +36,16 @@ func TestCodecEncodeMap(t *testing.T) {
 	if !bytes.Equal(b1, b2) {
 		t.Errorf("%v != %v", b1, b2)
 	}
+}
+
+func TestCodecEncodeUntypedNil(t *testing.T) {
+	codec := NewMsgpack()
+	_, err := codec.Encode(nil)
+	require.EqualError(t, err, "Cannot encode untyped nil")
+}
+
+func TestCodecEncodeTypedNil(t *testing.T) {
+	codec := NewMsgpack()
+	_, err := codec.Encode((*int)(nil))
+	require.EqualError(t, err, "Cannot encode nil of type *int")
 }

--- a/kbfscodec/codec_test.go
+++ b/kbfscodec/codec_test.go
@@ -1,0 +1,18 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfscodec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodecEqualNil(t *testing.T) {
+	codec := NewMsgpack()
+	eq, err := Equal(codec, nil, nil)
+	require.NoError(t, err)
+	require.True(t, eq)
+}

--- a/kbfscodec/codec_test.go
+++ b/kbfscodec/codec_test.go
@@ -12,7 +12,27 @@ import (
 
 func TestCodecEqualNil(t *testing.T) {
 	codec := NewMsgpack()
-	eq, err := Equal(codec, nil, nil)
-	require.NoError(t, err)
-	require.True(t, eq)
+
+	nils := []interface{}{nil, (*int)(nil), (*float64)(nil)}
+	nonNils := []interface{}{1, "two"}
+
+	for _, o1 := range nils {
+		for _, o2 := range nils {
+			eq, err := Equal(codec, o1, o2)
+			require.NoError(t, err)
+			require.True(t, eq)
+		}
+	}
+
+	for _, o1 := range nils {
+		for _, o2 := range nonNils {
+			eq, err := Equal(codec, o1, o2)
+			require.NoError(t, err)
+			require.False(t, eq)
+
+			eq, err = Equal(codec, o2, o1)
+			require.NoError(t, err)
+			require.False(t, eq)
+		}
+	}
 }

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -189,7 +190,7 @@ func TestBlockDiskStoreRemove(t *testing.T) {
 
 	// Should not be removable.
 	err := s.remove(bID)
-	require.Error(t, err, "Trying to remove data")
+	require.True(t, strings.HasPrefix(err.Error(), "Trying to remove data"))
 
 	// Remove reference.
 	liveCount, err := s.removeReferences(bID, []BlockContext{bCtx}, "")

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -312,7 +312,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, MetadataRevision(1))
 
 	_, err = mdOps.PutUnmerged(ctx, rmd)
-	require.Error(t, err, "Unmerged put with rmd.BID() == j.branchID == NullBranchID")
+	require.EqualError(t, err, "Unmerged put with rmd.BID() == j.branchID == NullBranchID")
 }
 
 func TestJournalMDOpsLocalSquashBranch(t *testing.T) {


### PR DESCRIPTION
Fortunately, it turns out we don't actually do this
(at least in tests).