### PR TITLE
folder_branch_ops: set latest merged head when journal conflicts

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4010,6 +4010,17 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			return err
 		}
 		if mergedRev != MetadataRevisionUninitialized {
+			if len(rmds) > 0 {
+				// We should update our view of the merged master though,
+				// to avoid re-registering for the same updates again.
+				func() {
+					fbo.headLock.Lock(lState)
+					defer fbo.headLock.Unlock(lState)
+					fbo.setLatestMergedRevisionLocked(
+						ctx, lState, rmds[len(rmds)-1].Revision(), false)
+				}()
+			}
+
 			fbo.log.CDebugf(ctx,
 				"Ignoring fetched revisions while MDs are in journal")
 			return nil


### PR DESCRIPTION
If we learn about something newer than the base of our journal, we
rightly ignore the updates until CR can resolve the issue.  However,
if we don't set our notion of the latest merged revision, we'll keep
re-registering for the same revision over and over, leading to
ugly throttle messages.

Issue: KBFS-1888