### PR TITLE
don't mark node as dirty in Write() if it's unlinked

### DIFF
--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -217,6 +217,7 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest,
 	if f.node.GetID().ParentID() == nil {
 		f.folder.fs.log.CDebugf(ctx,
 			"Ignoring write on unlinked file.", len(req.Data))
+		resp.Size = len(req.Data)
 		return nil
 	}
 

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -214,6 +214,12 @@ func (f *File) Write(ctx context.Context, req *fuse.WriteRequest,
 	f.folder.fs.log.CDebugf(ctx, "File Write sz=%d ", len(req.Data))
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
+	if f.node.GetID().ParentID() == nil {
+		f.folder.fs.log.CDebugf(ctx,
+			"Ignoring write on unlinked file.", len(req.Data))
+		return nil
+	}
+
 	f.eiCache.destroy()
 	if err := f.folder.fs.config.KBFSOps().Write(
 		ctx, f.node, req.Data, req.Offset); err != nil {


### PR DESCRIPTION
... so that a running process writing into an already-holding handle doesn't cause the file to show up again, or result in a stubborn entry in `DirtyNodes`.