### PR TITLE
Rework md dump command

### DIFF
--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -82,8 +82,8 @@ type publicByte32Container struct {
 var _ encoding.BinaryMarshaler = publicByte32Container{}
 var _ encoding.BinaryUnmarshaler = (*publicByte32Container)(nil)
 
-var _ json.Marshaler = publicByte32Container{}
-var _ json.Unmarshaler = (*publicByte32Container)(nil)
+var _ encoding.TextMarshaler = publicByte32Container{}
+var _ encoding.TextUnmarshaler = (*publicByte32Container)(nil)
 
 func (c publicByte32Container) Data() [32]byte {
 	return c.data
@@ -104,17 +104,12 @@ func (c *publicByte32Container) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func (c publicByte32Container) MarshalJSON() ([]byte, error) {
-	return json.Marshal(c.String())
+func (c publicByte32Container) MarshalText() ([]byte, error) {
+	return []byte(c.String()), nil
 }
 
-func (c *publicByte32Container) UnmarshalJSON(data []byte) error {
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err != nil {
-		return err
-	}
-	buf, err := hex.DecodeString(s)
+func (c *publicByte32Container) UnmarshalText(data []byte) error {
+	buf, err := hex.DecodeString(string(data))
 	if err != nil {
 		return err
 	}
@@ -132,8 +127,8 @@ type privateByte32Container struct {
 var _ encoding.BinaryMarshaler = privateByte32Container{}
 var _ encoding.BinaryUnmarshaler = (*privateByte32Container)(nil)
 
-var _ json.Marshaler = privateByte32Container{}
-var _ json.Unmarshaler = (*privateByte32Container)(nil)
+var _ encoding.TextMarshaler = privateByte32Container{}
+var _ encoding.TextUnmarshaler = (*privateByte32Container)(nil)
 
 func (c privateByte32Container) Data() [32]byte {
 	return c.data
@@ -154,12 +149,12 @@ func (c *privateByte32Container) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-func (c privateByte32Container) MarshalJSON() ([]byte, error) {
-	return nil, errors.New("Cannot marshal private 32 bytes to JSON")
+func (c privateByte32Container) MarshalText() ([]byte, error) {
+	return nil, errors.New("Cannot marshal private 32 bytes to text")
 }
 
-func (c *privateByte32Container) UnmarshalJSON(data []byte) error {
-	return errors.New("Cannot unmarshal private 32 bytes from JSON")
+func (c *privateByte32Container) UnmarshalText(data []byte) error {
+	return errors.New("Cannot unmarshal private 32 bytes from text")
 }
 
 func (c privateByte32Container) String() string {
@@ -178,8 +173,8 @@ type TLFPrivateKey struct {
 var _ encoding.BinaryMarshaler = TLFPrivateKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFPrivateKey)(nil)
 
-var _ json.Marshaler = TLFPrivateKey{}
-var _ json.Unmarshaler = (*TLFPrivateKey)(nil)
+var _ encoding.TextMarshaler = TLFPrivateKey{}
+var _ encoding.TextUnmarshaler = (*TLFPrivateKey)(nil)
 
 // MakeTLFPrivateKey returns a TLFPrivateKey containing the given
 // data.
@@ -200,8 +195,8 @@ type TLFPublicKey struct {
 var _ encoding.BinaryMarshaler = TLFPublicKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFPublicKey)(nil)
 
-var _ json.Marshaler = TLFPublicKey{}
-var _ json.Unmarshaler = (*TLFPublicKey)(nil)
+var _ encoding.TextMarshaler = TLFPublicKey{}
+var _ encoding.TextUnmarshaler = (*TLFPublicKey)(nil)
 
 // MakeTLFPublicKey returns a TLFPublicKey containing the given
 // data.
@@ -223,8 +218,8 @@ type TLFEphemeralPrivateKey struct {
 var _ encoding.BinaryMarshaler = TLFEphemeralPrivateKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFEphemeralPrivateKey)(nil)
 
-var _ json.Marshaler = TLFEphemeralPrivateKey{}
-var _ json.Unmarshaler = (*TLFEphemeralPrivateKey)(nil)
+var _ encoding.TextMarshaler = TLFEphemeralPrivateKey{}
+var _ encoding.TextUnmarshaler = (*TLFEphemeralPrivateKey)(nil)
 
 // MakeTLFEphemeralPrivateKey returns a TLFEphemeralPrivateKey
 // containing the given data.
@@ -297,8 +292,8 @@ type TLFEphemeralPublicKey struct {
 var _ encoding.BinaryMarshaler = TLFEphemeralPublicKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFEphemeralPublicKey)(nil)
 
-var _ json.Marshaler = TLFEphemeralPublicKey{}
-var _ json.Unmarshaler = (*TLFEphemeralPublicKey)(nil)
+var _ encoding.TextMarshaler = TLFEphemeralPublicKey{}
+var _ encoding.TextUnmarshaler = (*TLFEphemeralPublicKey)(nil)
 
 // MakeTLFEphemeralPublicKey returns a TLFEphemeralPublicKey
 // containing the given data.
@@ -322,8 +317,8 @@ type TLFCryptKeyServerHalf struct {
 var _ encoding.BinaryMarshaler = TLFCryptKeyServerHalf{}
 var _ encoding.BinaryUnmarshaler = (*TLFCryptKeyServerHalf)(nil)
 
-var _ json.Marshaler = TLFCryptKeyServerHalf{}
-var _ json.Unmarshaler = (*TLFCryptKeyServerHalf)(nil)
+var _ encoding.TextMarshaler = TLFCryptKeyServerHalf{}
+var _ encoding.TextUnmarshaler = (*TLFCryptKeyServerHalf)(nil)
 
 // MakeTLFCryptKeyServerHalf returns a TLFCryptKeyServerHalf
 // containing the given data.
@@ -344,8 +339,8 @@ type TLFCryptKeyClientHalf struct {
 var _ encoding.BinaryMarshaler = TLFCryptKeyClientHalf{}
 var _ encoding.BinaryUnmarshaler = (*TLFCryptKeyClientHalf)(nil)
 
-var _ json.Marshaler = TLFCryptKeyClientHalf{}
-var _ json.Unmarshaler = (*TLFCryptKeyClientHalf)(nil)
+var _ encoding.TextMarshaler = TLFCryptKeyClientHalf{}
+var _ encoding.TextUnmarshaler = (*TLFCryptKeyClientHalf)(nil)
 
 // MakeTLFCryptKeyClientHalf returns a TLFCryptKeyClientHalf
 // containing the given data.
@@ -366,8 +361,8 @@ type TLFCryptKey struct {
 var _ encoding.BinaryMarshaler = TLFCryptKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFCryptKey)(nil)
 
-var _ json.Marshaler = TLFCryptKey{}
-var _ json.Unmarshaler = (*TLFCryptKey)(nil)
+var _ encoding.TextMarshaler = TLFCryptKey{}
+var _ encoding.TextUnmarshaler = (*TLFCryptKey)(nil)
 
 // MakeTLFCryptKey returns a TLFCryptKey containing the given data.
 func MakeTLFCryptKey(data [32]byte) TLFCryptKey {
@@ -398,8 +393,8 @@ type BlockCryptKeyServerHalf struct {
 var _ encoding.BinaryMarshaler = BlockCryptKeyServerHalf{}
 var _ encoding.BinaryUnmarshaler = (*BlockCryptKeyServerHalf)(nil)
 
-var _ json.Marshaler = BlockCryptKeyServerHalf{}
-var _ json.Unmarshaler = (*BlockCryptKeyServerHalf)(nil)
+var _ encoding.TextMarshaler = BlockCryptKeyServerHalf{}
+var _ encoding.TextUnmarshaler = (*BlockCryptKeyServerHalf)(nil)
 
 // MakeBlockCryptKeyServerHalf returns a BlockCryptKeyServerHalf
 // containing the given data.
@@ -431,8 +426,8 @@ type BlockCryptKey struct {
 var _ encoding.BinaryMarshaler = BlockCryptKey{}
 var _ encoding.BinaryUnmarshaler = (*BlockCryptKey)(nil)
 
-var _ json.Marshaler = BlockCryptKey{}
-var _ json.Unmarshaler = (*BlockCryptKey)(nil)
+var _ encoding.TextMarshaler = BlockCryptKey{}
+var _ encoding.TextUnmarshaler = (*BlockCryptKey)(nil)
 
 // MakeBlockCryptKey returns a BlockCryptKey containing the given
 // data.

--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -24,6 +24,9 @@ type kidContainer struct {
 var _ encoding.BinaryMarshaler = kidContainer{}
 var _ encoding.BinaryUnmarshaler = (*kidContainer)(nil)
 
+// TODO: Make keybase1.KID implement {Binary,Text}{M,Unm}arshaler
+// directly.
+
 var _ json.Marshaler = kidContainer{}
 var _ json.Unmarshaler = (*kidContainer)(nil)
 

--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -81,6 +81,8 @@ type byte32Container struct {
 var _ encoding.BinaryMarshaler = byte32Container{}
 var _ encoding.BinaryUnmarshaler = (*byte32Container)(nil)
 
+var _ json.Marshaler = byte32Container{}
+
 func (c byte32Container) Data() [32]byte {
 	return c.data
 }
@@ -98,6 +100,10 @@ func (c *byte32Container) UnmarshalBinary(data []byte) error {
 
 	copy(c.data[:], data)
 	return nil
+}
+
+func (c byte32Container) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
 }
 
 func (c byte32Container) String() string {

--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -314,7 +314,7 @@ type TLFEphemeralPublicKeys []TLFEphemeralPublicKey
 // Copies of TLFCryptKeyServerHalf objects are deep copies.
 type TLFCryptKeyServerHalf struct {
 	// Should only be used by implementations of Crypto.
-	privateByte32Container
+	publicByte32Container
 }
 
 var _ encoding.BinaryMarshaler = TLFCryptKeyServerHalf{}
@@ -326,7 +326,7 @@ var _ encoding.TextUnmarshaler = (*TLFCryptKeyServerHalf)(nil)
 // MakeTLFCryptKeyServerHalf returns a TLFCryptKeyServerHalf
 // containing the given data.
 func MakeTLFCryptKeyServerHalf(data [32]byte) TLFCryptKeyServerHalf {
-	return TLFCryptKeyServerHalf{privateByte32Container{data}}
+	return TLFCryptKeyServerHalf{publicByte32Container{data}}
 }
 
 // TLFCryptKeyClientHalf (t_u^{f,0,i}) is the masked, client-side half
@@ -336,7 +336,7 @@ func MakeTLFCryptKeyServerHalf(data [32]byte) TLFCryptKeyServerHalf {
 // Copies of TLFCryptKeyClientHalf objects are deep copies.
 type TLFCryptKeyClientHalf struct {
 	// Should only be used by implementations of Crypto.
-	privateByte32Container
+	publicByte32Container
 }
 
 var _ encoding.BinaryMarshaler = TLFCryptKeyClientHalf{}
@@ -348,7 +348,7 @@ var _ encoding.TextUnmarshaler = (*TLFCryptKeyClientHalf)(nil)
 // MakeTLFCryptKeyClientHalf returns a TLFCryptKeyClientHalf
 // containing the given data.
 func MakeTLFCryptKeyClientHalf(data [32]byte) TLFCryptKeyClientHalf {
-	return TLFCryptKeyClientHalf{privateByte32Container{data}}
+	return TLFCryptKeyClientHalf{publicByte32Container{data}}
 }
 
 // TLFCryptKey (s^{f,0}) is used to encrypt/decrypt the private
@@ -390,7 +390,7 @@ var PublicTLFCryptKey = MakeTLFCryptKey([32]byte{
 // Copies of BlockCryptKeyServerHalf objects are deep copies.
 type BlockCryptKeyServerHalf struct {
 	// Should only be used by implementations of Crypto.
-	privateByte32Container
+	publicByte32Container
 }
 
 var _ encoding.BinaryMarshaler = BlockCryptKeyServerHalf{}
@@ -402,7 +402,7 @@ var _ encoding.TextUnmarshaler = (*BlockCryptKeyServerHalf)(nil)
 // MakeBlockCryptKeyServerHalf returns a BlockCryptKeyServerHalf
 // containing the given data.
 func MakeBlockCryptKeyServerHalf(data [32]byte) BlockCryptKeyServerHalf {
-	return BlockCryptKeyServerHalf{privateByte32Container{data}}
+	return BlockCryptKeyServerHalf{publicByte32Container{data}}
 }
 
 // ParseBlockCryptKeyServerHalf returns a BlockCryptKeyServerHalf

--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -82,6 +82,7 @@ var _ encoding.BinaryMarshaler = byte32Container{}
 var _ encoding.BinaryUnmarshaler = (*byte32Container)(nil)
 
 var _ json.Marshaler = byte32Container{}
+var _ json.Unmarshaler = (*byte32Container)(nil)
 
 func (c byte32Container) Data() [32]byte {
 	return c.data
@@ -106,6 +107,19 @@ func (c byte32Container) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.String())
 }
 
+func (c *byte32Container) UnmarshalJSON(data []byte) error {
+	var s string
+	err := json.Unmarshal(data, &s)
+	if err != nil {
+		return err
+	}
+	buf, err := hex.DecodeString(s)
+	if err != nil {
+		return err
+	}
+	return c.UnmarshalBinary(buf)
+}
+
 func (c byte32Container) String() string {
 	return hex.EncodeToString(c.data[:])
 }
@@ -121,6 +135,9 @@ type TLFPrivateKey struct {
 
 var _ encoding.BinaryMarshaler = TLFPrivateKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFPrivateKey)(nil)
+
+var _ json.Marshaler = TLFPrivateKey{}
+var _ json.Unmarshaler = (*TLFPrivateKey)(nil)
 
 // MakeTLFPrivateKey returns a TLFPrivateKey containing the given
 // data.
@@ -141,6 +158,9 @@ type TLFPublicKey struct {
 var _ encoding.BinaryMarshaler = TLFPublicKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFPublicKey)(nil)
 
+var _ json.Marshaler = TLFPublicKey{}
+var _ json.Unmarshaler = (*TLFPublicKey)(nil)
+
 // MakeTLFPublicKey returns a TLFPublicKey containing the given
 // data.
 func MakeTLFPublicKey(data [32]byte) TLFPublicKey {
@@ -160,6 +180,9 @@ type TLFEphemeralPrivateKey struct {
 
 var _ encoding.BinaryMarshaler = TLFEphemeralPrivateKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFEphemeralPrivateKey)(nil)
+
+var _ json.Marshaler = TLFEphemeralPrivateKey{}
+var _ json.Unmarshaler = (*TLFEphemeralPrivateKey)(nil)
 
 // MakeTLFEphemeralPrivateKey returns a TLFEphemeralPrivateKey
 // containing the given data.
@@ -232,6 +255,9 @@ type TLFEphemeralPublicKey struct {
 var _ encoding.BinaryMarshaler = TLFEphemeralPublicKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFEphemeralPublicKey)(nil)
 
+var _ json.Marshaler = TLFEphemeralPublicKey{}
+var _ json.Unmarshaler = (*TLFEphemeralPublicKey)(nil)
+
 // MakeTLFEphemeralPublicKey returns a TLFEphemeralPublicKey
 // containing the given data.
 func MakeTLFEphemeralPublicKey(data [32]byte) TLFEphemeralPublicKey {
@@ -254,6 +280,9 @@ type TLFCryptKeyServerHalf struct {
 var _ encoding.BinaryMarshaler = TLFCryptKeyServerHalf{}
 var _ encoding.BinaryUnmarshaler = (*TLFCryptKeyServerHalf)(nil)
 
+var _ json.Marshaler = TLFCryptKeyServerHalf{}
+var _ json.Unmarshaler = (*TLFCryptKeyServerHalf)(nil)
+
 // MakeTLFCryptKeyServerHalf returns a TLFCryptKeyServerHalf
 // containing the given data.
 func MakeTLFCryptKeyServerHalf(data [32]byte) TLFCryptKeyServerHalf {
@@ -273,6 +302,9 @@ type TLFCryptKeyClientHalf struct {
 var _ encoding.BinaryMarshaler = TLFCryptKeyClientHalf{}
 var _ encoding.BinaryUnmarshaler = (*TLFCryptKeyClientHalf)(nil)
 
+var _ json.Marshaler = TLFCryptKeyClientHalf{}
+var _ json.Unmarshaler = (*TLFCryptKeyClientHalf)(nil)
+
 // MakeTLFCryptKeyClientHalf returns a TLFCryptKeyClientHalf
 // containing the given data.
 func MakeTLFCryptKeyClientHalf(data [32]byte) TLFCryptKeyClientHalf {
@@ -291,6 +323,9 @@ type TLFCryptKey struct {
 
 var _ encoding.BinaryMarshaler = TLFCryptKey{}
 var _ encoding.BinaryUnmarshaler = (*TLFCryptKey)(nil)
+
+var _ json.Marshaler = TLFCryptKey{}
+var _ json.Unmarshaler = (*TLFCryptKey)(nil)
 
 // MakeTLFCryptKey returns a TLFCryptKey containing the given data.
 func MakeTLFCryptKey(data [32]byte) TLFCryptKey {
@@ -321,6 +356,9 @@ type BlockCryptKeyServerHalf struct {
 var _ encoding.BinaryMarshaler = BlockCryptKeyServerHalf{}
 var _ encoding.BinaryUnmarshaler = (*BlockCryptKeyServerHalf)(nil)
 
+var _ json.Marshaler = BlockCryptKeyServerHalf{}
+var _ json.Unmarshaler = (*BlockCryptKeyServerHalf)(nil)
+
 // MakeBlockCryptKeyServerHalf returns a BlockCryptKeyServerHalf
 // containing the given data.
 func MakeBlockCryptKeyServerHalf(data [32]byte) BlockCryptKeyServerHalf {
@@ -350,6 +388,9 @@ type BlockCryptKey struct {
 
 var _ encoding.BinaryMarshaler = BlockCryptKey{}
 var _ encoding.BinaryUnmarshaler = (*BlockCryptKey)(nil)
+
+var _ json.Marshaler = BlockCryptKey{}
+var _ json.Unmarshaler = (*BlockCryptKey)(nil)
 
 // MakeBlockCryptKey returns a BlockCryptKey containing the given
 // data.

--- a/kbfshash/hash.go
+++ b/kbfshash/hash.go
@@ -313,14 +313,14 @@ func (hmac *HMAC) UnmarshalBinary(data []byte) error {
 
 // MarshalJSON implements the encoding.json.Marshaler interface for
 // HMAC.
-func (h HMAC) MarshalJSON() ([]byte, error) {
-	return h.h.MarshalJSON()
+func (hmac HMAC) MarshalJSON() ([]byte, error) {
+	return hmac.h.MarshalJSON()
 }
 
 // UnmarshalJSON implements the encoding.json.Unmarshaler interface
 // for HMAC.
-func (h *HMAC) UnmarshalJSON(data []byte) error {
-	return h.h.UnmarshalJSON(data)
+func (hmac *HMAC) UnmarshalJSON(data []byte) error {
+	return hmac.h.UnmarshalJSON(data)
 }
 
 // Verify makes sure that the HMAC matches the given data.

--- a/kbfshash/hash.go
+++ b/kbfshash/hash.go
@@ -259,6 +259,9 @@ type HMAC struct {
 var _ encoding.BinaryMarshaler = HMAC{}
 var _ encoding.BinaryUnmarshaler = (*HMAC)(nil)
 
+var _ json.Marshaler = HMAC{}
+var _ json.Unmarshaler = (*HMAC)(nil)
+
 // DefaultHMAC computes the HMAC with the given key of the given data
 // using the default hash.
 func DefaultHMAC(key, buf []byte) (HMAC, error) {
@@ -306,6 +309,18 @@ func (hmac HMAC) MarshalBinary() (data []byte, err error) {
 // the HMAC is invalid.
 func (hmac *HMAC) UnmarshalBinary(data []byte) error {
 	return hmac.h.UnmarshalBinary(data)
+}
+
+// MarshalJSON implements the encoding.json.Marshaler interface for
+// HMAC.
+func (h HMAC) MarshalJSON() ([]byte, error) {
+	return h.h.MarshalJSON()
+}
+
+// UnmarshalJSON implements the encoding.json.Unmarshaler interface
+// for HMAC.
+func (h *HMAC) UnmarshalJSON(data []byte) error {
+	return h.h.UnmarshalJSON(data)
 }
 
 // Verify makes sure that the HMAC matches the given data.

--- a/kbfshash/hash.go
+++ b/kbfshash/hash.go
@@ -9,7 +9,6 @@ import (
 	"crypto/sha256"
 	"encoding"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 )
 
@@ -100,8 +99,8 @@ type Hash struct {
 var _ encoding.BinaryMarshaler = Hash{}
 var _ encoding.BinaryUnmarshaler = (*Hash)(nil)
 
-var _ json.Marshaler = Hash{}
-var _ json.Unmarshaler = (*Hash)(nil)
+var _ encoding.TextMarshaler = Hash{}
+var _ encoding.TextUnmarshaler = (*Hash)(nil)
 
 // HashFromRaw creates a hash from a type and raw hash data. If the
 // returned error is nil, the returned Hash is valid.
@@ -227,21 +226,16 @@ func (h Hash) Verify(buf []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the encoding.json.Marshaler interface for
+// MarshalText implements the encoding.TextMarshaler interface for
 // Hash.
-func (h Hash) MarshalJSON() ([]byte, error) {
-	return json.Marshal(h.String())
+func (h Hash) MarshalText() ([]byte, error) {
+	return []byte(h.String()), nil
 }
 
-// UnmarshalJSON implements the encoding.json.Unmarshaler interface
+// UnmarshalText implements the encoding.TextUnmarshaler interface
 // for Hash.
-func (h *Hash) UnmarshalJSON(data []byte) error {
-	var s string
-	err := json.Unmarshal(data, &s)
-	if err != nil {
-		return err
-	}
-	newH, err := HashFromString(s)
+func (h *Hash) UnmarshalText(data []byte) error {
+	newH, err := HashFromString(string(data))
 	if err != nil {
 		return err
 	}
@@ -259,8 +253,8 @@ type HMAC struct {
 var _ encoding.BinaryMarshaler = HMAC{}
 var _ encoding.BinaryUnmarshaler = (*HMAC)(nil)
 
-var _ json.Marshaler = HMAC{}
-var _ json.Unmarshaler = (*HMAC)(nil)
+var _ encoding.TextMarshaler = HMAC{}
+var _ encoding.TextUnmarshaler = (*HMAC)(nil)
 
 // DefaultHMAC computes the HMAC with the given key of the given data
 // using the default hash.
@@ -311,16 +305,16 @@ func (hmac *HMAC) UnmarshalBinary(data []byte) error {
 	return hmac.h.UnmarshalBinary(data)
 }
 
-// MarshalJSON implements the encoding.json.Marshaler interface for
+// MarshalText implements the encoding.TextMarshaler interface for
 // HMAC.
-func (hmac HMAC) MarshalJSON() ([]byte, error) {
-	return hmac.h.MarshalJSON()
+func (hmac HMAC) MarshalText() ([]byte, error) {
+	return hmac.h.MarshalText()
 }
 
-// UnmarshalJSON implements the encoding.json.Unmarshaler interface
+// UnmarshalText implements the encoding.TextUnmarshaler interface
 // for HMAC.
-func (hmac *HMAC) UnmarshalJSON(data []byte) error {
-	return hmac.h.UnmarshalJSON(data)
+func (hmac *HMAC) UnmarshalText(data []byte) error {
+	return hmac.h.UnmarshalText(data)
 }
 
 // Verify makes sure that the HMAC matches the given data.

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -61,7 +61,8 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 					// KIDNames only has mappings for
 					// verifying keys. Fix this.
 					if deviceName, ok := ui.KIDNames[k.KID()]; ok {
-						replacements[k.String()] = deviceName
+						replacements[k.String()] = fmt.Sprintf(
+							"%s (kid:%s)", deviceName, k)
 					}
 				}
 			} else {

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -57,9 +57,6 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 					if _, ok := replacements[k.String()]; ok {
 						continue
 					}
-					// TODO: This doesn't work, because
-					// KIDNames only has mappings for
-					// verifying keys. Fix this.
 					if deviceName, ok := ui.KIDNames[k.KID()]; ok {
 						replacements[k.String()] = fmt.Sprintf(
 							"%s (kid:%s)", deviceName, k)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -68,29 +68,8 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 		}
 	}
 
-	serializedBRMD, err := config.Codec().Encode(brmd)
-	if err != nil {
-		return err
-	}
-	brmdCopy, err := brmd.DeepCopy(config.Codec())
-	if err != nil {
-		return err
-	}
-	var serializedPrivateMetadata []byte
-	switch brmdCopy := brmdCopy.(type) {
-	case *libkbfs.BareRootMetadataV2:
-		serializedPrivateMetadata = brmdCopy.SerializedPrivateMetadata
-		brmdCopy.SerializedPrivateMetadata = nil
-	case *libkbfs.BareRootMetadataV3:
-		serializedPrivateMetadata = brmdCopy.WriterMetadata.SerializedPrivateMetadata
-		brmdCopy.WriterMetadata.SerializedPrivateMetadata = nil
-	default:
-		// Do nothing, and let SerializedPrivateMetadata get
-		// spewed, I guess.
-	}
-	fmt.Printf("MD size: %d bytes\n"+
-		"MD version: %s\n\n", len(serializedBRMD), rmd.Version())
-	mdDumpDumpWithReplacements(c, brmdCopy, replacements)
+	brmdDump := libkbfs.DumpBareRootMetadata(brmd)
+	mdDumpDumpWithReplacements(c, brmdDump, replacements)
 	fmt.Print("\n")
 
 	fmt.Print("Extra metadata\n")

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -21,7 +21,7 @@ func mdDumpGetDeviceString(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
 
 	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime, k), true
+			deviceName, revokedTime.Unix, k), true
 	} else {
 		return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
 	}

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -28,19 +28,26 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 	if err != nil {
 		return err
 	}
+
+	c := spew.NewDefaultConfig()
+	c.Indent = "  "
+	c.DisablePointerAddresses = true
+	c.DisableCapacities = true
+	c.SortKeys = true
+
 	fmt.Printf("MD size: %d bytes\nMD version: %s\n\n",
 		len(buf), rmd.Version())
-	spew.Dump(brmd)
+	c.Dump(brmd)
 	fmt.Print("\n")
 
 	fmt.Print("Extra metadata\n")
 	fmt.Print("--------------\n")
-	spew.Dump(rmd.Extra())
+	c.Dump(rmd.Extra())
 	fmt.Print("\n")
 
 	fmt.Print("Private metadata\n")
 	fmt.Print("----------------\n")
-	spew.Dump(rmd.Data())
+	c.Dump(rmd.Data())
 
 	return nil
 }

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -1,14 +1,11 @@
 package main
 
 import (
-	"encoding/hex"
 	"flag"
 	"fmt"
-	"reflect"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-codec/codec"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
@@ -24,241 +21,6 @@ func getUserString(
 	return fmt.Sprintf("%s (uid:%s)", username, uid)
 }
 
-func mdDumpUnknownFields(handler codec.UnknownFieldSetHandler) {
-	if reflect.DeepEqual(handler, codec.UnknownFieldSetHandler{}) {
-		return
-	}
-
-	fmt.Printf("Unknown fields: %+v\n", handler)
-}
-
-func mdDumpWriterFlags(wFlags libkbfs.WriterFlags) {
-	fmt.Printf("Unmerged: %t\n", wFlags&libkbfs.MetadataFlagUnmerged != 0)
-}
-
-func mdDumpTLFCryptKeyInfo(info libkbfs.TLFCryptKeyInfo) {
-	fmt.Printf("      Client half (encryption version=%d):\n",
-		info.ClientHalf.Version)
-	fmt.Printf("        Encrypted data: %s\n",
-		hex.EncodeToString(info.ClientHalf.EncryptedData))
-	fmt.Printf("        Nonce: %s\n",
-		hex.EncodeToString(info.ClientHalf.Nonce))
-	fmt.Printf("      Server half ID: %s\n",
-		info.ServerHalfID)
-	fmt.Printf("      Ephemeral key index: %d\n",
-		info.EPubKeyIndex)
-}
-
-func mdDumpUDKIMV2(ctx context.Context, config libkbfs.Config,
-	udkimV2 libkbfs.UserDeviceKeyInfoMapV2) {
-	for uid, dkimV2 := range udkimV2 {
-		fmt.Printf("  User: %s\n", getUserString(ctx, config, uid))
-		for kid, info := range dkimV2 {
-			fmt.Printf("    Device: %s\n", kid)
-			mdDumpTLFCryptKeyInfo(info)
-		}
-	}
-}
-
-func mdDumpEphemeralPublicKeys(ePubKeys kbfscrypto.TLFEphemeralPublicKeys) {
-	for i, ePubKey := range ePubKeys {
-		fmt.Printf("    %d: %s\n", i, ePubKey)
-	}
-}
-
-func mdDumpWriterKeyGenerationsV2(ctx context.Context, config libkbfs.Config,
-	wKeys libkbfs.TLFWriterKeyGenerationsV2) {
-	for i, wkb := range wKeys {
-		fmt.Printf("  KeyGen %d:\n", libkbfs.FirstValidKeyGen+libkbfs.KeyGen(i))
-		mdDumpUDKIMV2(ctx, config, wkb.WKeys)
-		fmt.Printf("  TLF public key: %s\n", wkb.TLFPublicKey)
-		mdDumpEphemeralPublicKeys(wkb.TLFEphemeralPublicKeys)
-		// TODO: Handle indent.
-		mdDumpUnknownFields(wkb.UnknownFieldSetHandler)
-	}
-}
-
-func mdDumpSocialAssertions(
-	name string, assertions []keybase1.SocialAssertion) {
-	if len(assertions) > 0 {
-		fmt.Printf("%s:\n", name)
-		for i, assertion := range assertions {
-			fmt.Printf("  %d: %s\n", i, assertion)
-		}
-	} else {
-		fmt.Printf("%s: none\n", name)
-	}
-}
-
-func mdDumpWMDV2(ctx context.Context, config libkbfs.Config,
-	wmd *libkbfs.WriterMetadataV2) {
-	fmt.Printf("Serialized private metadata size: %d bytes\n",
-		len(wmd.SerializedPrivateMetadata))
-	fmt.Printf("Last modifying writer: %s\n",
-		getUserString(ctx, config, wmd.LastModifyingWriter))
-	fmt.Print("Writers:\n")
-	if wmd.ID.IsPublic() {
-		for _, writer := range wmd.Writers {
-			fmt.Printf("  %s\n", getUserString(ctx, config, writer))
-		}
-	} else {
-		mdDumpWriterKeyGenerationsV2(ctx, config, wmd.WKeys)
-	}
-	mdDumpSocialAssertions("Unresolved writers",
-		wmd.Extra.UnresolvedWriters)
-	fmt.Printf("TLF ID: %s\n", wmd.ID)
-	fmt.Printf("Branch ID: %s\n", wmd.BID)
-	mdDumpWriterFlags(wmd.WFlags)
-	fmt.Printf("Disk usage: %d\n", wmd.DiskUsage)
-	fmt.Printf("Bytes in new blocks: %d\n", wmd.RefBytes)
-	fmt.Printf("Bytes in unreferenced blocks: %d\n", wmd.UnrefBytes)
-	mdDumpUnknownFields(wmd.Extra.UnknownFieldSetHandler)
-	fmt.Print("\n")
-}
-
-func mdDumpBRMDV2(ctx context.Context, config libkbfs.Config,
-	rmd *libkbfs.BareRootMetadataV2, extra libkbfs.ExtraMetadata) error {
-	bh, err := rmd.MakeBareTlfHandle(extra)
-	if err != nil {
-		return err
-	}
-
-	fmt.Print("Reader/writer metadata\n")
-	fmt.Print("----------------------\n")
-	if rmd.TlfID().IsPublic() {
-		fmt.Print("Readers: everybody (public)\n")
-	} else if len(bh.Readers) == 0 {
-		fmt.Print("Readers: empty\n")
-	} else {
-		fmt.Print("Readers:\n")
-		for _, reader := range bh.Readers {
-			fmt.Printf("  %s\n",
-				getUserString(ctx, config, reader))
-		}
-	}
-	fmt.Printf("Last modifying user: %s\n",
-		getUserString(ctx, config, rmd.LastModifyingUser))
-	// TODO: Print flags.
-	fmt.Printf("Revision: %s\n", rmd.Revision)
-	fmt.Printf("Prev MD ID: %s\n", rmd.PrevRoot)
-	fmt.Printf("Reader key bundle ID: %s\n", rmd.GetTLFReaderKeyBundleID())
-	// TODO: Print RKeys, unresolved readers, conflict info,
-	// finalized info, and unknown fields.
-	fmt.Print("\n")
-
-	fmt.Print("Writer metadata\n")
-	fmt.Print("---------------\n")
-	mdDumpWMDV2(ctx, config, &rmd.WriterMetadataV2)
-
-	return nil
-}
-
-func mdDumpBRMDV3(ctx context.Context, config libkbfs.Config,
-	rmd *libkbfs.BareRootMetadataV3, extra libkbfs.ExtraMetadata) error {
-	bh, err := rmd.MakeBareTlfHandle(extra)
-	if err != nil {
-		return err
-	}
-
-	fmt.Print("Reader/writer metadata\n")
-	fmt.Print("----------------------\n")
-	if rmd.TlfID().IsPublic() {
-		fmt.Print("Readers: everybody (public)\n")
-	} else if len(bh.Readers) == 0 {
-		fmt.Print("Readers: empty\n")
-	} else {
-		fmt.Print("Readers:\n")
-		for _, reader := range bh.Readers {
-			fmt.Printf("  %s\n",
-				getUserString(ctx, config, reader))
-		}
-	}
-	fmt.Printf("Last modifying user: %s\n",
-		getUserString(ctx, config, rmd.LastModifyingUser))
-	// TODO: Print flags.
-	fmt.Printf("Revision: %s\n", rmd.Revision)
-	fmt.Printf("Prev MD ID: %s\n", rmd.PrevRoot)
-	fmt.Printf("Reader key bundle ID: %s\n", rmd.GetTLFReaderKeyBundleID())
-	// TODO: Print RKeys, unresolved readers, conflict info,
-	// finalized info, and unknown fields.
-	fmt.Print("\n")
-
-	fmt.Print("Writer metadata\n")
-	fmt.Print("---------------\n")
-	fmt.Print("Writers:\n")
-	for _, writer := range bh.Writers {
-		fmt.Printf("  %s\n", getUserString(ctx, config, writer))
-	}
-	fmt.Printf("Last modifying writer: %s\n",
-		getUserString(ctx, config, rmd.LastModifyingWriter()))
-	// TODO: Print Writers/WKeys and unresolved writers.
-	fmt.Printf("TLF ID: %s\n", rmd.TlfID())
-	fmt.Printf("Branch ID: %s\n", rmd.BID())
-	fmt.Printf("Writer key bundle ID: %s\n", rmd.GetTLFWriterKeyBundleID())
-	// TODO: Print writer flags.
-	fmt.Printf("Disk usage: %d\n", rmd.DiskUsage())
-	fmt.Printf("Bytes in new blocks: %d\n", rmd.RefBytes())
-	fmt.Printf("Bytes in unreferenced blocks: %d\n", rmd.UnrefBytes())
-	// TODO: Print unknown fields.
-	fmt.Print("\n")
-
-	return nil
-}
-
-func mdDumpUDKIMV3(ctx context.Context, config libkbfs.Config,
-	udkimV3 libkbfs.UserDeviceKeyInfoMapV3) {
-	for uid, dkimV3 := range udkimV3 {
-		fmt.Printf("  User: %s\n", getUserString(ctx, config, uid))
-		for key, info := range dkimV3 {
-			fmt.Printf("    Device: %s\n", key)
-			mdDumpTLFCryptKeyInfo(info)
-		}
-	}
-}
-
-func mdDumpExtraV3(ctx context.Context, config libkbfs.Config,
-	extraV3 *libkbfs.ExtraMetadataV3) {
-	fmt.Print("Type: ExtraMetadataV3\n")
-	wkb := extraV3.GetWriterKeyBundle()
-	fmt.Print("Writer key bundle:\n")
-	mdDumpUDKIMV3(ctx, config, wkb.Keys)
-	fmt.Printf("  TLF public key: %s\n", wkb.TLFPublicKey)
-	fmt.Print("  Ephemeral writer keys\n")
-	mdDumpEphemeralPublicKeys(wkb.TLFEphemeralPublicKeys)
-	encryptedHistoricKeys := wkb.EncryptedHistoricTLFCryptKeys
-	if encryptedHistoricKeys.Version == 0 {
-		fmt.Print("  Encrypted historic TLF crypt keys: none\n")
-	} else {
-		fmt.Printf("  Encrypted historic TLF crypt keys (encryption version=%d):\n",
-			encryptedHistoricKeys.Version)
-		fmt.Printf("    Encrypted data: %s\n",
-			hex.EncodeToString(encryptedHistoricKeys.EncryptedData))
-		fmt.Printf("    Nonce: %s\n",
-			hex.EncodeToString(encryptedHistoricKeys.Nonce))
-	}
-	// TODO: Print unknown fields.
-	rkb := extraV3.GetReaderKeyBundle()
-	fmt.Print("Reader key bundle\n")
-	mdDumpUDKIMV3(ctx, config, rkb.Keys)
-	fmt.Print("  Ephemeral reader keys\n")
-	mdDumpEphemeralPublicKeys(wkb.TLFEphemeralPublicKeys)
-	// TODO: Print unknown fields.
-}
-
-func mdDumpPrivateMetadata(ctx context.Context, config libkbfs.Config,
-	pmd *libkbfs.PrivateMetadata) {
-	// TODO: Clean up output.
-	fmt.Printf("Dir: %s\n", pmd.Dir)
-	fmt.Print("TLF private key: {32 bytes}\n")
-	if pmd.ChangesBlockInfo() != (libkbfs.BlockInfo{}) {
-		fmt.Printf("Block changes block: %v\n", pmd.ChangesBlockInfo())
-	}
-	for i, op := range pmd.Changes.Ops {
-		fmt.Printf("Op[%d]: %s", i, op.StringWithRefs(1))
-	}
-	// TODO: Print unknown fields.
-}
-
 func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 	rmd libkbfs.ReadOnlyRootMetadata) error {
 	brmd := rmd.GetBareRootMetadata()
@@ -268,41 +30,17 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 	}
 	fmt.Printf("MD size: %d bytes\nMD version: %s\n\n",
 		len(buf), rmd.Version())
-
-	extra := rmd.Extra()
-
-	switch brmd := brmd.(type) {
-	case *libkbfs.BareRootMetadataV2:
-		err := mdDumpBRMDV2(ctx, config, brmd, extra)
-		if err != nil {
-			return err
-		}
-	case *libkbfs.BareRootMetadataV3:
-		err := mdDumpBRMDV3(ctx, config, brmd, extra)
-		if err != nil {
-			return err
-		}
-	default:
-		fmt.Printf("Unknown type: %T\n%+v\n", brmd, brmd)
-	}
+	spew.Dump(brmd)
+	fmt.Print("\n")
 
 	fmt.Print("Extra metadata\n")
 	fmt.Print("--------------\n")
-	switch extra := extra.(type) {
-	case nil:
-		fmt.Print("Type: nil\n")
-	case *libkbfs.ExtraMetadataV3:
-		mdDumpExtraV3(ctx, config, extra)
-	default:
-		fmt.Print("Type: unknown\n")
-		fmt.Printf("%+v\n", extra)
-	}
+	spew.Dump(rmd.Extra())
 	fmt.Print("\n")
 
 	fmt.Print("Private metadata\n")
 	fmt.Print("----------------\n")
-
-	mdDumpPrivateMetadata(ctx, config, rmd.Data())
+	spew.Dump(rmd.Data())
 
 	return nil
 }

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/kbfs/libkbfs"
@@ -12,6 +13,9 @@ import (
 func mdDumpDumpWithReplacements(
 	c *spew.ConfigState, o interface{}, replacements map[string]string) {
 	s := c.Sdump(o)
+	for old, new := range replacements {
+		s = strings.Replace(s, old, new, -1)
+	}
 	fmt.Printf("%s", s)
 }
 

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -193,9 +193,7 @@ func mdDumpExtraV3(ctx context.Context, config libkbfs.Config,
 }
 
 func mdDumpPrivateMetadata(ctx context.Context, config libkbfs.Config,
-	serializedSize int, pmd *libkbfs.PrivateMetadata) {
-	fmt.Printf("Serialized size: %d bytes\n", serializedSize)
-
+	pmd *libkbfs.PrivateMetadata) {
 	// TODO: Clean up output.
 	fmt.Printf("Dir: %s\n", pmd.Dir)
 	fmt.Print("TLF private key: {32 bytes}\n")
@@ -247,6 +245,11 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 		fmt.Printf("%+v\n", extra)
 	}
 	fmt.Print("\n")
+
+	fmt.Print("Private metadata\n")
+	fmt.Print("----------------\n")
+
+	mdDumpPrivateMetadata(ctx, config, rmd.Data())
 
 	return nil
 }

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -22,9 +22,9 @@ func mdDumpGetDeviceString(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
 	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
 			deviceName, revokedTime.Unix.Time(), k), true
-	} else {
-		return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
 	}
+
+	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
 }
 
 func mdDumpGetReplacements(ctx context.Context, codec kbfscodec.Codec,

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -4,8 +4,10 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"reflect"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
@@ -20,6 +22,18 @@ func getUserString(
 		return uid.String()
 	}
 	return fmt.Sprintf("%s (uid:%s)", username, uid)
+}
+
+func mdDumpUnknownFields(handler codec.UnknownFieldSetHandler) {
+	if reflect.DeepEqual(handler, codec.UnknownFieldSetHandler{}) {
+		return
+	}
+
+	fmt.Printf("Unknown fields: %+v\n", handler)
+}
+
+func mdDumpWriterFlags(wFlags libkbfs.WriterFlags) {
+	fmt.Printf("Unmerged: %t\n", wFlags&libkbfs.MetadataFlagUnmerged != 0)
 }
 
 func mdDumpWMDV2(ctx context.Context, config libkbfs.Config,
@@ -39,11 +53,11 @@ func mdDumpWMDV2(ctx context.Context, config libkbfs.Config,
 	// TODO: Print unresolved writers.
 	fmt.Printf("TLF ID: %s\n", wmd.ID)
 	fmt.Printf("Branch ID: %s\n", wmd.BID)
-	// TODO: Print writer flags.
+	mdDumpWriterFlags(wmd.WFlags)
 	fmt.Printf("Disk usage: %d\n", wmd.DiskUsage)
 	fmt.Printf("Bytes in new blocks: %d\n", wmd.RefBytes)
 	fmt.Printf("Bytes in unreferenced blocks: %d\n", wmd.UnrefBytes)
-	// TODO: Print unknown fields.
+	mdDumpUnknownFields(wmd.Extra.UnknownFieldSetHandler)
 	fmt.Print("\n")
 }
 

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -36,23 +36,26 @@ func mdDumpWriterFlags(wFlags libkbfs.WriterFlags) {
 	fmt.Printf("Unmerged: %t\n", wFlags&libkbfs.MetadataFlagUnmerged != 0)
 }
 
+func mdDumpTLFCryptKeyInfo(info libkbfs.TLFCryptKeyInfo) {
+	fmt.Printf("      Client half (encryption version=%d):\n",
+		info.ClientHalf.Version)
+	fmt.Printf("        Encrypted data: %s\n",
+		hex.EncodeToString(info.ClientHalf.EncryptedData))
+	fmt.Printf("        Nonce: %s\n",
+		hex.EncodeToString(info.ClientHalf.Nonce))
+	fmt.Printf("      Server half ID: %s\n",
+		info.ServerHalfID)
+	fmt.Printf("      Ephemeral key index: %d\n",
+		info.EPubKeyIndex)
+}
+
 func mdDumpUDKIMV2(ctx context.Context, config libkbfs.Config,
 	udkimV2 libkbfs.UserDeviceKeyInfoMapV2) {
 	for uid, dkimV2 := range udkimV2 {
 		fmt.Printf("  User: %s\n", getUserString(ctx, config, uid))
 		for kid, info := range dkimV2 {
 			fmt.Printf("    Device: %s\n", kid)
-			clientHalf := info.ClientHalf
-			fmt.Printf("      Client half (encryption version=%d):\n",
-				clientHalf.Version)
-			fmt.Printf("        Encrypted data: %s\n",
-				hex.EncodeToString(clientHalf.EncryptedData))
-			fmt.Printf("        Nonce: %s\n",
-				hex.EncodeToString(clientHalf.Nonce))
-			fmt.Printf("      Server half ID: %s\n",
-				info.ServerHalfID)
-			fmt.Printf("      Ephemeral key index: %d\n",
-				info.EPubKeyIndex)
+			mdDumpTLFCryptKeyInfo(info)
 		}
 	}
 }
@@ -208,17 +211,7 @@ func mdDumpUDKIMV3(ctx context.Context, config libkbfs.Config,
 		fmt.Printf("  User: %s\n", getUserString(ctx, config, uid))
 		for key, info := range dkimV3 {
 			fmt.Printf("    Device: %s\n", key)
-			clientHalf := info.ClientHalf
-			fmt.Printf("      Client half (encryption version=%d):\n",
-				clientHalf.Version)
-			fmt.Printf("        Encrypted data: %s\n",
-				hex.EncodeToString(clientHalf.EncryptedData))
-			fmt.Printf("        Nonce: %s\n",
-				hex.EncodeToString(clientHalf.Nonce))
-			fmt.Printf("      Server half ID: %s\n",
-				info.ServerHalfID)
-			fmt.Printf("      Ephemeral key index: %d\n",
-				info.EPubKeyIndex)
+			mdDumpTLFCryptKeyInfo(info)
 		}
 	}
 }

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -79,7 +79,6 @@ func mdDumpBRMDV2(ctx context.Context, config libkbfs.Config,
 
 	fmt.Print("Writer metadata\n")
 	fmt.Print("---------------\n")
-	fmt.Print("Writers:\n")
 	mdDumpWMDV2(ctx, config, &rmd.WriterMetadataV2)
 
 	return nil

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -21,7 +21,7 @@ func mdDumpGetDeviceString(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
 
 	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Unix, k), true
+			deviceName, revokedTime.Unix.Time(), k), true
 	} else {
 		return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
 	}

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -36,6 +36,18 @@ func mdDumpWriterFlags(wFlags libkbfs.WriterFlags) {
 	fmt.Printf("Unmerged: %t\n", wFlags&libkbfs.MetadataFlagUnmerged != 0)
 }
 
+func mdDumpSocialAssertions(
+	name string, assertions []keybase1.SocialAssertion) {
+	if len(assertions) > 0 {
+		fmt.Printf("%s:\n", name)
+		for i, assertion := range assertions {
+			fmt.Printf("  %d: %s\n", i, assertion)
+		}
+	} else {
+		fmt.Printf("%s: none\n", name)
+	}
+}
+
 func mdDumpWMDV2(ctx context.Context, config libkbfs.Config,
 	wmd *libkbfs.WriterMetadataV2) {
 	fmt.Printf("Serialized private metadata size: %d bytes\n",
@@ -50,7 +62,8 @@ func mdDumpWMDV2(ctx context.Context, config libkbfs.Config,
 	} else {
 		// TODO: Print WKeys.
 	}
-	// TODO: Print unresolved writers.
+	mdDumpSocialAssertions("Unresolved writers",
+		wmd.Extra.UnresolvedWriters)
 	fmt.Printf("TLF ID: %s\n", wmd.ID)
 	fmt.Printf("Branch ID: %s\n", wmd.BID)
 	mdDumpWriterFlags(wmd.WFlags)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -117,7 +117,7 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 	if err != nil {
 		return err
 	}
-	fmt.Printf("%s\n", mdDumpReplaceAll(pmdDump, replacements))
+	fmt.Printf("%s", mdDumpReplaceAll(pmdDump, replacements))
 
 	return nil
 }

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -22,13 +22,6 @@ func getUserString(
 	return fmt.Sprintf("%s (uid:%s)", username, uid)
 }
 
-func mdDumpOne(ctx context.Context, config libkbfs.Config,
-	rmd libkbfs.ImmutableRootMetadata) error {
-	fmt.Printf("MD ID: %s\n", rmd.MdID())
-
-	return mdDumpOneReadOnly(ctx, config, rmd.ReadOnly())
-}
-
 func mdDumpUDKIMV3(ctx context.Context, config libkbfs.Config,
 	udkimV3 libkbfs.UserDeviceKeyInfoMapV3) {
 	for uid, dkimV3 := range udkimV3 {
@@ -205,7 +198,7 @@ func mdDumpExtraV3(ctx context.Context, config libkbfs.Config,
 	// TODO: Print unknown fields.
 }
 
-func mdDumpOneReadOnly(ctx context.Context, config libkbfs.Config,
+func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 	rmd libkbfs.ReadOnlyRootMetadata) error {
 	brmd := rmd.GetBareRootMetadata()
 	buf, err := config.Codec().Encode(brmd)
@@ -252,6 +245,13 @@ func mdDumpOneReadOnly(ctx context.Context, config libkbfs.Config,
 		len(rmd.GetSerializedPrivateMetadata()), rmd.Data())
 
 	return nil
+}
+
+func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
+	rmd libkbfs.ImmutableRootMetadata) error {
+	fmt.Printf("MD ID: %s\n", rmd.MdID())
+
+	return mdDumpReadOnlyRMD(ctx, config, rmd.ReadOnly())
 }
 
 const mdDumpUsageStr = `Usage:
@@ -317,7 +317,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 
 		fmt.Printf("Result for %q:\n\n", input)
 
-		err = mdDumpOne(ctx, config, irmd)
+		err = mdDumpImmutableRMD(ctx, config, irmd)
 		if err != nil {
 			printError("md dump", err)
 			return 1

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -34,7 +34,7 @@ func mdForceQROne(
 
 	fmt.Printf(
 		"Will put a forced QR op up to revision %d:\n", irmd.Revision())
-	err = mdDumpOneReadOnly(ctx, config, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, config, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -61,7 +61,7 @@ func mdResetOne(
 		"Will put an empty root block for tlfID=%s with blockInfo=%s and bufLen=%d\n",
 		rmdNext.TlfID(), info, readyBlockData.GetEncodedSize())
 	fmt.Print("Will put MD:\n")
-	err = mdDumpOneReadOnly(ctx, config, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, config, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -5,6 +5,9 @@
 package libkbfs
 
 import (
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
 )
@@ -40,4 +43,40 @@ type ExtraMetadata interface {
 	MetadataVersion() MetadataVer
 	DeepCopy(kbfscodec.Codec) (ExtraMetadata, error)
 	MakeSuccessorCopy(kbfscodec.Codec) (ExtraMetadata, error)
+}
+
+// DumpBareRootMetadata returns a detailed dump of the given
+// BareRootMetadata's contents.
+func DumpBareRootMetadata(
+	codec kbfscodec.Codec, brmd BareRootMetadata) (string, error) {
+	serializedBRMD, err := codec.Encode(brmd)
+	if err != nil {
+		return "", err
+	}
+
+	// Make a copy so we can zero out SerializedPrivateMetadata.
+	brmdCopy, err := brmd.DeepCopy(codec)
+	if err != nil {
+		return "", err
+	}
+
+	c := spew.NewDefaultConfig()
+	c.Indent = "  "
+	c.DisablePointerAddresses = true
+	c.DisableCapacities = true
+	c.SortKeys = true
+
+	switch brmdCopy := brmdCopy.(type) {
+	case *BareRootMetadataV2:
+		brmdCopy.SerializedPrivateMetadata = nil
+	case *BareRootMetadataV3:
+		brmdCopy.WriterMetadata.SerializedPrivateMetadata = nil
+	default:
+		// Do nothing, and let SerializedPrivateMetadata get
+		// spewed, I guess.
+	}
+	s := fmt.Sprintf("MD size: %d bytes\n"+
+		"MD version: %s\n\n", len(serializedBRMD), brmd.Version())
+	s += c.Sdump(brmdCopy)
+	return s, nil
 }

--- a/libkbfs/bare_root_metadata.go
+++ b/libkbfs/bare_root_metadata.go
@@ -36,13 +36,13 @@ func MakeInitialBareRootMetadata(
 	return MakeInitialBareRootMetadataV3(tlfID, h)
 }
 
-// ExtraMetadata is a per-version blob of extra metadata which may
-// exist outside of the given metadata block, e.g. key bundles for
-// post-v2 metadata.
-type ExtraMetadata interface {
-	MetadataVersion() MetadataVer
-	DeepCopy(kbfscodec.Codec) (ExtraMetadata, error)
-	MakeSuccessorCopy(kbfscodec.Codec) (ExtraMetadata, error)
+func dumpConfig() *spew.ConfigState {
+	c := spew.NewDefaultConfig()
+	c.Indent = "  "
+	c.DisablePointerAddresses = true
+	c.DisableCapacities = true
+	c.SortKeys = true
+	return c
 }
 
 // DumpBareRootMetadata returns a detailed dump of the given
@@ -60,12 +60,6 @@ func DumpBareRootMetadata(
 		return "", err
 	}
 
-	c := spew.NewDefaultConfig()
-	c.Indent = "  "
-	c.DisablePointerAddresses = true
-	c.DisableCapacities = true
-	c.SortKeys = true
-
 	switch brmdCopy := brmdCopy.(type) {
 	case *BareRootMetadataV2:
 		brmdCopy.SerializedPrivateMetadata = nil
@@ -77,6 +71,6 @@ func DumpBareRootMetadata(
 	}
 	s := fmt.Sprintf("MD size: %d bytes\n"+
 		"MD version: %s\n\n", len(serializedBRMD), brmd.Version())
-	s += c.Sdump(brmdCopy)
+	s += dumpConfig().Sdump(brmdCopy)
 	return s, nil
 }

--- a/libkbfs/block_id.go
+++ b/libkbfs/block_id.go
@@ -6,7 +6,6 @@ package libkbfs
 
 import (
 	"encoding"
-	"encoding/json"
 
 	"github.com/keybase/kbfs/kbfshash"
 )
@@ -19,8 +18,8 @@ type BlockID struct {
 var _ encoding.BinaryMarshaler = BlockID{}
 var _ encoding.BinaryUnmarshaler = (*BlockID)(nil)
 
-var _ json.Marshaler = BlockID{}
-var _ json.Unmarshaler = (*BlockID)(nil)
+var _ encoding.TextMarshaler = BlockID{}
+var _ encoding.TextUnmarshaler = (*BlockID)(nil)
 
 // MaxBlockIDStringLength is the maximum length of the string
 // representation of a BlockID.
@@ -65,14 +64,14 @@ func (id *BlockID) UnmarshalBinary(data []byte) error {
 	return id.h.UnmarshalBinary(data)
 }
 
-// MarshalJSON implements the encoding.json.Marshaler interface for
+// MarshalText implements the encoding.TextMarshaler interface for
 // BlockID.
-func (id BlockID) MarshalJSON() ([]byte, error) {
-	return id.h.MarshalJSON()
+func (id BlockID) MarshalText() ([]byte, error) {
+	return id.h.MarshalText()
 }
 
-// UnmarshalJSON implements the encoding.json.Unmarshaler interface
+// UnmarshalText implements the encoding.TextUnmarshaler interface
 // for BlockID.
-func (id *BlockID) UnmarshalJSON(buf []byte) error {
-	return id.h.UnmarshalJSON(buf)
+func (id *BlockID) UnmarshalText(buf []byte) error {
+	return id.h.UnmarshalText(buf)
 }

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -114,7 +114,9 @@ func expectBlockEncrypt(config *ConfigMock, kmd KeyMetadata, decData Block, plai
 		kbfscrypto.TLFCryptKey{}).Return(
 		kbfscrypto.BlockCryptKey{}, nil)
 	encryptedBlock := EncryptedBlock{
-		EncryptedData: encData,
+		encryptedData{
+			EncryptedData: encData,
+		},
 	}
 	config.mockCrypto.EXPECT().EncryptBlock(decData,
 		kbfscrypto.BlockCryptKey{}).

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -292,8 +292,7 @@ func makeBlockReference(id BlockID, context BlockContext) keybase1.BlockReferenc
 // Get implements the BlockServer interface for BlockServerRemote.
 func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id BlockID,
 	context BlockContext) (
-	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	var err error
+	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	size := -1
 	defer func() {
 		if err != nil {
@@ -318,18 +317,17 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id BlockID,
 	}
 
 	size = len(res.Buf)
-	bk, err := kbfscrypto.ParseBlockCryptKeyServerHalf(res.BlockKey)
+	serverHalf, err = kbfscrypto.ParseBlockCryptKeyServerHalf(res.BlockKey)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}
-	return res.Buf, bk, nil
+	return res.Buf, serverHalf, nil
 }
 
 // Put implements the BlockServer interface for BlockServerRemote.
 func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id BlockID,
 	context BlockContext, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
-	var err error
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
 	size := len(buf)
 	defer func() {
 		if err != nil {
@@ -358,8 +356,7 @@ func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id BlockID,
 
 // AddBlockReference implements the BlockServer interface for BlockServerRemote
 func (b *BlockServerRemote) AddBlockReference(ctx context.Context, tlfID tlf.ID,
-	id BlockID, context BlockContext) error {
-	var err error
+	id BlockID, context BlockContext) (err error) {
 	defer func() {
 		if err != nil {
 			b.deferLog.CWarningf(

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -84,9 +84,11 @@ func (fc FakeCryptoClient) Call(ctx context.Context, s string, args interface{},
 		publicKey := kbfscrypto.MakeTLFEphemeralPublicKey(
 			arg.PeersPublicKey)
 		encryptedClientHalf := EncryptedTLFCryptKeyClientHalf{
-			Version:       EncryptionSecretbox,
-			EncryptedData: arg.EncryptedBytes32[:],
-			Nonce:         arg.Nonce[:],
+			encryptedData{
+				Version:       EncryptionSecretbox,
+				EncryptedData: arg.EncryptedBytes32[:],
+				Nonce:         arg.Nonce[:],
+			},
 		}
 		clientHalf, err := fc.Local.DecryptTLFCryptKeyClientHalf(
 			context.Background(), publicKey, encryptedClientHalf)
@@ -107,9 +109,11 @@ func (fc FakeCryptoClient) Call(ctx context.Context, s string, args interface{},
 			ePublicKey := kbfscrypto.MakeTLFEphemeralPublicKey(
 				k.PublicKey)
 			encryptedClientHalf := EncryptedTLFCryptKeyClientHalf{
-				Version:       EncryptionSecretbox,
-				EncryptedData: make([]byte, len(k.Ciphertext)),
-				Nonce:         make([]byte, len(k.Nonce)),
+				encryptedData{
+					Version:       EncryptionSecretbox,
+					EncryptedData: make([]byte, len(k.Ciphertext)),
+					Nonce:         make([]byte, len(k.Nonce)),
+				},
 			}
 			copy(encryptedClientHalf.EncryptedData, k.Ciphertext[:])
 			copy(encryptedClientHalf.Nonce, k.Nonce[:])
@@ -218,11 +222,13 @@ func TestCryptoClientDecryptTLFCryptKeyClientHalfBoxSeal(t *testing.T) {
 
 	clientHalfData := clientHalf.Data()
 	ephPrivateKeyData := ephPrivateKey.Data()
-	encryptedData := box.Seal(nil, clientHalfData[:], &nonce, (*[32]byte)(&dhKeyPair.Public), &ephPrivateKeyData)
+	encryptedBytes := box.Seal(nil, clientHalfData[:], &nonce, (*[32]byte)(&dhKeyPair.Public), &ephPrivateKeyData)
 	encryptedClientHalf := EncryptedTLFCryptKeyClientHalf{
-		Version:       EncryptionSecretbox,
-		Nonce:         nonce[:],
-		EncryptedData: encryptedData,
+		encryptedData{
+			Version:       EncryptionSecretbox,
+			Nonce:         nonce[:],
+			EncryptedData: encryptedBytes,
+		},
 	}
 
 	decryptedClientHalf, err := c.DecryptTLFCryptKeyClientHalf(

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -282,12 +282,14 @@ func (c CryptoCommon) EncryptTLFCryptKeyClientHalf(
 
 	clientHalfData := clientHalf.Data()
 	privateKeyData := privateKey.Data()
-	encryptedData := box.Seal(nil, clientHalfData[:], &nonce, (*[32]byte)(&dhKeyPair.Public), &privateKeyData)
+	encryptedBytes := box.Seal(nil, clientHalfData[:], &nonce, (*[32]byte)(&dhKeyPair.Public), &privateKeyData)
 
 	encryptedClientHalf = EncryptedTLFCryptKeyClientHalf{
-		Version:       EncryptionSecretbox,
-		Nonce:         nonce[:],
-		EncryptedData: encryptedData,
+		encryptedData{
+			Version:       EncryptionSecretbox,
+			Nonce:         nonce[:],
+			EncryptedData: encryptedBytes,
+		},
 	}
 	return
 }
@@ -322,7 +324,7 @@ func (c CryptoCommon) EncryptPrivateMetadata(
 		return
 	}
 
-	encryptedPmd = EncryptedPrivateMetadata(encryptedData)
+	encryptedPmd = EncryptedPrivateMetadata{encryptedData}
 	return
 }
 
@@ -349,7 +351,7 @@ func (c CryptoCommon) decryptData(encryptedData encryptedData, key [32]byte) ([]
 func (c CryptoCommon) DecryptPrivateMetadata(
 	encryptedPmd EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (
 	PrivateMetadata, error) {
-	encodedPmd, err := c.decryptData(encryptedData(encryptedPmd), key.Data())
+	encodedPmd, err := c.decryptData(encryptedPmd.encryptedData, key.Data())
 	if err != nil {
 		return PrivateMetadata{}, err
 	}
@@ -452,7 +454,7 @@ func (c CryptoCommon) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (
 	}
 
 	plainSize = len(encodedBlock)
-	encryptedBlock = EncryptedBlock(encryptedData)
+	encryptedBlock = EncryptedBlock{encryptedData}
 	return
 }
 
@@ -460,7 +462,7 @@ func (c CryptoCommon) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (
 func (c CryptoCommon) DecryptBlock(
 	encryptedBlock EncryptedBlock, key kbfscrypto.BlockCryptKey,
 	block Block) error {
-	paddedBlock, err := c.decryptData(encryptedData(encryptedBlock), key.Data())
+	paddedBlock, err := c.decryptData(encryptedBlock.encryptedData, key.Data())
 	if err != nil {
 		return err
 	}
@@ -566,7 +568,7 @@ func (c CryptoCommon) EncryptTLFCryptKeys(
 		return
 	}
 
-	encryptedKeys = EncryptedTLFCryptKeys(encryptedData)
+	encryptedKeys = EncryptedTLFCryptKeys{encryptedData}
 	return
 }
 
@@ -574,7 +576,7 @@ func (c CryptoCommon) EncryptTLFCryptKeys(
 func (c CryptoCommon) DecryptTLFCryptKeys(
 	encKeys EncryptedTLFCryptKeys, key kbfscrypto.TLFCryptKey) (
 	[]kbfscrypto.TLFCryptKey, error) {
-	encodedKeys, err := c.decryptData(encryptedData(encKeys), key.Data())
+	encodedKeys, err := c.decryptData(encKeys.encryptedData, key.Data())
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -460,7 +460,7 @@ func TestEncryptPrivateMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	encodedPrivateMetadata := checkSecretboxOpen(t, encryptedData(encryptedPrivateMetadata), cryptKey.Data())
+	encodedPrivateMetadata := checkSecretboxOpen(t, encryptedPrivateMetadata.encryptedData, cryptKey.Data())
 
 	if string(encodedPrivateMetadata) != string(expectedEncodedPrivateMetadata) {
 		t.Fatalf("Expected encoded data %v, got %v", expectedEncodedPrivateMetadata, encodedPrivateMetadata)
@@ -507,7 +507,7 @@ func TestDecryptPrivateMetadataSecretboxSeal(t *testing.T) {
 		TLFPrivateKey: tlfPrivateKey,
 	}
 
-	encryptedPrivateMetadata := EncryptedPrivateMetadata(secretboxSeal(t, &c, privateMetadata, cryptKey.Data()))
+	encryptedPrivateMetadata := EncryptedPrivateMetadata{secretboxSeal(t, &c, privateMetadata, cryptKey.Data())}
 
 	decryptedPrivateMetadata, err := c.DecryptPrivateMetadata(encryptedPrivateMetadata, cryptKey)
 	if err != nil {
@@ -623,10 +623,10 @@ func TestDecryptPrivateMetadataFailures(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkDecryptionFailures(t, encryptedData(encryptedPrivateMetadata), cryptKey,
+	checkDecryptionFailures(t, encryptedPrivateMetadata.encryptedData, cryptKey,
 		func(encryptedData encryptedData, key interface{}) error {
 			_, err = c.DecryptPrivateMetadata(
-				EncryptedPrivateMetadata(encryptedData),
+				EncryptedPrivateMetadata{encryptedData},
 				key.(kbfscrypto.TLFCryptKey))
 			return err
 		},
@@ -672,7 +672,7 @@ func TestEncryptBlock(t *testing.T) {
 		t.Errorf("Expected plain size %d, got %d", len(expectedEncodedBlock), plainSize)
 	}
 
-	paddedBlock := checkSecretboxOpen(t, encryptedData(encryptedBlock), cryptKey.Data())
+	paddedBlock := checkSecretboxOpen(t, encryptedBlock.encryptedData, cryptKey.Data())
 	encodedBlock, err := c.depadBlock(paddedBlock)
 	if err != nil {
 		t.Fatal(err)
@@ -702,7 +702,7 @@ func TestDecryptBlockSecretboxSeal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	encryptedBlock := EncryptedBlock(secretboxSealEncoded(t, &c, paddedBlock, cryptKey.Data()))
+	encryptedBlock := EncryptedBlock{secretboxSealEncoded(t, &c, paddedBlock, cryptKey.Data())}
 
 	var decryptedBlock TestBlock
 	err = c.DecryptBlock(encryptedBlock, cryptKey, &decryptedBlock)
@@ -753,11 +753,11 @@ func TestDecryptBlockFailures(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkDecryptionFailures(t, encryptedData(encryptedBlock), cryptKey,
+	checkDecryptionFailures(t, encryptedBlock.encryptedData, cryptKey,
 		func(encryptedData encryptedData, key interface{}) error {
 			var dummy TestBlock
 			return c.DecryptBlock(
-				EncryptedBlock(encryptedData),
+				EncryptedBlock{encryptedData},
 				key.(kbfscrypto.BlockCryptKey), &dummy)
 		},
 		func(key interface{}) interface{} {

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -266,6 +266,9 @@ func (c BlockContext) IsFirstRef() bool {
 }
 
 func (c BlockContext) String() string {
+	if c == (BlockContext{}) {
+		return "BlockContext{}"
+	}
 	s := fmt.Sprintf("BlockContext{Creator: %s", c.Creator)
 	if len(c.Writer) > 0 {
 		s += fmt.Sprintf(", Writer: %s", c.Writer)
@@ -302,6 +305,9 @@ func (p BlockPointer) IsValid() bool {
 }
 
 func (p BlockPointer) String() string {
+	if p == (BlockPointer{}) {
+		return "BlockPointer{}"
+	}
 	return fmt.Sprintf("BlockPointer{ID: %s, KeyGen: %d, DataVer: %d, Context: %s}", p.ID, p.KeyGen, p.DataVer, p.BlockContext)
 }
 
@@ -333,6 +339,9 @@ type BlockInfo struct {
 }
 
 func (bi BlockInfo) String() string {
+	if bi == (BlockInfo{}) {
+		return "BlockInfo{}"
+	}
 	return fmt.Sprintf("BlockInfo{BlockPointer: %s, EncodedSize: %d}",
 		bi.BlockPointer, bi.EncodedSize)
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -65,6 +65,15 @@ const (
 	EncryptionSecretbox EncryptionVer = 1
 )
 
+func (v EncryptionVer) String() string {
+	switch v {
+	case EncryptionSecretbox:
+		return "EncryptionSecretbox"
+	default:
+		return fmt.Sprintf("EncryptionVer(%d)", v)
+	}
+}
+
 // encryptedData is encrypted data with a nonce and a version.
 type encryptedData struct {
 	// Exported only for serialization purposes. Should only be
@@ -74,18 +83,35 @@ type encryptedData struct {
 	Nonce         []byte        `codec:"n"`
 }
 
+func (ed encryptedData) String() string {
+	if reflect.DeepEqual(ed, encryptedData{}) {
+		return "EncryptedData{}"
+	}
+	return fmt.Sprintf("%s{data=%s, nonce=%s}",
+		ed.Version, hex.EncodeToString(ed.EncryptedData),
+		hex.EncodeToString(ed.Nonce))
+}
+
 // EncryptedTLFCryptKeyClientHalf is an encrypted
-// TLFCryptKeyCLientHalf object.
-type EncryptedTLFCryptKeyClientHalf encryptedData
+// TLFCryptKeyClientHalf object.
+type EncryptedTLFCryptKeyClientHalf struct {
+	encryptedData
+}
 
 // EncryptedPrivateMetadata is an encrypted PrivateMetadata object.
-type EncryptedPrivateMetadata encryptedData
+type EncryptedPrivateMetadata struct {
+	encryptedData
+}
 
 // EncryptedBlock is an encrypted Block.
-type EncryptedBlock encryptedData
+type EncryptedBlock struct {
+	encryptedData
+}
 
 // EncryptedTLFCryptKeys is an encrypted TLFCryptKey array.
-type EncryptedTLFCryptKeys encryptedData
+type EncryptedTLFCryptKeys struct {
+	encryptedData
+}
 
 // EncryptedMerkleLeaf is an encrypted Merkle leaf.
 type EncryptedMerkleLeaf struct {

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1013,26 +1013,18 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 		default:
 		}
 
+		// Let all the workers go through.
 		cancel2()
 	}()
 
 	err = kbfsOps.Sync(ctx2, fileNode)
-	if err != context.Canceled {
+	if err != ctx2.Err() {
 		t.Errorf("Sync did not get canceled error: %v", err)
 	}
 	nowNBlocks := fc.numBlocks()
 	if nowNBlocks != prevNBlocks+2 {
 		t.Errorf("Unexpected number of blocks; prev = %d, now = %d",
 			prevNBlocks, nowNBlocks)
-	}
-
-	// Now clean up by letting the rest of the blocks through.
-	for i := 0; i < maxParallelBlockPuts; i++ {
-		select {
-		case <-finishChan:
-		case <-ctx.Done():
-			t.Fatal(ctx.Err())
-		}
 	}
 
 	// Make sure there are no more workers, i.e. the extra blocks

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1037,9 +1037,14 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 
 	// As a regression for KBFS-635, test that a second sync succeeds,
 	// and that future operations also succeed.
-	fc.readyChan = nil
-	fc.goChan = nil
-	fc.finishChan = nil
+	//
+	// Create new objects to avoid racing with goroutines from the
+	// first sync.
+	fc = NewFakeBServerClient(config.Crypto(), log, nil, nil, nil)
+	b = newBlockServerRemoteWithClient(
+		config.Codec(), config.KBPKI(), log, fc)
+	config.BlockServer().Shutdown()
+	config.SetBlockServer(b)
 	if err := kbfsOps.Sync(ctx, fileNode); err != nil {
 		t.Fatalf("Second sync failed: %v", err)
 	}

--- a/libkbfs/key_bundle_test.go
+++ b/libkbfs/key_bundle_test.go
@@ -36,9 +36,11 @@ func makeFakeTLFCryptKeyInfoFuture(t *testing.T) tlfCryptKeyInfoFuture {
 	require.NoError(t, err)
 	cki := TLFCryptKeyInfo{
 		EncryptedTLFCryptKeyClientHalf{
-			EncryptionSecretbox,
-			[]byte("fake encrypted data"),
-			[]byte("fake nonce"),
+			encryptedData{
+				EncryptionSecretbox,
+				[]byte("fake encrypted data"),
+				[]byte("fake nonce"),
+			},
 		},
 		TLFCryptKeyServerHalfID{hmac},
 		5,

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -83,6 +83,20 @@ type PrivateMetadata struct {
 	cachedChanges BlockChanges
 }
 
+// DumpPrivateMetadata returns a detailed dump of the given
+// PrivateMetadata's contents.
+func DumpPrivateMetadata(
+	codec kbfscodec.Codec, pmd PrivateMetadata) (string, error) {
+	serializedPMD, err := codec.Encode(pmd)
+	if err != nil {
+		return "", err
+	}
+
+	s := fmt.Sprintf("Size: %d bytes\n", len(serializedPMD))
+	s += dumpConfig().Sdump(pmd)
+	return s, nil
+}
+
 func (p PrivateMetadata) checkValid() error {
 	for i, op := range p.Changes.Ops {
 		err := op.checkValid()
@@ -96,6 +110,38 @@ func (p PrivateMetadata) checkValid() error {
 // ChangesBlockInfo returns the block info for any unembedded changes.
 func (p PrivateMetadata) ChangesBlockInfo() BlockInfo {
 	return p.cachedChanges.Info
+}
+
+// ExtraMetadata is a per-version blob of extra metadata which may
+// exist outside of the given metadata block, e.g. key bundles for
+// post-v2 metadata.
+type ExtraMetadata interface {
+	MetadataVersion() MetadataVer
+	DeepCopy(kbfscodec.Codec) (ExtraMetadata, error)
+	MakeSuccessorCopy(kbfscodec.Codec) (ExtraMetadata, error)
+}
+
+// DumpExtraMetadata returns a detailed dump of the given
+// ExtraMetadata's contents.
+func DumpExtraMetadata(
+	codec kbfscodec.Codec, extra ExtraMetadata) (string, error) {
+	var s string
+	switch extra := extra.(type) {
+	case *ExtraMetadataV3:
+		serializedWKB, err := codec.Encode(extra.GetWriterKeyBundle())
+		if err != nil {
+			return "", err
+		}
+		serializedRKB, err := codec.Encode(extra.GetReaderKeyBundle())
+		if err != nil {
+			return "", err
+		}
+		s = fmt.Sprintf("WKB size: %d\nRKB size: %d\n",
+			len(serializedWKB), len(serializedRKB))
+	}
+
+	s += dumpConfig().Sdump(extra)
+	return s, nil
 }
 
 // A RootMetadata is a BareRootMetadata but with a deserialized

--- a/tlf/id.go
+++ b/tlf/id.go
@@ -70,12 +70,12 @@ func (id *ID) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the encoding.TextMarshaler interface for ID.
+// MarshalText implements the encoding.TextMarshaler interface for ID.
 func (id ID) MarshalText() ([]byte, error) {
 	return []byte(id.String()), nil
 }
 
-// UnmarshalJSON implements the encoding.TextUnmarshaler interface for
+// UnmarshalText implements the encoding.TextUnmarshaler interface for
 // ID.
 func (id *ID) UnmarshalText(buf []byte) error {
 	newID, err := ParseID(string(buf))

--- a/tlf/id.go
+++ b/tlf/id.go
@@ -7,7 +7,6 @@ package tlf
 import (
 	"encoding"
 	"encoding/hex"
-	"encoding/json"
 
 	"github.com/keybase/kbfs/kbfscrypto"
 )
@@ -32,8 +31,8 @@ type ID struct {
 var _ encoding.BinaryMarshaler = ID{}
 var _ encoding.BinaryUnmarshaler = (*ID)(nil)
 
-var _ json.Marshaler = ID{}
-var _ json.Unmarshaler = (*ID)(nil)
+var _ encoding.TextMarshaler = ID{}
+var _ encoding.TextUnmarshaler = (*ID)(nil)
 
 // NullID is an empty ID
 var NullID = ID{}
@@ -71,21 +70,15 @@ func (id *ID) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the encoding.json.Marshaler interface for
-// ID.
-func (id ID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(id.String())
+// MarshalJSON implements the encoding.TextMarshaler interface for ID.
+func (id ID) MarshalText() ([]byte, error) {
+	return []byte(id.String()), nil
 }
 
-// UnmarshalJSON implements the encoding.json.Unmarshaler interface
-// for ID.
-func (id *ID) UnmarshalJSON(buf []byte) error {
-	var str string
-	err := json.Unmarshal(buf, &str)
-	if err != nil {
-		return err
-	}
-	newID, err := ParseID(str)
+// UnmarshalJSON implements the encoding.TextUnmarshaler interface for
+// ID.
+func (id *ID) UnmarshalText(buf []byte) error {
+	newID, err := ParseID(string(buf))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of manually writing prints, use
the spew library, which we already vendor
anyway, to add various Dump* functions.

Add String() methods to some types, and
clean up some existing String() methods.

Make distinction between publicByte32Container
and privateByte32Container, to avoid
inadvertently dumping/logging sensitive
data.

Make things implement
encoding.Text{M,Unm}arshaler instead of
json.{M,Unm}arshaller.

Also annotate dump with user names and
device names.