### PR TITLE
libkbfs: add `IsDirect` flag, data version for big files, and enable big file support

### DIFF
--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -113,7 +113,7 @@ func (config testBlockOpsConfig) MakeLogger(module string) logger.Logger {
 }
 
 func (config testBlockOpsConfig) DataVersion() DataVer {
-	return FilesWithHolesDataVer
+	return ChildHolesDataVer
 }
 
 func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -53,6 +53,7 @@ func makeRandomBlockPointer(t *testing.T) BlockPointer {
 		id,
 		5,
 		1,
+		true,
 		kbfsblock.MakeContext(
 			"fake creator",
 			"fake writer",

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -43,7 +43,7 @@ func (c *testBlockRetrievalConfig) MakeLogger(_ string) logger.Logger {
 }
 
 func (c testBlockRetrievalConfig) DataVersion() DataVer {
-	return FilesWithHolesDataVer
+	return ChildHolesDataVer
 }
 
 func makeRandomBlockPointer(t *testing.T) BlockPointer {
@@ -53,7 +53,7 @@ func makeRandomBlockPointer(t *testing.T) BlockPointer {
 		id,
 		5,
 		1,
-		directBlock,
+		DirectBlock,
 		kbfsblock.MakeContext(
 			"fake creator",
 			"fake writer",

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -53,7 +53,7 @@ func makeRandomBlockPointer(t *testing.T) BlockPointer {
 		id,
 		5,
 		1,
-		true,
+		directBlock,
 		kbfsblock.MakeContext(
 			"fake creator",
 			"fake writer",

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -196,7 +196,7 @@ func (fb *FileBlock) DataVersion() DataVer {
 	hasHoles := false
 	hasDirect := false
 	for i := range fb.IPtrs {
-		if fb.IPtrs[i].IsDirect {
+		if fb.IPtrs[i].IsDirect() {
 			hasDirect = true
 		} else if fb.IPtrs[i].Holes {
 			hasHoles = true

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -229,7 +229,7 @@ func (fb *FileBlock) DataVersion() DataVer {
 		panic("No known type for any indirect pointer")
 	}
 
-	if len(fb.IPtrs) > 0 && !hasDirect {
+	if !hasDirect {
 		return AtLeastTwoLevelsOfChildrenDataVer
 	} else if hasHoles {
 		return ChildHolesDataVer

--- a/libkbfs/block_types_test.go
+++ b/libkbfs/block_types_test.go
@@ -26,6 +26,7 @@ func makeFakeBlockPointer(t *testing.T) BlockPointer {
 		kbfsblock.FakeID(1),
 		5,
 		1,
+		true,
 		makeFakeBlockContext(t),
 	}
 }

--- a/libkbfs/block_types_test.go
+++ b/libkbfs/block_types_test.go
@@ -26,7 +26,7 @@ func makeFakeBlockPointer(t *testing.T) BlockPointer {
 		kbfsblock.FakeID(1),
 		5,
 		1,
-		true,
+		directBlock,
 		makeFakeBlockContext(t),
 	}
 }

--- a/libkbfs/block_types_test.go
+++ b/libkbfs/block_types_test.go
@@ -26,7 +26,7 @@ func makeFakeBlockPointer(t *testing.T) BlockPointer {
 		kbfsblock.FakeID(1),
 		5,
 		1,
-		directBlock,
+		DirectBlock,
 		makeFakeBlockContext(t),
 	}
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -605,7 +605,7 @@ func (c *ConfigLocal) SetMetadataVersion(mdVer MetadataVer) {
 
 // DataVersion implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) DataVersion() DataVer {
-	return FilesWithHolesDataVer
+	return BigFilesDataVer
 }
 
 // DoBackgroundFlushes implements the Config interface for ConfigLocal.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -600,7 +600,7 @@ func (c *ConfigLocal) SetMetadataVersion(mdVer MetadataVer) {
 
 // DataVersion implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) DataVersion() DataVer {
-	return BigFilesDataVer
+	return AtLeastTwoLevelsOfChildrenDataVer
 }
 
 // DoBackgroundFlushes implements the Config interface for ConfigLocal.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// Max supported plaintext size of a file in KBFS.  TODO: increase
-	// this once we support multiple levels of indirection.
-	maxFileBytesDefault = 2 * 1024 * 1024 * 1024
 	// Max supported size of a directory entry name.
 	maxNameBytesDefault = 255
 	// Maximum supported plaintext size of a directory in KBFS. TODO:
@@ -77,7 +74,6 @@ type ConfigLocal struct {
 	noBGFlush   bool // logic opposite so the default value is the common setting
 	rwpWaitTime time.Duration
 
-	maxFileBytes uint64
 	maxNameBytes uint32
 	maxDirBytes  uint64
 	rekeyQueue   RekeyQueue
@@ -244,7 +240,6 @@ func NewConfigLocal(loggerFn func(module string) logger.Logger) *ConfigLocal {
 	config.SetKeyOps(&KeyOpsStandard{config})
 	config.SetRekeyQueue(NewRekeyQueueStandard(config))
 
-	config.maxFileBytes = maxFileBytesDefault
 	config.maxNameBytes = maxNameBytesDefault
 	config.maxDirBytes = maxDirBytesDefault
 	config.rwpWaitTime = rekeyWithPromptWaitTimeDefault
@@ -666,11 +661,6 @@ func (c *ConfigLocal) QuotaReclamationMinHeadAge() time.Duration {
 // ReqsBufSize implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) ReqsBufSize() int {
 	return 20
-}
-
-// MaxFileBytes implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) MaxFileBytes() uint64 {
-	return c.maxFileBytes
 }
 
 // MaxNameBytes implements the Config interface for ConfigLocal.

--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -127,7 +127,6 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	// turn off background flushing by default during tests
 	config.noBGFlush = true
 
-	config.maxFileBytes = maxFileBytesDefault
 	config.maxNameBytes = maxNameBytesDefault
 	config.maxDirBytes = maxDirBytesDefault
 	config.rwpWaitTime = rekeyWithPromptWaitTimeDefault

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -195,6 +195,9 @@ const (
 	// FilesWithHolesDataVer is the data version for files
 	// with holes.
 	FilesWithHolesDataVer DataVer = 2
+	// BigFilesDataVer is the data version for files that have
+	// multiple levels of indirection.
+	BigFilesDataVer DataVer = 3
 )
 
 // BlockRef is a block ID/ref nonce pair, which defines a unique
@@ -223,9 +226,10 @@ func (r BlockRef) String() string {
 // NOTE: Don't add or modify anything in this struct without
 // considering how old clients will handle them.
 type BlockPointer struct {
-	ID      kbfsblock.ID `codec:"i"`
-	KeyGen  KeyGen       `codec:"k"` // if valid, which generation of the TLF{Writer,Reader}KeyBundle to use.
-	DataVer DataVer      `codec:"d"` // if valid, which version of the KBFS data structures is pointed to
+	ID       kbfsblock.ID `codec:"i"`
+	KeyGen   KeyGen       `codec:"k"`           // if valid, which generation of the TLF{Writer,Reader}KeyBundle to use.
+	DataVer  DataVer      `codec:"d"`           // if valid, which version of the KBFS data structures is pointed to
+	IsDirect bool         `codec:"s,omitempty"` // if true, the pointed-to block is definitely a leaf block
 	kbfsblock.Context
 }
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -311,7 +311,7 @@ func (p BlockPointer) String() string {
 		return "BlockPointer{}"
 	}
 	return fmt.Sprintf("BlockPointer{ID: %s, KeyGen: %d, DataVer: %d, "+
-		"Context: %s, DirectType=%s}",
+		"Context: %s, DirectType: %s}",
 		p.ID, p.KeyGen, p.DataVer, p.Context, p.DirectType)
 }
 

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1171,3 +1171,14 @@ type cachePutCacheFullError struct {
 func (e cachePutCacheFullError) Error() string {
 	return fmt.Sprintf("tried and failed to put transient block into the cache because it is full. Pointer: %+v", e.ptr)
 }
+
+// FileTooBigForCRError indicates that a file is too big to fit in
+// memory, and CR can't handle it.
+type FileTooBigForCRError struct {
+	p path
+}
+
+// Error implements the error interface for FileTooBigForCRError.
+func (e FileTooBigForCRError) Error() string {
+	return fmt.Sprintf("Cannot complete CR because the file %s is too big", e.p)
+}

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -253,7 +253,7 @@ func (fd *fileData) getBlocksForOffsetRange(ctx context.Context,
 				map[BlockPointer]*FileBlock{ptr: pblock}, -1, nil
 		}
 		// Return an empty child map with no blocks in it (since
-		// !getDirect is false).
+		// getDirect is false).
 		return [][]parentBlockAndChildIndex{nil}, nil, -1, nil
 	}
 

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -296,7 +296,7 @@ func (fd *fileData) getBlocksForOffsetRange(ctx context.Context,
 			var nextBlockOffset int64
 			// We only need to fetch direct blocks if we've been asked
 			// to do so.
-			if getDirect || !ptr.IsDirect {
+			if getDirect || !ptr.IsDirect() {
 				block, _, err := fd.getter(
 					groupCtx, fd.kmd, ptr, fd.file, blockReadParallel)
 				if err != nil {
@@ -1651,7 +1651,7 @@ func (fd *fileData) getIndirectFileBlockInfosWithTopBlock(ctx context.Context,
 
 func (fd *fileData) getIndirectFileBlockInfos(ctx context.Context) (
 	[]BlockInfo, error) {
-	if fd.rootBlockPointer().IsDirect {
+	if fd.rootBlockPointer().IsDirect() {
 		return nil, nil
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1743,9 +1743,9 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 	crypto cryptoPure, kmd KeyMetadata, block Block, uid keybase1.UID) (
 	info BlockInfo, plainSize int, readyBlockData ReadyBlockData, err error) {
 	var ptr BlockPointer
-	isDirect := false
+	directType := indirectBlock
 	if fBlock, ok := block.(*FileBlock); ok && !fBlock.IsInd {
-		isDirect = true
+		directType = directBlock
 		// first see if we are duplicating any known blocks in this folder
 		ptr, err = bcache.CheckForKnownPtr(kmd.TlfID(), fBlock)
 		if err != nil {
@@ -1756,7 +1756,7 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 			panic("Indirect directory blocks aren't supported yet")
 		}
 		// TODO: support indirect directory blocks.
-		isDirect = true
+		directType = directBlock
 	}
 
 	// Ready the block, even in the case where we can reuse an
@@ -1775,10 +1775,10 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 		ptr.SetWriter(uid)
 	} else {
 		ptr = BlockPointer{
-			ID:       id,
-			KeyGen:   kmd.LatestKeyGeneration(),
-			DataVer:  block.DataVersion(),
-			IsDirect: isDirect,
+			ID:         id,
+			KeyGen:     kmd.LatestKeyGeneration(),
+			DataVer:    block.DataVersion(),
+			DirectType: directType,
 			Context: kbfsblock.Context{
 				Creator:  uid,
 				RefNonce: kbfsblock.ZeroRefNonce,

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1743,9 +1743,9 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 	crypto cryptoPure, kmd KeyMetadata, block Block, uid keybase1.UID) (
 	info BlockInfo, plainSize int, readyBlockData ReadyBlockData, err error) {
 	var ptr BlockPointer
-	directType := indirectBlock
+	directType := IndirectBlock
 	if fBlock, ok := block.(*FileBlock); ok && !fBlock.IsInd {
-		directType = directBlock
+		directType = DirectBlock
 		// first see if we are duplicating any known blocks in this folder
 		ptr, err = bcache.CheckForKnownPtr(kmd.TlfID(), fBlock)
 		if err != nil {
@@ -1756,7 +1756,7 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 			panic("Indirect directory blocks aren't supported yet")
 		}
 		// TODO: support indirect directory blocks.
-		directType = directBlock
+		directType = DirectBlock
 	}
 
 	// Ready the block, even in the case where we can reuse an

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1302,11 +1302,6 @@ func (fbo *folderBlockOps) writeDataLocked(
 		fbo.log.CDebugf(ctx, "writeDataLocked done: %v", err)
 	}()
 
-	if sz := off + int64(len(data)); uint64(sz) > fbo.config.MaxFileBytes() {
-		return WriteRange{}, nil, 0,
-			FileTooBigError{file, sz, fbo.config.MaxFileBytes()}
-	}
-
 	fblock, uid, err := fbo.writeGetFileLocked(ctx, lState, kmd, file)
 	if err != nil {
 		return WriteRange{}, nil, 0, err
@@ -1752,12 +1747,20 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 	crypto cryptoPure, kmd KeyMetadata, block Block, uid keybase1.UID) (
 	info BlockInfo, plainSize int, readyBlockData ReadyBlockData, err error) {
 	var ptr BlockPointer
+	isDirect := false
 	if fBlock, ok := block.(*FileBlock); ok && !fBlock.IsInd {
+		isDirect = true
 		// first see if we are duplicating any known blocks in this folder
 		ptr, err = bcache.CheckForKnownPtr(kmd.TlfID(), fBlock)
 		if err != nil {
 			return
 		}
+	} else if dBlock, ok := block.(*DirBlock); ok {
+		if dBlock.IsInd {
+			panic("Indirect directory blocks aren't supported yet")
+		}
+		// TODO: support indirect directory blocks.
+		isDirect = true
 	}
 
 	// Ready the block, even in the case where we can reuse an
@@ -1776,9 +1779,10 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 		ptr.SetWriter(uid)
 	} else {
 		ptr = BlockPointer{
-			ID:      id,
-			KeyGen:  kmd.LatestKeyGeneration(),
-			DataVer: block.DataVersion(),
+			ID:       id,
+			KeyGen:   kmd.LatestKeyGeneration(),
+			DataVer:  block.DataVersion(),
+			IsDirect: isDirect,
 			Context: kbfsblock.Context{
 				Creator:  uid,
 				RefNonce: kbfsblock.ZeroRefNonce,

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1446,10 +1446,6 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	ctx context.Context, lState *lockState, kmd KeyMetadata,
 	file path, size uint64, parentBlocks []parentBlockAndChildIndex) (
 	WriteRange, []BlockPointer, error) {
-	if size > fbo.config.MaxFileBytes() {
-		return WriteRange{}, nil, FileTooBigError{file, int64(size), fbo.config.MaxFileBytes()}
-	}
-
 	fblock, uid, err := fbo.writeGetFileLocked(ctx, lState, kmd, file)
 	if err != nil {
 		return WriteRange{}, nil, err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1783,7 +1783,7 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		ID:         bid,
 		KeyGen:     md.LatestKeyGeneration(),
 		DataVer:    fbo.config.DataVersion(),
-		DirectType: directBlock,
+		DirectType: DirectBlock,
 		Context: kbfsblock.Context{
 			Creator:  uid,
 			RefNonce: kbfsblock.ZeroRefNonce,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1780,10 +1780,10 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		return err
 	}
 	ptr := BlockPointer{
-		ID:       bid,
-		KeyGen:   md.LatestKeyGeneration(),
-		DataVer:  fbo.config.DataVersion(),
-		IsDirect: true,
+		ID:         bid,
+		KeyGen:     md.LatestKeyGeneration(),
+		DataVer:    fbo.config.DataVersion(),
+		DirectType: directBlock,
 		Context: kbfsblock.Context{
 			Creator:  uid,
 			RefNonce: kbfsblock.ZeroRefNonce,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1780,9 +1780,10 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		return err
 	}
 	ptr := BlockPointer{
-		ID:      bid,
-		KeyGen:  md.LatestKeyGeneration(),
-		DataVer: fbo.config.DataVersion(),
+		ID:       bid,
+		KeyGen:   md.LatestKeyGeneration(),
+		DataVer:  fbo.config.DataVersion(),
+		IsDirect: true,
 		Context: kbfsblock.Context{
 			Creator:  uid,
 			RefNonce: kbfsblock.ZeroRefNonce,

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -398,8 +398,6 @@ func Init(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, onI
 	if err != nil {
 		return nil, err
 	}
-	// Turn off multiple levels of indirection in production for now.
-	bsplitter.maxPtrsPerBlock = int((^uint(0)) >> 1)
 	config.SetBlockSplitter(bsplitter)
 
 	if registry := config.MetricsRegistry(); registry != nil {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1475,9 +1475,6 @@ type Config interface {
 	// ReqsBufSize indicates the number of read or write operations
 	// that can be buffered per folder
 	ReqsBufSize() int
-	// MaxFileBytes indicates the maximum supported plaintext size of
-	// a file in bytes.
-	MaxFileBytes() uint64
 	// MaxNameBytes indicates the maximum supported size of a
 	// directory entry name in bytes.
 	MaxNameBytes() uint32

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1603,6 +1603,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// make blocks small
 	blockSize := int64(5)
 	config1.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
+	config1.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -998,6 +998,7 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 
 	// make blocks small
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = 5
+	config.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
@@ -1108,6 +1109,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	// make blocks small
 	blockSize := int64(5)
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
+	config.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
@@ -1255,6 +1257,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	// make blocks small
 	blockSize := int64(5)
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
+	config.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3565,44 +3565,6 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 		})
 }
 
-func TestKBFSOpsWriteFailTooBig(t *testing.T) {
-	mockCtrl, config, ctx, cancel := kbfsOpsInit(t, true)
-	defer kbfsTestShutdown(mockCtrl, config, ctx, cancel)
-
-	uid, id, rmd := injectNewRMD(t, config)
-
-	rootID := kbfsblock.FakeID(42)
-	fileID := kbfsblock.FakeID(43)
-	rootBlock := NewDirBlock().(*DirBlock)
-	rootBlock.Children["f"] = DirEntry{
-		BlockInfo: BlockInfo{
-			BlockPointer: makeBP(fileID, rmd, config, uid),
-			EncodedSize:  1,
-		},
-		EntryInfo: EntryInfo{
-			Type: File,
-			Size: 10,
-		},
-	}
-	fileBlock := NewFileBlock().(*FileBlock)
-	fileBlock.Contents = []byte{1, 2, 3, 4, 5}
-	node := pathNode{makeBP(rootID, rmd, config, uid), "p"}
-	fileNode := pathNode{makeBP(fileID, rmd, config, uid), "f"}
-	p := path{FolderBranch{Tlf: id}, []pathNode{node, fileNode}}
-	ops := getOps(config, id)
-	n := nodeFromPath(t, ops, p)
-	data := []byte{6, 7, 8}
-
-	config.maxFileBytes = 12
-
-	err := config.KBFSOps().Write(ctx, n, data, 10)
-	if err == nil {
-		t.Errorf("Got no expected error on Write")
-	} else if _, ok := err.(FileTooBigError); !ok {
-		t.Errorf("Got unexpected error on Write: %+v", err)
-	}
-}
-
 // Read tests check the same error cases, so no need for similar write
 // error tests
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5440,6 +5440,7 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	// make blocks small
 	blockSize := int64(5)
 	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
+	config.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1719,7 +1719,7 @@ func makeDirTree(id tlf.ID, uid keybase1.UID, components ...string) (
 }
 
 func makeFile(dir path, parentDirBlock *DirBlock, name string, et EntryType,
-	directType blockDirectType) (
+	directType BlockDirectType) (
 	path, *FileBlock) {
 	if et != File && et != Exec {
 		panic(fmt.Sprintf("Unexpected type %s", et))
@@ -1812,7 +1812,7 @@ func testKBFSOpsRemoveFileSuccess(t *testing.T, et EntryType) {
 	if et == Exec {
 		entryName += ".exe"
 	}
-	p, _ := makeFile(dirPath, parentDirBlock, entryName, et, directBlock)
+	p, _ := makeFile(dirPath, parentDirBlock, entryName, et, DirectBlock)
 
 	// sync block
 	var newRmd ImmutableRootMetadata
@@ -1996,10 +1996,10 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 		makeIFP(bid3, rmd, config, uid, 5, 10),
 		makeIFP(bid4, rmd, config, uid, 5, 15),
 	}
-	fileBlock.IPtrs[0].DirectType = directBlock
-	fileBlock.IPtrs[1].DirectType = directBlock
-	fileBlock.IPtrs[2].DirectType = directBlock
-	fileBlock.IPtrs[3].DirectType = directBlock
+	fileBlock.IPtrs[0].DirectType = DirectBlock
+	fileBlock.IPtrs[1].DirectType = DirectBlock
+	fileBlock.IPtrs[2].DirectType = DirectBlock
+	fileBlock.IPtrs[3].DirectType = DirectBlock
 	fileBP := makeBP(fileBID, rmd, config, uid)
 	p := dirPath.ChildPath(entryName, fileBP)
 	ops := getOps(config, id)
@@ -2095,7 +2095,7 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et EntryType) {
 	if et == Exec {
 		entryName += ".exe"
 	}
-	p, _ := makeFile(dirPath, parentDirBlock, entryName, et, indirectBlock)
+	p, _ := makeFile(dirPath, parentDirBlock, entryName, et, IndirectBlock)
 	// The operation might be retried several times.
 	config.mockBops.EXPECT().Get(
 		gomock.Any(), gomock.Any(), p.tailPointer(),

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1718,13 +1718,15 @@ func makeDirTree(id tlf.ID, uid keybase1.UID, components ...string) (
 	return rootEntry, path{FolderBranch{Tlf: id}, nodes}, blocks
 }
 
-func makeFile(dir path, parentDirBlock *DirBlock, name string, et EntryType) (
+func makeFile(dir path, parentDirBlock *DirBlock, name string, et EntryType,
+	isDirect bool) (
 	path, *FileBlock) {
 	if et != File && et != Exec {
 		panic(fmt.Sprintf("Unexpected type %s", et))
 	}
 	bid := kbfsblock.FakeIDAdd(dir.tailPointer().ID, 1)
 	bi := makeBIFromID(bid, dir.tailPointer().Creator)
+	bi.IsDirect = isDirect
 
 	parentDirBlock.Children[name] = DirEntry{
 		BlockInfo: bi,
@@ -1810,8 +1812,8 @@ func testKBFSOpsRemoveFileSuccess(t *testing.T, et EntryType) {
 	if et == Exec {
 		entryName += ".exe"
 	}
-	p, block := makeFile(dirPath, parentDirBlock, entryName, et)
-	testPutBlockInCache(t, config, p.tailPointer(), id, block)
+	p, _ := makeFile(dirPath, parentDirBlock, entryName, et, true)
+	//testPutBlockInCache(t, config, p.tailPointer(), id, block)
 
 	// sync block
 	var newRmd ImmutableRootMetadata
@@ -1832,7 +1834,8 @@ func testKBFSOpsRemoveFileSuccess(t *testing.T, et EntryType) {
 	_, ok := newParentDirBlock.Children[entryName]
 	require.False(t, ok)
 
-	for _, n := range p.path {
+	for i := 0; i < len(p.path)-1; i++ {
+		n := p.path[i]
 		blockIDs = append(blockIDs, n.ID)
 	}
 	checkBlockCache(t, config, id, blockIDs, nil)
@@ -1994,25 +1997,19 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 		makeIFP(bid3, rmd, config, uid, 5, 10),
 		makeIFP(bid4, rmd, config, uid, 5, 15),
 	}
-	block1 := NewFileBlock().(*FileBlock)
-	block1.Contents = []byte{5, 4, 3, 2, 1}
-	block2 := NewFileBlock().(*FileBlock)
-	block2.Contents = []byte{10, 9, 8, 7, 6}
-	block3 := NewFileBlock().(*FileBlock)
-	block3.Contents = []byte{15, 14, 13, 12, 11}
-	block4 := NewFileBlock().(*FileBlock)
-	block4.Contents = []byte{20, 19, 18, 17, 16}
+	fileBlock.IPtrs[0].IsDirect = true
+	fileBlock.IPtrs[1].IsDirect = true
+	fileBlock.IPtrs[2].IsDirect = true
+	fileBlock.IPtrs[3].IsDirect = true
 	fileBP := makeBP(fileBID, rmd, config, uid)
 	p := dirPath.ChildPath(entryName, fileBP)
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, dirPath)
 
-	// let the top block be uncached, so we have to fetch it from BlockOps.
+	// Let the top block be uncached, so we have to fetch it from
+	// BlockOps.  Don't cache any of the file direct blocks, to make
+	// sure we don't try to fetch them.
 	expectBlock(config, rmd, fileBP, fileBlock, nil)
-	testPutBlockInCache(t, config, fileBlock.IPtrs[0].BlockPointer, id, block1)
-	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
-	testPutBlockInCache(t, config, fileBlock.IPtrs[2].BlockPointer, id, block3)
-	testPutBlockInCache(t, config, fileBlock.IPtrs[3].BlockPointer, id, block4)
 
 	// sync block
 	blockIDs := make([]kbfsblock.ID, len(dirPath.path))
@@ -2035,7 +2032,6 @@ func TestKBFSOpRemoveMultiBlockFileSuccess(t *testing.T) {
 	for _, n := range p.path {
 		blockIDs = append(blockIDs, n.ID)
 	}
-	blockIDs = append(blockIDs, bid1, bid2, bid3, bid4)
 	checkBlockCache(t, config, id, blockIDs, nil)
 
 	unrefBlocks := []BlockPointer{
@@ -2100,7 +2096,7 @@ func testKBFSOpsRemoveFileMissingBlockSuccess(t *testing.T, et EntryType) {
 	if et == Exec {
 		entryName += ".exe"
 	}
-	p, _ := makeFile(dirPath, parentDirBlock, entryName, et)
+	p, _ := makeFile(dirPath, parentDirBlock, entryName, et, false)
 	// The operation might be retried several times.
 	config.mockBops.EXPECT().Get(
 		gomock.Any(), gomock.Any(), p.tailPointer(),

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4474,16 +4474,6 @@ func (_mr *_MockConfigRecorder) ReqsBufSize() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ReqsBufSize")
 }
 
-func (_m *MockConfig) MaxFileBytes() uint64 {
-	ret := _m.ctrl.Call(_m, "MaxFileBytes")
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-func (_mr *_MockConfigRecorder) MaxFileBytes() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaxFileBytes")
-}
-
 func (_m *MockConfig) MaxNameBytes() uint32 {
 	ret := _m.ctrl.Call(_m, "MaxNameBytes")
 	ret0, _ := ret[0].(uint32)

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -135,6 +135,9 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 	case FileTooBigError:
 		code = keybase1.FSErrorType_NOT_IMPLEMENTED
 		params[errorParamFeature] = errorFeatureFileLimit
+	case FileTooBigForCRError:
+		code = keybase1.FSErrorType_NOT_IMPLEMENTED
+		params[errorParamFeature] = errorFeatureFileLimit
 	case DirTooBigError:
 		code = keybase1.FSErrorType_NOT_IMPLEMENTED
 		params[errorParamFeature] = errorFeatureDirLimit


### PR DESCRIPTION
This PR enables writing files that are bigger than 2 GB, and those which have multiple levels of indirection.

It introduces a new data version for files with multiple levels of indirection, so that older clients won't attempt to read or write them (and will instead see a popup message about needing to upgrade their clients).

It also adds the `BlockPointer.IsDirect` flag, which states definitively whether the block being pointed to is a direct (leaf) block.  If the flag is false, code shouldn't assume the block is indirect (for backwards compatibility reasons with files written by older clients).  This PR uses that flag to not only set the data version correctly, but also to speed up scenarios where all the indirect `BlockInfo`s need to be fetched (e.g., when unlinking a file).

Issue: KBFS-35
Issue: KBFS-1739