### PR TITLE
[KBFS-1806] Keep track of wkbNew and rkbNew in MD ID journal

### DIFF
--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -17,7 +17,9 @@ func mdForceQROne(
 		return err
 	}
 
-	rmdNext, err := irmd.MakeSuccessor(ctx, config, irmd.MdID(), true)
+	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
+		config.Codec(), config.Crypto(), config.KeyManager(),
+		irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -42,7 +42,9 @@ func mdResetOne(
 		}
 	}
 
-	rmdNext, err := irmd.MakeSuccessor(ctx, config, irmd.MdID(), true)
+	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
+		config.Codec(), config.Crypto(), config.KeyManager(),
+		irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -4,7 +4,10 @@
 
 package libkbfs
 
-import "github.com/keybase/kbfs/tlf"
+import (
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/tlf"
+)
 
 // TODO: Wrap errors coming from BareRootMetadata.
 
@@ -28,4 +31,13 @@ func MakeInitialBareRootMetadata(
 	}
 
 	return MakeInitialBareRootMetadataV3(tlfID, h)
+}
+
+// ExtraMetadata is a per-version blob of extra metadata which may
+// exist outside of the given metadata block, e.g. key bundles for
+// post-v2 metadata.
+type ExtraMetadata interface {
+	MetadataVersion() MetadataVer
+	DeepCopy(kbfscodec.Codec) (ExtraMetadata, error)
+	MakeSuccessorCopy(kbfscodec.Codec) (ExtraMetadata, error)
 }

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -371,8 +371,10 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 	if md.LatestKeyGeneration() != PublicKeyGen {
 		// Fill out the writer key bundle.
 		wkbV2, wkbV3, err := md.WKeys.ToTLFWriterKeyBundleV3(
-			ctx, config.Codec(), config.Crypto(),
-			config.KeyManager(), kmd)
+			config.Codec(), config.Crypto(),
+			func() ([]kbfscrypto.TLFCryptKey, error) {
+				return config.KeyManager().GetTLFCryptKeyOfAllGenerations(ctx, kmd)
+			})
 		if err != nil {
 			return nil, nil, err
 		}

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -335,7 +335,8 @@ func (md *BareRootMetadataV2) MakeSuccessorCopy(
 		// or can't decrypt the MD, we have to continue with v2
 		// because we can't just copy a v2 signature into a v3 MD
 		// blindly.
-		mdCopy, err := md.makeSuccessorCopyV2(config, isReadableAndWriter)
+		mdCopy, err := md.makeSuccessorCopyV2(
+			config.Codec(), isReadableAndWriter)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -343,12 +344,16 @@ func (md *BareRootMetadataV2) MakeSuccessorCopy(
 	}
 
 	// Upconvert to the new version.
-	return md.makeSuccessorCopyV3(ctx, config, kmd)
+	return md.makeSuccessorCopyV3(config.Codec(), config.Crypto(),
+		func() ([]kbfscrypto.TLFCryptKey, error) {
+			return config.KeyManager().GetTLFCryptKeyOfAllGenerations(ctx, kmd)
+		})
 }
 
-func (md *BareRootMetadataV2) makeSuccessorCopyV2(config Config, isReadableAndWriter bool) (
+func (md *BareRootMetadataV2) makeSuccessorCopyV2(
+	codec kbfscodec.Codec, isReadableAndWriter bool) (
 	*BareRootMetadataV2, error) {
-	mdCopy, err := md.deepCopy(config.Codec())
+	mdCopy, err := md.deepCopy(codec)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +363,9 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV2(config Config, isReadableAndWr
 	return mdCopy, nil
 }
 
-func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Config, kmd KeyMetadata) (
+func (md *BareRootMetadataV2) makeSuccessorCopyV3(
+	codec kbfscodec.Codec, crypto cryptoPure,
+	tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error)) (
 	*BareRootMetadataV3, ExtraMetadata, error) {
 	mdV3 := &BareRootMetadataV3{}
 
@@ -371,16 +378,13 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 	if md.LatestKeyGeneration() != PublicKeyGen {
 		// Fill out the writer key bundle.
 		wkbV2, wkbV3, err := md.WKeys.ToTLFWriterKeyBundleV3(
-			config.Codec(), config.Crypto(),
-			func() ([]kbfscrypto.TLFCryptKey, error) {
-				return config.KeyManager().GetTLFCryptKeyOfAllGenerations(ctx, kmd)
-			})
+			codec, crypto, tlfCryptKeyGetter)
 		if err != nil {
 			return nil, nil, err
 		}
 
 		mdV3.WriterMetadata.WKeyBundleID, err =
-			config.Crypto().MakeTLFWriterKeyBundleID(wkbV3)
+			crypto.MakeTLFWriterKeyBundleID(wkbV3)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -388,13 +392,12 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(ctx context.Context, config Co
 		// Fill out the reader key bundle.  wkbV2 is passed
 		// because in V2 metadata ephemeral public keys for
 		// readers were sometimes in the writer key bundles.
-		rkbV3, err := md.RKeys.ToTLFReaderKeyBundleV3(
-			config.Codec(), wkbV2)
+		rkbV3, err := md.RKeys.ToTLFReaderKeyBundleV3(codec, wkbV2)
 		if err != nil {
 			return nil, nil, err
 		}
 		mdV3.RKeyBundleID, err =
-			config.Crypto().MakeTLFReaderKeyBundleID(rkbV3)
+			crypto.MakeTLFReaderKeyBundleID(rkbV3)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -383,18 +383,20 @@ func (md *BareRootMetadataV3) DeepCopy(
 
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) MakeSuccessorCopy(
-	ctx context.Context, config Config, kmd KeyMetadata,
-	extra ExtraMetadata, isReadableAndWriter bool) (
+	codec kbfscodec.Codec, crypto cryptoPure,
+	extra ExtraMetadata, latestMDVer MetadataVer,
+	tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error),
+	isReadableAndWriter bool) (
 	MutableBareRootMetadata, ExtraMetadata, error) {
 	var extraCopy ExtraMetadata
 	if extra != nil {
 		var err error
-		extraCopy, err = extra.DeepCopy(config.Codec())
+		extraCopy, err = extra.DeepCopy(codec)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
-	mdCopy, err := md.DeepCopy(config.Codec())
+	mdCopy, err := md.DeepCopy(codec)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -145,7 +145,20 @@ func (extra ExtraMetadataV3) DeepCopy(codec kbfscodec.Codec) (
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Justify dropping flags here.
+	return NewExtraMetadataV3(wkb, rkb, extra.wkbNew, extra.rkbNew), nil
+}
+
+// MakeSuccessorCopy implements the ExtraMetadata interface for ExtraMetadataV3.
+func (extra ExtraMetadataV3) MakeSuccessorCopy(codec kbfscodec.Codec) (
+	ExtraMetadata, error) {
+	wkb, err := extra.wkb.DeepCopy(codec)
+	if err != nil {
+		return nil, err
+	}
+	rkb, err := extra.rkb.DeepCopy(codec)
+	if err != nil {
+		return nil, err
+	}
 	return NewExtraMetadataV3(wkb, rkb, false, false), nil
 }
 
@@ -393,7 +406,7 @@ func (md *BareRootMetadataV3) MakeSuccessorCopy(
 	var extraCopy ExtraMetadata
 	if extra != nil {
 		var err error
-		extraCopy, err = extra.DeepCopy(codec)
+		extraCopy, err = extra.MakeSuccessorCopy(codec)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -137,13 +137,15 @@ func (extra *ExtraMetadataV3) updateNew(wkbNew, rkbNew bool) {
 // DeepCopy implements the ExtraMetadata interface for ExtraMetadataV3.
 func (extra ExtraMetadataV3) DeepCopy(codec kbfscodec.Codec) (
 	ExtraMetadata, error) {
-	wkb, rkb := TLFWriterKeyBundleV3{}, TLFReaderKeyBundleV3{}
-	if err := kbfscodec.Update(codec, &rkb, extra.rkb); err != nil {
+	wkb, err := extra.wkb.DeepCopy(codec)
+	if err != nil {
 		return nil, err
 	}
-	if err := kbfscodec.Update(codec, &wkb, extra.wkb); err != nil {
+	rkb, err := extra.rkb.DeepCopy(codec)
+	if err != nil {
 		return nil, err
 	}
+	// TODO: Justify dropping flags here.
 	return NewExtraMetadataV3(wkb, rkb, false, false), nil
 }
 

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -399,9 +399,8 @@ func (md *BareRootMetadataV3) DeepCopy(
 // MakeSuccessorCopy implements the ImmutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) MakeSuccessorCopy(
 	codec kbfscodec.Codec, crypto cryptoPure,
-	extra ExtraMetadata, latestMDVer MetadataVer,
-	tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error),
-	isReadableAndWriter bool) (
+	extra ExtraMetadata, _ MetadataVer,
+	_ func() ([]kbfscrypto.TLFCryptKey, error), isReadableAndWriter bool) (
 	MutableBareRootMetadata, ExtraMetadata, error) {
 	var extraCopy ExtraMetadata
 	if extra != nil {

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -5,7 +5,6 @@
 package libkbfs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -28,15 +27,6 @@ func TestBareRootMetadataVersionV3(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, SegregatedKeyBundlesVer, rmd.Version())
-}
-
-type codecOnlyConfig struct {
-	Config
-	codec kbfscodec.Codec
-}
-
-func (c codecOnlyConfig) Codec() kbfscodec.Codec {
-	return c.codec
 }
 
 func TestRootMetadataV3ExtraNew(t *testing.T) {
@@ -64,8 +54,7 @@ func TestRootMetadataV3ExtraNew(t *testing.T) {
 	require.True(t, extraV3.rkbNew)
 
 	_, extraCopy, err := rmd.MakeSuccessorCopy(
-		context.Background(), codecOnlyConfig{nil, codec},
-		nil, extra, true)
+		codec, nil, extra, -1, nil, true)
 	require.NoError(t, err)
 
 	extraV3Copy, ok := extraCopy.(*ExtraMetadataV3)

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2457,7 +2457,9 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 	}
 
 	newMD, err := mostRecentMergedMD.MakeSuccessor(
-		ctx, cr.config, mostRecentMergedMD.MdID(), true)
+		ctx, cr.config.MetadataVersion(), cr.config.Codec(),
+		cr.config.Crypto(), cr.config.KeyManager(),
+		mostRecentMergedMD.MdID(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1040,7 +1040,9 @@ func (fbo *folderBranchOps) getMDForWriteLockedForFilename(
 	// Make a new successor of the current MD to hold the coming
 	// writes.  The caller must pass this into
 	// syncBlockAndCheckEmbedLocked or the changes will be lost.
-	newMd, err := md.MakeSuccessor(ctx, fbo.config, md.mdID, true)
+	newMd, err := md.MakeSuccessor(ctx, fbo.config.MetadataVersion(),
+		fbo.config.Codec(), fbo.config.Crypto(),
+		fbo.config.KeyManager(), md.mdID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -1072,7 +1074,9 @@ func (fbo *folderBranchOps) getMDForRekeyWriteLocked(
 			NewRekeyPermissionError(md.GetTlfHandle(), username)
 	}
 
-	newMd, err := md.MakeSuccessor(ctx, fbo.config, md.mdID, handle.IsWriter(uid))
+	newMd, err := md.MakeSuccessor(ctx, fbo.config.MetadataVersion(),
+		fbo.config.Codec(), fbo.config.Crypto(),
+		fbo.config.KeyManager(), md.mdID, handle.IsWriter(uid))
 	if err != nil {
 		return nil, kbfscrypto.VerifyingKey{}, false, err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1608,12 +1608,14 @@ type BareRootMetadata interface {
 	// MakeSuccessorCopy returns a newly constructed successor
 	// copy to this metadata revision.  It differs from DeepCopy
 	// in that it can perform an up conversion to a new metadata
-	// version.
+	// version. tlfCryptKeyGetter should be a function that
+	// returns a list of TLFCryptKeys for all key generations in
+	// ascending order.
 	MakeSuccessorCopy(codec kbfscodec.Codec, crypto cryptoPure,
 		extra ExtraMetadata, latestMDVer MetadataVer,
 		tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error),
-		isReadableAndWriter bool) (
-		mdCopy MutableBareRootMetadata, extraCopy ExtraMetadata, err error)
+		isReadableAndWriter bool) (mdCopy MutableBareRootMetadata,
+		extraCopy ExtraMetadata, err error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.
 	CheckValidSuccessor(currID MdID, nextMd BareRootMetadata) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1605,13 +1605,14 @@ type BareRootMetadata interface {
 	IsReader(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool
 	// DeepCopy returns a deep copy of the underlying data structure.
 	DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error)
-	// MakeSuccessorCopy returns a newly constructed successor copy to this metadata revision.
-	// It differs from DeepCopy in that it can perform an up conversion to a new metadata
+	// MakeSuccessorCopy returns a newly constructed successor
+	// copy to this metadata revision.  It differs from DeepCopy
+	// in that it can perform an up conversion to a new metadata
 	// version.
-	//
-	// TODO: Replace Config argument.
-	MakeSuccessorCopy(ctx context.Context, config Config, kmd KeyMetadata,
-		extra ExtraMetadata, isReadableAndWriter bool) (
+	MakeSuccessorCopy(codec kbfscodec.Codec, crypto cryptoPure,
+		extra ExtraMetadata, latestMDVer MetadataVer,
+		tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error),
+		isReadableAndWriter bool) (
 		mdCopy MutableBareRootMetadata, extraCopy ExtraMetadata, err error)
 	// CheckValidSuccessor makes sure the given BareRootMetadata is a valid
 	// successor to the current one, and returns an error otherwise.

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -351,7 +351,9 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	mdID := initialMdID
 	// Put several MDs after a local squash
 	for i := 0; i < mdCount; i++ {
-		rmd, err = rmd.MakeSuccessor(ctx, config, mdID, true)
+		rmd, err = rmd.MakeSuccessor(ctx, config.MetadataVersion(),
+			config.Codec(), config.Crypto(), config.KeyManager(),
+			mdID, true)
 		require.NoError(t, err)
 		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
 			config.BlockSplitter(), rmd, false)

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -12,7 +12,6 @@ import (
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 type ePubKeyTypeV2 int
@@ -269,8 +268,8 @@ func (wkg TLFWriterKeyGenerationsV2) IsWriter(user keybase1.UID, deviceKID keyba
 //
 // TODO: Add a unit test for this.
 func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
-	ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure,
-	keyManager KeyManager, kmd KeyMetadata) (
+	codec kbfscodec.Codec, crypto cryptoPure,
+	tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error)) (
 	TLFWriterKeyBundleV2, TLFWriterKeyBundleV3, error) {
 	keyGen := wkg.LatestKeyGeneration()
 	if keyGen < FirstValidKeyGen {
@@ -298,7 +297,7 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 
 	if keyGen > FirstValidKeyGen {
 		// Fetch all of the TLFCryptKeys.
-		keys, err := keyManager.GetTLFCryptKeyOfAllGenerations(ctx, kmd)
+		keys, err := tlfCryptKeyGetter()
 		if err != nil {
 			return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err
 		}

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -275,10 +275,21 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 			errors.New("No key generations to convert")
 	}
 
+	wkbV2 := wkg[keyGen-FirstValidKeyGen]
+	for u, dkimV2 := range wkbV2.WKeys {
+		for kid, keyInfo := range dkimV2 {
+			index := keyInfo.EPubKeyIndex
+			if index < 0 || index >= len(wkbV2.TLFEphemeralPublicKeys) {
+				return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{},
+					fmt.Errorf("Invalid writer key index %d for user=%s, kid=%s",
+						index, u, kid)
+			}
+		}
+	}
+
 	var wkbV3 TLFWriterKeyBundleV3
 
 	// Copy the latest UserDeviceKeyInfoMap.
-	wkbV2 := wkg[keyGen-FirstValidKeyGen]
 	udkimV3, err := udkimV2ToV3(codec, wkbV2.WKeys)
 	if err != nil {
 		return TLFWriterKeyBundleV2{}, TLFWriterKeyBundleV3{}, err

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -265,8 +265,6 @@ func (wkg TLFWriterKeyGenerationsV2) IsWriter(user keybase1.UID, deviceKID keyba
 }
 
 // ToTLFWriterKeyBundleV3 converts a TLFWriterKeyGenerationsV2 to a TLFWriterKeyBundleV3.
-//
-// TODO: Add a unit test for this.
 func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 	codec kbfscodec.Codec, crypto cryptoPure,
 	tlfCryptKeyGetter func() ([]kbfscrypto.TLFCryptKey, error)) (

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -275,6 +275,8 @@ func (wkg TLFWriterKeyGenerationsV2) ToTLFWriterKeyBundleV3(
 			errors.New("No key generations to convert")
 	}
 
+	// Check for invalid indices into
+	// wkbV2.TLFEphemeralPublicKeys.
 	wkbV2 := wkg[keyGen-FirstValidKeyGen]
 	for u, dkimV2 := range wkbV2.WKeys {
 		for kid, keyInfo := range dkimV2 {

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -143,15 +143,15 @@ func TestToTLFWriterKeyBundleV3(t *testing.T) {
 		WKeys: UserDeviceKeyInfoMapV2{
 			uid1: DeviceKeyInfoMapV2{
 				key1a.KID(): TLFCryptKeyInfo{
-					EPubKeyIndex: -1,
+					EPubKeyIndex: 0,
 				},
 				key1b.KID(): TLFCryptKeyInfo{
-					EPubKeyIndex: +2,
+					EPubKeyIndex: 1,
 				},
 			},
 			uid2: DeviceKeyInfoMapV2{
 				key2a.KID(): TLFCryptKeyInfo{
-					EPubKeyIndex: -2,
+					EPubKeyIndex: 1,
 				},
 				key2b.KID(): TLFCryptKeyInfo{
 					EPubKeyIndex: 0,
@@ -181,15 +181,15 @@ func TestToTLFWriterKeyBundleV3(t *testing.T) {
 		Keys: UserDeviceKeyInfoMapV3{
 			uid1: DeviceKeyInfoMapV3{
 				key1a: TLFCryptKeyInfo{
-					EPubKeyIndex: -1,
+					EPubKeyIndex: 0,
 				},
 				key1b: TLFCryptKeyInfo{
-					EPubKeyIndex: +2,
+					EPubKeyIndex: 1,
 				},
 			},
 			uid2: DeviceKeyInfoMapV3{
 				key2a: TLFCryptKeyInfo{
-					EPubKeyIndex: -2,
+					EPubKeyIndex: 1,
 				},
 				key2b: TLFCryptKeyInfo{
 					EPubKeyIndex: 0,

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -217,7 +217,7 @@ func DeserializeTLFWriterKeyBundleV3(codec kbfscodec.Codec, path string) (
 	}
 	if len(wkb.Keys) == 0 {
 		return TLFWriterKeyBundleV3{}, errors.New(
-			"Writer key bundle with no keys")
+			"Writer key bundle with no keys (Deserialize)")
 	}
 	return wkb, nil
 }
@@ -226,6 +226,19 @@ func DeserializeTLFWriterKeyBundleV3(codec kbfscodec.Codec, path string) (
 func (wkb TLFWriterKeyBundleV3) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
 	_, ok := wkb.Keys[user][kbfscrypto.MakeCryptPublicKey(deviceKID)]
 	return ok
+}
+
+func (wkb TLFWriterKeyBundleV3) DeepCopy(codec kbfscodec.Codec) (
+	TLFWriterKeyBundleV3, error) {
+	if len(wkb.Keys) == 0 {
+		return TLFWriterKeyBundleV3{}, errors.New(
+			"Writer key bundle with no keys (DeepCopy)")
+	}
+	var wkbCopy TLFWriterKeyBundleV3
+	if err := kbfscodec.Update(codec, &wkbCopy, wkb); err != nil {
+		return TLFWriterKeyBundleV3{}, err
+	}
+	return wkbCopy, nil
 }
 
 // TLFWriterKeyBundleID is the hash of a serialized TLFWriterKeyBundle.
@@ -322,9 +335,21 @@ func DeserializeTLFReaderKeyBundleV3(codec kbfscodec.Codec, path string) (
 }
 
 // IsReader returns true if the given user device is in the reader set.
-func (trb TLFReaderKeyBundleV3) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
-	_, ok := trb.Keys[user][kbfscrypto.MakeCryptPublicKey(deviceKID)]
+func (rkb TLFReaderKeyBundleV3) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
+	_, ok := rkb.Keys[user][kbfscrypto.MakeCryptPublicKey(deviceKID)]
 	return ok
+}
+
+func (rkb TLFReaderKeyBundleV3) DeepCopy(codec kbfscodec.Codec) (
+	TLFReaderKeyBundleV3, error) {
+	var rkbCopy TLFReaderKeyBundleV3
+	if err := kbfscodec.Update(codec, &rkbCopy, rkb); err != nil {
+		return TLFReaderKeyBundleV3{}, err
+	}
+	if len(rkbCopy.Keys) == 0 {
+		rkbCopy.Keys = make(UserDeviceKeyInfoMapV3)
+	}
+	return rkbCopy, nil
 }
 
 // TLFReaderKeyBundleID is the hash of a serialized TLFReaderKeyBundle.

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -228,6 +228,7 @@ func (wkb TLFWriterKeyBundleV3) IsWriter(user keybase1.UID, deviceKID keybase1.K
 	return ok
 }
 
+// DeepCopy creates a deep copy of this key bundle.
 func (wkb TLFWriterKeyBundleV3) DeepCopy(codec kbfscodec.Codec) (
 	TLFWriterKeyBundleV3, error) {
 	if len(wkb.Keys) == 0 {
@@ -340,6 +341,7 @@ func (rkb TLFReaderKeyBundleV3) IsReader(user keybase1.UID, deviceKID keybase1.K
 	return ok
 }
 
+// DeepCopy creates a deep copy of this key bundle.
 func (rkb TLFReaderKeyBundleV3) DeepCopy(codec kbfscodec.Codec) (
 	TLFReaderKeyBundleV3, error) {
 	var rkbCopy TLFReaderKeyBundleV3

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -33,6 +33,8 @@ type mdIDJournal struct {
 type mdIDJournalEntry struct {
 	ID            MdID
 	IsLocalSquash bool
+	WKBNew        bool
+	RKBNew        bool
 
 	codec.UnknownFieldSetHandler
 }

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -32,9 +32,9 @@ type mdIDJournal struct {
 // false`, it will be the same in all the remaining entries.
 type mdIDJournalEntry struct {
 	ID            MdID
-	IsLocalSquash bool
-	WKBNew        bool
-	RKBNew        bool
+	IsLocalSquash bool `codec:",omitempty"`
+	WKBNew        bool `codec:",omitempty"`
+	RKBNew        bool `codec:",omitempty"`
 
 	codec.UnknownFieldSetHandler
 }

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -31,10 +31,18 @@ type mdIDJournal struct {
 // of the id journal; once there is one entry with `isLocalSquash =
 // false`, it will be the same in all the remaining entries.
 type mdIDJournalEntry struct {
-	ID            MdID
+	ID MdID
+	// IsLocalSquash is true when this MD is the result of
+	// squashing some other local MDs.
 	IsLocalSquash bool `codec:",omitempty"`
-	WKBNew        bool `codec:",omitempty"`
-	RKBNew        bool `codec:",omitempty"`
+	// WKBNew is true when the writer key bundle for this MD is
+	// new and has to be pushed to the server. This is always
+	// false for MDv2.
+	WKBNew bool `codec:",omitempty"`
+	// RKBNew is true when the reader key bundle for this MD is
+	// new and has to be pushed to the server. This is always
+	// false for MDv2.
+	RKBNew bool `codec:",omitempty"`
 
 	codec.UnknownFieldSetHandler
 }

--- a/libkbfs/md_id_journal_test.go
+++ b/libkbfs/md_id_journal_test.go
@@ -28,7 +28,7 @@ func makeFakeMDIDJournalEntryFuture(t *testing.T) mdIDJournalEntryFuture {
 	ef := mdIDJournalEntryFuture{
 		mdIDJournalEntry{
 			fakeMdID(1),
-			false,
+			false, false, false,
 			codec.UnknownFieldSetHandler{},
 		},
 		kbfscodec.MakeExtraOrBust("mdIDJournalEntry", t),

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -645,7 +645,7 @@ func (j *mdJournal) convertToBranch(
 	isPendingLocalSquash := bid == PendingLocalSquashBranchID
 	for _, entry := range allEntries {
 		brmd, _, ts, err := j.getMDAndExtra(
-			entry.ID, true, false, false)
+			entry.ID, true, entry.WKBNew, entry.RKBNew)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -475,7 +475,8 @@ func (j mdJournal) putMD(rmd BareRootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 
-	_, _, _, err = j.getMDAndExtra(id, true, false, false)
+	p := j.mdDataPath(id)
+	_, err = ioutil.Stat(p)
 	if ioutil.IsNotExist(err) {
 		// Continue on.
 	} else if err != nil {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -476,8 +476,7 @@ func (j mdJournal) putMD(rmd BareRootMetadata) (MdID, error) {
 		return MdID{}, err
 	}
 
-	p := j.mdDataPath(id)
-	_, err = ioutil.Stat(p)
+	_, err = ioutil.Stat(j.mdDataPath(id))
 	if ioutil.IsNotExist(err) {
 		// Continue on.
 	} else if err != nil {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -98,13 +98,6 @@ func (p PrivateMetadata) ChangesBlockInfo() BlockInfo {
 	return p.cachedChanges.Info
 }
 
-// ExtraMetadata is a per-version blob of extra metadata which may exist outside of the
-// given metadata block, e.g. key bundles for post-v2 metadata.
-type ExtraMetadata interface {
-	MetadataVersion() MetadataVer
-	DeepCopy(kbfscodec.Codec) (ExtraMetadata, error)
-}
-
 // A RootMetadata is a BareRootMetadata but with a deserialized
 // PrivateMetadata. However, note that it is possible that the
 // PrivateMetadata has to be left serialized due to not having the

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -236,7 +236,11 @@ func (md *RootMetadata) MakeSuccessor(
 	isReadableAndWriter := md.IsReadable() && isWriter
 
 	brmdCopy, extraCopy, err := md.bareMd.MakeSuccessorCopy(
-		ctx, config, md, md.extra, isReadableAndWriter)
+		config.Codec(), config.Crypto(), md.extra,
+		config.MetadataVersion(),
+		func() ([]kbfscrypto.TLFCryptKey, error) {
+			return config.KeyManager().GetTLFCryptKeyOfAllGenerations(ctx, md)
+		}, isReadableAndWriter)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -295,7 +295,8 @@ func testRootMetadataFinalIsFinal(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	rmd.SetFinalBit()
-	_, err = rmd.MakeSuccessor(context.Background(), nil, fakeMdID(1), true)
+	_, err = rmd.MakeSuccessor(context.Background(), -1, nil, nil, nil,
+		fakeMdID(1), true)
 	_, isFinalError := err.(MetadataIsFinalError)
 	require.Equal(t, isFinalError, true)
 }
@@ -407,7 +408,9 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	config.metadataVersion = SegregatedKeyBundlesVer
 
 	// create an MDv3 successor
-	rmd2, err := rmd.MakeSuccessor(context.Background(), config, fakeMdID(1), true)
+	rmd2, err := rmd.MakeSuccessor(context.Background(),
+		config.MetadataVersion(), config.Codec(), config.Crypto(),
+		config.KeyManager(), fakeMdID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, MetadataRevision(2), rmd2.Revision())
@@ -494,7 +497,9 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	config.metadataVersion = SegregatedKeyBundlesVer
 
 	// create an MDv3 successor
-	rmd2, err := rmd.MakeSuccessor(context.Background(), config, fakeMdID(1), true)
+	rmd2, err := rmd.MakeSuccessor(context.Background(),
+		config.MetadataVersion(), config.Codec(), config.Crypto(),
+		config.KeyManager(), fakeMdID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, MetadataRevision(2), rmd2.Revision())
@@ -606,7 +611,9 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	// reader.  This should keep the version the same, since readers
 	// can't upconvert.
 	configReader.metadataVersion = SegregatedKeyBundlesVer
-	rmd2, err := rmd.MakeSuccessor(context.Background(), configReader,
+	rmd2, err := rmd.MakeSuccessor(context.Background(),
+		configReader.MetadataVersion(), configReader.Codec(),
+		configReader.Crypto(), configReader.KeyManager(),
 		fakeMdID(1), false)
 	require.NoError(t, err)
 	require.Equal(t, rmd2.LatestKeyGeneration(), KeyGen(1))


### PR DESCRIPTION
Fix up MD journal tests to reveal the bug where wkbNew and
rkbNew aren't preserved.

Also remove dependency on Config from BareRootMetadata
and RootMetadata.

Also add unit test for ToTLFWriterKeyBundleV3 and
strengthen its checks.