### PR TITLE
fileData: refactor CR IndirectFilePtr usage

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -611,7 +611,7 @@ type createMapKey struct {
 // that doesn't represent a file.
 func (cr *ConflictResolver) addChildBlocksIfIndirectFile(ctx context.Context,
 	lState *lockState, unmergedChains *crChains, currPath path, op op) error {
-	// For files with indirect pointers, and all child blocks
+	// For files with indirect pointers, add all child blocks
 	// as refblocks for the re-created file.
 	infos, err := cr.fbo.blocks.GetIndirectFileBlockInfos(
 		ctx, lState, unmergedChains.mostRecentChainMDInfo.kmd, currPath)
@@ -2120,8 +2120,8 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	if err != nil {
 		return BlockPointer{}, err
 	}
-	fblock, ok := block.(*FileBlock)
-	if !ok {
+	fblock, isFileBlock := block.(*FileBlock)
+	if !isFileBlock {
 		return BlockPointer{}, NotFileBlockError{ptr, cr.fbo.branch(), file}
 	}
 

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -775,13 +775,15 @@ func newCRChains(
 			ccs.blockChangePointers[ptr] = true
 
 			// Any child block change pointers?
-			fblock, err := fbo.GetFileBlockForReading(ctx, makeFBOLockState(),
-				chainMD, ptr, MasterBranch, path{})
+			infos, err := fbo.GetIndirectFileBlockInfos(
+				ctx, makeFBOLockState(), chainMD,
+				path{fbo.folderBranch, []pathNode{{
+					ptr, fmt.Sprintf("<MD rev %d>", chainMD.Revision())}}})
 			if err != nil {
 				return nil, err
 			}
-			for _, iptr := range fblock.IPtrs {
-				ccs.blockChangePointers[iptr.BlockPointer] = true
+			for _, info := range infos {
+				ccs.blockChangePointers[info.BlockPointer] = true
 			}
 		}
 

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -1104,8 +1104,8 @@ func (fd *fileData) deepCopy(ctx context.Context, codec kbfscodec.Codec,
 
 // undupChildrenInCopy takes a top block that's been copied via
 // deepCopy(), and un-deduplicates all leaf children of the block.  It
-// add all child blocks to the provided `bps`, including both the ones
-// that were deduplicated and the ones that weren't (TODO).  It
+// adds all child blocks to the provided `bps`, including both the
+// ones that were deduplicated and the ones that weren't (TODO).  It
 // returns the BlockInfos for all children, including ones that
 // weren't de-duplicated.
 func (fd *fileData) undupChildrenInCopy(ctx context.Context,


### PR DESCRIPTION
This PR moves all direct usage of `IndirectFilePtr`s away from CR and info `fileData`, so it's all in one place when we add multiple levels of indirection.

This just a refactor, shouldn't introduce any new logic.

Issue: KBFS-35