### PR TITLE
return TLF breaks even if the channel is already closed

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -80,13 +80,15 @@ func (ei *extendedIdentify) makeTlfBreaksIfNeeded(
 func (ei *extendedIdentify) getTlfBreakAndClose() keybase1.TLFBreak {
 	ei.lock.Lock()
 	defer ei.lock.Unlock()
-	if ei.userBreaks != nil && ei.tlfBreaks != nil {
+
+	if ei.userBreaks != nil {
 		close(ei.userBreaks)
 		ei.userBreaks = nil
-		return *ei.tlfBreaks
-	} else if ei.tlfBreaks != nil {
+	}
+	if ei.tlfBreaks != nil {
 		return *ei.tlfBreaks
 	}
+
 	return keybase1.TLFBreak{}
 }
 

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -84,6 +84,8 @@ func (ei *extendedIdentify) getTlfBreakAndClose() keybase1.TLFBreak {
 		close(ei.userBreaks)
 		ei.userBreaks = nil
 		return *ei.tlfBreaks
+	} else if ei.tlfBreaks != nil {
+		return *ei.tlfBreaks
 	}
 	return keybase1.TLFBreak{}
 }


### PR DESCRIPTION
As it is now, if you call `getTlfBreakAndClose` more than once you don't get any break results back on the subsequent calls. The `GetTLFCryptKeys` codepath right now calls this guy twice, the second of which fails to load any breaks into the result. With this change, that behavior is fixed, and we check to see if the `tlfBreaks` field has any data before returning an empty result.

cc @maxtaco @chrisnojima 