### PR TITLE
[KBFS-1654] Parametrize KeyManager and MDOps tests

### DIFF
--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -134,6 +134,7 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 
 	config.qrPeriod = 0 * time.Second // no auto reclamation
 	config.qrUnrefAge = qrUnrefAgeDefault
+	config.SetMetadataVersion(defaultClientMetadataVer)
 
 	return config
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4366,6 +4366,11 @@ func (fbo *folderBranchOps) UnstageForTesting(
 // mdWriterLock must be taken by the caller.
 func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	lState *lockState, promptPaper bool) (err error) {
+	fbo.log.CDebugf(ctx, "rekeyLocked")
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "rekeyLocked Done: %v", err)
+	}()
+
 	fbo.mdWriterLock.AssertLocked(lState)
 
 	if !fbo.isMasterBranchLocked(lState) {
@@ -4551,11 +4556,6 @@ func (fbo *folderBranchOps) rekeyWithPrompt() {
 
 // Rekey rekeys the given folder.
 func (fbo *folderBranchOps) Rekey(ctx context.Context, tlf tlf.ID) (err error) {
-	fbo.log.CDebugf(ctx, "Rekey")
-	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %v", err)
-	}()
-
 	fb := FolderBranch{tlf, MasterBranch}
 	if fb != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, fb}

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,12 @@ func TestFBStatusAllFields(t *testing.T) {
 	rmd.SetUnmerged()
 	rmd.SetLastModifyingWriter(u)
 
+	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("fake seed")
+	signer := kbfscrypto.SigningKeySigner{Key: signingKey}
+	err = rmd.bareMd.SignWriterMetadataInternally(
+		ctx, kbfscodec.NewMsgpack(), signer)
+	require.NoError(t, err)
+
 	// make two nodes with expected PathFromNode calls
 	n1 := newMockNode(mockCtrl)
 	p1 := path{path: []pathNode{{Name: "a1"}, {Name: "b1"}}}
@@ -120,9 +127,9 @@ func TestFBStatusAllFields(t *testing.T) {
 	p2 := path{path: []pathNode{{Name: "a2"}, {Name: "b2"}}}
 	nodeCache.EXPECT().PathFromNode(mockNodeMatcher{n2}).AnyTimes().Return(p2)
 
-	key := kbfscrypto.MakeFakeVerifyingKeyOrBust("fake key")
 	fbsk.setRootMetadata(
-		MakeImmutableRootMetadata(rmd, key, fakeMdID(1), time.Now()))
+		MakeImmutableRootMetadata(rmd, signingKey.GetVerifyingKey(),
+			fakeMdID(1), time.Now()))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -121,7 +122,7 @@ func TestFBStatusAllFields(t *testing.T) {
 
 	key := kbfscrypto.MakeFakeVerifyingKeyOrBust("fake key")
 	fbsk.setRootMetadata(
-		makeImmutableRootMetadataForTest(t, rmd, key, fakeMdID(1)))
+		MakeImmutableRootMetadata(rmd, key, fakeMdID(1), time.Now()))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -294,6 +294,15 @@ func makeImmutableRMDForTest(t *testing.T, config Config, rmd *RootMetadata,
 	mdID MdID) ImmutableRootMetadata {
 	key, err := config.KBPKI().GetCurrentVerifyingKey(context.Background())
 	require.NoError(t, err)
+	if brmdv2, ok := rmd.bareMd.(*BareRootMetadataV2); ok {
+		vk := brmdv2.WriterMetadataSigInfo.VerifyingKey
+		require.True(t, vk == (kbfscrypto.VerifyingKey{}) || vk == key,
+			"Writer signature %s with unexpected non-nil verifying key != %s",
+			brmdv2.WriterMetadataSigInfo, key)
+		brmdv2.WriterMetadataSigInfo = kbfscrypto.SignatureInfo{
+			VerifyingKey: key,
+		}
+	}
 	return MakeImmutableRootMetadata(rmd, key, mdID, time.Now())
 }
 
@@ -1035,8 +1044,11 @@ func (s shimMDOps) Put(ctx context.Context, rmd *RootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.SignWriterMetadataInternally(
+	err = rmd.bareMd.SignWriterMetadataInternally(
 		ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
+	if err != nil {
+		return MdID{}, err
+	}
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 
@@ -1050,8 +1062,11 @@ func (s shimMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (MdID, er
 		return MdID{}, err
 	}
 	signingKey := MakeLocalUserSigningKeyOrBust(username)
-	rmd.bareMd.SignWriterMetadataInternally(
+	err = rmd.bareMd.SignWriterMetadataInternally(
 		ctx, s.codec, kbfscrypto.SigningKeySigner{Key: signingKey})
+	if err != nil {
+		return MdID{}, err
+	}
 	return s.crypto.MakeMdID(rmd.bareMd)
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -294,7 +294,7 @@ func makeImmutableRMDForTest(t *testing.T, config Config, rmd *RootMetadata,
 	mdID MdID) ImmutableRootMetadata {
 	key, err := config.KBPKI().GetCurrentVerifyingKey(context.Background())
 	require.NoError(t, err)
-	return makeImmutableRootMetadataForTest(t, rmd, key, mdID)
+	return MakeImmutableRootMetadata(rmd, key, mdID, time.Now())
 }
 
 // injectNewRMD creates a new RMD and makes sure the existing ops for

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -294,6 +294,10 @@ func makeImmutableRMDForTest(t *testing.T, config Config, rmd *RootMetadata,
 	mdID MdID) ImmutableRootMetadata {
 	key, err := config.KBPKI().GetCurrentVerifyingKey(context.Background())
 	require.NoError(t, err)
+	// We have to fake out the signature here because most tests
+	// in this file modify the returned value, invalidating any
+	// real signatures. TODO: Fix all the tests in this file to
+	// not do so, and then just use MakeImmutableRootMetadata.
 	if brmdv2, ok := rmd.bareMd.(*BareRootMetadataV2); ok {
 		vk := brmdv2.WriterMetadataSigInfo.VerifyingKey
 		require.True(t, vk == (kbfscrypto.VerifyingKey{}) || vk == key,

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -798,6 +798,8 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
+	config1.SetMetadataVersion(ver)
+
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
@@ -1014,6 +1016,8 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver MetadataVer) 
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
+	config1.SetMetadataVersion(ver)
+
 	// Revoke user 3's device for now, to test the "other" rekey error.
 	_, uid3, err := config1.KBPKI().Resolve(ctx, u3.String())
 	if err != nil {
@@ -1110,6 +1114,8 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver MetadataVer) {
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
+	config1.SetMetadataVersion(ver)
+
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
@@ -1196,6 +1202,8 @@ func testKeyManagerReaderRekey(t *testing.T, ver MetadataVer) {
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	_, uid1, err := config1.KBPKI().GetCurrentUserInfo(context.Background())
 
+	config1.SetMetadataVersion(ver)
+
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
@@ -1281,6 +1289,8 @@ func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver MetadataVer) {
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
+
+	config1.SetMetadataVersion(ver)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1377,6 +1387,8 @@ func testKeyManagerRekeyBit(t *testing.T, ver MetadataVer) {
 			kbfsConcurTestShutdown(t, config1, ctx, cancel)
 		}
 	}()
+
+	config1.SetMetadataVersion(ver)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1548,6 +1560,8 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver Metadat
 	clock := newTestClockNow()
 	config1.SetClock(clock)
 
+	config1.SetMetadataVersion(ver)
+
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
@@ -1692,6 +1706,8 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
+	config1.SetMetadataVersion(ver)
+
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
 	_, uid2, err := config2.KBPKI().GetCurrentUserInfo(context.Background())
@@ -1813,6 +1829,8 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
 	config1.SetClock(clock)
+
+	config1.SetMetadataVersion(ver)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)
@@ -1937,6 +1955,8 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
+
+	config1.SetMetadataVersion(ver)
 
 	config2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(t, config2)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -286,19 +286,13 @@ func testKeyManagerCachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver Me
 	require.Equal(t, cachedTLFCryptKey, tlfCryptKey)
 }
 
-// makeDirRKeyInfoMap creates a new user device key info map with a reader key.
-func makeDirRKeyInfoMap(ver MetadataVer, uid keybase1.UID,
+// makeDirWKeyInfoMap creates a new user device key info map with a writer key.
+func makeDirWKeyInfoMap(uid keybase1.UID,
 	cryptPublicKey kbfscrypto.CryptPublicKey) UserDeviceKeyInfoMap {
-	var ePubKeyIndex int
-	if ver < SegregatedKeyBundlesVer {
-		ePubKeyIndex = -1
-	} else {
-		ePubKeyIndex = 0
-	}
 	return UserDeviceKeyInfoMap{
 		uid: {
 			cryptPublicKey: TLFCryptKeyInfo{
-				EPubKeyIndex: ePubKeyIndex,
+				EPubKeyIndex: 0,
 			},
 		},
 	}
@@ -323,7 +317,7 @@ func testKeyManagerUncachedSecretKeyForEncryptionSuccess(t *testing.T, ver Metad
 	storedTLFCryptKey := kbfscrypto.MakeTLFCryptKey([32]byte{0x1})
 	rmd.addKeyGenerationForTest(config.Codec(), config.Crypto(),
 		kbfscrypto.TLFCryptKey{}, storedTLFCryptKey,
-		NewEmptyUserDeviceKeyInfoMap(), makeDirRKeyInfoMap(ver, uid, subkey))
+		makeDirWKeyInfoMap(uid, subkey), UserDeviceKeyInfoMap{})
 
 	storesHistoric := rmd.StoresHistoricTLFCryptKeys()
 	expectUncachedGetTLFCryptKey(t, config, rmd.TlfID(),
@@ -355,7 +349,7 @@ func testKeyManagerUncachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver Met
 	storedTLFCryptKey := kbfscrypto.MakeTLFCryptKey([32]byte{0x1})
 	rmd.addKeyGenerationForTest(config.Codec(), config.Crypto(),
 		kbfscrypto.TLFCryptKey{}, storedTLFCryptKey,
-		NewEmptyUserDeviceKeyInfoMap(), makeDirRKeyInfoMap(ver, uid, subkey))
+		makeDirWKeyInfoMap(uid, subkey), UserDeviceKeyInfoMap{})
 
 	expectUncachedGetTLFCryptKeyAnyDevice(
 		config, rmd.TlfID(), rmd.LatestKeyGeneration(), uid, subkey,
@@ -387,11 +381,11 @@ func testKeyManagerUncachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver 
 	storedTLFCryptKey2 := kbfscrypto.MakeTLFCryptKey([32]byte{0x2})
 	rmd.addKeyGenerationForTest(config.Codec(), config.Crypto(),
 		kbfscrypto.TLFCryptKey{}, storedTLFCryptKey1,
-		NewEmptyUserDeviceKeyInfoMap(), makeDirRKeyInfoMap(ver, uid, subkey))
+		makeDirWKeyInfoMap(uid, subkey), UserDeviceKeyInfoMap{})
 
 	rmd.addKeyGenerationForTest(config.Codec(), config.Crypto(),
 		storedTLFCryptKey1, storedTLFCryptKey2,
-		NewEmptyUserDeviceKeyInfoMap(), makeDirRKeyInfoMap(ver, uid, subkey))
+		makeDirWKeyInfoMap(uid, subkey), UserDeviceKeyInfoMap{})
 
 	keyGen := rmd.LatestKeyGeneration() - 1
 	storesHistoric := rmd.StoresHistoricTLFCryptKeys()

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -107,8 +107,9 @@ func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	md.fakeInitialRekey(codec, crypto)
 	md.SetPrevRoot(prevRoot)
 	md.SetDiskUsage(500)
-	md.bareMd.SignWriterMetadataInternally(context.Background(),
+	err = md.bareMd.SignWriterMetadataInternally(context.Background(),
 		kbfscodec.NewMsgpack(), signer)
+	require.NoError(t, err)
 	return md
 }
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -64,6 +64,7 @@ func mdOpsInit(t *testing.T, ver MetadataVer) (mockCtrl *gomock.Controller,
 	mdops := NewMDOpsStandard(config)
 	config.SetMDOps(mdops)
 	config.SetCodec(kbfscodec.NewMsgpack())
+	config.SetKeyBundleCache(NewKeyBundleCacheStandard(1))
 	config.mockMdserv.EXPECT().OffsetFromServerTime().
 		Return(time.Duration(0), true).AnyTimes()
 	h1, _ := kbfshash.DefaultHash([]byte{1})

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -35,6 +35,11 @@ func (c shimCrypto) Sign(
 	return c.key.Sign(data), nil
 }
 
+func (c shimCrypto) SignForKBFS(
+	ctx context.Context, data []byte) (kbfscrypto.SignatureInfo, error) {
+	return c.key.SignForKBFS(data)
+}
+
 func (c shimCrypto) Verify(
 	msg []byte, sigInfo kbfscrypto.SignatureInfo) (err error) {
 	return kbfscrypto.Verify(msg, sigInfo)

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -576,7 +576,7 @@ type keyBundleMDServer struct {
 	MDServer
 	nextGetRange []*RootMetadataSigned
 
-	lock sync.Mutex
+	lock sync.RWMutex
 	wkbs map[TLFWriterKeyBundleID]TLFWriterKeyBundleV3
 	rkbs map[TLFReaderKeyBundleID]TLFReaderKeyBundleV3
 }
@@ -622,8 +622,8 @@ func (mds *keyBundleMDServer) GetRange(
 func (mds *keyBundleMDServer) GetKeyBundles(ctx context.Context, tlfID tlf.ID,
 	wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	mds.lock.Lock()
-	defer mds.lock.Unlock()
+	mds.lock.RLock()
+	defer mds.lock.RUnlock()
 	wkb := mds.wkbs[wkbID]
 	rkb := mds.rkbs[rkbID]
 	return &wkb, &rkb, nil

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -606,8 +606,8 @@ func (mds *keyBundleMDServer) putRKB(
 func (mds *keyBundleMDServer) processRMDSes(
 	rmds *RootMetadataSigned, extra ExtraMetadata) {
 	if extraV3, ok := extra.(*ExtraMetadataV3); ok {
-		mds.putWKB(rmds.MD.GetTLFWriterKeyBundleID(), &extraV3.wkb)
-		mds.putRKB(rmds.MD.GetTLFReaderKeyBundleID(), &extraV3.rkb)
+		mds.putWKB(rmds.MD.GetTLFWriterKeyBundleID(), extraV3.wkb)
+		mds.putRKB(rmds.MD.GetTLFReaderKeyBundleID(), extraV3.rkb)
 	}
 }
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -206,7 +206,7 @@ func expectGetKeyBundles(ctx context.Context, config *ConfigMock, extra ExtraMet
 	if extraV3, ok := extra.(*ExtraMetadataV3); ok {
 		config.mockMdserv.EXPECT().GetKeyBundles(
 			ctx, gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(extraV3.wkb, extraV3.rkb, nil)
+			Return(&extraV3.wkb, &extraV3.rkb, nil)
 	}
 }
 
@@ -606,8 +606,8 @@ func (mds *keyBundleMDServer) putRKB(
 func (mds *keyBundleMDServer) processRMDSes(
 	rmds *RootMetadataSigned, extra ExtraMetadata) {
 	if extraV3, ok := extra.(*ExtraMetadataV3); ok {
-		mds.putWKB(rmds.MD.GetTLFWriterKeyBundleID(), extraV3.wkb)
-		mds.putRKB(rmds.MD.GetTLFReaderKeyBundleID(), extraV3.rkb)
+		mds.putWKB(rmds.MD.GetTLFWriterKeyBundleID(), &extraV3.wkb)
+		mds.putRKB(rmds.MD.GetTLFReaderKeyBundleID(), &extraV3.rkb)
 	}
 }
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -50,11 +50,12 @@ func injectShimCrypto(config Config) {
 	config.SetCrypto(crypto)
 }
 
-func mdOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
+func mdOpsInit(t *testing.T, ver MetadataVer) (mockCtrl *gomock.Controller,
 	config *ConfigMock, ctx context.Context) {
 	ctr := NewSafeTestReporter(t)
 	mockCtrl = gomock.NewController(ctr)
 	config = NewConfigMock(mockCtrl, ctr)
+	config.SetMetadataVersion(ver)
 	mdops := NewMDOpsStandard(config)
 	config.SetMDOps(mdops)
 	config.SetCodec(kbfscodec.NewMsgpack())
@@ -174,7 +175,11 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 }
 
 func TestMDOpsGetForHandlePublicSuccess(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForHandlePublicSuccess)
+}
+
+func testMDOpsGetForHandlePublicSuccess(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
@@ -200,7 +205,11 @@ func expectGetKeyBundles(ctx context.Context, config *ConfigMock, extra ExtraMet
 }
 
 func TestMDOpsGetForHandlePrivateSuccess(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForHandlePrivateSuccess)
+}
+
+func testMDOpsGetForHandlePrivateSuccess(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
@@ -219,7 +228,11 @@ func TestMDOpsGetForHandlePrivateSuccess(t *testing.T) {
 }
 
 func TestMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForUnresolvedHandlePublicSuccess)
+}
+
+func testMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
@@ -250,7 +263,11 @@ func TestMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T) {
 }
 
 func TestMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForUnresolvedMdHandlePublicSuccess)
+}
+
+func testMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	mdHandle1, err := ParseTlfHandle(ctx, config.KBPKI(),
@@ -306,7 +323,11 @@ func TestMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T) {
 }
 
 func TestMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForUnresolvedHandlePublicFailure)
+}
+
+func testMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
@@ -329,7 +350,11 @@ func TestMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T) {
 }
 
 func TestMDOpsGetForHandlePublicFailFindKey(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForHandlePublicFailFindKey)
+}
+
+func testMDOpsGetForHandlePublicFailFindKey(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
@@ -356,7 +381,11 @@ func (c failVerifyCrypto) Verify(msg []byte, sigInfo kbfscrypto.SignatureInfo) e
 }
 
 func TestMDOpsGetForHandlePublicFailVerify(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForHandlePublicFailVerify)
+}
+
+func testMDOpsGetForHandlePublicFailVerify(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", true)
@@ -375,7 +404,11 @@ func TestMDOpsGetForHandlePublicFailVerify(t *testing.T) {
 }
 
 func TestMDOpsGetForHandleFailGet(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForHandleFailGet)
+}
+
+func testMDOpsGetForHandleFailGet(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
@@ -391,7 +424,11 @@ func TestMDOpsGetForHandleFailGet(t *testing.T) {
 }
 
 func TestMDOpsGetForHandleFailHandleCheck(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetForHandleFailHandleCheck)
+}
+
+func testMDOpsGetForHandleFailHandleCheck(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
@@ -409,7 +446,11 @@ func TestMDOpsGetForHandleFailHandleCheck(t *testing.T) {
 }
 
 func TestMDOpsGetSuccess(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetSuccess)
+}
+
+func testMDOpsGetSuccess(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
@@ -429,7 +470,11 @@ func TestMDOpsGetSuccess(t *testing.T) {
 }
 
 func TestMDOpsGetBlankSigFailure(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetBlankSigFailure)
+}
+
+func testMDOpsGetBlankSigFailure(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
@@ -446,7 +491,11 @@ func TestMDOpsGetBlankSigFailure(t *testing.T) {
 }
 
 func TestMDOpsGetFailGet(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetFailGet)
+}
+
+func testMDOpsGetFailGet(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, true)
@@ -461,7 +510,11 @@ func TestMDOpsGetFailGet(t *testing.T) {
 }
 
 func TestMDOpsGetFailIdCheck(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetFailIdCheck)
+}
+
+func testMDOpsGetFailIdCheck(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
@@ -513,8 +566,8 @@ func makeRMDSRange(t *testing.T, config Config,
 	return rmdses, extras
 }
 
-func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+func testMDOpsGetRangeSuccess(t *testing.T, ver MetadataVer, fromStart bool) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	rmdses, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
@@ -549,15 +602,23 @@ func testMDOpsGetRangeSuccess(t *testing.T, fromStart bool) {
 }
 
 func TestMDOpsGetRangeSuccess(t *testing.T) {
-	testMDOpsGetRangeSuccess(t, false)
+	runTestOverMetadataVers(t, func(t *testing.T, ver MetadataVer) {
+		testMDOpsGetRangeSuccess(t, ver, false)
+	})
 }
 
 func TestMDOpsGetRangeFromStartSuccess(t *testing.T) {
-	testMDOpsGetRangeSuccess(t, true)
+	runTestOverMetadataVers(t, func(t *testing.T, ver MetadataVer) {
+		testMDOpsGetRangeSuccess(t, ver, true)
+	})
 }
 
 func TestMDOpsGetRangeFailBadPrevRoot(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetRangeFailBadPrevRoot)
+}
+
+func testMDOpsGetRangeFailBadPrevRoot(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	rmdses, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))
@@ -649,6 +710,10 @@ func validatePutPublicRMDS(
 }
 
 func TestMDOpsPutPublicSuccess(t *testing.T) {
+	runTestOverMetadataVers(t, testMDOpsPutPublicSuccess)
+}
+
+func testMDOpsPutPublicSuccess(t *testing.T, ver MetadataVer) {
 	config := MakeTestConfigOrBust(t, "alice", "bob")
 	defer CheckConfigAndShutdown(t, config)
 
@@ -672,7 +737,11 @@ func TestMDOpsPutPublicSuccess(t *testing.T) {
 }
 
 func TestMDOpsPutPrivateSuccess(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsPutPrivateSuccess)
+}
+
+func testMDOpsPutPrivateSuccess(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	config.SetCodec(kbfscodec.NewMsgpack())
@@ -700,7 +769,11 @@ func (c failEncodeCodec) Encode(obj interface{}) ([]byte, error) {
 }
 
 func TestMDOpsPutFailEncode(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsPutFailEncode)
+}
+
+func testMDOpsPutFailEncode(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	id := tlf.FakeID(1, false)
@@ -724,7 +797,11 @@ func TestMDOpsPutFailEncode(t *testing.T) {
 }
 
 func TestMDOpsGetRangeFailFinal(t *testing.T) {
-	mockCtrl, config, ctx := mdOpsInit(t)
+	runTestOverMetadataVers(t, testMDOpsGetRangeFailFinal)
+}
+
+func testMDOpsGetRangeFailFinal(t *testing.T, ver MetadataVer) {
+	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
 	rmdses, extras := makeRMDSRange(t, config, 100, 5, fakeMdID(1))

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -515,11 +515,11 @@ func testMDOpsGetFailGet(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func TestMDOpsGetFailIdCheck(t *testing.T) {
-	runTestOverMetadataVers(t, testMDOpsGetFailIdCheck)
+func TestMDOpsGetFailIDCheck(t *testing.T) {
+	runTestOverMetadataVers(t, testMDOpsGetFailIDCheck)
 }
 
-func testMDOpsGetFailIdCheck(t *testing.T, ver MetadataVer) {
+func testMDOpsGetFailIDCheck(t *testing.T, ver MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -796,6 +796,9 @@ func testMDOpsPutPublicSuccess(t *testing.T, ver MetadataVer) {
 	rmd.data = makeFakePrivateMetadataFuture(t).toCurrent()
 	rmd.tlfHandle = h
 
+	ctx := context.Background()
+	_, err = config.MDOps().Put(ctx, rmd)
+
 	rmds := mdServer.getLastRmds()
 	validatePutPublicRMDS(ctx, t, ver, config, rmd.bareMd, rmds)
 }

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -577,27 +577,27 @@ type keyBundleMDServer struct {
 	nextGetRange []*RootMetadataSigned
 
 	lock sync.Mutex
-	wkbs map[TLFWriterKeyBundleID]*TLFWriterKeyBundleV3
-	rkbs map[TLFReaderKeyBundleID]*TLFReaderKeyBundleV3
+	wkbs map[TLFWriterKeyBundleID]TLFWriterKeyBundleV3
+	rkbs map[TLFReaderKeyBundleID]TLFReaderKeyBundleV3
 }
 
 func makeKeyBundleMDServer(mdServer MDServer) *keyBundleMDServer {
 	return &keyBundleMDServer{
 		MDServer: mdServer,
-		wkbs:     make(map[TLFWriterKeyBundleID]*TLFWriterKeyBundleV3),
-		rkbs:     make(map[TLFReaderKeyBundleID]*TLFReaderKeyBundleV3),
+		wkbs:     make(map[TLFWriterKeyBundleID]TLFWriterKeyBundleV3),
+		rkbs:     make(map[TLFReaderKeyBundleID]TLFReaderKeyBundleV3),
 	}
 }
 
 func (mds *keyBundleMDServer) putWKB(
-	id TLFWriterKeyBundleID, wkb *TLFWriterKeyBundleV3) {
+	id TLFWriterKeyBundleID, wkb TLFWriterKeyBundleV3) {
 	mds.lock.Lock()
 	defer mds.lock.Unlock()
 	mds.wkbs[id] = wkb
 }
 
 func (mds *keyBundleMDServer) putRKB(
-	id TLFReaderKeyBundleID, rkb *TLFReaderKeyBundleV3) {
+	id TLFReaderKeyBundleID, rkb TLFReaderKeyBundleV3) {
 	mds.lock.Lock()
 	defer mds.lock.Unlock()
 	mds.rkbs[id] = rkb
@@ -624,7 +624,9 @@ func (mds *keyBundleMDServer) GetKeyBundles(ctx context.Context, tlfID tlf.ID,
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
 	mds.lock.Lock()
 	defer mds.lock.Unlock()
-	return mds.wkbs[wkbID], mds.rkbs[rkbID], nil
+	wkb := mds.wkbs[wkbID]
+	rkb := mds.rkbs[rkbID]
+	return &wkb, &rkb, nil
 }
 
 func testMDOpsGetRangeSuccess(t *testing.T, ver MetadataVer, fromStart bool) {

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -98,7 +98,7 @@ func newRMDS(t *testing.T, config Config, h *TlfHandle) (
 	*RootMetadataSigned, ExtraMetadata) {
 	id := tlf.FakeID(1, h.IsPublic())
 
-	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, id, h)
+	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
 
 	addFakeRMDData(t, config.Codec(), config.Crypto(), rmd, h)
@@ -485,7 +485,7 @@ func makeRMDSRange(t *testing.T, config Config,
 	id := tlf.FakeID(1, false)
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
 	for i := 0; i < count; i++ {
-		rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, id, h)
+		rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -679,7 +679,7 @@ func TestMDOpsPutPrivateSuccess(t *testing.T) {
 
 	id := tlf.FakeID(1, false)
 	h := parseTlfHandleOrBust(t, config, "alice,bob", false)
-	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, id, h)
+	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
 	addFakeRMDData(t, config.Codec(), config.Crypto(), rmd, h)
 

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -44,9 +44,10 @@ func testMdcachePut(t *testing.T, tlf tlf.ID, rev MetadataRevision,
 	}
 
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("fake signing key")
-	rmd.bareMd.SignWriterMetadataInternally(context.Background(),
+	err = rmd.bareMd.SignWriterMetadataInternally(context.Background(),
 		kbfscodec.NewMsgpack(),
 		kbfscrypto.SigningKeySigner{Key: signingKey})
+	require.NoError(t, err)
 
 	// put the md
 	irmd := MakeImmutableRootMetadata(

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -165,11 +165,8 @@ func (m *mdServerLocalUpdateManager) registerForUpdate(
 	return c
 }
 
-type keyBundleGetter interface {
-	getKeyBundles(tlfID tlf.ID,
-		wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
-		*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
-}
+type keyBundleGetter func(tlf.ID, TLFWriterKeyBundleID, TLFReaderKeyBundleID) (
+	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
 
 func getExtraMetadata(kbg keyBundleGetter, brmd BareRootMetadata) (ExtraMetadata, error) {
 	tlfID := brmd.TlfID()
@@ -187,7 +184,7 @@ func getExtraMetadata(kbg keyBundleGetter, brmd BareRootMetadata) (ExtraMetadata
 		return nil, nil
 	}
 
-	wkb, rkb, err := kbg.getKeyBundles(tlfID, wkbID, rkbID)
+	wkb, rkb, err := kbg(tlfID, wkbID, rkbID)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -202,7 +202,8 @@ func (md *MDServerMemory) checkGetParams(
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		extra, err := getExtraMetadata(md, mergedMasterHead.MD)
+		extra, err := getExtraMetadata(
+			md.getKeyBundles, mergedMasterHead.MD)
 		if err != nil {
 			return NullBranchID, MDServerError{err}
 		}
@@ -395,7 +396,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 	// TODO: Figure out nil case.
 	if mergedMasterHead != nil {
-		prevExtra, err := getExtraMetadata(md, mergedMasterHead.MD)
+		prevExtra, err := getExtraMetadata(
+			md.getKeyBundles, mergedMasterHead.MD)
 		if err != nil {
 			return MDServerError{err}
 		}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2796,8 +2796,8 @@ func (_mr *_MockMDServerRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, arg5 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockMDServer) Put(ctx context.Context, rmds *RootMetadataSigned, extraNew ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extraNew)
+func (_m *MockMDServer) Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2982,8 +2982,8 @@ func (_mr *_MockmdServerLocalRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockmdServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned, extraNew ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extraNew)
+func (_m *MockmdServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2796,8 +2796,8 @@ func (_mr *_MockMDServerRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, arg5 in
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockMDServer) Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extra)
+func (_m *MockMDServer) Put(ctx context.Context, rmds *RootMetadataSigned, extraNew ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extraNew)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2982,8 +2982,8 @@ func (_mr *_MockmdServerLocalRecorder) GetRange(arg0, arg1, arg2, arg3, arg4, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetRange", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockmdServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned, extra ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extra)
+func (_m *MockmdServerLocal) Put(ctx context.Context, rmds *RootMetadataSigned, extraNew ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmds, extraNew)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -102,20 +102,6 @@ func makeFakeTlfHandle(
 	}
 }
 
-func makeImmutableRootMetadataForTest(
-	t *testing.T, rmd *RootMetadata, key kbfscrypto.VerifyingKey,
-	mdID MdID) ImmutableRootMetadata {
-	brmdv2 := rmd.bareMd.(*BareRootMetadataV2)
-	vk := brmdv2.WriterMetadataSigInfo.VerifyingKey
-	require.True(t, vk == (kbfscrypto.VerifyingKey{}) || vk == key,
-		"Writer signature %s with unexpected non-nil verifying key != %s",
-		brmdv2.WriterMetadataSigInfo, key)
-	brmdv2.WriterMetadataSigInfo = kbfscrypto.SignatureInfo{
-		VerifyingKey: key,
-	}
-	return MakeImmutableRootMetadata(rmd, key, mdID, time.Now())
-}
-
 // Test that GetTlfHandle() and MakeBareTlfHandle() work properly for
 // public TLFs.
 func TestRootMetadataGetTlfHandlePublic(t *testing.T) {

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -222,6 +222,7 @@ func TestMakeRekeyReadError(t *testing.T) {
 
 func testMakeRekeyReadError(t *testing.T, ver MetadataVer) {
 	config := MakeTestConfigOrBust(t, "alice", "bob")
+	config.SetMetadataVersion(ver)
 	defer config.Shutdown()
 
 	tlfID := tlf.FakeID(1, false)
@@ -240,9 +241,12 @@ func testMakeRekeyReadError(t *testing.T, ver MetadataVer) {
 	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedSelfRekeyError{"alice"}, err)
 
-	// MDv3 TODO: This case will no longer be valid. We'll expect the error to be NeedSelfRekeyError.
 	err = makeRekeyReadErrorHelper(rmd.ReadOnly(), h, FirstValidKeyGen+1, h.FirstResolvedWriter(), "alice")
-	require.Equal(t, NeedOtherRekeyError{"alice"}, err)
+	if ver < SegregatedKeyBundlesVer {
+		require.Equal(t, NeedOtherRekeyError{"alice"}, err)
+	} else {
+		require.Equal(t, NeedSelfRekeyError{"alice"}, err)
+	}
 }
 
 func TestMakeRekeyReadErrorResolvedHandle(t *testing.T) {

--- a/libkbfs/safe_test_reporter_test.go
+++ b/libkbfs/safe_test_reporter_test.go
@@ -43,19 +43,15 @@ func makePrefix() string {
 }
 
 func (ctr *SafeTestReporter) error(s string) {
-	// Errorf() prepends the line number of the line below, but
-	// there's nothing we can do about that.
-	ctr.t.Errorf("%s: %s", makePrefix(), s)
+	// Use \r to clear out testing.T's prefix (at least on a terminal).
+	ctr.t.Errorf("\r%s: %s", makePrefix(), s)
 }
 
 func (ctr *SafeTestReporter) Errorf(format string, args ...interface{}) {
 	ctr.error(fmt.Sprintf(format, args...))
 }
 
-// Fatalf somewhat changes the testing.T.Fatalf semantics by first
-// calling Fail(), then runtime.Goexit(), and then later (in the main
-// thread) calling FailNow().  This helps prevent deadlocks when
-// something other than the main goroutine could be invoking Fatalf().
+// Fatalf errors and then panics.
 func (ctr *SafeTestReporter) Fatalf(format string, args ...interface{}) {
 	s := fmt.Sprintf(format, args...)
 	ctr.error(s)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -206,6 +206,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 // Config, regardless of the journal status in `config`.
 func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *ConfigLocal {
 	c := newConfigForTest(config.loggerFn)
+	c.SetMetadataVersion(config.MetadataVersion())
 
 	kbfsOps := NewKBFSOpsStandard(c)
 	c.SetKBFSOps(kbfsOps)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -300,11 +300,6 @@ func NewEmptyTLFReaderKeyBundle() TLFReaderKeyBundleV2 {
 	}
 }
 
-// NewEmptyUserDeviceKeyInfoMap creates a new empty UserDeviceKeyInfoMap.
-func NewEmptyUserDeviceKeyInfoMap() UserDeviceKeyInfoMap {
-	return UserDeviceKeyInfoMap{}
-}
-
 func keySaltForUserDevice(name libkb.NormalizedUsername,
 	index int) libkb.NormalizedUsername {
 	if index > 0 {


### PR DESCRIPTION
...on MetadataVer.

Fix tests that break with MDv3.