### PR TITLE
cr: fix handling of previous unmerged resolutionOps

### DIFF
--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -283,18 +283,8 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	}
 
 	// now re-login u1
-	timeoutCtx, cancel := context.WithTimeout(
-		context.Background(), individualTestTimeout)
-	ctx2, err := NewContextWithCancellationDelayer(NewContextReplayable(
-		timeoutCtx, func(c context.Context) context.Context {
-			return c
-		}))
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	config1B := ConfigAsUser(config1, userName1)
-	defer CheckConfigAndShutdown(ctx2, t, config1B)
+	defer CheckConfigAndShutdown(ctx, t, config1B)
 	config1B.EnableJournaling(tempdir, TLFJournalBackgroundWorkEnabled)
 	jServer, err = GetJournalServer(config1B)
 	if err != nil {
@@ -305,17 +295,15 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 
 	DisableCRForTesting(config1B, rootNode1.GetFolderBranch())
 
-	tlfHandle, err := ParseTlfHandle(ctx2, config1B.KBPKI(), name, false)
+	tlfHandle, err := ParseTlfHandle(ctx, config1B.KBPKI(), name, false)
 	if err != nil {
 		t.Fatalf("error making tlfHandle: %s", err)
 	}
 
-	_, _, err = config1B.KBFSOps().GetTLFCryptKeys(ctx2, tlfHandle)
+	_, _, err = config1B.KBFSOps().GetTLFCryptKeys(ctx, tlfHandle)
 	if err != nil {
 		t.Fatalf("error in GetTLFCryptKeys on unmerged TLF after restart: %s", err)
 	}
-
-	RestartCRForTesting(ctx2, config1B, rootNode1.GetFolderBranch())
 }
 
 // Tests that, in the face of a conflict, a user will commit its

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1052,7 +1052,7 @@ func testTLFJournalResolveBranch(t *testing.T, ver MetadataVer) {
 	require.Equal(t, bids[0], blocks.puts.blockStates[0].blockPtr.ID)
 	require.Equal(t, bids[2], blocks.puts.blockStates[1].blockPtr.ID)
 
-	// resolveBranch resumes background work.
+	tlfJournal.resumeBackgroundWork()
 	delegate.requireNextState(ctx, bwIdle)
 	delegate.requireNextState(ctx, bwBusy)
 }

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1030,6 +1030,12 @@ func testTLFJournalResolveBranch(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 	require.False(t, flushed)
 
+	// The background worker was already paused, so we won't get a
+	// paused signal here.  But resume the background work now so that
+	// later when the conflict resolves, it will be able to send a
+	// resume signal.
+	tlfJournal.resumeBackgroundWork()
+
 	// Resolve the branch.
 	resolveMD := config.makeMD(firstRevision, firstPrevRoot)
 	_, err = tlfJournal.resolveBranch(ctx,
@@ -1052,7 +1058,7 @@ func testTLFJournalResolveBranch(t *testing.T, ver MetadataVer) {
 	require.Equal(t, bids[0], blocks.puts.blockStates[0].blockPtr.ID)
 	require.Equal(t, bids[2], blocks.puts.blockStates[1].blockPtr.ID)
 
-	tlfJournal.resumeBackgroundWork()
+	// resolveBranch resumes background work.
 	delegate.requireNextState(ctx, bwIdle)
 	delegate.requireNextState(ctx, bwBusy)
 }


### PR DESCRIPTION
When doing conflict resolution on an unmerged branch that already contains resolutionOps (e.g., because of local squashes), CR was incorrectly unreferencing live blocks for files that were written/synced within a local squash branch.  This is because `alreadyUpdated` is true, since earlier in `syncBlocks`, these most-recent file blocks are explicitly added into `updates`. To fix, we make sure we don't reference anything that is the most recent block for a chain in the unmerged branch.

A second problem is that `alreadyUpdated` was using update.Unref, but really what we care about is when the original block for the chain has been updated (since update chains are collapsed back to the origin earlier in the function).

To test this reliably, this PR also fixes the `tlfJournal` so that resolutions don't unpause manually-paused journals.  We now track the reason(s) a journal has been paused (e.g., due to a conflict or an outside pause signal), and only resume background work if all those reasons have been cleared up.  This eliminates a source of flakiness in the journal tests.

Issue: KBFS-1829
Issue: KBFS-1838
