### PR TITLE
folder_branch_ops: allow unreadable heads, and clear heads on logout

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5506,7 +5506,7 @@ func (fbo *folderBranchOps) PushStatusChange() {
 
 // ClearPrivateFolderMD implements the KBFSOps interface for
 // folderBranchOps.
-func (fbo *folderBranchOps) ClearPrivateFolderMD() {
+func (fbo *folderBranchOps) ClearPrivateFolderMD(ctx context.Context) {
 	if fbo.folderBranch.Tlf.IsPublic() {
 		return
 	}
@@ -5517,7 +5517,7 @@ func (fbo *folderBranchOps) ClearPrivateFolderMD() {
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
 
-	fbo.log.CDebugf(context.TODO(), "Clearing folder MD")
+	fbo.log.CDebugf(ctx, "Clearing folder MD")
 	fbo.head = ImmutableRootMetadata{}
 	fbo.latestMergedRevision = MetadataRevisionUninitialized
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5504,6 +5504,24 @@ func (fbo *folderBranchOps) PushStatusChange() {
 	fbo.config.KBFSOps().PushStatusChange()
 }
 
+// ClearPrivateFolderMD implements the KBFSOps interface for
+// folderBranchOps.
+func (fbo *folderBranchOps) ClearPrivateFolderMD() {
+	if fbo.folderBranch.Tlf.IsPublic() {
+		return
+	}
+
+	lState := makeFBOLockState()
+	fbo.mdWriterLock.Lock(lState)
+	defer fbo.mdWriterLock.Unlock(lState)
+	fbo.headLock.Lock(lState)
+	defer fbo.headLock.Unlock(lState)
+
+	fbo.log.CDebugf(context.TODO(), "Clearing folder MD")
+	fbo.head = ImmutableRootMetadata{}
+	fbo.latestMergedRevision = MetadataRevisionUninitialized
+}
+
 // PushConnectionStatusChange pushes human readable connection status changes.
 func (fbo *folderBranchOps) PushConnectionStatusChange(service string, newStatus error) {
 	fbo.config.KBFSOps().PushConnectionStatusChange(service, newStatus)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1329,15 +1329,16 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 			md.Revision(), md.MergedStatus(), err)
 	}()
 
-	if md.data.Dir.Type != Dir {
-		// Not initialized.
-		return errors.Errorf("MD with revision=%d not initialized",
-			md.Revision())
+	if md.IsReadable() {
+		// We will prefetch this as on-demand so that it triggers downstream
+		// prefetches.
+		fbo.config.BlockOps().Prefetcher().PrefetchBlock(
+			&DirBlock{}, md.data.Dir.BlockPointer, md,
+			defaultOnDemandRequestPriority)
+	} else {
+		fbo.log.CDebugf(ctx,
+			"Setting an unreadable head with revision=%d", md.Revision())
 	}
-	// We will prefetch this as on-demand so that it triggers downstream
-	// prefetches.
-	fbo.config.BlockOps().Prefetcher().PrefetchBlock(
-		&DirBlock{}, md.data.Dir.BlockPointer, md, defaultOnDemandRequestPriority)
 
 	// Return early if the head is already set.  This avoids taking
 	// mdWriterLock for no reason, and it also avoids any side effects

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -314,6 +314,9 @@ type KBFSOps interface {
 	// PushStatusChange causes Status listeners to be notified via closing
 	// the status channel.
 	PushStatusChange()
+	// ClearPrivateFolderMD clears any cached private folder metadata,
+	// e.g. on a logout.
+	ClearPrivateFolderMD()
 }
 
 // KeybaseService is an interface for communicating with the keybase

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -316,7 +316,7 @@ type KBFSOps interface {
 	PushStatusChange()
 	// ClearPrivateFolderMD clears any cached private folder metadata,
 	// e.g. on a logout.
-	ClearPrivateFolderMD()
+	ClearPrivateFolderMD(ctx context.Context)
 }
 
 // KeybaseService is an interface for communicating with the keybase

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -137,17 +137,16 @@ func (fs *KBFSOpsStandard) PushStatusChange() {
 
 // ClearPrivateFolderMD implements the KBFSOps interface for
 // KBFSOpsStandard.
-func (fs *KBFSOpsStandard) ClearPrivateFolderMD() {
+func (fs *KBFSOpsStandard) ClearPrivateFolderMD(ctx context.Context) {
 	fs.opsLock.Lock()
 	defer fs.opsLock.Unlock()
 
 	// Block until all private folders have been reset.  TODO:
 	// parallelize these, as they can block for a while waiting for
 	// the lock.
-	for fb, fbo := range fs.ops {
-		if !fb.Tlf.IsPublic() {
-			fbo.ClearPrivateFolderMD()
-		}
+	for _, fbo := range fs.ops {
+		// This call is a no-op for public folders.
+		fbo.ClearPrivateFolderMD(ctx)
 	}
 }
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -135,6 +135,22 @@ func (fs *KBFSOpsStandard) PushStatusChange() {
 	fs.currentStatus.PushStatusChange()
 }
 
+// ClearPrivateFolderMD implements the KBFSOps interface for
+// KBFSOpsStandard.
+func (fs *KBFSOpsStandard) ClearPrivateFolderMD() {
+	fs.opsLock.Lock()
+	defer fs.opsLock.Unlock()
+
+	// Block until all private folders have been reset.  TODO:
+	// parallelize these, as they can block for a while waiting for
+	// the lock.
+	for fb, fbo := range fs.ops {
+		if !fb.Tlf.IsPublic() {
+			fbo.ClearPrivateFolderMD()
+		}
+	}
+}
+
 // GetFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetFavorites(ctx context.Context) (

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -956,6 +956,16 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 		t.Fatalf("Got unexpected error when reading with new key: %+v", err)
 	}
 
+	// GetTLFCryptKeys needs to return the same error.
+	rmd, err := config1.MDOps().GetForTLF(ctx, rootNode1.GetFolderBranch().Tlf)
+	if err != nil {
+		t.Fatalf("Couldn't get latest md: %+v", err)
+	}
+	_, _, err = config2Dev2.KBFSOps().GetTLFCryptKeys(ctx, rmd.GetTlfHandle())
+	if _, ok := err.(NeedSelfRekeyError); !ok {
+		t.Fatalf("Got unexpected error when reading with new key: %+v", err)
+	}
+
 	// Set the KBPKI so we can count the identify calls
 	countKBPKI := &identifyCountingKBPKI{
 		KBPKI: config1.KBPKI(),
@@ -1097,7 +1107,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 
 	// Make sure the server-side keys for the revoked device are gone
 	// for all keygens.
-	rmd, err := config1.MDOps().GetForTLF(ctx, rootNode1.GetFolderBranch().Tlf)
+	rmd, err = config1.MDOps().GetForTLF(ctx, rootNode1.GetFolderBranch().Tlf)
 	if err != nil {
 		t.Fatalf("Couldn't get latest md: %+v", err)
 	}

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -49,5 +49,5 @@ func serviceLoggedOut(ctx context.Context, config Config) {
 	// Clear any cached MD for all private TLFs, as they shouldn't be
 	// readable by a logged out user.  We assume that a logged-out
 	// call always comes before a logged-in call.
-	config.KBFSOps().ClearPrivateFolderMD()
+	config.KBFSOps().ClearPrivateFolderMD(ctx)
 }

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -45,4 +45,9 @@ func serviceLoggedOut(ctx context.Context, config Config) {
 	config.BlockServer().RefreshAuthToken(ctx)
 	config.KBFSOps().RefreshCachedFavorites(ctx)
 	config.KBFSOps().PushStatusChange()
+
+	// Clear any cached MD for all private TLFs, as they shouldn't be
+	// readable by a logged out user.  We assume that a logged-out
+	// call always comes before a logged-in call.
+	config.KBFSOps().ClearPrivateFolderMD()
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -293,12 +293,22 @@ func (_mr *_MockBlockRecorder) NewEmpty() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NewEmpty")
 }
 
-func (_m *MockBlock) Set(other Block, codec kbfscodec.Codec) {
-	_m.ctrl.Call(_m, "Set", other, codec)
+func (_m *MockBlock) Set(other Block) {
+	_m.ctrl.Call(_m, "Set", other)
 }
 
-func (_mr *_MockBlockRecorder) Set(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Set", arg0, arg1)
+func (_mr *_MockBlockRecorder) Set(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Set", arg0)
+}
+
+func (_m *MockBlock) ToCommonBlock() *CommonBlock {
+	ret := _m.ctrl.Call(_m, "ToCommonBlock")
+	ret0, _ := ret[0].(*CommonBlock)
+	return ret0
+}
+
+func (_mr *_MockBlockRecorder) ToCommonBlock() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ToCommonBlock")
 }
 
 // Mock of NodeID interface
@@ -763,12 +773,12 @@ func (_mr *_MockKBFSOpsRecorder) PushStatusChange() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PushStatusChange")
 }
 
-func (_m *MockKBFSOps) ClearPrivateFolderMD() {
-	_m.ctrl.Call(_m, "ClearPrivateFolderMD")
+func (_m *MockKBFSOps) ClearPrivateFolderMD(ctx context.Context) {
+	_m.ctrl.Call(_m, "ClearPrivateFolderMD", ctx)
 }
 
-func (_mr *_MockKBFSOpsRecorder) ClearPrivateFolderMD() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearPrivateFolderMD")
+func (_mr *_MockKBFSOpsRecorder) ClearPrivateFolderMD(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearPrivateFolderMD", arg0)
 }
 
 // Mock of KeybaseService interface

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -763,6 +763,14 @@ func (_mr *_MockKBFSOpsRecorder) PushStatusChange() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PushStatusChange")
 }
 
+func (_m *MockKBFSOps) ClearPrivateFolderMD() {
+	_m.ctrl.Call(_m, "ClearPrivateFolderMD")
+}
+
+func (_mr *_MockKBFSOpsRecorder) ClearPrivateFolderMD() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearPrivateFolderMD")
+}
+
 // Mock of KeybaseService interface
 type MockKeybaseService struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
`GetTLFCryptKeys` could fail with a weird error about a directory being uninitialized, when the caller is hoping for a nicer Need*Rekey error.  This happened in `SetInitialHeadFromServer`.  Instead, we can let that function cache the unreadable head, and let `GetTLFCryptKeys` encounter the rekey error later on.

Also, make sure we clear out cached heads on logout, or otherwise a newly logged in user might get the same error from a cached, unreadable head as the old user.

Issue: KBFS-1832