### PR TITLE
tlf_journal: relax stored bytes panic when block already exists

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1513,7 +1513,10 @@ func (j *tlfJournal) putBlockData(
 
 	storedBytesAfter := j.blockJournal.getStoredBytes()
 
-	if storedBytesAfter != (storedBytesBefore + bufLen) {
+	// Either the stored bytes increased by `bufLen`, or stayed the
+	// same because the already existed.
+	if storedBytesAfter != (storedBytesBefore+bufLen) &&
+		storedBytesBefore != storedBytesAfter {
 		panic(fmt.Sprintf(
 			"storedBytes changed from %d to %d, but bufLen is %d",
 			storedBytesBefore, storedBytesAfter, bufLen))


### PR DESCRIPTION
It's possible for the same block to be put multiple times, which
doesn't increase the stored bytes count.  This happens in particular
when a Sync fails because the disk acquire times out, and then the
Sync gets retried.

Issue: KBFS-1926