### PR TITLE
file_data: treat unknown children as direct blocks

### DIFF
--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -24,9 +24,10 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 	maxPtrsPerBlock int) (*fileData, BlockCache, DirtyBlockCache, *dirtyFile) {
 	// Make a fake file.
 	ptr := BlockPointer{
-		ID:      kbfsblock.FakeID(42),
-		KeyGen:  1,
-		DataVer: 1,
+		ID:         kbfsblock.FakeID(42),
+		KeyGen:     1,
+		DataVer:    1,
+		DirectType: DirectBlock,
 	}
 	id := tlf.FakeID(1, false)
 	file := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "file"}}}
@@ -378,13 +379,18 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 			children = prevChildren[prevChildIndex:newIndex]
 			fblock := NewFileBlock().(*FileBlock)
 			fblock.IsInd = true
+			dt := DirectBlock
+			if numLevels > 1 {
+				dt = IndirectBlock
+			}
 			for j, child := range children {
 				id, err := crypto.MakeTemporaryBlockID()
 				require.NoError(t, err)
 				ptr := BlockPointer{
-					ID:      id,
-					KeyGen:  1,
-					DataVer: 1,
+					ID:         id,
+					KeyGen:     1,
+					DataVer:    1,
+					DirectType: dt,
 				}
 				var off int64
 				if child.IsInd {
@@ -405,6 +411,11 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 		prevChildren = level
 		numLevels++
 	}
+
+	if numLevels > 1 {
+		fd.file.path[len(fd.file.path)-1].DirectType = IndirectBlock
+	}
+
 	cleanBcache.Put(
 		fd.rootBlockPointer(), fd.file.Tlf, prevChildren[0], TransientEntry)
 	return prevChildren[0], numLevels

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -25,8 +25,6 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 	// Make a fake file.
 	ptr := BlockPointer{
 		ID:         kbfsblock.FakeID(42),
-		KeyGen:     1,
-		DataVer:    1,
 		DirectType: DirectBlock,
 	}
 	id := tlf.FakeID(1, false)
@@ -388,8 +386,6 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 				require.NoError(t, err)
 				ptr := BlockPointer{
 					ID:         id,
-					KeyGen:     1,
-					DataVer:    1,
 					DirectType: dt,
 				}
 				var off int64


### PR DESCRIPTION
Since we didn't have multiple levels of indirection before introducing
the direct type.  Without this, a new client removing an old file
needs to download all child direct data blocks, which can be slow.

Also fix temporary block pointers and the fileData test to set direct
types on block pointers, since otherwise we'd violate the above
assumption about multiple levels of indirection.

Issue: KBFS-1924