### PR TITLE
[KBFS-1895] Refactor before Prefetching Workers

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -38,7 +38,7 @@ func NewBlockOpsStandard(config blockOpsConfig,
 		blockRetrievalParentConfig: config,
 		bg: bg,
 	}
-	q := newBlockRetrievalQueue(queueSize, defaultNumPrefetchWorkers, qConfig)
+	q := newBlockRetrievalQueue(queueSize, qConfig)
 	bops := &BlockOpsStandard{
 		config: config,
 		queue:  q,

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -44,10 +44,10 @@ func NewBlockOpsStandard(config blockOpsConfig,
 	}
 	bg := &realBlockGetter{config: config}
 	for i := 0; i < queueSize; i++ {
-		bops.workers = append(bops.workers, newBlockRetrievalWorker(bg, bops.queue))
+		bops.workers = append(bops.workers, newBlockRetrievalWorker(bg, bops.queue, false))
 	}
 	for i := 0; i < defaultNumPrefetchWorkers; i++ {
-		bops.prefetchWorkers = append(bops.prefetchWorkers, newBlockRetrievalWorker(bg, bops.queue))
+		bops.prefetchWorkers = append(bops.prefetchWorkers, newBlockRetrievalWorker(bg, bops.queue, true))
 	}
 	return bops
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -35,7 +35,7 @@ func NewBlockOpsStandard(config blockOpsConfig,
 	queueSize int) *BlockOpsStandard {
 	bg := &realBlockGetter{config: config}
 	qConfig := &realBlockRetrievalConfig{
-		blockRetrievalParentConfig: config,
+		blockRetrievalPartialConfig: config,
 		bg: bg,
 	}
 	q := newBlockRetrievalQueue(queueSize, qConfig)

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -21,19 +21,19 @@ const (
 	defaultOnDemandRequestPriority       int = 100
 )
 
-type blockRetrievalParentConfig interface {
+type blockRetrievalPartialConfig interface {
 	dataVersioner
 	logMaker
 	blockCacher
 }
 
 type blockRetrievalConfig interface {
-	blockRetrievalParentConfig
+	blockRetrievalPartialConfig
 	blockGetter() blockGetter
 }
 
 type realBlockRetrievalConfig struct {
-	blockRetrievalParentConfig
+	blockRetrievalPartialConfig
 	bg blockGetter
 }
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -158,6 +158,7 @@ func (brq *blockRetrievalQueue) popIfNotEmpty() *blockRetrieval {
 
 // notifyWorker notifies workers that there is a new request for processing.
 func (brq *blockRetrievalQueue) notifyWorker() {
+	// FIXME: this defeats the prioritized queueing. Completely.
 	retrieval := brq.popIfNotEmpty()
 	workerCh := brq.workerQueue
 	if retrieval.priority < defaultOnDemandRequestPriority {

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -236,12 +236,9 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context, priority int, kmd K
 	}
 }
 
-// WorkOnRequest returns a new channel for a worker to obtain a blockRetrieval.
-func (brq *blockRetrievalQueue) WorkOnRequest() <-chan *blockRetrieval {
-	ch := make(chan *blockRetrieval, 1)
+// Work accepts a worker's channel to assign work.
+func (brq *blockRetrievalQueue) Work(ch chan<- *blockRetrieval) {
 	brq.workerQueue <- ch
-
-	return ch
 }
 
 // FinalizeRequest is the last step of a retrieval request once a block has

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -105,8 +105,8 @@ type blockRetrievalQueue struct {
 var _ blockRetriever = (*blockRetrievalQueue)(nil)
 
 // newBlockRetrievalQueue creates a new block retrieval queue. The numWorkers
-// parameter determines how many workers can concurrently call WorkOnRequest
-// (more than numWorkers will block).
+// parameter determines how many workers can concurrently call Work (more than
+// numWorkers will block).
 func newBlockRetrievalQueue(numWorkers int, config blockRetrievalConfig) *blockRetrievalQueue {
 	q := &blockRetrievalQueue{
 		config:              config,
@@ -244,6 +244,11 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context, priority int, kmd K
 // Work accepts a worker's channel to assign work.
 func (brq *blockRetrievalQueue) Work(ch chan<- *blockRetrieval) {
 	brq.workerQueue <- ch
+}
+
+// PrefetchWork accepts a prefetch worker's channel to assign work.
+func (brq *blockRetrievalQueue) PrefetchWork(ch chan<- *blockRetrieval) {
+	brq.prefetchWorkerQueue <- ch
 }
 
 // FinalizeRequest is the last step of a retrieval request once a block has

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -91,7 +91,8 @@ type blockRetrievalQueue struct {
 	// This is a channel of channels to maximize the time that each request is
 	// in the heap, allowing preemption as long as possible. This way, a
 	// request only exits the heap once a worker is ready.
-	workerQueue chan chan *blockRetrieval
+	workerQueue         chan chan<- *blockRetrieval
+	prefetchWorkerQueue chan chan<- *blockRetrieval
 	// channel to be closed when we're done accepting requests
 	doneCh chan struct{}
 
@@ -111,8 +112,8 @@ func newBlockRetrievalQueue(numWorkers int, config blockRetrievalConfig) *blockR
 		config:              config,
 		ptrs:                make(map[blockPtrLookup]*blockRetrieval),
 		heap:                &blockRetrievalHeap{},
-		workerQueue:         make(chan chan *blockRetrieval, numWorkers),
-		prefetchWorkerQueue: make(chan chan *blockRetrieval, defaultNumPrefetchWorkers),
+		workerQueue:         make(chan chan<- *blockRetrieval, numWorkers),
+		prefetchWorkerQueue: make(chan chan<- *blockRetrieval, defaultNumPrefetchWorkers),
 		doneCh:              make(chan struct{}),
 	}
 	q.prefetcher = newBlockPrefetcher(q, config)

--- a/libkbfs/block_retrieval_worker.go
+++ b/libkbfs/block_retrieval_worker.go
@@ -13,6 +13,7 @@ type blockRetrievalWorker struct {
 	blockGetter
 	stopCh chan struct{}
 	queue  *blockRetrievalQueue
+	workCh chan *blockRetrieval
 }
 
 // run runs the worker loop until Shutdown is called
@@ -35,6 +36,7 @@ func newBlockRetrievalWorker(bg blockGetter, q *blockRetrievalQueue) *blockRetri
 		blockGetter: bg,
 		stopCh:      make(chan struct{}),
 		queue:       q,
+		workCh:      make(chan *blockRetrieval, 1),
 	}
 	go brw.run()
 	return brw
@@ -45,10 +47,10 @@ func newBlockRetrievalWorker(bg blockGetter, q *blockRetrievalQueue) *blockRetri
 // blockGetter.getBlock, and responds to the subscribed requestors with the
 // results.
 func (brw *blockRetrievalWorker) HandleRequest() (err error) {
-	retrievalCh := brw.queue.WorkOnRequest()
+	brw.queue.Work(brw.workCh)
 	var retrieval *blockRetrieval
 	select {
-	case retrieval = <-retrievalCh:
+	case retrieval = <-brw.workCh:
 		if retrieval == nil {
 			panic("Received a nil block retrieval. This should never happen.")
 		}

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -105,7 +105,7 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	defer q.Shutdown()
 
 	bg := newFakeBlockGetter(false)
-	w := newBlockRetrievalWorker(bg, q)
+	w := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w)
 	defer w.Shutdown()
 
@@ -128,7 +128,7 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	defer q.Shutdown()
 
 	bg := newFakeBlockGetter(false)
-	w1, w2 := newBlockRetrievalWorker(bg, q), newBlockRetrievalWorker(bg, q)
+	w1, w2 := newBlockRetrievalWorker(bg, q, true), newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w1)
 	require.NotNil(t, w2)
 	defer w1.Shutdown()
@@ -171,7 +171,7 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	defer q.Shutdown()
 
 	bg := newFakeBlockGetter(false)
-	w1 := newBlockRetrievalWorker(bg, q)
+	w1 := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w1)
 	defer w1.Shutdown()
 
@@ -222,7 +222,7 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	defer q.Shutdown()
 
 	bg := newFakeBlockGetter(true)
-	w := newBlockRetrievalWorker(bg, q)
+	w := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w)
 	defer w.Shutdown()
 
@@ -245,7 +245,7 @@ func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	defer q.Shutdown()
 
 	bg := newFakeBlockGetter(false)
-	w := newBlockRetrievalWorker(bg, q)
+	w := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w)
 
 	ptr1 := makeRandomBlockPointer(t)
@@ -278,7 +278,7 @@ func TestBlockRetrievalWorkerMultipleBlockTypes(t *testing.T) {
 	defer q.Shutdown()
 
 	bg := newFakeBlockGetter(false)
-	w1 := newBlockRetrievalWorker(bg, q)
+	w1 := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w1)
 	defer w1.Shutdown()
 

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -100,11 +100,11 @@ func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {
 
 func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
+	bg := newFakeBlockGetter(false)
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	bg := newFakeBlockGetter(false)
 	w := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w)
 	defer w.Shutdown()
@@ -123,11 +123,11 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 
 func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	t.Log("Test the ability of multiple workers to retrieve concurrently.")
-	q := newBlockRetrievalQueue(2, newTestBlockRetrievalConfig(t))
+	bg := newFakeBlockGetter(false)
+	q := newBlockRetrievalQueue(0, 2, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	bg := newFakeBlockGetter(false)
 	w1, w2 := newBlockRetrievalWorker(bg, q, true), newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w1)
 	require.NotNil(t, w2)
@@ -166,11 +166,11 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 
 func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	t.Log("Test the ability of a worker and queue to work correctly together.")
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
+	bg := newFakeBlockGetter(false)
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	bg := newFakeBlockGetter(false)
 	w1 := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w1)
 	defer w1.Shutdown()
@@ -217,11 +217,11 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 
 func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	t.Log("Test the ability of a worker to handle a request cancelation.")
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
+	bg := newFakeBlockGetter(true)
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	bg := newFakeBlockGetter(true)
 	w := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w)
 	defer w.Shutdown()
@@ -240,11 +240,11 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 
 func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	t.Log("Test that worker shutdown works.")
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
+	bg := newFakeBlockGetter(false)
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	bg := newFakeBlockGetter(false)
 	w := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w)
 
@@ -273,11 +273,11 @@ func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 func TestBlockRetrievalWorkerMultipleBlockTypes(t *testing.T) {
 	t.Log("Test that we can retrieve the same block into different block types.")
 	codec := kbfscodec.NewMsgpack()
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t))
+	bg := newFakeBlockGetter(false)
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	bg := newFakeBlockGetter(false)
 	w1 := newBlockRetrievalWorker(bg, q, true)
 	require.NotNil(t, w1)
 	defer w1.Shutdown()

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -101,11 +101,11 @@ func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {
 func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
+	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q, true)
+	w := newBlockRetrievalWorker(bg, q)
 	require.NotNil(t, w)
 	defer w.Shutdown()
 
@@ -124,15 +124,9 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	t.Log("Test the ability of multiple workers to retrieve concurrently.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 2, newTestBlockRetrievalConfig(t, bg))
+	q := newBlockRetrievalQueue(2, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
-
-	w1, w2 := newBlockRetrievalWorker(bg, q, true), newBlockRetrievalWorker(bg, q, true)
-	require.NotNil(t, w1)
-	require.NotNil(t, w2)
-	defer w1.Shutdown()
-	defer w2.Shutdown()
 
 	ptr1, ptr2 := makeRandomBlockPointer(t), makeRandomBlockPointer(t)
 	block1, block2 := makeFakeFileBlock(t, false), makeFakeFileBlock(t, false)
@@ -167,13 +161,9 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	t.Log("Test the ability of a worker and queue to work correctly together.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
+	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
-
-	w1 := newBlockRetrievalWorker(bg, q, true)
-	require.NotNil(t, w1)
-	defer w1.Shutdown()
 
 	ptr1, ptr2, ptr3 := makeRandomBlockPointer(t), makeRandomBlockPointer(t), makeRandomBlockPointer(t)
 	block1, block2, block3 := makeFakeFileBlock(t, false), makeFakeFileBlock(t, false), makeFakeFileBlock(t, false)
@@ -218,11 +208,11 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	t.Log("Test the ability of a worker to handle a request cancelation.")
 	bg := newFakeBlockGetter(true)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
+	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q, true)
+	w := newBlockRetrievalWorker(bg, q)
 	require.NotNil(t, w)
 	defer w.Shutdown()
 
@@ -241,11 +231,11 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	t.Log("Test that worker shutdown works.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
+	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q, true)
+	w := newBlockRetrievalWorker(bg, q)
 	require.NotNil(t, w)
 
 	ptr1 := makeRandomBlockPointer(t)
@@ -274,13 +264,9 @@ func TestBlockRetrievalWorkerMultipleBlockTypes(t *testing.T) {
 	t.Log("Test that we can retrieve the same block into different block types.")
 	codec := kbfscodec.NewMsgpack()
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg))
+	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg))
 	require.NotNil(t, q)
 	defer q.Shutdown()
-
-	w1 := newBlockRetrievalWorker(bg, q, true)
-	require.NotNil(t, w1)
-	defer w1.Shutdown()
 
 	t.Log("Setup source blocks")
 	ptr1 := makeRandomBlockPointer(t)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -110,7 +110,7 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, config.BlockCache(), t}))
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, config.BlockCache(), nil, t}))
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -56,28 +56,20 @@ func makeFakeDirBlock(t *testing.T, name string) *DirBlock {
 }
 
 func initPrefetcherTest(t *testing.T) (*blockRetrievalQueue,
-	*blockRetrievalWorker, *blockRetrievalWorker, *fakeBlockGetter,
-	*testBlockRetrievalConfig) {
-	config := newTestBlockRetrievalConfig(t)
-	q := newBlockRetrievalQueue(1, config)
-	require.NotNil(t, q)
-
+	*fakeBlockGetter, *testBlockRetrievalConfig) {
 	// We don't want the block getter to respect cancelation, because we need
 	// <-q.Prefetcher().Shutdown() to represent whether the retrieval requests
 	// _actually_ completed.
 	bg := newFakeBlockGetter(false)
-	w1 := newBlockRetrievalWorker(bg, q, true)
-	require.NotNil(t, w1)
-	w2 := newBlockRetrievalWorker(bg, q, false)
-	require.NotNil(t, w2)
+	config := newTestBlockRetrievalConfig(t, bg)
+	q := newBlockRetrievalQueue(1, 1, config)
+	require.NotNil(t, q)
 
-	return q, w1, w2, bg, config
+	return q, bg, config
 }
 
-func shutdownPrefetcherTest(q *blockRetrievalQueue, w1, w2 *blockRetrievalWorker) {
+func shutdownPrefetcherTest(q *blockRetrievalQueue) {
 	q.Shutdown()
-	w1.Shutdown()
-	w2.Shutdown()
 }
 
 func testPrefetcherCheckGet(t *testing.T, bcache BlockCache,
@@ -96,8 +88,8 @@ func testPrefetcherCheckGet(t *testing.T, bcache BlockCache,
 
 func TestPrefetcherIndirectFileBlock(t *testing.T) {
 	t.Log("Test indirect file block prefetching.")
-	q, w1, w2, bg, config := initPrefetcherTest(t)
-	defer shutdownPrefetcherTest(q, w1, w2)
+	q, bg, config := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q)
 
 	t.Log("Initialize an indirect file block pointing to 2 file data blocks.")
 	ptrs := []IndirectFilePtr{
@@ -139,8 +131,8 @@ func TestPrefetcherIndirectFileBlock(t *testing.T) {
 
 func TestPrefetcherIndirectDirBlock(t *testing.T) {
 	t.Log("Test indirect dir block prefetching.")
-	q, w1, w2, bg, config := initPrefetcherTest(t)
-	defer shutdownPrefetcherTest(q, w1, w2)
+	q, bg, config := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q)
 
 	t.Log("Initialize an indirect dir block pointing to 2 dir data blocks.")
 	ptrs := []IndirectDirPtr{
@@ -182,8 +174,8 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 
 func TestPrefetcherDirectDirBlock(t *testing.T) {
 	t.Log("Test direct dir block prefetching.")
-	q, w1, w2, bg, config := initPrefetcherTest(t)
-	defer shutdownPrefetcherTest(q, w1, w2)
+	q, bg, config := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q)
 
 	t.Log("Initialize a direct dir block with entries pointing to 3 files.")
 	file1 := makeFakeFileBlock(t, true)
@@ -239,9 +231,9 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 
 func TestPrefetcherAlreadyCached(t *testing.T) {
 	t.Log("Test direct dir block prefetching when the dir block is cached.")
-	q, w1, w2, bg, config := initPrefetcherTest(t)
+	q, bg, config := initPrefetcherTest(t)
 	cache := config.BlockCache()
-	defer shutdownPrefetcherTest(q, w1, w2)
+	defer shutdownPrefetcherTest(q)
 
 	t.Log("Initialize a direct dir block with an entry pointing to 1 folder, which in turn points to 1 file.")
 	file1 := makeFakeFileBlock(t, true)
@@ -323,10 +315,10 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 
 func TestPrefetcherNoPrefetchWhileCacheFull(t *testing.T) {
 	t.Log("Test that prefetches aren't triggered when the cache is full with permanent entries.")
-	q, w1, w2, bg, config := initPrefetcherTest(t)
+	q, bg, config := initPrefetcherTest(t)
 	cache := NewBlockCacheStandard(1, uint64(1))
 	config.testCache = cache
-	defer shutdownPrefetcherTest(q, w1, w2)
+	defer shutdownPrefetcherTest(q)
 
 	t.Log("Initialize a direct dir block with an entry pointing to 1 file.")
 	file1 := makeFakeFileBlock(t, true)
@@ -366,9 +358,9 @@ func TestPrefetcherNoPrefetchWhileCacheFull(t *testing.T) {
 
 func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 	t.Log("Test that prefetches are only triggered once for a given block.")
-	q, w1, w2, bg, config := initPrefetcherTest(t)
+	q, bg, config := initPrefetcherTest(t)
 	cache := config.BlockCache().(*BlockCacheStandard)
-	defer shutdownPrefetcherTest(q, w1, w2)
+	defer shutdownPrefetcherTest(q)
 
 	t.Log("Initialize a direct dir block with an entry pointing to 1 file.")
 	file1 := makeFakeFileBlock(t, true)

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -62,7 +62,7 @@ func initPrefetcherTest(t *testing.T) (*blockRetrievalQueue,
 	// _actually_ completed.
 	bg := newFakeBlockGetter(false)
 	config := newTestBlockRetrievalConfig(t, bg)
-	q := newBlockRetrievalQueue(1, 1, config)
+	q := newBlockRetrievalQueue(1, config)
 	require.NotNil(t, q)
 
 	return q, bg, config


### PR DESCRIPTION
Let's get this refactor in no matter what, because it's better separation of concerns, and will make it easier to add prefetch workers if we still want to.