### PR TITLE
file_data: return correct dirty status for direct blocks

### DIFF
--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -83,6 +83,17 @@ func (fd *fileData) getFileBlockAtOffset(ctx context.Context,
 	block = topBlock
 	nextBlockStartOff = -1
 	startOff = 0
+
+	if !topBlock.IsInd {
+		// If it's not an indirect block, we just need to figure out
+		// if it's dirty.
+		_, wasDirty, err = fd.getter(ctx, fd.kmd, ptr, fd.file, rtype)
+		if err != nil {
+			return zeroPtr, nil, nil, 0, 0, false, err
+		}
+		return ptr, nil, block, nextBlockStartOff, startOff, wasDirty, nil
+	}
+
 	// search until it's not an indirect block
 	for block.IsInd {
 		nextIndex := len(block.IPtrs) - 1


### PR DESCRIPTION
getFileBlockAtOffset was always returning wasDirty=false for files
with only one block.  This messes up the dirty bytes calculation in
some scenarios, i.e. when the same section of the block is overwritten
multiple times before the sync happens.

Issue: KBFS-1846