### PR TITLE
Parametrize DSL tests over MetadataVer

### DIFF
--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -24,7 +24,8 @@ var testMetadataVers = []MetadataVer{
 }
 
 // runTestOverMetadataVers runs the given test function over all
-// metadata versions to test. Example use:
+// metadata versions to test. The test is assumed to be parallelizable
+// with other instances of itself. Example use:
 //
 // func TestFoo(t *testing.T) {
 //	runTestOverMetadataVers(t, testFoo)
@@ -40,6 +41,7 @@ func runTestOverMetadataVers(
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
+			t.Parallel()
 			f(t, ver)
 		})
 	}

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -40,7 +40,7 @@ func runTestOverMetadataVers(
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
-p			f(t, ver)
+			f(t, ver)
 		})
 	}
 }

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -19,10 +19,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testMetadataVers = []MetadataVer{
-	InitialExtraMetadataVer, SegregatedKeyBundlesVer,
-}
-
 // runTestOverMetadataVers runs the given test function over all
 // metadata versions to test. Example use:
 //
@@ -37,7 +33,7 @@ var testMetadataVers = []MetadataVer{
 // }
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver MetadataVer)) {
-	for _, ver := range testMetadataVers {
+	for _, ver := range GetTestMetadataVers() {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
 			f(t, ver)
@@ -90,7 +86,7 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 // }
 func runBenchmarkOverMetadataVers(
 	b *testing.B, f func(b *testing.B, ver MetadataVer)) {
-	for _, ver := range testMetadataVers {
+	for _, ver := range GetTestMetadataVers() {
 		ver := ver // capture range variable.
 		b.Run(ver.String(), func(b *testing.B) {
 			f(b, ver)

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -40,7 +40,7 @@ func runTestOverMetadataVers(
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
-			f(t, ver)
+p			f(t, ver)
 		})
 	}
 }

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var testMetadataVers = []MetadataVer{
+	InitialExtraMetadataVer, SegregatedKeyBundlesVer,
+}
+
 // runTestOverMetadataVers runs the given test function over all
 // metadata versions to test. Example use:
 //
@@ -33,7 +37,7 @@ import (
 // }
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver MetadataVer)) {
-	for _, ver := range GetTestMetadataVers() {
+	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
 			f(t, ver)
@@ -86,7 +90,7 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 // }
 func runBenchmarkOverMetadataVers(
 	b *testing.B, f func(b *testing.B, ver MetadataVer)) {
-	for _, ver := range GetTestMetadataVers() {
+	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		b.Run(ver.String(), func(b *testing.B) {
 			f(b, ver)

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -183,12 +183,6 @@ func (v MetadataVer) String() string {
 	}
 }
 
-// GetTestMetadataVers returns the MetadataVers that should be used
-// for testing.
-func GetTestMetadataVers() []MetadataVer {
-	return []MetadataVer{InitialExtraMetadataVer, SegregatedKeyBundlesVer}
-}
-
 // DataVer is the type of a version for marshalled KBFS data
 // structures.
 type DataVer int

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -183,6 +183,12 @@ func (v MetadataVer) String() string {
 	}
 }
 
+// GetTestMetadataVers returns the MetadataVers that should be used
+// for testing.
+func GetTestMetadataVers() []MetadataVer {
+	return []MetadataVer{InitialExtraMetadataVer, SegregatedKeyBundlesVer}
+}
+
 // DataVer is the type of a version for marshalled KBFS data
 // structures.
 type DataVer int

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"math/rand"
 	"sync"
 
 	"github.com/keybase/kbfs/kbfsblock"
@@ -287,11 +288,12 @@ func StallMDOp(ctx context.Context, config Config, stalledOp StallableMDOp,
 	return onStalledCh, unstallCh, newCtx
 }
 
-var stallerCounter stallKeyType
-
 func newStallKey() stallKeyType {
-	stallerCounter++
-	return stallerCounter
+	stallKey := stallKeyStallEverything
+	for stallKey == stallKeyStallEverything {
+		stallKey = stallKeyType(rand.Int63())
+	}
+	return stallKey
 }
 
 // staller is a pair of channels. Whenever something is to be

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -48,7 +48,7 @@ func BenchmarkWrite1mb512k(b *testing.B) {
 func benchmarkWriteSeqN(b *testing.B, n int64, mask int64) {
 	buf := make([]byte, n)
 	b.SetBytes(n)
-	test(silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
@@ -101,7 +101,7 @@ func BenchmarkReadHole1mb512k(b *testing.B) {
 func benchmarkReadSeqHoleN(b *testing.B, n int64, mask int64) {
 	buf := make([]byte, n)
 	b.SetBytes(n)
-	test(silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
@@ -159,7 +159,7 @@ func benchmarkWriteWithBandwidthHelper(b *testing.B, fileBytes int64,
 	buf := make([]byte, perWriteBytes)
 	b.SetBytes(fileBytes)
 	numWritesPerFile := int(fileBytes / perWriteBytes)
-	test(silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		blockSize(512<<10),
 		bandwidth(writebwKBps),
@@ -231,7 +231,7 @@ func BenchmarkWriteMixedFilesNormalBandwidth(b *testing.B) {
 	}
 	b.SetBytes(totalSize)
 
-	test(silentBenchmark{b},
+	benchmark(b,
 		users("alice"),
 		blockSize(512<<10),
 		bandwidth(11*1024/8 /* 11 Mbps */),

--- a/test/benchmark_test.go
+++ b/test/benchmark_test.go
@@ -48,7 +48,7 @@ func BenchmarkWrite1mb512k(b *testing.B) {
 func benchmarkWriteSeqN(b *testing.B, n int64, mask int64) {
 	buf := make([]byte, n)
 	b.SetBytes(n)
-	benchmark(b,
+	benchmark(b, silentBenchmark{b},
 		users("alice"),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
@@ -101,7 +101,7 @@ func BenchmarkReadHole1mb512k(b *testing.B) {
 func benchmarkReadSeqHoleN(b *testing.B, n int64, mask int64) {
 	buf := make([]byte, n)
 	b.SetBytes(n)
-	benchmark(b,
+	benchmark(b, silentBenchmark{b},
 		users("alice"),
 		as(alice,
 			custom(func(cb func(fileOp) error) error {
@@ -159,7 +159,7 @@ func benchmarkWriteWithBandwidthHelper(b *testing.B, fileBytes int64,
 	buf := make([]byte, perWriteBytes)
 	b.SetBytes(fileBytes)
 	numWritesPerFile := int(fileBytes / perWriteBytes)
-	benchmark(b,
+	benchmark(b, silentBenchmark{b},
 		users("alice"),
 		blockSize(512<<10),
 		bandwidth(writebwKBps),
@@ -231,7 +231,7 @@ func BenchmarkWriteMixedFilesNormalBandwidth(b *testing.B) {
 	}
 	b.SetBytes(totalSize)
 
-	benchmark(b,
+	benchmark(b, silentBenchmark{b},
 		users("alice"),
 		blockSize(512<<10),
 		bandwidth(11*1024/8 /* 11 Mbps */),

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -53,6 +53,12 @@ type opt struct {
 // libkbfs/bare_root_metadata_test.go, so as to avoid having libkbfs
 // depend on testing.
 
+// Also copy testMetadataVers, so that we can set it independently
+// from libkbfs tests.
+var testMetadataVers = []libkbfs.MetadataVer{
+	libkbfs.InitialExtraMetadataVer, libkbfs.SegregatedKeyBundlesVer,
+}
+
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver libkbfs.MetadataVer)) {
 	for _, ver := range libkbfs.GetTestMetadataVers() {

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -58,6 +58,7 @@ func runTestOverMetadataVers(
 	for _, ver := range libkbfs.GetTestMetadataVers() {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
+			t.Parallel()
 			f(t, ver)
 		})
 	}

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -73,7 +73,8 @@ func runBenchmarkOverMetadataVers(
 	}
 }
 
-func runOneTestOrBenchmar(t testing.TB, actions ...optionOp) {
+func runOneTestOrBenchmark(
+	tb testing.TB, ver libkbfs.MetadataVer, actions ...optionOp) {
 	o := &opt{}
 	o.engine = createEngine(tb, ver)
 	o.engine.Init()
@@ -86,14 +87,14 @@ func runOneTestOrBenchmar(t testing.TB, actions ...optionOp) {
 
 func test(t *testing.T, actions ...optionOp) {
 	runTestOverMetadataVers(t, func(t *testing.T, ver libkbfs.MetadataVer) {
-		runOneTestOrBenchmark(t, actions...)
+		runOneTestOrBenchmark(t, ver, actions...)
 	})
 }
 
 func benchmark(b *testing.B, tb testing.TB, actions ...optionOp) {
 	runBenchmarkOverMetadataVers(
 		b, func(b *testing.B, ver libkbfs.MetadataVer) {
-			runOneTestOrBenchmark(tb, actions...)
+			runOneTestOrBenchmark(tb, ver, actions...)
 		})
 }
 

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -75,9 +75,8 @@ func runBenchmarkOverMetadataVers(
 
 func test(t *testing.T, actions ...optionOp) {
 	runTestOverMetadataVers(t, func(t *testing.T, ver libkbfs.MetadataVer) {
-		// TODO: Plumb through ver.
 		o := &opt{}
-		o.engine = createEngine(t)
+		o.engine = createEngine(t, ver)
 		o.engine.Init()
 		o.t = t
 		defer o.close()
@@ -89,9 +88,8 @@ func test(t *testing.T, actions ...optionOp) {
 
 func benchmark(b *testing.B, actions ...optionOp) {
 	runBenchmarkOverMetadataVers(b, func(b *testing.B, ver libkbfs.MetadataVer) {
-		// TODO: Plumb through ver.
 		o := &opt{}
-		o.engine = createEngine(b)
+		o.engine = createEngine(b, ver)
 		o.engine.Init()
 		o.t = b
 		defer o.close()

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -93,7 +93,6 @@ func runOneTestOrBenchmark(
 		tb:     tb,
 		engine: createEngine(tb),
 	}
-	o.engine.Init()
 	defer o.close()
 	for _, omod := range actions {
 		omod(o)

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -59,6 +59,9 @@ var testMetadataVers = []libkbfs.MetadataVer{
 	libkbfs.InitialExtraMetadataVer, libkbfs.SegregatedKeyBundlesVer,
 }
 
+// runTestOverMetadataVers runs the given test function over all
+// metadata versions to test. The test is assumed to be parallelizable
+// with other instances of itself.
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver libkbfs.MetadataVer)) {
 	for _, ver := range libkbfs.GetTestMetadataVers() {
@@ -70,6 +73,8 @@ func runTestOverMetadataVers(
 	}
 }
 
+// runBenchmarkOverMetadataVers runs the given benchmark function over
+// all metadata versions to test.
 func runBenchmarkOverMetadataVers(
 	b *testing.B, f func(b *testing.B, ver libkbfs.MetadataVer)) {
 	for _, ver := range libkbfs.GetTestMetadataVers() {

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -64,7 +64,7 @@ var testMetadataVers = []libkbfs.MetadataVer{
 // with other instances of itself.
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver libkbfs.MetadataVer)) {
-	for _, ver := range libkbfs.GetTestMetadataVers() {
+	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
 			t.Parallel()
@@ -77,7 +77,7 @@ func runTestOverMetadataVers(
 // all metadata versions to test.
 func runBenchmarkOverMetadataVers(
 	b *testing.B, f func(b *testing.B, ver libkbfs.MetadataVer)) {
-	for _, ver := range libkbfs.GetTestMetadataVers() {
+	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		b.Run(ver.String(), func(b *testing.B) {
 			f(b, ver)

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -49,13 +49,13 @@ type opt struct {
 	journal                  bool
 }
 
-var testMetadataVers = []libkbfs.MetadataVer{
-	libkbfs.InitialExtraMetadataVer, libkbfs.SegregatedKeyBundlesVer,
-}
+// run{Test,Benchmark}OverMetadataVers are copied from
+// libkbfs/bare_root_metadata_test.go, so as to avoid having libkbfs
+// depend on testing.
 
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver libkbfs.MetadataVer)) {
-	for _, ver := range testMetadataVers {
+	for _, ver := range libkbfs.GetTestMetadataVers() {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
 			f(t, ver)
@@ -65,7 +65,7 @@ func runTestOverMetadataVers(
 
 func runBenchmarkOverMetadataVers(
 	b *testing.B, f func(b *testing.B, ver libkbfs.MetadataVer)) {
-	for _, ver := range testMetadataVers {
+	for _, ver := range libkbfs.GetTestMetadataVers() {
 		ver := ver // capture range variable.
 		b.Run(ver.String(), func(b *testing.B) {
 			f(b, ver)

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -91,7 +91,7 @@ func runOneTestOrBenchmark(
 	o := &opt{
 		ver:    ver,
 		tb:     tb,
-		engine: createEngine(tb, ver),
+		engine: createEngine(tb),
 	}
 	o.engine.Init()
 	defer o.close()
@@ -167,8 +167,9 @@ func (o *opt) runInitOnce() {
 	o.initOnce.Do(func() {
 		o.clock = &libkbfs.TestClock{}
 		o.clock.Set(time.Unix(0, 0))
-		o.users = o.engine.InitTest(o.tb, o.blockSize, o.blockChangeSize,
-			o.bwKBps, o.timeout, o.usernames, o.clock, o.journal)
+		o.users = o.engine.InitTest(o.tb, o.ver, o.blockSize,
+			o.blockChangeSize, o.bwKBps, o.timeout, o.usernames,
+			o.clock, o.journal)
 		o.stallers = o.makeStallers()
 	})
 }

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -31,6 +31,7 @@ const (
 )
 
 type opt struct {
+	ver                      libkbfs.MetadataVer
 	usernames                []libkb.NormalizedUsername
 	tlfName                  string
 	expectedCanonicalTlfName string
@@ -87,10 +88,12 @@ func runBenchmarkOverMetadataVers(
 
 func runOneTestOrBenchmark(
 	tb testing.TB, ver libkbfs.MetadataVer, actions ...optionOp) {
-	o := &opt{}
-	o.engine = createEngine(tb, ver)
+	o := &opt{
+		ver:    ver,
+		t:      tb,
+		engine: createEngine(tb, ver),
+	}
 	o.engine.Init()
-	o.t = tb
 	defer o.close()
 	for _, omod := range actions {
 		omod(o)

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -167,7 +167,7 @@ func (o *opt) runInitOnce() {
 	o.initOnce.Do(func() {
 		o.clock = &libkbfs.TestClock{}
 		o.clock.Set(time.Unix(0, 0))
-		o.users = o.engine.InitTest(o.tb, o.ver, o.blockSize,
+		o.users = o.engine.InitTest(o.ver, o.blockSize,
 			o.blockChangeSize, o.bwKBps, o.timeout, o.usernames,
 			o.clock, o.journal)
 		o.stallers = o.makeStallers()

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -86,12 +86,12 @@ func test(t *testing.T, actions ...optionOp) {
 	})
 }
 
-func benchmark(b *testing.B, actions ...optionOp) {
+func benchmark(b *testing.B, tb testing.TB, actions ...optionOp) {
 	runBenchmarkOverMetadataVers(b, func(b *testing.B, ver libkbfs.MetadataVer) {
 		o := &opt{}
 		o.engine = createEngine(b, ver)
 		o.engine.Init()
-		o.t = b
+		o.t = tb
 		defer o.close()
 		for _, omod := range actions {
 			omod(o)

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -73,30 +73,28 @@ func runBenchmarkOverMetadataVers(
 	}
 }
 
+func runOneTestOrBenchmar(t testing.TB, actions ...optionOp) {
+	o := &opt{}
+	o.engine = createEngine(tb, ver)
+	o.engine.Init()
+	o.t = tb
+	defer o.close()
+	for _, omod := range actions {
+		omod(o)
+	}
+}
+
 func test(t *testing.T, actions ...optionOp) {
 	runTestOverMetadataVers(t, func(t *testing.T, ver libkbfs.MetadataVer) {
-		o := &opt{}
-		o.engine = createEngine(t, ver)
-		o.engine.Init()
-		o.t = t
-		defer o.close()
-		for _, omod := range actions {
-			omod(o)
-		}
+		runOneTestOrBenchmark(t, actions...)
 	})
 }
 
 func benchmark(b *testing.B, tb testing.TB, actions ...optionOp) {
-	runBenchmarkOverMetadataVers(b, func(b *testing.B, ver libkbfs.MetadataVer) {
-		o := &opt{}
-		o.engine = createEngine(b, ver)
-		o.engine.Init()
-		o.t = tb
-		defer o.close()
-		for _, omod := range actions {
-			omod(o)
-		}
-	})
+	runBenchmarkOverMetadataVers(
+		b, func(b *testing.B, ver libkbfs.MetadataVer) {
+			runOneTestOrBenchmark(tb, actions...)
+		})
 }
 
 func parallel(actions ...optionOp) optionOp {

--- a/test/engine.go
+++ b/test/engine.go
@@ -25,8 +25,6 @@ type username string
 type Engine interface {
 	// Name returns the name of the engine.
 	Name() string
-	// Init is called by the test harness once prior to using a KBFS interface implementation.
-	Init()
 	// InitTest is called by the test harness to initialize user
 	// instances and set up the configuration of the test.
 	// blockChange indicates the maximum size of each data block.

--- a/test/engine.go
+++ b/test/engine.go
@@ -5,7 +5,6 @@
 package test
 
 import (
-	"testing"
 	"time"
 
 	"github.com/keybase/client/go/libkb"
@@ -39,7 +38,7 @@ type Engine interface {
 	// second; if zero, the engine defaults are used.  opTimeout
 	// specifies a per-operation timeout; if it is more than the
 	// default engine timeout, or if it is zero, it has no effect.
-	InitTest(t testing.TB, ver libkbfs.MetadataVer, blockSize int64,
+	InitTest(ver libkbfs.MetadataVer, blockSize int64,
 		blockChangeSize int64, bwKBps int, opTimeout time.Duration,
 		users []libkb.NormalizedUsername, clock libkbfs.Clock,
 		journal bool) map[libkb.NormalizedUsername]User

--- a/test/engine.go
+++ b/test/engine.go
@@ -39,9 +39,10 @@ type Engine interface {
 	// second; if zero, the engine defaults are used.  opTimeout
 	// specifies a per-operation timeout; if it is more than the
 	// default engine timeout, or if it is zero, it has no effect.
-	InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
-		bwKBps int, opTimeout time.Duration, users []libkb.NormalizedUsername,
-		clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User
+	InitTest(t testing.TB, ver libkbfs.MetadataVer, blockSize int64,
+		blockChangeSize int64, bwKBps int, opTimeout time.Duration,
+		users []libkb.NormalizedUsername, clock libkbfs.Clock,
+		journal bool) map[libkb.NormalizedUsername]User
 	// GetUID is called by the test harness to retrieve a user instance's UID.
 	GetUID(u User) keybase1.UID
 	// GetFavorites returns the set of all public or private

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -31,6 +31,7 @@ type createUserFn func(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser
 
 type fsEngine struct {
+	ver        libkbfs.MetadataVer
 	name       string
 	t          testing.TB
 	createUser createUserFn

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -62,7 +62,7 @@ func (*fsEngine) Init() {}
 
 // Name returns the name of the Engine.
 func (e *fsEngine) Name() string {
-	return e.name
+	return fmt.Sprintf("%s(%s)", e.name, e.ver)
 }
 
 // GetUID is called by the test harness to retrieve a user instance's UID.

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -528,6 +528,7 @@ func (e *fsEngine) InitTest(t testing.TB, blockSize int64,
 
 	// create the first user specially
 	config0 := libkbfs.MakeTestConfigOrBust(t, users...)
+	config0.SetMetadataVersion(e.ver)
 	config0.SetClock(clock)
 
 	setBlockSizes(t, config0, blockSize, blockChangeSize)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -31,7 +31,6 @@ type createUserFn func(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser
 
 type fsEngine struct {
-	ver        libkbfs.MetadataVer
 	name       string
 	t          testing.TB
 	createUser createUserFn
@@ -62,7 +61,7 @@ func (*fsEngine) Init() {}
 
 // Name returns the name of the Engine.
 func (e *fsEngine) Name() string {
-	return fmt.Sprintf("%s(%s)", e.name, e.ver)
+	return e.name
 }
 
 // GetUID is called by the test harness to retrieve a user instance's UID.
@@ -506,9 +505,9 @@ func fiTypeString(fi os.FileInfo) string {
 	return "OTHER"
 }
 
-func (e *fsEngine) InitTest(t testing.TB, blockSize int64,
-	blockChangeSize int64, bwKBps int, opTimeout time.Duration,
-	users []libkb.NormalizedUsername,
+func (e *fsEngine) InitTest(t testing.TB, ver libkbfs.MetadataVer,
+	blockSize int64, blockChangeSize int64, bwKBps int,
+	opTimeout time.Duration, users []libkb.NormalizedUsername,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {
 	e.t = t
 	res := map[libkb.NormalizedUsername]User{}
@@ -528,7 +527,7 @@ func (e *fsEngine) InitTest(t testing.TB, blockSize int64,
 
 	// create the first user specially
 	config0 := libkbfs.MakeTestConfigOrBust(t, users...)
-	config0.SetMetadataVersion(e.ver)
+	config0.SetMetadataVersion(ver)
 	config0.SetClock(clock)
 
 	setBlockSizes(t, config0, blockSize, blockChangeSize)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -503,7 +503,7 @@ func fiTypeString(fi os.FileInfo) string {
 	return "OTHER"
 }
 
-func (e *fsEngine) InitTest(t testing.TB, ver libkbfs.MetadataVer,
+func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 	blockSize int64, blockChangeSize int64, bwKBps int,
 	opTimeout time.Duration, users []libkb.NormalizedUsername,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/libfs"
@@ -33,7 +32,7 @@ type createUserFn func(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 
 type fsEngine struct {
 	name       string
-	log        logger.Logger
+	tb         testing.TB
 	createUser createUserFn
 	// journal directory
 	journalDir string
@@ -68,8 +67,7 @@ func (e *fsEngine) GetUID(user User) keybase1.UID {
 	ctx := context.Background()
 	_, uid, err := u.config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
-		e.log.CFatalf(
-			ctx, "GetUID: GetCurrentUserInfo failed with %v", err)
+		e.tb.Fatalf("GetUID: GetCurrentUserInfo failed with %v", err)
 	}
 	return uid
 }
@@ -423,8 +421,7 @@ func (e *fsEngine) Shutdown(user User) error {
 		}
 		// Remove the overall journal dir if it's empty.
 		if err := ioutil.Remove(e.journalDir); err != nil {
-			e.log.CDebugf(ctx,
-				"Journal dir %s not empty yet", e.journalDir)
+			e.log.Debug("Journal dir %s not empty yet", e.journalDir)
 		}
 	}
 	return nil
@@ -522,7 +519,7 @@ func (e *fsEngine) InitTest(t testing.TB, ver libkbfs.MetadataVer,
 
 	if int(opTimeout) > 0 {
 		// TODO: wrap fs calls in our own timeout-able layer?
-		e.log.Debug("Ignoring op timeout for FS test")
+		e.tb.Debug("Ignoring op timeout for FS test")
 	}
 
 	// create the first user specially

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -57,9 +57,6 @@ func (u *fsUser) shutdown() {
 	u.close()
 }
 
-// Perform Init for the engine
-func (*fsEngine) Init() {}
-
 // Name returns the name of the Engine.
 func (e *fsEngine) Name() string {
 	return e.name

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -40,14 +40,6 @@ func (k *LibKBFS) Name() string {
 	return "libkbfs"
 }
 
-// Init implements the Engine interface.
-func (k *LibKBFS) Init() {
-	// Initialize reference holder and channels maps
-	k.refs = make(map[libkbfs.Config]map[libkbfs.Node]bool)
-	k.updateChannels =
-		make(map[libkbfs.Config]map[libkbfs.FolderBranch]chan<- struct{})
-}
-
 // InitTest implements the Engine interface.
 func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 	blockSize int64, blockChangeSize int64, bwKBps int,

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -59,6 +59,7 @@ func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 	userMap := make(map[libkb.NormalizedUsername]User)
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(t, users...)
+	config.SetMetadataVersion(libkbfs.InitialExtraMetadataVer)
 
 	setBlockSizes(t, config, blockSize, blockChangeSize)
 	maybeSetBw(t, config, bwKBps)

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -25,7 +25,8 @@ type LibKBFS struct {
 	refs map[libkbfs.Config]map[libkbfs.Node]bool
 	// channels used to re-enable updates if disabled
 	updateChannels map[libkbfs.Config]map[libkbfs.FolderBranch]chan<- struct{}
-	tb             testing.TB
+	// test object, for logging.
+	tb testing.TB
 	// timeout for all KBFS calls
 	opTimeout time.Duration
 	// journal directory

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -39,7 +39,7 @@ var _ Engine = (*LibKBFS)(nil)
 
 // Name returns the name of the Engine.
 func (k *LibKBFS) Name() string {
-	return "libkbfs"
+	return fmt.Sprintf("libkbfs(%s)", k.ver)
 }
 
 // Init implements the Engine interface.
@@ -60,7 +60,7 @@ func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 	userMap := make(map[libkb.NormalizedUsername]User)
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(t, users...)
-	config.SetMetadataVersion(libkbfs.InitialExtraMetadataVer)
+	config.SetMetadataVersion(k.ver)
 
 	setBlockSizes(t, config, blockSize, blockChangeSize)
 	maybeSetBw(t, config, bwKBps)

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -21,6 +21,7 @@ import (
 
 // LibKBFS implements the Engine interface for direct test harness usage of libkbfs.
 type LibKBFS struct {
+	ver libkbfs.MetadataVer
 	// hack: hold references on behalf of the test harness
 	refs map[libkbfs.Config]map[libkbfs.Node]bool
 	// channels used to re-enable updates if disabled

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -21,7 +21,6 @@ import (
 
 // LibKBFS implements the Engine interface for direct test harness usage of libkbfs.
 type LibKBFS struct {
-	ver libkbfs.MetadataVer
 	// hack: hold references on behalf of the test harness
 	refs map[libkbfs.Config]map[libkbfs.Node]bool
 	// channels used to re-enable updates if disabled
@@ -39,7 +38,7 @@ var _ Engine = (*LibKBFS)(nil)
 
 // Name returns the name of the Engine.
 func (k *LibKBFS) Name() string {
-	return fmt.Sprintf("libkbfs(%s)", k.ver)
+	return "libkbfs"
 }
 
 // Init implements the Engine interface.
@@ -51,8 +50,9 @@ func (k *LibKBFS) Init() {
 }
 
 // InitTest implements the Engine interface.
-func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
-	bwKBps int, opTimeout time.Duration, users []libkb.NormalizedUsername,
+func (k *LibKBFS) InitTest(t testing.TB, ver libkbfs.MetadataVer,
+	blockSize int64, blockChangeSize int64, bwKBps int,
+	opTimeout time.Duration, users []libkb.NormalizedUsername,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {
 	// Start a new log for this test.
 	k.t = t
@@ -60,7 +60,7 @@ func (k *LibKBFS) InitTest(t testing.TB, blockSize int64, blockChangeSize int64,
 	userMap := make(map[libkb.NormalizedUsername]User)
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(t, users...)
-	config.SetMetadataVersion(k.ver)
+	config.SetMetadataVersion(ver)
 
 	setBlockSizes(t, config, blockSize, blockChangeSize)
 	maybeSetBw(t, config, bwKBps)

--- a/test/run_dokan_test.go
+++ b/test/run_dokan_test.go
@@ -32,7 +32,7 @@ func createEngine(tb testing.TB) Engine {
 	}
 }
 
-func createUserDokan(t testing.TB, ith int, config *libkbfs.ConfigLocal,
+func createUserDokan(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser {
 	driveLetter := 'T' + byte(ith)
 	if driveLetter > 'Z' {
@@ -53,7 +53,7 @@ func createUserDokan(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 
 	username, _, err := config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	ctx, cancelFn := context.WithCancel(ctx)
@@ -65,11 +65,11 @@ func createUserDokan(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 
 	fs, err := libdokan.NewFS(ctx, config, logger.NewTestLogger(t))
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	if opTimeout > 0 {
-		t.Logf("Ignoring op timeout for Dokan test")
+		tb.Logf("Ignoring op timeout for Dokan test")
 	}
 
 	mnt, err := dokan.Mount(&dokan.Config{
@@ -78,7 +78,7 @@ func createUserDokan(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 		MountFlags: libdokan.DefaultMountFlags,
 	})
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	createSuccess = true

--- a/test/run_dokan_test.go
+++ b/test/run_dokan_test.go
@@ -26,7 +26,7 @@ func createEngine(tb testing.TB) Engine {
 	return &dokanEngine{
 		fsEngine: fsEngine{
 			name:       "dokan",
-			t:          tb,
+			tb:         tb,
 			createUser: createUserDokan,
 		},
 	}
@@ -36,7 +36,7 @@ func createUserDokan(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser {
 	driveLetter := 'T' + byte(ith)
 	if driveLetter > 'Z' {
-		t.Error("Too many users - out of drive letters")
+		tb.Error("Too many users - out of drive letters")
 	}
 
 	createSuccess := false
@@ -63,7 +63,7 @@ func createUserDokan(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	ctx = logger.NewContextWithLogTags(ctx, logTags)
 	ctx = context.WithValue(ctx, CtxUserKey, username)
 
-	fs, err := libdokan.NewFS(ctx, config, logger.NewTestLogger(t))
+	fs, err := libdokan.NewFS(ctx, config, logger.NewTestLogger(tb))
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/test/run_dokan_test.go
+++ b/test/run_dokan_test.go
@@ -22,10 +22,9 @@ type dokanEngine struct {
 	fsEngine
 }
 
-func createEngine(t testing.TB, ver libkbfs.MetadataVer) Engine {
+func createEngine(t testing.TB) Engine {
 	return &dokanEngine{
 		fsEngine: fsEngine{
-			ver:        ver,
 			name:       "dokan",
 			t:          t,
 			createUser: createUserDokan,

--- a/test/run_dokan_test.go
+++ b/test/run_dokan_test.go
@@ -22,11 +22,11 @@ type dokanEngine struct {
 	fsEngine
 }
 
-func createEngine(t testing.TB) Engine {
+func createEngine(tb testing.TB) Engine {
 	return &dokanEngine{
 		fsEngine: fsEngine{
 			name:       "dokan",
-			t:          t,
+			t:          tb,
 			createUser: createUserDokan,
 		},
 	}

--- a/test/run_dokan_test.go
+++ b/test/run_dokan_test.go
@@ -22,9 +22,10 @@ type dokanEngine struct {
 	fsEngine
 }
 
-func createEngine(t testing.TB) Engine {
+func createEngine(t testing.TB, ver libkbfs.MetadataVer) Engine {
 	return &dokanEngine{
 		fsEngine: fsEngine{
+			ver:        ver,
 			name:       "dokan",
 			t:          t,
 			createUser: createUserDokan,

--- a/test/run_fuse_test.go
+++ b/test/run_fuse_test.go
@@ -23,14 +23,14 @@ type fuseEngine struct {
 	fsEngine
 }
 
-func createEngine(t testing.TB) Engine {
+func createEngine(tb testing.TB) Engine {
 	log := logger.NewTestLogger(t)
 	debugLog := log.CloneWithAddedDepth(1)
 	fuse.Debug = libfuse.MakeFuseDebugFn(debugLog, false /* superVerbose */)
 	return &fuseEngine{
 		fsEngine: fsEngine{
 			name:       "fuse",
-			t:          t,
+			t:          tb,
 			createUser: createUserFuse,
 		},
 	}

--- a/test/run_fuse_test.go
+++ b/test/run_fuse_test.go
@@ -23,13 +23,12 @@ type fuseEngine struct {
 	fsEngine
 }
 
-func createEngine(t testing.TB, ver libkbfs.MetadataVer) Engine {
+func createEngine(t testing.TB) Engine {
 	log := logger.NewTestLogger(t)
 	debugLog := log.CloneWithAddedDepth(1)
 	fuse.Debug = libfuse.MakeFuseDebugFn(debugLog, false /* superVerbose */)
 	return &fuseEngine{
 		fsEngine: fsEngine{
-			ver:        ver,
 			name:       "fuse",
 			t:          t,
 			createUser: createUserFuse,

--- a/test/run_fuse_test.go
+++ b/test/run_fuse_test.go
@@ -24,19 +24,19 @@ type fuseEngine struct {
 }
 
 func createEngine(tb testing.TB) Engine {
-	log := logger.NewTestLogger(t)
+	log := logger.NewTestLogger(tb)
 	debugLog := log.CloneWithAddedDepth(1)
 	fuse.Debug = libfuse.MakeFuseDebugFn(debugLog, false /* superVerbose */)
 	return &fuseEngine{
 		fsEngine: fsEngine{
 			name:       "fuse",
-			t:          tb,
+			tb:         tb,
 			createUser: createUserFuse,
 		},
 	}
 }
 
-func createUserFuse(t testing.TB, ith int, config *libkbfs.ConfigLocal,
+func createUserFuse(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	opTimeout time.Duration) *fsUser {
 	filesys := libfuse.NewFS(config, nil, false, libfuse.PlatformParams{})
 	fn := func(mnt *fstestutil.Mount) fs.FS {
@@ -44,7 +44,7 @@ func createUserFuse(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 		return filesys
 	}
 	options := libfuse.GetPlatformSpecificMountOptionsForTest()
-	mnt, err := fstestutil.MountedFuncT(t, fn, &fs.Config{
+	mnt, err := fstestutil.MountedFuncT(tb, fn, &fs.Config{
 		WithContext: func(ctx context.Context, req fuse.Request) context.Context {
 			if int(opTimeout) > 0 {
 				// Safe to ignore cancel since fuse should clean up the parent
@@ -55,15 +55,15 @@ func createUserFuse(t testing.TB, ith int, config *libkbfs.ConfigLocal,
 		},
 	}, options...)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
-	t.Logf("FUSE HasInvalidate=%v", mnt.Conn.Protocol().HasInvalidate())
+	tb.Logf("FUSE HasInvalidate=%v", mnt.Conn.Protocol().HasInvalidate())
 
 	ctx := context.Background()
 
 	username, _, err := config.KBPKI().GetCurrentUserInfo(ctx)
 	if err != nil {
-		t.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	ctx, cancelFn := context.WithCancel(ctx)

--- a/test/run_fuse_test.go
+++ b/test/run_fuse_test.go
@@ -23,12 +23,13 @@ type fuseEngine struct {
 	fsEngine
 }
 
-func createEngine(t testing.TB) Engine {
+func createEngine(t testing.TB, ver libkbfs.MetadataVer) Engine {
 	log := logger.NewTestLogger(t)
 	debugLog := log.CloneWithAddedDepth(1)
 	fuse.Debug = libfuse.MakeFuseDebugFn(debugLog, false /* superVerbose */)
 	return &fuseEngine{
 		fsEngine: fsEngine{
+			ver:        ver,
 			name:       "fuse",
 			t:          t,
 			createUser: createUserFuse,

--- a/test/run_kbfs_test.go
+++ b/test/run_kbfs_test.go
@@ -6,8 +6,13 @@
 
 package test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/keybase/client/go/logger"
+)
 
 func createEngine(t testing.TB) Engine {
-	return &LibKBFS{}
+	log := logger.NewTestLogger(t)
+	return &LibKBFS{log: log}
 }

--- a/test/run_kbfs_test.go
+++ b/test/run_kbfs_test.go
@@ -6,8 +6,16 @@
 
 package test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/keybase/kbfs/libkbfs"
+)
 
 func createEngine(tb testing.TB) Engine {
-	return &LibKBFS{tb: tb}
+	return &LibKBFS{
+		tb:             tb,
+		refs:           make(map[libkbfs.Config]map[libkbfs.Node]bool),
+		updateChannels: make(map[libkbfs.Config]map[libkbfs.FolderBranch]chan<- struct{}),
+	}
 }

--- a/test/run_kbfs_test.go
+++ b/test/run_kbfs_test.go
@@ -6,13 +6,8 @@
 
 package test
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/keybase/client/go/logger"
-)
-
-func createEngine(t testing.TB) Engine {
-	log := logger.NewTestLogger(t)
-	return &LibKBFS{log: log}
+func createEngine(tb testing.TB) Engine {
+	return &LibKBFS{tb: tb}
 }

--- a/test/run_kbfs_test.go
+++ b/test/run_kbfs_test.go
@@ -6,8 +6,12 @@
 
 package test
 
-import "testing"
+import (
+	"testing"
 
-func createEngine(t testing.TB) Engine {
-	return &LibKBFS{}
+	"github.com/keybase/kbfs/libkbfs"
+)
+
+func createEngine(t testing.TB, ver libkbfs.MetadataVer) Engine {
+	return &LibKBFS{ver: ver}
 }

--- a/test/run_kbfs_test.go
+++ b/test/run_kbfs_test.go
@@ -6,12 +6,8 @@
 
 package test
 
-import (
-	"testing"
+import "testing"
 
-	"github.com/keybase/kbfs/libkbfs"
-)
-
-func createEngine(t testing.TB, ver libkbfs.MetadataVer) Engine {
-	return &LibKBFS{ver: ver}
+func createEngine(t testing.TB) Engine {
+	return &LibKBFS{}
 }


### PR DESCRIPTION
Also run tests over MetadataVer in parallel.

Also clean up Engine interface a bit, and
rename testing.TB vars to tb instead of t.

Fix race with stallers.