### PR TITLE
folder_block_ops: don't fail fast-forwarding if there are 0 nodes

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2692,7 +2692,8 @@ func (fbo *folderBlockOps) fastForwardDirAndChildrenLocked(ctx context.Context,
 // associated with nodes in the cache by searching for their paths in
 // the current version of the TLF.  If it can't find a corresponding
 // node, it assumes it's been deleted and unlinks it.  Returns the set
-// of node changes that resulted.
+// of node changes that resulted.  If there are no nodes, it returns a
+// nil error because there's nothing to be done.
 func (fbo *folderBlockOps) FastForwardAllNodes(ctx context.Context,
 	lState *lockState, md ReadOnlyRootMetadata) (
 	changes []NodeChange, err error) {
@@ -2705,6 +2706,10 @@ func (fbo *folderBlockOps) FastForwardAllNodes(ctx context.Context,
 	defer fbo.blockLock.Unlock(lState)
 
 	nodes := fbo.nodeCache.AllNodes()
+	if len(nodes) == 0 {
+		// Nothing needs to be done!
+		return nil, nil
+	}
 	fbo.log.CDebugf(ctx, "Fast-forwarding %d nodes", len(nodes))
 
 	// Build a "tree" representation for each interesting path prefix.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4825,7 +4825,9 @@ func (fbo *folderBranchOps) maybeFastForward(ctx context.Context,
 	}
 
 	// Invalidate all the affected nodes.
-	fbo.observers.batchChanges(ctx, changes)
+	if len(changes) > 0 {
+		fbo.observers.batchChanges(ctx, changes)
+	}
 
 	// Reset the edit history.  TODO: notify any listeners that we've
 	// done this.


### PR DESCRIPTION
That just means there's nothing to be done.

Issue: KBFS-1865