### PR TITLE
[KBFS-1522] Add a basic journal disk limit

### DIFF
--- a/kbfsblock/context.go
+++ b/kbfsblock/context.go
@@ -25,13 +25,16 @@ func (nonce RefNonce) String() string {
 	return hex.EncodeToString(nonce[:])
 }
 
-// MakeRefNonce generates a block reference nonce using a CSPRNG. This
-// is used for distinguishing different references to the same ID.
+// MakeRefNonce generates a non-zero block reference nonce using a
+// CSPRNG. This is used for distinguishing different references to the
+// same ID.
 func MakeRefNonce() (RefNonce, error) {
 	var nonce RefNonce
-	err := kbfscrypto.RandRead(nonce[:])
-	if err != nil {
-		return ZeroRefNonce, err
+	for nonce == ZeroRefNonce {
+		err := kbfscrypto.RandRead(nonce[:])
+		if err != nil {
+			return ZeroRefNonce, err
+		}
 	}
 	return nonce, nil
 }

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -30,9 +30,9 @@ func NewSemaphore() *Semaphore {
 	}
 }
 
-// Count returns the current resource count. It should be used only
-// for logging or testing.
-func (s *Semaphore) Count() int64 {
+// countForTest returns the current resource count. It should be used
+// only for testing.
+func (s *Semaphore) countForTest() int64 {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	return s.count

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -5,10 +5,10 @@
 package kbfssync
 
 import (
-	"context"
 	"sync"
 
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // A waiter represents a goroutine blocked on resource acquisition.

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -87,7 +87,7 @@ func (s *Semaphore) ForceAcquire(n int64) {
 
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	// Check for overflow.
+	// TODO: Check for overflow.
 	s.count -= n
 }
 

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -57,7 +57,8 @@ func (s *Semaphore) tryAcquire(n int64) (<-chan struct{}, int64) {
 // must be positive) from the resource count without causing it to go
 // negative, and then returns nil. If the given context is canceled
 // first, it instead returns a wrapped ctx.Err() and does not change
-// the resource count. The possibly-updated resource count is returned.
+// the resource count. The possibly-updated resource count is
+// returned, even when err != nil.
 func (s *Semaphore) Acquire(ctx context.Context, n int64) (int64, error) {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))
@@ -78,12 +79,12 @@ func (s *Semaphore) Acquire(ctx context.Context, n int64) (int64, error) {
 	}
 }
 
-// ForceAcquire atomically adds n (which must be positive) to the
-// resource count without waking up any waiting acquirers. It is meant
-// for correcting the initial resource count of the semaphore. It's
-// okay if adding n causes the resource count goes negative, but it
-// must not cause the resource count to overflow (in the negative
-// direction). The updated resource count is returned.
+// ForceAcquire atomically subtracts n (which must be positive) from
+// the resource count without waking up any waiting acquirers. It is
+// meant for correcting the initial resource count of the
+// semaphore. It's okay if adding n causes the resource count goes
+// negative, but it must not cause the resource count to overflow (in
+// the negative direction). The updated resource count is returned.
 func (s *Semaphore) ForceAcquire(n int64) int64 {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -77,11 +77,12 @@ func (s *Semaphore) Acquire(ctx context.Context, n int64) error {
 	}
 }
 
-// ForceAcquire atomically adds n to the resource count without waking
-// up any waiting acquirers. It is meant for correcting the initial
-// resource count of the semaphore. It's okay if adding n causes the
-// resource count goes negative, but it must not cause the resource
-// count to overflow (in the negative direction).
+// ForceAcquire atomically adds n (which must be positive) to the
+// resource count without waking up any waiting acquirers. It is meant
+// for correcting the initial resource count of the semaphore. It's
+// okay if adding n causes the resource count goes negative, but it
+// must not cause the resource count to overflow (in the negative
+// direction).
 func (s *Semaphore) ForceAcquire(n int64) {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -113,6 +113,9 @@ func (s *Semaphore) Release(n int64) {
 			s.count, n))
 	}
 	s.count += n
+	// TODO: A better implementation would keep track of each
+	// waiter and how much it wants to acquire and only wake up
+	// waiters that could possibly succeed.
 	close(s.onRelease)
 	s.onRelease = make(chan struct{})
 }

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -98,6 +98,7 @@ func TestForceAcquire(t *testing.T) {
 
 	count = s.ForceAcquire(n)
 	require.Equal(t, int64(-1), count)
+	require.Equal(t, int64(-1), s.Count())
 
 	count = s.Release(n + 1)
 	require.Equal(t, n, count)
@@ -220,13 +221,15 @@ func TestAcquireDifferentSizes(t *testing.T) {
 		if i == 0 {
 			require.Equal(t, int64(0), s.Count())
 		} else {
-			s.Release(int64(i))
+			count := s.Release(int64(i))
+			require.Equal(t, int64(i), count)
 			require.Equal(t, int64(i), s.Count())
 		}
 
 		requireNoCall(t, callCh)
 
-		s.Release(1)
+		count := s.Release(1)
+		require.Equal(t, int64(i+1), count)
 
 		select {
 		case call := <-callCh:

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -138,6 +138,9 @@ func TestSerialRelease(t *testing.T) {
 	require.Equal(t, acquirerCount, acquireCount)
 }
 
+// TestAcquireDifferentSizes tests the scenario where there are
+// multiple acquirers for different sizes, and we release each size in
+// increasing order.
 func TestAcquireDifferentSizes(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -150,7 +150,7 @@ func TestCancel(t *testing.T) {
 	select {
 	case call := <-callCh:
 		call.err = errors.Cause(call.err)
-		require.Equal(t, acquireCall{n, n - 1, ctx2.Err()}, call)
+		require.Equal(t, acquireCall{n, n - 1, context.Canceled}, call)
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -44,7 +44,7 @@ func TestSimple(t *testing.T) {
 	var n int64 = 10
 
 	s := NewSemaphore()
-	require.Equal(t, int64(0), s.Count())
+	require.Equal(t, int64(0), s.countForTest())
 
 	callCh := make(chan acquireCall, 1)
 	go func() {
@@ -55,7 +55,7 @@ func TestSimple(t *testing.T) {
 
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)
-	require.Equal(t, n-1, s.Count())
+	require.Equal(t, n-1, s.countForTest())
 
 	requireNoCall(t, callCh)
 
@@ -69,7 +69,7 @@ func TestSimple(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	require.Equal(t, int64(0), s.Count())
+	require.Equal(t, int64(0), s.countForTest())
 }
 
 // TestForceAcquire tests that ForceAcquire works in a simple two-goroutine
@@ -81,7 +81,7 @@ func TestForceAcquire(t *testing.T) {
 	var n int64 = 10
 
 	s := NewSemaphore()
-	require.Equal(t, int64(0), s.Count())
+	require.Equal(t, int64(0), s.countForTest())
 
 	callCh := make(chan acquireCall, 1)
 	go func() {
@@ -92,13 +92,13 @@ func TestForceAcquire(t *testing.T) {
 
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)
-	require.Equal(t, n-1, s.Count())
+	require.Equal(t, n-1, s.countForTest())
 
 	requireNoCall(t, callCh)
 
 	count = s.ForceAcquire(n)
 	require.Equal(t, int64(-1), count)
-	require.Equal(t, int64(-1), s.Count())
+	require.Equal(t, int64(-1), s.countForTest())
 
 	count = s.Release(n + 1)
 	require.Equal(t, n, count)
@@ -110,7 +110,7 @@ func TestForceAcquire(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	require.Equal(t, int64(0), s.Count())
+	require.Equal(t, int64(0), s.countForTest())
 }
 
 // TestCancel tests that cancelling the context passed into Acquire
@@ -125,7 +125,7 @@ func TestCancel(t *testing.T) {
 	var n int64 = 10
 
 	s := NewSemaphore()
-	require.Equal(t, int64(0), s.Count())
+	require.Equal(t, int64(0), s.countForTest())
 
 	callCh := make(chan acquireCall, 1)
 	go func() {
@@ -136,12 +136,12 @@ func TestCancel(t *testing.T) {
 
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)
-	require.Equal(t, n-1, s.Count())
+	require.Equal(t, n-1, s.countForTest())
 
 	requireNoCall(t, callCh)
 
 	cancel2()
-	require.Equal(t, n-1, s.Count())
+	require.Equal(t, n-1, s.countForTest())
 
 	select {
 	case call := <-callCh:
@@ -151,7 +151,7 @@ func TestCancel(t *testing.T) {
 		t.Fatal(ctx.Err())
 	}
 
-	require.Equal(t, n-1, s.Count())
+	require.Equal(t, n-1, s.countForTest())
 }
 
 // TestSerialRelease tests that Release(1) causes exactly one waiting
@@ -188,7 +188,7 @@ func TestSerialRelease(t *testing.T) {
 
 		requireNoCall(t, callCh)
 
-		require.Equal(t, int64(0), s.Count())
+		require.Equal(t, int64(0), s.countForTest())
 	}
 
 	// acquireCount should have been incremented race-free.
@@ -219,11 +219,11 @@ func TestAcquireDifferentSizes(t *testing.T) {
 		requireNoCall(t, callCh)
 
 		if i == 0 {
-			require.Equal(t, int64(0), s.Count())
+			require.Equal(t, int64(0), s.countForTest())
 		} else {
 			count := s.Release(int64(i))
 			require.Equal(t, int64(i), count)
-			require.Equal(t, int64(i), s.Count())
+			require.Equal(t, int64(i), s.countForTest())
 		}
 
 		requireNoCall(t, callCh)
@@ -240,7 +240,7 @@ func TestAcquireDifferentSizes(t *testing.T) {
 
 		requireNoCall(t, callCh)
 
-		require.Equal(t, int64(0), s.Count())
+		require.Equal(t, int64(0), s.countForTest())
 	}
 
 	// acquireCount should have been incremented race-free.

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -42,14 +42,16 @@ func TestSimple(t *testing.T) {
 
 	requireEmpty(t, errCh)
 
-	s.Release(n - 1)
+	count := s.Release(n - 1)
+	require.Equal(t, n-1, count)
 	require.Equal(t, n-1, s.Count())
 
 	requireEmpty(t, errCh)
 
-	s.Release(1)
+	count = s.Release(1)
+	require.Equal(t, n, count)
 
-	// s.Count() should go to n, then 0.
+	// s.Count() should go to 0.
 
 	select {
 	case err := <-errCh:
@@ -79,17 +81,18 @@ func TestForceAcquire(t *testing.T) {
 
 	requireEmpty(t, errCh)
 
-	s.Release(n - 1)
+	count := s.Release(n - 1)
+	require.Equal(t, n-1, count)
 	require.Equal(t, n-1, s.Count())
 
 	requireEmpty(t, errCh)
 
-	s.ForceAcquire(n)
-	require.Equal(t, int64(-1), s.Count())
+	count = s.ForceAcquire(n)
+	require.Equal(t, int64(-1), count)
 
-	s.Release(n + 1)
-
-	// s.Count() should go to n, then 0.
+	count = s.Release(n + 1)
+	require.Equal(t, n, count)
+	// s.Count() should go to 0.
 
 	select {
 	case err := <-errCh:
@@ -122,7 +125,8 @@ func TestCancel(t *testing.T) {
 
 	requireEmpty(t, errCh)
 
-	s.Release(n - 1)
+	count := s.Release(n - 1)
+	require.Equal(t, n-1, count)
 	require.Equal(t, n-1, s.Count())
 
 	requireEmpty(t, errCh)
@@ -162,7 +166,9 @@ func TestSerialRelease(t *testing.T) {
 	for i := 0; i < acquirerCount; i++ {
 		requireEmpty(t, errCh)
 
-		s.Release(1)
+		count := s.Release(1)
+		require.Equal(t, int64(1), count)
+
 		select {
 		case err := <-errCh:
 			require.NoError(t, err)

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -243,9 +243,39 @@ func TestAcquireDifferentSizes(t *testing.T) {
 	require.Equal(t, acquirerCount, acquireCount)
 }
 
-func TestPanics(t *testing.T) {
+func TestAcquirePanic(t *testing.T) {
 	s := NewSemaphore()
-	require.Equal(t, int64(0), s.Count())
+	ctx := context.Background()
+	require.Panics(t, func() {
+		s.Acquire(ctx, 0)
+	})
+	require.Panics(t, func() {
+		s.Acquire(ctx, -1)
+	})
+}
+
+func TestForceAcquirePanic(t *testing.T) {
+	s := NewSemaphore()
+	require.Panics(t, func() {
+		s.ForceAcquire(0)
+	})
+	require.Panics(t, func() {
+		s.ForceAcquire(-1)
+	})
+	s.ForceAcquire(2)
+	require.Panics(t, func() {
+		s.ForceAcquire(math.MaxInt64)
+	})
+}
+
+func TestReleasePanic(t *testing.T) {
+	s := NewSemaphore()
+	require.Panics(t, func() {
+		s.Release(0)
+	})
+	require.Panics(t, func() {
+		s.Release(-1)
+	})
 	s.Release(1)
 	require.Panics(t, func() {
 		s.Release(math.MaxInt64)

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -37,7 +37,8 @@ func TestSimple(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.Acquire(ctx, n)
+		_, err := s.Acquire(ctx, n)
+		errCh <- err
 	}()
 
 	requireEmpty(t, errCh)
@@ -76,7 +77,8 @@ func TestForceAcquire(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.Acquire(ctx, n)
+		_, err := s.Acquire(ctx, n)
+		errCh <- err
 	}()
 
 	requireEmpty(t, errCh)
@@ -120,7 +122,8 @@ func TestCancel(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- s.Acquire(ctx2, n)
+		_, err := s.Acquire(ctx2, n)
+		errCh <- err
 	}()
 
 	requireEmpty(t, errCh)
@@ -157,7 +160,7 @@ func TestSerialRelease(t *testing.T) {
 	errCh := make(chan error, acquirerCount)
 	for i := 0; i < acquirerCount; i++ {
 		go func() {
-			err := s.Acquire(ctx, 1)
+			_, err := s.Acquire(ctx, 1)
 			acquireCount++
 			errCh <- err
 		}()
@@ -213,7 +216,7 @@ func TestAcquireDifferentSizes(t *testing.T) {
 	acquirerCh := make(chan acquirer, acquirerCount)
 	for i := 0; i < acquirerCount; i++ {
 		go func(i int) {
-			err := s.Acquire(ctx, int64(i+1))
+			_, err := s.Acquire(ctx, int64(i+1))
 			acquireCount++
 			acquirerCh <- acquirer{int64(i + 1), err}
 		}(i)

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -27,6 +27,10 @@ func callAcquire(ctx context.Context, s *Semaphore, n int64) acquireCall {
 	return acquireCall{n, count, err}
 }
 
+// requireNoCall checks that there is nothing to read from
+// callCh. This is a racy check since it doesn't distinguish between
+// the goroutine with the call not having run yet, and the goroutine
+// with the call having run but being blocked on the semaphore.
 func requireNoCall(t *testing.T, callCh <-chan acquireCall) {
 	select {
 	case call := <-callCh:

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -6,6 +6,7 @@ package kbfssync
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -240,4 +241,13 @@ func TestAcquireDifferentSizes(t *testing.T) {
 
 	// acquireCount should have been incremented race-free.
 	require.Equal(t, acquirerCount, acquireCount)
+}
+
+func TestPanics(t *testing.T) {
+	s := NewSemaphore()
+	require.Equal(t, int64(0), s.Count())
+	s.Release(1)
+	require.Panics(t, func() {
+		s.Release(math.MaxInt64)
+	})
 }

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -23,7 +23,7 @@ func requireEmpty(t *testing.T, errCh <-chan error) {
 	}
 }
 
-// TestSimple tests that Adjust, Acquire, and Release work in a simple
+// TestSimple tests that Acquire and Release work in a simple
 // two-goroutine scenario.
 func TestSimple(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
@@ -41,7 +41,7 @@ func TestSimple(t *testing.T) {
 
 	requireEmpty(t, errCh)
 
-	s.Adjust(n - 1)
+	s.Release(n - 1)
 	require.Equal(t, n-1, s.Count())
 
 	requireEmpty(t, errCh)
@@ -81,7 +81,7 @@ func TestCancel(t *testing.T) {
 
 	requireEmpty(t, errCh)
 
-	s.Adjust(n - 1)
+	s.Release(n - 1)
 	require.Equal(t, n-1, s.Count())
 
 	requireEmpty(t, errCh)

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -304,7 +304,7 @@ func (j *blockJournal) isUnflushed(id kbfsblock.ID) (bool, error) {
 	return j.s.isUnflushed(id)
 }
 
-func (j *blockJournal) remove(id kbfsblock.ID) (
+func (j *blockJournal) remove(ctx context.Context, id kbfsblock.ID) (
 	removedBytes int64, err error) {
 	bytesToRemove, err := j.s.getDataSize(id)
 	if err != nil {
@@ -322,6 +322,8 @@ func (j *blockJournal) remove(id kbfsblock.ID) (
 	if err != nil {
 		return 0, err
 	}
+
+	j.log.CDebugf(ctx, "Removed %s for %d bytes", id, bytesToRemove)
 
 	return bytesToRemove, nil
 }
@@ -786,7 +788,7 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 		if j.saveUntilMDFlush == nil && liveCount == 0 {
 			// Garbage-collect the old entry if we are not
 			// saving blocks until the next MD flush.
-			idRemovedBytes, err := j.remove(id)
+			idRemovedBytes, err := j.remove(ctx, id)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -1008,7 +1010,7 @@ func (j *blockJournal) onMDFlush(ctx context.Context,
 			}
 			if !hasRef {
 				// Garbage-collect the old entry.
-				idRemovedBytes, err := j.remove(id)
+				idRemovedBytes, err := j.remove(ctx, id)
 				if err != nil {
 					return 0, 0, err
 				}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -799,16 +799,16 @@ func (j *blockJournal) removeFlushedEntry(ctx context.Context,
 
 func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 	entries blockEntriesToFlush, tlfID tlf.ID, reporter Reporter) (
-	totalRemovedBytes int64, err error) {
+	removedBytes int64, err error) {
 	// Remove them all!
 	for i, entry := range entries.all {
-		removedBytes, flushedBytes, err := j.removeFlushedEntry(
+		entryRemovedBytes, flushedBytes, err := j.removeFlushedEntry(
 			ctx, entries.first+journalOrdinal(i), entry)
 		if err != nil {
 			return 0, err
 		}
 
-		totalRemovedBytes += removedBytes
+		removedBytes += entryRemovedBytes
 		reporter.NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{
 			PublicTopLevelFolder: tlfID.IsPublic(),
 			// Path: TODO,
@@ -817,7 +817,7 @@ func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 			SyncedBytes: flushedBytes,
 		})
 	}
-	return totalRemovedBytes, nil
+	return removedBytes, nil
 }
 
 func (j *blockJournal) ignoreBlocksAndMDRevMarkers(ctx context.Context,

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -923,7 +923,8 @@ func TestBlockJournalByteCounters(t *testing.T) {
 			ctx, t, j, blockServer, bcache, reporter, tlfID)
 	}
 
-	// Flush the first put.
+	// Flush the first put. This causes the block to be GCed since
+	// the subsequent ops for that block remove the references.
 	removedBytes := flushOne()
 	require.Equal(t, int64(len(data1)), removedBytes)
 	expectedSize = len(data2)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -810,12 +810,12 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	// revision markers that also need removal.
 	lastToRemove := journalOrdinal(0)
 	for i := 0; i < len(savedBlocks)-1+2; i++ {
-		lastToRemove, err = j.onMDFlush(ctx, 1, lastToRemove)
+		lastToRemove, _, err = j.onMDFlush(ctx, 1, lastToRemove)
 		require.NoError(t, err)
 		require.NotZero(t, lastToRemove, "Iter %d", i)
 		require.NotNil(t, j.saveUntilMDFlush)
 	}
-	lastToRemove, err = j.onMDFlush(ctx, 1, lastToRemove)
+	lastToRemove, _, err = j.onMDFlush(ctx, 1, lastToRemove)
 	require.NoError(t, err)
 	require.Zero(t, lastToRemove)
 	require.Nil(t, j.saveUntilMDFlush)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -634,8 +634,10 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 		bcache, reporter, tlfID, CanonicalTlfName("fake TLF"),
 		entries)
 	require.NoError(t, err)
-	_, err = j.removeFlushedEntries(ctx, entries, tlfID, reporter)
+	totalFlushedBytes, err := j.removeFlushedEntries(
+		ctx, entries, tlfID, reporter)
 	require.NoError(t, err)
+	require.Equal(t, int64(len(data)), totalFlushedBytes)
 	err = j.checkInSyncForTest()
 	require.NoError(t, err)
 }

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -647,9 +647,9 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
 
 	// Put a few blocks
-	data1 := []byte{1, 2, 3, 4}
+	data1 := []byte{1, 2, 3}
 	bID1, _, _ := putBlockData(ctx, t, j, data1)
-	data2 := []byte{5, 6, 7, 8}
+	data2 := []byte{4, 5, 6, 7}
 	bID2, _, _ := putBlockData(ctx, t, j, data2)
 
 	// Put a revision marker
@@ -657,9 +657,9 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	err := j.markMDRevision(ctx, rev)
 	require.NoError(t, err)
 
-	data3 := []byte{9, 10, 11, 12}
+	data3 := []byte{8, 9, 10, 11, 12}
 	bID3, _, _ := putBlockData(ctx, t, j, data3)
-	data4 := []byte{13, 14, 15, 16}
+	data4 := []byte{13, 14, 15, 16, 17, 18}
 	bID4, _, _ := putBlockData(ctx, t, j, data4)
 
 	// Put a revision marker
@@ -692,8 +692,11 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 		bcache, reporter, tlfID, CanonicalTlfName("fake TLF"),
 		entries)
 	require.NoError(t, err)
-	_, err = j.removeFlushedEntries(ctx, entries, tlfID, reporter)
+	totalFlushedBytes, err := j.removeFlushedEntries(
+		ctx, entries, tlfID, reporter)
 	require.NoError(t, err)
+	require.Equal(t,
+		int64(len(data1)+len(data4)), totalFlushedBytes)
 	err = j.checkInSyncForTest()
 	require.NoError(t, err)
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -898,9 +898,12 @@ func (c *ConfigLocal) EnableJournaling(
 	log := c.MakeLogger("")
 	branchListener := c.KBFSOps().(branchChangeListener)
 	flushListener := c.KBFSOps().(mdFlushListener)
-	// Set the journal disk limit to 10 GiB for now. TODO: Base
-	// this on the size of the disk, e.g. a quarter of the total
-	// size of the disk up to a maximum of 100 GB.
+	// Set the journal disk limit to 10 GiB for now.
+	//
+	// TODO: Base this on the size of the disk, e.g. a quarter of
+	// the total size of the disk up to a maximum of 100 GB.
+	//
+	// TODO: Also keep track of and limit the inode count.
 	var journalDiskLimit int64 = 10 * 1024 * 1024 * 1024
 	// TODO: Use a diskLimiter implementation that applies
 	// backpressure.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -898,8 +898,9 @@ func (c *ConfigLocal) EnableJournaling(
 	log := c.MakeLogger("")
 	branchListener := c.KBFSOps().(branchChangeListener)
 	flushListener := c.KBFSOps().(mdFlushListener)
-	// Set the journal disk limit to 10 GiB for now. TODO: Make
-	// this configurable.
+	// Set the journal disk limit to 10 GiB for now. TODO: Base
+	// this on the size of the disk, e.g. a quarter of the total
+	// size of the disk up to a maximum of 100 GB.
 	var journalDiskLimit int64 = 10 * 1024 * 1024 * 1024
 	// TODO: Use a diskLimiter implementation that applies
 	// backpressure.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -901,7 +901,7 @@ func (c *ConfigLocal) EnableJournaling(
 	// 10 GiB
 	var journalDiskLimit int64 = 10 * 1024 * 1024 * 1024
 	diskLimitSemaphore := kbfssync.NewSemaphore()
-	diskLimitSemaphore.Adjust(journalDiskLimit)
+	diskLimitSemaphore.Release(journalDiskLimit)
 	jServer = makeJournalServer(c, log, journalRoot, c.BlockCache(),
 		c.DirtyBlockCache(), c.BlockServer(), c.MDOps(), branchListener,
 		flushListener, diskLimitSemaphore)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -898,8 +898,11 @@ func (c *ConfigLocal) EnableJournaling(
 	log := c.MakeLogger("")
 	branchListener := c.KBFSOps().(branchChangeListener)
 	flushListener := c.KBFSOps().(mdFlushListener)
-	// 10 GiB
+	// Set the journal disk limit to 10 GiB for now. TODO: Make
+	// this configurable.
 	var journalDiskLimit int64 = 10 * 1024 * 1024 * 1024
+	// TODO: Use a diskLimiter implementation that applies
+	// backpressure.
 	diskLimitSemaphore := kbfssync.NewSemaphore()
 	diskLimitSemaphore.Release(journalDiskLimit)
 	jServer = makeJournalServer(c, log, journalRoot, c.BlockCache(),

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -178,7 +178,7 @@ func TestCryptoClientSignCanceled(t *testing.T) {
 	testRPCWithCanceledContext(t, serverConn, f)
 }
 
-// Test that decrypting an TLF crypt key client half encrypted with
+// Test that decrypting a TLF crypt key client half encrypted with
 // box.Seal works.
 func TestCryptoClientDecryptTLFCryptKeyClientHalfBoxSeal(t *testing.T) {
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("client sign")

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -58,6 +58,10 @@ type mdFlushListener interface {
 	onMDFlush(tlf.ID, BranchID, MetadataRevision)
 }
 
+// diskLimiter is an interface for limiting disk usage. A simple
+// implementation would use a semaphore initialized with the maximum
+// disk usage, but a more sophisticated implementation would apply
+// backpressure on Acquire.
 type diskLimiter interface {
 	Acquire(ctx context.Context, nBytes int64) error
 	ForceAcquire(nBytes int64)

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -59,8 +59,8 @@ type mdFlushListener interface {
 }
 
 type diskLimiter interface {
-	Adjust(deltaBytes int64)
 	Acquire(ctx context.Context, nBytes int64) error
+	ForceAcquire(nBytes int64)
 	Release(nBytes int64)
 }
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -77,9 +77,9 @@ type diskLimiter interface {
 	ForceAcquire(n int64) int64
 
 	// Release is called after an operation that has freed up n
-	// bytes of disk space. It is also called when shutting down
-	// an TLF journal. The updated number of bytes available
-	// (which can be negative) must be returned.
+	// bytes of disk space. It is also called when shutting down a
+	// TLF journal. The updated number of bytes available (which
+	// can be negative) must be returned.
 	Release(n int64) int64
 }
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -378,14 +378,7 @@ func (j *JournalServer) enableLocked(
 		return err
 	}
 
-	unflushedBytes, err := tlfJournal.getUnflushedBytes()
-	if err != nil {
-		return err
-	}
-	j.diskLimitSemaphore.Adjust(-unflushedBytes)
-
 	j.tlfJournals[tlfID] = tlfJournal
-
 	return nil
 }
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -5,7 +5,6 @@
 package libkbfs
 
 import (
-	"math"
 	"os"
 	"testing"
 
@@ -117,7 +116,7 @@ func TestJournalServerRestart(t *testing.T) {
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil,
-		math.MaxInt64)
+		jServer.diskLimiter)
 	uid, verifyingKey, err :=
 		getCurrentUIDAndVerifyingKey(ctx, config.KBPKI())
 	require.NoError(t, err)
@@ -440,7 +439,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil,
-		math.MaxInt64)
+		jServer.diskLimiter)
 	uid, verifyingKey, err :=
 		getCurrentUIDAndVerifyingKey(ctx, config.KBPKI())
 	require.NoError(t, err)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -354,6 +354,10 @@ func makeTLFJournal(
 		j.wg.Pause()
 	}
 
+	// Do this only once we're sure we won't error.
+	unflushedBytes := blockJournal.getUnflushedBytes()
+	diskLimitSemaphore.Adjust(-unflushedBytes)
+
 	go j.doBackgroundWorkLoop(bws, backoff.NewExponentialBackOff())
 
 	// Signal work to pick up any existing journal entries.

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -355,8 +355,8 @@ func makeTLFJournal(
 	}
 
 	// Do this only once we're sure we won't error.
-	unflushedBytes := blockJournal.getUnflushedBytes()
-	j.diskLimiter.Adjust(-unflushedBytes)
+	storedBytes := blockJournal.getStoredBytes()
+	j.diskLimiter.Adjust(-storedBytes)
 
 	go j.doBackgroundWorkLoop(bws, backoff.NewExponentialBackOff())
 
@@ -1321,6 +1321,8 @@ func (j *tlfJournal) shutdown() {
 	// Make further accesses error out.
 	j.blockJournal = nil
 	j.mdJournal = nil
+
+	// TODO: Reset diskLimiter back.
 }
 
 // disable prevents new operations from hitting the journal.  Will

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -356,7 +356,9 @@ func makeTLFJournal(
 
 	// Do this only once we're sure we won't error.
 	storedBytes := blockJournal.getStoredBytes()
-	j.diskLimiter.ForceAcquire(storedBytes)
+	if storedBytes > 0 {
+		j.diskLimiter.ForceAcquire(storedBytes)
+	}
 
 	go j.doBackgroundWorkLoop(bws, backoff.NewExponentialBackOff())
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -355,7 +355,7 @@ func makeTLFJournal(
 	}
 
 	// Do this only once we're sure we won't error.
-	storedBytes := blockJournal.getStoredBytes()
+	storedBytes := j.blockJournal.getStoredBytes()
 	if storedBytes > 0 {
 		j.diskLimiter.ForceAcquire(storedBytes)
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1457,6 +1457,8 @@ func (j *tlfJournal) getBlockData(id kbfsblock.ID) (
 
 const diskLimitTimeout = 3 * time.Second
 
+// ErrDiskLimitTimeout is returned when putBlockData exceeds
+// diskLimitTimeout when trying to acquire bytes to put.
 type ErrDiskLimitTimeout struct {
 	timeout        time.Duration
 	requestedBytes int64

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1467,14 +1467,14 @@ func (j *tlfJournal) putBlockData(
 		return err
 	}
 
+	j.log.CDebugf(ctx, "Acquired %d bytes for %s: available=%d",
+		bufLen, j.tlfID, availableBytes)
+
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
 	if err := j.checkEnabledLocked(); err != nil {
 		return err
 	}
-
-	j.log.CDebugf(ctx, "Acquired %d bytes for %s: available=%d",
-		bufLen, j.tlfID, availableBytes)
 
 	storedBytesBefore := j.blockJournal.getStoredBytes()
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1492,7 +1492,7 @@ func (j *tlfJournal) putBlockData(
 	switch errors.Cause(err) {
 	case nil:
 		// Continue.
-	case acquireCtx.Err():
+	case context.DeadlineExceeded:
 		return errors.WithStack(ErrDiskLimitTimeout{
 			timeout, bufLen, availableBytes, err,
 		})

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1362,6 +1362,10 @@ func (j *tlfJournal) shutdown() {
 	// Even if we shut down the journal, its blocks still take up
 	// space, but we don't want to double-count them if we start
 	// up this journal again, so we need to adjust them here.
+	//
+	// TODO: If we ever expect to shut down non-empty journals any
+	// time other than during shutdown, we should still count
+	// shut-down journals against the disk limit.
 	storedBytes := j.blockJournal.getStoredBytes()
 	if storedBytes > 0 {
 		availableBytes := j.diskLimiter.Release(storedBytes)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1462,10 +1462,15 @@ func (j *tlfJournal) putBlockData(
 
 	bufLen := int64(len(buf))
 
+	j.log.CDebugf(ctx, "Acquiring %d bytes for %s", bufLen, j.tlfID)
+
 	availableBytes, err := j.diskLimiter.Acquire(ctx, bufLen)
 	if err != nil {
 		return err
 	}
+
+	j.log.CDebugf(ctx, "Acquired %d bytes for %s: available=%d",
+		bufLen, j.tlfID, availableBytes)
 
 	storedBytesBefore := j.blockJournal.getStoredBytes()
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1324,7 +1324,9 @@ func (j *tlfJournal) shutdown() {
 	// space, but we don't want to double-count them if we start
 	// up this journal again, so we need to adjust them here.
 	storedBytes := j.blockJournal.getStoredBytes()
-	j.diskLimiter.Release(storedBytes)
+	if storedBytes > 0 {
+		j.diskLimiter.Release(storedBytes)
+	}
 
 	// Make further accesses error out.
 	j.blockJournal = nil

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -719,13 +719,10 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 			blockEnd, mdEnd)
 
 		// Flush the block journal ops in parallel.
-		totalRemovedBytes, numFlushed, maxMDRevToFlush,
-			err := j.flushBlockEntries(ctx, blockEnd)
+		numFlushed, maxMDRevToFlush, err :=
+			j.flushBlockEntries(ctx, blockEnd)
 		if err != nil {
 			return err
-		}
-		if totalRemovedBytes > 0 {
-			j.diskLimiter.Release(totalRemovedBytes)
 		}
 		flushedBlockEntries += numFlushed
 
@@ -786,35 +783,47 @@ func (j *tlfJournal) getNextBlockEntriesToFlush(
 }
 
 func (j *tlfJournal) removeFlushedBlockEntries(ctx context.Context,
-	entries blockEntriesToFlush) (totalFlushedBytes int64, err error) {
+	entries blockEntriesToFlush) error {
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
 	if err := j.checkEnabledLocked(); err != nil {
-		return 0, err
+		return err
 	}
 
 	// Keep the flushed blocks around until we know for sure the MD
 	// flush will succeed; otherwise if we become unmerged, conflict
 	// resolution will be very expensive.
-	err = j.blockJournal.saveBlocksUntilNextMDFlush()
+	err := j.blockJournal.saveBlocksUntilNextMDFlush()
 	if err != nil {
-		return 0, err
+		return err
 	}
 
-	return j.blockJournal.removeFlushedEntries(ctx, entries, j.tlfID,
-		j.config.Reporter())
+	removedBytes, err := j.blockJournal.removeFlushedEntries(
+		ctx, entries, j.tlfID, j.config.Reporter())
+	if err != nil {
+		return err
+	}
+
+	// removedBytes should be zero since we're always saving
+	// blocks.
+	if removedBytes != 0 {
+		panic(fmt.Sprintf("removedBytes=%d unexpectedly non-zero",
+			removedBytes))
+	}
+
+	return nil
 }
 
 func (j *tlfJournal) flushBlockEntries(
 	ctx context.Context, end journalOrdinal) (
-	int64, int, MetadataRevision, error) {
+	int, MetadataRevision, error) {
 	entries, maxMDRevToFlush, err := j.getNextBlockEntriesToFlush(ctx, end)
 	if err != nil {
-		return 0, 0, MetadataRevisionUninitialized, err
+		return 0, MetadataRevisionUninitialized, err
 	}
 
 	if entries.length() == 0 {
-		return 0, 0, maxMDRevToFlush, nil
+		return 0, maxMDRevToFlush, nil
 	}
 
 	// TODO: fill this in for logging/error purposes.
@@ -823,15 +832,15 @@ func (j *tlfJournal) flushBlockEntries(
 		j.config.BlockCache(), j.config.Reporter(),
 		j.tlfID, tlfName, entries)
 	if err != nil {
-		return 0, 0, MetadataRevisionUninitialized, err
+		return 0, MetadataRevisionUninitialized, err
 	}
 
-	totalRemovedBytes, err := j.removeFlushedBlockEntries(ctx, entries)
+	err = j.removeFlushedBlockEntries(ctx, entries)
 	if err != nil {
-		return 0, 0, MetadataRevisionUninitialized, err
+		return 0, MetadataRevisionUninitialized, err
 	}
 
-	return totalRemovedBytes, entries.length(), maxMDRevToFlush, nil
+	return entries.length(), maxMDRevToFlush, nil
 }
 
 func (j *tlfJournal) getNextMDEntryToFlush(ctx context.Context,

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -157,12 +157,6 @@ type tlfJournalBWDelegate interface {
 	OnShutdown(ctx context.Context)
 }
 
-type diskLimiter interface {
-	Adjust(deltaBytes int64)
-	Acquire(ctx context.Context, nBytes int64) error
-	Release(nBytes int64)
-}
-
 // A tlfJournal contains all the journals for a (TLF, user, device)
 // tuple and controls the synchronization between the objects that are
 // adding to those journals (via journalBlockServer or journalMDOps)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -356,7 +356,7 @@ func makeTLFJournal(
 
 	// Do this only once we're sure we won't error.
 	storedBytes := blockJournal.getStoredBytes()
-	j.diskLimiter.Adjust(-storedBytes)
+	j.diskLimiter.ForceAcquire(storedBytes)
 
 	go j.doBackgroundWorkLoop(bws, backoff.NewExponentialBackOff())
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1318,11 +1318,15 @@ func (j *tlfJournal) shutdown() {
 		return
 	}
 
+	// Even if we shut down the journal, its blocks still take up
+	// space, but we don't want to double-count them if we start
+	// up this journal again, so we need to adjust them here.
+	storedBytes := j.blockJournal.getStoredBytes()
+	j.diskLimiter.Release(storedBytes)
+
 	// Make further accesses error out.
 	j.blockJournal = nil
 	j.mdJournal = nil
-
-	// TODO: Reset diskLimiter back.
 }
 
 // disable prevents new operations from hitting the journal.  Will

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -71,23 +71,23 @@ func (d testBWDelegate) requireNextState(
 // testTLFJournalConfig is the config we pass to the tlfJournal, and
 // also contains some helper functions for testing.
 type testTLFJournalConfig struct {
-	t                 *testing.T
-	log               logger.Logger
-	tlfID             tlf.ID
-	splitter          BlockSplitter
-	codec             kbfscodec.Codec
-	crypto            CryptoLocal
-	bcache            BlockCache
-	bops              BlockOps
-	mdcache           MDCache
-	ver               MetadataVer
-	reporter          Reporter
-	uid               keybase1.UID
-	verifyingKey      kbfscrypto.VerifyingKey
-	ekg               singleEncryptionKeyGetter
-	nug               normalizedUsernameGetter
-	mdserver          MDServer
-	_diskLimitTimeout time.Duration
+	t            *testing.T
+	log          logger.Logger
+	tlfID        tlf.ID
+	splitter     BlockSplitter
+	codec        kbfscodec.Codec
+	crypto       CryptoLocal
+	bcache       BlockCache
+	bops         BlockOps
+	mdcache      MDCache
+	ver          MetadataVer
+	reporter     Reporter
+	uid          keybase1.UID
+	verifyingKey kbfscrypto.VerifyingKey
+	ekg          singleEncryptionKeyGetter
+	nug          normalizedUsernameGetter
+	mdserver     MDServer
+	dlTimeout    time.Duration
 }
 
 func (c testTLFJournalConfig) BlockSplitter() BlockSplitter {
@@ -151,7 +151,7 @@ func (c testTLFJournalConfig) MakeLogger(module string) logger.Logger {
 }
 
 func (c testTLFJournalConfig) diskLimitTimeout() time.Duration {
-	return c._diskLimitTimeout
+	return c.dlTimeout
 }
 
 func (c testTLFJournalConfig) makeBlock(data []byte) (
@@ -535,7 +535,7 @@ func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver MetadataVer) {
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
 	tlfJournal.diskLimiter.ForceAcquire(math.MaxInt64)
-	config._diskLimitTimeout = 3 * time.Microsecond
+	config.dlTimeout = 3 * time.Microsecond
 
 	data := []byte{1, 2, 3, 4}
 	id, bCtx, serverHalf := config.makeBlock(data)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -519,11 +519,12 @@ func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver MetadataVer) {
 
 	tlfJournal.diskLimiter.ForceAcquire(math.MaxInt64)
 
-	cancel()
+	ctx2, cancel2 := context.WithCancel(ctx)
+	cancel2()
 
 	data := []byte{1, 2, 3, 4}
 	id, bCtx, serverHalf := config.makeBlock(data)
-	err := tlfJournal.putBlockData(ctx, id, bCtx, data, serverHalf)
+	err := tlfJournal.putBlockData(ctx2, id, bCtx, data, serverHalf)
 	require.Equal(t, context.Canceled, errors.Cause(err))
 }
 

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -406,7 +406,7 @@ func testTLFJournalBlockOpBasic(t *testing.T, ver MetadataVer) {
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
-	_, numFlushed, rev, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, err := tlfJournal.flushBlockEntries(ctx, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)


### PR DESCRIPTION
For now, hard-code it to 10 GB, and use a simple
semaphore to enforce it.

Add a simple Semaphore type to kbfssync.

Plumb up removedBytes count from blockJournal.

Add a diskLimiter interface and use it in tlfJournal.