### PR TITLE
file_data: support writes and truncates for >1 indirection levels

### DIFF
--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -14,6 +14,7 @@ import (
 // a simple max-size algorithm to determine when to split blocks.
 type BlockSplitterSimple struct {
 	maxSize                 int64
+	maxPtrsPerBlock         int
 	blockChangeEmbedMaxSize uint64
 }
 
@@ -75,6 +76,7 @@ func NewBlockSplitterSimple(desiredBlockSize int64,
 
 	return &BlockSplitterSimple{
 		maxSize:                 maxSize,
+		maxPtrsPerBlock:         int(maxSize / int64(bpSize)),
 		blockChangeEmbedMaxSize: blockChangeEmbedMaxSize,
 	}, nil
 }
@@ -122,6 +124,12 @@ func (b *BlockSplitterSimple) CopyUntilSplit(
 func (b *BlockSplitterSimple) CheckSplit(block *FileBlock) int64 {
 	// The split will always be right
 	return 0
+}
+
+// MaxPtrsPerBlock implements the BlockSplitter interface for
+// BlockSplitterSimple.
+func (b *BlockSplitterSimple) MaxPtrsPerBlock() int {
+	return b.maxPtrsPerBlock
 }
 
 // ShouldEmbedBlockChanges implements the BlockSplitter interface for

--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -75,8 +75,13 @@ func NewBlockSplitterSimple(desiredBlockSize int64,
 	}
 
 	return &BlockSplitterSimple{
-		maxSize:                 maxSize,
-		maxPtrsPerBlock:         int(maxSize / int64(bpSize)),
+		maxSize: maxSize,
+		// Currently set the max number of pointers per level of
+		// indirection to the maximum integer, as a way of turning off
+		// multiple levels of indirection in production.  TODO: remove
+		// this.
+		maxPtrsPerBlock: int((^uint(0)) >> 1),
+		//maxPtrsPerBlock:         int(maxSize / int64(bpSize)),
 		blockChangeEmbedMaxSize: blockChangeEmbedMaxSize,
 	}, nil
 }

--- a/libkbfs/bsplitter_simple_test.go
+++ b/libkbfs/bsplitter_simple_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBsplitterEmptyCopyAll(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	data := []byte{1, 2, 3, 4, 5}
 
@@ -24,7 +24,7 @@ func TestBsplitterEmptyCopyAll(t *testing.T) {
 }
 
 func TestBsplitterNonemptyCopyAll(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9}
 	data := []byte{1, 2, 3, 4, 5}
@@ -37,7 +37,7 @@ func TestBsplitterNonemptyCopyAll(t *testing.T) {
 }
 
 func TestBsplitterAppendAll(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9}
 	data := []byte{1, 2, 3, 4, 5}
@@ -50,7 +50,7 @@ func TestBsplitterAppendAll(t *testing.T) {
 }
 
 func TestBsplitterAppendExact(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9, 8, 7, 6}
 	data := []byte{1, 2, 3, 4, 5}
@@ -64,7 +64,7 @@ func TestBsplitterAppendExact(t *testing.T) {
 }
 
 func TestBsplitterSplitOne(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9, 8, 7, 6}
 	data := []byte{1, 2, 3, 4, 5, 6}
@@ -78,7 +78,7 @@ func TestBsplitterSplitOne(t *testing.T) {
 }
 
 func TestBsplitterOverwriteMaxSizeBlock(t *testing.T) {
-	bsplit := &BlockSplitterSimple{5, 10}
+	bsplit := &BlockSplitterSimple{5, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9, 8, 7, 6}
 	data := []byte{1, 2, 3, 4, 5, 6, 7, 8}
@@ -91,7 +91,7 @@ func TestBsplitterOverwriteMaxSizeBlock(t *testing.T) {
 }
 
 func TestBsplitterBlockTooBig(t *testing.T) {
-	bsplit := &BlockSplitterSimple{3, 10}
+	bsplit := &BlockSplitterSimple{3, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9, 8, 7, 6}
 	data := []byte{1, 2, 3, 4, 5, 6}
@@ -104,7 +104,7 @@ func TestBsplitterBlockTooBig(t *testing.T) {
 }
 
 func TestBsplitterOffTooBig(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	fblock := NewFileBlock().(*FileBlock)
 	fblock.Contents = []byte{10, 9, 8, 7, 6}
 	data := []byte{1, 2, 3, 4, 5, 6}
@@ -118,7 +118,7 @@ func TestBsplitterOffTooBig(t *testing.T) {
 }
 
 func TestBsplitterShouldEmbed(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	bc := &BlockChanges{}
 	bc.sizeEstimate = 1
 	if !bsplit.ShouldEmbedBlockChanges(bc) {
@@ -131,7 +131,7 @@ func TestBsplitterShouldEmbed(t *testing.T) {
 }
 
 func TestBsplitterShouldNotEmbed(t *testing.T) {
-	bsplit := &BlockSplitterSimple{10, 10}
+	bsplit := &BlockSplitterSimple{10, 5, 10}
 	bc := &BlockChanges{}
 	bc.sizeEstimate = 11
 	if bsplit.ShouldEmbedBlockChanges(bc) {

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -279,6 +279,20 @@ outer:
 	return pathsFromRoot, blocks, nextBlockOffset, nil
 }
 
+func (fd *fileData) getIndirectBlocksForOffsetRange(ctx context.Context,
+	pblock *FileBlock, startOff, endOff int64) (
+	pathsFromRoot [][]parentBlockAndChildIndex, err error) {
+	// TODO: once we have an IsDirect flag, we can avoid fetching the
+	// leaf blocks.
+	pfr, _, _, err := fd.getLeafBlocksForOffsetRange(
+		ctx, fd.rootBlockPointer(), pblock, startOff, endOff, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return pfr, nil
+}
+
 // getByteSlicesInOffsetRange returns an ordered, continuous slice of
 // byte ranges for the data described by the half-inclusive offset
 // range `[startOff, endOff)`.  If `endOff` == -1, it returns data to
@@ -384,6 +398,15 @@ func (fd *fileData) getByteSlicesInOffsetRange(ctx context.Context,
 			toRead = lastByteInBlock - nextByte
 		}
 
+		// Check for holes in the middle of a file.
+		if nextByte < blockOff {
+			fill := blockOff - nextByte
+			bytes = append(bytes, make([]byte, fill))
+			nRead += fill
+			nextByte += fill
+			toRead -= fill
+		}
+
 		firstByteToRead := nextByte - blockOff
 		bytes = append(bytes,
 			block.Contents[firstByteToRead:toRead+firstByteToRead])
@@ -481,7 +504,7 @@ func (fd *fileData) getBytes(ctx context.Context, startOff, endOff int64) (
 // for the existing block, and use the existing block's ID for the new
 // indirect block that becomes the parent.
 func (fd *fileData) createIndirectBlock(
-	df *dirtyFile, dver DataVer) (*FileBlock, error) {
+	ctx context.Context, df *dirtyFile, dver DataVer) (*FileBlock, error) {
 	newID, err := fd.crypto.MakeTemporaryBlockID()
 	if err != nil {
 		return nil, err
@@ -509,6 +532,9 @@ func (fd *fileData) createIndirectBlock(
 		},
 	}
 
+	fd.log.CDebugf(ctx, "Creating new level of indirect for file %v, "+
+		"new block id for old top level is %v", fd.rootBlockPointer(), newID)
+
 	// Mark the old block ID as not dirty, so that we will treat the
 	// old block ID as newly dirtied in cacheBlockIfNotYetDirtyLocked.
 	df.setBlockNotDirty(fd.rootBlockPointer())
@@ -520,44 +546,288 @@ func (fd *fileData) createIndirectBlock(
 	return fblock, nil
 }
 
-// newRightBlock appends a new block (with a temporary ID) to the end
-// of this file.
+// newRightBlock creates space for a new rightmost block,
+// creating parent blocks and a new level of indirection in the tree
+// as needed.  If there's no new level of indirection, it modifies the
+// blocks in `parentBlocks` to include the new right-most pointers.
+// If there is a new level of indirection, it returns the new top
+// block.  It also returns any newly-dirtied block pointers.
 func (fd *fileData) newRightBlock(
-	ctx context.Context, ptr BlockPointer, pblock *FileBlock,
-	off int64) error {
-	newRID, err := fd.crypto.MakeTemporaryBlockID()
-	if err != nil {
-		return err
-	}
-	rblock := &FileBlock{}
-
-	newPtr := BlockPointer{
-		ID:      newRID,
-		KeyGen:  fd.kmd.LatestKeyGeneration(),
-		DataVer: DefaultNewBlockDataVersion(false),
-		Context: kbfsblock.Context{
-			Creator:  fd.uid,
-			RefNonce: kbfsblock.ZeroRefNonce,
-		},
+	ctx context.Context, parentBlocks []parentBlockAndChildIndex, off int64,
+	df *dirtyFile, dver DataVer) (*FileBlock, []BlockPointer, error) {
+	// Find the lowest block that can accommodate a new right block.
+	lowestAncestorWithRoom := -1
+	for i := len(parentBlocks) - 1; i >= 0; i-- {
+		pb := parentBlocks[i]
+		if len(pb.pblock.IPtrs) < fd.bsplit.MaxPtrsPerBlock() {
+			lowestAncestorWithRoom = i
+			break
+		}
 	}
 
-	pblock.IPtrs = append(pblock.IPtrs, IndirectFilePtr{
-		BlockInfo: BlockInfo{
-			BlockPointer: newPtr,
-			EncodedSize:  0,
-		},
-		Off: off,
-	})
+	var newTopBlock *FileBlock
+	var newDirtyPtrs []BlockPointer
+	if lowestAncestorWithRoom < 0 {
+		// Create a new level of indirection at the top.
+		var err error
+		newTopBlock, err = fd.createIndirectBlock(ctx, df, dver)
+		if err != nil {
+			return nil, nil, err
+		}
 
-	err = fd.cacher(newPtr, rblock)
-	if err != nil {
-		return err
+		// The old top block needs to be cached under its new ID if it
+		// was indirect.
+		if len(parentBlocks) > 0 {
+			ptr := newTopBlock.IPtrs[0].BlockPointer
+			err = fd.cacher(ptr, parentBlocks[0].pblock)
+			if err != nil {
+				return nil, nil, err
+			}
+			newDirtyPtrs = append(newDirtyPtrs, ptr)
+		}
+
+		parentBlocks = append([]parentBlockAndChildIndex{{newTopBlock, 0}},
+			parentBlocks...)
+		lowestAncestorWithRoom = 0
 	}
-	err = fd.cacher(ptr, pblock)
-	if err != nil {
-		return err
+
+	fd.log.CDebugf(ctx, "Making new right block at off %d for file %v, "+
+		"lowestAncestor at level %d", off, fd.rootBlockPointer(),
+		lowestAncestorWithRoom)
+
+	// Make a new right block for every parent, starting with the
+	// lowest ancestor with room.
+	pblock := parentBlocks[lowestAncestorWithRoom].pblock
+	for i := lowestAncestorWithRoom; i < len(parentBlocks); i++ {
+		newRID, err := fd.crypto.MakeTemporaryBlockID()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		newPtr := BlockPointer{
+			ID:      newRID,
+			KeyGen:  fd.kmd.LatestKeyGeneration(),
+			DataVer: dver,
+			Context: kbfsblock.Context{
+				Creator:  fd.uid,
+				RefNonce: kbfsblock.ZeroRefNonce,
+			},
+		}
+
+		fd.log.CDebugf(ctx, "New right block for file %d, level %d, ptr %v",
+			fd.rootBlockPointer(), i, newPtr)
+
+		pblock.IPtrs = append(pblock.IPtrs, IndirectFilePtr{
+			BlockInfo: BlockInfo{
+				BlockPointer: newPtr,
+				EncodedSize:  0,
+			},
+			Off: off,
+		})
+
+		rblock := &FileBlock{}
+		if i != len(parentBlocks)-1 {
+			rblock.IsInd = true
+			pblock = rblock
+		}
+
+		err = fd.cacher(newPtr, rblock)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		newDirtyPtrs = append(newDirtyPtrs, newPtr)
 	}
-	return nil
+
+	// All parents up to and including the lowest ancestor with room
+	// will have to change, so mark them as dirty.
+	ptr := fd.rootBlockPointer()
+	for i := 0; i <= lowestAncestorWithRoom; i++ {
+		pb := parentBlocks[i]
+		if err := fd.cacher(ptr, pb.pblock); err != nil {
+			return nil, nil, err
+		}
+		newDirtyPtrs = append(newDirtyPtrs, ptr)
+		ptr = pb.childIPtr().BlockPointer
+	}
+
+	return newTopBlock, newDirtyPtrs, nil
+}
+
+// shiftBlocksToFillHole should be called after newRightBlock when the
+// offset for the new block (`newHoleStartOff`) is smaller than the
+// size of the file.  This happens when there is a hole in the file,
+// and the user is now writing data into that hole.  This function
+// moves the new block into the correct place, and rearranges all the
+// indirect pointers in the file as needed.  It returns any block
+// pointers that were dirtied in the process.
+func (fd *fileData) shiftBlocksToFillHole(
+	ctx context.Context, newTopBlock *FileBlock, newHoleStartOff int64) (
+	newDirtyPtrs []BlockPointer, err error) {
+	fd.log.CDebugf(ctx, "Shifting block with offset %d for file %v into "+
+		"position", newHoleStartOff, fd.rootBlockPointer())
+
+	// Walk down the right side of the tree to find the new rightmost
+	// indirect pointer, the offset of which should match
+	// `newHoleStartOff`.  Keep swapping it with its sibling on the
+	// left until its offset would be lower than that child's offset.
+	// If there are no children to the left, continue on with the
+	// children in the cousin block to the left.  If we swap a child
+	// between cousin blocks, we must update the offset in the right
+	// cousin's parent block.  If *that* updated pointer is the
+	// leftmost pointer in its parent block, update that one as well,
+	// up to the root.
+	var parents []parentBlockAndChildIndex
+	currBlock := newTopBlock
+	for currBlock.IsInd {
+		index := len(currBlock.IPtrs) - 1
+		nextPtr := currBlock.IPtrs[index].BlockPointer
+		parents = append(parents, parentBlockAndChildIndex{currBlock, index})
+		currBlock, _, err = fd.getter(ctx, fd.kmd, nextPtr, fd.file, blockWrite)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	immedParent := parents[len(parents)-1]
+	currIndex := immedParent.childIndex
+	if off := immedParent.pblock.IPtrs[currIndex].Off; off != newHoleStartOff {
+		return nil, fmt.Errorf("Offset of rightmost block %d doesn't "+
+			"match newHoleStartOff %d", off, newHoleStartOff)
+	}
+
+	// Swap left as needed.
+	for true {
+		var leftOff int64
+		var newParents []parentBlockAndChildIndex
+		if currIndex > 0 {
+			leftOff = immedParent.pblock.IPtrs[currIndex-1].Off
+		} else {
+			// Construct the new set of parents for the shifted block,
+			// by looking for the next left cousin.
+			newParents = make([]parentBlockAndChildIndex, len(parents))
+			copy(newParents, parents)
+			var level int
+			for level = len(newParents) - 2; level >= 0; level-- {
+				if newParents[level].childIndex > 0 {
+					break
+				}
+				// Keep going up until we find a way back down a left branch.
+			}
+
+			if level < 0 {
+				// We are already all the way on the left, we're done!
+				return newDirtyPtrs, nil
+			}
+			newParents[level].childIndex--
+
+			// Walk back down, shifting the new parents into position.
+			for ; level < len(newParents)-1; level++ {
+				nextChildPtr := newParents[level].childIPtr()
+				childBlock, _, err := fd.getter(
+					ctx, fd.kmd, nextChildPtr.BlockPointer, fd.file, blockWrite)
+				if err != nil {
+					return nil, err
+				}
+
+				newParents[level+1].pblock = childBlock
+				newParents[level+1].childIndex = len(childBlock.IPtrs) - 1
+				leftOff = childBlock.IPtrs[len(childBlock.IPtrs)-1].Off
+			}
+		}
+
+		// We're done!
+		if leftOff < newHoleStartOff {
+			return newDirtyPtrs, nil
+		}
+
+		// Otherwise, we need to swap the indirect file pointers.
+		if currIndex > 0 {
+			immedParent.pblock.IPtrs[currIndex-1],
+				immedParent.pblock.IPtrs[currIndex] =
+				immedParent.pblock.IPtrs[currIndex],
+				immedParent.pblock.IPtrs[currIndex-1]
+			currIndex--
+			continue
+		}
+
+		// Swap block pointers across cousins at the lowest level of
+		// indirection.
+		newImmedParent := newParents[len(newParents)-1]
+		newCurrIndex := len(newImmedParent.pblock.IPtrs) - 1
+		newImmedParent.pblock.IPtrs[newCurrIndex],
+			immedParent.pblock.IPtrs[currIndex] =
+			immedParent.pblock.IPtrs[currIndex],
+			newImmedParent.pblock.IPtrs[newCurrIndex]
+
+		// Cache the new immediate parent as dirty.
+		if len(newParents) > 1 {
+			i := len(newParents) - 2
+			iptr := newParents[i].childIPtr()
+			if err := fd.cacher(
+				iptr.BlockPointer, newImmedParent.pblock); err != nil {
+				return nil, err
+			}
+			newDirtyPtrs = append(newDirtyPtrs, iptr.BlockPointer)
+		}
+
+		// Now we need to update the parent offsets on the right side,
+		// all the way up to the common ancestor (which is the one
+		// with the one that doesn't have a childIndex of 0).  (We
+		// don't need to update the left side, since the offset of the
+		// new right-most block on that side doesn't affect the
+		// incoming indirect pointer offset, which already points to
+		// the left side of that branch.)
+		newRightOff := immedParent.pblock.IPtrs[currIndex].Off
+		for level := len(parents) - 2; level >= 0; level-- {
+			// Cache the block below this level, which was just
+			// modified.
+			childPtr := parents[level].childIPtr()
+			if err := fd.cacher(childPtr.BlockPointer,
+				parents[level+1].pblock); err != nil {
+				return nil, err
+			}
+			newDirtyPtrs = append(newDirtyPtrs, childPtr.BlockPointer)
+
+			// If we've reached a level where the child indirect
+			// offset wasn't affected, we're done.  If not, update the
+			// offset at this level and move up the tree.
+			if parents[level+1].childIndex > 0 {
+				break
+			}
+			index := parents[level].childIndex
+			parents[level].pblock.IPtrs[index].Off = newRightOff
+		}
+		immedParent = newImmedParent
+		currIndex = newCurrIndex
+		parents = newParents
+	}
+
+	return nil, fmt.Errorf("Couldn't find where to move the hole for offset %d",
+		newHoleStartOff)
+}
+
+// markParentsDirty caches all the blocks in `parentBlocks` as dirty,
+// and returns the dirtied block pointers as well as any block infos
+// with non-zero encoded sizes that will now need to be unreferenced.
+func (fd *fileData) markParentsDirty(ctx context.Context,
+	parentBlocks []parentBlockAndChildIndex) (
+	dirtyPtrs []BlockPointer, unrefs []BlockInfo, err error) {
+	parentPtr := fd.rootBlockPointer()
+	for _, pb := range parentBlocks {
+		if err := fd.cacher(parentPtr, pb.pblock); err != nil {
+			return nil, unrefs, err
+		}
+		dirtyPtrs = append(dirtyPtrs, parentPtr)
+		parentPtr = pb.childIPtr()
+
+		// Remember the size of each newly-dirtied child.
+		if pb.childIPtr().EncodedSize != 0 {
+			unrefs = append(unrefs, pb.childIPtr().BlockInfo)
+			pb.pblock.IPtrs[pb.childIndex].EncodedSize = 0
+		}
+	}
+	return dirtyPtrs, unrefs, nil
 }
 
 // write sets the given data and the given offset within the file,
@@ -566,7 +836,9 @@ func (fd *fileData) newRightBlock(
 // * newDe: a new directory entry with the EncodedSize cleared if the file
 //   was extended.
 // * dirtyPtrs: a slice of the BlockPointers that have been dirtied during
-//   the write.
+//   the write.  This includes any interior indirect blocks that may not
+//   have been changed yet, but which will need to change as part of the
+//   sync process because of leaf node changes below it.
 // * unrefs: a slice of BlockInfos that must be unreferenced as part of an
 //   eventual sync of this write.  May be non-nil even if err != nil.
 // * newlyDirtiedChildBytes is the total amount of block data dirtied by this
@@ -583,6 +855,9 @@ func (fd *fileData) write(ctx context.Context, data []byte, off int64,
 	oldSizeWithoutHoles := oldDe.Size
 	newDe = oldDe
 
+	fd.log.CDebugf(ctx, "Writing %d bytes at off %d", n, off)
+
+	dirtyMap := make(map[BlockPointer]bool)
 	for nCopied < n {
 		ptr, parentBlocks, block, nextBlockOff, startOff, wasDirty, err :=
 			fd.getFileBlockAtOffset(ctx, topBlock, off+nCopied, blockWrite)
@@ -604,52 +879,66 @@ func (fd *fileData) write(ctx context.Context, data []byte, off int64,
 		nCopied += fd.bsplit.CopyUntilSplit(
 			block, nextBlockOff < 0, data[nCopied:max], off+nCopied-startOff)
 
-		// TODO: support multiple levels of indirection.  Right now the
-		// code only does one but it should be straightforward to
-		// generalize, just annoying
-
-		// if we need another block but there are no more, then make one
+		// If we need another block but there are no more, then make one.
 		switchToIndirect := false
-		if nCopied < n && nextBlockOff < 0 {
-			// If the block doesn't already have a parent block, make one.
-			if ptr == fd.rootBlockPointer() {
-				topBlock, err = fd.createIndirectBlock(
-					df, DefaultNewBlockDataVersion(false))
+		if nCopied < n {
+			var newTopBlock *FileBlock
+			needExtendFile := nextBlockOff < 0
+			needFillHole := off+nCopied < nextBlockOff
+			nextOff := startOff + int64(len(block.Contents))
+			if nextOff < off+nCopied {
+				// We are writing somewhere inside a hole, not right
+				// at the start of it.
+				nextOff = off + nCopied
+			}
+			if needExtendFile || needFillHole {
+				// Make a new right block and update the parent's
+				// indirect block list, adding a level of indirection
+				// if needed.  If we're just filling a hole, the block
+				// will end up all the way to the right of the range,
+				// and its offset will be smaller than the block to
+				// its left -- we'll fix that up below.
+				var newDirtyPtrs []BlockPointer
+				fd.log.CDebugf(ctx, "Making new right block at nCopied=%d, nextOff=%d", nCopied, nextOff)
+				newTopBlock, newDirtyPtrs, err = fd.newRightBlock(
+					ctx, parentBlocks, nextOff, df,
+					DefaultNewBlockDataVersion(false))
 				if err != nil {
 					return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
 				}
-				ptr = topBlock.IPtrs[0].BlockPointer
-				// The whole block needs to be re-uploaded as an
-				// indirect block, so track those dirty bytes and
-				// cache the block as dirty.
-				switchToIndirect = true
+				for _, p := range newDirtyPtrs {
+					dirtyMap[p] = true
+				}
+				if newTopBlock != nil {
+					if !topBlock.IsInd {
+						// The whole block needs to be re-uploaded as
+						// a child block with a new block pointer, so
+						// below we'll need to track those dirty bytes
+						// and cache the block as dirty.
+						switchToIndirect = true
+						ptr = newTopBlock.IPtrs[0].BlockPointer
+					}
+					// A new level of indirection.
+					topBlock = newTopBlock
+				}
 			}
-
-			// Make a new right block and update the parent's
-			// indirect block list
-			err = fd.newRightBlock(ctx, fd.rootBlockPointer(), topBlock,
-				startOff+int64(len(block.Contents)))
-			if err != nil {
-				return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
-			}
-		} else if nCopied < n && off+nCopied < nextBlockOff {
-			// We need a new block to be inserted here
-			err = fd.newRightBlock(ctx, fd.rootBlockPointer(), topBlock,
-				startOff+int64(len(block.Contents)))
-			if err != nil {
-				return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
-			}
-			// And push the indirect pointers to right
-			newb := topBlock.IPtrs[len(topBlock.IPtrs)-1]
-			indexInParent := parentBlocks[0].childIndex
-			copy(topBlock.IPtrs[indexInParent+2:],
-				topBlock.IPtrs[indexInParent+1:])
-			topBlock.IPtrs[indexInParent+1] = newb
-			if oldSizeWithoutHoles == oldDe.Size {
-				// For the purposes of calculating the newly-dirtied
-				// bytes for the deferral calculation, disregard the
-				// existing "hole" in the file.
-				oldSizeWithoutHoles = uint64(newb.Off)
+			// If we're filling a hole, swap the new right block into
+			// the hole and shift everything else over.
+			if needFillHole {
+				newDirtyPtrs, err := fd.shiftBlocksToFillHole(
+					ctx, topBlock, nextOff)
+				if err != nil {
+					return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+				}
+				for _, p := range newDirtyPtrs {
+					dirtyMap[p] = true
+				}
+				if oldSizeWithoutHoles == oldDe.Size {
+					// For the purposes of calculating the newly-dirtied
+					// bytes for the deferral calculation, disregard the
+					// existing "hole" in the file.
+					oldSizeWithoutHoles = uint64(nextOff)
+				}
 			}
 		}
 
@@ -675,17 +964,20 @@ func (fd *fileData) write(ctx context.Context, data []byte, off int64,
 			newlyDirtiedChildBytes -= int64(oldLen)
 		}
 
-		for _, pb := range parentBlocks {
-			// Remember how many bytes it was.
-			unrefs = append(unrefs, pb.childIPtr().BlockInfo)
-			pb.pblock.IPtrs[pb.childIndex].EncodedSize = 0
+		newDirtyPtrs, newUnrefs, err := fd.markParentsDirty(ctx, parentBlocks)
+		unrefs = append(unrefs, newUnrefs...)
+		if err != nil {
+			return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
+		}
+		for _, p := range newDirtyPtrs {
+			dirtyMap[p] = true
 		}
 
 		// keep the old block ID while it's dirty
 		if err = fd.cacher(ptr, block); err != nil {
 			return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
 		}
-		dirtyPtrs = append(dirtyPtrs, ptr)
+		dirtyMap[ptr] = true
 	}
 
 	if topBlock.IsInd {
@@ -698,7 +990,7 @@ func (fd *fileData) write(ctx context.Context, data []byte, off int64,
 		if err = fd.cacher(fd.rootBlockPointer(), topBlock); err != nil {
 			return newDe, nil, unrefs, newlyDirtiedChildBytes, 0, err
 		}
-		dirtyPtrs = append(dirtyPtrs, fd.rootBlockPointer())
+		dirtyMap[fd.rootBlockPointer()] = true
 	}
 
 	lastByteWritten := off + int64(len(data)) // not counting holes
@@ -707,58 +999,59 @@ func (fd *fileData) write(ctx context.Context, data []byte, off int64,
 		bytesExtended = lastByteWritten - int64(oldSizeWithoutHoles)
 	}
 
+	dirtyPtrs = make([]BlockPointer, 0, len(dirtyMap))
+	for p := range dirtyMap {
+		dirtyPtrs = append(dirtyPtrs, p)
+	}
+
 	return newDe, dirtyPtrs, unrefs, newlyDirtiedChildBytes, bytesExtended, nil
 }
 
-// truncateExtend increases file size to the given size, by either
-// writing blank data or inserting "holes" into the file depending on
-// how big the extension is. Return params:
-// * newDe: a new directory entry with the EncodedSize cleared if the file
-//   was extended.
+// truncateExtend increases file size to the given size by appending
+// a "hole" to the file. Return params:
+// * newDe: a new directory entry with the EncodedSize cleared.
 // * dirtyPtrs: a slice of the BlockPointers that have been dirtied during
-//   the write.
+//   the truncate.
 func (fd *fileData) truncateExtend(ctx context.Context, size uint64,
-	topBlock *FileBlock, oldDe DirEntry, df *dirtyFile) (
+	topBlock *FileBlock, parentBlocks []parentBlockAndChildIndex,
+	oldDe DirEntry, df *dirtyFile) (
 	newDe DirEntry, dirtyPtrs []BlockPointer, err error) {
-	fd.log.CDebugf(ctx, "truncateExtendLocked: extending fblock %#v", topBlock)
-	if !topBlock.IsInd {
-		fd.log.CDebugf(ctx, "truncateExtendLocked: making block indirect %v",
+	fd.log.CDebugf(ctx, "truncateExtend: extending file %v to size %d",
+		fd.rootBlockPointer(), size)
+	switchToIndirect := !topBlock.IsInd
+	oldTopBlock := topBlock
+	if switchToIndirect {
+		fd.log.CDebugf(ctx, "truncateExtend: making block indirect %v",
 			fd.rootBlockPointer())
-		old := topBlock
-		topBlock, err = fd.createIndirectBlock(
-			df, DefaultNewBlockDataVersion(true))
-		if err != nil {
-			return DirEntry{}, nil, err
-		}
+	}
+
+	newTopBlock, newDirtyPtrs, err := fd.newRightBlock(
+		ctx, parentBlocks, int64(size), df,
+		DefaultNewBlockDataVersion(true))
+	if err != nil {
+		return DirEntry{}, nil, err
+	}
+	if newTopBlock != nil {
+		topBlock = newTopBlock
+	}
+
+	if switchToIndirect {
 		topBlock.IPtrs[0].Holes = true
-		err = fd.cacher(topBlock.IPtrs[0].BlockPointer, old)
+		err = fd.cacher(topBlock.IPtrs[0].BlockPointer, oldTopBlock)
 		if err != nil {
 			return DirEntry{}, nil, err
 		}
 		dirtyPtrs = append(dirtyPtrs, topBlock.IPtrs[0].BlockPointer)
-		fd.log.CDebugf(ctx, "truncateExtendLocked: new zero data block %v",
+		fd.log.CDebugf(ctx, "truncateExtend: new zero data block %v",
 			topBlock.IPtrs[0].BlockPointer)
 	}
-
-	// TODO: support multiple levels of indirection.  Right now the
-	// code only does one but it should be straightforward to
-	// generalize, just annoying
-
-	err = fd.newRightBlock(ctx, fd.rootBlockPointer(), topBlock, int64(size))
-	if err != nil {
-		return DirEntry{}, nil, err
-	}
-	dirtyPtrs = append(dirtyPtrs,
-		topBlock.IPtrs[len(topBlock.IPtrs)-1].BlockPointer)
-	fd.log.CDebugf(ctx, "truncateExtendLocked: new right data block %v",
-		topBlock.IPtrs[len(topBlock.IPtrs)-1].BlockPointer)
-
+	dirtyPtrs = append(dirtyPtrs, newDirtyPtrs...)
 	newDe = oldDe
 	newDe.EncodedSize = 0
 	// update the file info
 	newDe.Size = size
 
-	// Mark all for presense of holes, one would be enough,
+	// Mark all for presence of holes, one would be enough,
 	// but this is more robust and easy.
 	for i := range topBlock.IPtrs {
 		topBlock.IPtrs[i].Holes = true
@@ -780,24 +1073,31 @@ func (fd *fileData) truncateExtend(ctx context.Context, size uint64,
 // truncateShrink shrinks the file to the given size. Return params:
 // * newDe: a new directory entry with the EncodedSize cleared if the file
 //   was extended.
+// * dirtyPtrs: a slice of the BlockPointers that have been dirtied during
+//   the truncate.  This includes any interior indirect blocks that may not
+//   have been changed yet, but which will need to change as part of the
+//   sync process because of leaf node changes below it.
 // * unrefs: a slice of BlockInfos that must be unreferenced as part of an
 //   eventual sync of this write.  May be non-nil even if err != nil.
 // * newlyDirtiedChildBytes is the total amount of block data dirtied by this
-//   write, including the entire size of blocks that have had at least one
+//   truncate, including the entire size of blocks that have had at least one
 //   byte dirtied.  As above, it may be non-zero even if err != nil.
 func (fd *fileData) truncateShrink(ctx context.Context, size uint64,
 	topBlock *FileBlock, oldDe DirEntry) (
-	newDe DirEntry, unrefs []BlockInfo, newlyDirtiedChildBytes int64,
-	err error) {
+	newDe DirEntry, dirtyPtrs []BlockPointer, unrefs []BlockInfo,
+	newlyDirtiedChildBytes int64, err error) {
 	iSize := int64(size) // TODO: deal with overflow
+
 	ptr, parentBlocks, block, nextBlockOff, startOff, wasDirty, err :=
 		fd.getFileBlockAtOffset(ctx, topBlock, iSize, blockWrite)
 	if err != nil {
-		return DirEntry{}, nil, 0, err
+		return DirEntry{}, nil, nil, 0, err
 	}
 
 	oldLen := len(block.Contents)
-	// We need to delete some data (and possibly entire blocks).
+	// We need to delete some data (and possibly entire blocks).  Note
+	// we make a new slice and copy data in order to make sure the
+	// data being truncated can be fully garbage-collected.
 	block.Contents = append([]byte(nil), block.Contents[:iSize-startOff]...)
 
 	newlyDirtiedChildBytes = int64(len(block.Contents))
@@ -805,18 +1105,77 @@ func (fd *fileData) truncateShrink(ctx context.Context, size uint64,
 		newlyDirtiedChildBytes -= int64(oldLen) // negative
 	}
 
+	dirtyMap := make(map[BlockPointer]bool)
 	if nextBlockOff > 0 {
-		// TODO: if indexInParent == 0, we can remove the level of indirection.
-		// TODO: support multiple levels of indirection.
-		parentBlock := parentBlocks[0].pblock
-		indexInParent := parentBlocks[0].childIndex
-		for _, ptr := range parentBlock.IPtrs[indexInParent+1:] {
-			unrefs = append(unrefs, ptr.BlockInfo)
+		// TODO: remove any unnecessary levels of indirection if the
+		// number of leaf nodes shrinks significantly.
+
+		// Get all paths to any leaf nodes following the new
+		// right-most block, since those blocks need to be
+		// unreferenced, and their parents need to be modified or
+		// unreferenced.
+		pfr, err := fd.getIndirectBlocksForOffsetRange(
+			ctx, topBlock, nextBlockOff, -1)
+		if err != nil {
+			return DirEntry{}, nil, nil, 0, err
 		}
-		parentBlock.IPtrs = parentBlock.IPtrs[:indexInParent+1]
-		// always make the parent block dirty, so we will sync it
-		if err = fd.cacher(fd.rootBlockPointer(), parentBlock); err != nil {
-			return DirEntry{}, nil, newlyDirtiedChildBytes, err
+
+		cachedPtrs := make(map[BlockPointer][]IndirectFilePtr)
+		for _, path := range pfr {
+			// Fake an indirect pointer for the top block.
+			iptr := IndirectFilePtr{BlockInfo: BlockInfo{
+				BlockPointer: fd.rootBlockPointer(),
+			}}
+			leftMost := true
+			for i, pb := range path {
+				ptrs := cachedPtrs[iptr.BlockPointer]
+				if ptrs == nil {
+					// Process each block exactly once, removing all
+					// now-unnecessary indirect pointers (but caching
+					// that list so we can still walk the tree on the
+					// next iterations).
+					pblock := pb.pblock
+					ptrs = pblock.IPtrs
+					cachedPtrs[iptr.BlockPointer] = ptrs
+
+					// Remove the first child iptr and everything
+					// following it if all the child indices below
+					// this level are 0. If we remove iptr 0, this
+					// block can be unreferenced (unless it's on the
+					// left-most edge of the tree, in which case we
+					// keep it around for now -- see above TODO).
+					removeStartingFromIndex := pb.childIndex
+					for j := i + 1; j < len(path); j++ {
+						if path[j].childIndex > 0 {
+							removeStartingFromIndex++
+							break
+						}
+					}
+
+					if pb.childIndex == 0 && !leftMost {
+						if iptr.EncodedSize != 0 {
+							unrefs = append(unrefs, iptr.BlockInfo)
+						}
+					} else if removeStartingFromIndex < len(pblock.IPtrs) {
+						pblock.IPtrs = pblock.IPtrs[:removeStartingFromIndex]
+						err := fd.cacher(iptr.BlockPointer, pblock)
+						if err != nil {
+							return DirEntry{}, nil, nil,
+								newlyDirtiedChildBytes, err
+						}
+						dirtyMap[iptr.BlockPointer] = true
+					}
+				}
+
+				// Down to the next level.  If we've hit the leaf
+				// level, unreference the block.
+				iptr = ptrs[pb.childIndex]
+				if i == len(path)-1 && iptr.EncodedSize != 0 {
+					unrefs = append(unrefs, iptr.BlockInfo)
+				} else if pb.childIndex > 0 {
+					leftMost = false
+				}
+			}
 		}
 	}
 
@@ -828,14 +1187,18 @@ func (fd *fileData) truncateShrink(ctx context.Context, size uint64,
 		// being sync'd, since this top-most block will always be in
 		// the dirtyFiles map.
 		if err = fd.cacher(fd.rootBlockPointer(), topBlock); err != nil {
-			return DirEntry{}, nil, newlyDirtiedChildBytes, err
+			return DirEntry{}, nil, nil, newlyDirtiedChildBytes, err
 		}
+		dirtyMap[fd.rootBlockPointer()] = true
 	}
 
-	for _, pb := range parentBlocks {
-		// Remember how many bytes it was.
-		unrefs = append(unrefs, pb.childIPtr().BlockInfo)
-		pb.pblock.IPtrs[pb.childIndex].EncodedSize = 0
+	newDirtyPtrs, newUnrefs, err := fd.markParentsDirty(ctx, parentBlocks)
+	unrefs = append(unrefs, newUnrefs...)
+	if err != nil {
+		return DirEntry{}, nil, unrefs, newlyDirtiedChildBytes, err
+	}
+	for _, p := range newDirtyPtrs {
+		dirtyMap[p] = true
 	}
 
 	newDe = oldDe
@@ -844,10 +1207,16 @@ func (fd *fileData) truncateShrink(ctx context.Context, size uint64,
 
 	// Keep the old block ID while it's dirty.
 	if err = fd.cacher(ptr, block); err != nil {
-		return DirEntry{}, nil, newlyDirtiedChildBytes, err
+		return DirEntry{}, nil, nil, newlyDirtiedChildBytes, err
+	}
+	dirtyMap[ptr] = true
+
+	dirtyPtrs = make([]BlockPointer, 0, len(dirtyMap))
+	for p := range dirtyMap {
+		dirtyPtrs = append(dirtyPtrs, p)
 	}
 
-	return newDe, unrefs, newlyDirtiedChildBytes, nil
+	return newDe, dirtyPtrs, unrefs, newlyDirtiedChildBytes, nil
 }
 
 // split, if given an indirect top block of a file, checks whether any
@@ -856,7 +1225,7 @@ func (fd *fileData) truncateShrink(ctx context.Context, size uint64,
 // fingerprinting-based boundaries).  It returns the set of blocks
 // that now need to be unreferenced.
 func (fd *fileData) split(ctx context.Context, id tlf.ID,
-	dirtyBcache DirtyBlockCache, topBlock *FileBlock) (
+	dirtyBcache DirtyBlockCache, topBlock *FileBlock, df *dirtyFile) (
 	unrefs []BlockInfo, err error) {
 	if !topBlock.IsInd {
 		return nil, nil
@@ -885,7 +1254,7 @@ func (fd *fileData) split(ctx context.Context, id tlf.ID,
 		if !isDirty {
 			continue
 		}
-		_, _, block, nextBlockOff, _, _, err :=
+		_, parentBlocks, block, nextBlockOff, _, _, err :=
 			fd.getFileBlockAtOffset(ctx, topBlock, ptr.Off, blockWrite)
 		if err != nil {
 			return unrefs, err
@@ -901,10 +1270,10 @@ func (fd *fileData) split(ctx context.Context, id tlf.ID,
 			block.Contents = block.Contents[:splitAt]
 			// put the extra bytes in front of the next block
 			if nextBlockOff < 0 {
-				// need to make a new block
-				if err := fd.newRightBlock(
-					ctx, fd.rootBlockPointer(), topBlock,
-					endOfBlock); err != nil {
+				// Need to make a new block.
+				if _, _, err := fd.newRightBlock(
+					ctx, parentBlocks, endOfBlock, df,
+					DefaultNewBlockDataVersion(false)); err != nil {
 					return unrefs, err
 				}
 			}
@@ -1032,7 +1401,6 @@ func (fd *fileData) getIndirectFileBlockInfosWithTopBlock(ctx context.Context,
 
 func (fd *fileData) getIndirectFileBlockInfos(ctx context.Context) (
 	[]BlockInfo, error) {
-	// TODO: handle multiple levels of indirection.
 	topBlock, _, err := fd.getter(
 		ctx, fd.kmd, fd.rootBlockPointer(), fd.file, blockRead)
 	if err != nil {

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -1,0 +1,735 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func setupFileDataTest(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int) (*fileData, BlockCache, DirtyBlockCache, *dirtyFile) {
+	// Make a fake file.
+	ptr := BlockPointer{
+		ID:      kbfsblock.FakeID(42),
+		KeyGen:  1,
+		DataVer: 1,
+	}
+	id := tlf.FakeID(1, false)
+	file := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "file"}}}
+	uid := keybase1.MakeTestUID(1)
+	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
+	bsplit := &BlockSplitterSimple{maxBlockSize, maxPtrsPerBlock, 10}
+	kmd := emptyKeyMetadata{id, 1}
+
+	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)
+	dirtyBcache := simpleDirtyBlockCacheStandard()
+	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
+		_ path, _ blockReqType) (*FileBlock, bool, error) {
+		isDirty := true
+		block, err := dirtyBcache.Get(id, ptr, MasterBranch)
+		if err != nil {
+			// Check the clean cache.
+			block, err = cleanCache.Get(ptr)
+			if err != nil {
+				return nil, false, err
+			}
+			isDirty = false
+		}
+		fblock, ok := block.(*FileBlock)
+		if !ok {
+			return nil, false,
+				fmt.Errorf("Block for %s is not a file block", ptr)
+		}
+		return fblock, isDirty, nil
+	}
+	cacher := func(ptr BlockPointer, block Block) error {
+		return dirtyBcache.Put(id, ptr, MasterBranch, block)
+	}
+
+	fd := newFileData(
+		file, uid, crypto, bsplit, kmd, getter, cacher, logger.NewTestLogger(t))
+	df := newDirtyFile(file, dirtyBcache)
+	return fd, cleanCache, dirtyBcache, df
+}
+
+type testFileDataLevel struct {
+	dirty    bool
+	children []testFileDataLevel
+	off      int64
+	size     int
+}
+
+type testFileDataHole struct {
+	start int64
+	end   int64
+}
+
+func testFileDataLevelFromData(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int, existingLevels int, fullDataLen int64,
+	holes []testFileDataHole, startWrite, endWrite,
+	holeShiftAfter int64, truncateExtend bool) testFileDataLevel {
+	// First fill in the leaf level.
+	var prevChildren []testFileDataLevel
+	var off int64
+	size := 0
+	nextHole := 0
+	for off < fullDataLen {
+		var nextOff int64
+		size = int(maxBlockSize)
+		makeFinalHole := false
+		if nextHole < len(holes) &&
+			off+maxBlockSize >= holes[nextHole].start {
+			size = int(holes[nextHole].start - off)
+			nextOff = holes[nextHole].end
+			nextHole++
+			makeFinalHole = nextHole >= len(holes) &&
+				nextOff >= fullDataLen
+		} else if off+maxBlockSize > fullDataLen {
+			size = int(fullDataLen - off)
+			nextOff = fullDataLen
+		} else {
+			nextOff = off + maxBlockSize
+		}
+		dirty := off < endWrite && startWrite < off+int64(size)
+		// If this is a shrink, dirty the block containing startWrite.
+		if endWrite < 0 {
+			dirty = nextOff >= startWrite
+		}
+		newChild := testFileDataLevel{dirty, nil, off, size}
+		t.Logf("Expected leaf offset %d [dirty=%t]", off, dirty)
+		prevChildren = append(prevChildren, newChild)
+
+		if makeFinalHole {
+			// The final hole can only ever be dirty if there was a
+			// truncate to a new length.
+			newChild := testFileDataLevel{truncateExtend, nil, nextOff, 0}
+			t.Logf("Expected leaf offset %d (final)", nextOff)
+			prevChildren = append(prevChildren, newChild)
+		}
+
+		off = nextOff
+	}
+	if fullDataLen == 0 {
+		// Special case for a file that's been left empty.
+		newChild := testFileDataLevel{true, nil, 0, 0}
+		prevChildren = append(prevChildren, newChild)
+	}
+
+	// Now fill in any parents.  If this is a shrink, force the new
+	// data to have the same number of levels (we never remove levels
+	// of indirection at the moment).
+	newLevels := 1
+	for len(prevChildren) != 1 || (endWrite < 0 && newLevels < existingLevels) {
+		prevChildIndex := 0
+		var level []testFileDataLevel
+
+		numAtLevel := int(math.Ceil(float64(len(prevChildren)) /
+			float64(maxPtrsPerBlock)))
+		for i := 0; i < numAtLevel; i++ {
+			// Split the previous children up (if any) into
+			// maxPtrsPerBlock chunks.
+			var children []testFileDataLevel
+			var off int64
+			newIndex := prevChildIndex + maxPtrsPerBlock
+			if newIndex > len(prevChildren) {
+				newIndex = len(prevChildren)
+			}
+			off = prevChildren[prevChildIndex].off
+			children = prevChildren[prevChildIndex:newIndex]
+			prevChildIndex = newIndex
+			dirty := false
+			for _, child := range children {
+				// A parent is dirty if it has a dirty child.
+				if child.dirty {
+					dirty = true
+					break
+				}
+			}
+			// Also if a new block was made in a hole, any indirect
+			// parent that comes after the end of the write will be
+			// dirty, due to hole shifting.
+			if holeShiftAfter > 0 && off >= holeShiftAfter {
+				dirty = true
+			}
+			newChild := testFileDataLevel{dirty, children, off, 0}
+			level = append(level, newChild)
+		}
+		prevChildren = level
+		newLevels++
+	}
+
+	// Even in a shrink, the top block is always dirty.
+	currNode := &(prevChildren[0])
+	if endWrite < 0 {
+		currNode.dirty = true
+	}
+
+	// If we added new levels, we can expect the old topmost block to
+	// be dirty, since we have to upload it with a new block ID.
+	for i := 0; i <= newLevels-existingLevels; i++ {
+		t.Logf("Dirtying level %d %d %d", i, newLevels, existingLevels)
+		currNode.dirty = true
+		if len(currNode.children) == 0 {
+			break
+		}
+		currNode = &(currNode.children[0])
+	}
+
+	return prevChildren[0]
+}
+
+func (tfdl testFileDataLevel) check(t *testing.T, fd *fileData,
+	ptr BlockPointer, off int64, dirtyBcache DirtyBlockCache) (
+	dirtyPtrs map[BlockPointer]bool) {
+	dirtyPtrs = make(map[BlockPointer]bool)
+	levelString := fmt.Sprintf("ptr=%s, off=%d", ptr, off)
+	t.Logf("Checking %s", levelString)
+
+	require.Equal(t, tfdl.off, off, levelString)
+	if tfdl.dirty {
+		dirtyPtrs[ptr] = true
+		require.True(
+			t, dirtyBcache.IsDirty(fd.file.Tlf, ptr, MasterBranch), levelString)
+	}
+
+	fblock, isDirty, err := fd.getter(nil, nil, ptr, path{}, blockRead)
+	require.NoError(t, err, levelString)
+	require.Equal(t, tfdl.dirty, isDirty, levelString)
+	require.NotNil(t, fblock, levelString)
+
+	// We expect this to be a leaf block.
+	if len(tfdl.children) == 0 {
+		require.False(t, fblock.IsInd, levelString)
+		require.Len(t, fblock.IPtrs, 0, levelString)
+		require.Len(t, fblock.Contents, tfdl.size, levelString)
+		return dirtyPtrs
+	}
+
+	// Otherwise it's indirect, so check all the children.
+	require.True(t, fblock.IsInd, levelString)
+	require.Len(t, fblock.IPtrs, len(tfdl.children), levelString)
+	require.Len(t, fblock.Contents, 0, levelString)
+	for i, iptr := range fblock.IPtrs {
+		childDirtyPtrs := tfdl.children[i].check(
+			t, fd, iptr.BlockPointer, iptr.Off, dirtyBcache)
+		for ptr := range childDirtyPtrs {
+			dirtyPtrs[ptr] = true
+		}
+	}
+	return dirtyPtrs
+}
+
+func testFileDataCheckWrite(t *testing.T, fd *fileData,
+	dirtyBcache DirtyBlockCache, df *dirtyFile, data []byte, off int64,
+	topBlock *FileBlock, oldDe DirEntry, expectedSize uint64,
+	expectedUnrefs []BlockInfo, expectedDirtiedBytes int64,
+	expectedBytesExtended int64, expectedTopLevel testFileDataLevel) {
+	// Do the write.
+	ctx := context.Background()
+	newDe, dirtyPtrs, unrefs, newlyDirtiedChildBytes, bytesExtended, err :=
+		fd.write(ctx, data, off, topBlock, oldDe, df)
+	require.NoError(t, err)
+
+	// Check the basics.
+	require.Equal(t, expectedSize, newDe.Size)
+	require.Equal(t, expectedDirtiedBytes, newlyDirtiedChildBytes)
+	require.Equal(t, expectedBytesExtended, bytesExtended)
+
+	// Go through each expected level and make sure we have the right
+	// set of dirty pointers and children.
+	expectedDirtyPtrs := expectedTopLevel.check(
+		t, fd, fd.file.tailPointer(), 0, dirtyBcache)
+	dirtyPtrsMap := make(map[BlockPointer]bool)
+	for _, ptr := range dirtyPtrs {
+		dirtyPtrsMap[ptr] = true
+	}
+	require.True(t, reflect.DeepEqual(expectedDirtyPtrs, dirtyPtrsMap),
+		fmt.Sprintf("expected %v; got %v", expectedDirtyPtrs, dirtyPtrsMap))
+
+	// TODO: set the EncodedSize of the existing blocks to something
+	// non-zero so that we get some unrefs.
+	require.Len(t, unrefs, 0)
+}
+
+func testFileDataWriteExtendEmptyFile(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int, fullDataLen int64) {
+	fd, _, dirtyBcache, df := setupFileDataTest(
+		t, maxBlockSize, maxPtrsPerBlock)
+	topBlock := NewFileBlock().(*FileBlock)
+	de := DirEntry{}
+	data := make([]byte, fullDataLen)
+	for i := 0; i < int(fullDataLen); i++ {
+		data[i] = byte(i)
+	}
+	expectedTopLevel := testFileDataLevelFromData(
+		t, maxBlockSize, maxPtrsPerBlock, 0, fullDataLen, nil, 0,
+		fullDataLen, 0, false)
+
+	testFileDataCheckWrite(
+		t, fd, dirtyBcache, df, data, 0, topBlock, de, uint64(fullDataLen),
+		nil, fullDataLen, fullDataLen, expectedTopLevel)
+
+	// Make sure we can read back the complete data.
+	gotData := make([]byte, fullDataLen)
+	nRead, err := fd.read(context.Background(), gotData, 0)
+	require.NoError(t, err)
+	require.Equal(t, nRead, fullDataLen)
+	require.True(t, bytes.Equal(data, gotData))
+}
+
+func testFileDataWriteNewLevel(t *testing.T, levels float64) {
+	capacity := math.Pow(2, levels)
+	halfCapacity := capacity/2 + 1
+	if levels == 1 {
+		halfCapacity = capacity - 1
+	}
+	// Fills half the leaf level.
+	testFileDataWriteExtendEmptyFile(t, 2, 2, int64(halfCapacity))
+	// Fills whole leaf level.
+	testFileDataWriteExtendEmptyFile(t, 2, 2, int64(capacity))
+
+}
+
+func TestFileDataWriteNewOneLevel(t *testing.T) {
+	testFileDataWriteNewLevel(t, 1)
+}
+
+func TestFileDataWriteNewTwoLevels(t *testing.T) {
+	testFileDataWriteNewLevel(t, 2)
+}
+
+func TestFileDataWriteNewThreeLevels(t *testing.T) {
+	testFileDataWriteNewLevel(t, 3)
+}
+
+// Test when new file data all fits into ten levels.
+func TestFileDataWriteNewTenLevels(t *testing.T) {
+	testFileDataWriteNewLevel(t, 10)
+}
+
+func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
+	maxBlockSize int64, maxPtrsPerBlock int, existingData []byte,
+	holes []testFileDataHole, cleanBcache BlockCache) (*FileBlock, int) {
+	// First fill in the leaf blocks.
+	var off int64
+	existingDataLen := int64(len(existingData))
+	var prevChildren []*FileBlock
+	var leafOffs []int64
+	nextHole := 0
+	for off < existingDataLen {
+		endOff := off + maxBlockSize
+		var nextOff int64
+		makeFinalHole := false
+		if nextHole < len(holes) &&
+			endOff > holes[nextHole].start {
+			endOff = holes[nextHole].start
+			nextOff = holes[nextHole].end
+			nextHole++
+			makeFinalHole = nextHole >= len(holes) &&
+				nextOff >= existingDataLen
+		} else if endOff > existingDataLen {
+			endOff = existingDataLen
+			nextOff = existingDataLen
+		} else {
+			nextOff = endOff
+		}
+
+		fblock := NewFileBlock().(*FileBlock)
+		fblock.Contents = existingData[off:endOff]
+		prevChildren = append(prevChildren, fblock)
+		t.Logf("Initial leaf offset %d, size %d", off, len(fblock.Contents))
+		leafOffs = append(leafOffs, off)
+
+		if makeFinalHole {
+			fblock := NewFileBlock().(*FileBlock)
+			prevChildren = append(prevChildren, fblock)
+			t.Logf("Initial leaf offset %d (final)", nextOff)
+			leafOffs = append(leafOffs, nextOff)
+		}
+
+		off = nextOff
+	}
+
+	// Now fill in any parents.
+	numLevels := 1
+	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
+	for len(prevChildren) != 1 {
+		prevChildIndex := 0
+		var level []*FileBlock
+		numAtLevel := int(math.Ceil(float64(len(prevChildren)) /
+			float64(maxPtrsPerBlock)))
+		for i := 0; i < numAtLevel; i++ {
+			// Split the previous children up (if any) into maxPtrsPerBlock
+			// chunks.
+			var children []*FileBlock
+			newIndex := prevChildIndex + maxPtrsPerBlock
+			if newIndex > len(prevChildren) {
+				newIndex = len(prevChildren)
+			}
+			children = prevChildren[prevChildIndex:newIndex]
+			fblock := NewFileBlock().(*FileBlock)
+			fblock.IsInd = true
+			for j, child := range children {
+				id, err := crypto.MakeTemporaryBlockID()
+				require.NoError(t, err)
+				ptr := BlockPointer{
+					ID:      id,
+					KeyGen:  1,
+					DataVer: 1,
+				}
+				var off int64
+				if child.IsInd {
+					off = child.IPtrs[0].Off
+				} else {
+					off = leafOffs[prevChildIndex+j]
+				}
+
+				fblock.IPtrs = append(fblock.IPtrs, IndirectFilePtr{
+					BlockInfo: BlockInfo{ptr, 0},
+					Off:       off,
+				})
+				cleanBcache.Put(ptr, fd.file.Tlf, child, TransientEntry)
+			}
+			prevChildIndex = newIndex
+			level = append(level, fblock)
+		}
+		prevChildren = level
+		numLevels++
+	}
+	return prevChildren[0], numLevels
+}
+
+func testFileDataWriteExtendExistingFile(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int, existingLen int64, fullDataLen int64) {
+	fd, cleanBcache, dirtyBcache, df := setupFileDataTest(
+		t, maxBlockSize, maxPtrsPerBlock)
+	data := make([]byte, fullDataLen)
+	for i := 0; i < int(fullDataLen); i++ {
+		data[i] = byte(i)
+	}
+	topBlock, levels := testFileDataLevelExistingBlocks(
+		t, fd, maxBlockSize, maxPtrsPerBlock, data[:existingLen], nil,
+		cleanBcache)
+	de := DirEntry{
+		EntryInfo: EntryInfo{
+			Size: uint64(existingLen),
+		},
+	}
+	expectedTopLevel := testFileDataLevelFromData(
+		t, maxBlockSize, maxPtrsPerBlock, levels, fullDataLen, nil, existingLen,
+		fullDataLen, 0, false)
+
+	extendedBytes := fullDataLen - existingLen
+	// Round up to find out the number of dirty bytes.
+	remainder := extendedBytes % maxBlockSize
+	dirtiedBytes := extendedBytes
+	if remainder > 0 {
+		dirtiedBytes += (maxBlockSize - remainder)
+	}
+	// Add a block's worth of dirty bytes if we're extending past the
+	// first full level, because the original block still gets dirtied
+	// because it needs to be inserted under a new ID.
+	if existingLen == maxBlockSize {
+		dirtiedBytes += maxBlockSize
+	}
+	testFileDataCheckWrite(
+		t, fd, dirtyBcache, df, data[existingLen:], existingLen,
+		topBlock, de, uint64(fullDataLen),
+		nil, dirtiedBytes, extendedBytes, expectedTopLevel)
+
+	// Make sure we can read back the complete data.
+	gotData := make([]byte, fullDataLen)
+	nRead, err := fd.read(context.Background(), gotData, 0)
+	require.NoError(t, err)
+	require.Equal(t, nRead, fullDataLen)
+	require.True(t, bytes.Equal(data, gotData))
+}
+
+func testFileDataExtendExistingLevels(t *testing.T, levels float64) {
+	capacity := math.Pow(2, levels)
+	halfCapacity := capacity / 2
+	// Starts with one lower level and adds a level.
+	testFileDataWriteExtendExistingFile(
+		t, 2, 2, int64(halfCapacity), int64(capacity))
+}
+
+func TestFileDataExtendExistingOneLevel(t *testing.T) {
+	testFileDataExtendExistingLevels(t, 1)
+}
+
+func TestFileDataExtendExistingTwoLevels(t *testing.T) {
+	testFileDataExtendExistingLevels(t, 2)
+}
+
+func TestFileDataExtendExistingThreeLevels(t *testing.T) {
+	testFileDataExtendExistingLevels(t, 3)
+}
+
+func TestFileDataExtendExistingTenLevels(t *testing.T) {
+	testFileDataExtendExistingLevels(t, 10)
+}
+
+func testFileDataOverwriteExistingFile(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int, fullDataLen int64, holes []testFileDataHole,
+	startWrite, endWrite int64, finalHoles []testFileDataHole) {
+	fd, cleanBcache, dirtyBcache, df := setupFileDataTest(
+		t, maxBlockSize, maxPtrsPerBlock)
+	data := make([]byte, fullDataLen)
+	for i := 0; i < int(fullDataLen); i++ {
+		data[i] = byte(i)
+	}
+	holeShiftAfter := int64(0)
+	for _, hole := range holes {
+		for i := hole.start; i < hole.end; i++ {
+			data[i] = byte(0)
+			if holeShiftAfter == 0 {
+				if startWrite <= i && i < endWrite {
+					holeShiftAfter = i
+				}
+			}
+		}
+	}
+	topBlock, levels := testFileDataLevelExistingBlocks(
+		t, fd, maxBlockSize, maxPtrsPerBlock, data, holes, cleanBcache)
+	de := DirEntry{
+		EntryInfo: EntryInfo{
+			Size: uint64(fullDataLen),
+		},
+	}
+
+	t.Logf("holeShiftAfter=%d", holeShiftAfter)
+	expectedTopLevel := testFileDataLevelFromData(
+		t, maxBlockSize, maxPtrsPerBlock, levels, fullDataLen, finalHoles,
+		startWrite, endWrite, holeShiftAfter, false)
+
+	// Round up to find out the number of dirty bytes.
+	writtenBytes := endWrite - startWrite
+	remainder := writtenBytes % maxBlockSize
+	dirtiedBytes := writtenBytes
+	if remainder > 0 {
+		dirtiedBytes += (maxBlockSize - remainder)
+	}
+
+	// The extended bytes are the size of the new blocks that were
+	// added.  This isn't exactly right, but for now just pick the
+	// start of the last hole and round it up to the next block.
+	extendedBytes := int64(0)
+	existingBytes := holes[len(holes)-1].start
+	remainder = existingBytes % maxBlockSize
+	if remainder > 0 {
+		existingBytes += (maxBlockSize - remainder)
+	}
+	if endWrite > existingBytes {
+		extendedBytes = endWrite - existingBytes
+		// Also ignore any bytes that are still in the hole.
+		if existingBytes < holeShiftAfter {
+			extendedBytes -= holeShiftAfter - existingBytes
+		}
+	}
+
+	newData := make([]byte, writtenBytes)
+	for i := startWrite; i < endWrite; i++ {
+		// The new data shifts each byte over by 1.
+		newData[i-startWrite] = byte(i + 1)
+	}
+	testFileDataCheckWrite(
+		t, fd, dirtyBcache, df, newData, startWrite,
+		topBlock, de, uint64(fullDataLen),
+		nil, dirtiedBytes, extendedBytes, expectedTopLevel)
+
+	copy(data[startWrite:endWrite], newData)
+
+	// Make sure we can read back the complete data.
+	gotData := make([]byte, fullDataLen)
+	nRead, err := fd.read(context.Background(), gotData, 0)
+	require.NoError(t, err)
+	require.Equal(t, nRead, fullDataLen)
+	require.True(t, bytes.Equal(data, gotData))
+}
+
+func TestFileDataWriteStartOfHole(t *testing.T) {
+	testFileDataOverwriteExistingFile(t, 2, 2, 10, []testFileDataHole{{5, 10}},
+		5, 8, []testFileDataHole{{8, 10}})
+}
+
+func TestFileDataWriteEndOfHole(t *testing.T) {
+	// The first final hole starts at 6, instead of 5, because a write
+	// extends the existing block.
+	testFileDataOverwriteExistingFile(t, 2, 2, 10, []testFileDataHole{{5, 10}},
+		8, 10, []testFileDataHole{{6, 8}, {10, 10}})
+}
+
+func TestFileDataWriteMiddleOfHole(t *testing.T) {
+	// The first final hole starts at 6, instead of 5, because a write
+	// extends the existing block.
+	testFileDataOverwriteExistingFile(t, 2, 2, 10, []testFileDataHole{{5, 10}},
+		7, 9, []testFileDataHole{{6, 7}, {9, 10}})
+}
+
+func testFileDataCheckTruncateExtend(t *testing.T, fd *fileData,
+	dirtyBcache DirtyBlockCache, df *dirtyFile, size uint64,
+	topBlock *FileBlock, oldDe DirEntry, expectedTopLevel testFileDataLevel) {
+	// Do the extending truncate.
+	ctx := context.Background()
+
+	_, parentBlocks, _, _, _, _, err :=
+		fd.getFileBlockAtOffset(ctx, topBlock, int64(size), blockWrite)
+	require.NoError(t, err)
+
+	newDe, dirtyPtrs, err := fd.truncateExtend(
+		ctx, size, topBlock, parentBlocks, oldDe, df)
+	require.NoError(t, err)
+
+	// Check the basics.
+	require.Equal(t, size, newDe.Size)
+
+	// Go through each expected level and make sure we have the right
+	// set of dirty pointers and children.
+	expectedDirtyPtrs := expectedTopLevel.check(
+		t, fd, fd.file.tailPointer(), 0, dirtyBcache)
+	dirtyPtrsMap := make(map[BlockPointer]bool)
+	for _, ptr := range dirtyPtrs {
+		dirtyPtrsMap[ptr] = true
+	}
+	require.True(t, reflect.DeepEqual(expectedDirtyPtrs, dirtyPtrsMap),
+		fmt.Sprintf("expected %v; got %v", expectedDirtyPtrs, dirtyPtrsMap))
+}
+
+func testFileDataTruncateExtendFile(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int, currDataLen int64, newSize uint64,
+	holes []testFileDataHole) {
+	fd, cleanBcache, dirtyBcache, df := setupFileDataTest(
+		t, maxBlockSize, maxPtrsPerBlock)
+	data := make([]byte, currDataLen)
+	for i := 0; i < int(currDataLen); i++ {
+		data[i] = byte(i)
+	}
+	for _, hole := range holes {
+		for i := hole.start; i < hole.end; i++ {
+			data[i] = byte(0)
+		}
+	}
+	topBlock, levels := testFileDataLevelExistingBlocks(
+		t, fd, maxBlockSize, maxPtrsPerBlock, data, holes, cleanBcache)
+	de := DirEntry{
+		EntryInfo: EntryInfo{
+			Size: uint64(currDataLen),
+		},
+	}
+
+	expectedTopLevel := testFileDataLevelFromData(
+		t, maxBlockSize, maxPtrsPerBlock, levels, currDataLen,
+		append(holes, testFileDataHole{currDataLen, int64(newSize)}),
+		currDataLen, int64(newSize), 0, true)
+
+	testFileDataCheckTruncateExtend(
+		t, fd, dirtyBcache, df, newSize, topBlock, de, expectedTopLevel)
+
+	newZeroes := make([]byte, int64(newSize)-currDataLen)
+	data = append(data, newZeroes...)
+
+	// Make sure we can read back the complete data.
+	gotData := make([]byte, newSize)
+	nRead, err := fd.read(context.Background(), gotData, 0)
+	require.NoError(t, err)
+	require.Equal(t, nRead, int64(newSize))
+	require.True(t, bytes.Equal(data, gotData))
+}
+
+func TestFileDataTruncateExtendSameLevel(t *testing.T) {
+	testFileDataTruncateExtendFile(t, 2, 2, 5, 8, nil)
+}
+
+func TestFileDataTruncateExtendNewLevel(t *testing.T) {
+	testFileDataTruncateExtendFile(t, 2, 2, 3, 8, nil)
+}
+
+func testFileDataCheckTruncateShrink(t *testing.T, fd *fileData,
+	dirtyBcache DirtyBlockCache, size uint64,
+	topBlock *FileBlock, oldDe DirEntry, expectedUnrefs []BlockInfo,
+	expectedDirtiedBytes int64, expectedTopLevel testFileDataLevel) {
+	// Do the extending truncate.
+	ctx := context.Background()
+
+	newDe, dirtyPtrs, unrefs, newlyDirtiedChildBytes, err := fd.truncateShrink(
+		ctx, size, topBlock, oldDe)
+	require.NoError(t, err)
+
+	// Check the basics.
+	require.Equal(t, size, newDe.Size)
+	require.Equal(t, expectedDirtiedBytes, newlyDirtiedChildBytes)
+
+	// Go through each expected level and make sure we have the right
+	// set of dirty pointers and children.
+	expectedDirtyPtrs := expectedTopLevel.check(
+		t, fd, fd.file.tailPointer(), 0, dirtyBcache)
+	dirtyPtrsMap := make(map[BlockPointer]bool)
+	for _, ptr := range dirtyPtrs {
+		dirtyPtrsMap[ptr] = true
+	}
+	require.True(t, reflect.DeepEqual(expectedDirtyPtrs, dirtyPtrsMap),
+		fmt.Sprintf("expected %v; got %v", expectedDirtyPtrs, dirtyPtrsMap))
+
+	// TODO: set the EncodedSize of the existing blocks to something
+	// non-zero so that we get some unrefs.
+	require.Len(t, unrefs, 0)
+}
+
+func testFileDataShrinkExistingFile(t *testing.T, maxBlockSize int64,
+	maxPtrsPerBlock int, existingLen int64, newSize uint64) {
+	fd, cleanBcache, dirtyBcache, _ := setupFileDataTest(
+		t, maxBlockSize, maxPtrsPerBlock)
+	data := make([]byte, existingLen)
+	for i := 0; i < int(existingLen); i++ {
+		data[i] = byte(i)
+	}
+	topBlock, levels := testFileDataLevelExistingBlocks(
+		t, fd, maxBlockSize, maxPtrsPerBlock, data, nil, cleanBcache)
+	de := DirEntry{
+		EntryInfo: EntryInfo{
+			Size: uint64(existingLen),
+		},
+	}
+	expectedTopLevel := testFileDataLevelFromData(
+		t, maxBlockSize, maxPtrsPerBlock, levels, int64(newSize), nil,
+		int64(newSize), int64(newSize)-existingLen /*negative*/, 0, false)
+
+	// Round up to find out the number of dirty bytes.
+	dirtiedBytes := int64(newSize) % maxBlockSize
+	testFileDataCheckTruncateShrink(
+		t, fd, dirtyBcache, newSize, topBlock, de, nil, dirtiedBytes,
+		expectedTopLevel)
+
+	// Make sure we can read back the complete data.
+	gotData := make([]byte, newSize)
+	nRead, err := fd.read(context.Background(), gotData, 0)
+	require.NoError(t, err)
+	require.Equal(t, nRead, int64(newSize))
+	require.True(t, bytes.Equal(data[:newSize], gotData))
+}
+
+func TestFileDataTruncateShrinkWithinBlock(t *testing.T) {
+	testFileDataShrinkExistingFile(t, 2, 2, 6, 5)
+}
+
+func TestFileDataTruncateShrinkWithinLevel(t *testing.T) {
+	testFileDataShrinkExistingFile(t, 2, 2, 8, 5)
+}
+
+func TestFileDataTruncateShrinkToZero(t *testing.T) {
+	testFileDataShrinkExistingFile(t, 2, 2, 8, 0)
+}

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -267,9 +267,11 @@ func testFileDataCheckWrite(t *testing.T, fd *fileData,
 
 func testFileDataWriteExtendEmptyFile(t *testing.T, maxBlockSize int64,
 	maxPtrsPerBlock int, fullDataLen int64) {
-	fd, _, dirtyBcache, df := setupFileDataTest(
+	fd, cleanBcache, dirtyBcache, df := setupFileDataTest(
 		t, maxBlockSize, maxPtrsPerBlock)
 	topBlock := NewFileBlock().(*FileBlock)
+	cleanBcache.Put(
+		fd.rootBlockPointer(), fd.file.Tlf, topBlock, TransientEntry)
 	de := DirEntry{}
 	data := make([]byte, fullDataLen)
 	for i := 0; i < int(fullDataLen); i++ {

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -252,7 +252,7 @@ func testFileDataCheckWrite(t *testing.T, fd *fileData,
 	// Go through each expected level and make sure we have the right
 	// set of dirty pointers and children.
 	expectedDirtyPtrs := expectedTopLevel.check(
-		t, fd, fd.file.tailPointer(), 0, dirtyBcache)
+		t, fd, fd.rootBlockPointer(), 0, dirtyBcache)
 	dirtyPtrsMap := make(map[BlockPointer]bool)
 	for _, ptr := range dirtyPtrs {
 		dirtyPtrsMap[ptr] = true
@@ -410,6 +410,8 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 		prevChildren = level
 		numLevels++
 	}
+	cleanBcache.Put(
+		fd.rootBlockPointer(), fd.file.Tlf, prevChildren[0], TransientEntry)
 	return prevChildren[0], numLevels
 }
 
@@ -600,7 +602,7 @@ func testFileDataCheckTruncateExtend(t *testing.T, fd *fileData,
 	// Go through each expected level and make sure we have the right
 	// set of dirty pointers and children.
 	expectedDirtyPtrs := expectedTopLevel.check(
-		t, fd, fd.file.tailPointer(), 0, dirtyBcache)
+		t, fd, fd.rootBlockPointer(), 0, dirtyBcache)
 	dirtyPtrsMap := make(map[BlockPointer]bool)
 	for _, ptr := range dirtyPtrs {
 		dirtyPtrsMap[ptr] = true
@@ -676,7 +678,7 @@ func testFileDataCheckTruncateShrink(t *testing.T, fd *fileData,
 	// Go through each expected level and make sure we have the right
 	// set of dirty pointers and children.
 	expectedDirtyPtrs := expectedTopLevel.check(
-		t, fd, fd.file.tailPointer(), 0, dirtyBcache)
+		t, fd, fd.rootBlockPointer(), 0, dirtyBcache)
 	dirtyPtrsMap := make(map[BlockPointer]bool)
 	for _, ptr := range dirtyPtrs {
 		dirtyPtrsMap[ptr] = true

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -398,11 +398,6 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	if err != nil {
 		return nil, err
 	}
-	// Currently set the max number of pointers per level of
-	// indirection to the maximum integer, as a way of turning off
-	// multiple levels of indirection in production.  TODO: remove
-	// this.
-	bsplitter.maxPtrsPerBlock = int((^uint(0)) >> 1)
 	config.SetBlockSplitter(bsplitter)
 
 	if registry := config.MetricsRegistry(); registry != nil {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -398,6 +398,11 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	if err != nil {
 		return nil, err
 	}
+	// Currently set the max number of pointers per level of
+	// indirection to the maximum integer, as a way of turning off
+	// multiple levels of indirection in production.  TODO: remove
+	// this.
+	bsplitter.maxPtrsPerBlock = int((^uint(0)) >> 1)
 	config.SetBlockSplitter(bsplitter)
 
 	if registry := config.MetricsRegistry(); registry != nil {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1309,6 +1309,10 @@ type BlockSplitter interface {
 	// bytes from the next block should be appended.
 	CheckSplit(block *FileBlock) int64
 
+	// MaxPtrsPerBlock describes the number of indirect pointers we
+	// can fit into one indirect block.
+	MaxPtrsPerBlock() int
+
 	// ShouldEmbedBlockChanges decides whether we should keep the
 	// block changes embedded in the MD or not.
 	ShouldEmbedBlockChanges(bc *BlockChanges) bool

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -80,7 +80,7 @@ func setupMDJournalTest(t testing.TB, ver MetadataVer) (
 		tlfID, ver, tempdir, log)
 	require.NoError(t, err)
 
-	bsplit = &BlockSplitterSimple{64 * 1024, 8 * 1024}
+	bsplit = &BlockSplitterSimple{64 * 1024, int(64 * 1024 / bpSize), 8 * 1024}
 
 	return codec, crypto, tlfID, signer, ekg, bsplit, tempdir, j
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3617,6 +3617,16 @@ func (_mr *_MockBlockSplitterRecorder) CheckSplit(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckSplit", arg0)
 }
 
+func (_m *MockBlockSplitter) MaxPtrsPerBlock() int {
+	ret := _m.ctrl.Call(_m, "MaxPtrsPerBlock")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockBlockSplitterRecorder) MaxPtrsPerBlock() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaxPtrsPerBlock")
+}
+
 func (_m *MockBlockSplitter) ShouldEmbedBlockChanges(bc *BlockChanges) bool {
 	ret := _m.ctrl.Call(_m, "ShouldEmbedBlockChanges", bc)
 	ret0, _ := ret[0].(bool)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -58,7 +58,7 @@ func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
 	config.SetBlockOps(bops)
 
 	config.SetBlockSplitter(&BlockSplitterSimple{
-		64 * 1024, int(64 * 1024 / bpSize), 8 * 1024})
+		64 * 1024, int((^uint(0)) >> 1), 8 * 1024})
 
 	return config
 }

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -57,7 +57,8 @@ func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
 		testBlockRetrievalWorkerQueueSize)
 	config.SetBlockOps(bops)
 
-	config.SetBlockSplitter(&BlockSplitterSimple{64 * 1024, 8 * 1024})
+	config.SetBlockSplitter(&BlockSplitterSimple{
+		64 * 1024, int(64 * 1024 / bpSize), 8 * 1024})
 
 	return config
 }

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -198,7 +198,8 @@ func setupTLFJournalTest(
 	cancel context.CancelFunc, tlfJournal *tlfJournal,
 	delegate testBWDelegate) {
 	// Set up config and dependencies.
-	bsplitter := &BlockSplitterSimple{64 * 1024, 8 * 1024}
+	bsplitter := &BlockSplitterSimple{
+		64 * 1024, int(64 * 1024 / bpSize), 8 * 1024}
 	codec := kbfscodec.NewMsgpack()
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("client sign")
 	cryptPrivateKey := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("client crypt private")


### PR DESCRIPTION
[Sorry about the size of this PR, I can't think of a good way to shrink it and still keep the tests passing.  If you have suggestions, let me know.]

Note that this doesn't yet support syncing those multiple levels of indirection (or CR), so it is turned off for everything but the new fileData tests right now.

We view the data file as a tree of indirect blocks that ultimately point to a set of direct leaf blocks at the bottom level.  Whenever the existing leaf blocks can't accomodate a new write, we append a leaf block.  If the indirect parent can't accomodate a new block (as decided by the BlockSplitter), we add a new indirect block at that level, etc, all the way up to the root.  If the root can't handle a new block, we add a new level of indirection.

If we are writing into a "hole" in the file that was created by a previous `truncateExtend` call, the new right block will then have to be shifted into place by moving around indirect pointers in the interior of the tree.

When shrinking a file via `truncateShrink`, we truncate indirect pointer slices and unreference blocks whenever those slices no longer have any pointers. Note that for now we do not remove levels of indirection, so the left-most edge of the tree never shrinks.

Issue: KBFS-35
