### PR TITLE
Fix intermittent hang in MDServerDisk

### DIFF
--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -545,7 +545,7 @@ func (md *MDServerDisk) copy(config mdServerLocalConfig) mdServerLocal {
 func (md *MDServerDisk) isShutdown() bool {
 	md.lock.RLock()
 	defer md.lock.RUnlock()
-	return md.handleDb == nil
+	return md.checkShutdownLocked() != nil
 }
 
 // DisableRekeyUpdatesForTesting implements the MDServer interface.

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -643,13 +643,6 @@ func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
 func (md *MDServerDisk) GetKeyBundles(_ context.Context,
 	tlfID tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	md.lock.RLock()
-	defer md.lock.RUnlock()
-	err := md.checkShutdownLocked()
-	if err != nil {
-		return nil, nil, err
-	}
-
 	tlfStorage, err := md.getStorage(tlfID)
 	if err != nil {
 		return nil, nil, err

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -664,7 +664,7 @@ func (md *MDServerMemory) copy(config mdServerLocalConfig) mdServerLocal {
 func (md *MDServerMemory) isShutdown() bool {
 	md.lock.RLock()
 	defer md.lock.RUnlock()
-	return md.handleDb == nil
+	return md.checkShutdownLocked() != nil
 }
 
 // DisableRekeyUpdatesForTesting implements the MDServer interface.


### PR DESCRIPTION
GetExtraBundles was RLocking or Locking while
already RLocked, which only hangs intermittently.
This was actually present for a while, since
4c7a78 (Oct. 21), but only presented since we
started testing with MDv3.

Also make isShutdown delegate to
checkShutdownLocked.