### PR TITLE
Revert "Revert "libkbfs: enable mdv3 by default in production""

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -344,7 +344,9 @@ func (md *BareRootMetadataV2) MakeSuccessorCopy(
 	extra ExtraMetadata, isReadableAndWriter bool) (
 	MutableBareRootMetadata, ExtraMetadata, bool, error) {
 
-	if config.MetadataVersion() < SegregatedKeyBundlesVer {
+	// TODO: uncomment when we're ready to write mdv3 by default.
+	//if config.MetadataVersion() < SegregatedKeyBundlesVer {
+	if true {
 		// Continue with the current version.
 		mdCopy, err := md.makeSuccessorCopyV2(config, isReadableAndWriter)
 		if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1390,7 +1390,9 @@ func (fbo *folderBranchOps) SetInitialHeadToNew(
 	}()
 
 	rmd, err := makeInitialRootMetadata(
-		fbo.config.MetadataVersion(), id, handle)
+		InitialExtraMetadataVer, id, handle)
+	// TODO: uncomment when we're ready to turn mdv3 on everywhere.
+	//fbo.config.MetadataVersion(), id, handle)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -108,9 +108,9 @@ func GetDefaultMetadataVersion(ctx Context) MetadataVer {
 	case libkb.StagingRunMode:
 		return SegregatedKeyBundlesVer
 	case libkb.ProductionRunMode:
-		return InitialExtraMetadataVer
+		return SegregatedKeyBundlesVer
 	default:
-		return InitialExtraMetadataVer
+		return SegregatedKeyBundlesVer
 	}
 }
 

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -568,6 +568,8 @@ func (kc *dummyNoKeyCache) PutTLFCryptKey(_ tlf.ID, _ KeyGen, _ kbfscrypto.TLFCr
 
 // Test upconversion from MDv2 to MDv3 for a private folder.
 func TestRootMetadataUpconversionPrivate(t *testing.T) {
+	t.Skip("Skipping while in half-mdv3 state")
+
 	config := MakeTestConfigOrBust(t, "alice", "bob", "charlie")
 	config.SetKeyCache(&dummyNoKeyCache{})
 	defer config.Shutdown()
@@ -699,6 +701,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 
 // Test upconversion from MDv2 to MDv3 for a public folder.
 func TestRootMetadataUpconversionPublic(t *testing.T) {
+	t.Skip("Skipping while in half-mdv3 state")
+
 	config := MakeTestConfigOrBust(t, "alice", "bob")
 	defer config.Shutdown()
 


### PR DESCRIPTION
This reverts commit ac049d0641d4abdf26786f4cef1334b4df4a0438.