### PR TITLE
libkbfs: make test servers more context aware

### DIFF
--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -123,10 +123,8 @@ func (b *BlockServerDisk) getStorage(tlfID tlf.ID) (
 func (b *BlockServerDisk) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}
 
 	defer func() {
@@ -158,10 +156,8 @@ func (b *BlockServerDisk) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID
 func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	defer func() {
@@ -196,10 +192,8 @@ func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID
 // AddBlockReference implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	b.log.CDebugf(ctx, "BlockServerDisk.AddBlockReference id=%s "+
@@ -241,10 +235,8 @@ func (b *BlockServerDisk) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 func (b *BlockServerDisk) RemoveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (
 	liveCounts map[kbfsblock.ID]int, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	defer func() {
@@ -287,10 +279,8 @@ func (b *BlockServerDisk) RemoveBlockReferences(ctx context.Context,
 // BlockServerDisk.
 func (b *BlockServerDisk) ArchiveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (err error) {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	defer func() {
@@ -350,10 +340,8 @@ func (b *BlockServerDisk) getAllRefsForTest(ctx context.Context, tlfID tlf.ID) (
 // IsUnflushed implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) IsUnflushed(ctx context.Context, tlfID tlf.ID,
 	_ kbfsblock.ID) (bool, error) {
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return false, err
 	}
 
 	tlfStorage, err := b.getStorage(tlfID)
@@ -405,10 +393,8 @@ func (b *BlockServerDisk) RefreshAuthToken(_ context.Context) {}
 
 // GetUserQuotaInfo implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) GetUserQuotaInfo(ctx context.Context) (info *kbfsblock.UserQuotaInfo, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	// Return a dummy value here.

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -123,6 +123,12 @@ func (b *BlockServerDisk) getStorage(tlfID tlf.ID) (
 func (b *BlockServerDisk) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -152,6 +158,12 @@ func (b *BlockServerDisk) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID
 func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -184,6 +196,12 @@ func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID
 // AddBlockReference implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	b.log.CDebugf(ctx, "BlockServerDisk.AddBlockReference id=%s "+
 		"tlfID=%s context=%s", id, tlfID, context)
 	tlfStorage, err := b.getStorage(tlfID)
@@ -223,6 +241,12 @@ func (b *BlockServerDisk) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 func (b *BlockServerDisk) RemoveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (
 	liveCounts map[kbfsblock.ID]int, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -263,6 +287,12 @@ func (b *BlockServerDisk) RemoveBlockReferences(ctx context.Context,
 // BlockServerDisk.
 func (b *BlockServerDisk) ArchiveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -320,6 +350,12 @@ func (b *BlockServerDisk) getAllRefsForTest(ctx context.Context, tlfID tlf.ID) (
 // IsUnflushed implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) IsUnflushed(ctx context.Context, tlfID tlf.ID,
 	_ kbfsblock.ID) (bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
 	tlfStorage, err := b.getStorage(tlfID)
 	if err != nil {
 		return false, err
@@ -369,6 +405,12 @@ func (b *BlockServerDisk) RefreshAuthToken(_ context.Context) {}
 
 // GetUserQuotaInfo implements the BlockServer interface for BlockServerDisk.
 func (b *BlockServerDisk) GetUserQuotaInfo(ctx context.Context) (info *kbfsblock.UserQuotaInfo, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// Return a dummy value here.
 	return &kbfsblock.UserQuotaInfo{Limit: 0x7FFFFFFFFFFFFFFF}, nil
 }

--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -49,10 +49,8 @@ var errBlockServerMemoryShutdown = errors.New("BlockServerMemory is shutdown")
 func (b *BlockServerMemory) Get(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}
 
 	defer func() {
@@ -111,10 +109,8 @@ func validateBlockPut(
 func (b *BlockServerMemory) Put(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	defer func() {
@@ -176,10 +172,8 @@ func (b *BlockServerMemory) Put(ctx context.Context, tlfID tlf.ID,
 // AddBlockReference implements the BlockServer interface for BlockServerMemory.
 func (b *BlockServerMemory) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context) (err error) {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	defer func() {
@@ -256,10 +250,8 @@ func (b *BlockServerMemory) removeBlockReference(
 func (b *BlockServerMemory) RemoveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (
 	liveCounts map[kbfsblock.ID]int, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	defer func() {
@@ -317,10 +309,8 @@ func (b *BlockServerMemory) archiveBlockReference(
 // BlockServerMemory.
 func (b *BlockServerMemory) ArchiveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (err error) {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	defer func() {
@@ -395,10 +385,8 @@ func (b *BlockServerMemory) RefreshAuthToken(_ context.Context) {}
 
 // GetUserQuotaInfo implements the BlockServer interface for BlockServerMemory.
 func (b *BlockServerMemory) GetUserQuotaInfo(ctx context.Context) (info *kbfsblock.UserQuotaInfo, err error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	// Return a dummy value here.

--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -49,6 +49,12 @@ var errBlockServerMemoryShutdown = errors.New("BlockServerMemory is shutdown")
 func (b *BlockServerMemory) Get(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -105,6 +111,12 @@ func validateBlockPut(
 func (b *BlockServerMemory) Put(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -164,6 +176,12 @@ func (b *BlockServerMemory) Put(ctx context.Context, tlfID tlf.ID,
 // AddBlockReference implements the BlockServer interface for BlockServerMemory.
 func (b *BlockServerMemory) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 	id kbfsblock.ID, context kbfsblock.Context) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -238,6 +256,12 @@ func (b *BlockServerMemory) removeBlockReference(
 func (b *BlockServerMemory) RemoveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (
 	liveCounts map[kbfsblock.ID]int, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -293,6 +317,12 @@ func (b *BlockServerMemory) archiveBlockReference(
 // BlockServerMemory.
 func (b *BlockServerMemory) ArchiveBlockReferences(ctx context.Context,
 	tlfID tlf.ID, contexts kbfsblock.ContextMap) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	defer func() {
 		err = translateToBlockServerError(err)
 	}()
@@ -365,6 +395,12 @@ func (b *BlockServerMemory) RefreshAuthToken(_ context.Context) {}
 
 // GetUserQuotaInfo implements the BlockServer interface for BlockServerMemory.
 func (b *BlockServerMemory) GetUserQuotaInfo(ctx context.Context) (info *kbfsblock.UserQuotaInfo, err error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// Return a dummy value here.
 	return &kbfsblock.UserQuotaInfo{Limit: 0x7FFFFFFFFFFFFFFF}, nil
 }

--- a/libkbfs/key_server_local.go
+++ b/libkbfs/key_server_local.go
@@ -87,6 +87,10 @@ func NewKeyServerTempDir(config Config) (*KeyServerLocal, error) {
 func (ks *KeyServerLocal) GetTLFCryptKeyServerHalf(ctx context.Context,
 	serverHalfID TLFCryptKeyServerHalfID, key kbfscrypto.CryptPublicKey) (
 	serverHalf kbfscrypto.TLFCryptKeyServerHalf, err error) {
+	if err := checkContext(ctx); err != nil {
+		return kbfscrypto.TLFCryptKeyServerHalf{}, err
+	}
+
 	ks.shutdownLock.RLock()
 	defer ks.shutdownLock.RUnlock()
 	if *ks.shutdown {
@@ -120,6 +124,10 @@ func (ks *KeyServerLocal) GetTLFCryptKeyServerHalf(ctx context.Context,
 // PutTLFCryptKeyServerHalves implements the KeyOps interface for KeyServerLocal.
 func (ks *KeyServerLocal) PutTLFCryptKeyServerHalves(ctx context.Context,
 	keyServerHalves UserDeviceKeyServerHalves) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
 	ks.shutdownLock.RLock()
 	defer ks.shutdownLock.RUnlock()
 	if *ks.shutdown {
@@ -150,6 +158,10 @@ func (ks *KeyServerLocal) PutTLFCryptKeyServerHalves(ctx context.Context,
 func (ks *KeyServerLocal) DeleteTLFCryptKeyServerHalf(ctx context.Context,
 	_ keybase1.UID, _ keybase1.KID,
 	serverHalfID TLFCryptKeyServerHalfID) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
 	ks.shutdownLock.RLock()
 	defer ks.shutdownLock.RUnlock()
 	if *ks.shutdown {

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -185,6 +185,10 @@ func (k *KeybaseDaemonLocal) assertionToUIDLocked(ctx context.Context,
 // Resolve implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 	libkb.NormalizedUsername, keybase1.UID, error) {
+	if err := checkContext(ctx); err != nil {
+		return libkb.NormalizedUsername(""), keybase1.UID(""), err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 
@@ -199,6 +203,10 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 // Identify implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Identify(ctx context.Context, assertion, reason string) (
 	UserInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return UserInfo{}, err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	uid, err := k.assertionToUIDLocked(ctx, assertion)
@@ -220,6 +228,10 @@ func (k *KeybaseDaemonLocal) Identify(ctx context.Context, assertion, reason str
 
 // LoadUserPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID) (UserInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return UserInfo{}, err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	u, err := k.localUsers.getLocalUser(uid)
@@ -237,6 +249,10 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context, uid keybase1.
 // LoadUnverifiedKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
 	[]keybase1.PublicKey, error) {
+	if err := checkContext(ctx); err != nil {
+		return nil, err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	u, err := k.localUsers.getLocalUser(uid)
@@ -249,6 +265,10 @@ func (k *KeybaseDaemonLocal) LoadUnverifiedKeys(ctx context.Context, uid keybase
 // CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) CurrentSession(ctx context.Context, sessionID int) (
 	SessionInfo, error) {
+	if err := checkContext(ctx); err != nil {
+		return SessionInfo{}, err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	u, err := k.localUsers.getLocalUser(k.currentUID)
@@ -400,6 +420,10 @@ func (k *KeybaseDaemonLocal) switchDeviceForTesting(uid keybase1.UID,
 // FavoriteAdd implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) FavoriteAdd(
 	ctx context.Context, folder keybase1.Folder) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	return k.favoriteStore.FavoriteAdd(k.currentUID, folder)
@@ -408,6 +432,10 @@ func (k *KeybaseDaemonLocal) FavoriteAdd(
 // FavoriteDelete implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) FavoriteDelete(
 	ctx context.Context, folder keybase1.Folder) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	return k.favoriteStore.FavoriteDelete(k.currentUID, folder)
@@ -416,6 +444,10 @@ func (k *KeybaseDaemonLocal) FavoriteDelete(
 // FavoriteList implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) FavoriteList(
 	ctx context.Context, sessionID int) ([]keybase1.Folder, error) {
+	if err := checkContext(ctx); err != nil {
+		return nil, err
+	}
+
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	return k.favoriteStore.FavoriteList(k.currentUID)
@@ -423,12 +455,20 @@ func (k *KeybaseDaemonLocal) FavoriteList(
 
 // Notify implements KeybaseDaemon for KeybaseDeamonLocal.
 func (k *KeybaseDaemonLocal) Notify(ctx context.Context, notification *keybase1.FSNotification) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // NotifySyncStatus implements KeybaseDaemon for KeybaseDeamonLocal.
 func (k *KeybaseDaemonLocal) NotifySyncStatus(ctx context.Context,
 	_ *keybase1.FSPathSyncStatus) error {
+	if err := checkContext(ctx); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -207,10 +207,8 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 // GetForHandle implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForHandle(ctx context.Context, handle tlf.Handle,
 	mStatus MergeStatus) (tlf.ID, *RootMetadataSigned, error) {
-	select {
-	case <-ctx.Done():
-		return tlf.NullID, nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return tlf.NullID, nil, err
 	}
 
 	id, created, err := md.getHandleID(ctx, handle, mStatus)
@@ -323,10 +321,8 @@ func (md *MDServerDisk) deleteBranchID(ctx context.Context, id tlf.ID) error {
 // GetForTLF implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus) (*RootMetadataSigned, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	// Lookup the branch ID if not supplied
@@ -358,10 +354,8 @@ func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
 func (md *MDServerDisk) GetRange(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
@@ -394,10 +388,8 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id tlf.ID,
 // Put implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	currentUID, currentVerifyingKey, err :=
@@ -438,10 +430,8 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 // PruneBranch implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	if bid == NullBranchID {
@@ -477,10 +467,8 @@ func (md *MDServerDisk) getCurrentMergedHeadRevision(
 // RegisterForUpdate implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id tlf.ID,
 	currHead MetadataRevision) (<-chan error, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	// are we already past this revision?  If so, fire observer
@@ -497,10 +485,8 @@ func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id tlf.ID,
 // TruncateLock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateLock(ctx context.Context, id tlf.ID) (
 	bool, error) {
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return false, err
 	}
 
 	key, err := md.config.currentInfoGetter().GetCurrentCryptPublicKey(ctx)
@@ -521,10 +507,8 @@ func (md *MDServerDisk) TruncateLock(ctx context.Context, id tlf.ID) (
 // TruncateUnlock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateUnlock(ctx context.Context, id tlf.ID) (
 	bool, error) {
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return false, err
 	}
 
 	key, err := md.config.currentInfoGetter().GetCurrentCryptPublicKey(ctx)
@@ -650,10 +634,8 @@ func (md *MDServerDisk) addNewAssertionForTest(uid keybase1.UID,
 // GetLatestHandleForTLF implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (
 	tlf.Handle, error) {
-	select {
-	case <-ctx.Done():
-		return tlf.Handle{}, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return tlf.Handle{}, err
 	}
 
 	md.lock.RLock()
@@ -696,10 +678,8 @@ func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
 func (md *MDServerDisk) GetKeyBundles(ctx context.Context,
 	tlfID tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, nil, err
 	}
 
 	tlfStorage, err := md.getStorage(tlfID)

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -207,6 +207,12 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 // GetForHandle implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForHandle(ctx context.Context, handle tlf.Handle,
 	mStatus MergeStatus) (tlf.ID, *RootMetadataSigned, error) {
+	select {
+	case <-ctx.Done():
+		return tlf.NullID, nil, ctx.Err()
+	default:
+	}
+
 	id, created, err := md.getHandleID(ctx, handle, mStatus)
 	if err != nil {
 		return tlf.NullID, nil, err
@@ -317,6 +323,12 @@ func (md *MDServerDisk) deleteBranchID(ctx context.Context, id tlf.ID) error {
 // GetForTLF implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus) (*RootMetadataSigned, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// Lookup the branch ID if not supplied
 	if mStatus == Unmerged && bid == NullBranchID {
 		var err error
@@ -346,6 +358,12 @@ func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
 func (md *MDServerDisk) GetRange(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
 
 	// Lookup the branch ID if not supplied
@@ -376,6 +394,11 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id tlf.ID,
 // Put implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	currentUID, currentVerifyingKey, err :=
 		getCurrentUIDAndVerifyingKey(ctx, md.config.currentInfoGetter())
@@ -415,6 +438,12 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 // PruneBranch implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if bid == NullBranchID {
 		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
 	}
@@ -448,6 +477,12 @@ func (md *MDServerDisk) getCurrentMergedHeadRevision(
 // RegisterForUpdate implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id tlf.ID,
 	currHead MetadataRevision) (<-chan error, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// are we already past this revision?  If so, fire observer
 	// immediately
 	currMergedHeadRev, err := md.getCurrentMergedHeadRevision(ctx, id)
@@ -462,6 +497,12 @@ func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id tlf.ID,
 // TruncateLock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateLock(ctx context.Context, id tlf.ID) (
 	bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
 	key, err := md.config.currentInfoGetter().GetCurrentCryptPublicKey(ctx)
 	if err != nil {
 		return false, MDServerError{err}
@@ -480,6 +521,12 @@ func (md *MDServerDisk) TruncateLock(ctx context.Context, id tlf.ID) (
 // TruncateUnlock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateUnlock(ctx context.Context, id tlf.ID) (
 	bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
 	key, err := md.config.currentInfoGetter().GetCurrentCryptPublicKey(ctx)
 	if err != nil {
 		return false, MDServerError{err}
@@ -601,8 +648,14 @@ func (md *MDServerDisk) addNewAssertionForTest(uid keybase1.UID,
 }
 
 // GetLatestHandleForTLF implements the MDServer interface for MDServerDisk.
-func (md *MDServerDisk) GetLatestHandleForTLF(_ context.Context, id tlf.ID) (
+func (md *MDServerDisk) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (
 	tlf.Handle, error) {
+	select {
+	case <-ctx.Done():
+		return tlf.Handle{}, ctx.Err()
+	default:
+	}
+
 	md.lock.RLock()
 	defer md.lock.RUnlock()
 	err := md.checkShutdownLocked()
@@ -640,9 +693,15 @@ func (md *MDServerDisk) OffsetFromServerTime() (time.Duration, bool) {
 }
 
 // GetKeyBundles implements the MDServer interface for MDServerDisk.
-func (md *MDServerDisk) GetKeyBundles(_ context.Context,
+func (md *MDServerDisk) GetKeyBundles(ctx context.Context,
 	tlfID tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
+	}
+
 	tlfStorage, err := md.getStorage(tlfID)
 	if err != nil {
 		return nil, nil, err

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -164,10 +164,8 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 // GetForHandle implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetForHandle(ctx context.Context, handle tlf.Handle,
 	mStatus MergeStatus) (tlf.ID, *RootMetadataSigned, error) {
-	select {
-	case <-ctx.Done():
-		return tlf.NullID, nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return tlf.NullID, nil, err
 	}
 
 	id, created, err := md.getHandleID(ctx, handle, mStatus)
@@ -233,10 +231,8 @@ func (md *MDServerMemory) checkGetParams(
 // GetForTLF implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetForTLF(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus) (*RootMetadataSigned, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	bid, err := md.checkGetParams(ctx, id, bid, mStatus)
@@ -316,10 +312,8 @@ func (md *MDServerMemory) getCurrentDeviceKID(ctx context.Context) (keybase1.KID
 func (md *MDServerMemory) GetRange(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
@@ -384,10 +378,8 @@ func (md *MDServerMemory) GetRange(ctx context.Context, id tlf.ID,
 // Put implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	currentUID, currentVerifyingKey, err :=
@@ -542,10 +534,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 // PruneBranch implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return err
 	}
 
 	if bid == NullBranchID {
@@ -600,10 +590,8 @@ func (md *MDServerMemory) getBranchID(ctx context.Context, id tlf.ID) (BranchID,
 // RegisterForUpdate implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) RegisterForUpdate(ctx context.Context, id tlf.ID,
 	currHead MetadataRevision) (<-chan error, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, err
 	}
 
 	// are we already past this revision?  If so, fire observer
@@ -634,10 +622,8 @@ func (md *MDServerMemory) getCurrentDeviceKIDBytes(ctx context.Context) (
 // TruncateLock implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) TruncateLock(ctx context.Context, id tlf.ID) (
 	bool, error) {
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return false, err
 	}
 
 	md.lock.Lock()
@@ -658,10 +644,8 @@ func (md *MDServerMemory) TruncateLock(ctx context.Context, id tlf.ID) (
 // TruncateUnlock implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) TruncateUnlock(ctx context.Context, id tlf.ID) (
 	bool, error) {
-	select {
-	case <-ctx.Done():
-		return false, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return false, err
 	}
 
 	md.lock.Lock()
@@ -775,10 +759,8 @@ func (md *MDServerMemory) getCurrentMergedHeadRevision(
 // GetLatestHandleForTLF implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetLatestHandleForTLF(
 	ctx context.Context, id tlf.ID) (tlf.Handle, error) {
-	select {
-	case <-ctx.Done():
-		return tlf.Handle{}, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return tlf.Handle{}, err
 	}
 
 	md.lock.RLock()
@@ -879,10 +861,8 @@ func (md *MDServerMemory) getKeyBundles(tlfID tlf.ID,
 func (md *MDServerMemory) GetKeyBundles(ctx context.Context,
 	tlfID tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	default:
+	if err := checkContext(ctx); err != nil {
+		return nil, nil, err
 	}
 
 	wkb, rkb, err := md.getKeyBundles(tlfID, wkbID, rkbID)

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -164,6 +164,12 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 // GetForHandle implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetForHandle(ctx context.Context, handle tlf.Handle,
 	mStatus MergeStatus) (tlf.ID, *RootMetadataSigned, error) {
+	select {
+	case <-ctx.Done():
+		return tlf.NullID, nil, ctx.Err()
+	default:
+	}
+
 	id, created, err := md.getHandleID(ctx, handle, mStatus)
 	if err != nil {
 		return tlf.NullID, nil, err
@@ -227,6 +233,12 @@ func (md *MDServerMemory) checkGetParams(
 // GetForTLF implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetForTLF(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus) (*RootMetadataSigned, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	bid, err := md.checkGetParams(ctx, id, bid, mStatus)
 	if err != nil {
 		return nil, err
@@ -304,6 +316,12 @@ func (md *MDServerMemory) getCurrentDeviceKID(ctx context.Context) (keybase1.KID
 func (md *MDServerMemory) GetRange(ctx context.Context, id tlf.ID,
 	bid BranchID, mStatus MergeStatus, start, stop MetadataRevision) (
 	[]*RootMetadataSigned, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
 	bid, err := md.checkGetParams(ctx, id, bid, mStatus)
 	if err != nil {
@@ -366,6 +384,11 @@ func (md *MDServerMemory) GetRange(ctx context.Context, id tlf.ID,
 // Put implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	extra ExtraMetadata) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
 
 	currentUID, currentVerifyingKey, err :=
 		getCurrentUIDAndVerifyingKey(ctx, md.config.currentInfoGetter())
@@ -519,6 +542,12 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 // PruneBranch implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if bid == NullBranchID {
 		return MDServerErrorBadRequest{Reason: "Invalid branch ID"}
 	}
@@ -571,6 +600,12 @@ func (md *MDServerMemory) getBranchID(ctx context.Context, id tlf.ID) (BranchID,
 // RegisterForUpdate implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) RegisterForUpdate(ctx context.Context, id tlf.ID,
 	currHead MetadataRevision) (<-chan error, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// are we already past this revision?  If so, fire observer
 	// immediately
 	currMergedHeadRev, err := md.getCurrentMergedHeadRevision(ctx, id)
@@ -599,6 +634,12 @@ func (md *MDServerMemory) getCurrentDeviceKIDBytes(ctx context.Context) (
 // TruncateLock implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) TruncateLock(ctx context.Context, id tlf.ID) (
 	bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
 	md.lock.Lock()
 	defer md.lock.Unlock()
 	err := md.checkShutdownLocked()
@@ -617,6 +658,12 @@ func (md *MDServerMemory) TruncateLock(ctx context.Context, id tlf.ID) (
 // TruncateUnlock implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) TruncateUnlock(ctx context.Context, id tlf.ID) (
 	bool, error) {
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	default:
+	}
+
 	md.lock.Lock()
 	defer md.lock.Unlock()
 	err := md.checkShutdownLocked()
@@ -726,8 +773,14 @@ func (md *MDServerMemory) getCurrentMergedHeadRevision(
 }
 
 // GetLatestHandleForTLF implements the MDServer interface for MDServerMemory.
-func (md *MDServerMemory) GetLatestHandleForTLF(_ context.Context, id tlf.ID) (
-	tlf.Handle, error) {
+func (md *MDServerMemory) GetLatestHandleForTLF(
+	ctx context.Context, id tlf.ID) (tlf.Handle, error) {
+	select {
+	case <-ctx.Done():
+		return tlf.Handle{}, ctx.Err()
+	default:
+	}
+
 	md.lock.RLock()
 	defer md.lock.RUnlock()
 	err := md.checkShutdownLocked()
@@ -826,6 +879,12 @@ func (md *MDServerMemory) getKeyBundles(tlfID tlf.ID,
 func (md *MDServerMemory) GetKeyBundles(ctx context.Context,
 	tlfID tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	default:
+	}
+
 	wkb, rkb, err := md.getKeyBundles(tlfID, wkbID, rkbID)
 	if err != nil {
 		return nil, nil, MDServerError{err}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -671,6 +671,13 @@ func (j *tlfJournal) flush(ctx context.Context) (err error) {
 	// block ops. See KBFS-1502.
 
 	for {
+		select {
+		case <-ctx.Done():
+			j.log.CDebugf(ctx, "Flush canceled: %+v", ctx.Err())
+			return nil
+		default:
+		}
+
 		isConflict, err := j.isOnConflictBranch()
 		if err != nil {
 			return err

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -136,4 +137,13 @@ func checkDataVersion(versioner dataVersioner, p path, ptr BlockPointer) error {
 		return NewDataVersionError{p, ptr.DataVer}
 	}
 	return nil
+}
+
+func checkContext(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return errors.WithStack(ctx.Err())
+	default:
+		return nil
+	}
 }


### PR DESCRIPTION
Specifically this will help the `tlfJournal` flush loop exit faster
when its context has been canceled.  But it is also the right thing to
do for any test I think, to more accurately reflect the RPC-based
server implementations.

Issue: KBFS-1859