### PR TITLE
Avoid returning typed nils

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -374,7 +374,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV2(config Config, isReadableAndWr
 }
 
 func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Config, kmd KeyMetadata) (
-	*BareRootMetadataV3, *ExtraMetadataV3, error) {
+	*BareRootMetadataV3, ExtraMetadata, error) {
 	mdCopy := &BareRootMetadataV3{}
 
 	// Fill out the writer metadata and new writer key bundle.

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -415,7 +415,9 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 		return nil, nil, errors.New("Non-nil finalized info")
 	}
 
-	var extraCopy *ExtraMetadataV3
+	// Have this as ExtraMetadata so we return an untyped nil
+	// instead of a typed nil.
+	var extraCopy ExtraMetadata
 	if !md.ID.IsPublic() {
 		extraCopy = &ExtraMetadataV3{wkb: wkb, rkb: rkb}
 	}

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -725,7 +725,9 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	require.Equal(t, rmd2.LatestKeyGeneration(), PublicKeyGen)
 	require.Equal(t, rmd2.Revision(), MetadataRevision(2))
 	require.Equal(t, rmd2.Version(), SegregatedKeyBundlesVer)
-	require.Nil(t, rmd2.extra)
+	// Do this instead of require.Nil because we want to assert
+	// that it's untyped nil.
+	require.True(t, rmd2.extra == nil)
 
 	// compare numbers
 	require.Equal(t, diskUsage, rmd2.DiskUsage())


### PR DESCRIPTION
This fixes an MDv3 crash.