### PR TITLE
Make DSL tests not run per-version tests in parallel

### DIFF
--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -61,14 +61,14 @@ var testMetadataVers = []libkbfs.MetadataVer{
 }
 
 // runTestOverMetadataVers runs the given test function over all
-// metadata versions to test. The test is assumed to be parallelizable
-// with other instances of itself.
+// metadata versions to test.
 func runTestOverMetadataVers(
 	t *testing.T, f func(t *testing.T, ver libkbfs.MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
-			t.Parallel()
+			// Don't do t.Parallel() for now, as FUSE DSL
+			// tests might not like it.
 			f(t, ver)
 		})
 	}


### PR DESCRIPTION
This might help flakiness.