### PR TITLE
folder_branch_ops: cancel registration when clearing folder MD

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4954,6 +4954,12 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 		expBackoff.MaxElapsedTime = 0
 		// Register and wait in a loop unless we hit an unrecoverable error
 		fbo.cancelUpdatesLock.Lock()
+		if fbo.cancelUpdates != nil {
+			// It should be impossible to get here without having
+			// already called the cancel function, but just in case
+			// call it here again.
+			fbo.cancelUpdates()
+		}
 		ctx, fbo.cancelUpdates = context.WithCancel(ctx)
 		fbo.cancelUpdatesLock.Unlock()
 		for {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -280,6 +280,10 @@ type folderBranchOps struct {
 	// Can be used to turn off notifications for a while (e.g., for testing)
 	updatePauseChan chan (<-chan struct{})
 
+	cancelUpdatesLock sync.Mutex
+	// Cancels the goroutine currently waiting on TLF MD updates.
+	cancelUpdates context.CancelFunc
+
 	// After a shutdown, this channel will be closed when the register
 	// goroutine completes.
 	updateDoneChan chan struct{}
@@ -4949,7 +4953,9 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 		// Never give up hope until we shut down
 		expBackoff.MaxElapsedTime = 0
 		// Register and wait in a loop unless we hit an unrecoverable error
-		ctx, cancel := context.WithCancel(ctx)
+		fbo.cancelUpdatesLock.Lock()
+		ctx, fbo.cancelUpdates = context.WithCancel(ctx)
+		fbo.cancelUpdatesLock.Unlock()
 		for {
 			err := backoff.RetryNotifyWithContext(ctx, func() error {
 				// Replace the FBOID one with a fresh id for every attempt
@@ -4976,7 +4982,9 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 					fbo.log.CDebugf(ctx, "Abandoning updates since we can't "+
 						"read the newest metadata: %+v", err)
 					fbo.status.setPermErr(err)
-					cancel()
+					// No need to lock here, since `cancelUpdates` is
+					// only set within this same goroutine.
+					fbo.cancelUpdates()
 					return ctx.Err()
 				case MDServerErrorCannotReadFinalizedTLF:
 					fbo.log.CDebugf(ctx, "Abandoning updates since we can't "+
@@ -4988,7 +4996,9 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 					// new folder.
 					fbo.locallyFinalizeTLF(newCtx)
 
-					cancel()
+					// No need to lock here, since `cancelUpdates` is
+					// only set within this same goroutine.
+					fbo.cancelUpdates()
 					return ctx.Err()
 				}
 				select {
@@ -5519,8 +5529,25 @@ func (fbo *folderBranchOps) ClearPrivateFolderMD(ctx context.Context) {
 	defer fbo.mdWriterLock.Unlock(lState)
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
-
 	fbo.log.CDebugf(ctx, "Clearing folder MD")
+
+	// First cancel the background goroutine that's registered for
+	// updates, because the next time we set the head in this FBO
+	// we'll launch another one.
+	fbo.cancelUpdatesLock.Lock()
+	defer fbo.cancelUpdatesLock.Unlock()
+	if fbo.cancelUpdates != nil {
+		fbo.cancelUpdates()
+		select {
+		case <-fbo.updateDoneChan:
+		case <-ctx.Done():
+			fbo.log.CDebugf(
+				ctx, "Context canceled before updater was canceled")
+			return
+		}
+		fbo.config.MDServer().CancelRegistration(ctx, fbo.id())
+	}
+
 	fbo.head = ImmutableRootMetadata{}
 	fbo.latestMergedRevision = MetadataRevisionUninitialized
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1164,8 +1164,10 @@ type MDServer interface {
 	RegisterForUpdate(ctx context.Context, id tlf.ID,
 		currHead MetadataRevision) (<-chan error, error)
 
-	// CancelRegistration lets the MDserver know that we are no longer
-	// interested in updates for the specified folder.
+	// CancelRegistration lets the local MDServer instance know that
+	// we are no longer interested in updates for the specified
+	// folder.  It does not necessarily forward this cancellation to
+	// remote servers.
 	CancelRegistration(ctx context.Context, id tlf.ID)
 
 	// CheckForRekeys initiates the rekey checking process on the

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1164,6 +1164,10 @@ type MDServer interface {
 	RegisterForUpdate(ctx context.Context, id tlf.ID,
 		currHead MetadataRevision) (<-chan error, error)
 
+	// CancelRegistration lets the MDserver know that we are no longer
+	// interested in updates for the specified folder.
+	CancelRegistration(ctx context.Context, id tlf.ID)
+
 	// CheckForRekeys initiates the rekey checking process on the
 	// server.  The server is allowed to delay this request, and so it
 	// returns a channel for returning the error. Actual rekey

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -482,6 +482,11 @@ func (md *MDServerDisk) RegisterForUpdate(ctx context.Context, id tlf.ID,
 	return c, nil
 }
 
+// CancelRegistration implements the MDServer interface for MDServerDisk.
+func (md *MDServerDisk) CancelRegistration(_ context.Context, id tlf.ID) {
+	md.updateManager.cancel(id, md)
+}
+
 // TruncateLock implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) TruncateLock(ctx context.Context, id tlf.ID) (
 	bool, error) {

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -165,6 +165,23 @@ func (m *mdServerLocalUpdateManager) registerForUpdate(
 	return c
 }
 
+func (m *mdServerLocalUpdateManager) cancel(id tlf.ID, server mdServerLocal) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	// Cancel the registration for this server only.
+	for k, v := range m.observers[id] {
+		if k == server {
+			v <- errors.New("Registration canceled")
+			close(v)
+			delete(m.observers[id], k)
+		}
+	}
+	if len(m.observers[id]) == 0 {
+		delete(m.observers, id)
+	}
+}
+
 type keyBundleGetter func(tlf.ID, TLFWriterKeyBundleID, TLFReaderKeyBundleID) (
 	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -605,6 +605,11 @@ func (md *MDServerMemory) RegisterForUpdate(ctx context.Context, id tlf.ID,
 	return c, nil
 }
 
+// CancelRegistration implements the MDServer interface for MDServerMemory.
+func (md *MDServerMemory) CancelRegistration(_ context.Context, id tlf.ID) {
+	md.updateManager.cancel(id, md)
+}
+
 func (md *MDServerMemory) getCurrentDeviceKIDBytes(ctx context.Context) (
 	[]byte, error) {
 	buf := &bytes.Buffer{}

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -47,7 +48,9 @@ type MDServerRemote struct {
 	isAuthenticated  bool
 
 	observerMu sync.Mutex // protects observers
-	observers  map[tlf.ID]chan<- error
+	// chan is nil if we have unregistered locally, but not yet with
+	// the server.
+	observers map[tlf.ID]chan<- error
 
 	tickerCancel context.CancelFunc
 	tickerMu     sync.Mutex // protects the ticker cancel function
@@ -385,10 +388,30 @@ func (md *MDServerRemote) cancelObservers() {
 	}
 }
 
+// CancelRegistration implements the MDServer interface for MDServerRemote.
+func (md *MDServerRemote) CancelRegistration(ctx context.Context, id tlf.ID) {
+	md.observerMu.Lock()
+	defer md.observerMu.Unlock()
+	observerChan, ok := md.observers[id]
+	if !ok {
+		// not registered
+		return
+	}
+
+	// signal that we've seen the update
+	md.signalObserverLocked(
+		observerChan, id, errors.New("Registration canceled"))
+	// Setting nil here indicates that the server thinks we're still
+	// registered, though locally no one is listening.
+	md.observers[id] = nil
+}
+
 // Signal an observer. The observer lock must be held.
 func (md *MDServerRemote) signalObserverLocked(observerChan chan<- error, id tlf.ID, err error) {
-	observerChan <- err
-	close(observerChan)
+	if observerChan != nil {
+		observerChan <- err
+		close(observerChan)
+	}
 	delete(md.observers, id)
 }
 
@@ -639,16 +662,24 @@ func (md *MDServerRemote) RegisterForUpdate(ctx context.Context, id tlf.ID,
 
 		// keep re-adding the observer on retries, since
 		// disconnects or connection errors clear observers.
-		func() {
+		alreadyRegistered := func() bool {
 			md.observerMu.Lock()
 			defer md.observerMu.Unlock()
-			if _, ok := md.observers[id]; ok {
-				panic(fmt.Sprintf("Attempted double-registration for folder: %s",
-					id))
+			// It's possible for a nil channel to be in
+			// `md.observers`, if we are still registered with the
+			// server after a previous cancellation.
+			existingCh, alreadyRegistered := md.observers[id]
+			if existingCh != nil {
+				panic(fmt.Sprintf(
+					"Attempted double-registration for folder: %s", id))
 			}
 			c = make(chan error, 1)
 			md.observers[id] = c
+			return alreadyRegistered
 		}()
+		if alreadyRegistered {
+			return nil
+		}
 		// Use this instead of md.client since we're already
 		// inside a DoCommand().
 		c := keybase1.MetadataClient{Cli: rawClient}

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -401,8 +401,8 @@ func (md *MDServerRemote) CancelRegistration(ctx context.Context, id tlf.ID) {
 	// signal that we've seen the update
 	md.signalObserverLocked(
 		observerChan, id, errors.New("Registration canceled"))
-	// Setting nil here indicates that the server thinks we're still
-	// registered, though locally no one is listening.
+	// Setting nil here indicates that the remote MD server thinks
+	// we're still registered, though locally no one is listening.
 	md.observers[id] = nil
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4,8 +4,6 @@
 package libkbfs
 
 import (
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
@@ -16,6 +14,7 @@ import (
 	tlf "github.com/keybase/kbfs/tlf"
 	go_metrics "github.com/rcrowley/go-metrics"
 	context "golang.org/x/net/context"
+	time "time"
 )
 
 // Mock of dataVersioner interface
@@ -3166,6 +3165,14 @@ func (_mr *_MockMDServerRecorder) RegisterForUpdate(arg0, arg1, arg2 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterForUpdate", arg0, arg1, arg2)
 }
 
+func (_m *MockMDServer) CancelRegistration(ctx context.Context, id tlf.ID) {
+	_m.ctrl.Call(_m, "CancelRegistration", ctx, id)
+}
+
+func (_mr *_MockMDServerRecorder) CancelRegistration(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelRegistration", arg0, arg1)
+}
+
 func (_m *MockMDServer) CheckForRekeys(ctx context.Context) <-chan error {
 	ret := _m.ctrl.Call(_m, "CheckForRekeys", ctx)
 	ret0, _ := ret[0].(<-chan error)
@@ -3350,6 +3357,14 @@ func (_m *MockmdServerLocal) RegisterForUpdate(ctx context.Context, id tlf.ID, c
 
 func (_mr *_MockmdServerLocalRecorder) RegisterForUpdate(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RegisterForUpdate", arg0, arg1, arg2)
+}
+
+func (_m *MockmdServerLocal) CancelRegistration(ctx context.Context, id tlf.ID) {
+	_m.ctrl.Call(_m, "CancelRegistration", ctx, id)
+}
+
+func (_mr *_MockmdServerLocalRecorder) CancelRegistration(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CancelRegistration", arg0, arg1)
 }
 
 func (_m *MockmdServerLocal) CheckForRekeys(ctx context.Context) <-chan error {


### PR DESCRIPTION
If we don't, then the next time the head is set we'll have two update goroutines, and will end up panicking in MDServerRemote.

Issue: KBFS-1918