### PR TITLE
tlf_journal: always save flushed blocks until the next MD flush

### DIFF
--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -113,6 +113,8 @@ func (s *blockDiskStore) keyServerHalfPath(id BlockID) string {
 }
 
 func (s *blockDiskStore) infoPath(id BlockID) string {
+	// TODO: change the file name to "info" the next we change the
+	// journal layout.
 	return filepath.Join(s.blockPath(id), "refs")
 }
 
@@ -270,7 +272,11 @@ func (s *blockDiskStore) hasData(id BlockID) error {
 	return err
 }
 
-var errFlushedButPresentData = errors.New("Data is flushed but present")
+type errFlushedButPresentData struct{}
+
+func (e errFlushedButPresentData) Error() string {
+	return "Data is flushed but present"
+}
 
 func (s *blockDiskStore) isUnflushed(id BlockID) error {
 	err := s.hasData(id)
@@ -285,7 +291,7 @@ func (s *blockDiskStore) isUnflushed(id BlockID) error {
 	}
 
 	if info.Flushed {
-		return errFlushedButPresentData
+		return errors.WithStack(errFlushedButPresentData{})
 	}
 	return nil
 }

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -700,7 +700,7 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 			return 0, err
 		}
 
-		err = j.s.flushed(id)
+		err = j.s.markFlushed(id)
 		if err != nil {
 			return 0, err
 		}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -267,11 +267,11 @@ func (j *blockJournal) end() (journalOrdinal, error) {
 	return last + 1, nil
 }
 
-func (j *blockJournal) hasData(id BlockID) error {
+func (j *blockJournal) hasData(id BlockID) (bool, error) {
 	return j.s.hasData(id)
 }
 
-func (j *blockJournal) isUnflushed(id BlockID) error {
+func (j *blockJournal) isUnflushed(id BlockID) (bool, error) {
 	return j.s.isUnflushed(id)
 }
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -271,6 +271,10 @@ func (j *blockJournal) hasData(id BlockID) error {
 	return j.s.hasData(id)
 }
 
+func (j *blockJournal) isUnflushed(id BlockID) error {
+	return j.s.isUnflushed(id)
+}
+
 func (j *blockJournal) remove(id BlockID) error {
 	// TODO: we'll eventually need a sweeper to clean up entries
 	// left behind if we crash here.
@@ -695,6 +699,12 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 		if err != nil {
 			return 0, err
 		}
+
+		err = j.s.flushed(id)
+		if err != nil {
+			return 0, err
+		}
+
 		flushedBytes, err = j.s.getDataSize(id)
 		if err != nil {
 			return 0, err

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -717,13 +717,13 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	require.Zero(t, lastToRemove)
 	require.Nil(t, j.saveUntilMDFlush)
 
-	err = j.hasData(bID1)
+	err = j.isUnflushed(bID1)
 	require.True(t, ioutil.IsNotExist(err))
-	err = j.hasData(bID2)
+	err = j.isUnflushed(bID2)
 	require.True(t, ioutil.IsNotExist(err))
-	err = j.hasData(bID3)
+	err = j.isUnflushed(bID3)
 	require.True(t, ioutil.IsNotExist(err))
-	err = j.hasData(bID4)
+	err = j.isUnflushed(bID4)
 	require.True(t, ioutil.IsNotExist(err))
 
 	testBlockJournalGCd(t, j)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -667,8 +667,9 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 
 	// The blocks can still be fetched from the journal.
 	for _, bid := range savedBlocks {
-		err = j.hasData(bid)
+		ok, err := j.hasData(bid)
 		require.NoError(t, err)
+		require.True(t, ok)
 	}
 
 	// No more blocks to flush though.
@@ -691,8 +692,9 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	// Make sure all the blocks still exist, including both the old
 	// and the new ones.
 	for _, bid := range savedBlocks {
-		err = j.hasData(bid)
+		ok, err := j.hasData(bid)
 		require.NoError(t, err)
+		require.True(t, ok)
 	}
 
 	{
@@ -717,14 +719,18 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	require.Zero(t, lastToRemove)
 	require.Nil(t, j.saveUntilMDFlush)
 
-	err = j.isUnflushed(bID1)
-	require.True(t, ioutil.IsNotExist(err))
-	err = j.isUnflushed(bID2)
-	require.True(t, ioutil.IsNotExist(err))
-	err = j.isUnflushed(bID3)
-	require.True(t, ioutil.IsNotExist(err))
-	err = j.isUnflushed(bID4)
-	require.True(t, ioutil.IsNotExist(err))
+	ok, err := j.isUnflushed(bID1)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = j.isUnflushed(bID2)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = j.isUnflushed(bID3)
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = j.isUnflushed(bID4)
+	require.NoError(t, err)
+	require.False(t, ok)
 
 	testBlockJournalGCd(t, j)
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -714,6 +714,14 @@ func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
 		return err
 	}
 
+	// Keep the flushed blocks around until we know for sure the MD
+	// flush will succeed; otherwise if we become unmerged, conflict
+	// resolution will be very expensive.
+	err := j.blockJournal.saveBlocksUntilNextMDFlush()
+	if err != nil {
+		return err
+	}
+
 	return j.blockJournal.removeFlushedEntries(ctx, entries, j.tlfID,
 		j.config.Reporter())
 }
@@ -1394,7 +1402,7 @@ func (j *tlfJournal) isBlockUnflushed(id BlockID) (bool, error) {
 		return false, err
 	}
 
-	err := j.blockJournal.hasData(id)
+	err := j.blockJournal.isUnflushed(id)
 	if err != nil {
 		// Might exist on the server
 		return false, nil

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1402,12 +1402,7 @@ func (j *tlfJournal) isBlockUnflushed(id BlockID) (bool, error) {
 		return false, err
 	}
 
-	err := j.blockJournal.isUnflushed(id)
-	if err != nil {
-		// Might exist on the server
-		return false, nil
-	}
-	return true, nil
+	return j.blockJournal.isUnflushed(id)
 }
 
 func (j *tlfJournal) getBranchID() (BranchID, error) {


### PR DESCRIPTION
Otherwise, if we have a large MD update (say due to journal coalescing) and we flush all the blocks before finding out there's a conflict, we will have to re-download all those blocks during conflict resolution if they are forced out of the block cache or if there's a restart.

Issue: KBFS-1777