### PR TITLE
block_journal: don't remove unflushed blocks from the save journal

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -894,6 +894,8 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 				}
 			}
 
+			// If we've ignored all of the block IDs in `idsToIgnore`,
+			// we can avoid iterating through the rest of the journal.
 			if len(idsToIgnore) == ignored {
 				return nil
 			}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -959,7 +959,7 @@ func (j *tlfJournal) doOnMDFlush(ctx context.Context,
 			nextLastToRemove, removedBytes, err :=
 				j.blockJournal.onMDFlush(
 					ctx, maxSavedBlockRemovalsAtATime,
-					lastToRemove)
+					rmds.MD.RevisionNumber(), lastToRemove)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -1654,7 +1654,7 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 		return MdID{}, false, err
 	}
 
-	err = j.blockJournal.markMDRevision(ctx, rmd.Revision())
+	err = j.blockJournal.markMDRevision(ctx, rmd.Revision(), false)
 	if err != nil {
 		return MdID{}, false, err
 	}
@@ -1786,7 +1786,8 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	}
 
 	// Finally, append a new, non-ignored md rev marker for the new revision.
-	err = j.blockJournal.markMDRevision(ctx, rmd.Revision())
+	err = j.blockJournal.markMDRevision(
+		ctx, rmd.Revision(), isPendingLocalSquash)
 	if err != nil {
 		return MdID{}, false, err
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -501,7 +501,8 @@ func testTLFJournalBlockOpDiskLimit(t *testing.T, ver MetadataVer) {
 	require.Equal(t, rev, MetadataRevisionUninitialized)
 
 	// Fake an MD flush.
-	err = tlfJournal.doOnMDFlush(ctx, nil)
+	md := config.makeMD(MetadataRevisionInitial, MdID{})
+	err = tlfJournal.doOnMDFlush(ctx, &RootMetadataSigned{MD: md.bareMd})
 
 	select {
 	case err := <-errCh:


### PR DESCRIPTION
`onMDFlush` iterated the full savedUntilMDFlush journal and removed
all entries.  That made sense when we only saved blocks during CR, and
one CR flush cleared the entire journal.  However, now we always save
all blocks until the next MD flush, even without CR, and so when we
flushed one MD and there were still more left in the MD journal, we'd
wipe out the saved blocks for the subsequent MD revisions in the
journal.  Then, on the next flush, `saveBlocksUntilNextMDFlush` would
just repopulate the save journal again with a bunch of entries that
had just been removed, wasting a lot of time.

So this PR does a few things to fix that up:

1. Only remove blocks from the save journal that come before the
marker that signifies the MD revision that was just flushed.
2. When a local squash happens, that MD revision marker should NOT be ignored
on the next resolution (when `ignoreBlocksAndMDRevMarkers` is called), because
then it will look like we need to flush tons more blocks before flushing the
MD than we need to.
3. The saved journal needs the same ignore markings as the regular journal,
so it knows which MD revision markers are real.  So
`ignoreBlocksAndMDRevMarkers` needs to process both journals.
4. To speed up `ignoreBlocksAndMDRevMarkers`, iterate backwards through the
journal, rather than forwards, since the new list of blocks to ignore are
likely to be at the end of the journal.

This speeds up the "copy Go repo" scenario by about 33% in my tests
(though it doesn't seem to address the CPU issues we're having much).

Issue: KBFS-1885