### PR TITLE
Finder likes to use UID 0 so let\'s let it?

### DIFF
--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -385,9 +385,9 @@ func (f *Folder) fillAttrWithUIDAndWritePerm(
 }
 
 func (f *Folder) access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() {
-		// short path: not accessible by anybody other than the logged in user.
-		// This is in case we enable AllowOther in the future.
+	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+		// short path: not accessible by anybody other than root or the user who
+		// executed the kbfsfuse process.
 		return fuse.EPERM
 	}
 

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -385,7 +385,11 @@ func (f *Folder) fillAttrWithUIDAndWritePerm(
 }
 
 func (f *Folder) access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+	if int(r.Uid) != os.Getuid() &&
+		// Finder likes to use UID 0 for some operations. osxfuse already allows
+		// ACCESS and GETXATTR requests from root to go through. This allows root
+		// in ACCESS handler. See KBFS-1733 for more details.
+		int(r.Uid) != 0 {
 		// short path: not accessible by anybody other than root or the user who
 		// executed the kbfsfuse process.
 		return fuse.EPERM

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -119,7 +119,11 @@ var _ fs.NodeAccesser = (*File)(nil)
 // success, which makes it think the file is executable, yielding a "Unix
 // executable" UTI.
 func (f *File) Access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+	if int(r.Uid) != os.Getuid() &&
+		// Finder likes to use UID 0 for some operations. osxfuse already allows
+		// ACCESS and GETXATTR requests from root to go through. This allows root
+		// in ACCESS handler. See KBFS-1733 for more details.
+		int(r.Uid) != 0 {
 		// short path: not accessible by anybody other than root or the user who
 		// executed the kbfsfuse process.
 		return fuse.EPERM

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -119,9 +119,9 @@ var _ fs.NodeAccesser = (*File)(nil)
 // success, which makes it think the file is executable, yielding a "Unix
 // executable" UTI.
 func (f *File) Access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() {
-		// short path: not accessible by anybody other than the logged in user.
-		// This is in case we enable AllowOther in the future.
+	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+		// short path: not accessible by anybody other than root or the user who
+		// executed the kbfsfuse process.
 		return fuse.EPERM
 	}
 

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -35,7 +35,11 @@ var _ fs.NodeAccesser = (*FolderList)(nil)
 
 // Access implements fs.NodeAccesser interface for *FolderList.
 func (*FolderList) Access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+	if int(r.Uid) != os.Getuid() &&
+		// Finder likes to use UID 0 for some operations. osxfuse already allows
+		// ACCESS and GETXATTR requests from root to go through. This allows root
+		// in ACCESS handler. See KBFS-1733 for more details.
+		int(r.Uid) != 0 {
 		// short path: not accessible by anybody other than root or the user who
 		// executed the kbfsfuse process.
 		return fuse.EPERM

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -35,9 +35,9 @@ var _ fs.NodeAccesser = (*FolderList)(nil)
 
 // Access implements fs.NodeAccesser interface for *FolderList.
 func (*FolderList) Access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() {
-		// short path: not accessible by anybody other than the logged in user.
-		// This is in case we enable AllowOther in the future.
+	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+		// short path: not accessible by anybody other than root or the user who
+		// executed the kbfsfuse process.
 		return fuse.EPERM
 	}
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -224,9 +224,9 @@ var _ fs.NodeAccesser = (*FolderList)(nil)
 
 // Access implements fs.NodeAccesser interface for *Root.
 func (*Root) Access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() {
-		// short path: not accessible by anybody other than the logged in user.
-		// This is in case we enable AllowOther in the future.
+	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+		// short path: not accessible by anybody other than root or the user who
+		// executed the kbfsfuse process.
 		return fuse.EPERM
 	}
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -224,7 +224,11 @@ var _ fs.NodeAccesser = (*FolderList)(nil)
 
 // Access implements fs.NodeAccesser interface for *Root.
 func (*Root) Access(ctx context.Context, r *fuse.AccessRequest) error {
-	if int(r.Uid) != os.Getuid() && int(r.Uid) != 0 {
+	if int(r.Uid) != os.Getuid() &&
+		// Finder likes to use UID 0 for some operations. osxfuse already allows
+		// ACCESS and GETXATTR requests from root to go through. This allows root
+		// in ACCESS handler. See KBFS-1733 for more details.
+		int(r.Uid) != 0 {
 		// short path: not accessible by anybody other than root or the user who
 		// executed the kbfsfuse process.
 		return fuse.EPERM

--- a/libfuse/mounter_osx.go
+++ b/libfuse/mounter_osx.go
@@ -40,6 +40,11 @@ func getPlatformSpecificMountOptions(dir string, platformParams PlatformParams) 
 
 	options = append(options, fuse.VolumeName(volName))
 	options = append(options, fuse.ExclCreate())
+
+	// Finder likes to use UID 0 for some operations. This allows root access the
+	// mount. See KBFS-1733 for more details.
+	options = append(options, fuse.AllowRoot())
+
 	if platformParams.UseLocal {
 		options = append(options, fuse.LocalVolume())
 	}

--- a/libfuse/mounter_osx.go
+++ b/libfuse/mounter_osx.go
@@ -41,10 +41,6 @@ func getPlatformSpecificMountOptions(dir string, platformParams PlatformParams) 
 	options = append(options, fuse.VolumeName(volName))
 	options = append(options, fuse.ExclCreate())
 
-	// Finder likes to use UID 0 for some operations. This allows root access the
-	// mount. See KBFS-1733 for more details.
-	options = append(options, fuse.AllowRoot())
-
 	if platformParams.UseLocal {
 		options = append(options, fuse.LocalVolume())
 	}


### PR DESCRIPTION
This fixes those damaged/corrupted error from Finder on macOS