### PR TITLE
tlf_journal: explicit Gosched() during tight lock-unlock loop

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"time"
 
@@ -859,6 +860,7 @@ func (j *tlfJournal) doOnMDFlush(ctx context.Context,
 		if lastToRemove == 0 {
 			break
 		}
+		runtime.Gosched()
 	}
 
 	return nil


### PR DESCRIPTION
Try to achieve some fairness with other lock contenders, such as FS
operations.