### PR TITLE
Fix bug when rekeying after upconvert

### DIFF
--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -129,6 +129,11 @@ func (extra ExtraMetadataV3) MetadataVersion() MetadataVer {
 	return SegregatedKeyBundlesVer
 }
 
+func (extra *ExtraMetadataV3) updateNew(wkbNew, rkbNew bool) {
+	extra.wkbNew = extra.wkbNew || wkbNew
+	extra.rkbNew = extra.rkbNew || rkbNew
+}
+
 // DeepCopy implements the ExtraMetadata interface for ExtraMetadataV3.
 func (extra ExtraMetadataV3) DeepCopy(codec kbfscodec.Codec) (
 	ExtraMetadata, error) {
@@ -1311,11 +1316,7 @@ func (md *BareRootMetadataV3) FinalizeRekey(
 	md.WriterMetadata.WKeyBundleID = newWKBID
 	md.RKeyBundleID = newRKBID
 
-	// TODO: This should be or'ing with the existing parameters to
-	// handle the upconvert-then-rekey case. Also add a test for
-	// this.
-	extraV3.wkbNew = newWKBID != oldWKBID
-	extraV3.rkbNew = newRKBID != oldRKBID
+	extraV3.updateNew(newWKBID != oldWKBID, newRKBID != oldRKBID)
 
 	return nil
 }

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -58,6 +58,11 @@ func TestRootMetadataV3ExtraNew(t *testing.T) {
 	require.True(t, extraV3.wkbNew)
 	require.True(t, extraV3.rkbNew)
 
+	err = rmd.FinalizeRekey(crypto, extra)
+	require.NoError(t, err)
+	require.True(t, extraV3.wkbNew)
+	require.True(t, extraV3.rkbNew)
+
 	_, extraCopy, err := rmd.MakeSuccessorCopy(
 		context.Background(), codecOnlyConfig{nil, codec},
 		nil, extra, true)

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -652,7 +652,10 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.Equal(t, KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, MetadataRevision(2), rmd2.Revision())
 	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
-	require.NotNil(t, rmd2.extra)
+	extra, ok := rmd2.extra.(*ExtraMetadataV3)
+	require.True(t, ok)
+	require.True(t, extra.wkbNew)
+	require.True(t, extra.rkbNew)
 
 	// compare numbers
 	require.Equal(t, diskUsage, rmd2.DiskUsage())
@@ -695,6 +698,14 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 
 	// compare alice and charlie's keys
 	require.Equal(t, aliceKeys, charlieKeys)
+
+	// Rekeying again shouldn't change wkbNew/rkbNew.
+	err = rmd2.finalizeRekey(config.Crypto())
+	require.NoError(t, err)
+	extra, ok = rmd2.extra.(*ExtraMetadataV3)
+	require.True(t, ok)
+	require.True(t, extra.wkbNew)
+	require.True(t, extra.rkbNew)
 }
 
 // Test upconversion from MDv2 to MDv3 for a public folder.


### PR DESCRIPTION
We were erroneously clobbering the
wkbNew/rkbNew flags, and so we wouldn't
send up the new key bundle properly.