### PR TITLE
Make local MDServers match MDServerRemote

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1078,11 +1078,13 @@ type MDServer interface {
 	GetRange(ctx context.Context, id tlf.ID, bid BranchID, mStatus MergeStatus,
 		start, stop MetadataRevision) ([]*RootMetadataSigned, error)
 
-	// Put stores the (signed/encrypted) metadata object for the given
-	// top-level folder. Note: If the unmerged bit is set in the metadata
-	// block's flags bitmask it will be appended to the unmerged per-device
-	// history.
-	Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error
+	// Put stores the (signed/encrypted) metadata object for the
+	// given top-level folder. Note: If the unmerged bit is set in
+	// the metadata block's flags bitmask it will be appended to
+	// the unmerged per-device history. extraNew is allowed to
+	// drop data that exists as part of a previous extra bundle.
+	Put(ctx context.Context, rmds *RootMetadataSigned,
+		extraNew ExtraMetadata) error
 
 	// PruneBranch prunes all unmerged history for the given TLF branch.
 	PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error
@@ -1140,7 +1142,11 @@ type MDServer interface {
 	// don't have a current estimate for the offset.
 	OffsetFromServerTime() (time.Duration, bool)
 
-	// GetKeyBundles returns the key bundles for the given key bundle IDs.
+	// GetKeyBundles looks up the key bundles for the given key
+	// bundle IDs. tlfID must be non-zero but either or both wkbID
+	// and rkbID can be zero, in which case nil will be returned
+	// for the respective bundle. If a bundle cannot be found, an
+	// error is returned and nils are returned for both bundles.
 	GetKeyBundles(ctx context.Context, tlfID tlf.ID,
 		wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 		*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1081,10 +1081,9 @@ type MDServer interface {
 	// Put stores the (signed/encrypted) metadata object for the
 	// given top-level folder. Note: If the unmerged bit is set in
 	// the metadata block's flags bitmask it will be appended to
-	// the unmerged per-device history. extraNew is allowed to
-	// drop data that exists as part of a previous extra bundle.
+	// the unmerged per-device history.
 	Put(ctx context.Context, rmds *RootMetadataSigned,
-		extraNew ExtraMetadata) error
+		extra ExtraMetadata) error
 
 	// PruneBranch prunes all unmerged history for the given TLF branch.
 	PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1078,12 +1078,11 @@ type MDServer interface {
 	GetRange(ctx context.Context, id tlf.ID, bid BranchID, mStatus MergeStatus,
 		start, stop MetadataRevision) ([]*RootMetadataSigned, error)
 
-	// Put stores the (signed/encrypted) metadata object for the
-	// given top-level folder. Note: If the unmerged bit is set in
-	// the metadata block's flags bitmask it will be appended to
-	// the unmerged per-device history.
-	Put(ctx context.Context, rmds *RootMetadataSigned,
-		extra ExtraMetadata) error
+	// Put stores the (signed/encrypted) metadata object for the given
+	// top-level folder. Note: If the unmerged bit is set in the metadata
+	// block's flags bitmask it will be appended to the unmerged per-device
+	// history.
+	Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error
 
 	// PruneBranch prunes all unmerged history for the given TLF branch.
 	PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -369,12 +369,12 @@ func (j mdJournal) putExtraMetadata(
 		return err
 	}
 
-	// TODO: Avoid serializing if the file already exists.
-
 	err = checkRKBID(j.crypto, rkbID, extraV3.rkb)
 	if err != nil {
 		return err
 	}
+
+	// TODO: Avoid serializing if the file already exists.
 
 	err = kbfscodec.SerializeToFile(
 		j.codec, extraV3.wkb, j.writerKeyBundleV3Path(wkbID))

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -318,10 +318,10 @@ func (j mdJournal) getExtraMetadata(
 		return nil, err
 	}
 
-	err = checkKeyBundleIDs(j.crypto, wkbID, rkbID, wkb, rkb)
+	/*err = checkKeyBundlesIDs(j.crypto, wkbID, rkbID, &wkb, &rkb)
 	if err != nil {
 		return nil, err
-	}
+	}*/
 
 	// TODO: Store and retrieve the wkbNew/rkbNew parameters.
 	return NewExtraMetadataV3(wkb, rkb, true, true), nil
@@ -352,15 +352,15 @@ func (j mdJournal) putExtraMetadata(
 	// it as part of the mdInfo, so we don't needlessly send it
 	// while flushing.
 
-	err := checkKeyBundleIDs(
+	/*err := checkKeyBundleIDs(
 		j.crypto, wkbID, rkbID, extraV3.wkb, extraV3.rkb)
 	if err != nil {
 		return err
-	}
+	}*/
 
 	// TODO: Avoid serializing if the file already exists.
 
-	err = kbfscodec.SerializeToFile(
+	err := kbfscodec.SerializeToFile(
 		j.codec, extraV3.wkb, j.writerKeyBundleV3Path(wkbID))
 	if err != nil {
 		return err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -339,10 +339,10 @@ func (j mdJournal) putExtraMetadata(
 
 	if extra == nil {
 		if wkbID != (TLFWriterKeyBundleID{}) {
-			panic(fmt.Sprintf("unexpected non-nil wkbID %s", wkbID))
+			panic(errors.Errorf("unexpected non-nil wkbID %s", wkbID))
 		}
 		if rkbID != (TLFReaderKeyBundleID{}) {
-			panic(fmt.Sprintf("unexpected non-nil rkbID %s", rkbID))
+			panic(errors.Errorf("unexpected non-nil rkbID %s", rkbID))
 		}
 		return nil
 	}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -655,5 +655,5 @@ func (md *MDServerDisk) GetKeyBundles(_ context.Context,
 		return nil, nil, err
 	}
 
-	return tlfStorage.getKeyBundles(wkbID, rkbID)
+	return tlfStorage.getKeyBundles(tlfID, wkbID, rkbID)
 }

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -11,7 +11,6 @@ import (
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // TODO: Have the functions below wrap their errors.
@@ -167,13 +166,12 @@ func (m *mdServerLocalUpdateManager) registerForUpdate(
 }
 
 type keyBundleGetter interface {
-	getKeyBundles(ctx context.Context, tlfID tlf.ID,
+	getKeyBundles(tlfID tlf.ID,
 		wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 		*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
 }
 
-func getExtraMetadata(ctx context.Context, kbg keyBundleGetter,
-	brmd BareRootMetadata) (ExtraMetadata, error) {
+func getExtraMetadata(kbg keyBundleGetter, brmd BareRootMetadata) (ExtraMetadata, error) {
 	tlfID := brmd.TlfID()
 	wkbID := brmd.GetTLFWriterKeyBundleID()
 	rkbID := brmd.GetTLFReaderKeyBundleID()
@@ -189,10 +187,10 @@ func getExtraMetadata(ctx context.Context, kbg keyBundleGetter,
 		return nil, nil
 	}
 
-	wkb, rkb, err := kbg.getKeyBundles(ctx, tlfID, wkbID, rkbID)
+	wkb, rkb, err := kbg.getKeyBundles(tlfID, wkbID, rkbID)
 	if err != nil {
 		return nil, err
 	}
 
-	return &ExtraMetadataV3{wkb: *wkb, rkb: *rkb}, nil
+	return NewExtraMetadataV3(*wkb, *rkb, false, false), nil
 }

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -5,12 +5,13 @@
 package libkbfs
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // TODO: Have the functions below wrap their errors.
@@ -158,9 +159,40 @@ func (m *mdServerLocalUpdateManager) registerForUpdate(
 		// fatal bug.  Note that in the real MDServer implementation,
 		// we should allow this, in order to make the RPC properly
 		// idempotent.
-		panic(fmt.Errorf("Attempted double-registration for MDServerLocal %v",
+		panic(errors.Errorf("Attempted double-registration for MDServerLocal %v",
 			server))
 	}
 	m.observers[id][server] = c
 	return c
+}
+
+type keyBundleGetter interface {
+	getKeyBundles(ctx context.Context, tlfID tlf.ID,
+		wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
+		*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
+}
+
+func getExtraMetadata(ctx context.Context, kbg keyBundleGetter,
+	brmd BareRootMetadata) (ExtraMetadata, error) {
+	tlfID := brmd.TlfID()
+	wkbID := brmd.GetTLFWriterKeyBundleID()
+	rkbID := brmd.GetTLFReaderKeyBundleID()
+	if (wkbID == TLFWriterKeyBundleID{}) !=
+		(rkbID == TLFReaderKeyBundleID{}) {
+		return nil, errors.Errorf(
+			"wkbID is empty (%t) != rkbID is empty (%t)",
+			wkbID == TLFWriterKeyBundleID{},
+			rkbID == TLFReaderKeyBundleID{})
+	}
+
+	if wkbID == (TLFWriterKeyBundleID{}) {
+		return nil, nil
+	}
+
+	wkb, rkb, err := kbg.getKeyBundles(ctx, tlfID, wkbID, rkbID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ExtraMetadataV3{wkb: *wkb, rkb: *rkb}, nil
 }

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -823,19 +823,10 @@ func (md *MDServerMemory) getKeyBundles(_ context.Context, tlfID tlf.ID,
 				"Could not find WKB for ID %s", wkbID)
 		}
 
-		computedWKBID, err :=
-			md.config.cryptoPure().MakeTLFWriterKeyBundleID(foundWKB)
+		err := checkWKBID(md.config.cryptoPure(), wkbID, foundWKB)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		if wkbID != computedWKBID {
-			return nil, nil, errors.Errorf(
-				"Expected WKB ID %s, got %s",
-				wkbID, computedWKBID)
-		}
-
-		wkb = &foundWKB
 	}
 
 	var rkb *TLFReaderKeyBundleV3
@@ -846,19 +837,10 @@ func (md *MDServerMemory) getKeyBundles(_ context.Context, tlfID tlf.ID,
 				"Could not find RKB for ID %s", rkbID)
 		}
 
-		computedRKBID, err :=
-			md.config.cryptoPure().MakeTLFReaderKeyBundleID(foundRKB)
+		err := checkRKBID(md.config.cryptoPure(), rkbID, foundRKB)
 		if err != nil {
 			return nil, nil, err
 		}
-
-		if rkbID != computedRKBID {
-			return nil, nil, errors.Errorf(
-				"Expected RKB ID %s, got %s",
-				rkbID, computedRKBID)
-		}
-
-		rkb = &foundRKB
 	}
 
 	return wkb, rkb, nil

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -202,7 +202,7 @@ func (md *MDServerMemory) checkGetParams(
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		extra, err := getExtraMetadata(ctx, md, mergedMasterHead.MD)
+		extra, err := getExtraMetadata(md, mergedMasterHead.MD)
 		if err != nil {
 			return NullBranchID, MDServerError{err}
 		}
@@ -395,7 +395,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		prevExtra, err := getExtraMetadata(ctx, md, mergedMasterHead.MD)
+		prevExtra, err := getExtraMetadata(md, mergedMasterHead.MD)
 		if err != nil {
 			return MDServerError{err}
 		}
@@ -775,11 +775,11 @@ func (md *MDServerMemory) putExtraMetadataLocked(rmds *RootMetadataSigned,
 	return nil
 }
 
-func (md *MDServerMemory) getKeyBundles(_ context.Context, tlfID tlf.ID,
+func (md *MDServerMemory) getKeyBundles(tlfID tlf.ID,
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	md.lock.Lock()
-	defer md.lock.Unlock()
+	md.lock.RLock()
+	defer md.lock.RUnlock()
 	if md.writerKeyBundleDb == nil {
 		return nil, nil, errMDServerMemoryShutdown
 	}
@@ -819,7 +819,7 @@ func (md *MDServerMemory) getKeyBundles(_ context.Context, tlfID tlf.ID,
 func (md *MDServerMemory) GetKeyBundles(ctx context.Context,
 	tlfID tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	wkb, rkb, err := md.getKeyBundles(ctx, tlfID, wkbID, rkbID)
+	wkb, rkb, err := md.getKeyBundles(tlfID, wkbID, rkbID)
 	if err != nil {
 		return nil, nil, MDServerError{err}
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -815,8 +815,9 @@ func (md *MDServerMemory) GetKeyBundles(_ context.Context,
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	md.lock.Lock()
 	defer md.lock.Unlock()
-
-	// TODO: Check for shutdown.
+	if md.writerKeyBundleDb == nil {
+		return nil, nil, errMDServerMemoryShutdown
+	}
 
 	var wkb *TLFWriterKeyBundleV3
 	if wkbID != (TLFWriterKeyBundleID{}) {

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -816,6 +816,8 @@ func (md *MDServerMemory) GetKeyBundles(_ context.Context,
 	md.lock.Lock()
 	defer md.lock.Unlock()
 
+	// TODO: Check for shutdown.
+
 	var wkb *TLFWriterKeyBundleV3
 	if wkbID != (TLFWriterKeyBundleID{}) {
 		foundWKB, ok := md.writerKeyBundleDb[mdExtraWriterKey{tlfID, wkbID}]

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -797,6 +797,8 @@ func (md *MDServerMemory) getKeyBundles(tlfID tlf.ID,
 		if err != nil {
 			return nil, nil, err
 		}
+
+		wkb = &foundWKB
 	}
 
 	var rkb *TLFReaderKeyBundleV3
@@ -811,6 +813,8 @@ func (md *MDServerMemory) getKeyBundles(tlfID tlf.ID,
 		if err != nil {
 			return nil, nil, err
 		}
+
+		rkb = &foundRKB
 	}
 
 	return wkb, rkb, nil

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -780,8 +780,9 @@ func (md *MDServerMemory) getKeyBundles(tlfID tlf.ID,
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	md.lock.RLock()
 	defer md.lock.RUnlock()
-	if md.writerKeyBundleDb == nil {
-		return nil, nil, errMDServerMemoryShutdown
+	err := md.checkShutdownLocked()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var wkb *TLFWriterKeyBundleV3

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -750,7 +750,7 @@ func (md *MDServerMemory) putExtraMetadataLocked(rmds *RootMetadataSigned,
 
 	extraV3, ok := extra.(*ExtraMetadataV3)
 	if !ok {
-		return errors.New("Invalid new extra metadata")
+		return errors.New("Invalid extra metadata")
 	}
 
 	tlfID := rmds.MD.TlfID()

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -293,7 +293,7 @@ func (s *mdServerTlfStorage) putExtraMetadataLocked(rmds *RootMetadataSigned,
 
 	extraV3, ok := extra.(*ExtraMetadataV3)
 	if !ok {
-		return errors.New("Invalid new extra metadata")
+		return errors.New("Invalid extra metadata")
 	}
 
 	if extraV3.wkbNew {

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -235,9 +235,7 @@ func (s *mdServerTlfStorage) checkGetParamsReadLocked(
 	}
 
 	if mergedMasterHead != nil {
-		extra, err := s.getExtraMetadataReadLocked(
-			mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
-			mergedMasterHead.MD.GetTLFReaderKeyBundleID())
+		extra, err := getExtraMetadata(s, mergedMasterHead.MD)
 		if err != nil {
 			return MDServerError{err}
 		}
@@ -287,121 +285,40 @@ func (s *mdServerTlfStorage) getRangeReadLocked(
 	return rmdses, nil
 }
 
-func (s *mdServerTlfStorage) getExtraMetadataReadLocked(
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
-	ExtraMetadata, error) {
-	wkb, rkb, err := s.getKeyBundlesReadLocked(wkbID, rkbID)
-	if err != nil {
-		return nil, err
-	}
-	if wkb == nil || rkb == nil {
-		return nil, nil
-	}
-	return NewExtraMetadataV3(*wkb, *rkb, false, false), nil
-}
-
-func (s *mdServerTlfStorage) getKeyBundlesReadLocked(
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
-	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	if (wkbID == TLFWriterKeyBundleID{}) !=
-		(rkbID == TLFReaderKeyBundleID{}) {
-		return nil, nil, errors.Errorf(
-			"wkbID is empty (%t) != rkbID is empty (%t)",
-			wkbID == TLFWriterKeyBundleID{},
-			rkbID == TLFReaderKeyBundleID{})
-	}
-
-	if wkbID == (TLFWriterKeyBundleID{}) {
-		return nil, nil, nil
-	}
-
-	var wkb TLFWriterKeyBundleV3
-	err := kbfscodec.DeserializeFromFile(
-		s.codec, s.writerKeyBundleV3Path(wkbID), &wkb)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	var rkb TLFReaderKeyBundleV3
-	err = kbfscodec.DeserializeFromFile(
-		s.codec, s.readerKeyBundleV3Path(rkbID), &rkb)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	err = checkKeyBundleIDs(s.crypto, wkbID, rkbID, wkb, rkb)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &wkb, &rkb, nil
-}
-
-func checkKeyBundleIDs(crypto cryptoPure,
-	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID,
-	wkb TLFWriterKeyBundleV3, rkb TLFReaderKeyBundleV3) error {
-	computedWKBID, err := crypto.MakeTLFWriterKeyBundleID(wkb)
-	if err != nil {
-		return err
-	}
-
-	if wkbID != computedWKBID {
-		return errors.Errorf("Expected WKB ID %s, got %s",
-			wkbID, computedWKBID)
-	}
-
-	computedRKBID, err := crypto.MakeTLFReaderKeyBundleID(rkb)
-	if err != nil {
-		return err
-	}
-
-	if rkbID != computedRKBID {
-		return errors.Errorf("Expected RKB ID %s, got %s",
-			rkbID, computedRKBID)
-	}
-
-	return nil
-}
-
-func (s *mdServerTlfStorage) putExtraMetadataLocked(
-	rmds *RootMetadataSigned, extra ExtraMetadata) error {
+func (s *mdServerTlfStorage) putExtraMetadataLocked(rmds *RootMetadataSigned,
+	extra ExtraMetadata) error {
 	if extra == nil {
 		return nil
 	}
 
-	wkbID := rmds.MD.GetTLFWriterKeyBundleID()
-	if wkbID == (TLFWriterKeyBundleID{}) {
-		panic("writer key bundle ID is empty")
-	}
-
-	rkbID := rmds.MD.GetTLFReaderKeyBundleID()
-	if rkbID == (TLFReaderKeyBundleID{}) {
-		panic("reader key bundle ID is empty")
-	}
-
 	extraV3, ok := extra.(*ExtraMetadataV3)
 	if !ok {
-		return errors.New("Invalid extra metadata")
+		return errors.New("Invalid new extra metadata")
 	}
 
-	err := checkKeyBundleIDs(
-		s.crypto, wkbID, rkbID, extraV3.wkb, extraV3.rkb)
-	if err != nil {
-		return err
+	if extraV3.wkbNew {
+		wkbID := rmds.MD.GetTLFWriterKeyBundleID()
+		if wkbID == (TLFWriterKeyBundleID{}) {
+			panic("writer key bundle ID is empty")
+		}
+		err := kbfscodec.SerializeToFile(
+			s.codec, extraV3.wkb, s.writerKeyBundleV3Path(wkbID))
+		if err != nil {
+			return err
+		}
 	}
 
-	err = kbfscodec.SerializeToFile(
-		s.codec, extraV3.wkb, s.writerKeyBundleV3Path(wkbID))
-	if err != nil {
-		return err
+	if extraV3.rkbNew {
+		rkbID := rmds.MD.GetTLFReaderKeyBundleID()
+		if rkbID == (TLFReaderKeyBundleID{}) {
+			panic("reader key bundle ID is empty")
+		}
+		err := kbfscodec.SerializeToFile(
+			s.codec, extraV3.rkb, s.readerKeyBundleV3Path(rkbID))
+		if err != nil {
+			return err
+		}
 	}
-
-	err = kbfscodec.SerializeToFile(
-		s.codec, extraV3.rkb, s.readerKeyBundleV3Path(rkbID))
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -481,16 +398,6 @@ func (s *mdServerTlfStorage) put(
 		return false, err
 	}
 
-	if extra == nil {
-		var err error
-		extra, err = s.getExtraMetadataReadLocked(
-			rmds.MD.GetTLFWriterKeyBundleID(),
-			rmds.MD.GetTLFReaderKeyBundleID())
-		if err != nil {
-			return false, MDServerError{err}
-		}
-	}
-
 	err = rmds.IsValidAndSigned(s.codec, s.crypto, extra)
 	if err != nil {
 		return false, MDServerErrorBadRequest{Reason: err.Error()}
@@ -510,9 +417,7 @@ func (s *mdServerTlfStorage) put(
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		prevExtra, err := s.getExtraMetadataReadLocked(
-			mergedMasterHead.MD.GetTLFWriterKeyBundleID(),
-			mergedMasterHead.MD.GetTLFReaderKeyBundleID())
+		prevExtra, err := getExtraMetadata(s, mergedMasterHead.MD)
 		if err != nil {
 			return false, MDServerError{err}
 		}
@@ -589,12 +494,49 @@ func (s *mdServerTlfStorage) put(
 	return recordBranchID, nil
 }
 
-func (s *mdServerTlfStorage) getKeyBundles(
+func (s *mdServerTlfStorage) getKeyBundles(tlfID tlf.ID,
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	return s.getKeyBundlesReadLocked(wkbID, rkbID)
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	if s.isShutdownReadLocked() {
+		return nil, nil, errMDServerTlfStorageShutdown
+	}
+
+	var wkb *TLFWriterKeyBundleV3
+	if wkbID != (TLFWriterKeyBundleID{}) {
+		var foundWKB TLFWriterKeyBundleV3
+		err := kbfscodec.DeserializeFromFile(
+			s.codec, s.writerKeyBundleV3Path(wkbID), &foundWKB)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		err = checkWKBID(s.crypto, wkbID, foundWKB)
+		if err != nil {
+			return nil, nil, err
+		}
+		wkb = &foundWKB
+	}
+
+	var rkb *TLFReaderKeyBundleV3
+	if rkbID != (TLFReaderKeyBundleID{}) {
+		var foundRKB TLFReaderKeyBundleV3
+		err := kbfscodec.DeserializeFromFile(
+			s.codec, s.readerKeyBundleV3Path(rkbID), &foundRKB)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		err = checkRKBID(s.crypto, rkbID, foundRKB)
+		if err != nil {
+			return nil, nil, err
+		}
+		rkb = &foundRKB
+	}
+
+	return wkb, rkb, nil
 }
 
 func (s *mdServerTlfStorage) shutdown() {

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -499,9 +499,9 @@ func (s *mdServerTlfStorage) getKeyBundles(tlfID tlf.ID,
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
-
-	if s.isShutdownReadLocked() {
-		return nil, nil, errMDServerTlfStorageShutdown
+	err := s.checkShutdownReadLocked()
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var wkb *TLFWriterKeyBundleV3


### PR DESCRIPTION
In particular, let GetKeyBundles omit
arguments, and respect wkbNew/rkbNew flags.