### PR TITLE
libkbfs: >1 levels of indirection for file syncing and CR

### DIFF
--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -75,13 +75,8 @@ func NewBlockSplitterSimple(desiredBlockSize int64,
 	}
 
 	return &BlockSplitterSimple{
-		maxSize: maxSize,
-		// Currently set the max number of pointers per level of
-		// indirection to the maximum integer, as a way of turning off
-		// multiple levels of indirection in production.  TODO: remove
-		// this.
-		maxPtrsPerBlock: int((^uint(0)) >> 1),
-		//maxPtrsPerBlock:         int(maxSize / int64(bpSize)),
+		maxSize:                 maxSize,
+		maxPtrsPerBlock:         int(maxSize / int64(bpSize)),
 		blockChangeEmbedMaxSize: blockChangeEmbedMaxSize,
 	}, nil
 }

--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -74,9 +74,14 @@ func NewBlockSplitterSimple(desiredBlockSize int64,
 			"desired size of %d", desiredBlockSize)
 	}
 
+	maxPtrs := int(maxSize / int64(bpSize))
+	if maxPtrs < 2 {
+		maxPtrs = 2
+	}
+
 	return &BlockSplitterSimple{
 		maxSize:                 maxSize,
-		maxPtrsPerBlock:         int(maxSize / int64(bpSize)),
+		maxPtrsPerBlock:         maxPtrs,
 		blockChangeEmbedMaxSize: blockChangeEmbedMaxSize,
 	}, nil
 }

--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -74,7 +74,11 @@ func NewBlockSplitterSimple(desiredBlockSize int64,
 			"desired size of %d", desiredBlockSize)
 	}
 
-	maxPtrs := int(maxSize / int64(bpSize))
+	// Trial and error shows that this magic 75% constant maximizes
+	// the number of realistic indirect pointers you can fit into the
+	// default block size.  TODO: calculate this number more exactly
+	// during initialization for a given `maxSize`.
+	maxPtrs := int(.75 * float64(maxSize/int64(bpSize)))
 	if maxPtrs < 2 {
 		maxPtrs = 2
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2104,10 +2104,6 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	name string, ptr BlockPointer, blocks fileBlockMap) (
 	BlockPointer, error) {
 	kmd := chains.mostRecentChainMDInfo.kmd
-	_, uid, err := cr.config.KBPKI().GetCurrentUserInfo(ctx)
-	if err != nil {
-		return BlockPointer{}, err
-	}
 
 	file := parentPath.ChildPath(name, ptr)
 	oldInfos, err := cr.fbo.blocks.GetIndirectFileBlockInfos(
@@ -2119,10 +2115,8 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	// Simple dirty bcaches don't need to be shut down.
 
-	fd := cr.newFileData(lState, file, uid, kmd, dirtyBcache)
-
-	newPtr, allChildPtrs, err := fd.deepCopy(
-		ctx, cr.config.Codec(), cr.config.DataVersion())
+	newPtr, allChildPtrs, err := cr.fbo.blocks.DeepCopyFile(
+		ctx, lState, kmd, file, dirtyBcache, cr.config.DataVersion())
 	if err != nil {
 		return BlockPointer{}, err
 	}

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -1176,8 +1176,9 @@ func TestCRDoActionsSimple(t *testing.T) {
 
 	lbc := make(localBcache)
 	newFileBlocks := make(fileBlockMap)
+	dirtyBcache := simpleDirtyBlockCacheStandard()
 	err = cr2.doActions(ctx, lState, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks)
+		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)
 	if err != nil {
 		t.Fatalf("Couldn't do actions: %v", err)
 	}
@@ -1292,8 +1293,9 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 
 	lbc := make(localBcache)
 	newFileBlocks := make(fileBlockMap)
+	dirtyBcache := simpleDirtyBlockCacheStandard()
 	err = cr2.doActions(ctx, lState, unmergedChains, mergedChains,
-		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks)
+		unmergedPaths, mergedPaths, actionMap, lbc, newFileBlocks, dirtyBcache)
 	if err != nil {
 		t.Fatalf("Couldn't do actions: %v", err)
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -647,6 +647,28 @@ func (fbo *folderBlockOps) DeepCopyFile(
 	return fd.deepCopy(ctx, fbo.config.Codec(), dataVer)
 }
 
+func (fbo *folderBlockOps) UndupChildrenInCopy(ctx context.Context,
+	lState *lockState, kmd KeyMetadata, file path, bps *blockPutState,
+	dirtyBcache DirtyBlockCache, topBlock *FileBlock) ([]BlockInfo, error) {
+	fbo.blockLock.RLock(lState)
+	defer fbo.blockLock.RUnlock(lState)
+	var uid keybase1.UID // Data reads don't depend on the uid.
+	fd := fbo.newFileDataWithCache(lState, file, uid, kmd, dirtyBcache)
+	return fd.undupChildrenInCopy(ctx, fbo.config.BlockCache(),
+		fbo.config.BlockOps(), bps, topBlock)
+}
+
+func (fbo *folderBlockOps) ReadyNonLeafBlocksInCopy(ctx context.Context,
+	lState *lockState, kmd KeyMetadata, file path, bps *blockPutState,
+	dirtyBcache DirtyBlockCache, topBlock *FileBlock) ([]BlockInfo, error) {
+	fbo.blockLock.RLock(lState)
+	defer fbo.blockLock.RUnlock(lState)
+	var uid keybase1.UID // Data reads don't depend on the uid.
+	fd := fbo.newFileDataWithCache(lState, file, uid, kmd, dirtyBcache)
+	return fd.readyNonLeafBlocksInCopy(ctx, fbo.config.BlockCache(),
+		fbo.config.BlockOps(), bps, topBlock)
+}
+
 // getDirLocked retrieves the block pointed to by the tail pointer of
 // the given path, which must be valid, either from the cache or from
 // the server. An error is returned if the retrieved block is not a

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -601,8 +601,7 @@ func (fbo *folderBlockOps) getFileLocked(ctx context.Context,
 // recoverable one (as determined by
 // isRecoverableBlockErrorForRemoval), the returned list may still be
 // non-empty, and holds all the BlockInfos for all found indirect
-// blocks. (This will be relevant when we handle multiple levels of
-// indirection.)
+// blocks.
 func (fbo *folderBlockOps) GetIndirectFileBlockInfos(ctx context.Context,
 	lState *lockState, kmd KeyMetadata, file path) ([]BlockInfo, error) {
 	fbo.blockLock.RLock(lState)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -996,7 +996,12 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableErrorLocked(
 	// redirty all the sync'd blocks under their new IDs, so that
 	// future syncs will know they failed.
 	for newPtr, oldPtr := range redirtyOnRecoverableError {
-		found := fd.findIPtrsAndClearSize(fblock, newPtr)
+		found, err := fd.findIPtrsAndClearSize(ctx, fblock, newPtr)
+		if err != nil {
+			fbo.log.CWarningf(
+				ctx, "Couldn't find and clear iptrs during recovery: %v", err)
+			return
+		}
 		if !found {
 			continue
 		}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -398,6 +398,8 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	if err != nil {
 		return nil, err
 	}
+	// Turn off multiple levels of indirection in production for now.
+	bsplitter.maxPtrsPerBlock = int((^uint(0)) >> 1)
 	config.SetBlockSplitter(bsplitter)
 
 	if registry := config.MetricsRegistry(); registry != nil {

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1327,9 +1327,9 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	// leave ourselves in a dirty state.
 }
 
-// Test that writes that happens on a multi-block file concurrently
-// with a sync, which has to retry due to an archived block, works
-// correctly.  Regression test for KBFS-700.
+// When writes happen on a multi-block file concurrently with a sync,
+// and the sync has to retry due to an archived block, test that
+// everything works correctly.  Regression test for KBFS-700.
 func TestKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -58,7 +58,7 @@ func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
 	config.SetBlockOps(bops)
 
 	config.SetBlockSplitter(&BlockSplitterSimple{
-		64 * 1024, int((^uint(0)) >> 1), 8 * 1024})
+		64 * 1024, 64 * 1024 / int(bpSize), 8 * 1024})
 
 	return config
 }


### PR DESCRIPTION
This PR completes support for syncing files with more than one level of indirection, including during conflict resolution and state checking.  It turns on multiple levels of indirection in all tests, but not yet in production (I still want to bump the version number and add the IsDirect flag).

The bulk of the work here adds support for syncing multiple levels of indirection to `fileData`.  There are also some `ConflictResolver` changes to do its file operations through `folderBlockOps`, rather than `fileData`, so that the flow can take `blockLock`.

Issue: KBFS-35