### PR TITLE
folder_branch_ops: on unlink, don't user same path for each ptr

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3761,8 +3761,13 @@ func (fbo *folderBranchOps) unlinkFromCache(op op, oldDir BlockPointer,
 	// revert the parent pointer
 	childPath.path[len(childPath.path)-2].BlockPointer = oldDir
 	for _, ptr := range op.Unrefs() {
+		// It's ok to modify this path, since we break as soon as the
+		// node cache takes a reference to it.
 		childPath.path[len(childPath.path)-1].BlockPointer = ptr
-		fbo.nodeCache.Unlink(ptr.Ref(), childPath)
+		found := fbo.nodeCache.Unlink(ptr.Ref(), childPath)
+		if found {
+			break
+		}
 	}
 
 	return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1590,8 +1590,8 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	node Node, ei EntryInfo, err error) {
 	fbo.log.CDebugf(ctx, "Lookup %s %s", getNodeIDStr(dir), name)
 	defer func() {
-		fbo.deferLog.CDebugf(ctx, "Lookup %s %s done: %+v",
-			getNodeIDStr(dir), name, err)
+		fbo.deferLog.CDebugf(ctx, "Lookup %s %s done: %v %+v",
+			getNodeIDStr(dir), name, getNodeIDStr(node), err)
 	}()
 
 	err = fbo.checkNode(dir)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1570,7 +1570,8 @@ type NodeCache interface {
 	// ignores the call when ptr is not cached.  The path is required
 	// because the caller may have made changes to the parent nodes
 	// already that shouldn't be reflected in the cached path.
-	Unlink(ref BlockRef, oldPath path)
+	// Returns whether a node was actually updated.
+	Unlink(ref BlockRef, oldPath path) bool
 	// PathFromNode creates the path up to a given Node.
 	PathFromNode(node Node) path
 	// AllNodes returns the complete set of nodes currently in the cache.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4704,8 +4704,10 @@ func (_mr *_MockNodeCacheRecorder) Move(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Move", arg0, arg1, arg2)
 }
 
-func (_m *MockNodeCache) Unlink(ref BlockRef, oldPath path) {
-	_m.ctrl.Call(_m, "Unlink", ref, oldPath)
+func (_m *MockNodeCache) Unlink(ref BlockRef, oldPath path) bool {
+	ret := _m.ctrl.Call(_m, "Unlink", ref, oldPath)
+	ret0, _ := ret[0].(bool)
+	return ret0
 }
 
 func (_mr *_MockNodeCacheRecorder) Unlink(arg0, arg1 interface{}) *gomock.Call {

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -214,9 +214,9 @@ func (ncs *nodeCacheStandard) Move(
 }
 
 // Unlink implements the NodeCache interface for nodeCacheStandard.
-func (ncs *nodeCacheStandard) Unlink(ref BlockRef, oldPath path) {
+func (ncs *nodeCacheStandard) Unlink(ref BlockRef, oldPath path) bool {
 	if ref == (BlockRef{}) {
-		return
+		return false
 	}
 
 	// Temporary code to track down bad block pointers. Remove (or
@@ -229,13 +229,13 @@ func (ncs *nodeCacheStandard) Unlink(ref BlockRef, oldPath path) {
 	defer ncs.lock.Unlock()
 	entry, ok := ncs.nodes[ref]
 	if !ok {
-		return
+		return false
 	}
 
 	entry.core.cachedPath = oldPath
 	entry.core.parent = nil
 	entry.core.pathNode.Name = ""
-	return
+	return true
 }
 
 // PathFromNode implements the NodeCache interface for nodeCacheStandard.

--- a/libkbfs/node_cache_test.go
+++ b/libkbfs/node_cache_test.go
@@ -278,7 +278,10 @@ func TestNodeCacheUnlink(t *testing.T) {
 	childPtr2 := path2[2].BlockPointer
 
 	// unlink child2
-	ncs.Unlink(childPtr2.Ref(), ncs.PathFromNode(childNode2))
+	found := ncs.Unlink(childPtr2.Ref(), ncs.PathFromNode(childNode2))
+	if !found {
+		t.Fatalf("Couldn't unlink")
+	}
 
 	path := ncs.PathFromNode(childNode2)
 	checkNodeCachePath(t, id, branch, path, path2)
@@ -298,7 +301,10 @@ func TestNodeCacheUnlinkParent(t *testing.T) {
 	childPtr1 := path2[1].BlockPointer
 
 	// unlink node 2's parent
-	ncs.Unlink(childPtr1.Ref(), ncs.PathFromNode(childNode1))
+	found := ncs.Unlink(childPtr1.Ref(), ncs.PathFromNode(childNode1))
+	if !found {
+		t.Fatalf("Couldn't unlink")
+	}
 
 	path := ncs.PathFromNode(childNode2)
 	checkNodeCachePath(t, id, branch, path, path2)
@@ -319,7 +325,11 @@ func TestNodeCacheUnlinkThenRelink(t *testing.T) {
 	childPtr2 := path2[2].BlockPointer
 
 	// unlink child2
-	ncs.Unlink(childPtr2.Ref(), ncs.PathFromNode(childNode2))
+	found := ncs.Unlink(childPtr2.Ref(), ncs.PathFromNode(childNode2))
+	if !found {
+		t.Fatalf("Couldn't unlink")
+	}
+
 	newChildName := "newChildName"
 	newChildPtr2 := BlockPointer{ID: kbfsblock.FakeID(22)}
 	ncs.UpdatePointer(childPtr2.Ref(), newChildPtr2) // NO-OP


### PR DESCRIPTION
Remove operations of multi-block files can have many unref pointers,
with no indication of which one is the "top" block for the file.
Previously, this code looped through each of them and called
`NodeCache.Unlink` with the same `path` instance each time, just
changing the tail pointer for each call.  However, once one of those
succeeds, the other iterations of the loop will be modifying the same
path that's already been cached in the NodeCache.  This means that if
the user has an open file handle to the file, the next time they read
from it, they may try to read from the wrong block.

Instead, we should break the loop as soon as the node cache takes a
reference to the path, so we don't modify it again.  (We could also
make a new childPath for each iteration of the loop, but that seems
expensive for no good reason.)

Issue: KBFS-1200