### PR TITLE
[KBFS-1740] Fix common block retrieval panic

### DIFF
--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -205,7 +205,7 @@ func (brq *blockRetrievalQueue) FinalizeRequest(retrieval *blockRetrieval, block
 	bpLookup := blockPtrLookup{retrieval.blockPtr, reflect.TypeOf(block)}
 	delete(brq.ptrs, bpLookup)
 	brq.mtx.Unlock()
-	retrieval.cancelFunc()
+	defer retrieval.cancelFunc()
 
 	// This is a symbolic lock, since there shouldn't be any other goroutines
 	// accessing requests at this point. But requests had contentious access

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -56,6 +56,11 @@ type blockRetrieval struct {
 	insertionOrder uint64
 }
 
+// blockPtrLookup is used to uniquely identify block retrieval requests. The
+// reflect.Type is needed because sometimes a request is placed concurrently
+// for a specific block type and a generic block type. The requests will both
+// cause a retrieval, but branching on type allows us to avoid special casing
+// the code.
 type blockPtrLookup struct {
 	bp BlockPointer
 	t  reflect.Type

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -26,7 +26,7 @@ func TestBlockRetrievalQueueBasic(t *testing.T) {
 
 	t.Log("Begin working on the request.")
 	br := <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, -1, br.index)
 	require.Equal(t, 1, br.priority)
@@ -50,14 +50,14 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 
 	t.Log("Begin working on the preempted ptr2 request.")
 	br := <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr2, br.blockPtr)
 	require.Equal(t, 2, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
 
 	t.Log("Begin working on the ptr1 request.")
 	br = <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, 1, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
@@ -78,7 +78,7 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 
 	t.Log("Begin working on the ptr1 request.")
 	br := <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, 1, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
@@ -89,14 +89,14 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 
 	t.Log("Begin working on the ptr3 request.")
 	br = <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr3, br.blockPtr)
 	require.Equal(t, 2, br.priority)
 	require.Equal(t, uint64(2), br.insertionOrder)
 
 	t.Log("Begin working on the ptr2 request.")
 	br = <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr2, br.blockPtr)
 	require.Equal(t, 1, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
@@ -116,7 +116,7 @@ func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has 2 requests and that the queue is now empty.")
 	br := <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, -1, br.index)
 	require.Equal(t, 1, br.priority)
@@ -144,7 +144,7 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 
 	t.Log("Begin working on the ptr3 retrieval.")
 	br := <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr3, br.blockPtr)
 	require.Equal(t, 3, br.priority)
 	require.Equal(t, uint64(2), br.insertionOrder)
@@ -154,7 +154,7 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has increased in priority and has 2 requests.")
 	br = <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, 3, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
@@ -162,7 +162,7 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 
 	t.Log("Begin working on the ptr2 retrieval.")
 	br = <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr2, br.blockPtr)
 	require.Equal(t, 2, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
@@ -197,11 +197,11 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	require.Equal(t, block, br.requests[1].block)
 
 	t.Log("Finalize the existing request for ptr1.")
-	q.FinalizeRequest(br, nil, nil)
+	q.FinalizeRequest(br, &FileBlock{}, nil)
 	t.Log("Make another request for the same block. Verify that this is a new request.")
 	_ = q.Request(ctx, 2, nil, ptr1, block)
 	br = <-q.WorkOnRequest()
-	defer q.FinalizeRequest(br, nil, io.EOF)
+	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, 2, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
 	require.Len(t, br.requests, 1)

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -260,7 +260,7 @@ func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 }
 
 func TestBlockRetrievalWorkerMultipleBlockTypes(t *testing.T) {
-	t.Log("Test the ability of a worker and queue to work correctly together.")
+	t.Log("Test that we can retrieve the same block into different block types.")
 	codec := kbfscodec.NewMsgpack()
 	q := newBlockRetrievalQueue(1, codec)
 	require.NotNil(t, q)

--- a/libkbfs/block_types_test.go
+++ b/libkbfs/block_types_test.go
@@ -115,6 +115,10 @@ type dirBlockFuture struct {
 	kbfscodec.Extra
 }
 
+func (dbf *dirBlockFuture) NewEmpty() Block {
+	return &dirBlockFuture{}
+}
+
 func (dbf *dirBlockFuture) Set(other Block, codec kbfscodec.Codec) {
 	otherDbf := other.(*dirBlockFuture)
 	err := kbfscodec.Update(codec, dbf, otherDbf)
@@ -175,6 +179,10 @@ type fileBlockFuture struct {
 	// Overrides fileBlockCurrent.IPtrs.
 	IPtrs []indirectFilePtrFuture `codec:"i,omitempty"`
 	kbfscodec.Extra
+}
+
+func (fbf *fileBlockFuture) NewEmpty() Block {
+	return &fileBlockFuture{}
 }
 
 func (fbf *fileBlockFuture) Set(other Block, codec kbfscodec.Codec) {


### PR DESCRIPTION
Added fix and regression test for retrieving the same block pointer into different block types. The test panics without the fix (with the same error message as Patrick's log), and passes with it.