### PR TITLE
errors_fuse: give EACCES code for MetadataIsFinal error

### DIFF
--- a/libkbfs/errors_fuse.go
+++ b/libkbfs/errors_fuse.go
@@ -44,6 +44,14 @@ func (e WriteAccessError) Errno() fuse.Errno {
 	return fuse.Errno(syscall.EACCES)
 }
 
+var _ fuse.ErrorNumber = MetadataIsFinalError{}
+
+// Errno implements the fuse.ErrorNumber interface for
+// MetadataIsFinalError.
+func (e MetadataIsFinalError) Errno() fuse.Errno {
+	return fuse.Errno(syscall.EACCES)
+}
+
 var _ fuse.ErrorNumber = WriteUnsupportedError{}
 
 // Errno implements the fuse.ErrorNumber interface for


### PR DESCRIPTION
It's confusing to get an EIO error when trying to write to a finalized
TLF.

Issue: KBFS-1800