### PR TITLE
cr_chains: used cached changes when getting ops, if needed

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -726,8 +726,17 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 	privateMD PrivateMetadata, winfo writerInfo,
 	localTimestamp time.Time) error {
 	// Copy the ops since CR will change them.
-	ops := make(opsList, len(privateMD.Changes.Ops))
-	err := kbfscodec.Update(codec, &ops, privateMD.Changes.Ops)
+	var oldOps opsList
+	if privateMD.Changes.Info.BlockPointer.IsInitialized() {
+		// In some cases (e.g., journaling) we might not have been
+		// able to re-embed the block changes.  So used the cached
+		// version directly.
+		oldOps = privateMD.cachedChanges.Ops
+	} else {
+		oldOps = privateMD.Changes.Ops
+	}
+	ops := make(opsList, len(oldOps))
+	err := kbfscodec.Update(codec, &ops, oldOps)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1862,8 +1862,8 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 
 	md.AddRefBytes(uint64(info.EncodedSize))
 	md.AddDiskUsage(uint64(info.EncodedSize))
-	changes.Info = info
 	md.data.cachedChanges = *changes
+	changes.Info = info
 	changes.Ops = nil
 	return nil
 }

--- a/test/journal_test.go
+++ b/test/journal_test.go
@@ -231,7 +231,7 @@ func TestJournalDoubleCrSimple(t *testing.T) {
 // bob writes a multi-block file that conflicts with a file created by
 // alice when journaling is on.
 func TestJournalCrConflictUnmergedWriteMultiblockFile(t *testing.T) {
-	test(t, journal(), blockSize(20),
+	test(t, journal(), blockSize(20), blockChangeSize(5),
 		users("alice", "bob"),
 		as(alice,
 			mkdir("a"),
@@ -239,6 +239,7 @@ func TestJournalCrConflictUnmergedWriteMultiblockFile(t *testing.T) {
 		as(bob,
 			enableJournal(),
 			disableUpdates(),
+			checkUnflushedPaths(nil),
 		),
 		as(alice,
 			write("a/b", "hello"),


### PR DESCRIPTION
The journal can't easily re-embed block changes (since it involves reading and decrypting blocks from disk), so we need to look in cached changes too.

Included is a regression test, but it won't actually test the regression until KBFS-1912 is fixed.  I'll be doing that in a separate PR.

Issue: KBFS-1901