### PR TITLE
Clean up a bunch of places where we use KIDs

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -307,7 +307,7 @@ func (md *BareRootMetadataV2) IsFinal() bool {
 
 // IsWriter implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) IsWriter(
-	user keybase1.UID, deviceKID keybase1.KID, _ ExtraMetadata) bool {
+	user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, _ ExtraMetadata) bool {
 	if md.ID.IsPublic() {
 		for _, w := range md.Writers {
 			if w == user {
@@ -316,16 +316,16 @@ func (md *BareRootMetadataV2) IsWriter(
 		}
 		return false
 	}
-	return md.WKeys.IsWriter(user, deviceKID)
+	return md.WKeys.IsWriter(user, deviceKey)
 }
 
 // IsReader implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) IsReader(
-	user keybase1.UID, deviceKID keybase1.KID, _ ExtraMetadata) bool {
+	user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, _ ExtraMetadata) bool {
 	if md.ID.IsPublic() {
 		return true
 	}
-	return md.RKeys.IsReader(user, deviceKID)
+	return md.RKeys.IsReader(user, deviceKey)
 }
 
 func (md *BareRootMetadataV2) deepCopy(

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -365,7 +365,7 @@ func (md *BareRootMetadataV3) getTLFKeyBundles(extra ExtraMetadata) (
 
 // IsWriter implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) IsWriter(
-	user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, extra ExtraMetadata) bool {
 	if md.TlfID().IsPublic() {
 		err := md.checkPublicExtra(extra)
 		if err != nil {
@@ -383,12 +383,12 @@ func (md *BareRootMetadataV3) IsWriter(
 	if err != nil {
 		panic(err)
 	}
-	return wkb.IsWriter(user, deviceKID)
+	return wkb.IsWriter(user, deviceKey)
 }
 
 // IsReader implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) IsReader(
-	user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool {
+	user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, extra ExtraMetadata) bool {
 	if md.TlfID().IsPublic() {
 		err := md.checkPublicExtra(extra)
 		if err != nil {
@@ -400,7 +400,7 @@ func (md *BareRootMetadataV3) IsReader(
 	if err != nil {
 		panic(err)
 	}
-	return rkb.IsReader(user, deviceKID)
+	return rkb.IsReader(user, deviceKey)
 }
 
 // DeepCopy implements the BareRootMetadata interface for BareRootMetadataV3.

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -417,13 +417,13 @@ func (c CryptoCommon) GetTLFCryptKeyServerHalfID(
 // VerifyTLFCryptKeyServerHalfID implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) VerifyTLFCryptKeyServerHalfID(
 	serverHalfID TLFCryptKeyServerHalfID,
-	user keybase1.UID, deviceKID keybase1.KID,
+	user keybase1.UID, devicePubKey kbfscrypto.CryptPublicKey,
 	serverHalf kbfscrypto.TLFCryptKeyServerHalf) error {
 	key, err := serverHalf.MarshalBinary()
 	if err != nil {
 		return err
 	}
-	data := append(user.ToBytes(), deviceKID.ToBytes()...)
+	data := append(user.ToBytes(), devicePubKey.KID().ToBytes()...)
 	return serverHalfID.ID.Verify(key, data)
 }
 

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 )
 
@@ -581,15 +582,14 @@ func (e MDWriteNeededInRequest) Error() string {
 	return "This request needs MD write access, but doesn't have it."
 }
 
-// KeyNotFoundError indicates that a key matching the given KID
-// couldn't be found.
-type KeyNotFoundError struct {
-	kid keybase1.KID
+// VerifyingKeyNotFoundError indicates that a verifying key matching
+// the given one couldn't be found.
+type VerifyingKeyNotFoundError struct {
+	key kbfscrypto.VerifyingKey
 }
 
-// Error implements the error interface for KeyNotFoundError.
-func (e KeyNotFoundError) Error() string {
-	return fmt.Sprintf("Could not find key with kid=%s", e.kid)
+func (e VerifyingKeyNotFoundError) Error() string {
+	return fmt.Sprintf("Could not find verifyin key %s", e.key)
 }
 
 // UnverifiableTlfUpdateError indicates that a MD update could not be

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1744,8 +1744,8 @@ type BareRootMetadata interface {
 	IsValidAndSigned(codec kbfscodec.Codec,
 		crypto cryptoPure, extra ExtraMetadata) error
 	// IsLastModifiedBy verifies that the BareRootMetadata is
-	// written by the given user and device (identified by the KID
-	// of the device verifying key), and returns an error if not.
+	// written by the given user and device (identified by the
+	// device verifying key), and returns an error if not.
 	IsLastModifiedBy(uid keybase1.UID, key kbfscrypto.VerifyingKey) error
 	// LastModifyingWriter return the UID of the last user to modify the writer metadata.
 	LastModifyingWriter() keybase1.UID

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1033,7 +1033,7 @@ type KeyOps interface {
 	// DeleteTLFCryptKeyServerHalf deletes a server-side key half for a
 	// device given the key half ID.
 	DeleteTLFCryptKeyServerHalf(ctx context.Context,
-		uid keybase1.UID, kid keybase1.KID,
+		uid keybase1.UID, key kbfscrypto.CryptPublicKey,
 		serverHalfID TLFCryptKeyServerHalfID) error
 }
 
@@ -1374,7 +1374,7 @@ type KeyServer interface {
 	// DeleteTLFCryptKeyServerHalf deletes a server-side key half for a
 	// device given the key half ID.
 	DeleteTLFCryptKeyServerHalf(ctx context.Context,
-		uid keybase1.UID, kid keybase1.KID,
+		uid keybase1.UID, key kbfscrypto.CryptPublicKey,
 		serverHalfID TLFCryptKeyServerHalfID) error
 
 	// Shutdown is called to free any KeyServer resources.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -892,7 +892,7 @@ type cryptoPure interface {
 
 	// VerifyTLFCryptKeyServerHalfID verifies the ID is the proper HMAC result.
 	VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID,
-		user keybase1.UID, deviceKID keybase1.KID,
+		user keybase1.UID, devicePubKey kbfscrypto.CryptPublicKey,
 		serverHalf kbfscrypto.TLFCryptKeyServerHalf) error
 
 	// EncryptMerkleLeaf encrypts a Merkle leaf node with the TLFPublicKey.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1693,9 +1693,9 @@ type BareRootMetadata interface {
 	// folder.  This is only expected to be set for folder resets.
 	IsFinal() bool
 	// IsWriter returns whether or not the user+device is an authorized writer.
-	IsWriter(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool
+	IsWriter(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, extra ExtraMetadata) bool
 	// IsReader returns whether or not the user+device is an authorized reader.
-	IsReader(user keybase1.UID, deviceKID keybase1.KID, extra ExtraMetadata) bool
+	IsReader(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, extra ExtraMetadata) bool
 	// DeepCopy returns a deep copy of the underlying data structure.
 	DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error)
 	// MakeSuccessorCopy returns a newly constructed successor

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -143,7 +143,7 @@ func (k *KBPKIClient) HasVerifyingKey(ctx context.Context, uid keybase1.UID,
 		return err
 	}
 	if !ok {
-		return KeyNotFoundError{verifyingKey.KID()}
+		return VerifyingKeyNotFoundError{verifyingKey}
 	}
 	return nil
 }
@@ -165,7 +165,7 @@ func (k *KBPKIClient) HasUnverifiedVerifyingKey(
 		return err
 	}
 	if !ok {
-		return KeyNotFoundError{verifyingKey.KID()}
+		return VerifyingKeyNotFoundError{verifyingKey}
 	}
 	return nil
 }

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -212,8 +212,8 @@ type TLFWriterKeyBundleV2 struct {
 }
 
 // IsWriter returns true if the given user device is in the writer set.
-func (wkb TLFWriterKeyBundleV2) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
-	_, ok := wkb.WKeys[user][deviceKID]
+func (wkb TLFWriterKeyBundleV2) IsWriter(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey) bool {
+	_, ok := wkb.WKeys[user][deviceKey.KID()]
 	return ok
 }
 
@@ -228,12 +228,12 @@ func (wkg TLFWriterKeyGenerationsV2) LatestKeyGeneration() KeyGen {
 
 // IsWriter returns whether or not the user+device is an authorized writer
 // for the latest generation.
-func (wkg TLFWriterKeyGenerationsV2) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
+func (wkg TLFWriterKeyGenerationsV2) IsWriter(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey) bool {
 	keyGen := wkg.LatestKeyGeneration()
 	if keyGen < 1 {
 		return false
 	}
-	return wkg[keyGen-1].IsWriter(user, deviceKID)
+	return wkg[keyGen-1].IsWriter(user, deviceKey)
 }
 
 // ToTLFWriterKeyBundleV3 converts a TLFWriterKeyGenerationsV2 to a TLFWriterKeyBundleV3.
@@ -306,8 +306,8 @@ type TLFReaderKeyBundleV2 struct {
 }
 
 // IsReader returns true if the given user device is in the reader set.
-func (trb TLFReaderKeyBundleV2) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
-	_, ok := trb.RKeys[user][deviceKID]
+func (trb TLFReaderKeyBundleV2) IsReader(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey) bool {
+	_, ok := trb.RKeys[user][deviceKey.KID()]
 	return ok
 }
 
@@ -322,12 +322,12 @@ func (rkg TLFReaderKeyGenerationsV2) LatestKeyGeneration() KeyGen {
 
 // IsReader returns whether or not the user+device is an authorized reader
 // for the latest generation.
-func (rkg TLFReaderKeyGenerationsV2) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
+func (rkg TLFReaderKeyGenerationsV2) IsReader(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey) bool {
 	keyGen := rkg.LatestKeyGeneration()
 	if keyGen < 1 {
 		return false
 	}
-	return rkg[keyGen-1].IsReader(user, deviceKID)
+	return rkg[keyGen-1].IsReader(user, deviceKey)
 }
 
 // ToTLFReaderKeyBundleV3 converts a TLFReaderKeyGenerationsV2 to a TLFReaderkeyBundleV3.

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -215,8 +215,8 @@ func DeserializeTLFWriterKeyBundleV3(codec kbfscodec.Codec, path string) (
 }
 
 // IsWriter returns true if the given user device is in the device set.
-func (wkb TLFWriterKeyBundleV3) IsWriter(user keybase1.UID, deviceKID keybase1.KID) bool {
-	_, ok := wkb.Keys[user][kbfscrypto.MakeCryptPublicKey(deviceKID)]
+func (wkb TLFWriterKeyBundleV3) IsWriter(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey) bool {
+	_, ok := wkb.Keys[user][deviceKey]
 	return ok
 }
 
@@ -327,8 +327,8 @@ func DeserializeTLFReaderKeyBundleV3(codec kbfscodec.Codec, path string) (
 }
 
 // IsReader returns true if the given user device is in the reader set.
-func (rkb TLFReaderKeyBundleV3) IsReader(user keybase1.UID, deviceKID keybase1.KID) bool {
-	_, ok := rkb.Keys[user][kbfscrypto.MakeCryptPublicKey(deviceKID)]
+func (rkb TLFReaderKeyBundleV3) IsReader(user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey) bool {
+	_, ok := rkb.Keys[user][deviceKey]
 	return ok
 }
 

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -784,7 +784,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 					len(serverHalfIDs), key, uid)
 				for _, serverHalfID := range serverHalfIDs {
 					err := kops.DeleteTLFCryptKeyServerHalf(
-						ctx, uid, key.KID(), serverHalfID)
+						ctx, uid, key, serverHalfID)
 					if err != nil {
 						return false, nil, err
 					}

--- a/libkbfs/key_ops.go
+++ b/libkbfs/key_ops.go
@@ -52,8 +52,8 @@ func (k *KeyOpsStandard) PutTLFCryptKeyServerHalves(ctx context.Context,
 
 // DeleteTLFCryptKeyServerHalf is an implementation of the KeyOps interface.
 func (k *KeyOpsStandard) DeleteTLFCryptKeyServerHalf(ctx context.Context,
-	uid keybase1.UID, kid keybase1.KID,
+	uid keybase1.UID, key kbfscrypto.CryptPublicKey,
 	serverHalfID TLFCryptKeyServerHalfID) error {
 	return k.config.KeyServer().DeleteTLFCryptKeyServerHalf(
-		ctx, uid, kid, serverHalfID)
+		ctx, uid, key, serverHalfID)
 }

--- a/libkbfs/key_ops.go
+++ b/libkbfs/key_ops.go
@@ -36,7 +36,7 @@ func (k *KeyOpsStandard) GetTLFCryptKeyServerHalf(ctx context.Context,
 
 	// verify we got the expected key
 	crypto := k.config.Crypto()
-	err = crypto.VerifyTLFCryptKeyServerHalfID(serverHalfID, session.UID, key.KID(), serverHalf)
+	err = crypto.VerifyTLFCryptKeyServerHalfID(serverHalfID, session.UID, key, serverHalf)
 	if err != nil {
 		return kbfscrypto.TLFCryptKeyServerHalf{}, err
 	}

--- a/libkbfs/key_server_local.go
+++ b/libkbfs/key_server_local.go
@@ -113,7 +113,7 @@ func (ks *KeyServerLocal) GetTLFCryptKeyServerHalf(ctx context.Context,
 	}
 
 	err = ks.config.Crypto().VerifyTLFCryptKeyServerHalfID(
-		serverHalfID, session.UID, key.KID(), serverHalf)
+		serverHalfID, session.UID, key, serverHalf)
 	if err != nil {
 		ks.log.CDebugf(ctx, "error verifying server half ID: %+v", err)
 		return kbfscrypto.TLFCryptKeyServerHalf{}, MDServerErrorUnauthorized{

--- a/libkbfs/key_server_local.go
+++ b/libkbfs/key_server_local.go
@@ -157,7 +157,7 @@ func (ks *KeyServerLocal) PutTLFCryptKeyServerHalves(ctx context.Context,
 // DeleteTLFCryptKeyServerHalf implements the KeyOps interface for
 // KeyServerLocal.
 func (ks *KeyServerLocal) DeleteTLFCryptKeyServerHalf(ctx context.Context,
-	_ keybase1.UID, _ keybase1.KID,
+	_ keybase1.UID, _ kbfscrypto.CryptPublicKey,
 	serverHalfID TLFCryptKeyServerHalfID) error {
 	if err := checkContext(ctx); err != nil {
 		return err

--- a/libkbfs/key_server_local.go
+++ b/libkbfs/key_server_local.go
@@ -139,12 +139,12 @@ func (ks *KeyServerLocal) PutTLFCryptKeyServerHalves(ctx context.Context,
 	batch := &leveldb.Batch{}
 	crypto := ks.config.Crypto()
 	for uid, deviceMap := range keyServerHalves {
-		for deviceKID, serverHalf := range deviceMap {
+		for deviceKey, serverHalf := range deviceMap {
 			buf, err := ks.config.Codec().Encode(serverHalf)
 			if err != nil {
 				return err
 			}
-			id, err := crypto.GetTLFCryptKeyServerHalfID(uid, deviceKID, serverHalf)
+			id, err := crypto.GetTLFCryptKeyServerHalfID(uid, deviceKey, serverHalf)
 			if err != nil {
 				return err
 			}

--- a/libkbfs/key_server_measured.go
+++ b/libkbfs/key_server_measured.go
@@ -60,11 +60,11 @@ func (b KeyServerMeasured) PutTLFCryptKeyServerHalves(ctx context.Context,
 // DeleteTLFCryptKeyServerHalf implements the KeyServer interface for
 // KeyServerMeasured.
 func (b KeyServerMeasured) DeleteTLFCryptKeyServerHalf(ctx context.Context,
-	uid keybase1.UID, kid keybase1.KID,
+	uid keybase1.UID, key kbfscrypto.CryptPublicKey,
 	serverHalfID TLFCryptKeyServerHalfID) (err error) {
 	b.deleteTimer.Time(func() {
 		err = b.delegate.DeleteTLFCryptKeyServerHalf(
-			ctx, uid, kid, serverHalfID)
+			ctx, uid, key, serverHalfID)
 	})
 	return err
 }

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -37,7 +37,7 @@ func NewMDOpsStandard(config Config) *MDOpsStandard {
 // signed by a key that is no longer associated with the last writer.
 func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 	rmds *RootMetadataSigned, handle *TlfHandle, err error) error {
-	if _, ok := err.(KeyNotFoundError); !ok {
+	if _, ok := err.(VerifyingKeyNotFoundError); !ok {
 		return err
 	}
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -371,7 +371,7 @@ func testMDOpsGetForHandlePublicFailFindKey(t *testing.T, ver MetadataVer) {
 	rmds, _ := newRMDS(t, config, h)
 
 	// Do this before setting tlfHandle to nil.
-	verifyMDForPublic(config, rmds, KeyNotFoundError{})
+	verifyMDForPublic(config, rmds, VerifyingKeyNotFoundError{})
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(), Merged).Return(tlf.NullID, rmds, nil)
 

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -30,7 +30,7 @@ type mdServerDiskShared struct {
 	lock sync.RWMutex
 	// Bare TLF handle -> TLF ID
 	handleDb *leveldb.DB
-	// (TLF ID, device KID) -> branch ID
+	// (TLF ID, device crypt public key) -> branch ID
 	branchDb   *leveldb.DB
 	tlfStorage map[tlf.ID]*mdServerTlfStorage
 	// Always use memory for the lock storage, so it gets wiped
@@ -234,7 +234,7 @@ func (md *MDServerDisk) getBranchKey(ctx context.Context, id tlf.ID) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	// add device KID
+	// add device key
 	session, err := md.config.currentSessionGetter().GetCurrentSession(ctx)
 	if err != nil {
 		return nil, err

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -505,7 +505,7 @@ func (md *MDServerDisk) TruncateLock(ctx context.Context, id tlf.ID) (
 		return false, err
 	}
 
-	return md.truncateLockManager.truncateLock(session.CryptPublicKey.KID(), id)
+	return md.truncateLockManager.truncateLock(session.CryptPublicKey, id)
 }
 
 // TruncateUnlock implements the MDServer interface for MDServerDisk.
@@ -527,7 +527,7 @@ func (md *MDServerDisk) TruncateUnlock(ctx context.Context, id tlf.ID) (
 		return false, err
 	}
 
-	return md.truncateLockManager.truncateUnlock(session.CryptPublicKey.KID(), id)
+	return md.truncateLockManager.truncateUnlock(session.CryptPublicKey, id)
 }
 
 // Shutdown implements the MDServer interface for MDServerDisk.

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -862,7 +862,7 @@ func (md *MDServerRemote) PutTLFCryptKeyServerHalves(ctx context.Context,
 
 // DeleteTLFCryptKeyServerHalf is an implementation of the KeyServer interface.
 func (md *MDServerRemote) DeleteTLFCryptKeyServerHalf(ctx context.Context,
-	uid keybase1.UID, kid keybase1.KID,
+	uid keybase1.UID, key kbfscrypto.CryptPublicKey,
 	serverHalfID TLFCryptKeyServerHalfID) error {
 	// encode the ID
 	idBytes, err := md.config.Codec().Encode(serverHalfID)
@@ -873,7 +873,7 @@ func (md *MDServerRemote) DeleteTLFCryptKeyServerHalf(ctx context.Context,
 	// get the key
 	arg := keybase1.DeleteKeyArg{
 		Uid:       uid,
-		DeviceKID: kid,
+		DeviceKID: key.KID(),
 		KeyHalfID: idBytes,
 		LogTags:   nil,
 	}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2241,8 +2241,8 @@ func (_mr *_MockcryptoPureRecorder) GetTLFCryptKeyServerHalfID(arg0, arg1, arg2 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyServerHalfID", arg0, arg1, arg2)
 }
 
-func (_m *MockcryptoPure) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user keybase1.UID, deviceKID keybase1.KID, serverHalf kbfscrypto.TLFCryptKeyServerHalf) error {
-	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, deviceKID, serverHalf)
+func (_m *MockcryptoPure) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user keybase1.UID, devicePubKey kbfscrypto.CryptPublicKey, serverHalf kbfscrypto.TLFCryptKeyServerHalf) error {
+	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, devicePubKey, serverHalf)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -2517,8 +2517,8 @@ func (_mr *_MockCryptoRecorder) GetTLFCryptKeyServerHalfID(arg0, arg1, arg2 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyServerHalfID", arg0, arg1, arg2)
 }
 
-func (_m *MockCrypto) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user keybase1.UID, deviceKID keybase1.KID, serverHalf kbfscrypto.TLFCryptKeyServerHalf) error {
-	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, deviceKID, serverHalf)
+func (_m *MockCrypto) VerifyTLFCryptKeyServerHalfID(serverHalfID TLFCryptKeyServerHalfID, user keybase1.UID, devicePubKey kbfscrypto.CryptPublicKey, serverHalf kbfscrypto.TLFCryptKeyServerHalf) error {
+	ret := _m.ctrl.Call(_m, "VerifyTLFCryptKeyServerHalfID", serverHalfID, user, devicePubKey, serverHalf)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2830,8 +2830,8 @@ func (_mr *_MockKeyOpsRecorder) PutTLFCryptKeyServerHalves(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutTLFCryptKeyServerHalves", arg0, arg1)
 }
 
-func (_m *MockKeyOps) DeleteTLFCryptKeyServerHalf(ctx context.Context, uid keybase1.UID, kid keybase1.KID, serverHalfID TLFCryptKeyServerHalfID) error {
-	ret := _m.ctrl.Call(_m, "DeleteTLFCryptKeyServerHalf", ctx, uid, kid, serverHalfID)
+func (_m *MockKeyOps) DeleteTLFCryptKeyServerHalf(ctx context.Context, uid keybase1.UID, key kbfscrypto.CryptPublicKey, serverHalfID TLFCryptKeyServerHalfID) error {
+	ret := _m.ctrl.Call(_m, "DeleteTLFCryptKeyServerHalf", ctx, uid, key, serverHalfID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -3789,8 +3789,8 @@ func (_mr *_MockKeyServerRecorder) PutTLFCryptKeyServerHalves(arg0, arg1 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutTLFCryptKeyServerHalves", arg0, arg1)
 }
 
-func (_m *MockKeyServer) DeleteTLFCryptKeyServerHalf(ctx context.Context, uid keybase1.UID, kid keybase1.KID, serverHalfID TLFCryptKeyServerHalfID) error {
-	ret := _m.ctrl.Call(_m, "DeleteTLFCryptKeyServerHalf", ctx, uid, kid, serverHalfID)
+func (_m *MockKeyServer) DeleteTLFCryptKeyServerHalf(ctx context.Context, uid keybase1.UID, key kbfscrypto.CryptPublicKey, serverHalfID TLFCryptKeyServerHalfID) error {
+	ret := _m.ctrl.Call(_m, "DeleteTLFCryptKeyServerHalf", ctx, uid, key, serverHalfID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -1175,8 +1175,8 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 }
 
 // IsLastModifiedBy verifies that the RootMetadataSigned is written by
-// the given user and device (identified by the KID of the device
-// verifying key), and returns an error if not.
+// the given user and device (identified by the device verifying key),
+// and returns an error if not.
 func (rmds *RootMetadataSigned) IsLastModifiedBy(
 	uid keybase1.UID, key kbfscrypto.VerifyingKey) error {
 	err := rmds.MD.IsLastModifiedBy(uid, key)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -256,7 +256,7 @@ func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *C
 		keyServer = mdServer.(*MDServerRemote)
 	} else {
 		// copy the existing mdServer but update the config
-		// this way the current device KID is paired with
+		// this way the current device key is paired with
 		// the proper user yet the DB state is all shared.
 		mdServerToCopy := config.MDServer().(mdServerLocal)
 		mdServer = mdServerToCopy.copy(mdServerLocalConfigAdapter{c})


### PR DESCRIPTION
Use CryptPublicKeys instead, to avoid the possibility
of using the wrong key.