### PR TITLE
[KBFS-1641] Fix KeyManager test flakes

### DIFF
--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -40,7 +40,9 @@ func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
+		t.Logf("Running ver %s", ver)
 		t.Run(ver.String(), func(t *testing.T) {
+			t.Logf("Inside running ver %s", ver)
 			t.Parallel()
 			f(t, ver)
 		})
@@ -72,7 +74,9 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 			i = 0
 		}
 		name = name[i:]
+		t.Logf("Running %s", name)
 		t.Run(name, func(t *testing.T) {
+			t.Logf("Inside running %s", name)
 			t.Parallel()
 			runTestOverMetadataVers(t, f)
 		})

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -66,6 +66,7 @@ func runTestOverMetadataVers(
 func runTestsOverMetadataVers(t *testing.T, prefix string,
 	fs []func(t *testing.T, ver MetadataVer)) {
 	for _, f := range fs {
+		f := f // capture range variable.
 		name := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 		i := strings.LastIndex(name, prefix)
 		if i >= 0 {

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -73,6 +73,7 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 		}
 		name = name[i:]
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			runTestOverMetadataVers(t, f)
 		})
 	}

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -24,8 +24,8 @@ var testMetadataVers = []MetadataVer{
 }
 
 // runTestOverMetadataVers runs the given test function over all
-// metadata versions to test. The test is assumed to be parallelizable
-// with other instances of itself. Example use:
+// metadata versions to test. The test is assumed to be runnable
+// concurrently with other instances of itself. Example use:
 //
 // func TestFoo(t *testing.T) {
 //	runTestOverMetadataVers(t, testFoo)
@@ -40,9 +40,7 @@ func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
-		t.Logf("Running ver %s", ver)
 		t.Run(ver.String(), func(t *testing.T) {
-			t.Logf("Inside running ver %s", ver)
 			t.Parallel()
 			f(t, ver)
 		})
@@ -50,7 +48,8 @@ func runTestOverMetadataVers(
 }
 
 // runTestsOverMetadataVers runs the given list of test functions over
-// all metadata versions to test. prefix should be the common prefix
+// all metadata versions to test, all of which are assumed to be
+// mutually concurrently runnable. prefix should be the common prefix
 // for all the test function names, and the names of the subtest will
 // be taken to be the strings after that prefix. Example use:
 //
@@ -75,9 +74,7 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 			i = 0
 		}
 		name = name[i:]
-		t.Logf("Running %s", name)
 		t.Run(name, func(t *testing.T) {
-			t.Logf("Inside running %s", name)
 			t.Parallel()
 			runTestOverMetadataVers(t, f)
 		})

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -613,6 +613,12 @@ func (c *ConfigLocal) RekeyWithPromptWaitTime() time.Duration {
 	return c.rwpWaitTime
 }
 
+// SetRekeyWithPromptWaitTime implements the Config interface for
+// ConfigLocal.
+func (c *ConfigLocal) SetRekeyWithPromptWaitTime(d time.Duration) {
+	c.rwpWaitTime = d
+}
+
 // DelayedCancellationGracePeriod implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) DelayedCancellationGracePeriod() time.Duration {
 	return c.delayedCancellationGracePeriod

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4540,7 +4540,6 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) rekeyWithPrompt() {
-	var err error
 	ctx := ctxWithRandomIDReplayable(
 		context.Background(), CtxRekeyIDKey, CtxRekeyOpID, fbo.log)
 	// Only give the user limited time to enter their paper key, so we
@@ -4548,6 +4547,7 @@ func (fbo *folderBranchOps) rekeyWithPrompt() {
 	d := fbo.config.RekeyWithPromptWaitTime()
 	ctx, cancel := context.WithTimeout(ctx, d)
 	defer cancel()
+	var err error
 	if ctx, err = NewContextWithCancellationDelayer(ctx); err != nil {
 		panic(err)
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -4376,7 +4375,7 @@ func (fbo *folderBranchOps) UnstageForTesting(
 // mdWriterLock must be taken by the caller.
 func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	lState *lockState, promptPaper bool) (err error) {
-	fbo.log.CDebugf(ctx, "rekeyLocked: %s", debug.Stack())
+	fbo.log.CDebugf(ctx, "rekeyLocked")
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "rekeyLocked done: %+v", err)
 	}()
@@ -4572,8 +4571,6 @@ func (fbo *folderBranchOps) Rekey(ctx context.Context, tlf tlf.ID) (err error) {
 	if fb != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, fb}
 	}
-
-	fbo.log.CDebugf(ctx, "Rekey %s", debug.Stack())
 
 	return fbo.doMDWriteWithRetryUnlessCanceled(ctx,
 		func(lState *lockState) error {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -4375,9 +4376,9 @@ func (fbo *folderBranchOps) UnstageForTesting(
 // mdWriterLock must be taken by the caller.
 func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	lState *lockState, promptPaper bool) (err error) {
-	fbo.log.CDebugf(ctx, "rekeyLocked")
+	fbo.log.CDebugf(ctx, "rekeyLocked: %s", debug.Stack())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "rekeyLocked Done: %+v", err)
+		fbo.deferLog.CDebugf(ctx, "rekeyLocked done: %+v", err)
 	}()
 
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -4571,6 +4572,8 @@ func (fbo *folderBranchOps) Rekey(ctx context.Context, tlf tlf.ID) (err error) {
 	if fb != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, fb}
 	}
+
+	fbo.log.CDebugf(ctx, "Rekey %s", debug.Stack())
 
 	return fbo.doMDWriteWithRetryUnlessCanceled(ctx,
 		func(lState *lockState) error {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1395,11 +1395,6 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 // object and sets the head to that.
 func (fbo *folderBranchOps) SetInitialHeadToNew(
 	ctx context.Context, id tlf.ID, handle *TlfHandle) (err error) {
-	fbo.log.CDebugf(ctx, "SetInitialHeadToNew")
-	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %+v", err)
-	}()
-
 	rmd, err := makeInitialRootMetadata(
 		fbo.config.MetadataVersion(), id, handle)
 	if err != nil {
@@ -1407,6 +1402,12 @@ func (fbo *folderBranchOps) SetInitialHeadToNew(
 	}
 
 	return runUnlessCanceled(ctx, func() error {
+		fbo.log.CDebugf(ctx, "SetInitialHeadToNew")
+		defer func() {
+			fbo.deferLog.CDebugf(ctx,
+				"SetInitialHeadToNew done: %+v", err)
+		}()
+
 		fb := FolderBranch{rmd.TlfID(), MasterBranch}
 		if fb != fbo.folderBranch {
 			return WrongOpsError{fbo.folderBranch, fb}
@@ -1457,11 +1458,11 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	fbo.log.CDebugf(ctx, "getRootNode")
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %+v", err)
+			fbo.deferLog.CDebugf(ctx, "getRootNode error: %+v", err)
 		} else {
 			// node may still be nil if we're unwinding
 			// from a panic.
-			fbo.deferLog.CDebugf(ctx, "Done: %v", node)
+			fbo.deferLog.CDebugf(ctx, "getRootNode done: %v", node)
 		}
 	}()
 
@@ -4865,7 +4866,9 @@ func (fbo *folderBranchOps) registerForUpdates(ctx context.Context) (
 	lState := makeFBOLockState()
 	currRev := fbo.getLatestMergedRevision(lState)
 	fbo.log.CDebugf(ctx, "Registering for updates (curr rev = %d)", currRev)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "Registering for updates: %+v", err)
+	}()
 	// RegisterForUpdate will itself retry on connectivity issues
 	return fbo.config.MDServer().RegisterForUpdate(ctx, fbo.id(), currRev)
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1315,7 +1315,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	fbo.log.CDebugf(ctx, "SetInitialHeadFromServer, revision=%d (%s)",
 		md.Revision(), md.MergedStatus())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %+v", err)
+		fbo.deferLog.CDebugf(ctx, "SetInitialHeadFromServer done: %+v", err)
 	}()
 
 	if md.data.Dir.Type != Dir {
@@ -1521,7 +1521,7 @@ func (fbo *folderBranchOps) pathFromNodeForMDWriteLocked(
 func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "GetDirChildren %p", dir.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done GetDirChildren: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "GetDirChildren done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -1571,7 +1571,7 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Lookup %p %s", dir.GetID(), name)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Lookup done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -1654,7 +1654,7 @@ type blockState struct {
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Stat %p", node.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Stat done: %+v", err) }()
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
@@ -1670,7 +1670,7 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	ei NodeMetadata, err error) {
 	fbo.log.CDebugf(ctx, "GetNodeMetadata %p", node.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "GetNodeMetadata done: %+v", err) }()
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
@@ -2677,9 +2677,9 @@ func (fbo *folderBranchOps) CreateDir(
 	fbo.log.CDebugf(ctx, "CreateDir %p %s", dir.GetID(), path)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %+v", err)
+			fbo.deferLog.CDebugf(ctx, "CreateDir error: %+v", err)
 		} else {
-			fbo.deferLog.CDebugf(ctx, "Done: %p", n.GetID())
+			fbo.deferLog.CDebugf(ctx, "CreateDir done: %p", n.GetID())
 		}
 	}()
 
@@ -2713,9 +2713,9 @@ func (fbo *folderBranchOps) CreateFile(
 		dir.GetID(), path, isExec, excl)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %+v", err)
+			fbo.deferLog.CDebugf(ctx, "CreateFile error: %+v", err)
 		} else {
-			fbo.deferLog.CDebugf(ctx, "Done: %p", n.GetID())
+			fbo.deferLog.CDebugf(ctx, "CreateFile done: %p", n.GetID())
 		}
 	}()
 
@@ -2837,7 +2837,7 @@ func (fbo *folderBranchOps) CreateLink(
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "CreateLink %p %s -> %s",
 		dir.GetID(), fromName, toPath)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "CreateLink done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -2971,7 +2971,7 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveDir %p %s", dir.GetID(), dirName)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "RemoveDir done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -2987,7 +2987,7 @@ func (fbo *folderBranchOps) RemoveDir(
 func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveEntry %p %s", dir.GetID(), name)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "RemoveEntry done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -3159,7 +3159,7 @@ func (fbo *folderBranchOps) Rename(
 	newName string) (err error) {
 	fbo.log.CDebugf(ctx, "Rename %p/%s -> %p/%s", oldParent.GetID(),
 		oldName, newParent.GetID(), newName)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Rename done: %+v", err) }()
 
 	err = fbo.checkNode(newParent)
 	if err != nil {
@@ -3192,7 +3192,7 @@ func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
 	fbo.log.CDebugf(ctx, "Read %p %d %d", file.GetID(), len(dest), off)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Read done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3252,7 +3252,7 @@ func (fbo *folderBranchOps) Read(
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
 	fbo.log.CDebugf(ctx, "Write %p %d %d", file.GetID(), len(data), off)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Write done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3284,7 +3284,7 @@ func (fbo *folderBranchOps) Write(
 func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
 	fbo.log.CDebugf(ctx, "Truncate %p %d", file.GetID(), size)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Truncate done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3381,7 +3381,7 @@ func (fbo *folderBranchOps) setExLocked(
 func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
 	fbo.log.CDebugf(ctx, "SetEx %p %t", file.GetID(), ex)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "SetEx done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3450,7 +3450,7 @@ func (fbo *folderBranchOps) setMtimeLocked(
 func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
 	fbo.log.CDebugf(ctx, "SetMtime %p %v", file.GetID(), mtime)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "SetMtime done: %+v", err) }()
 
 	if mtime == nil {
 		// Can happen on some OSes (e.g. OSX) when trying to set the atime only
@@ -3581,7 +3581,7 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
 	fbo.log.CDebugf(ctx, "Sync %p", file.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Sync done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3614,7 +3614,7 @@ func (fbo *folderBranchOps) FolderStatus(
 	ctx context.Context, folderBranch FolderBranch) (
 	fbs FolderBranchStatus, updateChan <-chan StatusUpdate, err error) {
 	fbo.log.CDebugf(ctx, "Status")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Status done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return FolderBranchStatus{}, nil,
@@ -4329,7 +4329,7 @@ func (fbo *folderBranchOps) unstageLocked(ctx context.Context,
 func (fbo *folderBranchOps) UnstageForTesting(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "UnstageForTesting")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "UnstageForTesting done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -4581,7 +4581,7 @@ func (fbo *folderBranchOps) Rekey(ctx context.Context, tlf tlf.ID) (err error) {
 func (fbo *folderBranchOps) SyncFromServerForTesting(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "SyncFromServerForTesting")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "SyncFromServerForTesting done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -4878,7 +4878,7 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 	updateChan <-chan error) (currUpdate time.Time, err error) {
 	// successful registration; now, wait for an update or a shutdown
 	fbo.log.CDebugf(ctx, "Waiting for updates")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Waiting for updates done: %+v", err) }()
 
 	lState := makeFBOLockState()
 
@@ -5254,7 +5254,7 @@ func (fbo *folderBranchOps) onMDFlush(bid BranchID, rev MetadataRevision) {
 func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 	folderBranch FolderBranch) (history TLFUpdateHistory, err error) {
 	fbo.log.CDebugf(ctx, "GetUpdateHistory")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "GetUpdateHistory done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return TLFUpdateHistory{}, WrongOpsError{fbo.folderBranch, folderBranch}
@@ -5318,7 +5318,7 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 func (fbo *folderBranchOps) GetEditHistory(ctx context.Context,
 	folderBranch FolderBranch) (edits TlfWriterEdits, err error) {
 	fbo.log.CDebugf(ctx, "GetEditHistory")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "GetEditHistory done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return nil, WrongOpsError{fbo.folderBranch, folderBranch}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -858,7 +858,7 @@ func (fbo *folderBranchOps) identifyOnce(
 	kbpki := fbo.config.KBPKI()
 	err := identifyHandle(ctx, kbpki, kbpki, h)
 	if err != nil {
-		fbo.log.CDebugf(ctx, "Identify finished with error: %v", err)
+		fbo.log.CDebugf(ctx, "Identify finished with error: %+v", err)
 		// For now, if the identify fails, let the
 		// next function to hit this code path retry.
 		return err
@@ -1314,7 +1314,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	fbo.log.CDebugf(ctx, "SetInitialHeadFromServer, revision=%d (%s)",
 		md.Revision(), md.MergedStatus())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %v", err)
+		fbo.deferLog.CDebugf(ctx, "Done: %+v", err)
 	}()
 
 	if md.data.Dir.Type != Dir {
@@ -1396,7 +1396,7 @@ func (fbo *folderBranchOps) SetInitialHeadToNew(
 	ctx context.Context, id tlf.ID, handle *TlfHandle) (err error) {
 	fbo.log.CDebugf(ctx, "SetInitialHeadToNew")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %v", err)
+		fbo.deferLog.CDebugf(ctx, "Done: %+v", err)
 	}()
 
 	rmd, err := makeInitialRootMetadata(
@@ -1456,7 +1456,7 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	fbo.log.CDebugf(ctx, "getRootNode")
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %v", err)
+			fbo.deferLog.CDebugf(ctx, "Error: %+v", err)
 		} else {
 			// node may still be nil if we're unwinding
 			// from a panic.
@@ -1519,7 +1519,7 @@ func (fbo *folderBranchOps) pathFromNodeForMDWriteLocked(
 func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "GetDirChildren %p", dir.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done GetDirChildren: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done GetDirChildren: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -1569,7 +1569,7 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Lookup %p %s", dir.GetID(), name)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -1652,7 +1652,7 @@ type blockState struct {
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Stat %p", node.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
@@ -1668,7 +1668,7 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	ei NodeMetadata, err error) {
 	fbo.log.CDebugf(ctx, "GetNodeMetadata %p", node.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
@@ -2176,7 +2176,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 		// only do a normal Put if we're not already staged.
 		mdID, err = mdops.Put(ctx, md)
 		if doUnmergedPut = isRevisionConflict(err); doUnmergedPut {
-			fbo.log.CDebugf(ctx, "Conflict: %v", err)
+			fbo.log.CDebugf(ctx, "Conflict: %+v", err)
 			mergedRev = md.Revision()
 
 			if excl == WithExcl {
@@ -2621,7 +2621,7 @@ func (fbo *folderBranchOps) doMDWriteWithRetry(ctx context.Context,
 
 		err := fn(lState)
 		if isRetriableError(err, i) {
-			fbo.log.CDebugf(ctx, "Trying again after retriable error: %v", err)
+			fbo.log.CDebugf(ctx, "Trying again after retriable error: %+v", err)
 			// Release the lock to give someone else a chance
 			doUnlock = false
 			fbo.mdWriterLock.Unlock(lState)
@@ -2675,7 +2675,7 @@ func (fbo *folderBranchOps) CreateDir(
 	fbo.log.CDebugf(ctx, "CreateDir %p %s", dir.GetID(), path)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %v", err)
+			fbo.deferLog.CDebugf(ctx, "Error: %+v", err)
 		} else {
 			fbo.deferLog.CDebugf(ctx, "Done: %p", n.GetID())
 		}
@@ -2711,7 +2711,7 @@ func (fbo *folderBranchOps) CreateFile(
 		dir.GetID(), path, isExec, excl)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %v", err)
+			fbo.deferLog.CDebugf(ctx, "Error: %+v", err)
 		} else {
 			fbo.deferLog.CDebugf(ctx, "Done: %p", n.GetID())
 		}
@@ -2835,7 +2835,7 @@ func (fbo *folderBranchOps) CreateLink(
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "CreateLink %p %s -> %s",
 		dir.GetID(), fromName, toPath)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -2969,7 +2969,7 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveDir %p %s", dir.GetID(), dirName)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -2985,7 +2985,7 @@ func (fbo *folderBranchOps) RemoveDir(
 func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveEntry %p %s", dir.GetID(), name)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -3157,7 +3157,7 @@ func (fbo *folderBranchOps) Rename(
 	newName string) (err error) {
 	fbo.log.CDebugf(ctx, "Rename %p/%s -> %p/%s", oldParent.GetID(),
 		oldName, newParent.GetID(), newName)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(newParent)
 	if err != nil {
@@ -3190,7 +3190,7 @@ func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
 	fbo.log.CDebugf(ctx, "Read %p %d %d", file.GetID(), len(dest), off)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3250,7 +3250,7 @@ func (fbo *folderBranchOps) Read(
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
 	fbo.log.CDebugf(ctx, "Write %p %d %d", file.GetID(), len(data), off)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3282,7 +3282,7 @@ func (fbo *folderBranchOps) Write(
 func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
 	fbo.log.CDebugf(ctx, "Truncate %p %d", file.GetID(), size)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3379,7 +3379,7 @@ func (fbo *folderBranchOps) setExLocked(
 func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
 	fbo.log.CDebugf(ctx, "SetEx %p %t", file.GetID(), ex)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3448,7 +3448,7 @@ func (fbo *folderBranchOps) setMtimeLocked(
 func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
 	fbo.log.CDebugf(ctx, "SetMtime %p %v", file.GetID(), mtime)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	if mtime == nil {
 		// Can happen on some OSes (e.g. OSX) when trying to set the atime only
@@ -3579,7 +3579,7 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
 	fbo.log.CDebugf(ctx, "Sync %p", file.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3612,7 +3612,7 @@ func (fbo *folderBranchOps) FolderStatus(
 	ctx context.Context, folderBranch FolderBranch) (
 	fbs FolderBranchStatus, updateChan <-chan StatusUpdate, err error) {
 	fbo.log.CDebugf(ctx, "Status")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return FolderBranchStatus{}, nil,
@@ -3746,7 +3746,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		// and we need to unlink it in the node cache.
 		err := fbo.unlinkFromCache(op, realOp.Dir.Unref, node, realOp.OldName)
 		if err != nil {
-			fbo.log.CErrorf(ctx, "Couldn't unlink from cache: %v", err)
+			fbo.log.CErrorf(ctx, "Couldn't unlink from cache: %+v", err)
 			return
 		}
 	case *renameOp:
@@ -3814,12 +3814,12 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 				}
 				err := fbo.unlinkFromCache(op, unrefPtr, newNode, realOp.NewName)
 				if err != nil {
-					fbo.log.CErrorf(ctx, "Couldn't unlink from cache: %v", err)
+					fbo.log.CErrorf(ctx, "Couldn't unlink from cache: %+v", err)
 					return
 				}
 				err = fbo.nodeCache.Move(realOp.Renamed.Ref(), newNode, realOp.NewName)
 				if err != nil {
-					fbo.log.CErrorf(ctx, "Couldn't move node in cache: %v", err)
+					fbo.log.CErrorf(ctx, "Couldn't move node in cache: %+v", err)
 					return
 				}
 			}
@@ -3890,7 +3890,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			// If there is a node, unlink and invalidate.
 			p, err := fbo.pathFromNodeForRead(node)
 			if err != nil {
-				fbo.log.CErrorf(ctx, "Couldn't get path: %v", err)
+				fbo.log.CErrorf(ctx, "Couldn't get path: %+v", err)
 				continue
 			}
 			if !p.hasValidParent() {
@@ -4327,7 +4327,7 @@ func (fbo *folderBranchOps) unstageLocked(ctx context.Context,
 func (fbo *folderBranchOps) UnstageForTesting(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "UnstageForTesting")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -4375,7 +4375,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	lState *lockState, promptPaper bool) (err error) {
 	fbo.log.CDebugf(ctx, "rekeyLocked")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "rekeyLocked Done: %v", err)
+		fbo.deferLog.CDebugf(ctx, "rekeyLocked Done: %+v", err)
 	}()
 
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -4553,7 +4553,9 @@ func (fbo *folderBranchOps) rekeyWithPrompt() {
 	}
 
 	fbo.log.CDebugf(ctx, "rekeyWithPrompt")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "rekeyWithPrompt done: %+v", err)
+	}()
 
 	err = fbo.doMDWriteWithRetryUnlessCanceled(ctx,
 		func(lState *lockState) error {
@@ -4577,7 +4579,7 @@ func (fbo *folderBranchOps) Rekey(ctx context.Context, tlf tlf.ID) (err error) {
 func (fbo *folderBranchOps) SyncFromServerForTesting(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "SyncFromServerForTesting")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -4862,7 +4864,7 @@ func (fbo *folderBranchOps) registerForUpdates(ctx context.Context) (
 	lState := makeFBOLockState()
 	currRev := fbo.getLatestMergedRevision(lState)
 	fbo.log.CDebugf(ctx, "Registering for updates (curr rev = %d)", currRev)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 	// RegisterForUpdate will itself retry on connectivity issues
 	return fbo.config.MDServer().RegisterForUpdate(ctx, fbo.id(), currRev)
 }
@@ -4872,14 +4874,14 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 	updateChan <-chan error) (currUpdate time.Time, err error) {
 	// successful registration; now, wait for an update or a shutdown
 	fbo.log.CDebugf(ctx, "Waiting for updates")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	lState := makeFBOLockState()
 
 	for {
 		select {
 		case err := <-updateChan:
-			fbo.log.CDebugf(ctx, "Got an update: %v", err)
+			fbo.log.CDebugf(ctx, "Got an update: %+v", err)
 			if err != nil {
 				return time.Time{}, err
 			}
@@ -4901,7 +4903,7 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 			err = fbo.getAndApplyMDUpdates(ctx, lState, fbo.applyMDUpdates)
 			if err != nil {
 				fbo.log.CDebugf(ctx, "Got an error while applying "+
-					"updates: %v", err)
+					"updates: %+v", err)
 				return time.Time{}, err
 			}
 			return currUpdate, nil
@@ -5075,7 +5077,7 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 	err = fbo.setHeadConflictResolvedLocked(ctx, lState, irmd)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't set local MD head after a "+
-			"successful put: %v", err)
+			"successful put: %+v", err)
 		return err
 	}
 	fbo.setBranchIDLocked(lState, NullBranchID)
@@ -5173,7 +5175,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 	err = fbo.setHeadSuccessorLocked(ctx, lState, md, true /*rebased*/)
 	if err != nil {
 		fbo.log.CWarningf(ctx,
-			"Could not set head on journal branch change: %v", err)
+			"Could not set head on journal branch change: %+v", err)
 		return
 	}
 }
@@ -5248,7 +5250,7 @@ func (fbo *folderBranchOps) onMDFlush(bid BranchID, rev MetadataRevision) {
 func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 	folderBranch FolderBranch) (history TLFUpdateHistory, err error) {
 	fbo.log.CDebugf(ctx, "GetUpdateHistory")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return TLFUpdateHistory{}, WrongOpsError{fbo.folderBranch, folderBranch}
@@ -5312,7 +5314,7 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 func (fbo *folderBranchOps) GetEditHistory(ctx context.Context,
 	folderBranch FolderBranch) (edits TlfWriterEdits, err error) {
 	fbo.log.CDebugf(ctx, "GetEditHistory")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return nil, WrongOpsError{fbo.folderBranch, folderBranch}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1189,6 +1189,7 @@ func (fbo *folderBranchOps) initMDLocked(
 	if md.TlfID().IsPublic() {
 		expectedKeyGen = PublicKeyGen
 	} else {
+		fbo.log.CDebugf(ctx, "Doing initial rekey")
 		var rekeyDone bool
 		// create a new set of keys for this metadata
 		rekeyDone, tlfCryptKey, err = fbo.config.KeyManager().Rekey(ctx, md, false)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1449,6 +1449,7 @@ type Config interface {
 	// RekeyWithPromptWaitTime indicates how long to wait, after
 	// setting the rekey bit, before prompting for a paper key.
 	RekeyWithPromptWaitTime() time.Duration
+	SetRekeyWithPromptWaitTime(time.Duration)
 
 	// GracePeriod specifies a grace period for which a delayed cancellation
 	// waits before actual cancels the context. This is useful for giving

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -165,6 +165,7 @@ func kbfsTestShutdown(mockCtrl *gomock.Controller, config *ConfigMock,
 func kbfsOpsInitNoMocks(t *testing.T, users ...libkb.NormalizedUsername) (
 	*ConfigLocal, keybase1.UID, context.Context, context.CancelFunc) {
 	config := MakeTestConfigOrBust(t, users...)
+	config.SetRekeyWithPromptWaitTime(individualTestTimeout)
 
 	timeoutCtx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -237,6 +237,7 @@ func (km *KeyManagerStandard) getTLFCryptKeyParams(
 				kbfscrypto.CryptPublicKey{},
 				localMakeRekeyReadError(err)
 		}
+		km.log.CDebugf(ctx, "Trying to decrypt with keys = %#v", keys)
 		var index int
 		clientHalf, index, err = crypto.DecryptTLFCryptKeyClientHalfAny(ctx,
 			keys, flags&getTLFCryptKeyPromptPaper != 0)

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -281,7 +281,10 @@ func (km *KeyManagerStandard) getTLFCryptKeyParams(
 			return kbfscrypto.TLFCryptKeyClientHalf{},
 				TLFCryptKeyServerHalfID{},
 				kbfscrypto.CryptPublicKey{},
-				localMakeRekeyReadError(err)
+				localMakeRekeyReadError(errors.Errorf(
+					"could not find params for "+
+						"uid=%s device key=%s",
+					uid, cryptPublicKey))
 		}
 
 		clientHalf, err = crypto.DecryptTLFCryptKeyClientHalf(

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -237,7 +237,8 @@ func (km *KeyManagerStandard) getTLFCryptKeyParams(
 				kbfscrypto.CryptPublicKey{},
 				localMakeRekeyReadError(err)
 		}
-		km.log.CDebugf(ctx, "Trying to decrypt with keys = %#v", keys)
+		km.log.CDebugf(ctx, "Trying to decrypt with keys = %s",
+			dumpConfig().Sdump(keys))
 		var index int
 		clientHalf, index, err = crypto.DecryptTLFCryptKeyClientHalfAny(ctx,
 			keys, flags&getTLFCryptKeyPromptPaper != 0)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2006,6 +2006,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 }
 
 func TestKeyManager(t *testing.T) {
+	t.Parallel()
 	tests := []func(*testing.T, MetadataVer){
 		testKeyManagerPublicTLFCryptKey,
 		testKeyManagerCachedSecretKeyForEncryptionSuccess,

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1935,7 +1935,6 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	// Allow the prompt rekey attempt to fail by using dev2's crypto
 	// (which still isn't keyed for)
 	c := make(chan bool)
-	// Use our other device as a standin for the paper key.
 	clta := &cryptoLocalTrapAny{config2Dev2.Crypto(), c, config2Dev2.Crypto()}
 	config2Dev2.SetCrypto(clta)
 	ops.rekeyWithPromptTimer.Reset(1 * time.Millisecond)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1794,6 +1794,8 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2Dev2)
 
+	config2Dev2.SetKeyCache(&dummyNoKeyCache{})
+
 	// Now give u2 a new device.  The configs don't share a Keybase
 	// Daemon so we have to do it in all places.
 	AddDeviceForLocalUserOrBust(t, config1, uid2)
@@ -1904,6 +1906,8 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2Dev2)
+
+	config2Dev2.SetKeyCache(&dummyNoKeyCache{})
 
 	// Now give u2 a new device.  The configs don't share a Keybase
 	// Daemon so we have to do it in all places.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -1634,7 +1635,8 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 	select {
 	case clta.promptCh <- promptPaper:
 	case <-ctx.Done():
-		return kbfscrypto.TLFCryptKeyClientHalf{}, 0, ctx.Err()
+		return kbfscrypto.TLFCryptKeyClientHalf{}, 0,
+			errors.WithStack(ctx.Err())
 	}
 	// Decrypt the key half with the given config object
 	return clta.cryptoToUse.DecryptTLFCryptKeyClientHalfAny(
@@ -1956,7 +1958,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 			select {
 			case errCh <- err:
 			case <-ctx.Done():
-				errCh <- ctx.Err()
+				errCh <- errors.WithStack(ctx.Err())
 			}
 		}()
 		// One failed decryption attempt

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1913,6 +1913,8 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	devIndex := AddDeviceForLocalUserOrBust(t, config2Dev2, uid2)
 	SwitchDeviceForLocalUserOrBust(t, config2Dev2, devIndex)
 
+	t.Log("Doing first rekey")
+
 	// The new device should be unable to rekey on its own, and will
 	// just set the rekey bit.
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
@@ -1927,6 +1929,8 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	if !ops.head.IsRekeySet() {
 		t.Fatalf("Couldn't set rekey bit")
 	}
+
+	t.Log("Switching crypto")
 
 	// Allow the prompt rekey attempt to fail by using dev2's crypto
 	// (which still isn't keyed for)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1680,6 +1680,8 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 	devIndex := AddDeviceForLocalUserOrBust(t, config2Dev2, uid2)
 	SwitchDeviceForLocalUserOrBust(t, config2Dev2, devIndex)
 
+	t.Log("Doing first rekey")
+
 	// The new device should be unable to rekey on its own, and will
 	// just set the rekey bit.
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
@@ -1690,6 +1692,8 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 
 	ops := getOps(config2Dev2, rootNode1.GetFolderBranch().Tlf)
 	rev1 := ops.head.Revision()
+
+	t.Log("Doing second rekey")
 
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.  This shouldn't increase the MD version.
@@ -1803,6 +1807,8 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	clock.Add(1 * time.Minute)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev2, uid1, 0)
 
+	t.Log("Doing first rekey")
+
 	// The new device should be unable to rekey on its own, and will
 	// just set the rekey bit.
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
@@ -1813,6 +1819,8 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 
 	ops := getOps(config2Dev2, rootNode1.GetFolderBranch().Tlf)
 	rev1 := ops.head.Revision()
+
+	t.Log("Doing second rekey")
 
 	// Do it again, to simulate the mdserver sending back this node's
 	// own rekey request.  This shouldn't increase the MD version.
@@ -1835,7 +1843,9 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	ops.rekeyWithPromptTimer.Stop()
 	ops.rekeyWithPromptTimer = nil
 
-	// Try again, which should reset the timer (and so the Reser below
+	t.Log("Doing third rekey")
+
+	// Try again, which should reset the timer (and so the Reset below
 	// will be on a non-nil timer).
 	err = kbfsOps2Dev2.Rekey(ctx, rootNode1.GetFolderBranch().Tlf)
 	if err != nil {

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2028,6 +2028,7 @@ func TestKeyManager(t *testing.T) {
 }
 
 func TestKeyManagerFlake(t *testing.T) {
+	// TODO: testKeyManagerRekeyAddAndRevokeDevice is flaky, too.
 	flakyTests := []func(*testing.T, MetadataVer){
 		testKeyManagerRekeyAddDeviceWithPrompt,
 		testKeyManagerRekeyAddDeviceWithPromptAfterRestart,

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1886,7 +1886,6 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 }
 
 func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver MetadataVer) {
-	t.Log("Am in PromptViaFolderAccess")
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2017,3 +2017,10 @@ func TestKeyManager(t *testing.T) {
 	}
 	runTestsOverMetadataVers(t, "testKeyManager", tests)
 }
+
+func TestKeyManagerFlake(t *testing.T) {
+	runTestCopiesInParallel(t, 100, func(t *testing.T) {
+		testKeyManagerRekeyAddDeviceWithPrompt(t,
+			SegregatedKeyBundlesVer)
+	})
+}

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1712,6 +1712,8 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 		t.Fatalf("Couldn't set rekey bit")
 	}
 
+	t.Log("Switching crypto")
+
 	c := make(chan struct{}, 1)
 	// Use our other device as a standin for the paper key.
 	clta := &cryptoLocalTrapAny{config2Dev2.Crypto(), sync.Once{}, c, config2.Crypto()}
@@ -1841,6 +1843,8 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	if err != nil {
 		t.Fatalf("Third rekey failed %+v", err)
 	}
+
+	t.Log("Switching crypto")
 
 	c := make(chan struct{}, 1)
 	// Use our other device as a standin for the paper key.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1886,6 +1886,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 }
 
 func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver MetadataVer) {
+	t.Log("Am in PromptViaFolderAccess")
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1673,6 +1673,8 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2Dev2)
 
+	config2Dev2.SetKeyCache(&dummyNoKeyCache{})
+
 	// Now give u2 a new device.  The configs don't share a Keybase
 	// Daemon so we have to do it in all places.
 	AddDeviceForLocalUserOrBust(t, config1, uid2)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1959,11 +1959,15 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 			t.Fatalf("Got unexpected error when reading with new key: %+v", err)
 		}
 
+		t.Log("Switching crypto again")
+
 		// Let the background rekeyer decrypt.
-		c := make(chan struct{}, 1)
-		clta := &cryptoLocalTrapAny{config2Dev2.Crypto(), sync.Once{}, c, config2.Crypto()}
+		c = make(chan struct{}, 1)
+		clta = &cryptoLocalTrapAny{config2Dev2.Crypto(), sync.Once{}, c, config2.Crypto()}
 		config2Dev2.SetCrypto(clta)
 	}()
+
+	t.Log("Waiting for rekey attempt")
 
 	select {
 	case <-c:
@@ -1973,6 +1977,8 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	// Make sure the rekey attempt is finished
 	ops.mdWriterLock.Lock(lState)
 	ops.mdWriterLock.Unlock(lState)
+
+	t.Log("Getting the root node, which should now succeed")
 
 	GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -956,6 +956,7 @@ func testMDJournalRestartAfterBranchConversion(t *testing.T, ver MetadataVer) {
 }
 
 func TestMDJournal(t *testing.T) {
+	t.Parallel()
 	tests := []func(*testing.T, MetadataVer){
 		testMDJournalBasic,
 		testMDJournalGetNextEntry,

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -845,6 +845,7 @@ func testMDOpsGetRangeFailFinal(t *testing.T, ver MetadataVer) {
 }
 
 func TestMDOps(t *testing.T) {
+	t.Parallel()
 	tests := []func(*testing.T, MetadataVer){
 		testMDOpsGetForHandlePublicSuccess,
 		testMDOpsGetForHandlePrivateSuccess,

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -630,6 +630,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 }
 
 func TestRootMetadata(t *testing.T) {
+	t.Parallel()
 	tests := []func(*testing.T, MetadataVer){
 		testRootMetadataGetTlfHandlePublic,
 		testRootMetadataGetTlfHandlePrivate,

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -200,6 +200,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *ConfigLocal {
 	c := newConfigForTest(config.loggerFn)
 	c.SetMetadataVersion(config.MetadataVersion())
+	c.SetRekeyWithPromptWaitTime(config.RekeyWithPromptWaitTime())
 
 	kbfsOps := NewKBFSOpsStandard(c)
 	c.SetKBFSOps(kbfsOps)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -539,7 +539,7 @@ func (tc *TestClock) Add(d time.Duration) {
 func CheckConfigAndShutdown(
 	ctx context.Context, t logger.TestLogBackend, config Config) {
 	if err := config.Shutdown(ctx); err != nil {
-		t.Errorf(err.Error())
+		t.Errorf("err=%+v", err)
 	}
 }
 

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1058,6 +1058,7 @@ func testTLFJournalResolveBranch(t *testing.T, ver MetadataVer) {
 }
 
 func TestTLFJournal(t *testing.T) {
+	t.Parallel()
 	tests := []func(*testing.T, MetadataVer){
 		testTLFJournalBasic,
 		testTLFJournalPauseResume,

--- a/libkbfs/util_test.go
+++ b/libkbfs/util_test.go
@@ -9,14 +9,13 @@ import (
 	"testing"
 )
 
-// runTestCopiesInParallel runs numCopies of the given test function
+// runTestWithParallelCopies runs numCopies of the given test function
 // in parallel. This is used to induce failures in flaky tests.
-func runTestCopiesInParallel(
-	t *testing.T, numCopies int, f func(t *testing.T)) {
+func runTestWithParallelCopies(
+	t *testing.T, name string, numCopies int, f func(t *testing.T)) {
 	for i := 0; i < numCopies; i++ {
 		i := i // capture range variable.
-		name := fmt.Sprintf("%d", i)
-		t.Run(name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s(%d)", name, i), func(t *testing.T) {
 			t.Parallel()
 			f(t)
 		})

--- a/libkbfs/util_test.go
+++ b/libkbfs/util_test.go
@@ -1,0 +1,24 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"fmt"
+	"testing"
+)
+
+// runTestCopiesInParallel runs numCopies of the given test function
+// in parallel. This is used to induce failures in flaky tests.
+func runTestCopiesInParallel(
+	t *testing.T, numCopies int, f func(t *testing.T)) {
+	for i := 0; i < numCopies; i++ {
+		i := i // capture range variable.
+		name := fmt.Sprintf("%d", i)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			f(t)
+		})
+	}
+}


### PR DESCRIPTION
The background update task always fetches the head
whenever it receives an update, which triggers a rekey
that races with the rekey-with-prompt timer. Fix this
by, instead of waiting for the first rekey and checking
whether the prompt flag is set, waiting for a rekey
with the prompt flag set. At worst, this'll cause the
test to time out.

Set RekeyWithPromptWaitTime to the individual
test timeout for tests.

Clean up various logs.

Fix bug with runTestsWithMetadataVers.

Also run all MDv3 tests in parallel.