### PR TITLE
Make MDOps use errgroup.WithContext

### DIFF
--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2019,7 +2019,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 		defer ops.mdWriterLock.Unlock(lState)
 
 		// Now cause a paper prompt unlock via a folder access
-		errCh := make(chan error)
+		errCh := make(chan error, 1)
 		go func() {
 			_, err := GetRootNodeForTest(ctx, config2Dev2, name, false)
 			select {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
 )
 
 // MDOpsStandard provides plaintext RootMetadata objects to upper
@@ -370,61 +371,43 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 		return nil, nil
 	}
 
-	var wg sync.WaitGroup
-	numWorkers := len(rmdses)
-	if numWorkers > maxMDsAtATime {
-		numWorkers = maxMDsAtATime
-	}
-	wg.Add(numWorkers)
+	var eg errgroup.Group
 
 	// Parallelize the MD decryption, because it could involve
 	// fetching blocks to get unembedded block changes.
 	rmdsChan := make(chan *RootMetadataSigned, len(rmdses))
 	irmdChan := make(chan ImmutableRootMetadata, len(rmdses))
-	errChan := make(chan error, 1)
 	var getRangeLock sync.Mutex
-	worker := func() {
-		defer wg.Done()
+	worker := func() error {
 		for rmds := range rmdsChan {
 			extra, err := md.getExtraMD(ctx, rmds.MD)
 			if err != nil {
-				select {
-				case errChan <- err:
-				default:
-				}
-				return
+				return err
 			}
 			bareHandle, err := rmds.MD.MakeBareTlfHandle(extra)
 			if err != nil {
-				select {
-				case errChan <- err:
-				default:
-				}
-				return
+				return err
 			}
 			handle, err := MakeTlfHandle(ctx, bareHandle, md.config.KBPKI())
 			if err != nil {
-				select {
-				case errChan <- err:
-				default:
-				}
-				return
+				return err
 			}
 			irmd, err := md.processMetadataWithID(ctx, id, bid,
 				handle, rmds, extra, &getRangeLock)
 			if err != nil {
-				select {
-				case errChan <- err:
-				default:
-				}
-				return
+				return err
 			}
 			irmdChan <- irmd
 		}
+		return nil
 	}
 
+	numWorkers := len(rmdses)
+	if numWorkers > maxMDsAtATime {
+		numWorkers = maxMDsAtATime
+	}
 	for i := 0; i < numWorkers; i++ {
-		go worker()
+		eg.Go(worker)
 	}
 
 	// Do this first, since processMetadataWithID consumes its
@@ -437,15 +420,11 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 	}
 	close(rmdsChan)
 	rmdses = nil
-	go func() {
-		wg.Wait()
-		close(errChan)
-		close(irmdChan)
-	}()
-	err := <-errChan
+	err := eg.Wait()
 	if err != nil {
 		return nil, err
 	}
+	close(irmdChan)
 
 	// Sort into slice based on revision.
 	irmds := make([]ImmutableRootMetadata, rmdsCount)


### PR DESCRIPTION
Also fix a possible goroutine leak in key_manager_test.go.