### PR TITLE
tlf_journal: get blocks without specifying a context

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -287,6 +287,11 @@ func (j *blockJournal) getDataWithContext(id kbfsblock.ID, context kbfsblock.Con
 	return j.s.getDataWithContext(id, context)
 }
 
+func (j *blockJournal) getData(id kbfsblock.ID) (
+	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
+	return j.s.getData(id)
+}
+
 func (j *blockJournal) getUnflushedBytes() int64 {
 	return j.aggregateInfo.UnflushedBytes
 }

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -268,7 +268,7 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 	require.Equal(t, blockNonExistentError{bID}, err)
 
 	// But the actual data should remain (for flushing).
-	buf, half, err := j.s.getData(bID)
+	buf, half, err := j.getData(bID)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, half)

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -27,8 +27,7 @@ func (j journalBlockServer) Get(
 		defer func() {
 			err = translateToBlockServerError(err)
 		}()
-		data, serverHalf, err := tlfJournal.getBlockDataWithContext(
-			id, context)
+		data, serverHalf, err := tlfJournal.getBlockData(id)
 		switch errors.Cause(err).(type) {
 		case nil:
 			return data, serverHalf, nil


### PR DESCRIPTION
This allows us to serve blocks if they are on disk in the journal, even after they have been flushed to the server, mainly as an optimization during conflict resolution.

Issue: KBFS-1777