### PR TITLE
file_data: fix file size when writing past the end of last block

### DIFF
--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -488,15 +488,13 @@ func testFileDataOverwriteExistingFile(t *testing.T, maxBlockSize int64,
 	for _, hole := range holes {
 		for i := hole.start; i < hole.end; i++ {
 			data[i] = byte(0)
-			if holeShiftAfter == 0 {
-				if startWrite <= i && i < endWrite {
-					holeShiftAfter = i
-					// If we're writing in a hole, we might extend the
-					// block on its left edge to its block boundary,
-					// which means that's effectively the start of the
-					// write.
-					effectiveStartWrite = hole.start
-				}
+			if holeShiftAfter == 0 && startWrite <= i && i < endWrite {
+				holeShiftAfter = i
+				// If we're writing in a hole, we might extend the
+				// block on its left edge to its block boundary,
+				// which means that's effectively the start of the
+				// write.
+				effectiveStartWrite = hole.start
 			}
 		}
 	}


### PR DESCRIPTION
We were not properly setting the file size when writing to an offset
past the end of the last block of a file.  For example, say we had
2-byte blocks, and the existing file was 5 bytes long.  If we then
wrote 6 bytes starting at offset 10, we would create a new block at
off=10 and count for its new data, and in some cases we'd count for
the new byte that extends the block from 5 to 6, but we wouldn't count
the gap between 6 and 10, and so the file would be reported as size
12, rather than size 16.

This is a general problem, but came up specifically when a write
slipped in between a sync updating a file's path, and the sync
executing the deferred writes for that file.  In that case, even
though it was a contiguous write, it looked like the offset was bigger
than the file since we hadn't applied the deferred writes yet.

This also adds some fileData tests that catch the issue.

Issue: KBFS-1915