### PR TITLE
GetTLFCryptKeys: don't early out in identifyOnce for chat CORE-4465

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -837,7 +837,9 @@ func (fbo *folderBranchOps) identifyOnce(
 	ctx context.Context, md ReadOnlyRootMetadata) error {
 	fbo.identifyLock.Lock()
 	defer fbo.identifyLock.Unlock()
-	if fbo.identifyDone {
+
+	ei := getExtendedIdentify(ctx)
+	if fbo.identifyDone && !ei.behavior.AlwaysRunIdentify() {
 		return nil
 	}
 
@@ -852,7 +854,6 @@ func (fbo *folderBranchOps) identifyOnce(
 		return err
 	}
 
-	ei := getExtendedIdentify(ctx)
 	if ei.behavior.WarningInsteadOfErrorOnBrokenTracks() &&
 		len(ei.getTlfBreakAndClose().Breaks) > 0 {
 		fbo.log.CDebugf(ctx,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -840,6 +840,8 @@ func (fbo *folderBranchOps) identifyOnce(
 
 	ei := getExtendedIdentify(ctx)
 	if fbo.identifyDone && !ei.behavior.AlwaysRunIdentify() {
+		// TODO: provide a way for the service to break this cache when identify
+		// state changes on a TLF. For now, we do it this way to make chat work.
 		return nil
 	}
 


### PR DESCRIPTION
We don't want to use the KBFS cache on identifies in chat, the hope is the caching in the service will be able to handle the influx of calls. The particular symptom is that if an identify breaks and the service knows it (probably from the background identifier), then we want the chat system to be consistent with that knowledge. 

cc @maxtaco 