### PR TITLE
folder_branch_ops: compare md root pointer as block ID

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1567,7 +1567,7 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 		// directory.  In that case, just return an empty set of
 		// children so we don't return an incorrect set from the
 		// cache.
-		if md.data.Dir.BlockPointer != dirPath.path[0].BlockPointer {
+		if md.data.Dir.BlockPointer.ID != dirPath.path[0].BlockPointer.ID {
 			fbo.log.CDebugf(ctx, "Returning an empty children set for "+
 				"unlinked directory %v", dirPath.tailPointer())
 			return nil
@@ -3409,7 +3409,7 @@ func (fbo *folderBranchOps) setExLocked(
 	// If the MD doesn't match the MD expected by the path, that
 	// implies we are using a cached path, which implies the node has
 	// been unlinked.  In that case, we can safely ignore this setex.
-	if md.data.Dir.BlockPointer != file.path[0].BlockPointer {
+	if md.data.Dir.BlockPointer.ID != file.path[0].BlockPointer.ID {
 		fbo.log.CDebugf(ctx, "Skipping setex for a removed file %v",
 			file.tailPointer())
 		fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
@@ -3481,7 +3481,7 @@ func (fbo *folderBranchOps) setMtimeLocked(
 	// implies we are using a cached path, which implies the node has
 	// been unlinked.  In that case, we can safely ignore this
 	// setmtime.
-	if md.data.Dir.BlockPointer != file.path[0].BlockPointer {
+	if md.data.Dir.BlockPointer.ID != file.path[0].BlockPointer.ID {
 		fbo.log.CDebugf(ctx, "Skipping setmtime for a removed file %v",
 			file.tailPointer())
 		fbo.blocks.UpdateCachedEntryAttributesOnRemovedFile(
@@ -3547,7 +3547,7 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 	// If the MD doesn't match the MD expected by the path, that
 	// implies we are using a cached path, which implies the node has
 	// been unlinked.  In that case, we can safely ignore this sync.
-	if md.data.Dir.BlockPointer != file.path[0].BlockPointer {
+	if md.data.Dir.BlockPointer.ID != file.path[0].BlockPointer.ID {
 		fbo.log.CDebugf(ctx, "Skipping sync for a removed file %v",
 			file.tailPointer())
 		// Removing the cached info here is a little sketchy,


### PR DESCRIPTION
Older clients might leave unknown fields from old md root pointers set with values from new clients, and thus the full root pointer would not match whatever was in the op update.

---

Note that there's a larger issue here about whether the client should be doing this: https://github.com/keybase/kbfs/blob/c09ee0ca9b0cac9ec84a8295a32a850751d79d23/libkbfs/folder_branch_ops.go#L2008

The problem is that this leaves unknown codec fields in the `DirEntry` set to what they were written to by the previous writer.  `BlockPointer` doesn't support unknown codec fields, but it's embedded in `DirEntry`. So the unknown `DirectType` field got passed along to the md root pointer by an old client, which didn't match the `BlockPointer` added to the op update.  But I don't know if there's a better way to handle it, since the copied unknown fields might be coming from something other than the `BlockPointer` and should be copied.  Sigh.

Issue: KBFS-1911