### PR TITLE
Print function name and args in FBO on exit

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1416,8 +1416,8 @@ func (fbo *folderBranchOps) SetInitialHeadToNew(
 	ctx context.Context, id tlf.ID, handle *TlfHandle) (err error) {
 	fbo.log.CDebugf(ctx, "SetInitialHeadToNew %s", id)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"SetInitialHeadToNew %s done: %+v", id, err)
+		fbo.deferLog.CDebugf(ctx, "SetInitialHeadToNew %s done: %+v",
+			id, err)
 	}()
 
 	rmd, err := makeInitialRootMetadata(
@@ -1543,8 +1543,8 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "GetDirChildren %s", getNodeIDStr(dir))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"GetDirChildren %s done: %v", getNodeIDStr(dir), err)
+		fbo.deferLog.CDebugf(ctx, "GetDirChildren %s done: %+v",
+			getNodeIDStr(dir), err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -1682,8 +1682,8 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Stat %s", getNodeIDStr(node))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"Stat %s done: %+v", getNodeIDStr(node), err)
+		fbo.deferLog.CDebugf(ctx, "Stat %s done: %+v",
+			getNodeIDStr(node), err)
 	}()
 
 	var de DirEntry
@@ -1701,8 +1701,8 @@ func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	ei NodeMetadata, err error) {
 	fbo.log.CDebugf(ctx, "GetNodeMetadata %s", getNodeIDStr(node))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"GetNodeMetadata %s done: %+v", getNodeIDStr(node), err)
+		fbo.deferLog.CDebugf(ctx, "GetNodeMetadata %s done: %+v",
+			getNodeIDStr(node), err)
 	}()
 
 	var de DirEntry
@@ -2709,13 +2709,8 @@ func (fbo *folderBranchOps) CreateDir(
 	n Node, ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "CreateDir %s %s", getNodeIDStr(dir), path)
 	defer func() {
-		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "CreateDir %s %s error: %+v",
-				getNodeIDStr(dir), path, err)
-		} else {
-			fbo.deferLog.CDebugf(ctx, "CreateDir %s %s done: %s",
-				getNodeIDStr(dir), path, getNodeIDStr(n))
-		}
+		fbo.deferLog.CDebugf(ctx, "CreateDir %s %s done: %v %+v",
+			getNodeIDStr(dir), path, getNodeIDStr(n), err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -2747,13 +2742,10 @@ func (fbo *folderBranchOps) CreateFile(
 	fbo.log.CDebugf(ctx, "CreateFile %s %s isExec=%v Excl=%s",
 		getNodeIDStr(dir), path, isExec, excl)
 	defer func() {
-		if err != nil {
-			fbo.deferLog.CDebugf(ctx,
-				"CreateFile %s %s isExec=%v Excl=%s error: %+v", err)
-		} else {
-			fbo.deferLog.CDebugf(ctx,
-				"CreateFile %s %s isExec=%v Excl=%s done: %s", getNodeIDStr(n))
-		}
+		fbo.deferLog.CDebugf(ctx,
+			"CreateFile %s %s isExec=%v Excl=%s done: %v %+v",
+			getNodeIDStr(dir), path, isExec, excl,
+			getNodeIDStr(n), err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -2875,8 +2867,7 @@ func (fbo *folderBranchOps) CreateLink(
 	fbo.log.CDebugf(ctx, "CreateLink %s %s -> %s",
 		getNodeIDStr(dir), fromName, toPath)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"CreateLink %s %s -> %s done: %+v",
+		fbo.deferLog.CDebugf(ctx, "CreateLink %s %s -> %s done: %+v",
 			getNodeIDStr(dir), fromName, toPath, err)
 	}()
 
@@ -3013,8 +3004,8 @@ func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveDir %s %s", getNodeIDStr(dir), dirName)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"RemoveDir %s %s done: %+v", getNodeIDStr(dir), dirName, err)
+		fbo.deferLog.CDebugf(ctx, "RemoveDir %s %s done: %+v",
+			getNodeIDStr(dir), dirName, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3032,8 +3023,8 @@ func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveEntry %s %s", getNodeIDStr(dir), name)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"RemoveEntry %s %s done: %+v", getNodeIDStr(dir), name, err)
+		fbo.deferLog.CDebugf(ctx, "RemoveEntry %s %s done: %+v",
+			getNodeIDStr(dir), name, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3207,10 +3198,9 @@ func (fbo *folderBranchOps) Rename(
 	fbo.log.CDebugf(ctx, "Rename %s/%s -> %s/%s", getNodeIDStr(oldParent),
 		oldName, getNodeIDStr(newParent), newName)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"Rename %s/%s -> %s/%s done: %+v",
-			getNodeIDStr(oldParent),
-			oldName, getNodeIDStr(newParent), newName, err)
+		fbo.deferLog.CDebugf(ctx, "Rename %s/%s -> %s/%s done: %+v",
+			getNodeIDStr(oldParent), oldName,
+			getNodeIDStr(newParent), newName, err)
 	}()
 
 	err = fbo.checkNode(newParent)
@@ -3243,10 +3233,11 @@ func (fbo *folderBranchOps) Rename(
 func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
-	fbo.log.CDebugf(ctx, "Read %s %d %d", getNodeIDStr(file), len(dest), off)
+	fbo.log.CDebugf(ctx, "Read %s %d %d", getNodeIDStr(file),
+		len(dest), off)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"Read %s %d %d done: %+v", getNodeIDStr(file), len(dest), err)
+		fbo.deferLog.CDebugf(ctx, "Read %s %d %d done: %+v",
+			getNodeIDStr(file), len(dest), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3306,7 +3297,8 @@ func (fbo *folderBranchOps) Read(
 
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
-	fbo.log.CDebugf(ctx, "Write %s %d %d", getNodeIDStr(file), len(data), off)
+	fbo.log.CDebugf(ctx, "Write %s %d %d", getNodeIDStr(file),
+		len(data), off)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "Write %s %d %d done: %+v",
 			getNodeIDStr(file), len(data), err)
@@ -3343,8 +3335,8 @@ func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
 	fbo.log.CDebugf(ctx, "Truncate %s %d", getNodeIDStr(file), size)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"Truncate %s %d done: %+v", getNodeIDStr(file), size, err)
+		fbo.deferLog.CDebugf(ctx, "Truncate %s %d done: %+v",
+			getNodeIDStr(file), size, err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3443,8 +3435,8 @@ func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
 	fbo.log.CDebugf(ctx, "SetEx %s %t", getNodeIDStr(file), ex)
 	defer func() {
-		fbo.deferLog.CDebugf(
-			ctx, "SetEx %s %t done: %+v", getNodeIDStr(file), ex, err)
+		fbo.deferLog.CDebugf(ctx, "SetEx %s %t done: %+v",
+			getNodeIDStr(file), ex, err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3515,8 +3507,8 @@ func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
 	fbo.log.CDebugf(ctx, "SetMtime %s %v", getNodeIDStr(file), mtime)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"SetMtime %s %v done: %+v", getNodeIDStr(file), mtime, err)
+		fbo.deferLog.CDebugf(ctx, "SetMtime %s %v done: %+v",
+			getNodeIDStr(file), mtime, err)
 	}()
 
 	if mtime == nil {
@@ -3649,8 +3641,8 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
 	fbo.log.CDebugf(ctx, "Sync %s", getNodeIDStr(file))
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"Sync %s done: %+v", getNodeIDStr(file), err)
+		fbo.deferLog.CDebugf(ctx, "Sync %s done: %+v",
+			getNodeIDStr(file), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -4947,8 +4939,7 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 	// successful registration; now, wait for an update or a shutdown
 	fbo.log.CDebugf(ctx, "Waiting for updates")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"Waiting for updates done: %+v", err)
+		fbo.deferLog.CDebugf(ctx, "Waiting for updates done: %+v", err)
 	}()
 
 	lState := makeFBOLockState()

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1472,6 +1472,13 @@ func (fbo *folderBranchOps) execMDReadNoIdentifyThenMDWrite(
 	return err
 }
 
+func getNodeIDStr(n Node) string {
+	if n == nil {
+		return "NodeID(nil)"
+	}
+	return fmt.Sprintf("NodeID(%p)", n.GetID())
+}
+
 func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	node Node, ei EntryInfo, handle *TlfHandle, err error) {
 	fbo.log.CDebugf(ctx, "getRootNode")
@@ -1539,10 +1546,10 @@ func (fbo *folderBranchOps) pathFromNodeForMDWriteLocked(
 
 func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "GetDirChildren %p", dir.GetID())
+	fbo.log.CDebugf(ctx, "GetDirChildren %p", getNodeIDStr(dir))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"GetDirChildren %p done: %v", dir.GetID(), err)
+			"GetDirChildren %p done: %v", getNodeIDStr(dir), err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -1592,10 +1599,10 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 
 func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "Lookup %p %s", dir.GetID(), name)
+	fbo.log.CDebugf(ctx, "Lookup %p %s", getNodeIDStr(dir), name)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "Lookup %p %s done: %+v",
-			dir.GetID(), name, err)
+			getNodeIDStr(dir), name, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -1678,10 +1685,10 @@ type blockState struct {
 
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "Stat %p", node.GetID())
+	fbo.log.CDebugf(ctx, "Stat %p", getNodeIDStr(node))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Stat %p done: %+v", node.GetID(), err)
+			"Stat %p done: %+v", getNodeIDStr(node), err)
 	}()
 
 	var de DirEntry
@@ -1697,10 +1704,10 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 
 func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	ei NodeMetadata, err error) {
-	fbo.log.CDebugf(ctx, "GetNodeMetadata %p", node.GetID())
+	fbo.log.CDebugf(ctx, "GetNodeMetadata %p", getNodeIDStr(node))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"GetNodeMetadata %p done: %+v", node.GetID(), err)
+			"GetNodeMetadata %p done: %+v", getNodeIDStr(node), err)
 	}()
 
 	var de DirEntry
@@ -2705,14 +2712,14 @@ func (fbo *folderBranchOps) doMDWriteWithRetryUnlessCanceled(
 func (fbo *folderBranchOps) CreateDir(
 	ctx context.Context, dir Node, path string) (
 	n Node, ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateDir %p %s", dir.GetID(), path)
+	fbo.log.CDebugf(ctx, "CreateDir %p %s", getNodeIDStr(dir), path)
 	defer func() {
 		if err != nil {
 			fbo.deferLog.CDebugf(ctx, "CreateDir %p %s error: %+v",
-				dir.GetID(), path, err)
+				getNodeIDStr(dir), path, err)
 		} else {
 			fbo.deferLog.CDebugf(ctx, "CreateDir %p %s done: %p",
-				dir.GetID(), path, n.GetID())
+				getNodeIDStr(dir), path, getNodeIDStr(n))
 		}
 	}()
 
@@ -2743,14 +2750,14 @@ func (fbo *folderBranchOps) CreateFile(
 	ctx context.Context, dir Node, path string, isExec bool, excl Excl) (
 	n Node, ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "CreateFile %p %s isExec=%v Excl=%s",
-		dir.GetID(), path, isExec, excl)
+		getNodeIDStr(dir), path, isExec, excl)
 	defer func() {
 		if err != nil {
 			fbo.deferLog.CDebugf(ctx,
 				"CreateFile %p %s isExec=%v Excl=%s error: %+v", err)
 		} else {
 			fbo.deferLog.CDebugf(ctx,
-				"CreateFile %p %s isExec=%v Excl=%s done: %p", n.GetID())
+				"CreateFile %p %s isExec=%v Excl=%s done: %p", getNodeIDStr(n))
 		}
 	}()
 
@@ -2871,11 +2878,11 @@ func (fbo *folderBranchOps) CreateLink(
 	ctx context.Context, dir Node, fromName string, toPath string) (
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "CreateLink %p %s -> %s",
-		dir.GetID(), fromName, toPath)
+		getNodeIDStr(dir), fromName, toPath)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
 			"CreateLink %p %s -> %s done: %+v",
-			dir.GetID(), fromName, toPath, err)
+			getNodeIDStr(dir), fromName, toPath, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3009,10 +3016,10 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
-	fbo.log.CDebugf(ctx, "RemoveDir %p %s", dir.GetID(), dirName)
+	fbo.log.CDebugf(ctx, "RemoveDir %p %s", getNodeIDStr(dir), dirName)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"RemoveDir %p %s done: %+v", dir.GetID(), dirName, err)
+			"RemoveDir %p %s done: %+v", getNodeIDStr(dir), dirName, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3028,10 +3035,10 @@ func (fbo *folderBranchOps) RemoveDir(
 
 func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
-	fbo.log.CDebugf(ctx, "RemoveEntry %p %s", dir.GetID(), name)
+	fbo.log.CDebugf(ctx, "RemoveEntry %p %s", getNodeIDStr(dir), name)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"RemoveEntry %p %s done: %+v", dir.GetID(), name, err)
+			"RemoveEntry %p %s done: %+v", getNodeIDStr(dir), name, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3202,13 +3209,13 @@ func (fbo *folderBranchOps) renameLocked(
 func (fbo *folderBranchOps) Rename(
 	ctx context.Context, oldParent Node, oldName string, newParent Node,
 	newName string) (err error) {
-	fbo.log.CDebugf(ctx, "Rename %p/%s -> %p/%s", oldParent.GetID(),
-		oldName, newParent.GetID(), newName)
+	fbo.log.CDebugf(ctx, "Rename %p/%s -> %p/%s", getNodeIDStr(oldParent),
+		oldName, getNodeIDStr(newParent), newName)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
 			"Rename %p/%s -> %p/%s done: %+v",
-			oldParent.GetID(),
-			oldName, newParent.GetID(), newName, err)
+			getNodeIDStr(oldParent),
+			oldName, getNodeIDStr(newParent), newName, err)
 	}()
 
 	err = fbo.checkNode(newParent)
@@ -3241,10 +3248,10 @@ func (fbo *folderBranchOps) Rename(
 func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
-	fbo.log.CDebugf(ctx, "Read %p %d %d", file.GetID(), len(dest), off)
+	fbo.log.CDebugf(ctx, "Read %p %d %d", getNodeIDStr(file), len(dest), off)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Read %p %d %d done: %+v", file.GetID(), len(dest), err)
+			"Read %p %d %d done: %+v", getNodeIDStr(file), len(dest), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3304,10 +3311,10 @@ func (fbo *folderBranchOps) Read(
 
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
-	fbo.log.CDebugf(ctx, "Write %p %d %d", file.GetID(), len(data), off)
+	fbo.log.CDebugf(ctx, "Write %p %d %d", getNodeIDStr(file), len(data), off)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "Write %p %d %d done: %+v",
-			file.GetID(), len(data), err)
+			getNodeIDStr(file), len(data), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3339,10 +3346,10 @@ func (fbo *folderBranchOps) Write(
 
 func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
-	fbo.log.CDebugf(ctx, "Truncate %p %d", file.GetID(), size)
+	fbo.log.CDebugf(ctx, "Truncate %p %d", getNodeIDStr(file), size)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Truncate %p %d done: %+v", file.GetID(), size, err)
+			"Truncate %p %d done: %+v", getNodeIDStr(file), size, err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3439,10 +3446,10 @@ func (fbo *folderBranchOps) setExLocked(
 
 func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
-	fbo.log.CDebugf(ctx, "SetEx %p %t", file.GetID(), ex)
+	fbo.log.CDebugf(ctx, "SetEx %p %t", getNodeIDStr(file), ex)
 	defer func() {
 		fbo.deferLog.CDebugf(
-			ctx, "SetEx %p %t done: %+v", file.GetID(), ex, err)
+			ctx, "SetEx %p %t done: %+v", getNodeIDStr(file), ex, err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3511,10 +3518,10 @@ func (fbo *folderBranchOps) setMtimeLocked(
 
 func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
-	fbo.log.CDebugf(ctx, "SetMtime %p %v", file.GetID(), mtime)
+	fbo.log.CDebugf(ctx, "SetMtime %p %v", getNodeIDStr(file), mtime)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"SetMtime %p %v done: %+v", file.GetID(), mtime, err)
+			"SetMtime %p %v done: %+v", getNodeIDStr(file), mtime, err)
 	}()
 
 	if mtime == nil {
@@ -3645,10 +3652,10 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
-	fbo.log.CDebugf(ctx, "Sync %p", file.GetID())
+	fbo.log.CDebugf(ctx, "Sync %p", getNodeIDStr(file))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Sync %p done: %+v", file.GetID(), err)
+			"Sync %p done: %+v", getNodeIDStr(file), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3795,7 +3802,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			return
 		}
 		fbo.log.CDebugf(ctx, "notifyOneOp: create %s in node %p",
-			realOp.NewName, node.GetID())
+			realOp.NewName, getNodeIDStr(node))
 		changes = append(changes, NodeChange{
 			Node:       node,
 			DirUpdated: []string{realOp.NewName},
@@ -3806,7 +3813,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			return
 		}
 		fbo.log.CDebugf(ctx, "notifyOneOp: remove %s in node %p",
-			realOp.OldName, node.GetID())
+			realOp.OldName, getNodeIDStr(node))
 		changes = append(changes, NodeChange{
 			Node:       node,
 			DirUpdated: []string{realOp.OldName},
@@ -3846,13 +3853,9 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		}
 
 		if oldNode != nil {
-			var newNodeID NodeID
-			if newNode != nil {
-				newNodeID = newNode.GetID()
-			}
 			fbo.log.CDebugf(ctx, "notifyOneOp: rename %v from %s/%p to %s/%p",
-				realOp.Renamed, realOp.OldName, oldNode.GetID(), realOp.NewName,
-				newNodeID)
+				realOp.Renamed, realOp.OldName, getNodeIDStr(oldNode), realOp.NewName,
+				getNodeIDStr(newNode))
 
 			if newNode == nil {
 				if childNode :=
@@ -3900,7 +3903,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			return
 		}
 		fbo.log.CDebugf(ctx, "notifyOneOp: sync %d writes in node %p",
-			len(realOp.Writes), node.GetID())
+			len(realOp.Writes), getNodeIDStr(node))
 
 		changes = append(changes, NodeChange{
 			Node:        node,
@@ -3912,7 +3915,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			return
 		}
 		fbo.log.CDebugf(ctx, "notifyOneOp: setAttr %s for file %s in node %p",
-			realOp.Attr, realOp.Name, node.GetID())
+			realOp.Attr, realOp.Name, getNodeIDStr(node))
 
 		p, err := fbo.pathFromNodeForRead(node)
 		if err != nil {
@@ -3977,7 +3980,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			}
 
 			fbo.log.CDebugf(ctx, "resolutionOp: remove %s, node %p",
-				p.tailPointer(), node.GetID())
+				p.tailPointer(), getNodeIDStr(node))
 			// Revert the path back to the original BlockPointers,
 			// before the updates were applied.
 			if len(reverseUpdates) == 0 {
@@ -5084,7 +5087,7 @@ func (fbo *folderBranchOps) backgroundFlusher(betweenFlushes time.Duration) {
 					p := fbo.nodeCache.PathFromNode(node)
 					fbo.log.CWarningf(ctx, "Couldn't sync dirty file with "+
 						"ref=%v, nodeID=%p, and path=%v: %v",
-						ref, node.GetID(), p, err)
+						ref, getNodeIDStr(node), p, err)
 				}
 			}
 			return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1476,7 +1476,7 @@ func getNodeIDStr(n Node) string {
 	if n == nil {
 		return "NodeID(nil)"
 	}
-	return fmt.Sprintf("NodeID(%p)", n.GetID())
+	return fmt.Sprintf("NodeID(%v)", n.GetID())
 }
 
 func (fbo *folderBranchOps) getRootNode(ctx context.Context) (

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1483,13 +1483,8 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	node Node, ei EntryInfo, handle *TlfHandle, err error) {
 	fbo.log.CDebugf(ctx, "getRootNode")
 	defer func() {
-		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "getRootNode error: %+v", err)
-		} else {
-			// node may still be nil if we're unwinding
-			// from a panic.
-			fbo.deferLog.CDebugf(ctx, "getRootNode done: %+v", node)
-		}
+		fbo.deferLog.CDebugf(ctx, "getRootNode done: %s %+v",
+			getNodeIDStr(node), err)
 	}()
 
 	lState := makeFBOLockState()
@@ -1546,10 +1541,10 @@ func (fbo *folderBranchOps) pathFromNodeForMDWriteLocked(
 
 func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "GetDirChildren %p", getNodeIDStr(dir))
+	fbo.log.CDebugf(ctx, "GetDirChildren %s", getNodeIDStr(dir))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"GetDirChildren %p done: %v", getNodeIDStr(dir), err)
+			"GetDirChildren %s done: %v", getNodeIDStr(dir), err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -1599,9 +1594,9 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 
 func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "Lookup %p %s", getNodeIDStr(dir), name)
+	fbo.log.CDebugf(ctx, "Lookup %s %s", getNodeIDStr(dir), name)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Lookup %p %s done: %+v",
+		fbo.deferLog.CDebugf(ctx, "Lookup %s %s done: %+v",
 			getNodeIDStr(dir), name, err)
 	}()
 
@@ -1685,10 +1680,10 @@ type blockState struct {
 
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "Stat %p", getNodeIDStr(node))
+	fbo.log.CDebugf(ctx, "Stat %s", getNodeIDStr(node))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Stat %p done: %+v", getNodeIDStr(node), err)
+			"Stat %s done: %+v", getNodeIDStr(node), err)
 	}()
 
 	var de DirEntry
@@ -1704,10 +1699,10 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 
 func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	ei NodeMetadata, err error) {
-	fbo.log.CDebugf(ctx, "GetNodeMetadata %p", getNodeIDStr(node))
+	fbo.log.CDebugf(ctx, "GetNodeMetadata %s", getNodeIDStr(node))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"GetNodeMetadata %p done: %+v", getNodeIDStr(node), err)
+			"GetNodeMetadata %s done: %+v", getNodeIDStr(node), err)
 	}()
 
 	var de DirEntry
@@ -2712,13 +2707,13 @@ func (fbo *folderBranchOps) doMDWriteWithRetryUnlessCanceled(
 func (fbo *folderBranchOps) CreateDir(
 	ctx context.Context, dir Node, path string) (
 	n Node, ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateDir %p %s", getNodeIDStr(dir), path)
+	fbo.log.CDebugf(ctx, "CreateDir %s %s", getNodeIDStr(dir), path)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "CreateDir %p %s error: %+v",
+			fbo.deferLog.CDebugf(ctx, "CreateDir %s %s error: %+v",
 				getNodeIDStr(dir), path, err)
 		} else {
-			fbo.deferLog.CDebugf(ctx, "CreateDir %p %s done: %p",
+			fbo.deferLog.CDebugf(ctx, "CreateDir %s %s done: %s",
 				getNodeIDStr(dir), path, getNodeIDStr(n))
 		}
 	}()
@@ -2749,15 +2744,15 @@ func (fbo *folderBranchOps) CreateDir(
 func (fbo *folderBranchOps) CreateFile(
 	ctx context.Context, dir Node, path string, isExec bool, excl Excl) (
 	n Node, ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateFile %p %s isExec=%v Excl=%s",
+	fbo.log.CDebugf(ctx, "CreateFile %s %s isExec=%v Excl=%s",
 		getNodeIDStr(dir), path, isExec, excl)
 	defer func() {
 		if err != nil {
 			fbo.deferLog.CDebugf(ctx,
-				"CreateFile %p %s isExec=%v Excl=%s error: %+v", err)
+				"CreateFile %s %s isExec=%v Excl=%s error: %+v", err)
 		} else {
 			fbo.deferLog.CDebugf(ctx,
-				"CreateFile %p %s isExec=%v Excl=%s done: %p", getNodeIDStr(n))
+				"CreateFile %s %s isExec=%v Excl=%s done: %s", getNodeIDStr(n))
 		}
 	}()
 
@@ -2877,11 +2872,11 @@ func (fbo *folderBranchOps) createLinkLocked(
 func (fbo *folderBranchOps) CreateLink(
 	ctx context.Context, dir Node, fromName string, toPath string) (
 	ei EntryInfo, err error) {
-	fbo.log.CDebugf(ctx, "CreateLink %p %s -> %s",
+	fbo.log.CDebugf(ctx, "CreateLink %s %s -> %s",
 		getNodeIDStr(dir), fromName, toPath)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"CreateLink %p %s -> %s done: %+v",
+			"CreateLink %s %s -> %s done: %+v",
 			getNodeIDStr(dir), fromName, toPath, err)
 	}()
 
@@ -3016,10 +3011,10 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
-	fbo.log.CDebugf(ctx, "RemoveDir %p %s", getNodeIDStr(dir), dirName)
+	fbo.log.CDebugf(ctx, "RemoveDir %s %s", getNodeIDStr(dir), dirName)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"RemoveDir %p %s done: %+v", getNodeIDStr(dir), dirName, err)
+			"RemoveDir %s %s done: %+v", getNodeIDStr(dir), dirName, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3035,10 +3030,10 @@ func (fbo *folderBranchOps) RemoveDir(
 
 func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
-	fbo.log.CDebugf(ctx, "RemoveEntry %p %s", getNodeIDStr(dir), name)
+	fbo.log.CDebugf(ctx, "RemoveEntry %s %s", getNodeIDStr(dir), name)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"RemoveEntry %p %s done: %+v", getNodeIDStr(dir), name, err)
+			"RemoveEntry %s %s done: %+v", getNodeIDStr(dir), name, err)
 	}()
 
 	err = fbo.checkNode(dir)
@@ -3209,11 +3204,11 @@ func (fbo *folderBranchOps) renameLocked(
 func (fbo *folderBranchOps) Rename(
 	ctx context.Context, oldParent Node, oldName string, newParent Node,
 	newName string) (err error) {
-	fbo.log.CDebugf(ctx, "Rename %p/%s -> %p/%s", getNodeIDStr(oldParent),
+	fbo.log.CDebugf(ctx, "Rename %s/%s -> %s/%s", getNodeIDStr(oldParent),
 		oldName, getNodeIDStr(newParent), newName)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Rename %p/%s -> %p/%s done: %+v",
+			"Rename %s/%s -> %s/%s done: %+v",
 			getNodeIDStr(oldParent),
 			oldName, getNodeIDStr(newParent), newName, err)
 	}()
@@ -3248,10 +3243,10 @@ func (fbo *folderBranchOps) Rename(
 func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
-	fbo.log.CDebugf(ctx, "Read %p %d %d", getNodeIDStr(file), len(dest), off)
+	fbo.log.CDebugf(ctx, "Read %s %d %d", getNodeIDStr(file), len(dest), off)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Read %p %d %d done: %+v", getNodeIDStr(file), len(dest), err)
+			"Read %s %d %d done: %+v", getNodeIDStr(file), len(dest), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3311,9 +3306,9 @@ func (fbo *folderBranchOps) Read(
 
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
-	fbo.log.CDebugf(ctx, "Write %p %d %d", getNodeIDStr(file), len(data), off)
+	fbo.log.CDebugf(ctx, "Write %s %d %d", getNodeIDStr(file), len(data), off)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Write %p %d %d done: %+v",
+		fbo.deferLog.CDebugf(ctx, "Write %s %d %d done: %+v",
 			getNodeIDStr(file), len(data), err)
 	}()
 
@@ -3346,10 +3341,10 @@ func (fbo *folderBranchOps) Write(
 
 func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
-	fbo.log.CDebugf(ctx, "Truncate %p %d", getNodeIDStr(file), size)
+	fbo.log.CDebugf(ctx, "Truncate %s %d", getNodeIDStr(file), size)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Truncate %p %d done: %+v", getNodeIDStr(file), size, err)
+			"Truncate %s %d done: %+v", getNodeIDStr(file), size, err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3446,10 +3441,10 @@ func (fbo *folderBranchOps) setExLocked(
 
 func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
-	fbo.log.CDebugf(ctx, "SetEx %p %t", getNodeIDStr(file), ex)
+	fbo.log.CDebugf(ctx, "SetEx %s %t", getNodeIDStr(file), ex)
 	defer func() {
 		fbo.deferLog.CDebugf(
-			ctx, "SetEx %p %t done: %+v", getNodeIDStr(file), ex, err)
+			ctx, "SetEx %s %t done: %+v", getNodeIDStr(file), ex, err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3518,10 +3513,10 @@ func (fbo *folderBranchOps) setMtimeLocked(
 
 func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
-	fbo.log.CDebugf(ctx, "SetMtime %p %v", getNodeIDStr(file), mtime)
+	fbo.log.CDebugf(ctx, "SetMtime %s %v", getNodeIDStr(file), mtime)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"SetMtime %p %v done: %+v", getNodeIDStr(file), mtime, err)
+			"SetMtime %s %v done: %+v", getNodeIDStr(file), mtime, err)
 	}()
 
 	if mtime == nil {
@@ -3652,10 +3647,10 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
-	fbo.log.CDebugf(ctx, "Sync %p", getNodeIDStr(file))
+	fbo.log.CDebugf(ctx, "Sync %s", getNodeIDStr(file))
 	defer func() {
 		fbo.deferLog.CDebugf(ctx,
-			"Sync %p done: %+v", getNodeIDStr(file), err)
+			"Sync %s done: %+v", getNodeIDStr(file), err)
 	}()
 
 	err = fbo.checkNode(file)
@@ -3801,7 +3796,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			return
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: create %s in node %p",
+		fbo.log.CDebugf(ctx, "notifyOneOp: create %s in node %s",
 			realOp.NewName, getNodeIDStr(node))
 		changes = append(changes, NodeChange{
 			Node:       node,
@@ -3812,7 +3807,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			return
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: remove %s in node %p",
+		fbo.log.CDebugf(ctx, "notifyOneOp: remove %s in node %s",
 			realOp.OldName, getNodeIDStr(node))
 		changes = append(changes, NodeChange{
 			Node:       node,
@@ -3853,7 +3848,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		}
 
 		if oldNode != nil {
-			fbo.log.CDebugf(ctx, "notifyOneOp: rename %v from %s/%p to %s/%p",
+			fbo.log.CDebugf(ctx, "notifyOneOp: rename %v from %s/%s to %s/%s",
 				realOp.Renamed, realOp.OldName, getNodeIDStr(oldNode), realOp.NewName,
 				getNodeIDStr(newNode))
 
@@ -3902,7 +3897,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			return
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: sync %d writes in node %p",
+		fbo.log.CDebugf(ctx, "notifyOneOp: sync %d writes in node %s",
 			len(realOp.Writes), getNodeIDStr(node))
 
 		changes = append(changes, NodeChange{
@@ -3914,7 +3909,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if node == nil {
 			return
 		}
-		fbo.log.CDebugf(ctx, "notifyOneOp: setAttr %s for file %s in node %p",
+		fbo.log.CDebugf(ctx, "notifyOneOp: setAttr %s for file %s in node %s",
 			realOp.Attr, realOp.Name, getNodeIDStr(node))
 
 		p, err := fbo.pathFromNodeForRead(node)
@@ -3979,7 +3974,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 				})
 			}
 
-			fbo.log.CDebugf(ctx, "resolutionOp: remove %s, node %p",
+			fbo.log.CDebugf(ctx, "resolutionOp: remove %s, node %s",
 				p.tailPointer(), getNodeIDStr(node))
 			// Revert the path back to the original BlockPointers,
 			// before the updates were applied.
@@ -5086,7 +5081,7 @@ func (fbo *folderBranchOps) backgroundFlusher(betweenFlushes time.Duration) {
 					// sync the rest of the dirty files.
 					p := fbo.nodeCache.PathFromNode(node)
 					fbo.log.CWarningf(ctx, "Couldn't sync dirty file with "+
-						"ref=%v, nodeID=%p, and path=%v: %v",
+						"ref=%v, nodeID=%s, and path=%v: %v",
 						ref, getNodeIDStr(node), p, err)
 				}
 			}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1332,7 +1332,9 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	fbo.log.CDebugf(ctx, "SetInitialHeadFromServer, revision=%d (%s)",
 		md.Revision(), md.MergedStatus())
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %v", err)
+		fbo.deferLog.CDebugf(ctx,
+			"SetInitialHeadFromServer, revision=%d (%s) done: %+v",
+			md.Revision(), md.MergedStatus(), err)
 	}()
 
 	if md.data.Dir.Type != Dir {
@@ -1412,9 +1414,10 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 // object and sets the head to that.
 func (fbo *folderBranchOps) SetInitialHeadToNew(
 	ctx context.Context, id tlf.ID, handle *TlfHandle) (err error) {
-	fbo.log.CDebugf(ctx, "SetInitialHeadToNew")
+	fbo.log.CDebugf(ctx, "SetInitialHeadToNew %s", id)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Done: %v", err)
+		fbo.deferLog.CDebugf(ctx,
+			"SetInitialHeadToNew %s done: %+v", id, err)
 	}()
 
 	rmd, err := makeInitialRootMetadata(
@@ -1474,11 +1477,11 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	fbo.log.CDebugf(ctx, "getRootNode")
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %v", err)
+			fbo.deferLog.CDebugf(ctx, "getRootNode error: %+v", err)
 		} else {
 			// node may still be nil if we're unwinding
 			// from a panic.
-			fbo.deferLog.CDebugf(ctx, "Done: %v", node)
+			fbo.deferLog.CDebugf(ctx, "getRootNode done: %+v", node)
 		}
 	}()
 
@@ -1537,7 +1540,10 @@ func (fbo *folderBranchOps) pathFromNodeForMDWriteLocked(
 func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	children map[string]EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "GetDirChildren %p", dir.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done GetDirChildren: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"GetDirChildren %p done: %v", dir.GetID(), err)
+	}()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -1587,7 +1593,10 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Lookup %p %s", dir.GetID(), name)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "Lookup %p %s done: %+v",
+			dir.GetID(), name, err)
+	}()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -1670,7 +1679,10 @@ type blockState struct {
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Stat %p", node.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Stat %p done: %+v", node.GetID(), err)
+	}()
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
@@ -1686,7 +1698,10 @@ func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
 func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	ei NodeMetadata, err error) {
 	fbo.log.CDebugf(ctx, "GetNodeMetadata %p", node.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"GetNodeMetadata %p done: %+v", node.GetID(), err)
+	}()
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
@@ -2693,9 +2708,11 @@ func (fbo *folderBranchOps) CreateDir(
 	fbo.log.CDebugf(ctx, "CreateDir %p %s", dir.GetID(), path)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %v", err)
+			fbo.deferLog.CDebugf(ctx, "CreateDir %p %s error: %+v",
+				dir.GetID(), path, err)
 		} else {
-			fbo.deferLog.CDebugf(ctx, "Done: %p", n.GetID())
+			fbo.deferLog.CDebugf(ctx, "CreateDir %p %s done: %p",
+				dir.GetID(), path, n.GetID())
 		}
 	}()
 
@@ -2729,9 +2746,11 @@ func (fbo *folderBranchOps) CreateFile(
 		dir.GetID(), path, isExec, excl)
 	defer func() {
 		if err != nil {
-			fbo.deferLog.CDebugf(ctx, "Error: %v", err)
+			fbo.deferLog.CDebugf(ctx,
+				"CreateFile %p %s isExec=%v Excl=%s error: %+v", err)
 		} else {
-			fbo.deferLog.CDebugf(ctx, "Done: %p", n.GetID())
+			fbo.deferLog.CDebugf(ctx,
+				"CreateFile %p %s isExec=%v Excl=%s done: %p", n.GetID())
 		}
 	}()
 
@@ -2853,7 +2872,11 @@ func (fbo *folderBranchOps) CreateLink(
 	ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "CreateLink %p %s -> %s",
 		dir.GetID(), fromName, toPath)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"CreateLink %p %s -> %s done: %+v",
+			dir.GetID(), fromName, toPath, err)
+	}()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -2987,7 +3010,10 @@ func (fbo *folderBranchOps) removeDirLocked(ctx context.Context,
 func (fbo *folderBranchOps) RemoveDir(
 	ctx context.Context, dir Node, dirName string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveDir %p %s", dir.GetID(), dirName)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"RemoveDir %p %s done: %+v", dir.GetID(), dirName, err)
+	}()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -3003,7 +3029,10 @@ func (fbo *folderBranchOps) RemoveDir(
 func (fbo *folderBranchOps) RemoveEntry(ctx context.Context, dir Node,
 	name string) (err error) {
 	fbo.log.CDebugf(ctx, "RemoveEntry %p %s", dir.GetID(), name)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"RemoveEntry %p %s done: %+v", dir.GetID(), name, err)
+	}()
 
 	err = fbo.checkNode(dir)
 	if err != nil {
@@ -3175,7 +3204,12 @@ func (fbo *folderBranchOps) Rename(
 	newName string) (err error) {
 	fbo.log.CDebugf(ctx, "Rename %p/%s -> %p/%s", oldParent.GetID(),
 		oldName, newParent.GetID(), newName)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Rename %p/%s -> %p/%s done: %+v",
+			oldParent.GetID(),
+			oldName, newParent.GetID(), newName, err)
+	}()
 
 	err = fbo.checkNode(newParent)
 	if err != nil {
@@ -3208,7 +3242,10 @@ func (fbo *folderBranchOps) Read(
 	ctx context.Context, file Node, dest []byte, off int64) (
 	n int64, err error) {
 	fbo.log.CDebugf(ctx, "Read %p %d %d", file.GetID(), len(dest), off)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Read %p %d %d done: %+v", file.GetID(), len(dest), err)
+	}()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3268,7 +3305,10 @@ func (fbo *folderBranchOps) Read(
 func (fbo *folderBranchOps) Write(
 	ctx context.Context, file Node, data []byte, off int64) (err error) {
 	fbo.log.CDebugf(ctx, "Write %p %d %d", file.GetID(), len(data), off)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "Write %p %d %d done: %+v",
+			file.GetID(), len(data), err)
+	}()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3300,7 +3340,10 @@ func (fbo *folderBranchOps) Write(
 func (fbo *folderBranchOps) Truncate(
 	ctx context.Context, file Node, size uint64) (err error) {
 	fbo.log.CDebugf(ctx, "Truncate %p %d", file.GetID(), size)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Truncate %p %d done: %+v", file.GetID(), size, err)
+	}()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3397,7 +3440,10 @@ func (fbo *folderBranchOps) setExLocked(
 func (fbo *folderBranchOps) SetEx(
 	ctx context.Context, file Node, ex bool) (err error) {
 	fbo.log.CDebugf(ctx, "SetEx %p %t", file.GetID(), ex)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(
+			ctx, "SetEx %p %t done: %+v", file.GetID(), ex, err)
+	}()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3466,7 +3512,10 @@ func (fbo *folderBranchOps) setMtimeLocked(
 func (fbo *folderBranchOps) SetMtime(
 	ctx context.Context, file Node, mtime *time.Time) (err error) {
 	fbo.log.CDebugf(ctx, "SetMtime %p %v", file.GetID(), mtime)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"SetMtime %p %v done: %+v", file.GetID(), mtime, err)
+	}()
 
 	if mtime == nil {
 		// Can happen on some OSes (e.g. OSX) when trying to set the atime only
@@ -3597,7 +3646,10 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 
 func (fbo *folderBranchOps) Sync(ctx context.Context, file Node) (err error) {
 	fbo.log.CDebugf(ctx, "Sync %p", file.GetID())
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Sync %p done: %+v", file.GetID(), err)
+	}()
 
 	err = fbo.checkNode(file)
 	if err != nil {
@@ -3630,7 +3682,7 @@ func (fbo *folderBranchOps) FolderStatus(
 	ctx context.Context, folderBranch FolderBranch) (
 	fbs FolderBranchStatus, updateChan <-chan StatusUpdate, err error) {
 	fbo.log.CDebugf(ctx, "Status")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() { fbo.deferLog.CDebugf(ctx, "Status done: %+v", err) }()
 
 	if folderBranch != fbo.folderBranch {
 		return FolderBranchStatus{}, nil,
@@ -4345,7 +4397,9 @@ func (fbo *folderBranchOps) unstageLocked(ctx context.Context,
 func (fbo *folderBranchOps) UnstageForTesting(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "UnstageForTesting")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "UnstageForTesting done: %+v", err)
+	}()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -4393,7 +4447,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	lState *lockState, promptPaper bool) (err error) {
 	fbo.log.CDebugf(ctx, "rekeyLocked")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "rekeyLocked Done: %v", err)
+		fbo.deferLog.CDebugf(ctx, "rekeyLocked done: %+v", err)
 	}()
 
 	fbo.mdWriterLock.AssertLocked(lState)
@@ -4570,9 +4624,6 @@ func (fbo *folderBranchOps) rekeyWithPrompt() {
 		panic(err)
 	}
 
-	fbo.log.CDebugf(ctx, "rekeyWithPrompt")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
-
 	err = fbo.doMDWriteWithRetryUnlessCanceled(ctx,
 		func(lState *lockState) error {
 			return fbo.rekeyLocked(ctx, lState, true)
@@ -4595,7 +4646,10 @@ func (fbo *folderBranchOps) Rekey(ctx context.Context, tlf tlf.ID) (err error) {
 func (fbo *folderBranchOps) SyncFromServerForTesting(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "SyncFromServerForTesting")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"SyncFromServerForTesting done: %+v", err)
+	}()
 
 	if folderBranch != fbo.folderBranch {
 		return WrongOpsError{fbo.folderBranch, folderBranch}
@@ -4880,7 +4934,11 @@ func (fbo *folderBranchOps) registerForUpdates(ctx context.Context) (
 	lState := makeFBOLockState()
 	currRev := fbo.getLatestMergedRevision(lState)
 	fbo.log.CDebugf(ctx, "Registering for updates (curr rev = %d)", currRev)
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Registering for updates (curr rev = %d) done: %+v",
+			currRev, err)
+	}()
 	// RegisterForUpdate will itself retry on connectivity issues
 	return fbo.config.MDServer().RegisterForUpdate(ctx, fbo.id(), currRev)
 }
@@ -4890,7 +4948,10 @@ func (fbo *folderBranchOps) waitForAndProcessUpdates(
 	updateChan <-chan error) (currUpdate time.Time, err error) {
 	// successful registration; now, wait for an update or a shutdown
 	fbo.log.CDebugf(ctx, "Waiting for updates")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx,
+			"Waiting for updates done: %+v", err)
+	}()
 
 	lState := makeFBOLockState()
 
@@ -5266,7 +5327,9 @@ func (fbo *folderBranchOps) onMDFlush(bid BranchID, rev MetadataRevision) {
 func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 	folderBranch FolderBranch) (history TLFUpdateHistory, err error) {
 	fbo.log.CDebugf(ctx, "GetUpdateHistory")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "GetUpdateHistory done: %+v", err)
+	}()
 
 	if folderBranch != fbo.folderBranch {
 		return TLFUpdateHistory{}, WrongOpsError{fbo.folderBranch, folderBranch}
@@ -5330,7 +5393,9 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 func (fbo *folderBranchOps) GetEditHistory(ctx context.Context,
 	folderBranch FolderBranch) (edits TlfWriterEdits, err error) {
 	fbo.log.CDebugf(ctx, "GetEditHistory")
-	defer func() { fbo.deferLog.CDebugf(ctx, "Done: %v", err) }()
+	defer func() {
+		fbo.deferLog.CDebugf(ctx, "GetEditHistory done: %+v", err)
+	}()
 
 	if folderBranch != fbo.folderBranch {
 		return nil, WrongOpsError{fbo.folderBranch, folderBranch}

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -4,7 +4,10 @@
 
 package libkbfs
 
-import "runtime"
+import (
+	"fmt"
+	"runtime"
+)
 
 // nodeCore holds info shared among one or more nodeStandard objects.
 type nodeCore struct {
@@ -32,6 +35,13 @@ func (c *nodeCore) ParentID() NodeID {
 		return nil
 	}
 	return c.parent.GetID()
+}
+
+// String is to support printing *nodeCore as a NodeID. If we want to
+// print nodeCores as nodeCores (e.g., for debugging) we might have to
+// implement Formatter.
+func (c *nodeCore) String() string {
+	return fmt.Sprintf("%p", c)
 }
 
 type nodeStandard struct {


### PR DESCRIPTION
It's a pain to look up line numbers to figure out
which function a "Done" log corresponds to.