### PR TITLE
cr: fetch ref and unref blocks in parallel

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 )
 
 type overallBlockState int
@@ -394,6 +395,75 @@ func (fbo *folderBlockOps) GetBlockForReading(ctx context.Context,
 	defer fbo.blockLock.RUnlock(lState)
 	return fbo.getBlockHelperLocked(ctx, lState, kmd, ptr, branch,
 		NewCommonBlock, false, path{}, blockRead)
+}
+
+// GetBlocksForReading retrieves the blocks pointed to by ptrs, all of
+// which must be valid, either from the cache or from the server.  The
+// returned block may have a generic type (not DirBlock or FileBlock).
+//
+// The caller can specify a set of pointers using
+// `ignoreRecoverableErrors` for which "recoverable" fetch errors are
+// tolerated.  In that case, the returned map will not have an entry
+// for any pointers in the `ignoreRecoverableErrors` set that hit such
+// an error.
+//
+// This should be called for "internal" operations, like conflict
+// resolution and state checking, which don't know what kind of block
+// the pointers refer to.  The blocks will not be cached, if they
+// weren't in the cache already.
+func (fbo *folderBlockOps) GetBlocksForReading(ctx context.Context,
+	lState *lockState, kmd KeyMetadata, ptrs []BlockPointer,
+	ignoreRecoverableErrors map[BlockPointer]bool,
+	branch BranchName) (map[BlockPointer]Block, error) {
+	fbo.blockLock.RLock(lState)
+	defer fbo.blockLock.RUnlock(lState)
+
+	type resp struct {
+		ptr   BlockPointer
+		block Block
+	}
+
+	respChans := make([]<-chan resp, 0, len(ptrs))
+	eg, groupCtx := errgroup.WithContext(ctx)
+	for _, ptr := range ptrs {
+		ptr := ptr
+		respCh := make(chan resp, 1)
+		respChans = append(respChans, respCh)
+		eg.Go(func() error {
+			block, err := fbo.getBlockHelperLocked(groupCtx, nil, kmd, ptr,
+				branch, NewCommonBlock, false, path{}, blockReadParallel)
+			// TODO: we might be able to recover the size of the
+			// top-most block of a removed file using the merged
+			// directory entry, the same way we do in
+			// `folderBranchOps.unrefEntry`.
+			if isRecoverableBlockErrorForRemoval(err) &&
+				ignoreRecoverableErrors[ptr] {
+				fbo.log.CDebugf(groupCtx, "Hit an ignorable, recoverable "+
+					"error for block %v: %v", ptr, err)
+				respCh <- resp{}
+				return nil
+			}
+
+			if err != nil {
+				return err
+			}
+			respCh <- resp{ptr, block}
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	blocks := make(map[BlockPointer]Block)
+	for _, respCh := range respChans {
+		resp := <-respCh
+		if resp.ptr.IsValid() {
+			blocks[resp.ptr] = resp.block
+		}
+	}
+	return blocks, nil
 }
 
 // getDirBlockHelperLocked retrieves the block pointed to by ptr, which

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -421,8 +421,7 @@ func (fbo *folderBlockOps) GetBlocksForReading(ctx context.Context,
 	blockResults := make([]Block, len(ptrs))
 	eg, groupCtx := errgroup.WithContext(ctx)
 	for i, ptr := range ptrs {
-		index := i
-		ptr := ptr
+		i, ptr := i, ptr
 		eg.Go(func() error {
 			block, err := fbo.getBlockHelperLocked(groupCtx, nil, kmd, ptr,
 				branch, NewCommonBlock, false, path{}, blockReadParallel)
@@ -440,7 +439,7 @@ func (fbo *folderBlockOps) GetBlocksForReading(ctx context.Context,
 			if err != nil {
 				return err
 			}
-			blockResults[index] = block
+			blockResults[i] = block
 			return nil
 		})
 	}


### PR DESCRIPTION
If conflict resolution has to fetch a lot of blocks to do block accounting, it's best to fetch them in parallel to make it as fast as possible.

Note that once #579 goes in, this won't be as big an issue when journaling is enabled since all of referenced blocks should be locally available on disk.  However, the unref'd blocks still may be getting fetched from the remote server.

+@jzila as a reviewer since it involves block fetching.