### PR TITLE
block_types: handle data version for an empty iptrs list

### DIFF
--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -190,6 +190,12 @@ func (fb *FileBlock) DataVersion() DataVer {
 		return FirstValidDataVer
 	}
 
+	if len(fb.IPtrs) == 0 {
+		// This is a truncated file block that hasn't had its level of
+		// indirection removed.
+		return FirstValidDataVer
+	}
+
 	// If this is an indirect block, and none of its children are
 	// marked as direct blocks, then this must be a big file.  Note
 	// that we do it this way, rather than returning on the first


### PR DESCRIPTION
A list of IPtrs in an indirect block can be empty if the file has been
truncated to 0 bytes, since we don't currently remove the level of
indirection in that case.

Issue: KBFS-1924