### PR TITLE
libkbfs: don't let block changes blocks explode in test

### DIFF
--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1600,10 +1600,12 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	config2.SetClock(newTestClockNow())
 	name := userName1.String() + "," + userName2.String()
 
-	// make blocks small
+	// Make the blocks small, with multiple levels of indirection, but
+	// make the unembedded size large, so we don't create thousands of
+	// unembedded block change blocks.
 	blockSize := int64(5)
-	config1.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
-	config1.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	config1.SetBlockSplitter(bsplit)
 
 	// create and write to a file
 	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5437,10 +5437,12 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
-	// make blocks small
+	// Make the blocks small, with multiple levels of indirection, but
+	// make the unembedded size large, so we don't create thousands of
+	// unembedded block change blocks.
 	blockSize := int64(5)
-	config.BlockSplitter().(*BlockSplitterSimple).maxSize = blockSize
-	config.BlockSplitter().(*BlockSplitterSimple).maxPtrsPerBlock = 2
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	config.SetBlockSplitter(bsplit)
 
 	// create a file.
 	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)


### PR DESCRIPTION
And re-enable flaky test that was timing out.

The size of block pointers increased since I added a direct type to them, and that caused some tests to exceed the default `BlockSplitterSimple.blockChangeEmbedMaxSize` when they had `BlockSplitterSimple.maxSize = 5`.  That caused a HUGE explosion in the number of blocks being written by the test.

So instead bump up the embed max size, so we don't have to waste test time on unembedded block change blocks.