### PR TITLE
[KBFS-1898] Preserve user when their last key is revoked

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -1188,20 +1188,18 @@ func (md *BareRootMetadataV2) AddKeyGeneration(codec kbfscodec.Codec,
 	if len(md.WKeys) > 0 {
 		existingWriterKeys :=
 			md.WKeys[len(md.WKeys)-1].WKeys.toPublicKeys()
-		updatedWriterKeysRemoved := updatedWriterKeys.RemoveKeylessUsers()
-		if !existingWriterKeys.Equals(updatedWriterKeysRemoved) {
+		if !existingWriterKeys.Equals(updatedWriterKeys) {
 			return nil, nil, fmt.Errorf(
-				"existingWriterKeys=%+v != updatedWriterKeysRemoved=%+v",
-				existingWriterKeys, updatedWriterKeysRemoved)
+				"existingWriterKeys=%+v != updatedWriterKeys=%+v",
+				existingWriterKeys, updatedWriterKeys)
 		}
 
 		existingReaderKeys :=
 			md.RKeys[len(md.RKeys)-1].RKeys.toPublicKeys()
-		updatedReaderKeysRemoved := updatedReaderKeys.RemoveKeylessUsers()
-		if !existingReaderKeys.Equals(updatedReaderKeysRemoved) {
+		if !existingReaderKeys.Equals(updatedReaderKeys) {
 			return nil, nil, fmt.Errorf(
-				"existingReaderKeys=%+v != updatedReaderKeysRemoved=%+v",
-				existingReaderKeys, updatedReaderKeysRemoved)
+				"existingReaderKeys=%+v != updatedReaderKeys=%+v",
+				existingReaderKeys, updatedReaderKeys)
 		}
 	}
 

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -533,6 +533,9 @@ func TestRevokeRemovedDevicesV2(t *testing.T) {
 	require.Equal(t, expectedRKeys, brmd.RKeys)
 }
 
+// TestRevokeLastDeviceV2 checks behavior of RevokeRemovedDevices with
+// respect to removing the last device of a user vs. removing the user
+// completely.
 func TestRevokeLastDeviceV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -956,8 +956,7 @@ func checkKeyBundlesV2(t *testing.T, expectedRekeyInfos []expectedRekeyInfoV2,
 				expected.readerPrivKeys.toPublicKeys())
 			userPubKeys := userDeviceServerHalvesToPublicKeys(
 				expected.serverHalves[keyGen-FirstValidKeyGen])
-			// TODO: Remove need for RemoveKeylessUsers().
-			require.Equal(t, expectedUserPubKeys.RemoveKeylessUsers(), userPubKeys)
+			require.Equal(t, expectedUserPubKeys.removeKeylessUsersForTest(), userPubKeys)
 			checkGetTLFCryptKeyV2(t, keyGen, expected,
 				expectedTLFCryptKeys[keyGen-FirstValidKeyGen],
 				wkb, rkb)

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -533,41 +533,29 @@ func TestRevokeRemovedDevicesV2(t *testing.T) {
 	require.Equal(t, expectedRKeys, brmd.RKeys)
 }
 
-func TestRevokeRemovedDevicesLastDeviceV2(t *testing.T) {
+func TestRevokeLastDeviceV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)
 	uid3 := keybase1.MakeTestUID(0x3)
+	uid4 := keybase1.MakeTestUID(0x4)
 
 	key1 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key1")
 	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key2")
-	key3 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key3")
 
-	half1a := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x1})
-	half1b := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x2})
-	half2a := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x3})
-	half2b := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x4})
-	half3a := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x5})
-	half3b := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x6})
+	half1 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x1})
+	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x2})
 
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)
-	id1a, err := crypto.GetTLFCryptKeyServerHalfID(uid1, key1, half1a)
+	id1, err := crypto.GetTLFCryptKeyServerHalfID(uid1, key1, half1)
 	require.NoError(t, err)
-	id1b, err := crypto.GetTLFCryptKeyServerHalfID(uid1, key1, half1b)
-	require.NoError(t, err)
-	id2a, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2a)
-	require.NoError(t, err)
-	id2b, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2b)
-	require.NoError(t, err)
-	id3a, err := crypto.GetTLFCryptKeyServerHalfID(uid3, key3, half3a)
-	require.NoError(t, err)
-	id3b, err := crypto.GetTLFCryptKeyServerHalfID(uid3, key3, half3b)
+	id2, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2)
 	require.NoError(t, err)
 
 	tlfID := tlf.FakeID(1, false)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3}, nil, nil, nil)
+		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3, uid4}, nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadataV2(tlfID, bh)
@@ -578,30 +566,14 @@ func TestRevokeRemovedDevicesLastDeviceV2(t *testing.T) {
 			WKeys: UserDeviceKeyInfoMapV2{
 				uid1: DeviceKeyInfoMapV2{
 					key1.KID(): TLFCryptKeyInfo{
-						ServerHalfID: id1a,
+						ServerHalfID: id1,
 						EPubKeyIndex: 0,
 					},
 				},
 				uid2: DeviceKeyInfoMapV2{
 					key2.KID(): TLFCryptKeyInfo{
-						ServerHalfID: id2a,
+						ServerHalfID: id2,
 						EPubKeyIndex: 1,
-					},
-				},
-			},
-		},
-		TLFWriterKeyBundleV2{
-			WKeys: UserDeviceKeyInfoMapV2{
-				uid1: DeviceKeyInfoMapV2{
-					key1.KID(): TLFCryptKeyInfo{
-						ServerHalfID: id1b,
-						EPubKeyIndex: 0,
-					},
-				},
-				uid2: DeviceKeyInfoMapV2{
-					key2.KID(): TLFCryptKeyInfo{
-						ServerHalfID: id2b,
-						EPubKeyIndex: 0,
 					},
 				},
 			},
@@ -611,22 +583,8 @@ func TestRevokeRemovedDevicesLastDeviceV2(t *testing.T) {
 	brmd.RKeys = TLFReaderKeyGenerationsV2{
 		TLFReaderKeyBundleV2{
 			RKeys: UserDeviceKeyInfoMapV2{
-				uid3: DeviceKeyInfoMapV2{
-					key3.KID(): TLFCryptKeyInfo{
-						ServerHalfID: id3a,
-						EPubKeyIndex: 0,
-					},
-				},
-			},
-		},
-		TLFReaderKeyBundleV2{
-			RKeys: UserDeviceKeyInfoMapV2{
-				uid3: DeviceKeyInfoMapV2{
-					key3.KID(): TLFCryptKeyInfo{
-						ServerHalfID: id3b,
-						EPubKeyIndex: 0,
-					},
-				},
+				uid3: DeviceKeyInfoMapV2{},
+				uid4: DeviceKeyInfoMapV2{},
 			},
 		},
 	}
@@ -644,19 +602,18 @@ func TestRevokeRemovedDevicesLastDeviceV2(t *testing.T) {
 	require.Equal(t, ServerHalfRemovalInfo{
 		uid1: userServerHalfRemovalInfo{
 			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
-				key1: []TLFCryptKeyServerHalfID{id1a, id1b},
+				key1: []TLFCryptKeyServerHalfID{id1},
 			},
 		},
 		uid2: userServerHalfRemovalInfo{
 			userRemoved: true,
 			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
-				key2: []TLFCryptKeyServerHalfID{id2a, id2b},
+				key2: []TLFCryptKeyServerHalfID{id2},
 			},
 		},
-		uid3: userServerHalfRemovalInfo{
-			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
-				key3: []TLFCryptKeyServerHalfID{id3a, id3b},
-			},
+		uid4: userServerHalfRemovalInfo{
+			userRemoved:         true,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{},
 		},
 	}, removalInfo)
 
@@ -666,20 +623,10 @@ func TestRevokeRemovedDevicesLastDeviceV2(t *testing.T) {
 				uid1: DeviceKeyInfoMapV2{},
 			},
 		},
-		TLFWriterKeyBundleV2{
-			WKeys: UserDeviceKeyInfoMapV2{
-				uid1: DeviceKeyInfoMapV2{},
-			},
-		},
 	}
 	require.Equal(t, expectedWKeys, brmd.WKeys)
 
 	expectedRKeys := TLFReaderKeyGenerationsV2{
-		TLFReaderKeyBundleV2{
-			RKeys: UserDeviceKeyInfoMapV2{
-				uid3: DeviceKeyInfoMapV2{},
-			},
-		},
 		TLFReaderKeyBundleV2{
 			RKeys: UserDeviceKeyInfoMapV2{
 				uid3: DeviceKeyInfoMapV2{},

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -1138,6 +1138,8 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKeys, pubKeys, rmd)
 }
 
+// TestBareRootMetadataV2AddKeyGenerationKeylessUsers checks that
+// keyless users are handled properly by AddKeyGeneration.
 func TestBareRootMetadataV2AddKeyGenerationKeylessUsers(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(1)
 	uid2 := keybase1.MakeTestUID(2)
@@ -1175,9 +1177,6 @@ func TestBareRootMetadataV2AddKeyGenerationKeylessUsers(t *testing.T) {
 	pubKey := kbfscrypto.MakeTLFPublicKey(fakeKeyData)
 	tlfCryptKey := kbfscrypto.MakeTLFCryptKey(fakeKeyData)
 
-	// Use the same ephemeral keys for initial key
-	// generations, even though that can't happen in
-	// practice.
 	_, serverHalves1Gen, err := rmd.AddKeyGeneration(codec,
 		crypto, nil, updatedWriterKeys, updatedReaderKeys,
 		ePubKey1, ePrivKey1,
@@ -1199,21 +1198,6 @@ func TestBareRootMetadataV2AddKeyGenerationKeylessUsers(t *testing.T) {
 		serverHalves: serverHalves1,
 	}
 	expectedRekeyInfos := []expectedRekeyInfoV2{expectedRekeyInfo1}
-
-	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKeys, pubKeys, rmd)
-
-	// Do update to check idempotency.
-
-	serverHalves1b, err := rmd.UpdateKeyBundles(crypto, nil,
-		updatedWriterKeys, updatedReaderKeys,
-		ePubKey1, ePrivKey1, tlfCryptKeys)
-	require.NoError(t, err)
-
-	expectedRekeyInfo1b := expectedRekeyInfoV2{
-		serverHalves: serverHalves1b,
-	}
-
-	expectedRekeyInfos = append(expectedRekeyInfos, expectedRekeyInfo1b)
 
 	checkKeyBundlesV2(t, expectedRekeyInfos, tlfCryptKeys, pubKeys, rmd)
 }

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -1096,19 +1096,17 @@ func (md *BareRootMetadataV3) AddKeyGeneration(codec kbfscodec.Codec,
 		}
 
 		existingWriterKeys := currExtraV3.wkb.Keys.toPublicKeys()
-		updatedWriterKeysRemoved := updatedWriterKeys.RemoveKeylessUsers()
-		if !existingWriterKeys.Equals(updatedWriterKeysRemoved) {
+		if !existingWriterKeys.Equals(updatedWriterKeys) {
 			return nil, nil, fmt.Errorf(
-				"existingWriterKeys=%+v != updatedWriterKeysRemoved=%+v",
-				existingWriterKeys, updatedWriterKeysRemoved)
+				"existingWriterKeys=%+v != updatedWriterKeys=%+v",
+				existingWriterKeys, updatedWriterKeys)
 		}
 
 		existingReaderKeys := currExtraV3.rkb.Keys.toPublicKeys()
-		updatedReaderKeysRemoved := updatedReaderKeys.RemoveKeylessUsers()
-		if !existingReaderKeys.Equals(updatedReaderKeysRemoved) {
+		if !existingReaderKeys.Equals(updatedReaderKeys) {
 			return nil, nil, fmt.Errorf(
-				"existingReaderKeys=%+v != updatedReaderKeysRemoved=%+v",
-				existingReaderKeys, updatedReaderKeysRemoved)
+				"existingReaderKeys=%+v != updatedReaderKeys=%+v",
+				existingReaderKeys, updatedReaderKeys)
 		}
 
 		if latestKeyGen < FirstValidKeyGen {

--- a/libkbfs/key_bundle.go
+++ b/libkbfs/key_bundle.go
@@ -55,9 +55,9 @@ func (dpk DevicePublicKeys) Equals(other DevicePublicKeys) bool {
 // UserDevicePublicKeys is a map from users to that user's set of devices.
 type UserDevicePublicKeys map[keybase1.UID]DevicePublicKeys
 
-// RemoveKeylessUsers returns a new UserDevicePublicKeys objects with
+// removeKeylessUsersForTest returns a new UserDevicePublicKeys objects with
 // all the users with an empty DevicePublicKeys removed.
-func (udpk UserDevicePublicKeys) RemoveKeylessUsers() UserDevicePublicKeys {
+func (udpk UserDevicePublicKeys) removeKeylessUsersForTest() UserDevicePublicKeys {
 	udpkRemoved := make(UserDevicePublicKeys)
 	for u, dpk := range udpk {
 		if len(dpk) > 0 {

--- a/libkbfs/key_bundle_v2.go
+++ b/libkbfs/key_bundle_v2.go
@@ -126,10 +126,10 @@ func (udkimV2 UserDeviceKeyInfoMapV2) removeDevicesNotIn(
 	for uid, dkim := range udkimV2 {
 		userRemoved := false
 		deviceServerHalfIDs := make(deviceServerHalfRemovalInfo)
-		if _, hasUpdatedUser := updatedUserKeys[uid]; hasUpdatedUser {
+		if deviceKeys, ok := updatedUserKeys[uid]; ok {
 			for kid, info := range dkim {
 				key := kbfscrypto.MakeCryptPublicKey(kid)
-				if !updatedUserKeys[uid][key] {
+				if !deviceKeys[key] {
 					delete(dkim, kid)
 					deviceServerHalfIDs[key] = append(
 						deviceServerHalfIDs[key],
@@ -141,18 +141,17 @@ func (udkimV2 UserDeviceKeyInfoMapV2) removeDevicesNotIn(
 				continue
 			}
 		} else {
+			// The user was completely removed, which
+			// shouldn't happen but might as well make it
+			// work just in case.
 			userRemoved = true
 			for kid, info := range dkim {
 				key := kbfscrypto.MakeCryptPublicKey(kid)
-				delete(dkim, kid)
 				deviceServerHalfIDs[key] = append(
 					deviceServerHalfIDs[key],
 					info.ServerHalfID)
 			}
 
-			// The user was completely removed, which
-			// shouldn't happen but might as well make it
-			// work just in case.
 			delete(udkimV2, uid)
 		}
 

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -127,7 +127,7 @@ func TestRemoveDevicesNotInV2(t *testing.T) {
 }
 
 // TestRemoveLastDeviceV2 checks behavior of removeDevicesNotIn() with
-// respect to removing the last device vs. removing the user
+// respect to removing the last device of a user vs. removing the user
 // completely.
 func TestRemoveLastDeviceV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -124,6 +124,62 @@ func TestRemoveDevicesNotInV2(t *testing.T) {
 	}, removalInfo)
 }
 
+func TestRemoveLastDeviceV2(t *testing.T) {
+	uid1 := keybase1.MakeTestUID(0x1)
+	uid2 := keybase1.MakeTestUID(0x2)
+
+	key1 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key1")
+	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key3")
+
+	half1 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x1})
+	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x3})
+
+	codec := kbfscodec.NewMsgpack()
+	crypto := MakeCryptoCommon(codec)
+	id1, err := crypto.GetTLFCryptKeyServerHalfID(uid1, key1, half1)
+	require.NoError(t, err)
+	id2, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2)
+	require.NoError(t, err)
+
+	udkimV2 := UserDeviceKeyInfoMapV2{
+		uid1: DeviceKeyInfoMapV2{
+			key1.KID(): TLFCryptKeyInfo{
+				ServerHalfID: id1,
+				EPubKeyIndex: -1,
+			},
+		},
+		uid2: DeviceKeyInfoMapV2{
+			key2.KID(): TLFCryptKeyInfo{
+				ServerHalfID: id2,
+				EPubKeyIndex: -2,
+			},
+		},
+	}
+
+	removalInfo := udkimV2.removeDevicesNotIn(UserDevicePublicKeys{
+		uid1: {},
+	})
+
+	require.Equal(t, UserDeviceKeyInfoMapV2{
+		uid1: DeviceKeyInfoMapV2{},
+	}, udkimV2)
+
+	require.Equal(t, ServerHalfRemovalInfo{
+		uid1: userServerHalfRemovalInfo{
+			userRemoved: false,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
+				key1: []TLFCryptKeyServerHalfID{id1},
+			},
+		},
+		uid2: userServerHalfRemovalInfo{
+			userRemoved: true,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
+				key2: []TLFCryptKeyServerHalfID{id2},
+			},
+		},
+	}, removalInfo)
+}
+
 func TestToTLFWriterKeyBundleV3(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRemoveDevicesNotInV2 checks basic functionality of
+// removeDevicesNotIn().
 func TestRemoveDevicesNotInV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)
@@ -124,6 +126,9 @@ func TestRemoveDevicesNotInV2(t *testing.T) {
 	}, removalInfo)
 }
 
+// TestRemoveLastDeviceV2 checks behavior of removeDevicesNotIn() with
+// respect to removing the last device vs. removing the user
+// completely.
 func TestRemoveLastDeviceV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -136,10 +136,10 @@ func TestRemoveLastDeviceV2(t *testing.T) {
 	uid4 := keybase1.MakeTestUID(0x4)
 
 	key1 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key1")
-	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key3")
+	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key2")
 
 	half1 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x1})
-	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x3})
+	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x2})
 
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -129,6 +129,8 @@ func TestRemoveDevicesNotInV2(t *testing.T) {
 // TestRemoveLastDeviceV2 checks behavior of removeDevicesNotIn() with
 // respect to removing the last device of a user vs. removing the user
 // completely.
+//
+// This is a regression test for KBFS-1898.
 func TestRemoveLastDeviceV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)

--- a/libkbfs/key_bundle_v2_test.go
+++ b/libkbfs/key_bundle_v2_test.go
@@ -127,6 +127,8 @@ func TestRemoveDevicesNotInV2(t *testing.T) {
 func TestRemoveLastDeviceV2(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)
+	uid3 := keybase1.MakeTestUID(0x3)
+	uid4 := keybase1.MakeTestUID(0x4)
 
 	key1 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key1")
 	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key3")
@@ -154,14 +156,18 @@ func TestRemoveLastDeviceV2(t *testing.T) {
 				EPubKeyIndex: -2,
 			},
 		},
+		uid3: DeviceKeyInfoMapV2{},
+		uid4: DeviceKeyInfoMapV2{},
 	}
 
 	removalInfo := udkimV2.removeDevicesNotIn(UserDevicePublicKeys{
 		uid1: {},
+		uid3: {},
 	})
 
 	require.Equal(t, UserDeviceKeyInfoMapV2{
 		uid1: DeviceKeyInfoMapV2{},
+		uid3: DeviceKeyInfoMapV2{},
 	}, udkimV2)
 
 	require.Equal(t, ServerHalfRemovalInfo{
@@ -176,6 +182,10 @@ func TestRemoveLastDeviceV2(t *testing.T) {
 			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
 				key2: []TLFCryptKeyServerHalfID{id2},
 			},
+		},
+		uid4: userServerHalfRemovalInfo{
+			userRemoved:         true,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{},
 		},
 	}, removalInfo)
 }

--- a/libkbfs/key_bundle_v3.go
+++ b/libkbfs/key_bundle_v3.go
@@ -111,9 +111,9 @@ func (udkimV3 UserDeviceKeyInfoMapV3) removeDevicesNotIn(
 	for uid, dkim := range udkimV3 {
 		userRemoved := false
 		deviceServerHalfIDs := make(deviceServerHalfRemovalInfo)
-		if _, hasUpdatedUser := updatedUserKeys[uid]; hasUpdatedUser {
+		if deviceKeys, ok := updatedUserKeys[uid]; ok {
 			for key, info := range dkim {
-				if !updatedUserKeys[uid][key] {
+				if !deviceKeys[key] {
 					delete(dkim, key)
 					deviceServerHalfIDs[key] = append(
 						deviceServerHalfIDs[key],
@@ -125,17 +125,16 @@ func (udkimV3 UserDeviceKeyInfoMapV3) removeDevicesNotIn(
 				continue
 			}
 		} else {
+			// The user was completely removed, which
+			// shouldn't happen but might as well make it
+			// work just in case.
 			userRemoved = true
 			for key, info := range dkim {
-				delete(dkim, key)
 				deviceServerHalfIDs[key] = append(
 					deviceServerHalfIDs[key],
 					info.ServerHalfID)
 			}
 
-			// The user was completely removed, which
-			// shouldn't happen but might as well make it
-			// work just in case.
 			delete(udkimV3, uid)
 		}
 

--- a/libkbfs/key_bundle_v3_test.go
+++ b/libkbfs/key_bundle_v3_test.go
@@ -163,6 +163,8 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 // TestRemoveLastDeviceV3 checks behavior of removeDevicesNotIn() with
 // respect to removing the last device of a user vs. removing the user
 // completely.
+//
+// This is a regression test for KBFS-1898.
 func TestRemoveLastDeviceV3(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)

--- a/libkbfs/key_bundle_v3_test.go
+++ b/libkbfs/key_bundle_v3_test.go
@@ -170,10 +170,10 @@ func TestRemoveLastDeviceV3(t *testing.T) {
 	uid4 := keybase1.MakeTestUID(0x4)
 
 	key1 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key1")
-	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key3")
+	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key2")
 
 	half1 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x1})
-	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x3})
+	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x2})
 
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)

--- a/libkbfs/key_bundle_v3_test.go
+++ b/libkbfs/key_bundle_v3_test.go
@@ -161,7 +161,7 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 }
 
 // TestRemoveLastDeviceV3 checks behavior of removeDevicesNotIn() with
-// respect to removing the last device vs. removing the user
+// respect to removing the last device of a user vs. removing the user
 // completely.
 func TestRemoveLastDeviceV3(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)

--- a/libkbfs/key_bundle_v3_test.go
+++ b/libkbfs/key_bundle_v3_test.go
@@ -50,6 +50,8 @@ func TestRKBID(t *testing.T) {
 	require.Equal(t, id1, id2)
 }
 
+// TestRemoveDevicesNotInV3 checks basic functionality of
+// removeDevicesNotIn().
 func TestRemoveDevicesNotInV3(t *testing.T) {
 	uid1 := keybase1.MakeTestUID(0x1)
 	uid2 := keybase1.MakeTestUID(0x2)
@@ -88,17 +90,17 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 		uid1: DeviceKeyInfoMapV3{
 			key1a: TLFCryptKeyInfo{
 				ServerHalfID: id1a,
-				EPubKeyIndex: -1,
+				EPubKeyIndex: 1,
 			},
 			key1b: TLFCryptKeyInfo{
 				ServerHalfID: id1b,
-				EPubKeyIndex: +2,
+				EPubKeyIndex: 2,
 			},
 		},
 		uid2: DeviceKeyInfoMapV3{
 			key2a: TLFCryptKeyInfo{
 				ServerHalfID: id2a,
-				EPubKeyIndex: -2,
+				EPubKeyIndex: 2,
 			},
 			key2b: TLFCryptKeyInfo{
 				ServerHalfID: id2b,
@@ -112,7 +114,7 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 		uid3: DeviceKeyInfoMapV3{
 			key3a: TLFCryptKeyInfo{
 				ServerHalfID: id3a,
-				EPubKeyIndex: -2,
+				EPubKeyIndex: 2,
 			},
 		},
 	}
@@ -126,7 +128,7 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 		uid2: DeviceKeyInfoMapV3{
 			key2a: TLFCryptKeyInfo{
 				ServerHalfID: id2a,
-				EPubKeyIndex: -2,
+				EPubKeyIndex: 2,
 			},
 			key2c: TLFCryptKeyInfo{
 				ServerHalfID: id2c,
@@ -136,7 +138,7 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 		uid3: DeviceKeyInfoMapV3{
 			key3a: TLFCryptKeyInfo{
 				ServerHalfID: id3a,
-				EPubKeyIndex: -2,
+				EPubKeyIndex: 2,
 			},
 		},
 	}, udkimV3)
@@ -154,6 +156,75 @@ func TestRemoveDevicesNotInV3(t *testing.T) {
 			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
 				key2b: []TLFCryptKeyServerHalfID{id2b},
 			},
+		},
+	}, removalInfo)
+}
+
+// TestRemoveLastDeviceV3 checks behavior of removeDevicesNotIn() with
+// respect to removing the last device vs. removing the user
+// completely.
+func TestRemoveLastDeviceV3(t *testing.T) {
+	uid1 := keybase1.MakeTestUID(0x1)
+	uid2 := keybase1.MakeTestUID(0x2)
+	uid3 := keybase1.MakeTestUID(0x3)
+	uid4 := keybase1.MakeTestUID(0x4)
+
+	key1 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key1")
+	key2 := kbfscrypto.MakeFakeCryptPublicKeyOrBust("key3")
+
+	half1 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x1})
+	half2 := kbfscrypto.MakeTLFCryptKeyServerHalf([32]byte{0x3})
+
+	codec := kbfscodec.NewMsgpack()
+	crypto := MakeCryptoCommon(codec)
+	id1, err := crypto.GetTLFCryptKeyServerHalfID(uid1, key1, half1)
+	require.NoError(t, err)
+	id2, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2)
+	require.NoError(t, err)
+
+	udkimV3 := UserDeviceKeyInfoMapV3{
+		uid1: DeviceKeyInfoMapV3{
+			key1: TLFCryptKeyInfo{
+				ServerHalfID: id1,
+				EPubKeyIndex: 1,
+			},
+		},
+		uid2: DeviceKeyInfoMapV3{
+			key2: TLFCryptKeyInfo{
+				ServerHalfID: id2,
+				EPubKeyIndex: 2,
+			},
+		},
+		uid3: DeviceKeyInfoMapV3{},
+		uid4: DeviceKeyInfoMapV3{},
+	}
+
+	removalInfo := udkimV3.removeDevicesNotIn(UserDevicePublicKeys{
+		uid1: {},
+		uid3: {},
+	})
+
+	require.Equal(t, UserDeviceKeyInfoMapV3{
+		uid1: DeviceKeyInfoMapV3{},
+		uid3: DeviceKeyInfoMapV3{},
+	}, udkimV3)
+
+	require.Equal(t, ServerHalfRemovalInfo{
+		uid1: userServerHalfRemovalInfo{
+			userRemoved: false,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
+				key1: []TLFCryptKeyServerHalfID{id1},
+			},
+		},
+		uid2: userServerHalfRemovalInfo{
+			userRemoved: true,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{
+				key2: []TLFCryptKeyServerHalfID{id2},
+			},
+		},
+		uid4: userServerHalfRemovalInfo{
+			userRemoved:         true,
+			deviceServerHalfIDs: deviceServerHalfRemovalInfo{},
 		},
 	}, removalInfo)
 }


### PR DESCRIPTION
Only delete a user during rekey if the user
has been deleted from the handle.

Also add regression tests.