### PR TITLE
Simplify init flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ See our [kbfsdokan](kbfsdokan/) documentation.
 ### To run from source against local in-memory servers
 
 ```bash
-kbfsfuse -server-in-memory -localuser strib /keybase
+kbfsfuse -bserver=memory -mdserver=memory -localuser strib /keybase
 ```
 
-(Use "`-server-root <dir>` if instead you want to save your data to
-local disk.)
+(Use `-bserver=dir:/path/to/dir` and `-mdserver=dir:/path/to/dir` if
+instead you want to save your data to local disk.)
 
 Now you can do cool stuff like:
 

--- a/kbfsdokan/README.md
+++ b/kbfsdokan/README.md
@@ -55,7 +55,7 @@ Fix this by setting CGOENABLED=1 and recheck `go env`.
 ## Try it out like kbfsfuse:
 
 For local only functionality:
-```kbfsdokan.exe -debug -localuser <user> -server-in-memory M:```
+```kbfsdokan.exe -debug -localuser <user> -bserver=memory -mdserver=memory M:```
 For normal functionality:
 ```kbfsdokan.exe -debug -log-to-file M:```
 

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libdokan"
 	"github.com/keybase/kbfs/libfs"
-	"github.com/keybase/kbfs/libfuse"
 	"github.com/keybase/kbfs/libkbfs"
 )
 
@@ -52,11 +51,9 @@ Defaults:
 func getUsageString(ctx libkbfs.Context) string {
 	remoteUsageStr := libkbfs.GetRemoteUsageString()
 	localUsageStr := libkbfs.GetLocalUsageString()
-	platformUsageStr := libfuse.GetPlatformUsageString()
 	defaultUsageStr := libkbfs.GetDefaultsUsageString(ctx)
-	return fmt.Sprintf(usageFormatStr,
-		remoteUsageStr, platformUsageStr,
-		localUsageStr, platformUsageStr, defaultUsageStr)
+	return fmt.Sprintf(usageFormatStr, remoteUsageStr,
+		localUsageStr, defaultUsageStr)
 }
 
 func start() *libfs.Error {

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -35,6 +35,7 @@ To run against remote KBFS servers:
     [-bserver=host:port] [-mdserver=host:port]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
     [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
+    [-mount-flags=n] [-dokan-dll=path/to/dokan.dll]
     -mount-from-service | /path/to/mountpoint
 
 To run in a local testing environment:
@@ -43,6 +44,7 @@ To run in a local testing environment:
     [-localuser=<user>] [-local-fav-storage=[memory|dir:/path/to/dir]]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
     [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
+    [-mount-flags=n] [-dokan-dll=path/to/dokan.dll]
     -mount-from-service | /path/to/mountpoint
 
 defaults:

--- a/kbfsdokan/main.go
+++ b/kbfsdokan/main.go
@@ -32,32 +32,31 @@ const usageFormatStr = `Usage:
 
 To run against remote KBFS servers:
   kbfsdokan [-debug] [-cpuprofile=path/to/dir]
-    [-bserver=%s] [-mdserver=%s]
+    [-bserver=host:port] [-mdserver=host:port]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file]
-		[-clean-bcache-cap=0]
+    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
     -mount-from-service | /path/to/mountpoint
 
 To run in a local testing environment:
   kbfsdokan [-debug] [-cpuprofile=path/to/dir]
-    [-server-in-memory|-server-root=path/to/dir] [-localuser=<user>]
+    [-bserver=[memory|dir:/path/to/dir]] [-mdserver=[memory|dir:/path/to/dir]]
+    [-localuser=<user>] [-local-fav-storage=[memory|dir:/path/to/dir]]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file]
-		[-clean-bcache-cap=0]
+    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
     -mount-from-service | /path/to/mountpoint
 
+defaults:
+  -bserver=%s -mdserver=%s -localuser=%s -local-fav-storage=%s
 `
 
 func getUsageStr(ctx libkbfs.Context) string {
 	defaultBServer := libkbfs.GetDefaultBServer(ctx)
-	if len(defaultBServer) == 0 {
-		defaultBServer = "host:port"
-	}
 	defaultMDServer := libkbfs.GetDefaultMDServer(ctx)
-	if len(defaultMDServer) == 0 {
-		defaultMDServer = "host:port"
-	}
-	return fmt.Sprintf(usageFormatStr, defaultBServer, defaultMDServer)
+	defaultLocalUser := libkbfs.GetDefaultLocalUser(ctx)
+	defaultLocalFavoriteStorage :=
+		libkbfs.GetDefaultLocalFavoriteStorage(ctx)
+	return fmt.Sprintf(usageFormatStr, defaultBServer, defaultMDServer,
+		defaultLocalUser, defaultLocalFavoriteStorage)
 }
 
 func start() *libfs.Error {

--- a/kbfsfuse/kbfsfuse.sh
+++ b/kbfsfuse/kbfsfuse.sh
@@ -25,7 +25,7 @@ fi
 
 keybase service &
 SERVICE=$!
-KEYBASE_DEBUG=1 kbfsfuse -debug -mdserver $MDSERVER_ADDR -bserver $BSERVER_ADDR -md-version $KBFS_METADATA_VERSION -log-to-file /keybase &
+KEYBASE_DEBUG=1 kbfsfuse -debug -mdserver $MDSERVER_ADDR -bserver $BSERVER_ADDR -localuser= -md-version $KBFS_METADATA_VERSION -log-to-file /keybase &
 KBFS=$!
 
 wait "$SERVICE"

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -40,7 +40,7 @@ To run in a local testing environment:
 %s
     %s/path/to/mountpoint
 
-defaults:
+Defaults:
 %s
 `
 

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -30,35 +30,33 @@ const usageFormatStr = `Usage:
 
 To run against remote KBFS servers:
   kbfsfuse [-debug] [-cpuprofile=path/to/dir]
-    [-bserver=%s] [-mdserver=%s]
+    [-bserver=host:port] [-mdserver=host:port]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file] [-md-version=version]
-		[-clean-bcache-cap=0]
+    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
     %s/path/to/mountpoint
 
 To run in a local testing environment:
   kbfsfuse [-debug] [-cpuprofile=path/to/dir]
-    [-server-in-memory|-server-root=path/to/dir] [-localuser=<user>]
+    [-bserver=[memory|dir:/path/to/dir]] [-mdserver=[memory|dir:/path/to/dir]]
+    [-localuser=<user>] [-local-fav-storage=[memory|dir:/path/to/dir]]
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file] [-md-version=version]
-		[-clean-bcache-cap=0]
+    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
     %s/path/to/mountpoint
 
+defaults:
+  -bserver=%s -mdserver=%s -localuser=%s -local-fav-storage=%s
 `
 
 func getUsageStr(ctx libkbfs.Context) string {
-	defaultBServer := libkbfs.GetDefaultBServer(ctx)
-	if len(defaultBServer) == 0 {
-		defaultBServer = "host:port"
-	}
-	defaultMDServer := libkbfs.GetDefaultMDServer(ctx)
-	if len(defaultMDServer) == 0 {
-		defaultMDServer = "host:port"
-	}
 	platformUsageString := libfuse.GetPlatformUsageString()
-	return fmt.Sprintf(
-		usageFormatStr, defaultBServer, defaultMDServer,
-		platformUsageString, platformUsageString)
+	defaultBServer := libkbfs.GetDefaultBServer(ctx)
+	defaultMDServer := libkbfs.GetDefaultMDServer(ctx)
+	defaultLocalUser := libkbfs.GetDefaultLocalUser(ctx)
+	defaultLocalFavoriteStorage :=
+		libkbfs.GetDefaultLocalFavoriteStorage(ctx)
+	return fmt.Sprintf(usageFormatStr, platformUsageString,
+		platformUsageString, defaultBServer, defaultMDServer,
+		defaultLocalUser, defaultLocalFavoriteStorage)
 }
 
 func start() *libfs.Error {

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -29,34 +29,29 @@ const usageFormatStr = `Usage:
   kbfsfuse -version
 
 To run against remote KBFS servers:
-  kbfsfuse [-debug] [-cpuprofile=path/to/dir]
-    [-bserver=host:port] [-mdserver=host:port]
+  kbfsfuse
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
+%s
     %s/path/to/mountpoint
 
 To run in a local testing environment:
-  kbfsfuse [-debug] [-cpuprofile=path/to/dir]
-    [-bserver=[memory|dir:/path/to/dir]] [-mdserver=[memory|dir:/path/to/dir]]
-    [-localuser=<user>] [-local-fav-storage=[memory|dir:/path/to/dir]]
+  kbfsfuse
     [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
-    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]
+%s
     %s/path/to/mountpoint
 
 defaults:
-  -bserver=%s -mdserver=%s -localuser=%s -local-fav-storage=%s
+%s
 `
 
-func getUsageStr(ctx libkbfs.Context) string {
-	platformUsageString := libfuse.GetPlatformUsageString()
-	defaultBServer := libkbfs.GetDefaultBServer(ctx)
-	defaultMDServer := libkbfs.GetDefaultMDServer(ctx)
-	defaultLocalUser := libkbfs.GetDefaultLocalUser(ctx)
-	defaultLocalFavoriteStorage :=
-		libkbfs.GetDefaultLocalFavoriteStorage(ctx)
-	return fmt.Sprintf(usageFormatStr, platformUsageString,
-		platformUsageString, defaultBServer, defaultMDServer,
-		defaultLocalUser, defaultLocalFavoriteStorage)
+func getUsageString(ctx libkbfs.Context) string {
+	remoteUsageStr := libkbfs.GetRemoteUsageString()
+	localUsageStr := libkbfs.GetLocalUsageString()
+	platformUsageStr := libfuse.GetPlatformUsageString()
+	defaultUsageStr := libkbfs.GetDefaultsUsageString(ctx)
+	return fmt.Sprintf(usageFormatStr,
+		remoteUsageStr, platformUsageStr,
+		localUsageStr, platformUsageStr, defaultUsageStr)
 }
 
 func start() *libfs.Error {
@@ -73,12 +68,12 @@ func start() *libfs.Error {
 	}
 
 	if len(flag.Args()) < 1 {
-		fmt.Print(getUsageStr(ctx))
+		fmt.Print(getUsageString(ctx))
 		return libfs.InitError("no mount specified")
 	}
 
 	if len(flag.Args()) > 1 {
-		fmt.Print(getUsageStr(ctx))
+		fmt.Print(getUsageString(ctx))
 		return libfs.InitError("extra arguments specified (flags go before the first argument)")
 	}
 

--- a/kbfstool/main.go
+++ b/kbfstool/main.go
@@ -22,19 +22,17 @@ const usageFormatStr = `Usage:
   kbfstool -version
 
 To run against remote KBFS servers:
-  env KEYBASE_RUN_MODE=[staging|prod] kbfstool [-debug]
-    [-cpuprofile=path/to/dir] <command> [<args>]
-
-or
-
-  kbfstool [-debug] [-cpuprofile=path/to/dir] [-bserver=%s] [-mdserver=%s]
+  kbfstool
+%s
     <command> [<args>]
 
 To run in a local testing environment:
-  kbfstool [-debug] [-cpuprofile=path/to/dir]
-    [-bserver=[memory|dir:/path/to/dir]] [-mdserver=[memory|dir:/path/to/dir]]
-    [-localuser=<user>]
+  kbfstool
+%s
     <command> [<args>]
+
+Defaults:
+%s
 
 The possible commands are:
   stat		Display file status
@@ -46,16 +44,12 @@ The possible commands are:
 
 `
 
-func getUsageStr(kbCtx libkbfs.Context) string {
-	defaultBServer := libkbfs.GetDefaultBServer(kbCtx)
-	if len(defaultBServer) == 0 {
-		defaultBServer = "host:port"
-	}
-	defaultMDServer := libkbfs.GetDefaultMDServer(kbCtx)
-	if len(defaultMDServer) == 0 {
-		defaultMDServer = "host:port"
-	}
-	return fmt.Sprintf(usageFormatStr, defaultBServer, defaultMDServer)
+func getUsageString(ctx libkbfs.Context) string {
+	remoteUsageStr := libkbfs.GetRemoteUsageString()
+	localUsageStr := libkbfs.GetLocalUsageString()
+	defaultUsageStr := libkbfs.GetDefaultsUsageString(ctx)
+	return fmt.Sprintf(usageFormatStr, remoteUsageStr,
+		localUsageStr, defaultUsageStr)
 }
 
 // Define this so deferred functions get executed before exit.
@@ -71,7 +65,7 @@ func realMain() (exitStatus int) {
 	}
 
 	if len(flag.Args()) < 1 {
-		fmt.Print(getUsageStr(kbCtx))
+		fmt.Print(getUsageString(kbCtx))
 		return 1
 	}
 

--- a/kbfstool/main.go
+++ b/kbfstool/main.go
@@ -32,7 +32,8 @@ or
 
 To run in a local testing environment:
   kbfstool [-debug] [-cpuprofile=path/to/dir]
-    [-server-in-memory|-server-root=path/to/dir] [-localuser=<user>]
+    [-bserver=[memory|dir:/path/to/dir]] [-mdserver=[memory|dir:/path/to/dir]]
+    [-localuser=<user>]
     <command> [<args>]
 
 The possible commands are:

--- a/libfuse/platform_flags_osx.go
+++ b/libfuse/platform_flags_osx.go
@@ -22,7 +22,7 @@ func (p PlatformParams) shouldAppendPlatformRootDirs() bool {
 // GetPlatformUsageString returns a string to be included in a usage
 // string corresponding to the flags added by AddPlatformFlags.
 func GetPlatformUsageString() string {
-	return "[--use-system-fuse] [--local-experimental]"
+	return "[--use-system-fuse] [--local-experimental]\n    "
 }
 
 // AddPlatformFlags adds platform-specific flags to the given FlagSet

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -47,7 +47,7 @@ type InitParams struct {
 	LocalUser string
 
 	// Where to put favorites. Has an effect only when LocalUser
-	// is non-empty. Must be either "memory" or
+	// is non-empty, in which case it must be either "memory" or
 	// "dir:/path/to/dir".
 	LocalFavoriteStorage string
 
@@ -79,24 +79,57 @@ type InitParams struct {
 // GetDefaultBServer returns the default value for the -bserver flag.
 func GetDefaultBServer(ctx Context) string {
 	switch ctx.GetRunMode() {
+	case libkb.DevelRunMode:
+		return memoryAddr
 	case libkb.StagingRunMode:
 		return "bserver.dev.keybase.io:443"
 	case libkb.ProductionRunMode:
 		return "bserver.kbfs.keybase.io:443"
 	default:
-		return memoryAddr
+		return ""
 	}
 }
 
 // GetDefaultMDServer returns the default value for the -mdserver flag.
 func GetDefaultMDServer(ctx Context) string {
 	switch ctx.GetRunMode() {
+	case libkb.DevelRunMode:
+		return memoryAddr
 	case libkb.StagingRunMode:
 		return "mdserver.dev.keybase.io:443"
 	case libkb.ProductionRunMode:
 		return "mdserver.kbfs.keybase.io:443"
 	default:
-		return memoryAddr
+		return ""
+	}
+}
+
+// GetDefaultLocalUser returns the default value for the -localuser flag.
+func GetDefaultLocalUser(ctx Context) string {
+	switch ctx.GetRunMode() {
+	case libkb.DevelRunMode:
+		return "strib"
+	case libkb.StagingRunMode:
+		return ""
+	case libkb.ProductionRunMode:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// GetDefaultLocalFavoriteStorage returns the default value for the
+// -local-fav-storage flag.
+func GetDefaultLocalFavoriteStorage(ctx Context) string {
+	switch ctx.GetRunMode() {
+	case libkb.DevelRunMode:
+		return "memory"
+	case libkb.StagingRunMode:
+		return ""
+	case libkb.ProductionRunMode:
+		return ""
+	default:
+		return ""
 	}
 }
 
@@ -122,7 +155,8 @@ func DefaultInitParams(ctx Context) InitParams {
 		Debug:                BoolForString(os.Getenv("KBFS_DEBUG")),
 		BServerAddr:          GetDefaultBServer(ctx),
 		MDServerAddr:         GetDefaultMDServer(ctx),
-		LocalFavoriteStorage: memoryAddr,
+		LocalUser:            GetDefaultLocalUser(ctx),
+		LocalFavoriteStorage: GetDefaultLocalFavoriteStorage(ctx),
 		TLFValidDuration:     tlfValidDurationDefault,
 		MetadataVersion:      int(GetDefaultMetadataVersion(ctx)),
 		LogFileConfig: logger.LogFileConfig{

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -32,6 +32,7 @@ type InitParams struct {
 	// be "memory" for an in-memory test server or
 	// "dir:/path/to/dir" for an on-disk test server.
 	BServerAddr string
+
 	// If non-empty the host:port of the metadata server. If
 	// empty, a default value is used depending on the run mode.
 	// Can also be "memory" for an in-memory test server or
@@ -42,9 +43,13 @@ type InitParams struct {
 	// zero, the capacity is set using getDefaultBlockCacheCapacity().
 	CleanBlockCacheCapacity uint64
 
-	// Fake local user name. If non-empty, MDServerAddr must be
-	// either "memory" or "dir:/path/to/dir".
+	// Fake local user name.
 	LocalUser string
+
+	// Where to put favorites. Has an effect only when LocalUser
+	// is non-empty. Must be either "memory" or
+	// "dir:/path/to/dir".
+	LocalFavoriteStorage string
 
 	// TLFValidDuration is the duration that TLFs are valid
 	// before marked for lazy revalidation.
@@ -114,11 +119,12 @@ func defaultLogPath(ctx Context) string {
 // DefaultInitParams returns default init params
 func DefaultInitParams(ctx Context) InitParams {
 	return InitParams{
-		Debug:            BoolForString(os.Getenv("KBFS_DEBUG")),
-		BServerAddr:      GetDefaultBServer(ctx),
-		MDServerAddr:     GetDefaultMDServer(ctx),
-		TLFValidDuration: tlfValidDurationDefault,
-		MetadataVersion:  int(GetDefaultMetadataVersion(ctx)),
+		Debug:                BoolForString(os.Getenv("KBFS_DEBUG")),
+		BServerAddr:          GetDefaultBServer(ctx),
+		MDServerAddr:         GetDefaultMDServer(ctx),
+		LocalFavoriteStorage: memoryAddr,
+		TLFValidDuration:     tlfValidDurationDefault,
+		MetadataVersion:      int(GetDefaultMetadataVersion(ctx)),
 		LogFileConfig: logger.LogFileConfig{
 			MaxAge:       30 * 24 * time.Hour,
 			MaxSize:      128 * 1024 * 1024,
@@ -141,6 +147,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.StringVar(&params.BServerAddr, "bserver", defaultParams.BServerAddr, "host:port of the block server, 'memory', or 'dir:/path/to/dir'")
 	flags.StringVar(&params.MDServerAddr, "mdserver", defaultParams.MDServerAddr, "host:port of the metadata server, 'memory', or 'dir:/path/to/dir'")
 	flags.StringVar(&params.LocalUser, "localuser", "", "fake local user (used only with -mdserver=memory or -mdserver=disk")
+	flags.StringVar(&params.LocalFavoriteStorage, "local-fav-storage", defaultParams.LocalFavoriteStorage, "where to put favorites; used only when -localuser is set, then must either be 'memory' or 'dir:/path/to/dir'")
 	flags.DurationVar(&params.TLFValidDuration, "tlf-valid", defaultParams.TLFValidDuration, "time tlfs are valid before redoing identification")
 	flags.BoolVar(&params.LogToFile, "log-to-file", false, fmt.Sprintf("Log to default file: %s", defaultLogPath(ctx)))
 	flags.StringVar(&params.LogFileConfig.Path, "log-file", "", "Path to log file")

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -214,7 +214,7 @@ func GetLocalUsageString() string {
     [-bserver=(memory | dir:/path/to/dir | host:port)]
     [-mdserver=(memory | dir:/path/to/dir | host:port)]
     [-localuser=<user>]
-    [-local-fav-storage=(memory |dir :/path/to/dir)]
+    [-local-fav-storage=(memory | dir:/path/to/dir)]
     [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]`
 }
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -41,14 +41,15 @@ type InitParams struct {
 	// MDServerAddr, and ServerRootDir.
 	ServerInMemory bool
 	// If true, use in-memory bserver and ignore BServerAddr,
-	// and ServerRootDir for the bserver.
+	// and BServerRootDir for the bserver.
 	BServerInMemory bool
 	// If true, use in-memory mdserver and ignore MDServerAddr,
-	// and ServerRootDir for the mdserver.
+	// and MDServerRootDir for the mdserver.
 	MDServerInMemory bool
-	// If non-empty, use on-disk servers and ignore BServerAddr
-	// and MDServerAddr.
-	ServerRootDir string
+	// If non-empty, use on-disk servers and ignore BServerAddr.
+	BServerRootDir string
+	// If non-empty, use on-disk servers and ignore MDServerAddr.
+	MDServerRootDir string
 	// Fake local user name. If non-empty, either ServerInMemory
 	// must be true or ServerRootDir must be non-empty.
 	LocalUser string
@@ -148,11 +149,11 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.StringVar(&params.BServerAddr, "bserver", defaultParams.BServerAddr, "host:port of the block server")
 	flags.StringVar(&params.MDServerAddr, "mdserver", defaultParams.MDServerAddr, "host:port of the metadata server")
 
-	flags.BoolVar(&params.ServerInMemory, "server-in-memory", false, "use in-memory server (and ignore -bserver, -mdserver, and -server-root)")
-	flags.BoolVar(&params.BServerInMemory, "bserver-in-memory", false, "use in-memory bserver (and ignore -bserver and -server-root for the bserver)")
-	flags.BoolVar(&params.MDServerInMemory, "mdserver-in-memory", false, "use in-memory mdserver (and ignore -mdserver, and -server-root for the mdserver)")
-	flags.StringVar(&params.ServerRootDir, "server-root", "", "directory to put local server files (and ignore -bserver and -mdserver)")
-	flags.StringVar(&params.LocalUser, "localuser", "", "fake local user (used only with -server-in-memory or -server-root)")
+	flags.BoolVar(&params.BServerInMemory, "bserver-in-memory", false, "use in-memory bserver (and ignore -bserver and -bserver-root for the bserver)")
+	flags.BoolVar(&params.MDServerInMemory, "mdserver-in-memory", false, "use in-memory mdserver (and ignore -mdserver, and -mdserver-root for the mdserver)")
+	flags.StringVar(&params.BServerRootDir, "bserver-root", "", "directory to put local block server files (and ignore -bserver)")
+	flags.StringVar(&params.MDServerRootDir, "mdserver-root", "", "directory to put local MD server files (and ignore -mdserver)")
+	flags.StringVar(&params.LocalUser, "localuser", "", "fake local user (used only with -{b,md}server-in-memory or -{b,md}server-root)")
 	flags.DurationVar(&params.TLFValidDuration, "tlf-valid", defaultParams.TLFValidDuration, "time tlfs are valid before redoing identification")
 	flags.BoolVar(&params.LogToFile, "log-to-file", false, fmt.Sprintf("Log to default file: %s", defaultLogPath(ctx)))
 	flags.StringVar(&params.LogFileConfig.Path, "log-file", "", "Path to log file")
@@ -397,7 +398,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	config.SetCrypto(crypto)
 
 	mdServer, err := makeMDServer(
-		config, params.ServerInMemory || params.MDServerInMemory, params.ServerRootDir, params.MDServerAddr, ctx)
+		config, params.ServerInMemory || params.MDServerInMemory, params.MDServerRootDir, params.MDServerAddr, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("problem creating MD server: %v", err)
 	}
@@ -405,7 +406,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 
 	// note: the mdserver is the keyserver at the moment.
 	keyServer, err := makeKeyServer(
-		config, params.ServerInMemory || params.MDServerInMemory, params.ServerRootDir, params.MDServerAddr)
+		config, params.ServerInMemory || params.MDServerInMemory, params.MDServerRootDir, params.MDServerAddr)
 	if err != nil {
 		return nil, fmt.Errorf("problem creating key server: %v", err)
 	}
@@ -416,7 +417,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 
 	config.SetKeyServer(keyServer)
 
-	bserv, err := makeBlockServer(config, params.ServerInMemory || params.BServerInMemory, params.ServerRootDir, params.BServerAddr, ctx, log)
+	bserv, err := makeBlockServer(config, params.ServerInMemory || params.BServerInMemory, params.BServerRootDir, params.BServerAddr, ctx, log)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open block database: %v", err)
 	}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -219,15 +219,17 @@ func GetLocalUsageString() string {
 }
 
 func GetDefaultsUsageString(ctx Context) string {
+	runMode := ctx.GetRunMode()
 	defaultBServer := GetDefaultBServer(ctx)
 	defaultMDServer := GetDefaultMDServer(ctx)
 	defaultLocalUser := GetDefaultLocalUser(ctx)
 	defaultLocalFavoriteStorage := GetDefaultLocalFavoriteStorage(ctx)
-	return fmt.Sprintf(`  -bserver=%s
+	return fmt.Sprintf(`  (KEYBASE_RUN_MODE=%s)
+  -bserver=%s
   -mdserver=%s
   -localuser=%s
   -local-fav-storage=%s`,
-		defaultBServer, defaultMDServer, defaultLocalUser,
+		runMode, defaultBServer, defaultMDServer, defaultLocalUser,
 		defaultLocalFavoriteStorage)
 }
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -182,7 +182,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 
 	flags.StringVar(&params.BServerAddr, "bserver", defaultParams.BServerAddr, "host:port of the block server, 'memory', or 'dir:/path/to/dir'")
 	flags.StringVar(&params.MDServerAddr, "mdserver", defaultParams.MDServerAddr, "host:port of the metadata server, 'memory', or 'dir:/path/to/dir'")
-	flags.StringVar(&params.LocalUser, "localuser", "", "fake local user (used only with -mdserver=memory or -mdserver=disk")
+	flags.StringVar(&params.LocalUser, "localuser", defaultParams.LocalUser, "fake local user (used only with -mdserver=memory or -mdserver=disk")
 	flags.StringVar(&params.LocalFavoriteStorage, "local-fav-storage", defaultParams.LocalFavoriteStorage, "where to put favorites; used only when -localuser is set, then must either be 'memory' or 'dir:/path/to/dir'")
 	flags.DurationVar(&params.TLFValidDuration, "tlf-valid", defaultParams.TLFValidDuration, "time tlfs are valid before redoing identification")
 	flags.BoolVar(&params.LogToFile, "log-to-file", false, fmt.Sprintf("Log to default file: %s", defaultLogPath(ctx)))

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -57,7 +57,7 @@ type InitParams struct {
 
 	// MetadataVersion is the default version of metadata to use
 	// when creating new metadata.
-	MetadataVersion int
+	MetadataVersion MetadataVer
 
 	// LogToFile if true, logs to a default file location.
 	LogToFile bool
@@ -136,6 +136,8 @@ func GetDefaultLocalFavoriteStorage(ctx Context) string {
 // GetDefaultMetadataVersion returns the default metadata version per run mode.
 func GetDefaultMetadataVersion(ctx Context) MetadataVer {
 	switch ctx.GetRunMode() {
+	case libkb.DevelRunMode:
+		return SegregatedKeyBundlesVer
 	case libkb.StagingRunMode:
 		return SegregatedKeyBundlesVer
 	case libkb.ProductionRunMode:
@@ -158,7 +160,7 @@ func DefaultInitParams(ctx Context) InitParams {
 		LocalUser:            GetDefaultLocalUser(ctx),
 		LocalFavoriteStorage: GetDefaultLocalFavoriteStorage(ctx),
 		TLFValidDuration:     tlfValidDurationDefault,
-		MetadataVersion:      int(GetDefaultMetadataVersion(ctx)),
+		MetadataVersion:      GetDefaultMetadataVersion(ctx),
 		LogFileConfig: logger.LogFileConfig{
 			MaxAge:       30 * 24 * time.Hour,
 			MaxSize:      128 * 1024 * 1024,
@@ -197,7 +199,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	// params.TLFJournalBackgroundWorkStatus via a flag.
 	params.TLFJournalBackgroundWorkStatus = defaultParams.TLFJournalBackgroundWorkStatus
 
-	flags.IntVar(&params.MetadataVersion, "md-version", defaultParams.MetadataVersion, "Metadata version to use when creating new metadata")
+	flags.IntVar((*int)(&params.MetadataVersion), "md-version", int(defaultParams.MetadataVersion), "Metadata version to use when creating new metadata")
 	return &params
 }
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -203,12 +203,16 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	return &params
 }
 
+// GetRemoteUsageString returns a string describing the flags to use
+// to run against remote KBFS servers.
 func GetRemoteUsageString() string {
 	return `    [-debug] [-cpuprofile=path/to/dir]
     [-bserver=host:port] [-mdserver=host:port]
     [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]`
 }
 
+// GetLocalUsageString returns a string describing the flags to use to
+// run in a local testing environment.
 func GetLocalUsageString() string {
 	return `    [-debug] [-cpuprofile=path/to/dir]
     [-bserver=(memory | dir:/path/to/dir | host:port)]
@@ -218,6 +222,8 @@ func GetLocalUsageString() string {
     [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]`
 }
 
+// GetDefaultsUsageString returns a string describing the default
+// values of flags based on the run mode.
 func GetDefaultsUsageString(ctx Context) string {
 	runMode := ctx.GetRunMode()
 	defaultBServer := defaultBServer(ctx)

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -182,7 +182,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 
 	flags.StringVar(&params.BServerAddr, "bserver", defaultParams.BServerAddr, "host:port of the block server, 'memory', or 'dir:/path/to/dir'")
 	flags.StringVar(&params.MDServerAddr, "mdserver", defaultParams.MDServerAddr, "host:port of the metadata server, 'memory', or 'dir:/path/to/dir'")
-	flags.StringVar(&params.LocalUser, "localuser", defaultParams.LocalUser, "fake local user (used only with -mdserver=memory or -mdserver=disk")
+	flags.StringVar(&params.LocalUser, "localuser", defaultParams.LocalUser, "fake local user")
 	flags.StringVar(&params.LocalFavoriteStorage, "local-fav-storage", defaultParams.LocalFavoriteStorage, "where to put favorites; used only when -localuser is set, then must either be 'memory' or 'dir:/path/to/dir'")
 	flags.DurationVar(&params.TLFValidDuration, "tlf-valid", defaultParams.TLFValidDuration, "time tlfs are valid before redoing identification")
 	flags.BoolVar(&params.LogToFile, "log-to-file", false, fmt.Sprintf("Log to default file: %s", defaultLogPath(ctx)))

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -479,8 +479,8 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 
 	config.SetBlockServer(bserv)
 
-	// TODO: Don't turn on journaling if -server-in-memory is
-	// used.
+	// TODO: Don't turn on journaling if either -bserver or
+	// -mdserver point to local implementations.
 
 	if len(params.WriteJournalRoot) > 0 {
 		config.EnableJournaling(params.WriteJournalRoot,

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -37,9 +37,6 @@ type InitParams struct {
 	// zero, the capacity is set using getDefaultBlockCacheCapacity().
 	CleanBlockCacheCapacity uint64
 
-	// If true, use in-memory servers and ignore BServerAddr,
-	// MDServerAddr, and ServerRootDir.
-	ServerInMemory bool
 	// If true, use in-memory bserver and ignore BServerAddr,
 	// and BServerRootDir for the bserver.
 	BServerInMemory bool
@@ -398,7 +395,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	config.SetCrypto(crypto)
 
 	mdServer, err := makeMDServer(
-		config, params.ServerInMemory || params.MDServerInMemory, params.MDServerRootDir, params.MDServerAddr, ctx)
+		config, params.MDServerInMemory, params.MDServerRootDir, params.MDServerAddr, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("problem creating MD server: %v", err)
 	}
@@ -406,7 +403,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 
 	// note: the mdserver is the keyserver at the moment.
 	keyServer, err := makeKeyServer(
-		config, params.ServerInMemory || params.MDServerInMemory, params.MDServerRootDir, params.MDServerAddr)
+		config, params.MDServerInMemory, params.MDServerRootDir, params.MDServerAddr)
 	if err != nil {
 		return nil, fmt.Errorf("problem creating key server: %v", err)
 	}
@@ -417,7 +414,7 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 
 	config.SetKeyServer(keyServer)
 
-	bserv, err := makeBlockServer(config, params.ServerInMemory || params.BServerInMemory, params.BServerRootDir, params.BServerAddr, ctx, log)
+	bserv, err := makeBlockServer(config, params.BServerInMemory, params.BServerRootDir, params.BServerAddr, ctx, log)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open block database: %v", err)
 	}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -203,6 +203,34 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	return &params
 }
 
+func GetRemoteUsageString() string {
+	return `    [-debug] [-cpuprofile=path/to/dir]
+    [-bserver=host:port] [-mdserver=host:port]
+    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]`
+}
+
+func GetLocalUsageString() string {
+	return `    [-debug] [-cpuprofile=path/to/dir]
+    [-bserver=(memory | dir:/path/to/dir | host:port)]
+    [-mdserver=(memory | dir:/path/to/dir | host:port)]
+    [-localuser=<user>]
+    [-local-fav-storage=(memory |dir :/path/to/dir)]
+    [-log-to-file] [-log-file=path/to/file] [-clean-bcache-cap=0]`
+}
+
+func GetDefaultsUsageString(ctx Context) string {
+	defaultBServer := GetDefaultBServer(ctx)
+	defaultMDServer := GetDefaultMDServer(ctx)
+	defaultLocalUser := GetDefaultLocalUser(ctx)
+	defaultLocalFavoriteStorage := GetDefaultLocalFavoriteStorage(ctx)
+	return fmt.Sprintf(`  -bserver=%s
+  -mdserver=%s
+  -localuser=%s
+  -local-fav-storage=%s`,
+		defaultBServer, defaultMDServer, defaultLocalUser,
+		defaultLocalFavoriteStorage)
+}
+
 const memoryAddr = "memory"
 
 const dirAddrPrefix = "dir:"

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -76,8 +76,8 @@ type InitParams struct {
 	WriteJournalRoot string
 }
 
-// GetDefaultBServer returns the default value for the -bserver flag.
-func GetDefaultBServer(ctx Context) string {
+// defaultBServer returns the default value for the -bserver flag.
+func defaultBServer(ctx Context) string {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
 		return memoryAddr
@@ -90,8 +90,8 @@ func GetDefaultBServer(ctx Context) string {
 	}
 }
 
-// GetDefaultMDServer returns the default value for the -mdserver flag.
-func GetDefaultMDServer(ctx Context) string {
+// defaultMDServer returns the default value for the -mdserver flag.
+func defaultMDServer(ctx Context) string {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
 		return memoryAddr
@@ -104,8 +104,8 @@ func GetDefaultMDServer(ctx Context) string {
 	}
 }
 
-// GetDefaultLocalUser returns the default value for the -localuser flag.
-func GetDefaultLocalUser(ctx Context) string {
+// defaultLocalUser returns the default value for the -localuser flag.
+func defaultLocalUser(ctx Context) string {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
 		return "strib"
@@ -118,9 +118,9 @@ func GetDefaultLocalUser(ctx Context) string {
 	}
 }
 
-// GetDefaultLocalFavoriteStorage returns the default value for the
+// defaultLocalFavoriteStorage returns the default value for the
 // -local-fav-storage flag.
-func GetDefaultLocalFavoriteStorage(ctx Context) string {
+func defaultLocalFavoriteStorage(ctx Context) string {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
 		return "memory"
@@ -133,8 +133,8 @@ func GetDefaultLocalFavoriteStorage(ctx Context) string {
 	}
 }
 
-// GetDefaultMetadataVersion returns the default metadata version per run mode.
-func GetDefaultMetadataVersion(ctx Context) MetadataVer {
+// defaultMetadataVersion returns the default metadata version per run mode.
+func defaultMetadataVersion(ctx Context) MetadataVer {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
 		return SegregatedKeyBundlesVer
@@ -155,12 +155,12 @@ func defaultLogPath(ctx Context) string {
 func DefaultInitParams(ctx Context) InitParams {
 	return InitParams{
 		Debug:                BoolForString(os.Getenv("KBFS_DEBUG")),
-		BServerAddr:          GetDefaultBServer(ctx),
-		MDServerAddr:         GetDefaultMDServer(ctx),
-		LocalUser:            GetDefaultLocalUser(ctx),
-		LocalFavoriteStorage: GetDefaultLocalFavoriteStorage(ctx),
+		BServerAddr:          defaultBServer(ctx),
+		MDServerAddr:         defaultMDServer(ctx),
+		LocalUser:            defaultLocalUser(ctx),
+		LocalFavoriteStorage: defaultLocalFavoriteStorage(ctx),
 		TLFValidDuration:     tlfValidDurationDefault,
-		MetadataVersion:      GetDefaultMetadataVersion(ctx),
+		MetadataVersion:      defaultMetadataVersion(ctx),
 		LogFileConfig: logger.LogFileConfig{
 			MaxAge:       30 * 24 * time.Hour,
 			MaxSize:      128 * 1024 * 1024,
@@ -220,10 +220,10 @@ func GetLocalUsageString() string {
 
 func GetDefaultsUsageString(ctx Context) string {
 	runMode := ctx.GetRunMode()
-	defaultBServer := GetDefaultBServer(ctx)
-	defaultMDServer := GetDefaultMDServer(ctx)
-	defaultLocalUser := GetDefaultLocalUser(ctx)
-	defaultLocalFavoriteStorage := GetDefaultLocalFavoriteStorage(ctx)
+	defaultBServer := defaultBServer(ctx)
+	defaultMDServer := defaultMDServer(ctx)
+	defaultLocalUser := defaultLocalUser(ctx)
+	defaultLocalFavoriteStorage := defaultLocalFavoriteStorage(ctx)
 	return fmt.Sprintf(`  (KEYBASE_RUN_MODE=%s)
   -bserver=%s
   -mdserver=%s

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -47,19 +47,16 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()
 
-	// Arbitrarily use the MDServer params to decide between
-	// memory/disk.
-
-	if params.MDServerAddr == memoryAddr {
+	if params.LocalFavoriteStorage == memoryAddr {
 		return NewKeybaseDaemonMemory(localUID, localUsers, codec), nil
 	}
 
-	if serverRootDir, ok := parseRootDir(params.MDServerAddr); ok {
+	if serverRootDir, ok := parseRootDir(params.LocalFavoriteStorage); ok {
 		favPath := filepath.Join(serverRootDir, "kbfs_favs")
 		return NewKeybaseDaemonDisk(localUID, localUsers, favPath, codec)
 	}
 
-	return nil, errors.New("Can't user localuser without a local MDserver")
+	return nil, errors.New("Can't user localuser without LocalFavoriteStorage being 'memory' or 'dir:/path/to/dir'")
 }
 
 func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, log logger.Logger) (Crypto, error) {

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -47,16 +47,19 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()
 
-	if params.BServerInMemory && params.MDServerInMemory {
+	// Arbitrarily use the MDServer params to decide between
+	// memory/disk.
+
+	if params.MDServerAddr == memoryAddr {
 		return NewKeybaseDaemonMemory(localUID, localUsers, codec), nil
 	}
 
-	if len(params.BServerRootDir) > 0 && len(params.MDServerRootDir) > 0 {
-		favPath := filepath.Join(params.MDServerRootDir, "kbfs_favs")
+	if serverRootDir, ok := parseRootDir(params.MDServerAddr); ok {
+		favPath := filepath.Join(serverRootDir, "kbfs_favs")
 		return NewKeybaseDaemonDisk(localUID, localUsers, favPath, codec)
 	}
 
-	return nil, errors.New("Can't user localuser without a local server")
+	return nil, errors.New("Can't user localuser without a local MDserver")
 }
 
 func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, log logger.Logger) (Crypto, error) {

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -46,14 +46,13 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()
-	serverInMemory, serverRootDir := params.ServerInMemory, params.ServerRootDir
 
-	if serverInMemory {
+	if params.BServerInMemory && params.MDServerInMemory {
 		return NewKeybaseDaemonMemory(localUID, localUsers, codec), nil
 	}
 
-	if len(serverRootDir) > 0 {
-		favPath := filepath.Join(serverRootDir, "kbfs_favs")
+	if len(params.BServerRootDir) > 0 && len(params.MDServerRootDir) > 0 {
+		favPath := filepath.Join(params.MDServerRootDir, "kbfs_favs")
 		return NewKeybaseDaemonDisk(localUID, localUsers, favPath, codec)
 	}
 

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -24,7 +24,10 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 		return NewKeybaseDaemonRPC(config, ctx, log, params.Debug), nil
 	}
 
-	users := []libkb.NormalizedUsername{"strib", "max", "chris", "fred"}
+	users := []libkb.NormalizedUsername{
+		"strib", "max", "chris", "akalin", "jzila", "alness",
+		"jinyang", "songgao", "taru", "zanderz",
+	}
 	userIndex := -1
 	for i := range users {
 		if localUser == users[i] {
@@ -43,6 +46,12 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 	localUsers[1].Asserts = []string{"twitter:maxtaco"}
 	localUsers[2].Asserts = []string{"twitter:malgorithms"}
 	localUsers[3].Asserts = []string{"twitter:fakalin"}
+	localUsers[4].Asserts = []string{"twitter:jzila"}
+	localUsers[5].Asserts = []string{"github:aalness"}
+	localUsers[6].Asserts = []string{"github:jinyangli"}
+	localUsers[7].Asserts = []string{"github:songgao"}
+	// No asserts for 8.
+	localUsers[9].Asserts = []string{"github:zanderz"}
 
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()


### PR DESCRIPTION
Remove -server-in-memory and -server-root flags
in favor of just having -bserver and -mdserver
understand "memory" and "dir:/path/to/dir"
arguments. This also lets one use a local
bserver with a production mdserver and vice
versa.

Decouple favorite storage from bserver and
mdserver storage by adding a -local-fav-storage
flag.

Set default flags in DevelRunMode to use all
in-memory servers, for convenience.

Add a few more users to the hard-coded list of
local test users.

Factor out common usage strings.