### PR TITLE
[KBFS-1744] Fix reader promotion bug

### DIFF
--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -30,15 +30,14 @@ func mdDumpGetDeviceString(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
 func mdDumpGetReplacements(ctx context.Context, codec kbfscodec.Codec,
 	service libkbfs.KeybaseService, brmd libkbfs.BareRootMetadata,
 	extra libkbfs.ExtraMetadata) (map[string]string, error) {
-	readers, writers, err := brmd.GetUserDeviceKeyInfoMaps(
-		codec, brmd.LatestKeyGeneration(), extra)
+	writers, readers, err := brmd.GetUserDevicePublicKeys(extra)
 	if err != nil {
 		return nil, err
 	}
 
 	replacements := make(map[string]string)
-	for _, udkim := range []libkbfs.UserDeviceKeyInfoMap{writers, readers} {
-		for u, dkim := range udkim {
+	for _, userKeys := range []libkbfs.UserDevicePublicKeys{writers, readers} {
+		for u, deviceKeys := range userKeys {
 			if _, ok := replacements[u.String()]; ok {
 				continue
 			}
@@ -57,7 +56,7 @@ func mdDumpGetReplacements(ctx context.Context, codec kbfscodec.Codec,
 				continue
 			}
 
-			for k := range dkim {
+			for k := range deviceKeys {
 				if _, ok := replacements[k.String()]; ok {
 					continue
 				}

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -124,7 +124,7 @@ func testRootMetadataFinalVerify(t *testing.T, ver MetadataVer) {
 		Key: kbfscrypto.MakeFakeSigningKeyOrBust("key"),
 	}
 
-	extra := FakeInitialRekey(brmd, codec, bh, kbfscrypto.TLFPublicKey{})
+	extra := FakeInitialRekey(brmd, bh, kbfscrypto.TLFPublicKey{})
 
 	brmd.SetLastModifyingWriter(uid)
 	brmd.SetLastModifyingUser(uid)

--- a/libkbfs/bare_root_metadata_test_util.go
+++ b/libkbfs/bare_root_metadata_test_util.go
@@ -19,7 +19,7 @@ import (
 // server-side tests.
 func FakeInitialRekey(md MutableBareRootMetadata,
 	h tlf.Handle, pubKey kbfscrypto.TLFPublicKey) ExtraMetadata {
-	if md.LatestKeyGeneration() != 0 {
+	if md.LatestKeyGeneration() >= FirstValidKeyGen {
 		panic(fmt.Errorf("FakeInitialRekey called on MD with existing key generations"))
 	}
 

--- a/libkbfs/bare_root_metadata_test_util.go
+++ b/libkbfs/bare_root_metadata_test_util.go
@@ -15,7 +15,7 @@ import (
 // BareRootMetadata objects don't have enough data to build a
 // TlfHandle from until the first rekey. pubKey is non-empty only for
 // server-side tests.
-func FakeInitialRekey(md MutableBareRootMetadata, codec kbfscodec.Codec,
+func FakeInitialRekey(md MutableBareRootMetadata,
 	h tlf.Handle, pubKey kbfscrypto.TLFPublicKey) ExtraMetadata {
 	wKeys := make(UserDevicePublicKeys)
 	for _, w := range h.Writers {
@@ -33,6 +33,7 @@ func FakeInitialRekey(md MutableBareRootMetadata, codec kbfscodec.Codec,
 		}
 	}
 
+	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)
 	tlfCryptKey := kbfscrypto.MakeTLFCryptKey([32]byte{0x1})
 	extra, _, err := md.AddKeyGeneration(

--- a/libkbfs/bare_root_metadata_test_util.go
+++ b/libkbfs/bare_root_metadata_test_util.go
@@ -5,6 +5,8 @@
 package libkbfs
 
 import (
+	"fmt"
+
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
@@ -17,6 +19,10 @@ import (
 // server-side tests.
 func FakeInitialRekey(md MutableBareRootMetadata,
 	h tlf.Handle, pubKey kbfscrypto.TLFPublicKey) ExtraMetadata {
+	if md.LatestKeyGeneration() != 0 {
+		panic(fmt.Errorf("FakeInitialRekey called on MD with existing key generations"))
+	}
+
 	wKeys := make(UserDevicePublicKeys)
 	for _, w := range h.Writers {
 		k := kbfscrypto.MakeFakeCryptPublicKeyOrBust(string(w))

--- a/libkbfs/bare_root_metadata_test_util.go
+++ b/libkbfs/bare_root_metadata_test_util.go
@@ -40,6 +40,8 @@ func FakeInitialRekey(md MutableBareRootMetadata,
 	}
 
 	codec := kbfscodec.NewMsgpack()
+	// TODO: Consider making crypto a parameter once we remove all
+	// uses of mocked-out crypto.
 	crypto := MakeCryptoCommon(codec)
 	tlfCryptKey := kbfscrypto.MakeTLFCryptKey([32]byte{0x1})
 	extra, _, err := md.AddKeyGeneration(

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1061,29 +1061,6 @@ func (md *BareRootMetadataV2) GetCurrentTLFPublicKey(
 	return md.WKeys[len(md.WKeys)-1].TLFPublicKey, nil
 }
 
-// AreKeyGenerationsEqual implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) AreKeyGenerationsEqual(
-	codec kbfscodec.Codec, other BareRootMetadata) (
-	bool, error) {
-	md2, ok := other.(*BareRootMetadataV2)
-	if !ok {
-		// No idea what this is.
-		return false, errors.New("Unknown metadata version")
-	}
-	ok, err := kbfscodec.Equal(codec, md.WKeys, md2.WKeys)
-	if err != nil {
-		return false, err
-	}
-	if !ok {
-		return false, nil
-	}
-	ok, err = kbfscodec.Equal(codec, md.RKeys, md2.RKeys)
-	if err != nil {
-		return false, err
-	}
-	return ok, nil
-}
-
 // GetUnresolvedParticipants implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion) {
 	return md.UnresolvedReaders, md.WriterMetadataV2.Extra.UnresolvedWriters

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -600,10 +600,10 @@ func (md *BareRootMetadataV2) PromoteReaders(
 				return fmt.Errorf("Could not find %s in key gen %d",
 					reader, FirstValidKeyGen+KeyGen(i))
 			}
-			// TODO: This is incorrect, since dkim may
-			// contain negative offsets, and a lot of code
-			// assumes that writers will only contain
-			// non-negative offsets.
+			// TODO: This may be incorrect, since dkim may
+			// contain negative EPubKey indices, and the
+			// upconversion code assumes that writers will
+			// only contain non-negative EPubKey indices.
 			//
 			// See KBFS-1719.
 			md.WKeys[i].WKeys[reader] = dkim

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -693,40 +693,6 @@ func (md *BareRootMetadataV2) GetUserDevicePublicKeys(_ ExtraMetadata) (
 	return wUDKIM.WKeys.toPublicKeys(), rUDKIM.RKeys.toPublicKeys(), nil
 }
 
-// GetDevicePublicKeys implements the BareRootMetadata interface for
-// BareRootMetadataV2.
-func (md *BareRootMetadataV2) GetDevicePublicKeys(
-	user keybase1.UID, _ ExtraMetadata) (
-	isWriter bool, keys DevicePublicKeys, err error) {
-	if md.ID.IsPublic() {
-		return false, nil, InvalidPublicTLFOperation{
-			md.ID, "GetDevicePublicKeys", md.Version(),
-		}
-	}
-
-	if len(md.WKeys) == 0 || len(md.RKeys) == 0 {
-		return false, nil, errors.New(
-			"GetDevicePublicKeys called with no key generations (V2)")
-	}
-
-	dkim := md.WKeys[len(md.WKeys)-1].WKeys[user]
-	isWriter = true
-	if len(dkim) == 0 {
-		dkim = md.RKeys[len(md.RKeys)-1].RKeys[user]
-		isWriter = false
-		if len(dkim) == 0 {
-			return false, nil, nil
-		}
-	}
-
-	keys = make(DevicePublicKeys, len(dkim))
-	for kid := range dkim {
-		keys[kbfscrypto.MakeCryptPublicKey(kid)] = true
-	}
-
-	return isWriter, keys, nil
-}
-
 // HasKeyForUser implements the BareRootMetadata interface for
 // BareRootMetadataV2.
 func (md *BareRootMetadataV2) HasKeyForUser(

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1139,7 +1139,7 @@ func (md *BareRootMetadataV2) updateKeyGeneration(
 // AddKeyGeneration implements the MutableBareRootMetadata interface
 // for BareRootMetadataV2.
 func (md *BareRootMetadataV2) AddKeyGeneration(codec kbfscodec.Codec,
-	crypto cryptoPure, _ ExtraMetadata,
+	crypto cryptoPure, extra ExtraMetadata,
 	wKeys, rKeys UserDevicePublicKeys,
 	ePubKey kbfscrypto.TLFEphemeralPublicKey,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
@@ -1159,6 +1159,9 @@ func (md *BareRootMetadataV2) AddKeyGeneration(codec kbfscodec.Codec,
 	if currCryptKey != (kbfscrypto.TLFCryptKey{}) {
 		return nil, nil, errors.New("currCryptKey unexpectedly non-zero")
 	}
+
+	// TODO: If we already have existing keys, make sure wKeys and
+	// rKeys match them.
 
 	newWriterKeys := TLFWriterKeyBundleV2{
 		WKeys:        make(UserDeviceKeyInfoMapV2),

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1067,10 +1067,16 @@ func (md *BareRootMetadataV2) GetUnresolvedParticipants() (readers, writers []ke
 }
 
 func (md *BareRootMetadataV2) updateKeyGenerationForReaderRekey(
-	crypto cryptoPure, keyGen KeyGen, rKeys UserDevicePublicKeys,
+	crypto cryptoPure, keyGen KeyGen,
+	updatedReaderKeys UserDevicePublicKeys,
 	ePubKey kbfscrypto.TLFEphemeralPublicKey,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
 	tlfCryptKey kbfscrypto.TLFCryptKey) (UserDeviceKeyServerHalves, error) {
+	if len(updatedReaderKeys) != 1 {
+		return nil, fmt.Errorf("Expected updatedReaderKeys to have only one entry, got %d",
+			len(updatedReaderKeys))
+	}
+
 	_, rkb, err := md.getTLFKeyBundles(keyGen)
 	if err != nil {
 		return nil, err
@@ -1082,7 +1088,7 @@ func (md *BareRootMetadataV2) updateKeyGenerationForReaderRekey(
 	newIndex := -len(rkb.TLFReaderEphemeralPublicKeys) - 1
 
 	rServerHalves, err := rkb.RKeys.fillInUserInfos(
-		crypto, newIndex, rKeys, ePrivKey, tlfCryptKey)
+		crypto, newIndex, updatedReaderKeys, ePrivKey, tlfCryptKey)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -693,25 +693,6 @@ func (md *BareRootMetadataV2) GetUserDevicePublicKeys(_ ExtraMetadata) (
 	return wUDKIM.WKeys.toPublicKeys(), rUDKIM.RKeys.toPublicKeys(), nil
 }
 
-// HasKeyForUser implements the BareRootMetadata interface for
-// BareRootMetadataV2.
-func (md *BareRootMetadataV2) HasKeyForUser(
-	user keybase1.UID, _ ExtraMetadata) (bool, error) {
-	if md.ID.IsPublic() {
-		return false, InvalidPublicTLFOperation{md.ID, "HasKeyForUser", md.Version()}
-	}
-
-	if len(md.WKeys) == 0 || len(md.RKeys) == 0 {
-		return false, errors.New(
-			"HasKeyForUser called with no key generations (V2)")
-	}
-
-	wDKIM := md.WKeys[len(md.WKeys)-1].WKeys[user]
-	rDKIM := md.RKeys[len(md.RKeys)-1].RKeys[user]
-
-	return (len(wDKIM) > 0) || (len(rDKIM) > 0), nil
-}
-
 // GetTLFCryptKeyParams implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey,

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1099,6 +1099,8 @@ func (md *BareRootMetadataV2) updateKeyGenerationForReaderRekey(
 		return nil, err
 	}
 
+	// If we didn't fill in any new user infos, don't add a new
+	// ephemeral key.
 	if len(rServerHalves) > 0 {
 		rkb.TLFReaderEphemeralPublicKeys = append(
 			rkb.TLFReaderEphemeralPublicKeys, ePubKey)
@@ -1142,6 +1144,8 @@ func (md *BareRootMetadataV2) updateKeyGeneration(
 		return nil, err
 	}
 
+	// If we didn't fill in any new user infos, don't add a new
+	// ephemeral key.
 	if len(serverHalves) > 0 {
 		wkb.TLFEphemeralPublicKeys =
 			append(wkb.TLFEphemeralPublicKeys, ePubKey)

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1144,7 +1144,7 @@ func (md *BareRootMetadataV2) GetUserDeviceKeyInfoMaps(
 	return rUDKIM, wUDKIM, nil
 }
 
-func (md *BareRootMetadataV2) updateKeyGenerationForReader(
+func (md *BareRootMetadataV2) updateKeyGenerationForReaderRekey(
 	crypto cryptoPure, keyGen KeyGen, rKeys UserDevicePublicKeys,
 	ePubKey kbfscrypto.TLFEphemeralPublicKey,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
@@ -1283,10 +1283,12 @@ func (md *BareRootMetadataV2) UpdateKeyBundles(crypto cryptoPure,
 	serverHalves := make([]UserDeviceKeyServerHalves, len(tlfCryptKeys))
 	if len(wKeys) == 0 {
 		// Reader rekey case.
+
 		for keyGen := FirstValidKeyGen; keyGen <= md.LatestKeyGeneration(); keyGen++ {
-			serverHalvesGen, err := md.updateKeyGenerationForReader(
-				crypto, keyGen, rKeys, ePubKey, ePrivKey,
-				tlfCryptKeys[keyGen-FirstValidKeyGen])
+			serverHalvesGen, err :=
+				md.updateKeyGenerationForReaderRekey(crypto,
+					keyGen, rKeys, ePubKey, ePrivKey,
+					tlfCryptKeys[keyGen-FirstValidKeyGen])
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1061,9 +1061,15 @@ func (md *BareRootMetadataV2) GetCurrentTLFPublicKey(
 	return md.WKeys[len(md.WKeys)-1].TLFPublicKey, nil
 }
 
-// GetUnresolvedParticipants implements the BareRootMetadata interface for BareRootMetadataV2.
-func (md *BareRootMetadataV2) GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion) {
-	return md.UnresolvedReaders, md.WriterMetadataV2.Extra.UnresolvedWriters
+// GetUnresolvedParticipants implements the BareRootMetadata interface
+// for BareRootMetadataV2.
+func (md *BareRootMetadataV2) GetUnresolvedParticipants() []keybase1.SocialAssertion {
+	writers := md.WriterMetadataV2.Extra.UnresolvedWriters
+	readers := md.UnresolvedReaders
+	users := make([]keybase1.SocialAssertion, 0, len(writers)+len(readers))
+	users = append(users, writers...)
+	users = append(users, readers...)
+	return users
 }
 
 func (md *BareRootMetadataV2) updateKeyGenerationForReaderRekey(

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -991,11 +991,11 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	ePubKey4, ePrivKey4, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
-	updatedReaderKeysReader := UserDevicePublicKeys{
+	filteredReaderKeys := UserDevicePublicKeys{
 		uid3: updatedReaderKeys[uid3],
 	}
 	serverHalves4, err := rmd.UpdateKeyBundles(crypto, nil,
-		nil, updatedReaderKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		nil, filteredReaderKeys, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo4 := expectedRekeyInfoV2{
@@ -1013,7 +1013,7 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves4b, err := rmd.UpdateKeyBundles(crypto, nil,
-		nil, updatedReaderKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		nil, filteredReaderKeys, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo4b := expectedRekeyInfoV2{

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -465,14 +465,15 @@ func TestRevokeRemovedDevicesV2(t *testing.T) {
 		},
 	}
 
-	wKeys := UserDevicePublicKeys{
+	updatedWriterKeys := UserDevicePublicKeys{
 		uid1: {key1: true},
 	}
-	rKeys := UserDevicePublicKeys{
+	updatedReaderKeys := UserDevicePublicKeys{
 		uid3: {key3: true},
 	}
 
-	removalInfo, err := brmd.RevokeRemovedDevices(wKeys, rKeys, nil)
+	removalInfo, err := brmd.RevokeRemovedDevices(
+		updatedWriterKeys, updatedReaderKeys, nil)
 	require.NoError(t, err)
 	require.Equal(t, ServerHalfRemovalInfo{
 		uid2: userServerHalfRemovalInfo{
@@ -809,12 +810,12 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	privKey2 := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key2")
 	privKey3 := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3")
 
-	wKeys := UserDevicePublicKeys{
+	updatedWriterKeys := UserDevicePublicKeys{
 		uid1: {privKey1.GetPublicKey(): true},
 		uid2: {privKey2.GetPublicKey(): true},
 	}
 
-	rKeys := UserDevicePublicKeys{
+	updatedReaderKeys := UserDevicePublicKeys{
 		uid3: {privKey3.GetPublicKey(): true},
 	}
 
@@ -850,7 +851,8 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 		// generations, even though that can't happen in
 		// practice.
 		_, serverHalves1Gen, err := rmd.AddKeyGeneration(codec,
-			crypto, nil, wKeys, rKeys, ePubKey1, ePrivKey1,
+			crypto, nil, updatedWriterKeys, updatedReaderKeys,
+			ePubKey1, ePrivKey1,
 			pubKey, kbfscrypto.TLFCryptKey{}, tlfCryptKey)
 		require.NoError(t, err)
 		serverHalves1 = append(serverHalves1, serverHalves1Gen)
@@ -878,7 +880,8 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Do update to check idempotency.
 
 	serverHalves1b, err := rmd.UpdateKeyBundles(crypto, nil,
-		wKeys, rKeys, ePubKey1, ePrivKey1, tlfCryptKeys)
+		updatedWriterKeys, updatedReaderKeys,
+		ePubKey1, ePrivKey1, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo1b := expectedRekeyInfoV2{
@@ -892,16 +895,17 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Rekey.
 
 	privKey1b := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key1b")
-	wKeys[uid1][privKey1b.GetPublicKey()] = true
+	updatedWriterKeys[uid1][privKey1b.GetPublicKey()] = true
 
 	privKey3b := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3b")
-	rKeys[uid3][privKey3b.GetPublicKey()] = true
+	updatedReaderKeys[uid3][privKey3b.GetPublicKey()] = true
 
 	ePubKey2, ePrivKey2, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
 	serverHalves2, err := rmd.UpdateKeyBundles(crypto, nil,
-		wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKeys)
+		updatedWriterKeys, updatedReaderKeys,
+		ePubKey2, ePrivKey2, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo2 := expectedRekeyInfoV2{
@@ -923,7 +927,8 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves2b, err := rmd.UpdateKeyBundles(crypto, nil,
-		wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKeys)
+		updatedWriterKeys, updatedReaderKeys,
+		ePubKey2, ePrivKey2, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo2b := expectedRekeyInfoV2{
@@ -937,13 +942,14 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Rekey writers only.
 
 	privKey1c := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key1c")
-	wKeys[uid1][privKey1c.GetPublicKey()] = true
+	updatedWriterKeys[uid1][privKey1c.GetPublicKey()] = true
 
 	ePubKey3, ePrivKey3, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
 	serverHalves3, err := rmd.UpdateKeyBundles(crypto, nil,
-		wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKeys)
+		updatedWriterKeys, updatedReaderKeys,
+		ePubKey3, ePrivKey3, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo3 := expectedRekeyInfoV2{
@@ -963,7 +969,8 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves3b, err := rmd.UpdateKeyBundles(crypto, nil,
-		wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKeys)
+		updatedWriterKeys, updatedReaderKeys,
+		ePubKey3, ePrivKey3, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo3b := expectedRekeyInfoV2{
@@ -978,17 +985,17 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 
 	privKey3c := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3c")
 	privKey3d := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3d")
-	rKeys[uid3][privKey3c.GetPublicKey()] = true
-	rKeys[uid3][privKey3d.GetPublicKey()] = true
+	updatedReaderKeys[uid3][privKey3c.GetPublicKey()] = true
+	updatedReaderKeys[uid3][privKey3d.GetPublicKey()] = true
 
 	ePubKey4, ePrivKey4, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
-	rKeysReader := UserDevicePublicKeys{
-		uid3: rKeys[uid3],
+	updatedReaderKeysReader := UserDevicePublicKeys{
+		uid3: updatedReaderKeys[uid3],
 	}
 	serverHalves4, err := rmd.UpdateKeyBundles(crypto, nil,
-		nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		nil, updatedReaderKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo4 := expectedRekeyInfoV2{
@@ -1006,7 +1013,7 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves4b, err := rmd.UpdateKeyBundles(crypto, nil,
-		nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		nil, updatedReaderKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 
 	expectedRekeyInfo4b := expectedRekeyInfoV2{

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -728,9 +728,11 @@ func userDeviceServerHalvesToPublicKeys(serverHalves UserDeviceKeyServerHalves) 
 // checkKeyBundlesV2 checks that wkb and rkb contain exactly the info
 // expected from expectedRekeyInfos and expectedPubKey.
 func checkKeyBundlesV2(t *testing.T, expectedRekeyInfos []expectedRekeyInfoV2,
+	expectedLatestKeyGeneration KeyGen,
 	expectedTLFCryptKey kbfscrypto.TLFCryptKey,
 	expectedPubKey kbfscrypto.TLFPublicKey,
 	rmd *BareRootMetadataV2) {
+	require.Equal(t, expectedLatestKeyGeneration, rmd.LatestKeyGeneration())
 	for keyGen := FirstValidKeyGen; keyGen <= rmd.LatestKeyGeneration(); keyGen++ {
 		wkb, rkb, err := rmd.getTLFKeyBundles(FirstValidKeyGen)
 		require.NoError(t, err)
@@ -849,7 +851,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 	}
 	expectedRekeyInfos := []expectedRekeyInfoV2{expectedRekeyInfo1}
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Do update to check idempotency.
 
@@ -863,7 +865,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo1b)
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Rekey.
 
@@ -894,7 +896,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo2)
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Do again to check idempotency.
 
@@ -908,7 +910,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo2b)
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Rekey writers only.
 
@@ -934,7 +936,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo3)
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Do again to check idempotency.
 
@@ -948,7 +950,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo3b)
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Reader rekey.
 
@@ -978,7 +980,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 		ePubKey:      ePubKey4,
 	}
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo4)
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 
 	// Do again to check idempotency.
 
@@ -993,5 +995,5 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo4b)
 
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKey, pubKey, rmd)
+	checkKeyBundlesV2(t, expectedRekeyInfos, FirstValidKeyGen, tlfCryptKey, pubKey, rmd)
 }

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -841,6 +841,9 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 		pubKey := kbfscrypto.MakeTLFPublicKey([32]byte{byte(keyGen)})
 		tlfCryptKey := kbfscrypto.MakeTLFCryptKey([32]byte{byte(keyGen)})
 
+		// Use the same ephemeral keys for initial key
+		// generations, even though that can't happen in
+		// practice.
 		_, serverHalves1Gen, err := rmd.AddKeyGeneration(
 			codec, crypto, nil,
 			wKeys, rKeys, ePubKey1, ePrivKey1, pubKey,

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -832,8 +832,7 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)
 
-	ePubKey1, ePrivKey1, err :=
-		crypto.MakeRandomTLFEphemeralKeys()
+	ePubKey1, ePrivKey1, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
 	// Add first key generations.
@@ -850,10 +849,9 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 		// Use the same ephemeral keys for initial key
 		// generations, even though that can't happen in
 		// practice.
-		_, serverHalves1Gen, err := rmd.AddKeyGeneration(
-			codec, crypto, nil,
-			wKeys, rKeys, ePubKey1, ePrivKey1, pubKey,
-			kbfscrypto.TLFCryptKey{}, tlfCryptKey)
+		_, serverHalves1Gen, err := rmd.AddKeyGeneration(codec,
+			crypto, nil, wKeys, rKeys, ePubKey1, ePrivKey1,
+			pubKey, kbfscrypto.TLFCryptKey{}, tlfCryptKey)
 		require.NoError(t, err)
 		serverHalves1 = append(serverHalves1, serverHalves1Gen)
 

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -961,7 +961,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 	rKeysReader := UserDevicePublicKeys{
 		uid3: rKeys[uid3],
 	}
-	serverHalves4, err := rmd.updateKeyGenerationForReader(
+	serverHalves4, err := rmd.updateKeyGenerationForReaderRekey(
 		crypto, FirstValidKeyGen, rKeysReader, ePubKey4, ePrivKey4,
 		tlfCryptKey)
 	require.NoError(t, err)
@@ -980,7 +980,7 @@ func TestBareRootMetadataV2UpdateKeyGeneration(t *testing.T) {
 
 	// Do again to check idempotency.
 
-	serverHalves4b, err := rmd.updateKeyGenerationForReader(
+	serverHalves4b, err := rmd.updateKeyGenerationForReaderRekey(
 		crypto, FirstValidKeyGen, rKeysReader, ePubKey4,
 		ePrivKey4, tlfCryptKey)
 	require.NoError(t, err)

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1211,8 +1211,13 @@ func (md *BareRootMetadataV3) GetCurrentTLFPublicKey(
 }
 
 // GetUnresolvedParticipants implements the BareRootMetadata interface for BareRootMetadataV3.
-func (md *BareRootMetadataV3) GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion) {
-	return md.UnresolvedReaders, md.WriterMetadata.UnresolvedWriters
+func (md *BareRootMetadataV3) GetUnresolvedParticipants() []keybase1.SocialAssertion {
+	writers := md.WriterMetadata.UnresolvedWriters
+	readers := md.UnresolvedReaders
+	users := make([]keybase1.SocialAssertion, 0, len(writers)+len(readers))
+	users = append(users, writers...)
+	users = append(users, readers...)
+	return users
 }
 
 // UpdateKeyBundles implements the MutableBareRootMetadata interface

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1074,7 +1074,7 @@ func (md *BareRootMetadataV3) AddKeyGeneration(codec kbfscodec.Codec,
 
 	if len(updatedWriterKeys) == 0 {
 		return nil, nil, errors.New(
-			"updatedWriterKeys unexpectedly non-empty")
+			"updatedWriterKeys unexpectedly empty")
 	}
 
 	if nextCryptKey == (kbfscrypto.TLFCryptKey{}) {

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1188,19 +1188,6 @@ func (md *BareRootMetadataV3) GetCurrentTLFPublicKey(
 	return wkb.TLFPublicKey, nil
 }
 
-// AreKeyGenerationsEqual implements the BareRootMetadata interface for BareRootMetadataV3.
-func (md *BareRootMetadataV3) AreKeyGenerationsEqual(
-	codec kbfscodec.Codec, other BareRootMetadata) (bool, error) {
-	md3, ok := other.(*BareRootMetadataV3)
-	if !ok {
-		// MDv3 TODO: handle comparisons across versions
-		return false, nil
-	}
-	rekey := md3.RKeyBundleID != md.RKeyBundleID ||
-		md3.WriterMetadata.WKeyBundleID != md.WriterMetadata.WKeyBundleID
-	return rekey, nil
-}
-
 // GetUnresolvedParticipants implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion) {
 	return md.UnresolvedReaders, md.WriterMetadata.UnresolvedWriters

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1073,6 +1073,9 @@ func (md *BareRootMetadataV3) AddKeyGeneration(codec kbfscodec.Codec,
 		return nil, nil, errors.New("Zero next crypt key")
 	}
 
+	// TODO: If we already have existing keys, make sure wKeys and
+	// rKeys match them.
+
 	latestKeyGen := md.LatestKeyGeneration()
 	var encryptedHistoricKeys EncryptedTLFCryptKeys
 	if currCryptKey == (kbfscrypto.TLFCryptKey{}) {

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -652,39 +652,6 @@ func (md *BareRootMetadataV3) GetUserDevicePublicKeys(extra ExtraMetadata) (
 	return wkb.Keys.toPublicKeys(), rkb.Keys.toPublicKeys(), nil
 }
 
-// GetDevicePublicKeys implements the BareRootMetadata interface for
-// BareRootMetadataV3.
-func (md *BareRootMetadataV3) GetDevicePublicKeys(
-	user keybase1.UID, extra ExtraMetadata) (
-	isWriter bool, keys DevicePublicKeys, err error) {
-	if md.TlfID().IsPublic() {
-		return false, nil, InvalidPublicTLFOperation{
-			md.TlfID(), "GetDevicePublicKeys", md.Version()}
-	}
-
-	wkb, rkb, err := md.getTLFKeyBundles(extra)
-	if err != nil {
-		return false, nil, err
-	}
-
-	dkim := wkb.Keys[user]
-	isWriter = true
-	if len(dkim) == 0 {
-		dkim = rkb.Keys[user]
-		isWriter = false
-		if len(dkim) == 0 {
-			return false, nil, nil
-		}
-	}
-
-	keys = make(DevicePublicKeys, len(dkim))
-	for key := range dkim {
-		keys[key] = true
-	}
-
-	return isWriter, keys, nil
-}
-
 // HasKeyForUser implements the BareRootMetadata interface for
 // BareRootMetadataV3.
 func (md *BareRootMetadataV3) HasKeyForUser(

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1029,6 +1029,8 @@ func (md *BareRootMetadataV3) updateKeyBundles(crypto cryptoPure,
 	if err != nil {
 		return nil, err
 	}
+	// If we didn't fill in any new writer infos, don't add a new
+	// writer ephemeral key.
 	if len(wServerHalves) > 0 {
 		wkb.TLFEphemeralPublicKeys =
 			append(wkb.TLFEphemeralPublicKeys, ePubKey)
@@ -1044,6 +1046,8 @@ func (md *BareRootMetadataV3) updateKeyBundles(crypto cryptoPure,
 	if err != nil {
 		return nil, err
 	}
+	// If we didn't fill in any new reader infos, don't add a new
+	// reader ephemeral key.
 	if len(rServerHalves) > 0 {
 		rkb.TLFEphemeralPublicKeys =
 			append(rkb.TLFEphemeralPublicKeys, ePubKey)

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -671,7 +671,7 @@ func (md *BareRootMetadataV3) GetDevicePublicKeys(
 // HasKeyForUser implements the BareRootMetadata interface for
 // BareRootMetadataV3.
 func (md *BareRootMetadataV3) HasKeyForUser(
-	keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) (bool, error) {
+	user keybase1.UID, extra ExtraMetadata) (bool, error) {
 	wkb, rkb, err := md.getTLFKeyBundles(extra)
 	if err != nil {
 		return false, err

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -652,17 +652,6 @@ func (md *BareRootMetadataV3) GetUserDevicePublicKeys(extra ExtraMetadata) (
 	return wkb.Keys.toPublicKeys(), rkb.Keys.toPublicKeys(), nil
 }
 
-// HasKeyForUser implements the BareRootMetadata interface for
-// BareRootMetadataV3.
-func (md *BareRootMetadataV3) HasKeyForUser(
-	user keybase1.UID, extra ExtraMetadata) (bool, error) {
-	wkb, rkb, err := md.getTLFKeyBundles(extra)
-	if err != nil {
-		return false, err
-	}
-	return (len(wkb.Keys[user]) > 0) || (len(rkb.Keys[user]) > 0), nil
-}
-
 // GetTLFCryptKeyParams implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID,

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -177,14 +177,15 @@ func TestRevokeRemovedDevicesV3(t *testing.T) {
 		},
 	}
 
-	wKeys := UserDevicePublicKeys{
+	updatedWriterKeys := UserDevicePublicKeys{
 		uid1: {key1: true},
 	}
-	rKeys := UserDevicePublicKeys{
+	updatedReaderKeys := UserDevicePublicKeys{
 		uid3: {key3: true},
 	}
 
-	removalInfo, err := brmd.RevokeRemovedDevices(wKeys, rKeys, extra)
+	removalInfo, err := brmd.RevokeRemovedDevices(
+		updatedWriterKeys, updatedReaderKeys, extra)
 	require.NoError(t, err)
 	require.Equal(t, ServerHalfRemovalInfo{
 		uid2: userServerHalfRemovalInfo{
@@ -354,12 +355,12 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	privKey2 := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key2")
 	privKey3 := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3")
 
-	wKeys := UserDevicePublicKeys{
+	updatedWriterKeys := UserDevicePublicKeys{
 		uid1: {privKey1.GetPublicKey(): true},
 		uid2: {privKey2.GetPublicKey(): true},
 	}
 
-	rKeys := UserDevicePublicKeys{
+	updatedReaderKeys := UserDevicePublicKeys{
 		uid3: {privKey3.GetPublicKey(): true},
 	}
 
@@ -398,7 +399,8 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 		// practice.
 		var err error
 		extra, serverHalves1, err = rmd.AddKeyGeneration(codec,
-			crypto, extra, wKeys, rKeys, ePubKey1, ePrivKey1,
+			crypto, extra, updatedWriterKeys, updatedReaderKeys,
+			ePubKey1, ePrivKey1,
 			pubKey, tlfCryptKey, nextTLFCryptKey)
 		require.NoError(t, err)
 
@@ -430,7 +432,8 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	tlfCryptKeys := []kbfscrypto.TLFCryptKey{tlfCryptKey}
 
 	serverHalves1b, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey1, ePrivKey1, tlfCryptKeys)
+		extra, updatedWriterKeys, updatedReaderKeys,
+		ePubKey1, ePrivKey1, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves1b))
 
@@ -445,16 +448,17 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Rekey.
 
 	privKey1b := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key1b")
-	wKeys[uid1][privKey1b.GetPublicKey()] = true
+	updatedWriterKeys[uid1][privKey1b.GetPublicKey()] = true
 
 	privKey3b := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3b")
-	rKeys[uid3][privKey3b.GetPublicKey()] = true
+	updatedReaderKeys[uid3][privKey3b.GetPublicKey()] = true
 
 	ePubKey2, ePrivKey2, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
 	serverHalves2, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKeys)
+		extra, updatedWriterKeys, updatedReaderKeys,
+		ePubKey2, ePrivKey2, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves2))
 
@@ -478,7 +482,8 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves2b, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKeys)
+		extra, updatedWriterKeys, updatedReaderKeys,
+		ePubKey2, ePrivKey2, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves2b))
 
@@ -493,13 +498,14 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Rekey writers only.
 
 	privKey1c := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key1c")
-	wKeys[uid1][privKey1c.GetPublicKey()] = true
+	updatedWriterKeys[uid1][privKey1c.GetPublicKey()] = true
 
 	ePubKey3, ePrivKey3, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
 	serverHalves3, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKeys)
+		extra, updatedWriterKeys, updatedReaderKeys,
+		ePubKey3, ePrivKey3, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves3))
 
@@ -521,7 +527,8 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves3b, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKeys)
+		extra, updatedWriterKeys, updatedReaderKeys,
+		ePubKey3, ePrivKey3, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves3b))
 
@@ -537,17 +544,18 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 
 	privKey3c := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3c")
 	privKey3d := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("key3d")
-	rKeys[uid3][privKey3c.GetPublicKey()] = true
-	rKeys[uid3][privKey3d.GetPublicKey()] = true
+	updatedReaderKeys[uid3][privKey3c.GetPublicKey()] = true
+	updatedReaderKeys[uid3][privKey3d.GetPublicKey()] = true
 
 	ePubKey4, ePrivKey4, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
-	rKeysReader := UserDevicePublicKeys{
-		uid3: rKeys[uid3],
+	updatedReaderKeysReader := UserDevicePublicKeys{
+		uid3: updatedReaderKeys[uid3],
 	}
 	serverHalves4, err := rmd.UpdateKeyBundles(crypto,
-		extra, nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		extra, nil, updatedReaderKeysReader,
+		ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves4))
 
@@ -567,7 +575,7 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves4b, err := rmd.UpdateKeyBundles(crypto,
-		extra, nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		extra, nil, updatedReaderKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves4b))
 

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -427,9 +427,12 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 
 	// Do update to check idempotency.
 
+	tlfCryptKeys := []kbfscrypto.TLFCryptKey{tlfCryptKey}
+
 	serverHalves1b, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey1, ePrivKey1, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, wKeys, rKeys, ePubKey1, ePrivKey1, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves1b))
 
 	expectedRekeyInfo1b := expectedRekeyInfoV3{
 		serverHalves: serverHalves1b[0],
@@ -451,8 +454,9 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	require.NoError(t, err)
 
 	serverHalves2, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey2, ePrivKey2, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves2))
 
 	expectedRekeyInfo2 := expectedRekeyInfoV3{
 		writerPrivKeys: userDevicePrivateKeys{
@@ -474,8 +478,9 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves2b, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey2, ePrivKey2, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves2b))
 
 	expectedRekeyInfo2b := expectedRekeyInfoV3{
 		serverHalves: serverHalves2b[0],
@@ -494,8 +499,9 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	require.NoError(t, err)
 
 	serverHalves3, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey3, ePrivKey3, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves3))
 
 	expectedRekeyInfo3 := expectedRekeyInfoV3{
 		writerPrivKeys: userDevicePrivateKeys{
@@ -515,8 +521,9 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves3b, err := rmd.UpdateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey3, ePrivKey3, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves3b))
 
 	expectedRekeyInfo3b := expectedRekeyInfoV3{
 		serverHalves: serverHalves3b[0],
@@ -540,8 +547,9 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 		uid3: rKeys[uid3],
 	}
 	serverHalves4, err := rmd.UpdateKeyBundles(crypto,
-		extra, nil, rKeysReader, ePubKey4, ePrivKey4, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves4))
 
 	expectedRekeyInfo4 := expectedRekeyInfoV3{
 		writerPrivKeys: nil,
@@ -559,8 +567,9 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves4b, err := rmd.UpdateKeyBundles(crypto,
-		extra, nil, rKeysReader, ePubKey4, ePrivKey4, []kbfscrypto.TLFCryptKey{tlfCryptKey})
+		extra, nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
+	require.Equal(t, 1, len(serverHalves4b))
 
 	expectedRekeyInfo4b := expectedRekeyInfoV3{
 		serverHalves: serverHalves4b[0],

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -550,11 +550,11 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	ePubKey4, ePrivKey4, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
-	updatedReaderKeysReader := UserDevicePublicKeys{
+	filteredReaderKeys := UserDevicePublicKeys{
 		uid3: updatedReaderKeys[uid3],
 	}
 	serverHalves4, err := rmd.UpdateKeyBundles(crypto,
-		extra, nil, updatedReaderKeysReader,
+		extra, nil, filteredReaderKeys,
 		ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves4))
@@ -575,7 +575,8 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	// Do again to check idempotency.
 
 	serverHalves4b, err := rmd.UpdateKeyBundles(crypto,
-		extra, nil, updatedReaderKeysReader, ePubKey4, ePrivKey4, tlfCryptKeys)
+		extra, nil, filteredReaderKeys,
+		ePubKey4, ePrivKey4, tlfCryptKeys)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(serverHalves4b))
 

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -345,7 +345,7 @@ func checkKeyBundlesV3(t *testing.T, expectedRekeyInfos []expectedRekeyInfoV3,
 	}
 }
 
-func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
+func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(1)
 	uid2 := keybase1.MakeTestUID(2)
 	uid3 := keybase1.MakeTestUID(3)
@@ -412,12 +412,12 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 
 	// Do update to check idempotency.
 
-	serverHalves1b, err := rmd.updateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey1, ePrivKey1, tlfCryptKey)
+	serverHalves1b, err := rmd.UpdateKeyBundles(crypto,
+		extra, wKeys, rKeys, ePubKey1, ePrivKey1, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo1b := expectedRekeyInfoV3{
-		serverHalves: serverHalves1b,
+		serverHalves: serverHalves1b[0],
 	}
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo1b)
@@ -435,8 +435,8 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 	ePubKey2, ePrivKey2, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
-	serverHalves2, err := rmd.updateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKey)
+	serverHalves2, err := rmd.UpdateKeyBundles(crypto,
+		extra, wKeys, rKeys, ePubKey2, ePrivKey2, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo2 := expectedRekeyInfoV3{
@@ -446,7 +446,7 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 		readerPrivKeys: userDevicePrivateKeys{
 			uid3: {privKey3b: true},
 		},
-		serverHalves:       serverHalves2,
+		serverHalves:       serverHalves2[0],
 		writerEPubKeyIndex: 1,
 		readerEPubKeyIndex: 1,
 		ePubKey:            ePubKey2,
@@ -458,12 +458,12 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 
 	// Do again to check idempotency.
 
-	serverHalves2b, err := rmd.updateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey2, ePrivKey2, tlfCryptKey)
+	serverHalves2b, err := rmd.UpdateKeyBundles(crypto,
+		extra, wKeys, rKeys, ePubKey2, ePrivKey2, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo2b := expectedRekeyInfoV3{
-		serverHalves: serverHalves2b,
+		serverHalves: serverHalves2b[0],
 	}
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo2b)
@@ -478,8 +478,8 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 	ePubKey3, ePrivKey3, err := crypto.MakeRandomTLFEphemeralKeys()
 	require.NoError(t, err)
 
-	serverHalves3, err := rmd.updateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKey)
+	serverHalves3, err := rmd.UpdateKeyBundles(crypto,
+		extra, wKeys, rKeys, ePubKey3, ePrivKey3, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo3 := expectedRekeyInfoV3{
@@ -487,7 +487,7 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 			uid1: {privKey1c: true},
 		},
 		readerPrivKeys:     nil,
-		serverHalves:       serverHalves3,
+		serverHalves:       serverHalves3[0],
 		writerEPubKeyIndex: 2,
 		readerEPubKeyIndex: -1,
 		ePubKey:            ePubKey3,
@@ -499,12 +499,12 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 
 	// Do again to check idempotency.
 
-	serverHalves3b, err := rmd.updateKeyBundles(crypto,
-		extra, wKeys, rKeys, ePubKey3, ePrivKey3, tlfCryptKey)
+	serverHalves3b, err := rmd.UpdateKeyBundles(crypto,
+		extra, wKeys, rKeys, ePubKey3, ePrivKey3, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo3b := expectedRekeyInfoV3{
-		serverHalves: serverHalves3b,
+		serverHalves: serverHalves3b[0],
 	}
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo3b)
@@ -524,8 +524,8 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 	rKeysReader := UserDevicePublicKeys{
 		uid3: rKeys[uid3],
 	}
-	serverHalves4, err := rmd.updateKeyBundles(crypto,
-		extra, nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKey)
+	serverHalves4, err := rmd.UpdateKeyBundles(crypto,
+		extra, nil, rKeysReader, ePubKey4, ePrivKey4, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo4 := expectedRekeyInfoV3{
@@ -533,7 +533,7 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 		readerPrivKeys: userDevicePrivateKeys{
 			uid3: {privKey3c: true, privKey3d: true},
 		},
-		serverHalves:       serverHalves4,
+		serverHalves:       serverHalves4[0],
 		writerEPubKeyIndex: -1,
 		readerEPubKeyIndex: 2,
 		ePubKey:            ePubKey4,
@@ -543,12 +543,12 @@ func TestBareRootMetadataV3UpdateKeyGeneration(t *testing.T) {
 
 	// Do again to check idempotency.
 
-	serverHalves4b, err := rmd.updateKeyBundles(crypto,
-		extra, nil, rKeysReader, ePubKey4, ePrivKey4, tlfCryptKey)
+	serverHalves4b, err := rmd.UpdateKeyBundles(crypto,
+		extra, nil, rKeysReader, ePubKey4, ePrivKey4, []kbfscrypto.TLFCryptKey{tlfCryptKey})
 	require.NoError(t, err)
 
 	expectedRekeyInfo4b := expectedRekeyInfoV3{
-		serverHalves: serverHalves4b,
+		serverHalves: serverHalves4b[0],
 	}
 
 	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo4b)

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -41,7 +41,7 @@ func TestRootMetadataV3ExtraNew(t *testing.T) {
 
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)
-	extra := FakeInitialRekey(rmd, codec, bh, kbfscrypto.TLFPublicKey{})
+	extra := FakeInitialRekey(rmd, bh, kbfscrypto.TLFPublicKey{})
 	extraV3, ok := extra.(*ExtraMetadataV3)
 	require.True(t, ok)
 	require.True(t, extraV3.wkbNew)
@@ -73,7 +73,7 @@ func TestIsValidRekeyRequestBasicV3(t *testing.T) {
 
 	brmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
 	require.NoError(t, err)
-	extra := FakeInitialRekey(brmd, codec, bh, kbfscrypto.TLFPublicKey{})
+	extra := FakeInitialRekey(brmd, bh, kbfscrypto.TLFPublicKey{})
 
 	newBrmd, err := brmd.DeepCopy(codec)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestRevokeRemovedDevicesV3(t *testing.T) {
 	brmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
 	require.NoError(t, err)
 
-	extra := FakeInitialRekey(brmd, codec, bh, kbfscrypto.TLFPublicKey{})
+	extra := FakeInitialRekey(brmd, bh, kbfscrypto.TLFPublicKey{})
 
 	wkb, rkb, err := brmd.getTLFKeyBundles(extra)
 	require.NoError(t, err)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -92,7 +92,7 @@ func (c CryptoCommon) MakeTLFWriterKeyBundleID(wkb TLFWriterKeyBundleV3) (
 	TLFWriterKeyBundleID, error) {
 	if len(wkb.Keys) == 0 {
 		return TLFWriterKeyBundleID{}, errors.New(
-			"Writer key bundle with no keys")
+			"Writer key bundle with no keys (MakeTLFWriterKeyBundleID)")
 	}
 	buf, err := c.codec.Encode(wkb)
 	if err != nil {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1843,8 +1843,6 @@ type MutableBareRootMetadata interface {
 	// An array of server halves to push to the server are
 	// returned, with each entry corresponding to each key
 	// generation in KeyGenerationsToUpdate(), in ascending order.
-	//
-	// TODO: Also handle reader promotion.
 	UpdateKeyBundles(crypto cryptoPure, extra ExtraMetadata,
 		updatedWriterKeys, updatedReaderKeys UserDevicePublicKeys,
 		ePubKey kbfscrypto.TLFEphemeralPublicKey,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1682,10 +1682,6 @@ type BareRootMetadata interface {
 	// there are no key generations yet.
 	GetUserDevicePublicKeys(extra ExtraMetadata) (
 		writers, readers UserDevicePublicKeys, err error)
-	// HasKeyForUser returns whether or not the given user has
-	// keys for at least one device. Returns an error if the TLF
-	// is public.
-	HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error)
 	// GetTLFCryptKeyParams returns all the necessary info to construct
 	// the TLF crypt key for the given key generation, user, and device
 	// (identified by its crypt public key), or false if not found. This

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -819,7 +819,7 @@ type cryptoPure interface {
 		kbfscrypto.TLFEphemeralPrivateKey, error)
 
 	// MakeRandomTLFKeys generates keys using a CSPRNG for a
-	// single key generation of TLF.
+	// single key generation of a TLF.
 	MakeRandomTLFKeys() (kbfscrypto.TLFPublicKey,
 		kbfscrypto.TLFPrivateKey, kbfscrypto.TLFCryptKey, error)
 	// MakeRandomTLFCryptKeyServerHalf generates the server-side of a

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1677,9 +1677,8 @@ type BareRootMetadata interface {
 	// TlfHandleExtensions returns a list of handle extensions associated with the TLf.
 	TlfHandleExtensions() (extensions []tlf.HandleExtension)
 	// GetDevicePublicKeys returns the kbfscrypto.CryptPublicKeys
-	// for all known users and devices for the current key
-	// generation. Returns an error if the TLF is public, or if
-	// there are no key generations yet.
+	// for all known users and devices. Returns an error if the
+	// TLF is public.
 	GetUserDevicePublicKeys(extra ExtraMetadata) (
 		writers, readers UserDevicePublicKeys, err error)
 	// GetTLFCryptKeyParams returns all the necessary info to construct
@@ -1830,11 +1829,12 @@ type MutableBareRootMetadata interface {
 		nextExtra ExtraMetadata,
 		serverHalves UserDeviceKeyServerHalves, err error)
 
-	// UpdateKeyBundles ensures that every device in the given key
-	// generation for every writer and reader in the provided
-	// lists has complete TLF crypt key info, and uses the new
-	// ephemeral key pair to generate the info if it doesn't yet
-	// exist.
+	// UpdateKeyBundles ensures that every device for every writer
+	// and reader in the provided lists has complete TLF crypt key
+	// info, and uses the new ephemeral key pair to generate the
+	// info if it doesn't yet exist. tlfCryptKeys must contain an
+	// entry for each key generation in KeyGenerationsToUpdate(),
+	// in ascending order.
 	//
 	// wKeys and rKeys usually contains the full maps of writers
 	// to per-device crypt public keys, but for reader rekey,
@@ -1843,6 +1843,10 @@ type MutableBareRootMetadata interface {
 	//
 	// UpdateKeyGeneration must only be called on metadata for
 	// private TLFs.
+	//
+	// An array of server halves to push to the server are
+	// returned, with each entry corresponding to each key
+	// generation in KeyGenerationsToUpdate(), in ascending order.
 	//
 	// TODO: Also handle reader promotion.
 	UpdateKeyBundles(crypto cryptoPure, extra ExtraMetadata,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1624,7 +1624,7 @@ type RekeyQueue interface {
 type BareRootMetadata interface {
 	// TlfID returns the ID of the TLF this BareRootMetadata is for.
 	TlfID() tlf.ID
-	// KeyGenerationToUpdates returns a range that has to be
+	// KeyGenerationsToUpdate returns a range that has to be
 	// updated when rekeying. start is included, but end is not
 	// included. This range can be empty, in which case there's
 	// nothing to update, i.e. the TLF is public, or there aren't

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1815,6 +1815,9 @@ type MutableBareRootMetadata interface {
 	//
 	// AddKeyGeneration must only be called on metadata for
 	// private TLFs.
+	//
+	// Note that the TLFPrivateKey corresponding to privKey must
+	// also be stored in PrivateMetadata.
 	AddKeyGeneration(codec kbfscodec.Codec, crypto cryptoPure,
 		currExtra ExtraMetadata,
 		updatedWriterKeys, updatedReaderKeys UserDevicePublicKeys,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1682,12 +1682,6 @@ type BareRootMetadata interface {
 	// there are no key generations yet.
 	GetUserDevicePublicKeys(extra ExtraMetadata) (
 		writers, readers UserDevicePublicKeys, err error)
-	// GetDevicePublicKeys returns the kbfscrypto.CryptPublicKeys
-	// for all known devices for the given user at the current key
-	// generation. Returns an error if the TLF is public, or if
-	// there are no key generations yet.
-	GetDevicePublicKeys(user keybase1.UID, extra ExtraMetadata) (
-		isWriter bool, keys DevicePublicKeys, err error)
 	// HasKeyForUser returns whether or not the given user has
 	// keys for at least one device. Returns an error if the TLF
 	// is public.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1626,9 +1626,9 @@ type BareRootMetadata interface {
 	TlfID() tlf.ID
 	// KeyGenerationsToUpdate returns a range that has to be
 	// updated when rekeying. start is included, but end is not
-	// included. This range can be empty, in which case there's
-	// nothing to update, i.e. the TLF is public, or there aren't
-	// any existing key generations.
+	// included. This range can be empty (i.e., start >= end), in
+	// which case there's nothing to update, i.e. the TLF is
+	// public, or there aren't any existing key generations.
 	KeyGenerationsToUpdate() (start KeyGen, end KeyGen)
 	// LatestKeyGeneration returns the most recent key generation in this
 	// BareRootMetadata, or PublicKeyGen if this TLF is public.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1815,10 +1815,9 @@ type MutableBareRootMetadata interface {
 	//
 	// AddKeyGeneration must only be called on metadata for
 	// private TLFs.
-	//
-	// TODO: Use better names than wKeys, rKeys.
 	AddKeyGeneration(codec kbfscodec.Codec, crypto cryptoPure,
-		currExtra ExtraMetadata, wKeys, rKeys UserDevicePublicKeys,
+		currExtra ExtraMetadata,
+		updatedWriterKeys, updatedReaderKeys UserDevicePublicKeys,
 		ePubKey kbfscrypto.TLFEphemeralPublicKey,
 		ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
 		pubKey kbfscrypto.TLFPublicKey,
@@ -1833,10 +1832,10 @@ type MutableBareRootMetadata interface {
 	// entry for each key generation in KeyGenerationsToUpdate(),
 	// in ascending order.
 	//
-	// wKeys and rKeys usually contains the full maps of writers
-	// to per-device crypt public keys, but for reader rekey,
-	// wKeys will be empty and rKeys will contain only a single
-	// entry.
+	// updatedWriterKeys and updatedReaderKeys usually contains
+	// the full maps of writers to per-device crypt public keys,
+	// but for reader rekey, updatedWriterKeys will be empty and
+	// updatedReaderKeys will contain only a single entry.
 	//
 	// UpdateKeyGeneration must only be called on metadata for
 	// private TLFs.
@@ -1847,7 +1846,7 @@ type MutableBareRootMetadata interface {
 	//
 	// TODO: Also handle reader promotion.
 	UpdateKeyBundles(crypto cryptoPure, extra ExtraMetadata,
-		wKeys, rKeys UserDevicePublicKeys,
+		updatedWriterKeys, updatedReaderKeys UserDevicePublicKeys,
 		ePubKey kbfscrypto.TLFEphemeralPublicKey,
 		ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
 		tlfCryptKeys []kbfscrypto.TLFCryptKey) (
@@ -1865,7 +1864,8 @@ type MutableBareRootMetadata interface {
 	// Note: the returned server halves may not be for all key
 	// generations, e.g. for MDv3 it's only for the latest key
 	// generation.
-	RevokeRemovedDevices(wKeys, rKeys UserDevicePublicKeys,
+	RevokeRemovedDevices(
+		updatedWriterKeys, updatedReaderKeys UserDevicePublicKeys,
 		extra ExtraMetadata) (ServerHalfRemovalInfo, error)
 
 	// FinalizeRekey must be called called after all rekeying work

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1677,6 +1677,12 @@ type BareRootMetadata interface {
 	// TlfHandleExtensions returns a list of handle extensions associated with the TLf.
 	TlfHandleExtensions() (extensions []tlf.HandleExtension)
 	// GetDevicePublicKeys returns the kbfscrypto.CryptPublicKeys
+	// for all known users and devices for the current key
+	// generation. Returns an error if the TLF is public, or if
+	// there are no key generations yet.
+	GetUserDevicePublicKeys(extra ExtraMetadata) (
+		writers, readers UserDevicePublicKeys, err error)
+	// GetDevicePublicKeys returns the kbfscrypto.CryptPublicKeys
 	// for all known devices for the given user at the current key
 	// generation. Returns an error if the TLF is public, or if
 	// there are no key generations yet.
@@ -1756,11 +1762,6 @@ type BareRootMetadata interface {
 	GetHistoricTLFCryptKey(c cryptoPure, keyGen KeyGen,
 		currentKey kbfscrypto.TLFCryptKey, extra ExtraMetadata) (
 		kbfscrypto.TLFCryptKey, error)
-	// GetUserDeviceKeyInfoMaps returns copies of the given user
-	// device key info maps for the given key generation.
-	GetUserDeviceKeyInfoMaps(
-		codec kbfscodec.Codec, keyGen KeyGen, extra ExtraMetadata) (
-		readers, writers UserDeviceKeyInfoMap, err error)
 }
 
 // MutableBareRootMetadata is a mutable interface to the bare serializeable MD that is signed by the reader or writer.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1854,8 +1854,6 @@ type MutableBareRootMetadata interface {
 	// private TLFs.
 	//
 	// TODO: Also handle reader promotion.
-	//
-	// TODO: Move the key generation handling into this function.
 	UpdateKeyBundles(crypto cryptoPure, extra ExtraMetadata,
 		wKeys, rKeys UserDevicePublicKeys,
 		ePubKey kbfscrypto.TLFEphemeralPublicKey,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1730,8 +1730,10 @@ type BareRootMetadata interface {
 	// GetCurrentTLFPublicKey returns the TLF public key for the
 	// current key generation.
 	GetCurrentTLFPublicKey(ExtraMetadata) (kbfscrypto.TLFPublicKey, error)
-	// GetUnresolvedParticipants returns any unresolved readers and writers present in this revision of metadata.
-	GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion)
+	// GetUnresolvedParticipants returns any unresolved readers
+	// and writers present in this revision of metadata. The
+	// returned array should be safe to modify by the caller.
+	GetUnresolvedParticipants() []keybase1.SocialAssertion
 	// GetTLFWriterKeyBundleID returns the ID of the externally-stored writer key bundle, or the zero value if
 	// this object stores it internally.
 	GetTLFWriterKeyBundleID() TLFWriterKeyBundleID

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1815,6 +1815,8 @@ type MutableBareRootMetadata interface {
 	//
 	// AddKeyGeneration must only be called on metadata for
 	// private TLFs.
+	//
+	// TODO: Use better names than wKeys, rKeys.
 	AddKeyGeneration(codec kbfscodec.Codec, crypto cryptoPure,
 		currExtra ExtraMetadata, wKeys, rKeys UserDevicePublicKeys,
 		ePubKey kbfscrypto.TLFEphemeralPublicKey,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1686,9 +1686,8 @@ type BareRootMetadata interface {
 	// HasKeyForUser returns whether or not the given user has
 	// keys for at least one device at the given key
 	// generation. Returns an error if the TLF is public, or if
-	// the given key generation is invalid. May also return an
-	// error if the given key generation isn't the current one
-	// (i.e., for MDv3).
+	// the given key generation is invalid, or not in
+	// KeyGenerationsToUpdate().
 	HasKeyForUser(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) (
 		bool, error)
 	// GetTLFCryptKeyParams returns all the necessary info to construct

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1730,11 +1730,6 @@ type BareRootMetadata interface {
 	// GetCurrentTLFPublicKey returns the TLF public key for the
 	// current key generation.
 	GetCurrentTLFPublicKey(ExtraMetadata) (kbfscrypto.TLFPublicKey, error)
-	// AreKeyGenerationsEqual returns true if all key generations in the passed metadata are equal to those
-	// in this revision.
-	//
-	// TODO: Implement this fully.
-	AreKeyGenerationsEqual(kbfscodec.Codec, BareRootMetadata) (bool, error)
 	// GetUnresolvedParticipants returns any unresolved readers and writers present in this revision of metadata.
 	GetUnresolvedParticipants() (readers, writers []keybase1.SocialAssertion)
 	// GetTLFWriterKeyBundleID returns the ID of the externally-stored writer key bundle, or the zero value if

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -495,10 +495,9 @@ type KeyMetadata interface {
 	GetTlfHandle() *TlfHandle
 
 	// HasKeyForUser returns whether or not the given user has
-	// keys for at least one device at the given key
-	// generation. Returns an error if the TLF is public, or if
-	// the given key generation is invalid.
-	HasKeyForUser(keyGen KeyGen, user keybase1.UID) (bool, error)
+	// keys for at least one device. Returns an error if the TLF
+	// is public.
+	HasKeyForUser(user keybase1.UID) (bool, error)
 
 	// GetTLFCryptKeyParams returns all the necessary info to
 	// construct the TLF crypt key for the given key generation,
@@ -1684,12 +1683,9 @@ type BareRootMetadata interface {
 	GetDevicePublicKeys(user keybase1.UID, extra ExtraMetadata) (
 		isWriter bool, keys DevicePublicKeys, err error)
 	// HasKeyForUser returns whether or not the given user has
-	// keys for at least one device at the given key
-	// generation. Returns an error if the TLF is public, or if
-	// the given key generation is invalid, or not in
-	// KeyGenerationsToUpdate().
-	HasKeyForUser(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) (
-		bool, error)
+	// keys for at least one device. Returns an error if the TLF
+	// is public.
+	HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error)
 	// GetTLFCryptKeyParams returns all the necessary info to construct
 	// the TLF crypt key for the given key generation, user, and device
 	// (identified by its crypt public key), or false if not found. This

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1868,8 +1868,10 @@ type MutableBareRootMetadata interface {
 		tlfCryptKeys []kbfscrypto.TLFCryptKey) (
 		[]UserDeviceKeyServerHalves, error)
 
-	// PromoteReader converts the given user from a reader to a writer.
-	PromoteReader(uid keybase1.UID, extra ExtraMetadata) error
+	// PromoteReaders converts the given set of users (which may
+	// be empty) from readers to writers.
+	PromoteReaders(readersToPromote map[keybase1.UID]bool,
+		extra ExtraMetadata) error
 
 	// RevokeRemovedDevices removes key info for any device not in
 	// the given maps, and returns a corresponding map of server

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1842,7 +1842,7 @@ type MutableBareRootMetadata interface {
 	// but for reader rekey, updatedWriterKeys will be empty and
 	// updatedReaderKeys will contain only a single entry.
 	//
-	// UpdateKeyGeneration must only be called on metadata for
+	// UpdateKeyBundles must only be called on metadata for
 	// private TLFs.
 	//
 	// An array of server halves to push to the server are

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -348,7 +348,7 @@ func injectNewRMD(t *testing.T, config *ConfigMock) (
 			EncodedSize: 1,
 		},
 	}
-	rmd.fakeInitialRekey(config.Codec())
+	rmd.fakeInitialRekey()
 
 	ops := getOps(config, id)
 	ops.head = makeImmutableRMDForTest(
@@ -503,7 +503,7 @@ func (p ptrMatcher) String() string {
 
 func fillInNewMD(t *testing.T, config *ConfigMock, rmd *RootMetadata) {
 	if !rmd.TlfID().IsPublic() {
-		rmd.fakeInitialRekey(config.Codec())
+		rmd.fakeInitialRekey()
 	}
 	rootPtr := BlockPointer{
 		ID:      kbfsblock.FakeID(42),

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -37,8 +37,51 @@ type TLFCryptKeyInfo struct {
 // corresponding device CryptPublicKey).
 type DevicePublicKeys map[kbfscrypto.CryptPublicKey]bool
 
+// Equals returns whether both sets of keys are equal.
+func (dpk DevicePublicKeys) Equals(other DevicePublicKeys) bool {
+	if len(dpk) != len(other) {
+		return false
+	}
+
+	for k := range dpk {
+		if !other[k] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // UserDevicePublicKeys is a map from users to that user's set of devices.
 type UserDevicePublicKeys map[keybase1.UID]DevicePublicKeys
+
+// RemoveKeylessUsers returns a new UserDevicePublicKeys objects with
+// all the users with an empty DevicePublicKeys removed.
+func (udpk UserDevicePublicKeys) RemoveKeylessUsers() UserDevicePublicKeys {
+	udpkRemoved := make(UserDevicePublicKeys)
+	for u, dpk := range udpk {
+		if len(dpk) > 0 {
+			udpkRemoved[u] = dpk
+		}
+	}
+	return udpkRemoved
+}
+
+// Equals returns whether both sets of users are equal, and they all
+// have corresponding equal sets of keys.
+func (udpk UserDevicePublicKeys) Equals(other UserDevicePublicKeys) bool {
+	if len(udpk) != len(other) {
+		return false
+	}
+
+	for u, dpk := range udpk {
+		if !dpk.Equals(other[u]) {
+			return false
+		}
+	}
+
+	return true
+}
 
 // DeviceKeyServerHalves is a map from a user devices (identified by the
 // corresponding device CryptPublicKey) to corresponding key server

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -33,19 +33,6 @@ type TLFCryptKeyInfo struct {
 	codec.UnknownFieldSetHandler
 }
 
-// TODO: UserDeviceKeyInfoMap and DeviceKeyInfoMap exist only because
-// of BareRootMetadata.GetUserDeviceKeyInfoMaps. That will eventually
-// go away, so remove these types once that happens.
-
-// DeviceKeyInfoMap is a map from a user devices (identified by the
-// corresponding device CryptPublicKey) to the TLF's symmetric secret
-// key information.
-type DeviceKeyInfoMap map[kbfscrypto.CryptPublicKey]TLFCryptKeyInfo
-
-// UserDeviceKeyInfoMap maps a user's keybase UID to their
-// DeviceKeyInfoMap.
-type UserDeviceKeyInfoMap map[keybase1.UID]DeviceKeyInfoMap
-
 // DevicePublicKeys is a set of a user's devices (identified by the
 // corresponding device CryptPublicKey).
 type DevicePublicKeys map[kbfscrypto.CryptPublicKey]bool

--- a/libkbfs/key_bundle_cache_test.go
+++ b/libkbfs/key_bundle_cache_test.go
@@ -18,7 +18,7 @@ func getKeyBundlesForTesting(t *testing.T, c Config, tlfByte byte, handleStr str
 	h := parseTlfHandleOrBust(t, c, handleStr, false)
 	rmd, err := makeInitialRootMetadata(SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
-	rmd.fakeInitialRekey(c.Codec())
+	rmd.fakeInitialRekey()
 	wkbID := rmd.bareMd.GetTLFWriterKeyBundleID()
 	rkbID := rmd.bareMd.GetTLFReaderKeyBundleID()
 	wkb, rkb, err := rmd.bareMd.(*BareRootMetadataV3).getTLFKeyBundles(

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -67,11 +67,11 @@ type DeviceKeyInfoMapV2 map[keybase1.KID]TLFCryptKeyInfo
 func (dkimV2 DeviceKeyInfoMapV2) fillInDeviceInfos(crypto cryptoPure,
 	uid keybase1.UID, tlfCryptKey kbfscrypto.TLFCryptKey,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey, ePubIndex int,
-	publicKeys DevicePublicKeys) (
+	updatedDeviceKeys DevicePublicKeys) (
 	serverHalves DeviceKeyServerHalves, err error) {
-	serverHalves = make(DeviceKeyServerHalves, len(publicKeys))
+	serverHalves = make(DeviceKeyServerHalves, len(updatedDeviceKeys))
 	// TODO: parallelize
-	for k := range publicKeys {
+	for k := range updatedDeviceKeys {
 		// Skip existing entries, and only fill in new ones.
 		if _, ok := dkimV2[k.KID()]; ok {
 			continue
@@ -156,18 +156,19 @@ func (udkimV2 UserDeviceKeyInfoMapV2) removeDevicesNotIn(
 }
 
 func (udkimV2 UserDeviceKeyInfoMapV2) fillInUserInfos(
-	crypto cryptoPure, newIndex int, pubKeys UserDevicePublicKeys,
+	crypto cryptoPure, newIndex int, updatedUserKeys UserDevicePublicKeys,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
 	tlfCryptKey kbfscrypto.TLFCryptKey) (
 	serverHalves UserDeviceKeyServerHalves, err error) {
-	serverHalves = make(UserDeviceKeyServerHalves, len(pubKeys))
-	for u, keys := range pubKeys {
+	serverHalves = make(UserDeviceKeyServerHalves, len(updatedUserKeys))
+	for u, updatedDeviceKeys := range updatedUserKeys {
 		if _, ok := udkimV2[u]; !ok {
 			udkimV2[u] = DeviceKeyInfoMapV2{}
 		}
 
 		deviceServerHalves, err := udkimV2[u].fillInDeviceInfos(
-			crypto, u, tlfCryptKey, ePrivKey, newIndex, keys)
+			crypto, u, tlfCryptKey, ePrivKey, newIndex,
+			updatedDeviceKeys)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -279,7 +279,7 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 	var wkbV3 TLFWriterKeyBundleV3
 
 	// Copy the latest UserDeviceKeyInfoMap.
-	wkbV2 := wkg[keyGen-FirstValidKeyGen]
+	wkbV2 = wkg[keyGen-FirstValidKeyGen]
 	udkimV3, err := writerUDKIMV2ToV3(codec, wkbV2.WKeys)
 	if err != nil {
 		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -113,20 +113,15 @@ func (udkimV2 UserDeviceKeyInfoMapV2) toPublicKeys() UserDevicePublicKeys {
 // removeDevicesNotIn removes any info for any device that is not
 // contained in the given map of users and devices.
 func (udkimV2 UserDeviceKeyInfoMapV2) removeDevicesNotIn(
-	keys UserDevicePublicKeys) ServerHalfRemovalInfo {
+	updatedUserKeys UserDevicePublicKeys) ServerHalfRemovalInfo {
 	removalInfo := make(ServerHalfRemovalInfo)
 	for uid, dkim := range udkimV2 {
-		userKIDs := make(map[keybase1.KID]bool, len(keys[uid]))
-		for key := range keys[uid] {
-			userKIDs[key.KID()] = true
-		}
-
 		deviceServerHalfIDs := make(deviceServerHalfRemovalInfo)
 
 		for kid, info := range dkim {
-			if !userKIDs[kid] {
+			key := kbfscrypto.MakeCryptPublicKey(kid)
+			if !updatedUserKeys[uid][key] {
 				delete(dkim, kid)
-				key := kbfscrypto.MakeCryptPublicKey(kid)
 				deviceServerHalfIDs[key] = append(
 					deviceServerHalfIDs[key],
 					info.ServerHalfID)

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -135,19 +135,6 @@ func (udkimV2 UserDeviceKeyInfoMapV2) toUDKIM(
 	return udkim, nil
 }
 
-func udkimToV2(codec kbfscodec.Codec, udkim UserDeviceKeyInfoMap) (
-	UserDeviceKeyInfoMapV2, error) {
-	udkimV2 := make(UserDeviceKeyInfoMapV2, len(udkim))
-	for u, dkim := range udkim {
-		dkimV2, err := dkimToV2(codec, dkim)
-		if err != nil {
-			return nil, err
-		}
-		udkimV2[u] = dkimV2
-	}
-	return udkimV2, nil
-}
-
 // removeDevicesNotIn removes any info for any device that is not
 // contained in the given map of users and devices.
 func (udkimV2 UserDeviceKeyInfoMapV2) removeDevicesNotIn(

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -292,7 +292,8 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 	var wkbV3 TLFWriterKeyBundleV3
 
 	// Copy the latest UserDeviceKeyInfoMap.
-	udkimV3, err := udkimV2ToV3(codec, wkbV2.WKeys)
+	wkbV2 := wkg[keyGen-FirstValidKeyGen]
+	udkimV3, err := writerUDKIMV2ToV3(codec, wkbV2.WKeys)
 	if err != nil {
 		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
 	}

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -14,6 +14,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+// ePubKeyLocationV2 represents the location of a user's ephemeral
+// public key. Note that for V2, a reader ePubKey can be in either the
+// writers array (if rekeyed normally) or the readers array (if
+// rekeyed by a reader), but a writer ePubKey can be in either array
+// also; if a reader whose ePubKey is in the readers array is
+// promoted, then the reader becomes a writer whose ePubKey is still
+// in the readers array.
 type ePubKeyLocationV2 int
 
 const (

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -98,20 +98,6 @@ func (dkimV2 DeviceKeyInfoMapV2) toPublicKeys() DevicePublicKeys {
 	return publicKeys
 }
 
-func dkimToV2(codec kbfscodec.Codec, dkim DeviceKeyInfoMap) (
-	DeviceKeyInfoMapV2, error) {
-	dkimV2 := make(DeviceKeyInfoMapV2, len(dkim))
-	for key, info := range dkim {
-		var infoCopy TLFCryptKeyInfo
-		err := kbfscodec.Update(codec, &infoCopy, info)
-		if err != nil {
-			return nil, err
-		}
-		dkimV2[key.KID()] = infoCopy
-	}
-	return dkimV2, nil
-}
-
 // UserDeviceKeyInfoMapV2 maps a user's keybase UID to their
 // DeviceKeyInfoMapV2.
 type UserDeviceKeyInfoMapV2 map[keybase1.UID]DeviceKeyInfoMapV2

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -51,9 +51,10 @@ func getEphemeralPublicKeyInfoV2(info TLFCryptKeyInfo,
 	}
 	keyCount := len(publicKeys)
 	if index >= keyCount {
-		return ePubKeyTypeV2(0), 0, kbfscrypto.TLFEphemeralPublicKey{},
+		return ePubKeyLocationV2(0),
+			0, kbfscrypto.TLFEphemeralPublicKey{},
 			fmt.Errorf("Invalid key in %s with index %d >= %d",
-				keyType, index, keyCount)
+				keyLocation, index, keyCount)
 	}
 
 	return keyLocation, index, publicKeys[index], nil
@@ -380,7 +381,7 @@ func (rkg TLFReaderKeyGenerationsV2) ToTLFReaderKeyBundleV3(
 				// Use the real index in the reader list.
 				infoCopy.EPubKeyIndex = index
 			default:
-				return TLFReaderKeyBundleV3{}, fmt.Errorf("Unknown key type %s", keyType)
+				return TLFReaderKeyBundleV3{}, fmt.Errorf("Unknown key location %s", keyLocation)
 			}
 			dkimV3[kbfscrypto.MakeCryptPublicKey(kid)] = infoCopy
 		}

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -263,7 +263,7 @@ func TestToTLFReaderKeyBundleV3(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
 	_, err := rkg.ToTLFReaderKeyBundleV3(codec, TLFWriterKeyBundleV2{})
 	require.Error(t, err)
-	require.True(t, strings.HasPrefix(err.Error(), "Invalid writer key index "),
+	require.True(t, strings.HasPrefix(err.Error(), "Invalid key in writerEPubKeys with index "),
 		"err: %v", err)
 
 	wEPubKey1 := kbfscrypto.MakeTLFEphemeralPublicKey([32]byte{0x3})

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -91,13 +91,13 @@ func writerUDKIMV2ToV3(codec kbfscodec.Codec, udkimV2 UserDeviceKeyInfoMapV2) (
 // removeDevicesNotIn removes any info for any device that is not
 // contained in the given map of users and devices.
 func (udkimV3 UserDeviceKeyInfoMapV3) removeDevicesNotIn(
-	keys UserDevicePublicKeys) ServerHalfRemovalInfo {
+	updatedUserKeys UserDevicePublicKeys) ServerHalfRemovalInfo {
 	removalInfo := make(ServerHalfRemovalInfo)
 	for uid, dkim := range udkimV3 {
 		deviceServerHalfIDs := make(deviceServerHalfRemovalInfo)
 
 		for key, info := range dkim {
-			if !keys[uid][key] {
+			if !updatedUserKeys[uid][key] {
 				delete(dkim, key)
 				deviceServerHalfIDs[key] = append(
 					deviceServerHalfIDs[key],

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -27,11 +27,11 @@ type DeviceKeyInfoMapV3 map[kbfscrypto.CryptPublicKey]TLFCryptKeyInfo
 func (dkimV3 DeviceKeyInfoMapV3) fillInDeviceInfos(crypto cryptoPure,
 	uid keybase1.UID, tlfCryptKey kbfscrypto.TLFCryptKey,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey, ePubIndex int,
-	publicKeys DevicePublicKeys) (
+	updatedDeviceKeys DevicePublicKeys) (
 	serverHalves DeviceKeyServerHalves, err error) {
-	serverHalves = make(DeviceKeyServerHalves, len(publicKeys))
+	serverHalves = make(DeviceKeyServerHalves, len(updatedDeviceKeys))
 	// TODO: parallelize
-	for k := range publicKeys {
+	for k := range updatedDeviceKeys {
 		// Skip existing entries, and only fill in new ones
 		if _, ok := dkimV3[k]; ok {
 			continue
@@ -128,18 +128,19 @@ func (udkimV3 UserDeviceKeyInfoMapV3) removeDevicesNotIn(
 }
 
 func (udkimV3 UserDeviceKeyInfoMapV3) fillInUserInfos(
-	crypto cryptoPure, newIndex int, pubKeys UserDevicePublicKeys,
+	crypto cryptoPure, newIndex int, updatedUserKeys UserDevicePublicKeys,
 	ePrivKey kbfscrypto.TLFEphemeralPrivateKey,
 	tlfCryptKey kbfscrypto.TLFCryptKey) (
 	serverHalves UserDeviceKeyServerHalves, err error) {
-	serverHalves = make(UserDeviceKeyServerHalves, len(pubKeys))
-	for u, keys := range pubKeys {
+	serverHalves = make(UserDeviceKeyServerHalves, len(updatedUserKeys))
+	for u, updatedDeviceKeys := range updatedUserKeys {
 		if _, ok := udkimV3[u]; !ok {
 			udkimV3[u] = DeviceKeyInfoMapV3{}
 		}
 
 		deviceServerHalves, err := udkimV3[u].fillInDeviceInfos(
-			crypto, u, tlfCryptKey, ePrivKey, newIndex, keys)
+			crypto, u, tlfCryptKey, ePrivKey, newIndex,
+			updatedDeviceKeys)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -58,20 +58,6 @@ func (dkimV3 DeviceKeyInfoMapV3) toPublicKeys() DevicePublicKeys {
 	return publicKeys
 }
 
-func dkimToV3(codec kbfscodec.Codec, dkim DeviceKeyInfoMap) (
-	DeviceKeyInfoMapV3, error) {
-	dkimV3 := make(DeviceKeyInfoMapV3, len(dkim))
-	for key, info := range dkim {
-		var infoCopy TLFCryptKeyInfo
-		err := kbfscodec.Update(codec, &infoCopy, info)
-		if err != nil {
-			return nil, err
-		}
-		dkimV3[key] = infoCopy
-	}
-	return dkimV3, nil
-}
-
 // UserDeviceKeyInfoMapV3 maps a user's keybase UID to their
 // DeviceKeyInfoMapV3.
 type UserDeviceKeyInfoMapV3 map[keybase1.UID]DeviceKeyInfoMapV3
@@ -82,19 +68,6 @@ func (udkimV3 UserDeviceKeyInfoMapV3) toPublicKeys() UserDevicePublicKeys {
 		publicKeys[u] = dkimV3.toPublicKeys()
 	}
 	return publicKeys
-}
-
-func udkimToV3(codec kbfscodec.Codec, udkim UserDeviceKeyInfoMap) (
-	UserDeviceKeyInfoMapV3, error) {
-	udkimV3 := make(UserDeviceKeyInfoMapV3, len(udkim))
-	for u, dkim := range udkim {
-		dkimV3, err := dkimToV3(codec, dkim)
-		if err != nil {
-			return nil, err
-		}
-		udkimV3[u] = dkimV3
-	}
-	return udkimV3, nil
 }
 
 func writerUDKIMV2ToV3(codec kbfscodec.Codec, udkimV2 UserDeviceKeyInfoMapV2) (

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -6,7 +6,6 @@ package libkbfs
 
 import (
 	"encoding"
-	"fmt"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
@@ -109,19 +108,8 @@ func udkimToV3(codec kbfscodec.Codec, udkim UserDeviceKeyInfoMap) (
 	return udkimV3, nil
 }
 
-func udkimV2ToV3(codec kbfscodec.Codec, udkimV2 UserDeviceKeyInfoMapV2) (
+func writerUDKIMV2ToV3(codec kbfscodec.Codec, udkimV2 UserDeviceKeyInfoMapV2) (
 	UserDeviceKeyInfoMapV3, error) {
-	// Check for an instance of KBFS-1719, specifically where a
-	// reader with a negative offset gets promoted to a writer.
-	for uid, dkimV2 := range udkimV2 {
-		for key, info := range dkimV2 {
-			if info.EPubKeyIndex < 0 {
-				return nil, fmt.Errorf(
-					"Unexpected negative index for user %s and device %s", uid, key)
-			}
-		}
-	}
-
 	udkim, err := udkimV2.toUDKIM(codec)
 	if err != nil {
 		return nil, err

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -80,6 +80,7 @@ func writerUDKIMV2ToV3(codec kbfscodec.Codec, udkimV2 UserDeviceKeyInfoMapV2,
 		for kid, info := range dkimV2 {
 			index := info.EPubKeyIndex
 			if index < 0 {
+				// TODO: Fix this; see KBFS-1719.
 				return nil, fmt.Errorf(
 					"Writer key with index %d for user=%s, kid=%s not handled yet",
 					index, uid, kid)

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -79,7 +79,12 @@ func writerUDKIMV2ToV3(codec kbfscodec.Codec, udkimV2 UserDeviceKeyInfoMapV2,
 		dkimV3 := make(DeviceKeyInfoMapV3, len(dkimV2))
 		for kid, info := range dkimV2 {
 			index := info.EPubKeyIndex
-			if index < 0 || index >= ePubKeyCount {
+			if index < 0 {
+				return nil, fmt.Errorf(
+					"Writer key with index %d for user=%s, kid=%s not handled yet",
+					index, uid, kid)
+			}
+			if index >= ePubKeyCount {
 				return nil, fmt.Errorf(
 					"Invalid writer key index %d for user=%s, kid=%s",
 					index, uid, kid)

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -407,6 +407,9 @@ func (km *KeyManagerStandard) identifyUIDSets(ctx context.Context,
 	return identifyUserList(ctx, kbpki, kbpki, uids, tlfID.IsPublic())
 }
 
+// generateKeyMapForUsers returns a UserDevicePublicKeys object for
+// the given list of users. Note that keyless users are retained in
+// the returned UserDevicePublicKeys object.
 func (km *KeyManagerStandard) generateKeyMapForUsers(
 	ctx context.Context, users []keybase1.UID) (
 	UserDevicePublicKeys, error) {

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -612,7 +612,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		}
 
 		if _, userHasNewKeys := newReaderUsers[uid]; userHasNewKeys {
-			// Only rekey the logged-in reader, and only if that reader isn't being promoted
+			// Only rekey the logged-in reader.
 			rKeys = UserDevicePublicKeys{
 				uid: rKeys[uid],
 			}

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -437,7 +437,8 @@ func (km *KeyManagerStandard) generateKeyMapForUsers(
 }
 
 // Rekey implements the KeyManager interface for KeyManagerStandard.
-// TODO make this less terrible.
+//
+// TODO: Make this less terrible. See KBFS-1799.
 func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promptPaper bool) (
 	mdChanged bool, cryptKey *kbfscrypto.TLFCryptKey, err error) {
 	km.log.CDebugf(ctx, "Rekey %s (prompt for paper key: %t)",

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -606,7 +606,12 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	}
 
 	if !isWriter {
-		if _, userHasNewKeys := newReaderUsers[uid]; userHasNewKeys && !promotedReaders[uid] {
+		if promotedReaders[uid] {
+			return false, nil, fmt.Errorf(
+				"%s isn't a writer, but is marked for reader promotion", uid)
+		}
+
+		if _, userHasNewKeys := newReaderUsers[uid]; userHasNewKeys {
 			// Only rekey the logged-in reader, and only if that reader isn't being promoted
 			rKeys = UserDevicePublicKeys{
 				uid: rKeys[uid],

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -606,9 +606,12 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	}
 
 	if !isWriter {
-		if promotedReaders[uid] {
-			return false, nil, fmt.Errorf(
-				"%s isn't a writer, but is marked for reader promotion", uid)
+		// This shouldn't happen; see the code above where we
+		// either use the original handle or resolve only the
+		// current UID.
+		if len(promotedReaders) != 0 {
+			return false, nil, errors.New(
+				"promoted readers unexpectedly non-empty")
 		}
 
 		if _, userHasNewKeys := newReaderUsers[uid]; userHasNewKeys {
@@ -625,8 +628,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		}
 	}
 
-	// TODO: Should be done only if isWriter is true.
-
+	// If promotedReader is non-empty, then isWriter is true (see
+	// check above).
 	for uid := range promotedReaders {
 		// If there are readers that need to be promoted to
 		// writers, do that here.

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -622,6 +622,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	// TODO: Should be done only if isWriter is true.
 
+	km.log.CDebugf(ctx, "promoting %+v\n", promotedReaders)
+
 	for uid := range promotedReaders {
 		// If there are readers that need to be promoted to
 		// writers, do that here.

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -5,8 +5,6 @@
 package libkbfs
 
 import (
-	"errors"
-
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -191,8 +189,7 @@ func (km *KeyManagerStandard) getTLFCryptKeyParams(
 	kbpki := km.config.KBPKI()
 	crypto := km.config.Crypto()
 	localMakeRekeyReadError := func(err error) error {
-		return makeRekeyReadError(ctx, err, kbpki,
-			kmd, keyGen, uid, username)
+		return makeRekeyReadError(ctx, err, kbpki, kmd, uid, username)
 	}
 
 	if flags&getTLFCryptKeyAnyDevice != 0 {

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -622,8 +622,6 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 	// TODO: Should be done only if isWriter is true.
 
-	km.log.CDebugf(ctx, "promoting %+v\n", promotedReaders)
-
 	for uid := range promotedReaders {
 		// If there are readers that need to be promoted to
 		// writers, do that here.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -643,7 +643,7 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver MetadataVer) {
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
 	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
 
-	// Make the second key generation.
+	// Rekey as alice.
 	done, _, err = config.KeyManager().Rekey(ctx, rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
@@ -693,8 +693,7 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver MetadataVer) {
 	daemon := config2.KeybaseService().(*KeybaseDaemonLocal)
 	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
 
-	// Make the second key generation as bob, which should still
-	// succeed.
+	// Rekey as bob, which should still succeed.
 	done, _, err = config2.KeyManager().Rekey(ctx, rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -600,6 +600,18 @@ func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver MetadataVer
 	require.Equal(t, newH.ToBareHandleOrBust(), newBareH)
 }
 
+func hasWriterKey(t *testing.T, rmd *RootMetadata, uid keybase1.UID) bool {
+	writers, _, err := rmd.getUserDevicePublicKeys()
+	require.NoError(t, err)
+	return len(writers[uid]) > 0
+}
+
+func hasReaderKey(t *testing.T, rmd *RootMetadata, uid keybase1.UID) bool {
+	_, readers, err := rmd.getUserDevicePublicKeys()
+	require.NoError(t, err)
+	return len(readers[uid]) > 0
+}
+
 func testKeyManagerPromoteReaderSuccess(t *testing.T, ver MetadataVer) {
 	ctx := context.Background()
 
@@ -622,12 +634,8 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver MetadataVer) {
 	aliceUID := keybase1.MakeTestUID(1)
 	bobUID := keybase1.MakeTestUID(2)
 
-	isWriter, _, err := rmd.GetDevicePublicKeys(aliceUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(bobUID)
-	require.NoError(t, err)
-	require.False(t, isWriter)
+	require.True(t, hasWriterKey(t, rmd, aliceUID))
+	require.False(t, hasWriterKey(t, rmd, bobUID))
 
 	oldKeyGen := rmd.LatestKeyGeneration()
 
@@ -643,12 +651,8 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver MetadataVer) {
 	// Reader promotion shouldn't increase the key generation.
 	require.Equal(t, oldKeyGen, rmd.LatestKeyGeneration())
 
-	isWriter, _, err = rmd.GetDevicePublicKeys(aliceUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(bobUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
+	require.True(t, hasWriterKey(t, rmd, aliceUID))
+	require.True(t, hasWriterKey(t, rmd, bobUID))
 
 	newH := rmd.GetTlfHandle()
 	require.Equal(t,
@@ -678,12 +682,8 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver MetadataVer) {
 	aliceUID := keybase1.MakeTestUID(1)
 	bobUID := keybase1.MakeTestUID(2)
 
-	isWriter, _, err := rmd.GetDevicePublicKeys(aliceUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(bobUID)
-	require.NoError(t, err)
-	require.False(t, isWriter)
+	require.True(t, hasWriterKey(t, rmd, aliceUID))
+	require.False(t, hasWriterKey(t, rmd, bobUID))
 
 	oldKeyGen := rmd.LatestKeyGeneration()
 
@@ -702,12 +702,8 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver MetadataVer) {
 	// Reader promotion shouldn't increase the key generation.
 	require.Equal(t, oldKeyGen, rmd.LatestKeyGeneration())
 
-	isWriter, _, err = rmd.GetDevicePublicKeys(aliceUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(bobUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
+	require.True(t, hasWriterKey(t, rmd, aliceUID))
+	require.True(t, hasWriterKey(t, rmd, bobUID))
 
 	newH := rmd.GetTlfHandle()
 	require.Equal(t,
@@ -738,15 +734,9 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver MetadataVer) {
 	bobUID := keybase1.MakeTestUID(2)
 	charlieUID := keybase1.MakeTestUID(3)
 
-	isWriter, _, err := rmd.GetDevicePublicKeys(aliceUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(bobUID)
-	require.NoError(t, err)
-	require.False(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(charlieUID)
-	require.NoError(t, err)
-	require.False(t, isWriter)
+	require.True(t, hasWriterKey(t, rmd, aliceUID))
+	require.False(t, hasWriterKey(t, rmd, bobUID))
+	require.False(t, hasWriterKey(t, rmd, charlieUID))
 
 	config2 := ConfigAsUser(config, "bob")
 
@@ -761,15 +751,9 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 	require.True(t, done)
 
-	isWriter, _, err = rmd.GetDevicePublicKeys(aliceUID)
-	require.NoError(t, err)
-	require.True(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(bobUID)
-	require.NoError(t, err)
-	require.False(t, isWriter)
-	isWriter, _, err = rmd.GetDevicePublicKeys(charlieUID)
-	require.NoError(t, err)
-	require.False(t, isWriter)
+	require.True(t, hasWriterKey(t, rmd, aliceUID))
+	require.False(t, hasWriterKey(t, rmd, bobUID))
+	require.False(t, hasWriterKey(t, rmd, charlieUID))
 }
 
 func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver MetadataVer) {

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -193,8 +193,7 @@ func (kmd emptyKeyMetadata) LatestKeyGeneration() KeyGen {
 	return kmd.keyGen
 }
 
-func (kmd emptyKeyMetadata) HasKeyForUser(
-	keyGen KeyGen, user keybase1.UID) (bool, error) {
+func (kmd emptyKeyMetadata) HasKeyForUser(user keybase1.UID) (bool, error) {
 	return false, nil
 }
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -100,11 +100,10 @@ func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	require.NoError(t, err)
 	h, err := MakeTlfHandle(context.Background(), bh, nug)
 	require.NoError(t, err)
-	codec := kbfscodec.NewMsgpack()
 	md, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)
 	md.SetRevision(revision)
-	md.fakeInitialRekey(codec)
+	md.fakeInitialRekey()
 	md.SetPrevRoot(prevRoot)
 	md.SetDiskUsage(500)
 	return md

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -100,7 +100,7 @@ func addFakeRMDData(t *testing.T,
 	rmd.SetLastModifyingWriter(h.FirstResolvedWriter())
 	rmd.SetLastModifyingUser(h.FirstResolvedWriter())
 	if !h.IsPublic() {
-		rmd.fakeInitialRekey(codec)
+		rmd.fakeInitialRekey()
 	}
 }
 

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -24,7 +24,7 @@ type mdRange struct {
 }
 
 func makeRekeyReadErrorHelper(
-	err error, kmd KeyMetadata, resolvedHandle *TlfHandle, keyGen KeyGen,
+	err error, kmd KeyMetadata, resolvedHandle *TlfHandle,
 	uid keybase1.UID, username libkb.NormalizedUsername) error {
 	if resolvedHandle.IsPublic() {
 		panic("makeRekeyReadError called on public folder")
@@ -37,17 +37,16 @@ func makeRekeyReadErrorHelper(
 
 	// Otherwise, this folder needs to be rekeyed for this device.
 	tlfName := resolvedHandle.GetCanonicalName()
-	hasKeys, err := kmd.HasKeyForUser(keyGen, uid)
-	if (err == nil) && hasKeys {
-		return NeedSelfRekeyError{tlfName}
+	hasKeys, hasKeyErr := kmd.HasKeyForUser(uid)
+	if (hasKeyErr == nil) && hasKeys {
+		return NeedSelfRekeyError{tlfName, err}
 	}
 	return NeedOtherRekeyError{tlfName, err}
 }
 
 func makeRekeyReadError(
-	ctx context.Context, err error, kbpki KBPKI,
-	kmd KeyMetadata, keyGen KeyGen, uid keybase1.UID,
-	username libkb.NormalizedUsername) error {
+	ctx context.Context, err error, kbpki KBPKI, kmd KeyMetadata,
+	uid keybase1.UID, username libkb.NormalizedUsername) error {
 	h := kmd.GetTlfHandle()
 	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki)
 	if resolveErr != nil {
@@ -55,8 +54,7 @@ func makeRekeyReadError(
 		// resolved.
 		resolvedHandle = h
 	}
-	return makeRekeyReadErrorHelper(
-		err, kmd, resolvedHandle, keyGen, uid, username)
+	return makeRekeyReadErrorHelper(err, kmd, resolvedHandle, uid, username)
 }
 
 // Helper which returns nil if the md block is uninitialized or readable by
@@ -74,8 +72,7 @@ func isReadableOrError(
 	}
 	err = errors.Errorf("%s is not readable by %s (uid:%s)", md.TlfID(),
 		username, uid)
-	return makeRekeyReadError(ctx, err, kbpki, md,
-		md.LatestKeyGeneration(), uid, username)
+	return makeRekeyReadError(ctx, err, kbpki, md, uid, username)
 }
 
 func getMDRange(ctx context.Context, config Config, id tlf.ID, bid BranchID,

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -28,7 +28,7 @@ func makeBRMDForTest(t *testing.T, codec kbfscodec.Codec, crypto cryptoPure,
 	md.SetRevision(revision)
 	md.SetLastModifyingWriter(uid)
 	md.SetLastModifyingUser(uid)
-	FakeInitialRekey(&md, codec, h, kbfscrypto.TLFPublicKey{})
+	FakeInitialRekey(&md, h, kbfscrypto.TLFPublicKey{})
 	md.SetPrevRoot(prevRoot)
 	return &md
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5763,8 +5763,8 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetTlfID(arg0 interface{}) *gom
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTlfID", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) AddKeyGeneration(codec kbfscodec.Codec, crypto cryptoPure, currExtra ExtraMetadata, wKeys UserDevicePublicKeys, rKeys UserDevicePublicKeys, ePubKey kbfscrypto.TLFEphemeralPublicKey, ePrivKey kbfscrypto.TLFEphemeralPrivateKey, pubKey kbfscrypto.TLFPublicKey, currCryptKey kbfscrypto.TLFCryptKey, nextCryptKey kbfscrypto.TLFCryptKey) (ExtraMetadata, UserDeviceKeyServerHalves, error) {
-	ret := _m.ctrl.Call(_m, "AddKeyGeneration", codec, crypto, currExtra, wKeys, rKeys, ePubKey, ePrivKey, pubKey, currCryptKey, nextCryptKey)
+func (_m *MockMutableBareRootMetadata) AddKeyGeneration(codec kbfscodec.Codec, crypto cryptoPure, currExtra ExtraMetadata, updatedWriterKeys UserDevicePublicKeys, updatedReaderKeys UserDevicePublicKeys, ePubKey kbfscrypto.TLFEphemeralPublicKey, ePrivKey kbfscrypto.TLFEphemeralPrivateKey, pubKey kbfscrypto.TLFPublicKey, currCryptKey kbfscrypto.TLFCryptKey, nextCryptKey kbfscrypto.TLFCryptKey) (ExtraMetadata, UserDeviceKeyServerHalves, error) {
+	ret := _m.ctrl.Call(_m, "AddKeyGeneration", codec, crypto, currExtra, updatedWriterKeys, updatedReaderKeys, ePubKey, ePrivKey, pubKey, currCryptKey, nextCryptKey)
 	ret0, _ := ret[0].(ExtraMetadata)
 	ret1, _ := ret[1].(UserDeviceKeyServerHalves)
 	ret2, _ := ret[2].(error)
@@ -5775,8 +5775,8 @@ func (_mr *_MockMutableBareRootMetadataRecorder) AddKeyGeneration(arg0, arg1, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddKeyGeneration", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
 }
 
-func (_m *MockMutableBareRootMetadata) UpdateKeyBundles(crypto cryptoPure, extra ExtraMetadata, wKeys UserDevicePublicKeys, rKeys UserDevicePublicKeys, ePubKey kbfscrypto.TLFEphemeralPublicKey, ePrivKey kbfscrypto.TLFEphemeralPrivateKey, tlfCryptKeys []kbfscrypto.TLFCryptKey) ([]UserDeviceKeyServerHalves, error) {
-	ret := _m.ctrl.Call(_m, "UpdateKeyBundles", crypto, extra, wKeys, rKeys, ePubKey, ePrivKey, tlfCryptKeys)
+func (_m *MockMutableBareRootMetadata) UpdateKeyBundles(crypto cryptoPure, extra ExtraMetadata, updatedWriterKeys UserDevicePublicKeys, updatedReaderKeys UserDevicePublicKeys, ePubKey kbfscrypto.TLFEphemeralPublicKey, ePrivKey kbfscrypto.TLFEphemeralPrivateKey, tlfCryptKeys []kbfscrypto.TLFCryptKey) ([]UserDeviceKeyServerHalves, error) {
+	ret := _m.ctrl.Call(_m, "UpdateKeyBundles", crypto, extra, updatedWriterKeys, updatedReaderKeys, ePubKey, ePrivKey, tlfCryptKeys)
 	ret0, _ := ret[0].([]UserDeviceKeyServerHalves)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -5796,8 +5796,8 @@ func (_mr *_MockMutableBareRootMetadataRecorder) PromoteReaders(arg0, arg1 inter
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReaders", arg0, arg1)
 }
 
-func (_m *MockMutableBareRootMetadata) RevokeRemovedDevices(wKeys UserDevicePublicKeys, rKeys UserDevicePublicKeys, extra ExtraMetadata) (ServerHalfRemovalInfo, error) {
-	ret := _m.ctrl.Call(_m, "RevokeRemovedDevices", wKeys, rKeys, extra)
+func (_m *MockMutableBareRootMetadata) RevokeRemovedDevices(updatedWriterKeys UserDevicePublicKeys, updatedReaderKeys UserDevicePublicKeys, extra ExtraMetadata) (ServerHalfRemovalInfo, error) {
+	ret := _m.ctrl.Call(_m, "RevokeRemovedDevices", updatedWriterKeys, updatedReaderKeys, extra)
 	ret0, _ := ret[0].(ServerHalfRemovalInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4918,17 +4918,6 @@ func (_mr *_MockBareRootMetadataRecorder) GetUserDevicePublicKeys(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDevicePublicKeys", arg0)
 }
 
-func (_m *MockBareRootMetadata) HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", user, extra)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
-}
-
 func (_m *MockBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey, extra ExtraMetadata) (kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
 	ret := _m.ctrl.Call(_m, "GetTLFCryptKeyParams", keyGen, user, key, extra)
 	ret0, _ := ret[0].(kbfscrypto.TLFEphemeralPublicKey)
@@ -5355,17 +5344,6 @@ func (_m *MockMutableBareRootMetadata) GetUserDevicePublicKeys(extra ExtraMetada
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetUserDevicePublicKeys(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDevicePublicKeys", arg0)
-}
-
-func (_m *MockMutableBareRootMetadata) HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", user, extra)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey, extra ExtraMetadata) (kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5854,14 +5854,14 @@ func (_mr *_MockMutableBareRootMetadataRecorder) UpdateKeyBundles(arg0, arg1, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateKeyBundles", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-func (_m *MockMutableBareRootMetadata) PromoteReader(uid keybase1.UID, extra ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "PromoteReader", uid, extra)
+func (_m *MockMutableBareRootMetadata) PromoteReaders(readersToPromote map[keybase1.UID]bool, extra ExtraMetadata) error {
+	ret := _m.ctrl.Call(_m, "PromoteReaders", readersToPromote, extra)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) PromoteReader(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReader", arg0, arg1)
+func (_mr *_MockMutableBareRootMetadataRecorder) PromoteReaders(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PromoteReaders", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) RevokeRemovedDevices(wKeys UserDevicePublicKeys, rKeys UserDevicePublicKeys, extra ExtraMetadata) (ServerHalfRemovalInfo, error) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1231,15 +1231,15 @@ func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
 }
 
-func (_m *MockKeyMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID) (bool, error) {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user)
+func (_m *MockKeyMetadata) HasKeyForUser(user keybase1.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", user)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKeyMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
+func (_mr *_MockKeyMetadataRecorder) HasKeyForUser(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0)
 }
 
 func (_m *MockKeyMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
@@ -4906,6 +4906,18 @@ func (_mr *_MockBareRootMetadataRecorder) TlfHandleExtensions() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfHandleExtensions")
 }
 
+func (_m *MockBareRootMetadata) GetUserDevicePublicKeys(extra ExtraMetadata) (UserDevicePublicKeys, UserDevicePublicKeys, error) {
+	ret := _m.ctrl.Call(_m, "GetUserDevicePublicKeys", extra)
+	ret0, _ := ret[0].(UserDevicePublicKeys)
+	ret1, _ := ret[1].(UserDevicePublicKeys)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockBareRootMetadataRecorder) GetUserDevicePublicKeys(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDevicePublicKeys", arg0)
+}
+
 func (_m *MockBareRootMetadata) GetDevicePublicKeys(user keybase1.UID, extra ExtraMetadata) (bool, DevicePublicKeys, error) {
 	ret := _m.ctrl.Call(_m, "GetDevicePublicKeys", user, extra)
 	ret0, _ := ret[0].(bool)
@@ -4918,15 +4930,15 @@ func (_mr *_MockBareRootMetadataRecorder) GetDevicePublicKeys(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDevicePublicKeys", arg0, arg1)
 }
 
-func (_m *MockBareRootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user, extra)
+func (_m *MockBareRootMetadata) HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error) {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", user, extra)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) HasKeyForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1, arg2)
+func (_mr *_MockBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
 }
 
 func (_m *MockBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey, extra ExtraMetadata) (kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
@@ -5158,18 +5170,6 @@ func (_mr *_MockBareRootMetadataRecorder) GetHistoricTLFCryptKey(arg0, arg1, arg
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHistoricTLFCryptKey", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBareRootMetadata) GetUserDeviceKeyInfoMaps(codec kbfscodec.Codec, keyGen KeyGen, extra ExtraMetadata) (UserDeviceKeyInfoMap, UserDeviceKeyInfoMap, error) {
-	ret := _m.ctrl.Call(_m, "GetUserDeviceKeyInfoMaps", codec, keyGen, extra)
-	ret0, _ := ret[0].(UserDeviceKeyInfoMap)
-	ret1, _ := ret[1].(UserDeviceKeyInfoMap)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockBareRootMetadataRecorder) GetUserDeviceKeyInfoMaps(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDeviceKeyInfoMaps", arg0, arg1, arg2)
-}
-
 // Mock of MutableBareRootMetadata interface
 type MockMutableBareRootMetadata struct {
 	ctrl     *gomock.Controller
@@ -5357,6 +5357,18 @@ func (_mr *_MockMutableBareRootMetadataRecorder) TlfHandleExtensions() *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TlfHandleExtensions")
 }
 
+func (_m *MockMutableBareRootMetadata) GetUserDevicePublicKeys(extra ExtraMetadata) (UserDevicePublicKeys, UserDevicePublicKeys, error) {
+	ret := _m.ctrl.Call(_m, "GetUserDevicePublicKeys", extra)
+	ret0, _ := ret[0].(UserDevicePublicKeys)
+	ret1, _ := ret[1].(UserDevicePublicKeys)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) GetUserDevicePublicKeys(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDevicePublicKeys", arg0)
+}
+
 func (_m *MockMutableBareRootMetadata) GetDevicePublicKeys(user keybase1.UID, extra ExtraMetadata) (bool, DevicePublicKeys, error) {
 	ret := _m.ctrl.Call(_m, "GetDevicePublicKeys", user, extra)
 	ret0, _ := ret[0].(bool)
@@ -5369,15 +5381,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) GetDevicePublicKeys(arg0, arg1 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDevicePublicKeys", arg0, arg1)
 }
 
-func (_m *MockMutableBareRootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "HasKeyForUser", keyGen, user, extra)
+func (_m *MockMutableBareRootMetadata) HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error) {
+	ret := _m.ctrl.Call(_m, "HasKeyForUser", user, extra)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) HasKeyForUser(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1, arg2)
+func (_mr *_MockMutableBareRootMetadataRecorder) HasKeyForUser(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HasKeyForUser", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey, extra ExtraMetadata) (kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
@@ -5607,18 +5619,6 @@ func (_m *MockMutableBareRootMetadata) GetHistoricTLFCryptKey(c cryptoPure, keyG
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetHistoricTLFCryptKey(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetHistoricTLFCryptKey", arg0, arg1, arg2, arg3)
-}
-
-func (_m *MockMutableBareRootMetadata) GetUserDeviceKeyInfoMaps(codec kbfscodec.Codec, keyGen KeyGen, extra ExtraMetadata) (UserDeviceKeyInfoMap, UserDeviceKeyInfoMap, error) {
-	ret := _m.ctrl.Call(_m, "GetUserDeviceKeyInfoMaps", codec, keyGen, extra)
-	ret0, _ := ret[0].(UserDeviceKeyInfoMap)
-	ret1, _ := ret[1].(UserDeviceKeyInfoMap)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) GetUserDeviceKeyInfoMaps(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDeviceKeyInfoMaps", arg0, arg1, arg2)
 }
 
 func (_m *MockMutableBareRootMetadata) SetRefBytes(refBytes uint64) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5084,17 +5084,6 @@ func (_mr *_MockBareRootMetadataRecorder) GetCurrentTLFPublicKey(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentTLFPublicKey", arg0)
 }
 
-func (_m *MockBareRootMetadata) AreKeyGenerationsEqual(_param0 kbfscodec.Codec, _param1 BareRootMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "AreKeyGenerationsEqual", _param0, _param1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockBareRootMetadataRecorder) AreKeyGenerationsEqual(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AreKeyGenerationsEqual", arg0, arg1)
-}
-
 func (_m *MockBareRootMetadata) GetUnresolvedParticipants() ([]keybase1.SocialAssertion, []keybase1.SocialAssertion) {
 	ret := _m.ctrl.Call(_m, "GetUnresolvedParticipants")
 	ret0, _ := ret[0].([]keybase1.SocialAssertion)
@@ -5510,17 +5499,6 @@ func (_m *MockMutableBareRootMetadata) GetCurrentTLFPublicKey(_param0 ExtraMetad
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetCurrentTLFPublicKey(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentTLFPublicKey", arg0)
-}
-
-func (_m *MockMutableBareRootMetadata) AreKeyGenerationsEqual(_param0 kbfscodec.Codec, _param1 BareRootMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "AreKeyGenerationsEqual", _param0, _param1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) AreKeyGenerationsEqual(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "AreKeyGenerationsEqual", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) GetUnresolvedParticipants() ([]keybase1.SocialAssertion, []keybase1.SocialAssertion) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4918,18 +4918,6 @@ func (_mr *_MockBareRootMetadataRecorder) GetUserDevicePublicKeys(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDevicePublicKeys", arg0)
 }
 
-func (_m *MockBareRootMetadata) GetDevicePublicKeys(user keybase1.UID, extra ExtraMetadata) (bool, DevicePublicKeys, error) {
-	ret := _m.ctrl.Call(_m, "GetDevicePublicKeys", user, extra)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(DevicePublicKeys)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockBareRootMetadataRecorder) GetDevicePublicKeys(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDevicePublicKeys", arg0, arg1)
-}
-
 func (_m *MockBareRootMetadata) HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error) {
 	ret := _m.ctrl.Call(_m, "HasKeyForUser", user, extra)
 	ret0, _ := ret[0].(bool)
@@ -5367,18 +5355,6 @@ func (_m *MockMutableBareRootMetadata) GetUserDevicePublicKeys(extra ExtraMetada
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetUserDevicePublicKeys(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUserDevicePublicKeys", arg0)
-}
-
-func (_m *MockMutableBareRootMetadata) GetDevicePublicKeys(user keybase1.UID, extra ExtraMetadata) (bool, DevicePublicKeys, error) {
-	ret := _m.ctrl.Call(_m, "GetDevicePublicKeys", user, extra)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(DevicePublicKeys)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockMutableBareRootMetadataRecorder) GetDevicePublicKeys(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetDevicePublicKeys", arg0, arg1)
 }
 
 func (_m *MockMutableBareRootMetadata) HasKeyForUser(user keybase1.UID, extra ExtraMetadata) (bool, error) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5084,11 +5084,10 @@ func (_mr *_MockBareRootMetadataRecorder) GetCurrentTLFPublicKey(arg0 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentTLFPublicKey", arg0)
 }
 
-func (_m *MockBareRootMetadata) GetUnresolvedParticipants() ([]keybase1.SocialAssertion, []keybase1.SocialAssertion) {
+func (_m *MockBareRootMetadata) GetUnresolvedParticipants() []keybase1.SocialAssertion {
 	ret := _m.ctrl.Call(_m, "GetUnresolvedParticipants")
 	ret0, _ := ret[0].([]keybase1.SocialAssertion)
-	ret1, _ := ret[1].([]keybase1.SocialAssertion)
-	return ret0, ret1
+	return ret0
 }
 
 func (_mr *_MockBareRootMetadataRecorder) GetUnresolvedParticipants() *gomock.Call {
@@ -5501,11 +5500,10 @@ func (_mr *_MockMutableBareRootMetadataRecorder) GetCurrentTLFPublicKey(arg0 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentTLFPublicKey", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) GetUnresolvedParticipants() ([]keybase1.SocialAssertion, []keybase1.SocialAssertion) {
+func (_m *MockMutableBareRootMetadata) GetUnresolvedParticipants() []keybase1.SocialAssertion {
 	ret := _m.ctrl.Call(_m, "GetUnresolvedParticipants")
 	ret0, _ := ret[0].([]keybase1.SocialAssertion)
-	ret1, _ := ret[1].([]keybase1.SocialAssertion)
-	return ret0, ret1
+	return ret0
 }
 
 func (_mr *_MockMutableBareRootMetadataRecorder) GetUnresolvedParticipants() *gomock.Call {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -799,10 +799,9 @@ func (md *RootMetadata) finalizeRekey(crypto cryptoPure) error {
 	return md.bareMd.FinalizeRekey(crypto, md.extra)
 }
 
-func (md *RootMetadata) getUserDeviceKeyInfoMaps(
-	codec kbfscodec.Codec, keyGen KeyGen) (
-	rDkim, wDkim UserDeviceKeyInfoMap, err error) {
-	return md.bareMd.GetUserDeviceKeyInfoMaps(codec, keyGen, md.extra)
+func (md *RootMetadata) getUserDevicePublicKeys() (
+	writers, readers UserDevicePublicKeys, err error) {
+	return md.bareMd.GetUserDevicePublicKeys(md.extra)
 }
 
 // GetTLFWriterKeyBundleID returns the ID of the externally-stored

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -727,12 +727,6 @@ func (md *RootMetadata) SetTlfID(tlf tlf.ID) {
 	md.bareMd.SetTlfID(tlf)
 }
 
-// GetDevicePublicKeys wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) GetDevicePublicKeys(user keybase1.UID) (
-	isWriter bool, keys DevicePublicKeys, err error) {
-	return md.bareMd.GetDevicePublicKeys(user, md.extra)
-}
-
 // HasKeyForUser wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) HasKeyForUser(user keybase1.UID) (
 	bool, error) {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -741,13 +741,12 @@ func (md *RootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID) (
 
 // fakeInitialRekey wraps the FakeInitialRekey test function for
 // convenience.
-func (md *RootMetadata) fakeInitialRekey(codec kbfscodec.Codec) {
+func (md *RootMetadata) fakeInitialRekey() {
 	bh, err := md.tlfHandle.ToBareHandle()
 	if err != nil {
 		panic(err)
 	}
-	md.extra = FakeInitialRekey(
-		md.bareMd, codec, bh, kbfscrypto.TLFPublicKey{})
+	md.extra = FakeInitialRekey(md.bareMd, bh, kbfscrypto.TLFPublicKey{})
 }
 
 // GetBareRootMetadata returns an interface to the underlying serializeable metadata.

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -734,9 +734,9 @@ func (md *RootMetadata) GetDevicePublicKeys(user keybase1.UID) (
 }
 
 // HasKeyForUser wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) HasKeyForUser(keyGen KeyGen, user keybase1.UID) (
+func (md *RootMetadata) HasKeyForUser(user keybase1.UID) (
 	bool, error) {
-	return md.bareMd.HasKeyForUser(keyGen, user, md.extra)
+	return md.bareMd.HasKeyForUser(user, md.extra)
 }
 
 // fakeInitialRekey wraps the FakeInitialRekey test function for

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -775,8 +775,9 @@ func (md *RootMetadata) AddKeyGeneration(codec kbfscodec.Codec,
 	return serverHalves, nil
 }
 
-func (md *RootMetadata) promoteReader(uid keybase1.UID) error {
-	return md.bareMd.PromoteReader(uid, md.extra)
+func (md *RootMetadata) promoteReaders(
+	readersToPromote map[keybase1.UID]bool) error {
+	return md.bareMd.PromoteReaders(readersToPromote, md.extra)
 }
 
 func (md *RootMetadata) revokeRemovedDevices(

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -730,7 +730,11 @@ func (md *RootMetadata) SetTlfID(tlf tlf.ID) {
 // HasKeyForUser wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) HasKeyForUser(user keybase1.UID) (
 	bool, error) {
-	return md.bareMd.HasKeyForUser(user, md.extra)
+	writers, readers, err := md.bareMd.GetUserDevicePublicKeys(md.extra)
+	if err != nil {
+		return false, err
+	}
+	return len(writers[user]) > 0 || len(readers[user]) > 0, nil
 }
 
 // fakeInitialRekey wraps the FakeInitialRekey test function for

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -134,7 +134,6 @@ func testRootMetadataGetTlfHandlePublic(t *testing.T, ver MetadataVer) {
 // Test that GetTlfHandle() and MakeBareTlfHandle() work properly for
 // non-public TLFs.
 func testRootMetadataGetTlfHandlePrivate(t *testing.T, ver MetadataVer) {
-	codec := kbfscodec.NewMsgpack()
 	uw := []keybase1.SocialAssertion{
 		{
 			User:    "user2",
@@ -160,7 +159,7 @@ func testRootMetadataGetTlfHandlePrivate(t *testing.T, ver MetadataVer) {
 	rmd, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)
 
-	rmd.fakeInitialRekey(codec)
+	rmd.fakeInitialRekey()
 
 	dirHandle := rmd.GetTlfHandle()
 	require.Equal(t, h, dirHandle)
@@ -173,7 +172,6 @@ func testRootMetadataGetTlfHandlePrivate(t *testing.T, ver MetadataVer) {
 
 // Test that key generations work as expected for private TLFs.
 func testRootMetadataLatestKeyGenerationPrivate(t *testing.T, ver MetadataVer) {
-	codec := kbfscodec.NewMsgpack()
 	tlfID := tlf.FakeID(0, false)
 	h := makeFakeTlfHandle(t, 14, false, nil, nil)
 	rmd, err := makeInitialRootMetadata(ver, tlfID, h)
@@ -182,7 +180,7 @@ func testRootMetadataLatestKeyGenerationPrivate(t *testing.T, ver MetadataVer) {
 	if rmd.LatestKeyGeneration() != 0 {
 		t.Errorf("Expected key generation to be invalid (0)")
 	}
-	rmd.fakeInitialRekey(codec)
+	rmd.fakeInitialRekey()
 	if rmd.LatestKeyGeneration() != FirstValidKeyGen {
 		t.Errorf("Expected key generation to be valid(%d)", FirstValidKeyGen)
 	}
@@ -211,7 +209,7 @@ func testMakeRekeyReadError(t *testing.T, ver MetadataVer) {
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
 
-	rmd.fakeInitialRekey(config.Codec())
+	rmd.fakeInitialRekey()
 
 	u, uid, err := config.KBPKI().Resolve(ctx, "bob")
 	require.NoError(t, err)
@@ -246,7 +244,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver MetadataVer) {
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
 
-	rmd.fakeInitialRekey(config.Codec())
+	rmd.fakeInitialRekey()
 
 	u, uid, err := config.KBPKI().Resolve(ctx, "bob")
 	require.NoError(t, err)
@@ -520,7 +518,7 @@ func TestRootMetadataV3NoPanicOnWriterMismatch(t *testing.T) {
 	h := makeFakeTlfHandle(t, 14, false, nil, nil)
 	rmd, err := makeInitialRootMetadata(SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
-	rmd.fakeInitialRekey(config.Codec())
+	rmd.fakeInitialRekey()
 	rmd.SetLastModifyingWriter(uid)
 	rmd.SetLastModifyingUser(uid)
 

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -340,8 +340,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, MetadataRevision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
-	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
+	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
 	// prove charlie
 	config.KeybaseService().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
@@ -354,8 +354,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, MetadataRevision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
-	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 	require.Equal(t, 2, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
+	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
 	// add a device for charlie and rekey as charlie
 	_, charlieUID, err := config.KBPKI().Resolve(context.Background(), "charlie")
@@ -372,8 +372,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, MetadataRevision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
-	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 	require.Equal(t, 2, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
+	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
 	// override the metadata version
 	config.metadataVersion = SegregatedKeyBundlesVer
@@ -541,9 +541,9 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	h := parseTlfHandleOrBust(t, configWriter, "alice#bob", false)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(0))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), PreExtraMetadataVer)
+	require.Equal(t, KeyGen(0), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, PreExtraMetadataVer, rmd.Version())
 
 	// set some dummy numbers
 	diskUsage, refBytes, unrefBytes := uint64(12345), uint64(4321), uint64(1234)
@@ -556,11 +556,11 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, rmd.LatestKeyGeneration(), KeyGen(1))
-	require.Equal(t, rmd.Revision(), MetadataRevision(1))
-	require.Equal(t, rmd.Version(), PreExtraMetadataVer)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys), 0)
-	require.Equal(t, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys), 1)
+	require.Equal(t, KeyGen(1), rmd.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(1), rmd.Revision())
+	require.Equal(t, PreExtraMetadataVer, rmd.Version())
+	require.Equal(t, 1, len(rmd.bareMd.(*BareRootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
+	require.Equal(t, 0, len(rmd.bareMd.(*BareRootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
 	// Set the private MD, to make sure it gets copied properly during
 	// upconversion.
@@ -590,9 +590,9 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		configReader.Crypto(), configReader.KeyManager(),
 		fakeMdID(1), false)
 	require.NoError(t, err)
-	require.Equal(t, rmd2.LatestKeyGeneration(), KeyGen(1))
-	require.Equal(t, rmd2.Revision(), MetadataRevision(2))
-	require.Equal(t, rmd2.Version(), PreExtraMetadataVer)
+	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(2), rmd2.Revision())
+	require.Equal(t, PreExtraMetadataVer, rmd2.Version())
 	// Do this instead of require.Nil because we want to assert
 	// that it's untyped nil.
 	require.True(t, rmd2.extra == nil)
@@ -600,9 +600,9 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		context.Background(), rmd2, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, rmd2.LatestKeyGeneration(), KeyGen(1))
-	require.Equal(t, rmd2.Revision(), MetadataRevision(2))
-	require.Equal(t, rmd2.Version(), PreExtraMetadataVer)
+	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())
+	require.Equal(t, MetadataRevision(2), rmd2.Revision())
+	require.Equal(t, PreExtraMetadataVer, rmd2.Version())
 	require.True(t, rmd2.IsWriterMetadataCopiedSet())
 	require.True(t, bytes.Equal(rmd.GetSerializedPrivateMetadata(),
 		rmd2.GetSerializedPrivateMetadata()))

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -215,21 +215,12 @@ func testMakeRekeyReadError(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	dummyErr := errors.New("dummy")
-	err = makeRekeyReadErrorHelper(dummyErr,
-		rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
+	err = makeRekeyReadErrorHelper(dummyErr, rmd.ReadOnly(), h, uid, u)
 	require.Equal(t, NewReadAccessError(h, u, "/keybase/private/alice"), err)
 
 	err = makeRekeyReadErrorHelper(dummyErr,
-		rmd.ReadOnly(), h, FirstValidKeyGen, h.FirstResolvedWriter(), "alice")
+		rmd.ReadOnly(), h, h.FirstResolvedWriter(), "alice")
 	require.Equal(t, NeedSelfRekeyError{"alice", dummyErr}, err)
-
-	err = makeRekeyReadErrorHelper(dummyErr,
-		rmd.ReadOnly(), h, FirstValidKeyGen+1, h.FirstResolvedWriter(), "alice")
-	if ver < SegregatedKeyBundlesVer {
-		require.Equal(t, NeedOtherRekeyError{"alice", dummyErr}, err)
-	} else {
-		require.Equal(t, NeedSelfRekeyError{"alice", dummyErr}, err)
-	}
 }
 
 func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver MetadataVer) {
@@ -250,7 +241,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	err = makeRekeyReadErrorHelper(errors.New("dummy"),
-		rmd.ReadOnly(), h, FirstValidKeyGen, uid, u)
+		rmd.ReadOnly(), h, uid, u)
 	require.Equal(t, NewReadAccessError(h, u, "/keybase/private/alice,bob@twitter"), err)
 
 	config.KeybaseService().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
@@ -261,7 +252,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver MetadataVer) {
 
 	dummyErr := errors.New("dummy")
 	err = makeRekeyReadErrorHelper(dummyErr,
-		rmd.ReadOnly(), resolvedHandle, FirstValidKeyGen, uid, u)
+		rmd.ReadOnly(), resolvedHandle, uid, u)
 	require.Equal(t, NeedOtherRekeyError{"alice,bob", dummyErr}, err)
 }
 


### PR DESCRIPTION
...where it causes a new key generation to
always happen.

Also refactor rekeying-related BareRootMetadata
functions.

In particular, replace GetDeviceKIDs
and HasKeyForUser, GetUserDeviceKeyInfoMaps,
and AreKeyGenerationsEqual with
GetUserDevicePublicKeys.

Remove now-unneeded code in key_bundles.go.

Make AddKeyGeneration add and update
the new key generation in one go, and remove
addKeyGenerationForTest.

Change UpdateKeyGeneration to UpdateKeyBundles.

Make PromoteReader take a map of readers, and
rename it to PromoteReaders.

Also add various sanity checks in BareRootMetadataV{2,3}
and the rekeying code.

Also change BareRootMetadata.GetUnresolvedParticipants
to return a single array.