### PR TITLE
[MDv3] Remove extraNew in favor of bools in extra

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -338,16 +338,7 @@ func (md *BareRootMetadataV2) MakeSuccessorCopy(
 	}
 
 	// Upconvert to the new version.
-	mdCopy, extraCopyV3, err := md.makeSuccessorCopyV3(ctx, config, kmd)
-	if err != nil {
-		return nil, nil, err
-	}
-	// Do this so that a typed nil gets converted to an untyped nil.
-	var extraV3 ExtraMetadata
-	if extraCopyV3 != nil {
-		extraV3 = extraCopyV3
-	}
-	return mdCopy, extraV3, nil
+	return md.makeSuccessorCopyV3(ctx, config, kmd)
 }
 
 func (md *BareRootMetadataV2) makeSuccessorCopyV2(config Config, isReadableAndWriter bool) (

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -373,7 +373,8 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 			return nil, nil, err
 		}
 
-		mdV3.WriterMetadata.WKeyBundleID, err = config.Crypto().MakeTLFWriterKeyBundleID(wkbV3)
+		mdV3.WriterMetadata.WKeyBundleID, err =
+			config.Crypto().MakeTLFWriterKeyBundleID(wkbV3)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -381,16 +382,18 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 		// Fill out the reader key bundle.  wkbV2 is passed
 		// because in V2 metadata ephemeral public keys for
 		// readers were sometimes in the writer key bundles
-		rkb, err := md.RKeys.ToTLFReaderKeyBundleV3(config.Codec(), wkbV2)
+		rkbV3, err := md.RKeys.ToTLFReaderKeyBundleV3(
+			config.Codec(), wkbV2)
 		if err != nil {
 			return nil, nil, err
 		}
-		mdV3.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(rkb)
+		mdV3.RKeyBundleID, err =
+			config.Crypto().MakeTLFReaderKeyBundleID(rkbV3)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		extraCopy = NewExtraMetadataV3(wkbV3, rkb, true, true)
+		extraCopy = NewExtraMetadataV3(wkbV3, rkbV3, true, true)
 	}
 
 	mdV3.LastModifyingUser = md.LastModifyingUser

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -52,7 +52,8 @@ type WriterMetadataV2 struct {
 	Extra WriterMetadataExtra `codec:"x,omitempty,omitemptycheckstruct"`
 }
 
-// ToWriterMetadataV3 converts the WriterMetadataV2 to a WriterMetadataV3 in place.
+// ToWriterMetadataV3 converts the WriterMetadataV2 to a
+// WriterMetadataV3.
 func (wmd *WriterMetadataV2) ToWriterMetadataV3() WriterMetadataV3 {
 	var wmdV3 WriterMetadataV3
 	wmdV3.Writers = make([]keybase1.UID, len(wmd.Writers))

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -628,7 +628,7 @@ func (md *BareRootMetadataV2) RevokeRemovedDevices(
 func (md *BareRootMetadataV2) getTLFKeyBundles(keyGen KeyGen) (
 	*TLFWriterKeyBundleV2, *TLFReaderKeyBundleV2, error) {
 	if md.ID.IsPublic() {
-		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles (V2)", md.Version()}
+		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles", md.Version()}
 	}
 
 	if keyGen < FirstValidKeyGen {

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -55,8 +55,7 @@ type WriterMetadataV2 struct {
 // ToWriterMetadataV3 converts the WriterMetadataV2 to a WriterMetadataV3 in place.
 func (wmd *WriterMetadataV2) ToWriterMetadataV3(
 	ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, keyManager KeyManager,
-	kmd KeyMetadata, wmdCopy *WriterMetadataV3) (
-	TLFWriterKeyBundleV2, TLFWriterKeyBundleV3, error) {
+	kmd KeyMetadata, wmdCopy *WriterMetadataV3) error {
 	wmdCopy.Writers = make([]keybase1.UID, len(wmd.Writers))
 	copy(wmdCopy.Writers, wmd.Writers)
 
@@ -72,21 +71,10 @@ func (wmd *WriterMetadataV2) ToWriterMetadataV3(
 
 	if wmd.ID.IsPublic() {
 		wmdCopy.LatestKeyGen = PublicKeyGen
-		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, nil
+	} else {
+		wmdCopy.LatestKeyGen = wmd.WKeys.LatestKeyGeneration()
 	}
-
-	wmdCopy.LatestKeyGen = wmd.WKeys.LatestKeyGeneration()
-	wkbV2, wkbV3, err := wmd.WKeys.ToTLFWriterKeyBundleV3(ctx, codec, crypto, keyManager, kmd)
-	if err != nil {
-		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
-	}
-
-	wmdCopy.WKeyBundleID, err = crypto.MakeTLFWriterKeyBundleID(wkbV3)
-	if err != nil {
-		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
-	}
-
-	return wkbV2, wkbV3, nil
+	return nil
 }
 
 // WriterMetadataExtra stores more fields for WriterMetadata. (See
@@ -381,7 +369,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 
 	// Fill out the writer metadata and maybe a new writer key
 	// bundle.
-	wkbV2, wkbV3, err := md.WriterMetadataV2.ToWriterMetadataV3(
+	err := md.WriterMetadataV2.ToWriterMetadataV3(
 		ctx, config.Codec(), config.Crypto(), config.KeyManager(), kmd, &mdCopy.WriterMetadata)
 	if err != nil {
 		return nil, nil, err
@@ -391,19 +379,31 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 	// instead of a typed nil.
 	var extraCopy ExtraMetadata
 	if md.LatestKeyGeneration() != PublicKeyGen {
-		// Fill out the reader key bundle.  wkbV2 is passed
-		// because in V2 metadata ephemeral public keys for
-		// readers were sometimes in the writer key bundles.
-		rkb, err := md.RKeys.ToTLFReaderKeyBundleV3(config.Codec(), wkbV2)
-		if err != nil {
-			return nil, nil, err
-		}
-		mdCopy.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(*rkb)
+		wkbV2, wkbV3, err := md.WKeys.ToTLFWriterKeyBundleV3(
+			ctx, config.Codec(), config.Crypto(),
+			config.KeyManager(), kmd)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		extraCopy = NewExtraMetadataV3(wkbV3, *rkb, true, true)
+		mdCopy.WriterMetadata.WKeyBundleID, err = config.Crypto().MakeTLFWriterKeyBundleID(wkbV3)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Fill out the reader key bundle.  wkbV2 is passed
+		// because in V2 metadata ephemeral public keys for
+		// readers were sometimes in the writer key bundles
+		rkb, err := md.RKeys.ToTLFReaderKeyBundleV3(config.Codec(), wkbV2)
+		if err != nil {
+			return nil, nil, err
+		}
+		mdCopy.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(rkb)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		extraCopy = NewExtraMetadataV3(wkbV3, rkb, true, true)
 	}
 
 	mdCopy.LastModifyingUser = md.LastModifyingUser

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -566,7 +566,7 @@ func (md *BareRootMetadataV2) TlfHandleExtensions() (
 func (md *BareRootMetadataV2) PromoteReader(
 	uid keybase1.UID, _ ExtraMetadata) error {
 	if md.TlfID().IsPublic() {
-		return InvalidPublicTLFOperation{md.TlfID(), "PromoteReader"}
+		return InvalidPublicTLFOperation{md.TlfID(), "PromoteReader", md.Version()}
 	}
 
 	for i, rkb := range md.RKeys {
@@ -589,7 +589,7 @@ func (md *BareRootMetadataV2) RevokeRemovedDevices(
 	ServerHalfRemovalInfo, error) {
 	if md.TlfID().IsPublic() {
 		return nil, InvalidPublicTLFOperation{
-			md.TlfID(), "RevokeRemovedDevices"}
+			md.TlfID(), "RevokeRemovedDevices", md.Version()}
 	}
 
 	var wRemovalInfo ServerHalfRemovalInfo
@@ -628,7 +628,7 @@ func (md *BareRootMetadataV2) RevokeRemovedDevices(
 func (md *BareRootMetadataV2) getTLFKeyBundles(keyGen KeyGen) (
 	*TLFWriterKeyBundleV2, *TLFReaderKeyBundleV2, error) {
 	if md.ID.IsPublic() {
-		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles (V2)"}
+		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles (V2)", md.Version()}
 	}
 
 	if keyGen < FirstValidKeyGen {
@@ -993,7 +993,7 @@ func (md *BareRootMetadataV2) addKeyGenerationHelper(codec kbfscodec.Codec,
 	wPublicKeys, rPublicKeys []kbfscrypto.TLFEphemeralPublicKey) error {
 	if md.TlfID().IsPublic() {
 		return InvalidPublicTLFOperation{
-			md.TlfID(), "addKeyGenerationHelper"}
+			md.TlfID(), "addKeyGenerationHelper", md.Version()}
 	}
 
 	wUDKIMV2, err := udkimToV2(codec, wUDKIM)
@@ -1205,7 +1205,7 @@ func (md *BareRootMetadataV2) UpdateKeyGeneration(crypto cryptoPure,
 	tlfCryptKey kbfscrypto.TLFCryptKey) (UserDeviceKeyServerHalves, error) {
 	if md.TlfID().IsPublic() {
 		return nil, InvalidPublicTLFOperation{
-			md.TlfID(), "UpdateKeyGeneration"}
+			md.TlfID(), "UpdateKeyGeneration", md.Version()}
 	}
 
 	wkb, rkb, err := md.getTLFKeyBundles(keyGen)

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -381,7 +381,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 
 		// Fill out the reader key bundle.  wkbV2 is passed
 		// because in V2 metadata ephemeral public keys for
-		// readers were sometimes in the writer key bundles
+		// readers were sometimes in the writer key bundles.
 		rkbV3, err := md.RKeys.ToTLFReaderKeyBundleV3(
 			config.Codec(), wkbV2)
 		if err != nil {

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -81,9 +81,7 @@ func (wmd *WriterMetadataV2) ToWriterMetadataV3(
 		if err != nil {
 			return nil, nil, err
 		}
-		// wkbV3 is passed because in V2 metadata ephemeral public keys for readers
-		// were sometimes in the writer key bundles
-		wmdCopy.WKeyBundleID, err = crypto.MakeTLFWriterKeyBundleID(wkbV3)
+		wmdCopy.WKeyBundleID, err = crypto.MakeTLFWriterKeyBundleID(*wkbV3)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -394,17 +392,19 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 	// instead of a typed nil.
 	var extraCopy ExtraMetadata
 	if md.LatestKeyGeneration() != PublicKeyGen {
-		// Fill out the reader key bundle.
+		// Fill out the reader key bundle.  wkbV2 is passed
+		// because in V2 metadata ephemeral public keys for
+		// readers were sometimes in the writer key bundles.
 		rkb, err := md.RKeys.ToTLFReaderKeyBundleV3(config.Codec(), wkbV2)
 		if err != nil {
 			return nil, nil, err
 		}
-		mdCopy.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(rkb)
+		mdCopy.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(*rkb)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		extraCopy = NewExtraMetadataV3(wkbV3, rkb, true, true)
+		extraCopy = NewExtraMetadataV3(*wkbV3, *rkb, true, true)
 	}
 
 	mdCopy.LastModifyingUser = md.LastModifyingUser

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -628,7 +628,7 @@ func (md *BareRootMetadataV2) RevokeRemovedDevices(
 func (md *BareRootMetadataV2) getTLFKeyBundles(keyGen KeyGen) (
 	*TLFWriterKeyBundleV2, *TLFReaderKeyBundleV2, error) {
 	if md.ID.IsPublic() {
-		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles"}
+		return nil, nil, InvalidPublicTLFOperation{md.ID, "getTLFKeyBundles (V2)"}
 	}
 
 	if keyGen < FirstValidKeyGen {

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -54,25 +54,25 @@ type WriterMetadataV2 struct {
 
 // ToWriterMetadataV3 converts the WriterMetadataV2 to a
 // WriterMetadataV3.
-func (wmd *WriterMetadataV2) ToWriterMetadataV3() WriterMetadataV3 {
+func (wmdV2 *WriterMetadataV2) ToWriterMetadataV3() WriterMetadataV3 {
 	var wmdV3 WriterMetadataV3
-	wmdV3.Writers = make([]keybase1.UID, len(wmd.Writers))
-	copy(wmdV3.Writers, wmd.Writers)
+	wmdV3.Writers = make([]keybase1.UID, len(wmdV2.Writers))
+	copy(wmdV3.Writers, wmdV2.Writers)
 
-	wmdV3.UnresolvedWriters = make([]keybase1.SocialAssertion, len(wmd.Extra.UnresolvedWriters))
-	copy(wmdV3.UnresolvedWriters, wmd.Extra.UnresolvedWriters)
+	wmdV3.UnresolvedWriters = make([]keybase1.SocialAssertion, len(wmdV2.Extra.UnresolvedWriters))
+	copy(wmdV3.UnresolvedWriters, wmdV2.Extra.UnresolvedWriters)
 
-	wmdV3.ID = wmd.ID
-	wmdV3.BID = wmd.BID
-	wmdV3.WFlags = wmd.WFlags
-	wmdV3.DiskUsage = wmd.DiskUsage
-	wmdV3.RefBytes = wmd.RefBytes
-	wmdV3.UnrefBytes = wmd.UnrefBytes
+	wmdV3.ID = wmdV2.ID
+	wmdV3.BID = wmdV2.BID
+	wmdV3.WFlags = wmdV2.WFlags
+	wmdV3.DiskUsage = wmdV2.DiskUsage
+	wmdV3.RefBytes = wmdV2.RefBytes
+	wmdV3.UnrefBytes = wmdV2.UnrefBytes
 
-	if wmd.ID.IsPublic() {
+	if wmdV2.ID.IsPublic() {
 		wmdV3.LatestKeyGen = PublicKeyGen
 	} else {
-		wmdV3.LatestKeyGen = wmd.WKeys.LatestKeyGeneration()
+		wmdV3.LatestKeyGen = wmdV2.WKeys.LatestKeyGeneration()
 	}
 	return wmdV3
 }

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -342,28 +342,28 @@ func (md *BareRootMetadataV2) DeepCopy(
 func (md *BareRootMetadataV2) MakeSuccessorCopy(
 	ctx context.Context, config Config, kmd KeyMetadata,
 	extra ExtraMetadata, isReadableAndWriter bool) (
-	MutableBareRootMetadata, ExtraMetadata, bool, error) {
+	MutableBareRootMetadata, ExtraMetadata, error) {
 
 	if config.MetadataVersion() < SegregatedKeyBundlesVer {
 		// Continue with the current version.
 		mdCopy, err := md.makeSuccessorCopyV2(config, isReadableAndWriter)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
-		return mdCopy, nil, false, nil
+		return mdCopy, nil, nil
 	}
 
 	// Upconvert to the new version.
 	mdCopy, extraCopyV3, err := md.makeSuccessorCopyV3(ctx, config, kmd)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 	// Do this so that a typed nil gets converted to an untyped nil.
 	var extraV3 ExtraMetadata
 	if extraCopyV3 != nil {
 		extraV3 = extraCopyV3
 	}
-	return mdCopy, extraV3, true, nil
+	return mdCopy, extraV3, nil
 }
 
 func (md *BareRootMetadataV2) makeSuccessorCopyV2(config Config, isReadableAndWriter bool) (

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -356,10 +356,10 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV2(config Config, isReadableAndWr
 
 func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Config, kmd KeyMetadata) (
 	*BareRootMetadataV3, ExtraMetadata, error) {
-	mdCopy := &BareRootMetadataV3{}
+	mdV3 := &BareRootMetadataV3{}
 
 	// Fill out the writer metadata.
-	mdCopy.WriterMetadata = md.WriterMetadataV2.ToWriterMetadataV3()
+	mdV3.WriterMetadata = md.WriterMetadataV2.ToWriterMetadataV3()
 
 	// Have this as ExtraMetadata so we return an untyped nil
 	// instead of a typed nil.
@@ -373,7 +373,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 			return nil, nil, err
 		}
 
-		mdCopy.WriterMetadata.WKeyBundleID, err = config.Crypto().MakeTLFWriterKeyBundleID(wkbV3)
+		mdV3.WriterMetadata.WKeyBundleID, err = config.Crypto().MakeTLFWriterKeyBundleID(wkbV3)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -385,7 +385,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 		if err != nil {
 			return nil, nil, err
 		}
-		mdCopy.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(rkb)
+		mdV3.RKeyBundleID, err = config.Crypto().MakeTLFReaderKeyBundleID(rkb)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -393,12 +393,12 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 		extraCopy = NewExtraMetadataV3(wkbV3, rkb, true, true)
 	}
 
-	mdCopy.LastModifyingUser = md.LastModifyingUser
-	mdCopy.Flags = md.Flags
-	mdCopy.Revision = md.Revision // Incremented by the caller.
+	mdV3.LastModifyingUser = md.LastModifyingUser
+	mdV3.Flags = md.Flags
+	mdV3.Revision = md.Revision // Incremented by the caller.
 	// PrevRoot is set by the caller.
-	mdCopy.UnresolvedReaders = make([]keybase1.SocialAssertion, len(md.UnresolvedReaders))
-	copy(mdCopy.UnresolvedReaders, md.UnresolvedReaders)
+	mdV3.UnresolvedReaders = make([]keybase1.SocialAssertion, len(md.UnresolvedReaders))
+	copy(mdV3.UnresolvedReaders, md.UnresolvedReaders)
 
 	if md.ConflictInfo != nil {
 		ci := *md.ConflictInfo
@@ -411,7 +411,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 		return nil, nil, errors.New("Non-nil finalized info")
 	}
 
-	return mdCopy, extraCopy, nil
+	return mdV3, extraCopy, nil
 }
 
 // CheckValidSuccessor implements the BareRootMetadata interface for BareRootMetadataV2.

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -404,7 +404,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 			return nil, nil, err
 		}
 
-		extraCopy = NewExtraMetadataV3(wkbV3, rkb)
+		extraCopy = NewExtraMetadataV3(wkbV3, rkb, true, true)
 	}
 
 	mdCopy.LastModifyingUser = md.LastModifyingUser

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -384,7 +384,7 @@ func checkGetTLFCryptKeyV2(t *testing.T, expected expectedRekeyInfoV2,
 			require.True(t, ok)
 
 			_, _, ePubKey, err := getEphemeralPublicKeyInfoV2(
-				info, wkb, rkb)
+				info, *wkb, *rkb)
 			require.NoError(t, err)
 
 			checkCryptKeyInfo(t, privKey, serverHalf,

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -319,7 +319,7 @@ func (md *BareRootMetadataV3) getTLFKeyBundles(extra ExtraMetadata) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	if md.TlfID().IsPublic() {
 		return nil, nil, InvalidPublicTLFOperation{
-			md.TlfID(), "getTLFKeyBundles (V3)",
+			md.TlfID(), "getTLFKeyBundles", md.Version(),
 		}
 	}
 
@@ -559,7 +559,7 @@ func (md *BareRootMetadataV3) TlfHandleExtensions() (
 func (md *BareRootMetadataV3) PromoteReader(
 	uid keybase1.UID, extra ExtraMetadata) error {
 	if md.TlfID().IsPublic() {
-		return InvalidPublicTLFOperation{md.TlfID(), "PromoteReader"}
+		return InvalidPublicTLFOperation{md.TlfID(), "PromoteReader", md.Version()}
 	}
 
 	wkb, rkb, ok := getKeyBundlesV3(extra)
@@ -595,7 +595,7 @@ func (md *BareRootMetadataV3) RevokeRemovedDevices(
 	ServerHalfRemovalInfo, error) {
 	if md.TlfID().IsPublic() {
 		return nil, InvalidPublicTLFOperation{
-			md.TlfID(), "RevokeRemovedDevices"}
+			md.TlfID(), "RevokeRemovedDevices", md.Version()}
 	}
 
 	wkb, rkb, ok := getKeyBundlesV3(extra)
@@ -613,7 +613,7 @@ func (md *BareRootMetadataV3) GetDeviceKIDs(
 	keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) ([]keybase1.KID, error) {
 	if md.TlfID().IsPublic() {
 		return nil, InvalidPublicTLFOperation{
-			md.TlfID(), "GetDeviceKIDs"}
+			md.TlfID(), "GetDeviceKIDs", md.Version()}
 	}
 
 	wkb, rkb, ok := getKeyBundlesV3(extra)
@@ -1005,7 +1005,7 @@ func (md *BareRootMetadataV3) addKeyGenerationHelper(codec kbfscodec.Codec,
 	ExtraMetadata, error) {
 	if md.TlfID().IsPublic() {
 		return nil, InvalidPublicTLFOperation{
-			md.TlfID(), "addKeyGenerationHelper"}
+			md.TlfID(), "addKeyGenerationHelper", md.Version()}
 	}
 	if nextCryptKey == (kbfscrypto.TLFCryptKey{}) {
 		return nil, errors.New("Zero next crypt key")
@@ -1214,7 +1214,7 @@ func (md *BareRootMetadataV3) GetUserDeviceKeyInfoMaps(
 	codec kbfscodec.Codec, keyGen KeyGen, extra ExtraMetadata) (
 	readers, writers UserDeviceKeyInfoMap, err error) {
 	if md.TlfID().IsPublic() {
-		return nil, nil, InvalidPublicTLFOperation{md.TlfID(), "GetTLFKeyBundles"}
+		return nil, nil, InvalidPublicTLFOperation{md.TlfID(), "GetTLFKeyBundles", md.Version()}
 	}
 	if keyGen != md.LatestKeyGeneration() {
 		return nil, nil, TLFCryptKeyNotPerDeviceEncrypted{md.TlfID(), keyGen}
@@ -1246,7 +1246,7 @@ func (md *BareRootMetadataV3) UpdateKeyGeneration(crypto cryptoPure,
 	tlfCryptKey kbfscrypto.TLFCryptKey) (UserDeviceKeyServerHalves, error) {
 	if md.TlfID().IsPublic() {
 		return nil, InvalidPublicTLFOperation{
-			md.TlfID(), "UpdateKeyGeneration"}
+			md.TlfID(), "UpdateKeyGeneration", md.Version()}
 	}
 
 	if keyGen != md.LatestKeyGeneration() {

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1182,10 +1182,9 @@ func (md *BareRootMetadataV3) Version() MetadataVer {
 // for BareRootMetadataV3.
 func (md *BareRootMetadataV3) GetCurrentTLFPublicKey(
 	extra ExtraMetadata) (kbfscrypto.TLFPublicKey, error) {
-	wkb, _, ok := getKeyBundlesV3(extra)
-	if !ok {
-		return kbfscrypto.TLFPublicKey{}, errors.New(
-			"Invalid key bundles in GetCurrentTLFPublicKey")
+	wkb, _, err := md.getTLFKeyBundles(extra)
+	if err != nil {
+		return kbfscrypto.TLFPublicKey{}, err
 	}
 	return wkb.TLFPublicKey, nil
 }

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -150,7 +150,7 @@ func (extra ExtraMetadataV3) DeepCopy(codec kbfscodec.Codec) (
 	if err := kbfscodec.Update(codec, &wkb, *extra.wkb); err != nil {
 		return nil, err
 	}
-	return NewExtraMetadataV3(&wkb, &rkb, extra.wkbNew, extra.rkbNew), nil
+	return NewExtraMetadataV3(&wkb, &rkb, false, false), nil
 }
 
 // GetWriterKeyBundle returns the contained writer key bundle.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -150,7 +150,7 @@ func (extra ExtraMetadataV3) DeepCopy(codec kbfscodec.Codec) (
 	if err := kbfscodec.Update(codec, &wkb, *extra.wkb); err != nil {
 		return nil, err
 	}
-	return &ExtraMetadataV3{wkb: &wkb, rkb: &rkb}, nil
+	return NewExtraMetadataV3(&wkb, &rkb, extra.wkbNew, extra.rkbNew), nil
 }
 
 // GetWriterKeyBundle returns the contained writer key bundle.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1311,6 +1311,9 @@ func (md *BareRootMetadataV3) FinalizeRekey(
 	md.WriterMetadata.WKeyBundleID = newWKBID
 	md.RKeyBundleID = newRKBID
 
+	// TODO: This should be or'ing with the existing parameters to
+	// handle the upconvert-then-rekey case. Also add a test for
+	// this.
 	extraV3.wkbNew = newWKBID != oldWKBID
 	extraV3.rkbNew = newRKBID != oldRKBID
 

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -303,6 +303,27 @@ func (md *BareRootMetadataV3) IsFinal() bool {
 	return md.Flags&MetadataFlagFinal != 0
 }
 
+func (md *BareRootMetadataV3) getTLFKeyBundles(extra ExtraMetadata) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	if md.TlfID().IsPublic() {
+		return nil, nil, InvalidPublicTLFOperation{
+			md.TlfID(), "getTLFKeyBundles (V3)",
+		}
+	}
+
+	if extra == nil {
+		return nil, nil, makeMissingKeyBundlesError()
+	}
+
+	extraV3, ok := extra.(*ExtraMetadataV3)
+	if !ok {
+		return nil, nil, fmt.Errorf(
+			"Expected *ExtraMetadataV3, got %T", extra)
+	}
+
+	return &extraV3.wkb, &extraV3.rkb, nil
+}
+
 // IsWriter implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) IsWriter(
 	user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1287,7 +1287,7 @@ func (md *BareRootMetadataV3) FinalizeRekey(
 	extraV3.wkbNew = newWKBID != oldWKBID
 	extraV3.rkbNew = newRKBID != oldRKBID
 
-	return err
+	return nil
 }
 
 // StoresHistoricTLFCryptKeys implements the BareRootMetadata interface for BareRootMetadataV3.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -107,17 +107,28 @@ func makeMissingKeyBundlesError() missingKeyBundlesError {
 // ExtraMetadataV3 contains references to key bundles stored outside of metadata
 // blocks.  This only ever exists in memory and is never serialized itself.
 type ExtraMetadataV3 struct {
+	// wkb must not be nil.
 	wkb *TLFWriterKeyBundleV3
+	// rkb must not be nil.
 	rkb *TLFReaderKeyBundleV3
+	// Set if wkb is new and should be sent to the server on an MD
+	// put.
+	wkbNew bool
+	// Set if rkb is new and should be sent to the server on an MD
+	// put.
+	rkbNew bool
 }
 
 // NewExtraMetadataV3 creates a new ExtraMetadataV3 given a pair of key bundles
-func NewExtraMetadataV3(wkb *TLFWriterKeyBundleV3, rkb *TLFReaderKeyBundleV3) (
-	*ExtraMetadataV3, error) {
-	if wkb == nil || rkb == nil {
-		return nil, errors.New("Nil key bundle passed")
+func NewExtraMetadataV3(
+	wkb *TLFWriterKeyBundleV3, rkb *TLFReaderKeyBundleV3) *ExtraMetadataV3 {
+	if wkb == nil {
+		panic("nil wkb")
 	}
-	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
+	if rkb == nil {
+		panic("nil rkb")
+	}
+	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}
 }
 
 // MetadataVersion implements the ExtraMetadata interface for ExtraMetadataV3.
@@ -1002,10 +1013,7 @@ func (md *BareRootMetadataV3) addKeyGenerationHelper(codec kbfscodec.Codec,
 		TLFEphemeralPublicKeys: rPublicKeys,
 	}
 	md.WriterMetadata.LatestKeyGen++
-	return &ExtraMetadataV3{
-		rkb: newReaderKeys,
-		wkb: newWriterKeys,
-	}, nil
+	return NewExtraMetadataV3(newWriterKeys, newReaderKeys), nil
 }
 
 func (md *BareRootMetadataV3) addKeyGenerationForTest(codec kbfscodec.Codec,

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -163,18 +163,6 @@ func (extra ExtraMetadataV3) GetReaderKeyBundle() *TLFReaderKeyBundleV3 {
 	return extra.rkb
 }
 
-// Copy implements the ExtraMetadata interface for ExtraMetadataV3.
-func (extra ExtraMetadataV3) Copy(includeWkb, includeRkb bool) ExtraMetadata {
-	extraCopy := &ExtraMetadataV3{}
-	if includeWkb {
-		extraCopy.wkb = extra.wkb
-	}
-	if includeRkb {
-		extraCopy.rkb = extra.rkb
-	}
-	return extraCopy
-}
-
 // Helper function to extract key bundles for the ExtraMetadata interface.
 func getKeyBundlesV3(extra ExtraMetadata) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, bool) {
@@ -186,16 +174,6 @@ func getKeyBundlesV3(extra ExtraMetadata) (
 		return nil, nil, false
 	}
 	return extraV3.wkb, extraV3.rkb, true
-}
-
-// Helper function to extract key bundles for the ExtraMetadata interface.
-func getAnyKeyBundlesV3(extra ExtraMetadata) (
-	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3) {
-	extraV3, ok := extra.(*ExtraMetadataV3)
-	if !ok {
-		return nil, nil
-	}
-	return extraV3.wkb, extraV3.rkb
 }
 
 // MakeInitialBareRootMetadataV3 creates a new BareRootMetadataV3
@@ -384,21 +362,21 @@ func (md *BareRootMetadataV3) DeepCopy(
 func (md *BareRootMetadataV3) MakeSuccessorCopy(
 	ctx context.Context, config Config, kmd KeyMetadata,
 	extra ExtraMetadata, isReadableAndWriter bool) (
-	MutableBareRootMetadata, ExtraMetadata, bool, error) {
+	MutableBareRootMetadata, ExtraMetadata, error) {
 	var extraCopy ExtraMetadata
 	if extra != nil {
 		var err error
 		extraCopy, err = extra.DeepCopy(config.Codec())
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, err
 		}
 	}
 	mdCopy, err := md.DeepCopy(config.Codec())
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, err
 	}
 	// TODO: If there is ever a BareRootMetadataV4 this will need to perform the conversion.
-	return mdCopy, extraCopy, false, nil
+	return mdCopy, extraCopy, nil
 }
 
 // CheckValidSuccessor implements the BareRootMetadata interface for BareRootMetadataV3.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -152,16 +152,6 @@ func (extra ExtraMetadataV3) GetReaderKeyBundle() TLFReaderKeyBundleV3 {
 	return extra.rkb
 }
 
-// Helper function to extract key bundles for the ExtraMetadata interface.
-func getKeyBundlesV3(extra ExtraMetadata) (
-	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, bool) {
-	extraV3, ok := extra.(*ExtraMetadataV3)
-	if !ok {
-		return nil, nil, false
-	}
-	return &extraV3.wkb, &extraV3.rkb, true
-}
-
 // MakeInitialBareRootMetadataV3 creates a new BareRootMetadataV3
 // object with revision MetadataRevisionInitial, and the given TLF ID
 // and handle. Note that if the given ID/handle are private, rekeying

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -29,6 +29,26 @@ func TestBareRootMetadataVersionV3(t *testing.T) {
 	require.Equal(t, SegregatedKeyBundlesVer, rmd.Version())
 }
 
+func TestRootMetadataV3InitialRekey(t *testing.T) {
+	tlfID := tlf.FakeID(1, false)
+
+	uid := keybase1.MakeTestUID(1)
+	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	rmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
+	require.NoError(t, err)
+
+	codec := kbfscodec.NewMsgpack()
+	crypto := MakeCryptoCommon(codec)
+	extra := FakeInitialRekey(
+		rmd, codec, crypto, bh, kbfscrypto.TLFPublicKey{})
+	extraV3, ok := extra.(*ExtraMetadataV3)
+	require.True(t, ok)
+	require.True(t, extraV3.wkbNew)
+	require.True(t, extraV3.rkbNew)
+}
+
 func TestIsValidRekeyRequestBasicV3(t *testing.T) {
 	tlfID := tlf.FakeID(1, false)
 

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -67,7 +67,6 @@ func TestRootMetadataV3ExtraNew(t *testing.T) {
 	require.True(t, ok)
 	require.False(t, extraV3Copy.wkbNew)
 	require.False(t, extraV3Copy.rkbNew)
-
 }
 
 func TestIsValidRekeyRequestBasicV3(t *testing.T) {

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -157,8 +157,8 @@ func TestRevokeRemovedDevicesV3(t *testing.T) {
 	extra := FakeInitialRekey(
 		brmd, codec, crypto, bh, kbfscrypto.TLFPublicKey{})
 
-	wkb, rkb, ok := getKeyBundlesV3(extra)
-	require.True(t, ok)
+	wkb, rkb, err := brmd.getTLFKeyBundles(extra)
+	require.NoError(t, err)
 
 	*wkb = TLFWriterKeyBundleV3{
 		Keys: UserDeviceKeyInfoMapV3{
@@ -398,8 +398,8 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 		kbfscrypto.TLFCryptKey{}, tlfCryptKey, pubKey)
 	require.NoError(t, err)
 
-	wkb, rkb, ok := getKeyBundlesV3(extra)
-	require.True(t, ok)
+	wkb, rkb, err := rmd.getTLFKeyBundles(extra)
+	require.NoError(t, err)
 
 	var expectedRekeyInfos []expectedRekeyInfoV3
 	checkKeyBundlesV3(t, expectedRekeyInfos, tlfCryptKey, pubKey, wkb, rkb)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -88,7 +88,7 @@ func (c CryptoCommon) MakeMerkleHash(md *RootMetadataSigned) (MerkleHash, error)
 }
 
 // MakeTLFWriterKeyBundleID implements the Crypto interface for CryptoCommon.
-func (c CryptoCommon) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (
+func (c CryptoCommon) MakeTLFWriterKeyBundleID(wkb TLFWriterKeyBundleV3) (
 	TLFWriterKeyBundleID, error) {
 	buf, err := c.codec.Encode(wkb)
 	if err != nil {
@@ -102,7 +102,7 @@ func (c CryptoCommon) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (
 }
 
 // MakeTLFReaderKeyBundleID implements the Crypto interface for CryptoCommon.
-func (c CryptoCommon) MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (
+func (c CryptoCommon) MakeTLFReaderKeyBundleID(rkb TLFReaderKeyBundleV3) (
 	TLFReaderKeyBundleID, error) {
 	buf, err := c.codec.Encode(rkb)
 	if err != nil {

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -636,12 +636,13 @@ func (e NoKeysError) Error() string {
 type InvalidPublicTLFOperation struct {
 	id     tlf.ID
 	opName string
+	ver    MetadataVer
 }
 
 // Error implements the error interface for InvalidPublicTLFOperation.
 func (e InvalidPublicTLFOperation) Error() string {
-	return fmt.Sprintf("Tried to do invalid operation %s on public TLF %v",
-		e.opName, e.id)
+	return fmt.Sprintf("Tried to do invalid operation %s on public TLF %v (ver=%v)",
+		e.opName, e.id, e.ver)
 }
 
 // WrongOpsError indicates that an unexpected path got passed into a

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1608,7 +1608,7 @@ type BareRootMetadata interface {
 	// TODO: Replace Config argument.
 	MakeSuccessorCopy(ctx context.Context, config Config, kmd KeyMetadata,
 		extra ExtraMetadata, isReadableAndWriter bool) (
-		mdCopy MutableBareRootMetadata, extraCopy ExtraMetadata, extraCopyIsNew bool, err error)
+		mdCopy MutableBareRootMetadata, extraCopy ExtraMetadata, err error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.
 	CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -869,10 +869,10 @@ type cryptoPure interface {
 		ePubKey kbfscrypto.TLFEphemeralPublicKey) (*MerkleLeaf, error)
 
 	// MakeTLFWriterKeyBundleID hashes a TLFWriterKeyBundleV3 to create an ID.
-	MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error)
+	MakeTLFWriterKeyBundleID(wkb TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error)
 
 	// MakeTLFReaderKeyBundleID hashes a TLFReaderKeyBundleV3 to create an ID.
-	MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error)
+	MakeTLFReaderKeyBundleID(rkb TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error)
 
 	// EncryptTLFCryptKeys encrypts an array of historic TLFCryptKeys.
 	EncryptTLFCryptKeys(oldKeys []kbfscrypto.TLFCryptKey,

--- a/libkbfs/key_bundle_cache_test.go
+++ b/libkbfs/key_bundle_cache_test.go
@@ -20,10 +20,9 @@ func getKeyBundlesForTesting(t *testing.T, c Config, tlfByte byte, handleStr str
 	rmd.fakeInitialRekey(c.Codec(), c.Crypto())
 	wkbID := rmd.bareMd.GetTLFWriterKeyBundleID()
 	rkbID := rmd.bareMd.GetTLFReaderKeyBundleID()
-	wkb, rkb, ok := getKeyBundlesV3(rmd.extra)
-	if !ok {
-		t.Fatal(makeMissingKeyBundlesError())
-	}
+	wkb, rkb, err := rmd.bareMd.(*BareRootMetadataV3).getTLFKeyBundles(
+		rmd.extra)
+	require.NoError(t, err)
 	return tlfID, wkbID, wkb, rkbID, rkb
 }
 

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -367,14 +367,13 @@ func (rkg TLFReaderKeyGenerationsV2) IsReader(user keybase1.UID, deviceKID keyba
 // ToTLFReaderKeyBundleV3 converts a TLFReaderKeyGenerationsV2 to a TLFReaderkeyBundleV3.
 func (rkg TLFReaderKeyGenerationsV2) ToTLFReaderKeyBundleV3(
 	codec kbfscodec.Codec, wkb TLFWriterKeyBundleV2) (
-	*TLFReaderKeyBundleV3, error) {
-
+	TLFReaderKeyBundleV3, error) {
 	keyGen := rkg.LatestKeyGeneration()
-	if keyGen < 1 {
-		return nil, errors.New("No key generations to convert")
+	if keyGen < FirstValidKeyGen {
+		return TLFReaderKeyBundleV3{}, errors.New("No key generations to convert")
 	}
 
-	rkbV3 := &TLFReaderKeyBundleV3{
+	rkbV3 := TLFReaderKeyBundleV3{
 		Keys: make(UserDeviceKeyInfoMapV3),
 	}
 
@@ -400,12 +399,12 @@ func (rkg TLFReaderKeyGenerationsV2) ToTLFReaderKeyBundleV3(
 			var infoCopy TLFCryptKeyInfo
 			err := kbfscodec.Update(codec, &infoCopy, info)
 			if err != nil {
-				return nil, err
+				return TLFReaderKeyBundleV3{}, err
 			}
 
 			keyType, index, ePubKey, err := getEphemeralPublicKeyInfoV2(info, wkb, rkb)
 			if err != nil {
-				return nil, err
+				return TLFReaderKeyBundleV3{}, err
 			}
 
 			switch keyType {
@@ -428,7 +427,7 @@ func (rkg TLFReaderKeyGenerationsV2) ToTLFReaderKeyBundleV3(
 				// Use the real index in the reader list.
 				infoCopy.EPubKeyIndex = index
 			default:
-				return nil, fmt.Errorf("Unknown key type %s", keyType)
+				return TLFReaderKeyBundleV3{}, fmt.Errorf("Unknown key type %s", keyType)
 			}
 			dkimV3[kbfscrypto.MakeCryptPublicKey(kid)] = infoCopy
 		}

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -269,7 +269,8 @@ func (wkg TLFWriterKeyGenerationsV2) IsWriter(user keybase1.UID, deviceKID keyba
 //
 // TODO: Add a unit test for this.
 func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
-	ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, keyManager KeyManager, kmd KeyMetadata) (
+	ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure,
+	keyManager KeyManager, kmd KeyMetadata) (
 	TLFWriterKeyBundleV2, TLFWriterKeyBundleV3, error) {
 	keyGen := wkg.LatestKeyGeneration()
 	if keyGen < FirstValidKeyGen {

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -37,7 +37,7 @@ func (t ePubKeyTypeV2) String() string {
 // deal with the "negative hack" from
 // BareRootMetadataV2.UpdateKeyGeneration.
 func getEphemeralPublicKeyInfoV2(info TLFCryptKeyInfo,
-	wkb *TLFWriterKeyBundleV2, rkb *TLFReaderKeyBundleV2) (
+	wkb TLFWriterKeyBundleV2, rkb TLFReaderKeyBundleV2) (
 	keyType ePubKeyTypeV2, index int,
 	ePubKey kbfscrypto.TLFEphemeralPublicKey, err error) {
 	var publicKeys kbfscrypto.TLFEphemeralPublicKeys
@@ -270,20 +270,20 @@ func (wkg TLFWriterKeyGenerationsV2) IsWriter(user keybase1.UID, deviceKID keyba
 // TODO: Add a unit test for this.
 func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 	ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, keyManager KeyManager, kmd KeyMetadata) (
-	*TLFWriterKeyBundleV2, *TLFWriterKeyBundleV3, error) {
-
+	TLFWriterKeyBundleV2, TLFWriterKeyBundleV3, error) {
 	keyGen := wkg.LatestKeyGeneration()
 	if keyGen < FirstValidKeyGen {
-		return nil, nil, errors.New("No key generations to convert")
+		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{},
+			errors.New("No key generations to convert")
 	}
 
-	wkbV3 := &TLFWriterKeyBundleV3{}
+	var wkbV3 TLFWriterKeyBundleV3
 
 	// Copy the latest UserDeviceKeyInfoMap.
 	wkbV2 := wkg[keyGen-FirstValidKeyGen]
 	udkimV3, err := udkimV2ToV3(codec, wkbV2.WKeys)
 	if err != nil {
-		return nil, nil, err
+		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
 	}
 	wkbV3.Keys = udkimV3
 
@@ -299,11 +299,12 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 		// Fetch all of the TLFCryptKeys.
 		keys, err := keyManager.GetTLFCryptKeyOfAllGenerations(ctx, kmd)
 		if err != nil {
-			return nil, nil, err
+			return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
 		}
 		// Sanity check.
 		if len(keys) != int(keyGen) {
-			return nil, nil, fmt.Errorf("expected %d keys, found %d", keyGen, len(keys))
+			return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{},
+				fmt.Errorf("expected %d keys, found %d", keyGen, len(keys))
 		}
 		// Save the current key.
 		currKey := keys[len(keys)-1]
@@ -312,11 +313,11 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 		// Encrypt the historic keys with the current key.
 		wkbV3.EncryptedHistoricTLFCryptKeys, err = crypto.EncryptTLFCryptKeys(keys, currKey)
 		if err != nil {
-			return nil, nil, err
+			return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
 		}
 	}
 
-	return &wkbV2, wkbV3, nil
+	return wkbV2, wkbV3, nil
 }
 
 // TLFReaderKeyBundleV2 stores all the reader keys with reader
@@ -364,7 +365,7 @@ func (rkg TLFReaderKeyGenerationsV2) IsReader(user keybase1.UID, deviceKID keyba
 
 // ToTLFReaderKeyBundleV3 converts a TLFReaderKeyGenerationsV2 to a TLFReaderkeyBundleV3.
 func (rkg TLFReaderKeyGenerationsV2) ToTLFReaderKeyBundleV3(
-	codec kbfscodec.Codec, wkb *TLFWriterKeyBundleV2) (
+	codec kbfscodec.Codec, wkb TLFWriterKeyBundleV2) (
 	*TLFReaderKeyBundleV3, error) {
 
 	keyGen := rkg.LatestKeyGeneration()
@@ -401,7 +402,7 @@ func (rkg TLFReaderKeyGenerationsV2) ToTLFReaderKeyBundleV3(
 				return nil, err
 			}
 
-			keyType, index, ePubKey, err := getEphemeralPublicKeyInfoV2(info, wkb, &rkb)
+			keyType, index, ePubKey, err := getEphemeralPublicKeyInfoV2(info, wkb, rkb)
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -167,7 +167,7 @@ func TestToTLFReaderKeyBundleV3(t *testing.T) {
 	rkg := TLFReaderKeyGenerationsV2{TLFReaderKeyBundleV2{}, rkbV2}
 
 	codec := kbfscodec.NewMsgpack()
-	_, err := rkg.ToTLFReaderKeyBundleV3(codec, &TLFWriterKeyBundleV2{})
+	_, err := rkg.ToTLFReaderKeyBundleV3(codec, TLFWriterKeyBundleV2{})
 	require.Error(t, err)
 	require.True(t, strings.HasPrefix(err.Error(), "Invalid writer key index "),
 		"err: %v", err)
@@ -239,7 +239,7 @@ func TestToTLFReaderKeyBundleV3(t *testing.T) {
 		},
 	}
 
-	rkbV3, err := rkg.ToTLFReaderKeyBundleV3(codec, &wkbV2)
+	rkbV3, err := rkg.ToTLFReaderKeyBundleV3(codec, wkbV2)
 	require.NoError(t, err)
 	if !reflect.DeepEqual(expectedRKBV3a, *rkbV3) {
 		require.Equal(t, expectedRKBV3b, *rkbV3)

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -241,8 +241,8 @@ func TestToTLFReaderKeyBundleV3(t *testing.T) {
 
 	rkbV3, err := rkg.ToTLFReaderKeyBundleV3(codec, wkbV2)
 	require.NoError(t, err)
-	if !reflect.DeepEqual(expectedRKBV3a, *rkbV3) {
-		require.Equal(t, expectedRKBV3b, *rkbV3)
+	if !reflect.DeepEqual(expectedRKBV3a, rkbV3) {
+		require.Equal(t, expectedRKBV3b, rkbV3)
 	}
 }
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -35,12 +35,12 @@ func (c shimKMCrypto) DecryptTLFCryptKeys(
 }
 
 func (c shimKMCrypto) MakeTLFWriterKeyBundleID(
-	wkb *TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
+	wkb TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
 	return c.pure.MakeTLFWriterKeyBundleID(wkb)
 }
 
 func (c shimKMCrypto) MakeTLFReaderKeyBundleID(
-	wkb *TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
+	wkb TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
 	return c.pure.MakeTLFReaderKeyBundleID(wkb)
 }
 

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1047,22 +1047,6 @@ func (j *mdJournal) put(
 		}
 	}()
 
-	extra := rmd.extra
-	if extra == nil {
-		// TODO: This could fail if the key bundle isn't part
-		// of the journal. Always mandate that the extra field
-		// be plumbed through with a RootMetadata, and keep
-		// around a flag as to whether it should be sent up to
-		// the remote MDServer.
-		var err error
-		extra, err = j.getExtraMetadata(
-			rmd.bareMd.GetTLFWriterKeyBundleID(),
-			rmd.bareMd.GetTLFReaderKeyBundleID())
-		if err != nil {
-			return MdID{}, err
-		}
-	}
-
 	head, err := j.getLatest(true)
 	if err != nil {
 		return MdID{}, err
@@ -1143,7 +1127,7 @@ func (j *mdJournal) put(
 	if head != (ImmutableBareRootMetadata{}) {
 		ok, err := isWriterOrValidRekey(
 			j.codec, j.uid, head.BareRootMetadata, rmd.bareMd,
-			head.extra, extra)
+			head.extra, rmd.extra)
 		if err != nil {
 			return MdID{}, err
 		}
@@ -1188,7 +1172,7 @@ func (j *mdJournal) put(
 		return MdID{}, err
 	}
 
-	err = rmd.bareMd.IsValidAndSigned(j.codec, j.crypto, extra)
+	err = rmd.bareMd.IsValidAndSigned(j.codec, j.crypto, rmd.extra)
 	if err != nil {
 		return MdID{}, err
 	}
@@ -1198,7 +1182,7 @@ func (j *mdJournal) put(
 		return MdID{}, err
 	}
 
-	err = j.putExtraMetadata(rmd.bareMd, extra)
+	err = j.putExtraMetadata(rmd.bareMd, rmd.extra)
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -323,7 +323,7 @@ func (j mdJournal) getExtraMetadata(
 		return nil, err
 	}
 
-	return &ExtraMetadataV3{wkb: &wkb, rkb: &rkb}, nil
+	return NewExtraMetadataV3(&wkb, &rkb), nil
 }
 
 func (j mdJournal) putExtraMetadata(

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -318,12 +318,12 @@ func (j mdJournal) getExtraMetadata(
 		return nil, err
 	}
 
-	err = checkKeyBundleIDs(j.crypto, wkbID, rkbID, &wkb, &rkb)
+	err = checkKeyBundleIDs(j.crypto, wkbID, rkbID, wkb, rkb)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewExtraMetadataV3(&wkb, &rkb, false, false), nil
+	return NewExtraMetadataV3(wkb, rkb, false, false), nil
 }
 
 func (j mdJournal) putExtraMetadata(

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -347,11 +347,17 @@ func (j mdJournal) putExtraMetadata(
 		return errors.New("Invalid extra metadata")
 	}
 
+	// TODO: We lose extraV3.wkbNew and extraV3.rkbNew here. Store
+	// it as part of the mdInfo, so we don't needlessly send it
+	// while flushing.
+
 	err := checkKeyBundleIDs(
 		j.crypto, wkbID, rkbID, extraV3.wkb, extraV3.rkb)
 	if err != nil {
 		return err
 	}
+
+	// TODO: Avoid serializing if the file already exists.
 
 	err = kbfscodec.SerializeToFile(
 		j.codec, extraV3.wkb, j.writerKeyBundleV3Path(wkbID))

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -323,7 +323,8 @@ func (j mdJournal) getExtraMetadata(
 		return nil, err
 	}
 
-	return NewExtraMetadataV3(wkb, rkb, false, false), nil
+	// TODO: Store and retrieve the wkbNew/rkbNew parameters.
+	return NewExtraMetadataV3(wkb, rkb, true, true), nil
 }
 
 func (j mdJournal) putExtraMetadata(

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -323,7 +323,7 @@ func (j mdJournal) getExtraMetadata(
 		return nil, err
 	}
 
-	return NewExtraMetadataV3(&wkb, &rkb), nil
+	return NewExtraMetadataV3(&wkb, &rkb, false, false), nil
 }
 
 func (j mdJournal) putExtraMetadata(

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -282,6 +282,7 @@ func TestMDJournalPutCase1Empty(t *testing.T) {
 	head, err := j.getHead(NullBranchID)
 	require.NoError(t, err)
 	require.Equal(t, md.bareMd, head.BareRootMetadata)
+	require.Equal(t, md.extra, head.extra)
 }
 
 func TestMDJournalPutCase1Conflict(t *testing.T) {
@@ -330,6 +331,7 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, md.Revision(), head.RevisionNumber())
 	require.Equal(t, md.DiskUsage(), head.DiskUsage())
+	require.Equal(t, md.extra, head.extra)
 }
 
 func TestMDJournalPutCase2NonEmptyReplace(t *testing.T) {

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -122,17 +122,19 @@ func makeMDForTest(t testing.TB, tlfID tlf.ID, revision MetadataRevision,
 func putMDRange(t testing.TB, tlfID tlf.ID, signer kbfscrypto.Signer,
 	ekg encryptionKeyGetter, bsplit BlockSplitter,
 	firstRevision MetadataRevision, firstPrevRoot MdID, mdCount int,
-	j *mdJournal) MdID {
+	j *mdJournal) ([]*RootMetadata, MdID) {
 	prevRoot := firstPrevRoot
 	ctx := context.Background()
+	var mds []*RootMetadata
 	for i := 0; i < mdCount; i++ {
 		revision := firstRevision + MetadataRevision(i)
 		md := makeMDForTest(t, tlfID, revision, j.uid, signer, prevRoot)
 		mdID, err := j.put(ctx, signer, ekg, bsplit, md, false)
 		require.NoError(t, err)
+		mds = append(mds, md)
 		prevRoot = mdID
 	}
-	return prevRoot
+	return mds, prevRoot
 }
 
 func checkBRMD(t *testing.T, uid keybase1.UID, key kbfscrypto.VerifyingKey,
@@ -170,6 +172,9 @@ func checkIBRMDRange(t *testing.T, uid keybase1.UID,
 	}
 }
 
+// TODO: Create a separate journal for each iteration, instead of
+// using the same one.
+
 func BenchmarkMDJournalBasicMDv2(b *testing.B) {
 	_, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTestWithMetadataVer(b, InitialExtraMetadataVer)
@@ -183,7 +188,7 @@ func BenchmarkMDJournalBasicMDv2(b *testing.B) {
 	defer b.StopTimer()
 
 	for i := 0; i < b.N; i++ {
-		prevRoot = putMDRange(b, id, signer, ekg, bsplit,
+		_, prevRoot = putMDRange(b, id, signer, ekg, bsplit,
 			revision, prevRoot, mdCount, j)
 		revision += MetadataRevision(mdCount)
 	}
@@ -202,7 +207,7 @@ func BenchmarkMDJournalBasicMDv3(b *testing.B) {
 	defer b.StopTimer()
 
 	for i := 0; i < b.N; i++ {
-		prevRoot = putMDRange(b, id, signer, ekg, bsplit,
+		_, prevRoot = putMDRange(b, id, signer, ekg, bsplit,
 			revision, prevRoot, mdCount, j)
 		revision += MetadataRevision(mdCount)
 	}
@@ -314,7 +319,7 @@ func TestMDJournalPutCase1ReplaceHead(t *testing.T) {
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 3
-	prevRoot := putMDRange(t, id, signer, ekg, bsplit,
+	_, prevRoot := putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
 	// Should just replace the head.

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -230,9 +230,10 @@ func TestMDJournalBasic(t *testing.T) {
 	firstRevision := MetadataRevision(10)
 	firstPrevRoot := fakeMdID(1)
 	mdCount := 10
-	putMDRange(t, id, signer, ekg, bsplit,
+	mds, _ := putMDRange(t, id, signer, ekg, bsplit,
 		firstRevision, firstPrevRoot, mdCount, j)
 
+	require.Equal(t, mdCount, len(mds))
 	require.Equal(t, mdCount, getMDJournalLength(t, j))
 
 	// Should now be non-empty.
@@ -247,6 +248,11 @@ func TestMDJournalBasic(t *testing.T) {
 	head, err = j.getHead(NullBranchID)
 	require.NoError(t, err)
 	require.Equal(t, ibrmds[len(ibrmds)-1], head)
+
+	for i := 0; i < mdCount; i++ {
+		require.Equal(t, mds[i].bareMd, ibrmds[i].BareRootMetadata)
+		require.Equal(t, mds[i].extra, ibrmds[i].extra)
+	}
 }
 
 func TestMDJournalGetNextEntry(t *testing.T) {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -551,7 +551,7 @@ func (md *MDOpsStandard) put(
 		return MdID{}, err
 	}
 
-	err = md.config.MDServer().Put(ctx, rmds, rmd.NewExtra())
+	err = md.config.MDServer().Put(ctx, rmds, rmd.extra)
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -643,7 +643,7 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 			rkbID, tlf, err2)
 	}
 	if wkb != nil && rkb != nil {
-		return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
+		return NewExtraMetadataV3(wkb, rkb), nil
 	}
 	if wkb != nil {
 		// Don't need the writer bundle.
@@ -661,5 +661,5 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 	// Cache the results.
 	kbcache.PutTLFWriterKeyBundle(tlf, wkbID, wkb)
 	kbcache.PutTLFReaderKeyBundle(tlf, rkbID, rkb)
-	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
+	return NewExtraMetadataV3(wkb, rkb), nil
 }

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -643,7 +643,7 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 			rkbID, tlf, err2)
 	}
 	if wkb != nil && rkb != nil {
-		return NewExtraMetadataV3(wkb, rkb, false, false), nil
+		return NewExtraMetadataV3(*wkb, *rkb, false, false), nil
 	}
 	if wkb != nil {
 		// Don't need the writer bundle.
@@ -661,5 +661,5 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 	// Cache the results.
 	kbcache.PutTLFWriterKeyBundle(tlf, wkbID, wkb)
 	kbcache.PutTLFReaderKeyBundle(tlf, rkbID, rkb)
-	return NewExtraMetadataV3(wkb, rkb, false, false), nil
+	return NewExtraMetadataV3(*wkb, *rkb, false, false), nil
 }

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -643,7 +643,7 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 			rkbID, tlf, err2)
 	}
 	if wkb != nil && rkb != nil {
-		return NewExtraMetadataV3(wkb, rkb), nil
+		return NewExtraMetadataV3(wkb, rkb, false, false), nil
 	}
 	if wkb != nil {
 		// Don't need the writer bundle.
@@ -661,5 +661,5 @@ func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd BareRootMetadata) 
 	// Cache the results.
 	kbcache.PutTLFWriterKeyBundle(tlf, wkbID, wkb)
 	kbcache.PutTLFReaderKeyBundle(tlf, rkbID, rkb)
-	return NewExtraMetadataV3(wkb, rkb), nil
+	return NewExtraMetadataV3(wkb, rkb, false, false), nil
 }

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -64,9 +64,9 @@ type mdServerMemShared struct {
 	// (TLF ID, branch ID) -> list of MDs
 	mdDb map[mdBlockKey]mdBlockMemList
 	// Writer key bundle ID -> writer key bundles
-	writerKeyBundleDb map[mdExtraWriterKey]*TLFWriterKeyBundleV3
+	writerKeyBundleDb map[mdExtraWriterKey]TLFWriterKeyBundleV3
 	// Reader key bundle ID -> reader key bundles
-	readerKeyBundleDb map[mdExtraReaderKey]*TLFReaderKeyBundleV3
+	readerKeyBundleDb map[mdExtraReaderKey]TLFReaderKeyBundleV3
 	// (TLF ID, device KID) -> branch ID
 	branchDb            map[mdBranchKey]BranchID
 	truncateLockManager *mdServerLocalTruncateLockManager
@@ -91,8 +91,8 @@ func NewMDServerMemory(config mdServerLocalConfig) (*MDServerMemory, error) {
 	latestHandleDb := make(map[tlf.ID]tlf.Handle)
 	mdDb := make(map[mdBlockKey]mdBlockMemList)
 	branchDb := make(map[mdBranchKey]BranchID)
-	writerKeyBundleDb := make(map[mdExtraWriterKey]*TLFWriterKeyBundleV3)
-	readerKeyBundleDb := make(map[mdExtraReaderKey]*TLFReaderKeyBundleV3)
+	writerKeyBundleDb := make(map[mdExtraWriterKey]TLFWriterKeyBundleV3)
+	readerKeyBundleDb := make(map[mdExtraReaderKey]TLFReaderKeyBundleV3)
 	log := config.MakeLogger("MDSM")
 	truncateLockManager := newMDServerLocalTruncatedLockManager()
 	shared := mdServerMemShared{
@@ -766,7 +766,7 @@ func (md *MDServerMemory) getExtraMetadata(
 	if wkb == nil || rkb == nil {
 		return nil, nil
 	}
-	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
+	return NewExtraMetadataV3(*wkb, *rkb, false, false), nil
 }
 
 func (md *MDServerMemory) putExtraMetadataLocked(rmds *RootMetadataSigned,
@@ -828,7 +828,7 @@ func (md *MDServerMemory) getKeyBundles(
 		return nil, nil, err
 	}
 
-	return wkb, rkb, nil
+	return &wkb, &rkb, nil
 }
 
 // GetKeyBundles implements the MDServer interface for MDServerMemory.

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -892,7 +892,7 @@ func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 			return nil, nil, err
 		}
 		// Verify it's what we expect.
-		bundleID, err := md.config.Crypto().MakeTLFWriterKeyBundleID(wkb)
+		bundleID, err := md.config.Crypto().MakeTLFWriterKeyBundleID(*wkb)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -916,7 +916,7 @@ func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 			return nil, nil, err
 		}
 		// Verify it's what we expect.
-		bundleID, err := md.config.Crypto().MakeTLFReaderKeyBundleID(rkb)
+		bundleID, err := md.config.Crypto().MakeTLFReaderKeyBundleID(*rkb)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -493,25 +493,27 @@ func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
 	}
 
 	// add any new key bundles
-	wkb, rkb := getAnyKeyBundlesV3(extra)
-	if wkb != nil {
-		wkbBytes, err := md.config.Codec().Encode(wkb)
-		if err != nil {
-			return err
+	extraV3, ok := extra.(*ExtraMetadataV3)
+	if ok {
+		if extraV3.wkbNew {
+			wkbBytes, err := md.config.Codec().Encode(extraV3.wkb)
+			if err != nil {
+				return err
+			}
+			arg.WriterKeyBundle = keybase1.KeyBundle{
+				Version: int(rmds.Version()),
+				Bundle:  wkbBytes,
+			}
 		}
-		arg.WriterKeyBundle = keybase1.KeyBundle{
-			Version: int(rmds.Version()),
-			Bundle:  wkbBytes,
-		}
-	}
-	if rkb != nil {
-		rkbBytes, err := md.config.Codec().Encode(rkb)
-		if err != nil {
-			return err
-		}
-		arg.ReaderKeyBundle = keybase1.KeyBundle{
-			Version: int(rmds.Version()),
-			Bundle:  rkbBytes,
+		if extraV3.rkbNew {
+			rkbBytes, err := md.config.Codec().Encode(extraV3.rkb)
+			if err != nil {
+				return err
+			}
+			arg.ReaderKeyBundle = keybase1.KeyBundle{
+				Version: int(rmds.Version()),
+				Bundle:  rkbBytes,
+			}
 		}
 	}
 

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -297,7 +297,7 @@ func (s *mdServerTlfStorage) getExtraMetadataReadLocked(
 	if wkb == nil || rkb == nil {
 		return nil, nil
 	}
-	return &ExtraMetadataV3{wkb: wkb, rkb: rkb}, nil
+	return &ExtraMetadataV3{wkb: *wkb, rkb: *rkb}, nil
 }
 
 func (s *mdServerTlfStorage) getKeyBundlesReadLocked(
@@ -329,7 +329,7 @@ func (s *mdServerTlfStorage) getKeyBundlesReadLocked(
 		return nil, nil, err
 	}
 
-	err = checkKeyBundleIDs(s.crypto, wkbID, rkbID, &wkb, &rkb)
+	err = checkKeyBundleIDs(s.crypto, wkbID, rkbID, wkb, rkb)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -339,7 +339,7 @@ func (s *mdServerTlfStorage) getKeyBundlesReadLocked(
 
 func checkKeyBundleIDs(crypto cryptoPure,
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID,
-	wkb *TLFWriterKeyBundleV3, rkb *TLFReaderKeyBundleV3) error {
+	wkb TLFWriterKeyBundleV3, rkb TLFReaderKeyBundleV3) error {
 	computedWKBID, err := crypto.MakeTLFWriterKeyBundleID(wkb)
 	if err != nil {
 		return err

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -297,7 +297,7 @@ func (s *mdServerTlfStorage) getExtraMetadataReadLocked(
 	if wkb == nil || rkb == nil {
 		return nil, nil
 	}
-	return &ExtraMetadataV3{wkb: *wkb, rkb: *rkb}, nil
+	return NewExtraMetadataV3(*wkb, *rkb, false, false), nil
 }
 
 func (s *mdServerTlfStorage) getKeyBundlesReadLocked(

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4637,13 +4637,12 @@ func (_mr *_MockBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
 }
 
-func (_m *MockBareRootMetadata) MakeSuccessorCopy(ctx context.Context, config Config, kmd KeyMetadata, extra ExtraMetadata, isReadableAndWriter bool) (MutableBareRootMetadata, ExtraMetadata, bool, error) {
+func (_m *MockBareRootMetadata) MakeSuccessorCopy(ctx context.Context, config Config, kmd KeyMetadata, extra ExtraMetadata, isReadableAndWriter bool) (MutableBareRootMetadata, ExtraMetadata, error) {
 	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", ctx, config, kmd, extra, isReadableAndWriter)
 	ret0, _ := ret[0].(MutableBareRootMetadata)
 	ret1, _ := ret[1].(ExtraMetadata)
-	ret2, _ := ret[2].(bool)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockBareRootMetadataRecorder) MakeSuccessorCopy(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
@@ -5076,13 +5075,12 @@ func (_mr *_MockMutableBareRootMetadataRecorder) DeepCopy(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeepCopy", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) MakeSuccessorCopy(ctx context.Context, config Config, kmd KeyMetadata, extra ExtraMetadata, isReadableAndWriter bool) (MutableBareRootMetadata, ExtraMetadata, bool, error) {
+func (_m *MockMutableBareRootMetadata) MakeSuccessorCopy(ctx context.Context, config Config, kmd KeyMetadata, extra ExtraMetadata, isReadableAndWriter bool) (MutableBareRootMetadata, ExtraMetadata, error) {
 	ret := _m.ctrl.Call(_m, "MakeSuccessorCopy", ctx, config, kmd, extra, isReadableAndWriter)
 	ret0, _ := ret[0].(MutableBareRootMetadata)
 	ret1, _ := ret[1].(ExtraMetadata)
-	ret2, _ := ret[2].(bool)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockMutableBareRootMetadataRecorder) MakeSuccessorCopy(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2010,7 +2010,7 @@ func (_mr *_MockcryptoPureRecorder) DecryptMerkleLeaf(arg0, arg1, arg2, arg3 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptMerkleLeaf", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockcryptoPure) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
+func (_m *MockcryptoPure) MakeTLFWriterKeyBundleID(wkb TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
 	ret := _m.ctrl.Call(_m, "MakeTLFWriterKeyBundleID", wkb)
 	ret0, _ := ret[0].(TLFWriterKeyBundleID)
 	ret1, _ := ret[1].(error)
@@ -2021,7 +2021,7 @@ func (_mr *_MockcryptoPureRecorder) MakeTLFWriterKeyBundleID(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTLFWriterKeyBundleID", arg0)
 }
 
-func (_m *MockcryptoPure) MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
+func (_m *MockcryptoPure) MakeTLFReaderKeyBundleID(rkb TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
 	ret := _m.ctrl.Call(_m, "MakeTLFReaderKeyBundleID", rkb)
 	ret0, _ := ret[0].(TLFReaderKeyBundleID)
 	ret1, _ := ret[1].(error)
@@ -2340,7 +2340,7 @@ func (_mr *_MockCryptoRecorder) DecryptMerkleLeaf(arg0, arg1, arg2, arg3 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DecryptMerkleLeaf", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockCrypto) MakeTLFWriterKeyBundleID(wkb *TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
+func (_m *MockCrypto) MakeTLFWriterKeyBundleID(wkb TLFWriterKeyBundleV3) (TLFWriterKeyBundleID, error) {
 	ret := _m.ctrl.Call(_m, "MakeTLFWriterKeyBundleID", wkb)
 	ret0, _ := ret[0].(TLFWriterKeyBundleID)
 	ret1, _ := ret[1].(error)
@@ -2351,7 +2351,7 @@ func (_mr *_MockCryptoRecorder) MakeTLFWriterKeyBundleID(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeTLFWriterKeyBundleID", arg0)
 }
 
-func (_m *MockCrypto) MakeTLFReaderKeyBundleID(rkb *TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
+func (_m *MockCrypto) MakeTLFReaderKeyBundleID(rkb TLFReaderKeyBundleV3) (TLFReaderKeyBundleID, error) {
 	ret := _m.ctrl.Call(_m, "MakeTLFReaderKeyBundleID", rkb)
 	ret0, _ := ret[0].(TLFReaderKeyBundleID)
 	ret1, _ := ret[1].(error)

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -576,9 +576,9 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	h := parseTlfHandleOrBust(t, config, "alice,alice@twitter#bob,charlie@twitter,eve@reddit", false)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(0))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), InitialExtraMetadataVer)
+	require.Equal(t, KeyGen(0), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 
 	// set some dummy numbers
 	diskUsage, refBytes, unrefBytes := uint64(12345), uint64(4321), uint64(1234)
@@ -590,11 +590,11 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err := config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(1))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), InitialExtraMetadataVer)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys), 0)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys), 1)
+	require.Equal(t, KeyGen(1), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
+	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 
 	// revoke bob's device
 	_, bobUID, err := config.KBPKI().Resolve(context.Background(), "bob")
@@ -605,11 +605,11 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err = config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(2))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), InitialExtraMetadataVer)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys), 0)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys), 1)
+	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
+	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 
 	// prove charlie
 	config.KeybaseService().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
@@ -619,11 +619,11 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err = config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(2))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), InitialExtraMetadataVer)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys), 0)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys), 2)
+	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
+	require.Equal(t, 2, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 
 	// add a device for charlie and rekey as charlie
 	_, charlieUID, err := config.KBPKI().Resolve(context.Background(), "charlie")
@@ -637,11 +637,11 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err = config2.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(2))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), InitialExtraMetadataVer)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys), 1)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys), 2)
+	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
+	require.Equal(t, 2, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 
 	// override the metadata version
 	config.metadataVersion = SegregatedKeyBundlesVer
@@ -649,9 +649,9 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(), config, fakeMdID(1), true)
 	require.NoError(t, err)
-	require.Equal(t, rmd2.LatestKeyGeneration(), KeyGen(2))
-	require.Equal(t, rmd2.Revision(), MetadataRevision(2))
-	require.Equal(t, rmd2.Version(), SegregatedKeyBundlesVer)
+	require.Equal(t, KeyGen(2), rmd2.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(2), rmd2.Revision())
+	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
 	require.NotNil(t, rmd2.extra)
 
 	// compare numbers
@@ -670,19 +670,19 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	// compare tlf crypt keys
 	keys, err := config.KeyManager().GetTLFCryptKeyOfAllGenerations(context.Background(), rmd)
 	require.NoError(t, err)
-	require.Equal(t, len(keys), 2)
+	require.Equal(t, 2, len(keys))
 
 	keys2, err := config.KeyManager().GetTLFCryptKeyOfAllGenerations(context.Background(), rmd2)
 	require.NoError(t, err)
-	require.Equal(t, len(keys2), 2)
-	require.Equal(t, keys2, keys)
+	require.Equal(t, 2, len(keys2))
+	require.Equal(t, keys, keys2)
 
 	// get each key generation for alice from each version of metadata
 	aliceKeys := getAllUsersKeysForTest(t, config, rmd, "alice")
 	aliceKeys2 := getAllUsersKeysForTest(t, config, rmd2, "alice")
 
 	// compare alice's keys
-	require.Equal(t, len(aliceKeys), 2)
+	require.Equal(t, 2, len(aliceKeys))
 	require.Equal(t, aliceKeys, aliceKeys2)
 
 	// get each key generation for charlie from each version of metadata
@@ -690,7 +690,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	charlieKeys2 := getAllUsersKeysForTest(t, config2, rmd2, "charlie")
 
 	// compare charlie's keys
-	require.Equal(t, len(charlieKeys), 2)
+	require.Equal(t, 2, len(charlieKeys))
 	require.Equal(t, charlieKeys, charlieKeys2)
 
 	// compare alice and charlie's keys
@@ -706,9 +706,9 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	h := parseTlfHandleOrBust(t, config, "alice,bob,charlie@twitter", true)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, rmd.LatestKeyGeneration(), PublicKeyGen)
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), InitialExtraMetadataVer)
+	require.Equal(t, PublicKeyGen, rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 
 	// set some dummy numbers
 	diskUsage, refBytes, unrefBytes := uint64(12345), uint64(4321), uint64(1234)

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -722,9 +722,9 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(), config, fakeMdID(1), true)
 	require.NoError(t, err)
-	require.Equal(t, rmd2.LatestKeyGeneration(), PublicKeyGen)
-	require.Equal(t, rmd2.Revision(), MetadataRevision(2))
-	require.Equal(t, rmd2.Version(), SegregatedKeyBundlesVer)
+	require.Equal(t, PublicKeyGen, rmd2.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(2), rmd2.Revision())
+	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
 	// Do this instead of require.Nil because we want to assert
 	// that it's untyped nil.
 	require.True(t, rmd2.extra == nil)


### PR DESCRIPTION
Otherwise, the journal would not be able to
easily serve up MDs with fleshed-out
ExtraMetadata objects.

Use NewExtraMetadataV3 everywhere.

Use TLF{Writer,Reader}KeyBundleV3 instead of
pointers in more places.

Lots of misc. cleanup.