### PR TITLE
folder_block_ops: don't share a syncOp between unrefCache and MD

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1768,6 +1768,12 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 			fmt.Errorf("No syncOp found for file ref %v", fileRef)
 	}
 
+	// If this function returns a success, we need to make sure the op
+	// in `md` is not the same variable as the op in `unrefCache`,
+	// because the latter could get updated still by local writes
+	// before `md` is flushed to the server.  We don't copy it here
+	// because code below still needs to modify it (and by extension,
+	// the one stored in `syncState.si`).
 	md.AddOp(si.op)
 
 	// Fill in syncState.
@@ -1866,13 +1872,14 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 	}
 
 	// Leave a copy of the syncOp in `unrefCache`, since it may be
-	// modified by future writes while the syncOp in `md` and
-	// `syncState` should remain immutable.
-	err = kbfscodec.Update(
-		fbo.config.Codec(), &fbo.unrefCache[fileRef].op, si.op)
+	// modified by future local writes while the syncOp in `md` should
+	// only be modified by the rest of this sync process.
+	var syncOpCopy *syncOp
+	err = kbfscodec.Update(fbo.config.Codec(), &syncOpCopy, si.op)
 	if err != nil {
 		return nil, nil, syncState, nil, err
 	}
+	fbo.unrefCache[fileRef].op = syncOpCopy
 
 	// TODO: Returning si.bps in this way is racy, since si is a
 	// member of unrefCache.

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1865,6 +1865,15 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 		dirtyDe = &de
 	}
 
+	// Leave a copy of the syncOp in `unrefCache`, since it may be
+	// modified by future writes while the syncOp in `md` and
+	// `syncState` should remain immutable.
+	err = kbfscodec.Update(
+		fbo.config.Codec(), &fbo.unrefCache[fileRef].op, si.op)
+	if err != nil {
+		return nil, nil, syncState, nil, err
+	}
+
 	// TODO: Returning si.bps in this way is racy, since si is a
 	// member of unrefCache.
 	return fblock, si.bps, syncState, dirtyDe, nil

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -716,8 +716,6 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 // overwrites, plus one write that blocks until the dirty bcache has
 // room.  This is a repro for KBFS-1846.
 func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
-	t.Skip("Pending KBFS-1852")
-
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 


### PR DESCRIPTION
The unrefCache state might get updated while the MD is still being processed, leading to races.

Issue: KBFS-1852