### PR TITLE
Fix race in TestCancel in semaphore_test.go

### DIFF
--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -55,10 +55,11 @@ func (s *Semaphore) tryAcquire(n int64) (<-chan struct{}, int64) {
 
 // Acquire blocks until it is possible to atomically subtract n (which
 // must be positive) from the resource count without causing it to go
-// negative, and then returns nil. If the given context is canceled
-// first, it instead returns a wrapped ctx.Err() and does not change
-// the resource count. The possibly-updated resource count is
-// returned, even when err != nil.
+// negative, and then returns the updated resource count and nil. If
+// the given context is canceled first, it instead does not change the
+// resource count, and returns the resource count at the time it
+// blocked (which is necessarily less than n), and a wrapped
+// ctx.Err().
 func (s *Semaphore) Acquire(ctx context.Context, n int64) (int64, error) {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -131,7 +131,7 @@ func TestCancel(t *testing.T) {
 	s := NewSemaphore()
 	require.Equal(t, int64(0), s.countForTest())
 
-	// Do this before spawning the goroutine, so that the
+	// Do this before spawning the goroutine, so that
 	// callAcquire() will always return a count of n-1.
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -132,9 +132,9 @@ func TestCancel(t *testing.T) {
 	require.Equal(t, int64(0), s.countForTest())
 
 	// Do this before spawning the goroutine. Otherwise, the
-	// s.Release() will race with the s.Acquire() in callAcquire,
-	// and depending on which one happens first, s.Acquire() will
-	// return either 0 or n - 1.
+	// s.Release() will race with the s.Acquire() in
+	// callAcquire(), and depending on which one happens first,
+	// s.Acquire() will return either 0 or n - 1.
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)
 	require.Equal(t, n-1, s.countForTest())

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -131,16 +131,16 @@ func TestCancel(t *testing.T) {
 	s := NewSemaphore()
 	require.Equal(t, int64(0), s.countForTest())
 
+	// Do this before spawning the goroutine to avoid a race on
+	// the count field of the result of callAcquire.
+	count := s.Release(n - 1)
+	require.Equal(t, n-1, count)
+	require.Equal(t, n-1, s.countForTest())
+
 	callCh := make(chan acquireCall, 1)
 	go func() {
 		callCh <- callAcquire(ctx2, s, n)
 	}()
-
-	requireNoCall(t, callCh)
-
-	count := s.Release(n - 1)
-	require.Equal(t, n-1, count)
-	require.Equal(t, n-1, s.countForTest())
 
 	requireNoCall(t, callCh)
 

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -131,8 +131,10 @@ func TestCancel(t *testing.T) {
 	s := NewSemaphore()
 	require.Equal(t, int64(0), s.countForTest())
 
-	// Do this before spawning the goroutine to avoid a race on
-	// the count field of the result of callAcquire.
+	// Do this before spawning the goroutine. Otherwise, the
+	// s.Release() will race with the s.Acquire() in callAcquire,
+	// and depending on which one happens first, s.Acquire() will
+	// return either 0 or n - 1.
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)
 	require.Equal(t, n-1, s.countForTest())

--- a/kbfssync/semaphore_test.go
+++ b/kbfssync/semaphore_test.go
@@ -131,10 +131,8 @@ func TestCancel(t *testing.T) {
 	s := NewSemaphore()
 	require.Equal(t, int64(0), s.countForTest())
 
-	// Do this before spawning the goroutine. Otherwise, the
-	// s.Release() will race with the s.Acquire() in
-	// callAcquire(), and depending on which one happens first,
-	// s.Acquire() will return either 0 or n - 1.
+	// Do this before spawning the goroutine, so that the
+	// callAcquire() will always return a count of n-1.
 	count := s.Release(n - 1)
 	require.Equal(t, n-1, count)
 	require.Equal(t, n-1, s.countForTest())


### PR DESCRIPTION
The spawned goroutine could run before the release
in the main goroutine happens, leading to a race on
the count field of acquireCall. Fix this by doing the
release first before spawning the goroutine.

This only applies for TestCancel, since all other tests
have a successful acquire, which will then have a
count of 0.