### PR TITLE
kbfs_ops: retry md reads with identify if this could be 1st access

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1012,6 +1012,24 @@ func (fbo *folderBranchOps) getMDForReadNeedIdentify(
 	return fbo.getMDForReadHelper(ctx, lState, mdReadNeedIdentify)
 }
 
+// getMDForReadNeedIdentifyOnMaybeFirstAccess should be called by a
+// code path (like chat) that might be accessing this folder for the
+// first time.  Other folderBranchOps methods like Lookup which know
+// the folder has already been accessed at least once (to get the root
+// node, for example) do not need to call this.
+func (fbo *folderBranchOps) getMDForReadNeedIdentifyOnMaybeFirstAccess(
+	ctx context.Context, lState *lockState) (ImmutableRootMetadata, error) {
+	irmd, err := fbo.getMDForReadHelper(ctx, lState, mdReadNeedIdentify)
+
+	if _, ok := err.(MDWriteNeededInRequest); ok {
+		fbo.mdWriterLock.Lock(lState)
+		defer fbo.mdWriterLock.Unlock(lState)
+		irmd, err = fbo.getMDForReadHelper(ctx, lState, mdWrite)
+	}
+
+	return irmd, err
+}
+
 // getMDForWriteLocked returns a new RootMetadata object with an
 // incremented version number for modification. If the returned object
 // is put to the MDServer (via MDOps), mdWriterLock must be held until

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -369,7 +369,7 @@ func (fs *KBFSOpsStandard) GetTLFCryptKeys(
 	ctx context.Context, tlfHandle *TlfHandle) (
 	keys []kbfscrypto.TLFCryptKey, id tlf.ID, err error) {
 	fs.log.CDebugf(ctx, "GetTLFCryptKeys(%s)", tlfHandle.GetCanonicalPath())
-	defer func() { fs.deferLog.CDebugf(ctx, "Done: %#v", err) }()
+	defer func() { fs.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	rmd, err := fs.getMDByHandle(ctx, tlfHandle)
 	if err != nil {
@@ -383,7 +383,7 @@ func (fs *KBFSOpsStandard) GetTLFCryptKeys(
 func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context,
 	tlfHandle *TlfHandle) (id tlf.ID, err error) {
 	fs.log.CDebugf(ctx, "GetTLFID(%s)", tlfHandle.GetCanonicalPath())
-	defer func() { fs.deferLog.CDebugf(ctx, "Done: %#v", err) }()
+	defer func() { fs.deferLog.CDebugf(ctx, "Done: %+v", err) }()
 
 	rmd, err := fs.getMDByHandle(ctx, tlfHandle)
 	if err != nil {

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -328,7 +328,7 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 	}()
 	if fbo != nil {
 		lState := makeFBOLockState()
-		rmd, err = fbo.getMDForReadNeedIdentify(ctx, lState)
+		rmd, err = fbo.getMDForReadNeedIdentifyOnMaybeFirstAccess(ctx, lState)
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -368,6 +368,9 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 func (fs *KBFSOpsStandard) GetTLFCryptKeys(
 	ctx context.Context, tlfHandle *TlfHandle) (
 	keys []kbfscrypto.TLFCryptKey, id tlf.ID, err error) {
+	fs.log.CDebugf(ctx, "GetTLFCryptKeys(%s)", tlfHandle.GetCanonicalPath())
+	defer func() { fs.deferLog.CDebugf(ctx, "Done: %#v", err) }()
+
 	rmd, err := fs.getMDByHandle(ctx, tlfHandle)
 	if err != nil {
 		return nil, tlf.ID{}, err
@@ -378,7 +381,10 @@ func (fs *KBFSOpsStandard) GetTLFCryptKeys(
 
 // GetTLFID implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context,
-	tlfHandle *TlfHandle) (tlf.ID, error) {
+	tlfHandle *TlfHandle) (id tlf.ID, err error) {
+	fs.log.CDebugf(ctx, "GetTLFID(%s)", tlfHandle.GetCanonicalPath())
+	defer func() { fs.deferLog.CDebugf(ctx, "Done: %#v", err) }()
+
 	rmd, err := fs.getMDByHandle(ctx, tlfHandle)
 	if err != nil {
 		return tlf.ID{}, err


### PR DESCRIPTION
Otherwise, if chat is the first thing to access a TLF, it could get a `MDWriteNeededInRequest` error (which indicates the request should be retried with the writer lock taken).

Issue: KBFS-1822