### PR TITLE
prefetcher: Don't prefetch when initializing block helpers if the blo…

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -277,8 +277,10 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
-			block, kmd, defaultOnDemandRequestPriority)
+		// FIXME: This is triggering explosive prefetching since it triggers
+		// directory prefetches at every node of the path, on every fs op.
+		//fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
+		//	block, kmd, defaultOnDemandRequestPriority)
 		return block, nil
 	}
 


### PR DESCRIPTION
…ck has already been cached. This causes prefetcher explosion because the way we navigate node paths.

This is a temporary solution, I'm trying to figure out a way to fix it in such a way that we can still prefetch if we haven't prefetched before. Maybe by storing the `Get` priority in the cache.