### PR TITLE
unflushed_path_cache: don't populate paths if we already know them

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -732,7 +732,8 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 		return err
 	}
 
-	for _, op := range ops {
+	for i, op := range ops {
+		op.setFinalPath(privateMD.Changes.Ops[i].getFinalPath())
 		op.setWriterInfo(winfo)
 		op.setLocalTimestamp(localTimestamp)
 		err := ccs.makeChainForOp(op)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1091,6 +1091,11 @@ func (fbo *folderBlockOps) PrepRename(
 	if err != nil {
 		return nil, nil, DirEntry{}, nil, err
 	}
+	// A renameOp doesn't have a single path to represent it, so we
+	// can't call setFinalPath here unfortunately.  That means any
+	// rename may force a manual paths population at other layers
+	// (e.g., for journal statuses).  TODO: allow a way to set more
+	// than one final path for renameOps?
 	md.AddOp(ro)
 
 	lbc = make(localBcache)
@@ -1854,6 +1859,7 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 	// before `md` is flushed to the server.  We don't copy it here
 	// because code below still needs to modify it (and by extension,
 	// the one stored in `syncState.si`).
+	si.op.setFinalPath(file)
 	md.AddOp(si.op)
 
 	// Fill in syncState.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2603,6 +2603,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 	if err != nil {
 		return nil, DirEntry{}, err
 	}
+	co.setFinalPath(dirPath)
 	md.AddOp(co)
 	// create new data block
 	var newBlock Block
@@ -2834,6 +2835,7 @@ func (fbo *folderBranchOps) createLinkLocked(
 	if err != nil {
 		return DirEntry{}, err
 	}
+	co.setFinalPath(dirPath)
 	md.AddOp(co)
 
 	// Create a direntry for the link, and then sync
@@ -2937,6 +2939,7 @@ func (fbo *folderBranchOps) removeEntryLocked(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	ro.setFinalPath(dir)
 	md.AddOp(ro)
 	err = fbo.unrefEntry(ctx, lState, md, dir, de, name)
 	if err != nil {
@@ -3418,6 +3421,7 @@ func (fbo *folderBranchOps) setExLocked(
 		return nil
 	}
 
+	sao.setFinalPath(file)
 	md.AddOp(sao)
 
 	dblock.Children[file.tailName()] = de
@@ -3490,6 +3494,7 @@ func (fbo *folderBranchOps) setMtimeLocked(
 		return nil
 	}
 
+	sao.setFinalPath(file)
 	md.AddOp(sao)
 
 	dblock.Children[file.tailName()] = de

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -134,7 +134,7 @@ type OpCommon struct {
 	writerInfo writerInfo
 	// finalPath is the final resolved path to the node that this
 	// operation affects in a set of MD updates.  Not exported; only
-	// used during conflict resolution.
+	// used locally.
 	finalPath path
 	// localTimestamp should be set to the localTimestamp of the
 	// corresponding ImmutableRootMetadata when ops need individual

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -193,16 +193,16 @@ func addUnflushedPaths(ctx context.Context,
 	// take a fair amount of CPU since the node cache isn't already
 	// up-to-date with the current set of pointers (because the MDs
 	// haven't been committed yet).
-	skipPaths := true
+	populatePaths := false
 	for _, chain := range chains.byOriginal {
 		if len(chain.ops) > 0 &&
 			!chain.ops[len(chain.ops)-1].getFinalPath().isValid() {
-			skipPaths = false
+			populatePaths = true
 			break
 		}
 	}
 
-	if !skipPaths {
+	if populatePaths {
 		err := cpp.populateChainPaths(ctx, log, chains, true)
 		if err != nil {
 			return err


### PR DESCRIPTION
In almost all cases (with the exception being renames), ops already have paths attached to them, and we don't need to run the expensive path population algorithm when they do.

This is just a simple optimization, but it saves about 9% of the foreground time when copying the go source code into KBFS when journaling is enabled and the journal status has already been viewed once.

Issue: KBFS-1910