### PR TITLE
test: set block sizes for all users, and fix resulting bugs

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -82,6 +82,10 @@ func (cc *crChain) collapse(createdOriginals map[BlockPointer]bool,
 			wr = realOp.collapseWriteRange(wr)
 			indicesToRemove[i] = true
 			lastSyncOp = i
+			// The last op will have its unrefs listed twice, once in
+			// the op itself and once in the resolutionOp, but that's
+			// harmless.
+			toUnrefs = append(toUnrefs, op.Unrefs()...)
 		default:
 			// ignore other op types
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2607,8 +2607,6 @@ func (fbo *folderBranchOps) createEntryLocked(
 	md.AddOp(co)
 	// create new data block
 	var newBlock Block
-	// XXX: for now, put a unique ID in every new block, to make sure it
-	// has a unique block ID. This may not be needed once we have encryption.
 	if entryType == Dir {
 		newBlock = &DirBlock{
 			Children: make(map[string]DirEntry),

--- a/test/cr_multi_blocks_test.go
+++ b/test/cr_multi_blocks_test.go
@@ -11,7 +11,7 @@ import "testing"
 // bob writes a multi-block file while unmerged, no conflicts
 func TestCrUnmergedWriteMultiblockFile(t *testing.T) {
 	test(t,
-		blockSize(20), users("alice", "bob"),
+		blockSize(20), blockChangeSize(20*1024), users("alice", "bob"),
 		as(alice,
 			mkdir("a"),
 		),
@@ -98,7 +98,7 @@ func TestCrConflictMergedWriteMultiblockFile(t *testing.T) {
 // bob resurrects a file that was removed by alice
 func TestCrConflictWriteToRemovedMultiblockFile(t *testing.T) {
 	test(t,
-		blockSize(20), users("alice", "bob"),
+		blockSize(20), blockChangeSize(20*1024), users("alice", "bob"),
 		as(alice,
 			mkdir("a"),
 			write("a/b", ntimesString(15, "0123456789")),
@@ -177,10 +177,10 @@ func TestCrConflictMoveRemovedMultiblockFile(t *testing.T) {
 }
 
 // bob writes a multi-block file while unmerged and the block change
-// size is small, no conflicts
+// size is small, no conflicts.
 func TestCrUnmergedWriteMultiblockFileWithSmallBlockChangeSize(t *testing.T) {
 	test(t,
-		blockSize(20), blockChangeSize(5), users("alice", "bob"),
+		blockSize(100), blockChangeSize(5), users("alice", "bob"),
 		as(alice,
 			mkdir("a"),
 		),

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -548,6 +548,7 @@ func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 	uids[0] = nameToUID(e.tb, config0)
 	for i, name := range users[1:] {
 		c := libkbfs.ConfigAsUser(config0, name)
+		setBlockSizes(e.tb, c, blockSize, blockChangeSize)
 		c.SetClock(clock)
 		cfgs[i+1] = c
 		uids[i+1] = nameToUID(e.tb, c)

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -63,6 +63,7 @@ func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 	// create the rest of the users as copies of the original config
 	for _, name := range users[1:] {
 		c := libkbfs.ConfigAsUser(config, name)
+		setBlockSizes(k.tb, c, blockSize, blockChangeSize)
 		c.SetClock(clock)
 		userMap[name] = c
 		k.refs[c] = make(map[libkbfs.Node]bool)

--- a/test/journal_test.go
+++ b/test/journal_test.go
@@ -231,7 +231,7 @@ func TestJournalDoubleCrSimple(t *testing.T) {
 // bob writes a multi-block file that conflicts with a file created by
 // alice when journaling is on.
 func TestJournalCrConflictUnmergedWriteMultiblockFile(t *testing.T) {
-	test(t, journal(), blockSize(20), blockChangeSize(5),
+	test(t, journal(), blockSize(100), blockChangeSize(5),
 		users("alice", "bob"),
 		as(alice,
 			mkdir("a"),
@@ -342,7 +342,7 @@ func TestJournalCrResolutionHitsConflict(t *testing.T) {
 
 func TestJournalCrResolutionHitsConflictWithIndirectBlocks(t *testing.T) {
 	testJournalCrResolutionHitsConflict(t,
-		[]optionOp{blockChangeSize(20), blockChangeSize(5)})
+		[]optionOp{blockChangeSize(100), blockChangeSize(5)})
 }
 
 // Check that simple quota reclamation works when journaling is enabled.
@@ -500,7 +500,7 @@ func TestJournalCoalescingWrites(t *testing.T) {
 		busyWork = append(busyWork, write("a/b", contents))
 	}
 
-	test(t, journal(), blockSize(20), blockChangeSize(5),
+	test(t, journal(), blockSize(100), blockChangeSize(5),
 		users("alice", "bob"),
 		as(alice,
 			mkdir("a"),
@@ -544,7 +544,7 @@ func TestJournalCoalescingMixedOperations(t *testing.T) {
 	}
 
 	targetMtime := time.Now().Add(1 * time.Minute)
-	test(t, journal(), blockSize(20), blockChangeSize(5),
+	test(t, journal(), blockSize(100), blockChangeSize(5),
 		users("alice", "bob"),
 		as(alice,
 			mkdir("a"),


### PR DESCRIPTION
It turns out the DSL tests had a problem where the block sizes weren't being properly set for all users after the first one.  Once I fixed it, there was some other fallout that needed fixing:

* When syncOps were collapsed together during CR, the unref pointers from the now-deleted sync ops did not make it to the final resolution.  This would leak quota for the user, and leave defunct blocks unarchived.
* When unflushed blocks were deleted from the journal after CR, we were still leaving them in the resulting `resolutionOp`.  This is harmless in practice except for making the `resolutionOp` larger than necessary.  But in tests, it confused the `StateChecker`.
* Fixing the test issue caused the libkbfs DSL tests to take 3x as long as before, due to all the new blocks.  This was mostly caused by tests where `blockSize=20` and `blockChangeSize=5`, because the size of the unembedded block changes would grow exponentially, creating a ton more work for the test.  Instead I increased the block size for those tests a bit, which makes a huge difference and doesn't sacrifice coverage as far as I can tell.  On my laptop, both libkbfs and FUSE-based DSL tests only each increase by ~10s.

Issue: KBFS-1912 