### PR TITLE
cr: cancel existing CRs synchronously with Resolve() call

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -206,13 +206,15 @@ func (cr *ConflictResolver) Resolve(unmerged MetadataRevision,
 		return
 	}
 
-	cr.inputLock.Lock()
-	defer cr.inputLock.Unlock()
 	ci := conflictInput{unmerged, merged}
-	// Cancel any running CR before we return, so the caller can be
-	// confident any ongoing CR superseded by this new input will be
-	// canceled before it releases any locks it holds.
-	_ = cr.cancelExistingLocked(ci)
+	func() {
+		cr.inputLock.Lock()
+		defer cr.inputLock.Unlock()
+		// Cancel any running CR before we return, so the caller can be
+		// confident any ongoing CR superseded by this new input will be
+		// canceled before it releases any locks it holds.
+		_ = cr.cancelExistingLocked(ci)
+	}()
 
 	cr.resolveGroup.Add(1)
 	cr.inputChan <- ci


### PR DESCRIPTION
When folderBranchOps writes a new unmerged update, it calls
cr.Resolve() while holding mdWriterLock, to let CR know that new data
has been committed to the branch.  This should cause any current CR to
be canceled.  However, that happened via a channel, and so the current
CR could complete, and clear the unmerged branch completely including
the new commit, before it learns about the new input.

To fix the race, this change makes sure that cr.Resolve() cancels any
existing CR before it returns to the caller.  This solves the race
because the existing CR will need to take mdWriterLock before
completing its resolution, and after it takes mdWriterLock it checks
whether it's been canceled or not.

Issue: KBFS-1746