### PR TITLE
[KBFS-1842] More fixes

### DIFF
--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -216,6 +216,11 @@ func (b *BlockCacheStandard) makeRoomForSize(size uint64) bool {
 }
 
 // PutWithPrefetch implements the BlockCache interface for BlockCacheStandard.
+// This method is idempotent for a given ptr, but that invariant is not
+// currently goroutine-safe, and it does not hold if a block size changes
+// between Puts. That is, we assume that a cached block associated with a given
+// pointer will never change its size, even when it gets Put into the cache
+// again.
 func (b *BlockCacheStandard) PutWithPrefetch(
 	ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime,
 	hasPrefetched bool) (err error) {

--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -90,6 +90,10 @@ func (b *BlockCacheStandard) GetWithPrefetch(ptr BlockPointer) (Block, bool, err
 		return b.cleanPermanent[ptr.ID]
 	}()
 	if block != nil {
+		// A permanent entry can only be created if this client is performing a
+		// write. Since the client is writing, it knows what goes into it,
+		// including any potential directory entries or indirect blocks.
+		// Thus, it is treated as already prefetched.
 		return block, true, nil
 	}
 

--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -218,7 +218,7 @@ func (b *BlockCacheStandard) makeRoomForSize(size uint64) bool {
 // PutWithPrefetch implements the BlockCache interface for BlockCacheStandard.
 func (b *BlockCacheStandard) PutWithPrefetch(
 	ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime,
-	hasPrefetched bool) error {
+	hasPrefetched bool) (err error) {
 
 	madeRoom := false
 
@@ -242,6 +242,8 @@ func (b *BlockCacheStandard) PutWithPrefetch(
 		defer func() {
 			if madeRoom {
 				b.cleanTransient.Add(ptr.ID, blockContainer{block, hasPrefetched})
+			} else {
+				err = cachePutCacheFullError{ptr}
 			}
 		}()
 

--- a/libkbfs/bcache_test.go
+++ b/libkbfs/bcache_test.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func blockCacheTestBlockCacheInit(t *testing.T, capacity int,
+func blockCacheTestInit(t *testing.T, capacity int,
 	bytesCapacity uint64) Config {
 	b := NewBlockCacheStandard(capacity, bytesCapacity)
 	config := MakeTestConfigOrBust(t, "test")
@@ -50,7 +50,7 @@ func testExpectedMissing(t *testing.T, id kbfsblock.ID, bcache BlockCache) {
 
 func TestBlockCachePut(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	testBcachePut(t, kbfsblock.FakeID(1), config.BlockCache(), TransientEntry)
 	testBcachePut(t, kbfsblock.FakeID(2), config.BlockCache(), PermanentEntry)
@@ -58,7 +58,7 @@ func TestBlockCachePut(t *testing.T) {
 
 func TestBlockCachePutPastCapacity(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 2, 1<<30)
+	config := blockCacheTestInit(t, 2, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 	id1 := kbfsblock.FakeID(1)
@@ -80,7 +80,7 @@ func TestBlockCachePutPastCapacity(t *testing.T) {
 
 func TestBlockCacheCheckPtrSuccess(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 
@@ -100,7 +100,7 @@ func TestBlockCacheCheckPtrSuccess(t *testing.T) {
 
 func TestBlockCacheCheckPtrPermanent(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer config.Shutdown(ctx)
 	bcache := config.BlockCache()
 
@@ -120,7 +120,7 @@ func TestBlockCacheCheckPtrPermanent(t *testing.T) {
 
 func TestBlockCacheCheckPtrNotFound(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 
@@ -142,7 +142,7 @@ func TestBlockCacheCheckPtrNotFound(t *testing.T) {
 
 func TestBlockCacheDeleteTransient(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 
@@ -166,7 +166,7 @@ func TestBlockCacheDeleteTransient(t *testing.T) {
 
 func TestBlockCacheDeletePermanent(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 
@@ -189,7 +189,7 @@ func TestBlockCacheDeletePermanent(t *testing.T) {
 
 func TestBlockCacheEmptyTransient(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 0, 1<<30)
+	config := blockCacheTestInit(t, 0, 1<<30)
 	defer config.Shutdown(ctx)
 
 	bcache := config.BlockCache()
@@ -218,7 +218,7 @@ func TestBlockCacheEmptyTransient(t *testing.T) {
 func TestBlockCacheEvictOnBytes(t *testing.T) {
 	ctx := context.Background()
 	// Make a cache that can only handle 5 bytes
-	config := blockCacheTestBlockCacheInit(t, 1000, 5)
+	config := blockCacheTestInit(t, 1000, 5)
 	defer config.Shutdown(ctx)
 
 	bcache := config.BlockCache()
@@ -251,7 +251,7 @@ func TestBlockCacheEvictOnBytes(t *testing.T) {
 func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 	ctx := context.Background()
 	// Make a cache that can only handle 5 bytes
-	config := blockCacheTestBlockCacheInit(t, 1000, 5)
+	config := blockCacheTestInit(t, 1000, 5)
 	defer config.Shutdown(ctx)
 
 	bcache := config.BlockCache()
@@ -330,7 +330,7 @@ func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 
 func TestBlockCachePutNoHashCalculation(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 100, 1<<30)
+	config := blockCacheTestInit(t, 100, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 	ptr := BlockPointer{ID: kbfsblock.FakeID(1)}
@@ -354,7 +354,7 @@ func TestBlockCachePutNoHashCalculation(t *testing.T) {
 
 func TestBlockCacheDoublePut(t *testing.T) {
 	ctx := context.Background()
-	config := blockCacheTestBlockCacheInit(t, 1, 1<<30)
+	config := blockCacheTestInit(t, 1, 1<<30)
 	defer CheckConfigAndShutdown(ctx, t, config)
 	cache := config.BlockCache().(*BlockCacheStandard)
 	id1 := kbfsblock.FakeID(1)
@@ -372,6 +372,7 @@ func TestBlockCacheDoublePut(t *testing.T) {
 
 	t.Log("Put a new block into the cache, evicting the first one. Check that the byte usage is updated correctly.")
 	block = NewFileBlock().(*FileBlock)
+	block.Contents = []byte{1, 2, 3, 4, 5}
 	bytes = uint64(len(block.Contents))
 	testBcachePutWithBlock(t, id2, cache, TransientEntry, block)
 	require.Equal(t, bytes, cache.cleanTotalBytes)

--- a/libkbfs/bcache_test.go
+++ b/libkbfs/bcache_test.go
@@ -340,8 +340,8 @@ func TestBcacheEvictIncludesPermanentSize(t *testing.T) {
 	block.SetEncodedSize(7)
 	id := kbfsblock.FakeID(8)
 	ptr = BlockPointer{ID: id}
-	if err := bcache.Put(ptr, tlf, block, TransientEntry); err != nil {
-		t.Errorf("Got error on Put for block %s: %v", id, err)
+	if err, isCacheFullError := bcache.Put(ptr, tlf, block, TransientEntry).(cachePutCacheFullError); !isCacheFullError {
+		t.Errorf("Got wrong error on Put for block %s: %v", id, err)
 	}
 
 	// All transient blocks should be gone (including the new one)

--- a/libkbfs/bcache_test.go
+++ b/libkbfs/bcache_test.go
@@ -341,12 +341,12 @@ func TestBcacheEvictIncludesPermanentSize(t *testing.T) {
 	id := kbfsblock.FakeID(8)
 	ptr = BlockPointer{ID: id}
 	if err, isCacheFullError := bcache.Put(ptr, tlf, block, TransientEntry).(cachePutCacheFullError); !isCacheFullError {
-		t.Errorf("Got wrong error on Put for block %s: %v", id, err)
+		t.Errorf("Got wrong unexpected on Put for block %s: %v", id, err)
 	}
 
 	// All transient blocks should be gone (including the new one)
 	if _, err := bcache.Get(BlockPointer{ID: idPerm}); err != nil {
-		t.Errorf("Got unexpected error on get: %v", err)
+		t.Errorf("Got unexpected error on Get: %v", err)
 	}
 
 	// Only transient blocks 5 through 7 should be left

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -76,6 +76,7 @@ func TestBlockRetrievalQueueBasic(t *testing.T) {
 	t.Log("Add a block retrieval request to the queue and retrieve it.")
 	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
 	require.NotNil(t, q)
+	defer q.Shutdown()
 
 	ctx := context.Background()
 	ptr1 := makeRandomBlockPointer(t)
@@ -98,6 +99,7 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 	t.Log("Preempt a lower-priority block retrieval request with a higher priority request.")
 	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
 	require.NotNil(t, q)
+	defer q.Shutdown()
 
 	ctx := context.Background()
 	ptr1 := makeRandomBlockPointer(t)
@@ -126,6 +128,7 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 	t.Log("Handle a first request and then preempt another one.")
 	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
 	require.NotNil(t, q)
+	defer q.Shutdown()
 
 	ctx := context.Background()
 	ptr1 := makeRandomBlockPointer(t)
@@ -165,6 +168,7 @@ func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 	t.Log("Request the same block multiple times.")
 	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
 	require.NotNil(t, q)
+	defer q.Shutdown()
 
 	ctx := context.Background()
 	ptr1 := makeRandomBlockPointer(t)
@@ -190,6 +194,7 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	t.Log("Elevate the priority on an existing request.")
 	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
 	require.NotNil(t, q)
+	defer q.Shutdown()
 
 	ctx := context.Background()
 	ptr1 := makeRandomBlockPointer(t)
@@ -231,6 +236,7 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	t.Log("Begin processing a request and then add another one for the same block.")
 	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
 	require.NotNil(t, q)
+	defer q.Shutdown()
 
 	ctx := context.Background()
 	ptr1 := makeRandomBlockPointer(t)

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1163,3 +1163,11 @@ func (e TLFCryptKeyNotPerDeviceEncrypted) Error() string {
 	return fmt.Sprintf("TLF crypt key for %s at generation %d is not per-device encrypted",
 		e.tlf, e.keyGen)
 }
+
+type cachePutCacheFullError struct {
+	ptr BlockPointer
+}
+
+func (e cachePutCacheFullError) Error() string {
+	return fmt.Sprintf("tried and failed to put transient block into the cache because it is full. Pointer: %+v", e.ptr)
+}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2663,7 +2663,7 @@ func (fbo *folderBlockOps) fastForwardDirAndChildrenLocked(ctx context.Context,
 		fbo.log.CDebugf(ctx, "Fast-forwarding %v -> %v",
 			child.BlockPointer, entry.BlockPointer)
 		fbo.updatePointer(kmd, child.BlockPointer,
-			entry.BlockPointer, false)
+			entry.BlockPointer, true)
 		node := fbo.nodeCache.Get(entry.BlockPointer.Ref())
 		newPath := fbo.nodeCache.PathFromNode(node)
 		if entry.Type == Dir {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -278,7 +278,8 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
 		fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
-			block, kmd, defaultOnDemandRequestPriority, hasPrefetched)
+			block, ptr, kmd, defaultOnDemandRequestPriority, TransientEntry,
+			hasPrefetched)
 		return block, nil
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2588,7 +2588,9 @@ func (fbo *folderBlockOps) getDeferredWriteCountForTest(lState *lockState) int {
 }
 
 func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, newPtr BlockPointer) {
-	fbo.log.CDebugf(context.Background(), "Updating reference for pointer %s to %s", oldPtr.ID, newPtr.ID)
+	// TODO: Remove this comment when we're done debugging because it'll be
+	// everywhere.
+	fbo.log.CDebugf(context.TODO(), "Updating reference for pointer %s to %s", oldPtr.ID, newPtr.ID)
 	updated := fbo.nodeCache.UpdatePointer(oldPtr.Ref(), newPtr)
 	if !updated {
 		return

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1026,7 +1026,7 @@ type Prefetcher interface {
 	// block. It caches if it has triggered a prefetch and returns that.
 	PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		hasPrefetched bool) bool
+		hasPrefetched bool)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1023,9 +1023,10 @@ type Prefetcher interface {
 	// PrefetchAfterBlockRetrieved allows the prefetcher to trigger prefetches
 	// after a block has been retrieved. Whichever component is responsible for
 	// retrieving blocks will call this method once it's done retrieving a
-	// block.
-	PrefetchAfterBlockRetrieved(b Block, kmd KeyMetadata, priority int,
-		hasPrefetched bool)
+	// block. It caches if it has triggered a prefetch and returns that.
+	PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer,
+		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
+		hasPrefetched bool) bool
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1023,7 +1023,7 @@ type Prefetcher interface {
 	// PrefetchAfterBlockRetrieved allows the prefetcher to trigger prefetches
 	// after a block has been retrieved. Whichever component is responsible for
 	// retrieving blocks will call this method once it's done retrieving a
-	// block. It caches if it has triggered a prefetch and returns that.
+	// block. It caches if it has triggered a prefetch.
 	PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
 		hasPrefetched bool)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2788,12 +2788,14 @@ func (_mr *_MockPrefetcherRecorder) PrefetchBlock(arg0, arg1, arg2, arg3 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchBlock", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, kmd KeyMetadata, priority int) {
-	_m.ctrl.Call(_m, "PrefetchAfterBlockRetrieved", b, kmd, priority)
+func (_m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata, priority int, hasPrefetched bool) bool {
+	ret := _m.ctrl.Call(_m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd, priority, hasPrefetched)
+	ret0, _ := ret[0].(bool)
+	return ret0
 }
 
-func (_mr *_MockPrefetcherRecorder) PrefetchAfterBlockRetrieved(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchAfterBlockRetrieved", arg0, arg1, arg2)
+func (_mr *_MockPrefetcherRecorder) PrefetchAfterBlockRetrieved(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchAfterBlockRetrieved", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockPrefetcher) Shutdown() <-chan struct{} {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2788,14 +2788,12 @@ func (_mr *_MockPrefetcherRecorder) PrefetchBlock(arg0, arg1, arg2, arg3 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchBlock", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata, priority int, hasPrefetched bool) bool {
-	ret := _m.ctrl.Call(_m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd, priority, hasPrefetched)
-	ret0, _ := ret[0].(bool)
-	return ret0
+func (_m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, hasPrefetched bool) {
+	_m.ctrl.Call(_m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd, priority, lifetime, hasPrefetched)
 }
 
-func (_mr *_MockPrefetcherRecorder) PrefetchAfterBlockRetrieved(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchAfterBlockRetrieved", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockPrefetcherRecorder) PrefetchAfterBlockRetrieved(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchAfterBlockRetrieved", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockPrefetcher) Shutdown() <-chan struct{} {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -89,13 +89,10 @@ func (p *blockPrefetcher) run() {
 	for {
 		select {
 		case req := <-p.progressCh:
+			ctx, cancel := context.WithCancel(context.TODO())
+			errCh := p.retriever.Request(ctx, req.priority, req.kmd, req.ptr, req.block, TransientEntry)
 			wg.Add(1)
 			go func() {
-				// Request must be called in a goroutine because this prefetch
-				// request could have been triggered by the retriever itself.
-				ctx, cancel := context.WithCancel(context.TODO())
-				errCh := p.retriever.Request(ctx, req.priority, req.kmd,
-					req.ptr, req.block, TransientEntry)
 				defer wg.Done()
 				defer cancel()
 				select {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -89,7 +89,7 @@ func (p *blockPrefetcher) run() {
 	for {
 		select {
 		case req := <-p.progressCh:
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.TODO())
 			errCh := p.retriever.Request(ctx, req.priority, req.kmd, req.ptr, req.block, TransientEntry)
 			wg.Add(1)
 			go func() {
@@ -135,7 +135,7 @@ func (p *blockPrefetcher) prefetchIndirectFileBlock(b *FileBlock, kmd KeyMetadat
 	if numIPtrs > defaultIndirectPointerPrefetchCount {
 		numIPtrs = defaultIndirectPointerPrefetchCount
 	}
-	p.log.CDebugf(context.Background(), "Prefetching pointers for indirect file block. Num pointers to prefetch: %d", numIPtrs)
+	p.log.CDebugf(context.TODO(), "Prefetching pointers for indirect file block. Num pointers to prefetch: %d", numIPtrs)
 	for _, ptr := range b.IPtrs[:numIPtrs] {
 		p.request(fileIndirectBlockPrefetchPriority, kmd,
 			ptr.BlockPointer, b.NewEmpty(), "")
@@ -148,7 +148,7 @@ func (p *blockPrefetcher) prefetchIndirectDirBlock(b *DirBlock, kmd KeyMetadata)
 	if numIPtrs > defaultIndirectPointerPrefetchCount {
 		numIPtrs = defaultIndirectPointerPrefetchCount
 	}
-	p.log.CDebugf(context.Background(), "Prefetching pointers for indirect dir block. Num pointers to prefetch: %d", numIPtrs)
+	p.log.CDebugf(context.TODO(), "Prefetching pointers for indirect dir block. Num pointers to prefetch: %d", numIPtrs)
 	for _, ptr := range b.IPtrs[:numIPtrs] {
 		_ = p.request(fileIndirectBlockPrefetchPriority, kmd,
 			ptr.BlockPointer, b.NewEmpty(), "")
@@ -156,7 +156,7 @@ func (p *blockPrefetcher) prefetchIndirectDirBlock(b *DirBlock, kmd KeyMetadata)
 }
 
 func (p *blockPrefetcher) prefetchDirectDirBlock(b *DirBlock, kmd KeyMetadata) {
-	p.log.CDebugf(context.Background(), "Prefetching entries for directory block. Num entries: %d", len(b.Children))
+	p.log.CDebugf(context.TODO(), "Prefetching entries for directory block. Num entries: %d", len(b.Children))
 	// Prefetch all DirEntry root blocks.
 	dirEntries := dirEntriesBySizeAsc{dirEntryMapToDirEntries(b.Children)}
 	sort.Sort(dirEntries)
@@ -172,7 +172,7 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(b *DirBlock, kmd KeyMetadata) {
 		case Exec:
 			block = &FileBlock{}
 		default:
-			p.log.CDebugf(context.Background(), "Skipping prefetch for entry of unknown type %T", entry.DirEntry)
+			p.log.CDebugf(context.TODO(), "Skipping prefetch for entry of unknown type %T", entry.DirEntry)
 			continue
 		}
 		p.request(priority, kmd, entry.BlockPointer, block, entry.entryName)
@@ -182,7 +182,7 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(b *DirBlock, kmd KeyMetadata) {
 // PrefetchBlock implements the Prefetcher interface for blockPrefetcher.
 func (p *blockPrefetcher) PrefetchBlock(
 	block Block, ptr BlockPointer, kmd KeyMetadata, priority int) error {
-	p.log.CDebugf(context.Background(), "Prefetching block by request from upstream component. Priority: %d", priority)
+	p.log.CDebugf(context.TODO(), "Prefetching block by request from upstream component. Priority: %d", priority)
 	return p.request(priority, kmd, ptr, block, "")
 }
 
@@ -214,7 +214,7 @@ func (p *blockPrefetcher) PrefetchAfterBlockRetrieved(
 			p.prefetchDirectDirBlock(b, kmd)
 		}
 	default:
-		p.log.CDebugf(context.Background(), "Skipping prefetch for entry of unknown type %T", b)
+		p.log.CDebugf(context.TODO(), "Skipping prefetch for entry of unknown type %T", b)
 	}
 	return true
 }

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -89,10 +89,13 @@ func (p *blockPrefetcher) run() {
 	for {
 		select {
 		case req := <-p.progressCh:
-			ctx, cancel := context.WithCancel(context.TODO())
-			errCh := p.retriever.Request(ctx, req.priority, req.kmd, req.ptr, req.block, TransientEntry)
 			wg.Add(1)
 			go func() {
+				// Request must be called in a goroutine because this prefetch
+				// request could have been triggered by the retriever itself.
+				ctx, cancel := context.WithCancel(context.TODO())
+				errCh := p.retriever.Request(ctx, req.priority, req.kmd,
+					req.ptr, req.block, TransientEntry)
 				defer wg.Done()
 				defer cancel()
 				select {

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -102,7 +102,7 @@ func TestPrefetcherIndirectFileBlock(t *testing.T) {
 	t.Log("Shutdown the prefetcher and wait until it's done prefetching.")
 	continueCh2 <- nil
 	continueCh3 <- nil
-	q.TogglePrefetcher(context.Background(), false)
+	<-q.Prefetcher().Shutdown()
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	block, err = cacheFunc().Get(ptr1)
@@ -146,7 +146,7 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 	t.Log("Shutdown the prefetcher and wait until it's done prefetching.")
 	continueCh2 <- nil
 	continueCh3 <- nil
-	q.TogglePrefetcher(context.Background(), false)
+	<-q.Prefetcher().Shutdown()
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	block, err = cacheFunc().Get(ptr1)
@@ -197,7 +197,7 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	continueCh3 <- nil
 	continueCh2 <- context.Canceled
 	t.Log("Shutdown the prefetcher and wait until it's done prefetching.")
-	q.TogglePrefetcher(context.Background(), false)
+	<-q.Prefetcher().Shutdown()
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	block, err = cacheFunc().Get(ptr1)

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -216,3 +216,63 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	block, err = cacheFunc().Get(dir2.Children["d"].BlockPointer)
 	require.EqualError(t, err, NoSuchBlockError{dir2.Children["d"].BlockPointer.ID}.Error())
 }
+
+func TestPrefetcherDirectDirBlockAlreadyCached(t *testing.T) {
+	t.Log("Test direct dir block prefetching when the dir block is cached.")
+	q, w, bg, cacheFunc := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q, w)
+
+	t.Log("Initialize a direct dir block with an entry pointing to 1 folder, which in turn points to 1 file.")
+	file1 := makeFakeFileBlock(t, true)
+	ptr1 := makeRandomBlockPointer(t)
+	dir1 := &DirBlock{Children: map[string]DirEntry{
+		"a": makeRandomDirEntry(t, Dir, 60, "a"),
+	}}
+	dir2 := &DirBlock{Children: map[string]DirEntry{
+		"b": makeRandomDirEntry(t, File, 100, "b"),
+	}}
+
+	_, continueCh1 := bg.setBlockToReturn(ptr1, dir1)
+	_, continueCh2 := bg.setBlockToReturn(dir1.Children["a"].BlockPointer, dir2)
+	_, continueCh3 := bg.setBlockToReturn(dir2.Children["b"].BlockPointer, file1)
+
+	t.Log("Request the block for ptr1.")
+	var block Block = &DirBlock{}
+	ch := q.Request(context.Background(), defaultOnDemandRequestPriority, makeKMD(), ptr1, block, TransientEntry)
+	continueCh1 <- nil
+	err := <-ch
+	require.NoError(t, err)
+	require.Equal(t, dir1, block)
+
+	t.Log("Release the prefetch for dir2.")
+	continueCh2 <- nil
+	t.Log("Shutdown the prefetcher and wait until it's done prefetching.")
+	<-q.Prefetcher().Shutdown()
+
+	t.Log("Ensure that the prefetched block is in the cache.")
+	block, err = cacheFunc().Get(dir1.Children["a"].BlockPointer)
+	require.NoError(t, err)
+	require.Equal(t, dir2, block)
+	t.Log("Ensure that the second-level directory didn't cause a prefetch.")
+	block, err = cacheFunc().Get(dir2.Children["b"].BlockPointer)
+	require.EqualError(t, err, NoSuchBlockError{dir2.Children["b"].BlockPointer.ID}.Error())
+
+	t.Log("Restart the prefetcher.")
+	q.TogglePrefetcher(context.Background(), true)
+
+	t.Log("Request the already-cached second-level directory block. We don't need to unblock this one.")
+	block = &DirBlock{}
+	ch = q.Request(context.Background(), defaultOnDemandRequestPriority, makeKMD(), dir1.Children["a"].BlockPointer, block, TransientEntry)
+	err = <-ch
+	require.NoError(t, err)
+	require.Equal(t, dir2, block)
+
+	t.Log("Release the prefetch for file1.")
+	continueCh3 <- nil
+	t.Log("Shutdown the prefetcher and wait until it's done prefetching.")
+	<-q.Prefetcher().Shutdown()
+
+	block, err = cacheFunc().Get(dir2.Children["b"].BlockPointer)
+	require.NoError(t, err)
+	require.Equal(t, file1, block)
+}


### PR DESCRIPTION
In this PR:
* The Prefetcher correctly caches the prefetched state of a block.
* `Put`s to the block cache don't trigger prefetches unless they come through via the `Get` path, and they didn't already trigger prefetches before.
* `UpdatePointers` prefetches now only happen when a change comes from the server rather than locally.