### PR TITLE
reporter_kbpki: set filename for read timeout errors

### DIFF
--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -159,6 +159,8 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 
 	if code < 0 && err == context.DeadlineExceeded {
 		code = keybase1.FSErrorType_TIMEOUT
+		// Workaround for DESKTOP-2442
+		filename = string(tlfName)
 	}
 
 	if code >= 0 {


### PR DESCRIPTION
To workaround DESKTOP-2442.

Issue: KBFS-1795