### PR TITLE
if TLF has not been identified, and we are in AlwaysRunIdentify mode

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -488,6 +488,7 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 	return favorites.Delete(ctx, h.ToFavorite())
 }
 
+// getHead should not be called outside of folder_branch_ops.go.
 func (fbo *folderBranchOps) getHead(lState *lockState) ImmutableRootMetadata {
 	fbo.headLock.RLock(lState)
 	defer fbo.headLock.RUnlock(lState)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -317,14 +317,13 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 	}()
 	if fbo != nil {
 		lState := makeFBOLockState()
-		rmd = fbo.getHead(lState)
+		rmd, err = fbo.getMDForReadNeedIdentify(ctx, lState)
+		if err != nil {
+			return ImmutableRootMetadata{}, err
+		}
 	}
 	if rmd != (ImmutableRootMetadata{}) {
-		if !fbo.identifyDone && getExtendedIdentify(ctx).behavior.AlwaysRunIdentify() {
-			kbpki := fs.config.KBPKI()
-			err = identifyHandle(ctx, kbpki, kbpki, tlfHandle)
-		}
-		return rmd, err
+		return rmd, nil
 	}
 
 	_, rmd, err = fs.config.MDOps().GetForHandle(ctx, tlfHandle, Unmerged)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -320,7 +320,11 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 		rmd = fbo.getHead(lState)
 	}
 	if rmd != (ImmutableRootMetadata{}) {
-		return rmd, nil
+		if !fbo.identifyDone && getExtendedIdentify(ctx).behavior.AlwaysRunIdentify() {
+			kbpki := fs.config.KBPKI()
+			err = identifyHandle(ctx, kbpki, kbpki, tlfHandle)
+		}
+		return rmd, err
 	}
 
 	_, rmd, err = fs.config.MDOps().GetForHandle(ctx, tlfHandle, Unmerged)


### PR DESCRIPTION
@strib @songgao r?

It seems like the following can happen in the KBFS client when calling `GetTLFCryptKeys`. 

1.) We run`GetTLFCryptKeys` on a TLF with `TLFIdentifyBehavior_CHAT_GUI` on a TLF with a user with a failing tracker statement. In this case, KBFS will seemingly store the folder_branch_ops thing with`identifyDone` set to false.
2.) When we call `GetTLFCryptKeys` again, but this time with `TLFIdentifyBehavior_CHAT_CLI` on the same TLF, then even with the failing tracker statement, we are able to get crypt keys since it will skip the identify after hitting this folder_branch_ops cache.

My change makes it so that if you hit this cache, but `identifyDone` is false we run an identify.

Let me know if this works, I don't know this code very well so I it could be this is the wrong approach.

cc @maxtaco 