### PR TITLE
[KBFS-1842] Initial Fixes

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -15,11 +15,11 @@ import (
 type blockOpsConfig interface {
 	dataVersioner
 	logMaker
+	blockCacher
 	blockServer() BlockServer
 	codec() kbfscodec.Codec
 	crypto() cryptoPure
 	keyGetter() blockKeyGetter
-	blockCache() BlockCache
 }
 
 type blockOpsConfigAdapter struct {
@@ -42,10 +42,6 @@ func (config blockOpsConfigAdapter) crypto() cryptoPure {
 
 func (config blockOpsConfigAdapter) keyGetter() blockKeyGetter {
 	return config.Config.KeyManager()
-}
-
-func (config blockOpsConfigAdapter) blockCache() BlockCache {
-	return config.Config.BlockCache()
 }
 
 // BlockOpsStandard implements the BlockOps interface by relaying

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -104,7 +104,7 @@ func (config testBlockOpsConfig) keyGetter() blockKeyGetter {
 	return fakeBlockKeyGetter{}
 }
 
-func (config testBlockOpsConfig) blockCache() BlockCache {
+func (config testBlockOpsConfig) BlockCache() BlockCache {
 	return config.cache
 }
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -175,9 +175,12 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context, priority int, kmd K
 			// specific type where the request blocks are CommonBlocks, but
 			// that direction can Set correctly. The cache will never have
 			// CommonBlocks.
-			cachedBlock, err := brq.config.BlockCache().Get(ptr)
+			cachedBlock, hasPrefetched, err :=
+				brq.config.BlockCache().GetWithPrefetch(ptr)
 			if err == nil && cachedBlock != nil {
 				block.Set(cachedBlock, brq.config.codec())
+				brq.triggerPrefetchAfterBlockRetrieved(
+					cachedBlock, kmd, priority, hasPrefetched)
 				ch <- nil
 				return ch
 			}
@@ -232,11 +235,26 @@ func (brq *blockRetrievalQueue) WorkOnRequest() <-chan *blockRetrieval {
 	return ch
 }
 
+func (brq *blockRetrievalQueue) triggerPrefetchAfterBlockRetrieved(
+	block Block, kmd KeyMetadata, priority int, hasPrefetched bool) {
+	if hasPrefetched {
+		return
+	}
+	// We have to trigger prefetches in a goroutine because otherwise we
+	// can deadlock with `TogglePrefetcher`.
+	go func() {
+		brq.prefetchMtx.RLock()
+		defer brq.prefetchMtx.RUnlock()
+		brq.prefetcher.PrefetchAfterBlockRetrieved(block, kmd, priority)
+	}()
+}
+
 // FinalizeRequest is the last step of a retrieval request once a block has
 // been obtained. It removes the request from the blockRetrievalQueue,
 // preventing more requests from mutating the retrieval, then notifies all
 // subscribed requests.
-func (brq *blockRetrievalQueue) FinalizeRequest(retrieval *blockRetrieval, block Block, err error) {
+func (brq *blockRetrievalQueue) FinalizeRequest(
+	retrieval *blockRetrieval, block Block, err error) {
 	brq.mtx.Lock()
 	// This might have already been removed if the context has been canceled.
 	// That's okay, because this will then be a no-op.
@@ -248,15 +266,14 @@ func (brq *blockRetrievalQueue) FinalizeRequest(retrieval *blockRetrieval, block
 	// Cache the block and trigger prefetches if there is no error.
 	if err == nil {
 		if brq.config.BlockCache() != nil {
-			_ = brq.config.BlockCache().Put(retrieval.blockPtr, retrieval.kmd.TlfID(), block, retrieval.cacheLifetime)
+			_ = brq.config.BlockCache().Put(
+				retrieval.blockPtr, retrieval.kmd.TlfID(), block,
+				retrieval.cacheLifetime)
 		}
-		// We have to trigger prefetches in a goroutine because otherwise we
-		// can deadlock with `TogglePrefetcher`.
-		go func() {
-			brq.prefetchMtx.RLock()
-			defer brq.prefetchMtx.RUnlock()
-			brq.prefetcher.PrefetchAfterBlockRetrieved(block, retrieval.kmd, retrieval.priority)
-		}()
+		// We treat this request as not having been prefetched, because the
+		// only way to get here is if the request wasn't already cached.
+		brq.triggerPrefetchAfterBlockRetrieved(
+			block, retrieval.kmd, retrieval.priority, false)
 	}
 
 	// This is a symbolic lock, since there shouldn't be any other goroutines

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -245,7 +245,7 @@ func (brq *blockRetrievalQueue) triggerPrefetchAfterBlockRetrieved(
 	go func() {
 		brq.prefetchMtx.RLock()
 		defer brq.prefetchMtx.RUnlock()
-		brq.prefetcher.PrefetchAfterBlockRetrieved(block, kmd, priority)
+		brq.prefetcher.PrefetchAfterBlockRetrieved(block, kmd, priority, false)
 	}()
 }
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -24,10 +24,9 @@ const (
 type blockRetrievalConfig interface {
 	dataVersioner
 	logMaker
+	blockCacher
 	// Codec for copying blocks
 	codec() kbfscodec.Codec
-	// BlockCache for writethrough caching
-	blockCache() BlockCache
 }
 
 // blockRetrievalRequest represents one consumer's request for a block.
@@ -238,8 +237,8 @@ func (brq *blockRetrievalQueue) FinalizeRequest(retrieval *blockRetrieval, block
 
 	// Cache the block and trigger prefetches if there is no error.
 	if err == nil {
-		if brq.config.blockCache() != nil {
-			_ = brq.config.blockCache().Put(retrieval.blockPtr, retrieval.kmd.TlfID(), block, retrieval.cacheLifetime)
+		if brq.config.BlockCache() != nil {
+			_ = brq.config.BlockCache().Put(retrieval.blockPtr, retrieval.kmd.TlfID(), block, retrieval.cacheLifetime)
 		}
 		// We have to trigger prefetches in a goroutine because otherwise we
 		// can deadlock with `TogglePrefetcher`.

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -266,9 +266,9 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 	// Cache the block and trigger prefetches if there is no error.
 	if err == nil {
 		if brq.config.BlockCache() != nil {
-			_ = brq.config.BlockCache().Put(
+			_ = brq.config.BlockCache().PutWithPrefetch(
 				retrieval.blockPtr, retrieval.kmd.TlfID(), block,
-				retrieval.cacheLifetime)
+				retrieval.cacheLifetime, true)
 		}
 		// We treat this request as not having been prefetched, because the
 		// only way to get here is if the request wasn't already cached.

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -34,7 +34,7 @@ func (c *testBlockRetrievalConfig) codec() kbfscodec.Codec {
 	return c.testCodec
 }
 
-func (c *testBlockRetrievalConfig) blockCache() BlockCache {
+func (c *testBlockRetrievalConfig) BlockCache() BlockCache {
 	return c.testCache
 }
 

--- a/libkbfs/block_retrieval_worker.go
+++ b/libkbfs/block_retrieval_worker.go
@@ -68,27 +68,11 @@ func (brw *blockRetrievalWorker) HandleRequest() (err error) {
 	default:
 	}
 
-	wasBlockCached := func() bool {
+	func() {
 		retrieval.reqMtx.RLock()
 		defer retrieval.reqMtx.RUnlock()
-		if retrieval.requests[0].block == nil {
-			panic("Nil block passed in for first request. This should never happen.")
-		}
-		// Attempt to retrieve the block from the cache. This might be a
-		// specific type where the request blocks are CommonBlocks, but that
-		// direction can Set correctly. The cache will never have CommonBlocks.
-		block, err = brw.queue.config.BlockCache().Get(retrieval.blockPtr)
-		if err == nil && block != nil {
-			return true
-		}
-		// Create a new block of the same type as the first request
 		block = retrieval.requests[0].block.NewEmpty()
-		return false
 	}()
-
-	if wasBlockCached {
-		return nil
-	}
 
 	return brw.getBlock(retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block)
 }

--- a/libkbfs/block_retrieval_worker.go
+++ b/libkbfs/block_retrieval_worker.go
@@ -77,7 +77,7 @@ func (brw *blockRetrievalWorker) HandleRequest() (err error) {
 		// Attempt to retrieve the block from the cache. This might be a
 		// specific type where the request blocks are CommonBlocks, but that
 		// direction can Set correctly. The cache will never have CommonBlocks.
-		block, err = brw.queue.config.blockCache().Get(retrieval.blockPtr)
+		block, err = brw.queue.config.BlockCache().Get(retrieval.blockPtr)
 		if err == nil && block != nil {
 			return true
 		}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -279,8 +279,8 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// correctly according to the new on-demand fetch priority.
 		// FIXME: This is triggering explosive prefetching since it triggers
 		// directory prefetches at every node of the path, on every fs op.
-		//fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
-		//	block, kmd, defaultOnDemandRequestPriority)
+		fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
+			block, kmd, defaultOnDemandRequestPriority)
 		return block, nil
 	}
 
@@ -2588,6 +2588,7 @@ func (fbo *folderBlockOps) getDeferredWriteCountForTest(lState *lockState) int {
 }
 
 func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, newPtr BlockPointer) {
+	fbo.log.CDebugf(context.Background(), "Updating reference for pointer %s to %s", oldPtr.ID, newPtr.ID)
 	updated := fbo.nodeCache.UpdatePointer(oldPtr.Ref(), newPtr)
 	if !updated {
 		return

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -273,14 +273,12 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		fbo.id(), ptr, branch); err == nil {
 		return block, nil
 	}
-	if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
+	if block, hasPrefetched, err := fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		// FIXME: This is triggering explosive prefetching since it triggers
-		// directory prefetches at every node of the path, on every fs op.
 		fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
-			block, kmd, defaultOnDemandRequestPriority)
+			block, kmd, defaultOnDemandRequestPriority, hasPrefetched)
 		return block, nil
 	}
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -685,9 +685,13 @@ type BlockCache interface {
 	// block. It does not remove the block itself.
 	DeleteKnownPtr(tlf tlf.ID, block *FileBlock) error
 	// GetWithPrefetch retrieves a block from the cache, along with whether or
-	// not it has been marked for prefetching.
-	//GetWithPrefetch(ptr BlockPointer) (
-	//	block Block, hasPrefetched bool, err error)
+	// not it has triggered a prefetch.
+	GetWithPrefetch(ptr BlockPointer) (
+		block Block, hasPrefetched bool, err error)
+	// PutWithPrefetch puts a block into the cache, along with whether or not
+	// it has triggered a prefetch.
+	PutWithPrefetch(ptr BlockPointer, tlf tlf.ID, block Block,
+		lifetime BlockCacheLifetime, hasPrefetched bool) error
 
 	// SetCleanBytesCapacity atomically sets clean bytes capacity for block
 	// cache.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -27,6 +27,10 @@ type logMaker interface {
 	MakeLogger(module string) logger.Logger
 }
 
+type blockCacher interface {
+	BlockCache() BlockCache
+}
+
 // Block just needs to be (de)serialized using msgpack
 type Block interface {
 	dataVersioner
@@ -1388,6 +1392,7 @@ type ConflictRenamer interface {
 type Config interface {
 	dataVersioner
 	logMaker
+	blockCacher
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI
@@ -1402,7 +1407,6 @@ type Config interface {
 	SetKeyBundleCache(KeyBundleCache)
 	KeyBundleCache() KeyBundleCache
 	SetKeyCache(KeyCache)
-	BlockCache() BlockCache
 	SetBlockCache(BlockCache)
 	DirtyBlockCache() DirtyBlockCache
 	SetDirtyBlockCache(DirtyBlockCache)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1019,12 +1019,14 @@ type KeyOps interface {
 // Prefetcher is an interface to a block prefetcher.
 type Prefetcher interface {
 	// PrefetchBlock directs the prefetcher to prefetch a block.
-	PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata, priority int) error
+	PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata,
+		priority int) error
 	// PrefetchAfterBlockRetrieved allows the prefetcher to trigger prefetches
 	// after a block has been retrieved. Whichever component is responsible for
 	// retrieving blocks will call this method once it's done retrieving a
 	// block.
-	PrefetchAfterBlockRetrieved(b Block, kmd KeyMetadata, priority int)
+	PrefetchAfterBlockRetrieved(b Block, kmd KeyMetadata, priority int,
+		hasPrefetched bool)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -684,6 +684,10 @@ type BlockCache interface {
 	// DeleteKnownPtr removes the cached ID for the given file
 	// block. It does not remove the block itself.
 	DeleteKnownPtr(tlf tlf.ID, block *FileBlock) error
+	// GetWithPrefetch retrieves a block from the cache, along with whether or
+	// not it has been marked for prefetching.
+	//GetWithPrefetch(ptr BlockPointer) (
+	//	block Block, hasPrefetched bool, err error)
 
 	// SetCleanBytesCapacity atomically sets clean bytes capacity for block
 	// cache.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -106,7 +106,7 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, nil))
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, config.BlockCache(), t}))
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -4783,8 +4783,8 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 	config.mockDirtyBcache.EXPECT().Get(gomock.Any(),
 		ptrMatcher{fileBlock.IPtrs[2].BlockPointer}, p.Branch).Return(nil,
 		NoSuchBlockError{fileBlock.IPtrs[2].BlockPointer.ID})
-	config.mockBcache.EXPECT().Get(ptrMatcher{fileBlock.IPtrs[2].BlockPointer}).
-		Return(block3, nil)
+	config.mockBcache.EXPECT().GetWithPrefetch(ptrMatcher{fileBlock.IPtrs[2].BlockPointer}).
+		Return(block3, true, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(gomock.Any(),
 		ptrMatcher{fileBlock.IPtrs[3].BlockPointer},
 		p.Branch).AnyTimes().Return(false)
@@ -4800,9 +4800,9 @@ func TestSyncDirtyMultiBlocksSplitInBlockSuccess(t *testing.T) {
 		ptrMatcher{fileNode.BlockPointer}, p.Branch).
 		AnyTimes().Return(fileBlock, nil)
 	config.mockBcache.EXPECT().Get(ptrMatcher{node.BlockPointer}).
-		Return(rootBlock, nil)
+		AnyTimes().Return(rootBlock, nil)
 	config.mockBcache.EXPECT().Get(ptrMatcher{fileNode.BlockPointer}).
-		Return(fileBlock, nil)
+		AnyTimes().Return(fileBlock, nil)
 
 	// no matching pointers
 	config.mockBcache.EXPECT().CheckForKnownPtr(gomock.Any(), gomock.Any()).
@@ -4993,16 +4993,16 @@ func TestSyncDirtyMultiBlocksCopyNextBlockSuccess(t *testing.T) {
 	config.mockDirtyBcache.EXPECT().Get(gomock.Any(),
 		ptrMatcher{fileBlock.IPtrs[1].BlockPointer}, p.Branch).Return(nil,
 		NoSuchBlockError{fileBlock.IPtrs[1].BlockPointer.ID})
-	config.mockBcache.EXPECT().Get(ptrMatcher{fileBlock.IPtrs[1].BlockPointer}).
-		Return(block2, nil)
+	config.mockBcache.EXPECT().GetWithPrefetch(ptrMatcher{fileBlock.IPtrs[1].BlockPointer}).
+		Return(block2, true, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(gomock.Any(),
 		ptrMatcher{fileBlock.IPtrs[1].BlockPointer},
 		p.Branch).AnyTimes().Return(false)
 	config.mockDirtyBcache.EXPECT().Get(gomock.Any(),
 		ptrMatcher{fileBlock.IPtrs[3].BlockPointer}, p.Branch).Return(nil,
 		NoSuchBlockError{fileBlock.IPtrs[3].BlockPointer.ID})
-	config.mockBcache.EXPECT().Get(ptrMatcher{fileBlock.IPtrs[3].BlockPointer}).
-		Return(block4, nil)
+	config.mockBcache.EXPECT().GetWithPrefetch(ptrMatcher{fileBlock.IPtrs[3].BlockPointer}).
+		Return(block4, true, nil)
 	config.mockDirtyBcache.EXPECT().IsDirty(gomock.Any(),
 		ptrMatcher{fileBlock.IPtrs[3].BlockPointer},
 		p.Branch).Return(false)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -79,6 +79,37 @@ func (_mr *_MocklogMakerRecorder) MakeLogger(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeLogger", arg0)
 }
 
+// Mock of blockCacher interface
+type MockblockCacher struct {
+	ctrl     *gomock.Controller
+	recorder *_MockblockCacherRecorder
+}
+
+// Recorder for MockblockCacher (not exported)
+type _MockblockCacherRecorder struct {
+	mock *MockblockCacher
+}
+
+func NewMockblockCacher(ctrl *gomock.Controller) *MockblockCacher {
+	mock := &MockblockCacher{ctrl: ctrl}
+	mock.recorder = &_MockblockCacherRecorder{mock}
+	return mock
+}
+
+func (_m *MockblockCacher) EXPECT() *_MockblockCacherRecorder {
+	return _m.recorder
+}
+
+func (_m *MockblockCacher) BlockCache() BlockCache {
+	ret := _m.ctrl.Call(_m, "BlockCache")
+	ret0, _ := ret[0].(BlockCache)
+	return ret0
+}
+
+func (_mr *_MockblockCacherRecorder) BlockCache() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockCache")
+}
+
 // Mock of Block interface
 type MockBlock struct {
 	ctrl     *gomock.Controller
@@ -1749,6 +1780,28 @@ func (_m *MockBlockCache) DeleteKnownPtr(tlf tlf.ID, block *FileBlock) error {
 
 func (_mr *_MockBlockCacheRecorder) DeleteKnownPtr(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteKnownPtr", arg0, arg1)
+}
+
+func (_m *MockBlockCache) GetWithPrefetch(ptr BlockPointer) (Block, bool, error) {
+	ret := _m.ctrl.Call(_m, "GetWithPrefetch", ptr)
+	ret0, _ := ret[0].(Block)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockBlockCacheRecorder) GetWithPrefetch(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetWithPrefetch", arg0)
+}
+
+func (_m *MockBlockCache) PutWithPrefetch(ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime, hasPrefetched bool) error {
+	ret := _m.ctrl.Call(_m, "PutWithPrefetch", ptr, tlf, block, lifetime, hasPrefetched)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBlockCacheRecorder) PutWithPrefetch(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutWithPrefetch", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockBlockCache) SetCleanBytesCapacity(capacity uint64) {
@@ -3823,6 +3876,16 @@ func (_mr *_MockConfigRecorder) MakeLogger(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "MakeLogger", arg0)
 }
 
+func (_m *MockConfig) BlockCache() BlockCache {
+	ret := _m.ctrl.Call(_m, "BlockCache")
+	ret0, _ := ret[0].(BlockCache)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) BlockCache() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockCache")
+}
+
 func (_m *MockConfig) KBFSOps() KBFSOps {
 	ret := _m.ctrl.Call(_m, "KBFSOps")
 	ret0, _ := ret[0].(KBFSOps)
@@ -3947,16 +4010,6 @@ func (_m *MockConfig) SetKeyCache(_param0 KeyCache) {
 
 func (_mr *_MockConfigRecorder) SetKeyCache(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetKeyCache", arg0)
-}
-
-func (_m *MockConfig) BlockCache() BlockCache {
-	ret := _m.ctrl.Call(_m, "BlockCache")
-	ret0, _ := ret[0].(BlockCache)
-	return ret0
-}
-
-func (_mr *_MockConfigRecorder) BlockCache() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockCache")
 }
 
 func (_m *MockConfig) SetBlockCache(_param0 BlockCache) {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -185,9 +185,10 @@ func (p *blockPrefetcher) PrefetchBlock(block Block, ptr BlockPointer, kmd KeyMe
 	return p.request(priority, kmd, ptr, block, "")
 }
 
-// PrefetchAfterBlockRetrieved implements the Prefetcher interface for blockPrefetcher.
-func (p *blockPrefetcher) PrefetchAfterBlockRetrieved(b Block, kmd KeyMetadata, priority int) {
-	if priority < defaultOnDemandRequestPriority {
+// PrefetchAfterBlockRetrieved implements the Prefetcher interface for
+// blockPrefetcher.
+func (p *blockPrefetcher) PrefetchAfterBlockRetrieved(b Block, kmd KeyMetadata, priority int, hasPrefetched bool) {
+	if hasPrefetched || priority < defaultOnDemandRequestPriority {
 		// Only on-demand or higher priority requests can trigger prefetches.
 		return
 	}

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -64,7 +64,7 @@ func initPrefetcherTest(t *testing.T) (*blockRetrievalQueue, *blockRetrievalWork
 	w := newBlockRetrievalWorker(bg, q)
 	require.NotNil(t, w)
 
-	return q, w, bg, config.blockCache
+	return q, w, bg, config.BlockCache
 }
 
 func shutdownPrefetcherTest(q *blockRetrievalQueue, w *blockRetrievalWorker) {


### PR DESCRIPTION
TODO

- [ ] Need to correctly handle `Put`s, in that currently the prefetcher doesn't notice when a new directory is the same as the old one.
- [ ] UpdatePointer is called both when we write a new block and when an update comes from remote. We need to figure out how to tell them apart. Only the remote one should trigger a prefetch.
- [ ] Capture these prefetch explosion scenarios in prefetcher tests.

 