### PR TITLE
Revert "libkbfs: enable mdv3 by default in production"

### DIFF
--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -108,9 +108,9 @@ func GetDefaultMetadataVersion(ctx Context) MetadataVer {
 	case libkb.StagingRunMode:
 		return SegregatedKeyBundlesVer
 	case libkb.ProductionRunMode:
-		return SegregatedKeyBundlesVer
+		return InitialExtraMetadataVer
 	default:
-		return SegregatedKeyBundlesVer
+		return InitialExtraMetadataVer
 	}
 }
 


### PR DESCRIPTION
Reverts keybase/kbfs#561