### PR TITLE
Improve MD journal benchmark

### DIFF
--- a/kbfscodec/codec.go
+++ b/kbfscodec/codec.go
@@ -92,6 +92,21 @@ func SerializeToFile(c Codec, obj interface{}, path string) error {
 	return ioutil.WriteFile(path, buf, 0600)
 }
 
+// SerializeToFileIfNotExist is like SerializeToFile, but does nothing
+// if the file already exists.
+func SerializeToFileIfNotExist(c Codec, obj interface{}, path string) error {
+	_, err := ioutil.Stat(path)
+	if ioutil.IsExist(err) {
+		return nil
+	} else if ioutil.IsNotExist(err) {
+		// Continue.
+	} else if err != nil {
+		return err
+	}
+
+	return SerializeToFile(c, obj, path)
+}
+
 // DeserializeFromFile deserializes the given file into the object
 // pointed to by objPtr. It may return an error for which
 // ioutil.IsNotExist() returns true.

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -371,15 +371,13 @@ func (j mdJournal) putExtraMetadata(rmd BareRootMetadata, extra ExtraMetadata) (
 		return false, false, err
 	}
 
-	// TODO: Avoid serializing if the file already exists.
-
-	err = kbfscodec.SerializeToFile(
+	err = kbfscodec.SerializeToFileIfNotExist(
 		j.codec, extraV3.wkb, j.writerKeyBundleV3Path(wkbID))
 	if err != nil {
 		return false, false, err
 	}
 
-	err = kbfscodec.SerializeToFile(
+	err = kbfscodec.SerializeToFileIfNotExist(
 		j.codec, extraV3.rkb, j.readerKeyBundleV3Path(rkbID))
 	if err != nil {
 		return false, false, err
@@ -486,7 +484,8 @@ func (j mdJournal) putMD(rmd BareRootMetadata) (MdID, error) {
 		return MdID{}, nil
 	}
 
-	err = kbfscodec.SerializeToFile(j.codec, rmd, j.mdDataPath(id))
+	err = kbfscodec.SerializeToFileIfNotExist(
+		j.codec, rmd, j.mdDataPath(id))
 	if err != nil {
 		return MdID{}, err
 	}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -185,10 +185,6 @@ func checkIBRMDRange(t *testing.T, uid keybase1.UID,
 	}
 }
 
-func BenchmarkMDJournalBasic(b *testing.B) {
-	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
-}
-
 // noLogTB is an implementation of testing.TB that squelches all logs
 // (for benchmarks).
 type noLogTB struct {
@@ -198,6 +194,24 @@ type noLogTB struct {
 func (tb noLogTB) Log(args ...interface{}) {}
 
 func (tb noLogTB) Logf(format string, args ...interface{}) {}
+
+func BenchmarkMDJournalBasic(b *testing.B) {
+	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
+}
+
+func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
+	for _, mdCount := range []int{1, 10, 100, 1000, 10000} {
+		mdCount := mdCount // capture range variable.
+		name := fmt.Sprintf("mdCount=%d", mdCount)
+		b.Run(name, func(b *testing.B) {
+			b.StopTimer()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkMDJournalBasicBody(b, ver, mdCount)
+			}
+		})
+	}
+}
 
 func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer, mdCount int) {
 	b.StopTimer()
@@ -213,20 +227,6 @@ func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer, mdCount int) {
 			defer b.StopTimer()
 			return j.put(ctx, signer, ekg, bsplit, md, false)
 		})
-}
-
-func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
-	for _, mdCount := range []int{1, 10, 100, 1000, 10000} {
-		mdCount := mdCount // capture range variable.
-		name := fmt.Sprintf("mdCount=%d", mdCount)
-		b.Run(name, func(b *testing.B) {
-			b.StopTimer()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				benchmarkMDJournalBasicBody(b, ver, mdCount)
-			}
-		})
-	}
 }
 
 func TestMDJournalBasic(t *testing.T) {

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -185,9 +185,6 @@ func checkIBRMDRange(t *testing.T, uid keybase1.UID,
 	}
 }
 
-// TODO: Create a separate journal for each iteration, instead of
-// using the same one.
-
 func BenchmarkMDJournalBasic(b *testing.B) {
 	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -182,7 +182,9 @@ func BenchmarkMDJournalBasic(b *testing.B) {
 	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
 }
 
-func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
+func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer) {
+	b.StopTimer()
+
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(b, ver)
 	defer teardownMDJournalTest(b, tempdir)
 
@@ -190,13 +192,20 @@ func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
 	revision := MetadataRevision(10)
 	prevRoot := fakeMdID(1)
 
+	b.StartTimer()
+
+	_, prevRoot = putMDRange(b, ver, id,
+		signer, ekg, bsplit, revision, prevRoot, mdCount, j)
+
+	b.StopTimer()
+}
+
+func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
 	b.ResetTimer()
-	defer b.StopTimer()
+	b.StopTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, prevRoot = putMDRange(b, ver, id,
-			signer, ekg, bsplit, revision, prevRoot, mdCount, j)
-		revision += MetadataRevision(mdCount)
+		benchmarkMDJournalBasicBody(b, ver)
 	}
 }
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -182,10 +182,19 @@ func BenchmarkMDJournalBasic(b *testing.B) {
 	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
 }
 
+type noLogTB struct {
+	testing.TB
+}
+
+func (tb noLogTB) Log(args ...interface{}) {}
+
+func (tb noLogTB) Logf(format string, args ...interface{}) {}
+
 func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer) {
 	b.StopTimer()
 
-	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(b, ver)
+	_, _, id, signer, ekg, bsplit, tempdir, j :=
+		setupMDJournalTest(noLogTB{b}, ver)
 	defer teardownMDJournalTest(b, tempdir)
 
 	mdCount := 500

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -614,7 +614,7 @@ func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
 	mdcache := NewMDCacheStandard(10)
 	cachedMd := makeMDForTest(
 		t, ver, id, firstRevision, j.uid, signer, firstPrevRoot)
-	err = cachedMd.bareMd.SignWriterMetadataInternally(ctx, codec, signer)
+	err := cachedMd.bareMd.SignWriterMetadataInternally(ctx, codec, signer)
 	require.NoError(t, err)
 	cachedMdID, _, _, _, err := j.getEarliestWithExtra(false)
 	require.NoError(t, err)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -108,9 +108,6 @@ func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	md.fakeInitialRekey(codec, crypto)
 	md.SetPrevRoot(prevRoot)
 	md.SetDiskUsage(500)
-	err = md.bareMd.SignWriterMetadataInternally(context.Background(),
-		kbfscodec.NewMsgpack(), signer)
-	require.NoError(t, err)
 	return md
 }
 
@@ -620,6 +617,8 @@ func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
 	mdcache := NewMDCacheStandard(10)
 	cachedMd := makeMDForTest(
 		t, ver, id, firstRevision, j.uid, signer, firstPrevRoot)
+	err = cachedMd.bareMd.SignWriterMetadataInternally(ctx, codec, signer)
+	require.NoError(t, err)
 	cachedMdID, _, _, _, err := j.getEarliestWithExtra(false)
 	require.NoError(t, err)
 	err = mdcache.Put(MakeImmutableRootMetadata(cachedMd,

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -199,20 +199,6 @@ func BenchmarkMDJournalBasic(b *testing.B) {
 	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
 }
 
-func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
-	for _, mdCount := range []int{1, 10, 100, 1000, 10000} {
-		mdCount := mdCount // capture range variable.
-		name := fmt.Sprintf("mdCount=%d", mdCount)
-		b.Run(name, func(b *testing.B) {
-			b.StopTimer()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				benchmarkMDJournalBasicBody(b, ver, mdCount)
-			}
-		})
-	}
-}
-
 func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer, mdCount int) {
 	b.StopTimer()
 
@@ -227,6 +213,20 @@ func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer, mdCount int) {
 			defer b.StopTimer()
 			return j.put(ctx, signer, ekg, bsplit, md, false)
 		})
+}
+
+func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
+	for _, mdCount := range []int{1, 10, 100, 1000, 10000} {
+		mdCount := mdCount // capture range variable.
+		name := fmt.Sprintf("mdCount=%d", mdCount)
+		b.Run(name, func(b *testing.B) {
+			b.StopTimer()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkMDJournalBasicBody(b, ver, mdCount)
+			}
+		})
+	}
 }
 
 func TestMDJournalBasic(t *testing.T) {

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -185,7 +185,7 @@ func (s *mdServerTlfStorage) putMDLocked(
 		Version:     rmds.MD.Version(),
 	}
 
-	err = kbfscodec.SerializeToFile(s.codec, srmds, s.mdPath(id))
+	err = kbfscodec.SerializeToFileIfNotExist(s.codec, srmds, s.mdPath(id))
 	if err != nil {
 		return MdID{}, err
 	}
@@ -302,7 +302,7 @@ func (s *mdServerTlfStorage) putExtraMetadataLocked(rmds *RootMetadataSigned,
 		if wkbID == (TLFWriterKeyBundleID{}) {
 			panic("writer key bundle ID is empty")
 		}
-		err := kbfscodec.SerializeToFile(
+		err := kbfscodec.SerializeToFileIfNotExist(
 			s.codec, extraV3.wkb, s.writerKeyBundleV3Path(wkbID))
 		if err != nil {
 			return err
@@ -314,7 +314,7 @@ func (s *mdServerTlfStorage) putExtraMetadataLocked(rmds *RootMetadataSigned,
 		if rkbID == (TLFReaderKeyBundleID{}) {
 			panic("reader key bundle ID is empty")
 		}
-		err := kbfscodec.SerializeToFile(
+		err := kbfscodec.SerializeToFileIfNotExist(
 			s.codec, extraV3.rkb, s.readerKeyBundleV3Path(rkbID))
 		if err != nil {
 			return err


### PR DESCRIPTION
In particular, have it time only the actual put
operation. Also test with varying MD counts, and
have it not reuse the same journal across runs.

Add SerializeToFileIfNotExist helper function
and use it appropriately (although without consistent
speedup).