### PR TITLE
libkbfs: store block type in context, and track MD bytes separately

### DIFF
--- a/kbfsblock/context.go
+++ b/kbfsblock/context.go
@@ -62,6 +62,10 @@ type Context struct {
 	// RefNonce (it can't be a monotonically increasing number because
 	// that would require coordination among clients).
 	RefNonce RefNonce `codec:"r,omitempty"`
+	// BlockType indicates the type of the block (data
+	// vs. metadata). This is used, for example, when deciding how the
+	// block affects quotas.
+	BlockType keybase1.BlockType `codec:"b,omitempty"`
 }
 
 // MakeFirstContext makes the initial context for a block with the
@@ -104,6 +108,11 @@ func (c *Context) SetWriter(newWriter keybase1.UID) {
 // GetRefNonce returns the ref nonce of the associated block.
 func (c Context) GetRefNonce() RefNonce {
 	return c.RefNonce
+}
+
+// GetBlockType returns the block type of the associated block.
+func (c Context) GetBlockType() keybase1.BlockType {
+	return c.BlockType
 }
 
 // IsFirstRef returns whether or not p represents the first reference

--- a/kbfsblock/context.go
+++ b/kbfsblock/context.go
@@ -70,15 +70,21 @@ type Context struct {
 
 // MakeFirstContext makes the initial context for a block with the
 // given creator.
-func MakeFirstContext(creator keybase1.UID) Context {
-	return Context{Creator: creator}
+func MakeFirstContext(creator keybase1.UID, bType keybase1.BlockType) Context {
+	return Context{Creator: creator, BlockType: bType}
 }
 
 // MakeContext makes a context with the given creator, writer, and
 // nonce, where the writer is not necessarily equal to the creator,
 // and the nonce is usually non-zero.
-func MakeContext(creator, writer keybase1.UID, nonce RefNonce) Context {
-	return Context{Creator: creator, Writer: writer, RefNonce: nonce}
+func MakeContext(creator, writer keybase1.UID, nonce RefNonce,
+	bType keybase1.BlockType) Context {
+	return Context{
+		Creator:   creator,
+		Writer:    writer,
+		RefNonce:  nonce,
+		BlockType: bType,
+	}
 }
 
 // GetCreator returns the creator of the associated block.

--- a/kbfsblock/context.go
+++ b/kbfsblock/context.go
@@ -138,6 +138,9 @@ func (c Context) String() string {
 	if c.RefNonce != ZeroRefNonce {
 		s += fmt.Sprintf(", RefNonce: %s", c.RefNonce)
 	}
+	if c.BlockType != keybase1.BlockType_DATA {
+		s += ", BlockType: MD"
+	}
 	s += "}"
 	return s
 }

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -205,8 +205,10 @@ func makeFakeWriterMetadataV2Future(t *testing.T) writerMetadataV2Future {
 		NullBranchID,
 		0xa,
 		100,
+		0,
 		99,
 		101,
+		0,
 		WriterMetadataExtraV2{},
 	}
 	wkb := makeFakeTLFWriterKeyBundleV2Future(t)

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -46,10 +46,14 @@ type WriterMetadataV3 struct {
 
 	// Estimated disk usage at this revision
 	DiskUsage uint64
-	// The total number of bytes in new blocks
+	// Estimated MD disk usage at this revision
+	MDDiskUsage uint64 `codec:",omitempty"`
+	// The total number of bytes in new data blocks
 	RefBytes uint64
 	// The total number of bytes in unreferenced blocks
 	UnrefBytes uint64
+	// The total number of bytes in new MD blocks
+	MDRefBytes uint64 `codec:",omitempty"`
 
 	codec.UnknownFieldSetHandler
 }
@@ -486,6 +490,16 @@ func (md *BareRootMetadataV3) CheckValidSuccessor(
 			actualDiskUsage:   nextMd.DiskUsage(),
 		}
 	}
+	expectedMDUsage := md.MDDiskUsage()
+	if !nextMd.IsWriterMetadataCopiedSet() {
+		expectedMDUsage += nextMd.MDRefBytes()
+	}
+	if nextMd.MDDiskUsage() != expectedMDUsage {
+		return MDDiskUsageMismatch{
+			expectedDiskUsage: expectedMDUsage,
+			actualDiskUsage:   nextMd.MDDiskUsage(),
+		}
+	}
 
 	// TODO: Check that the successor (bare) TLF handle is the
 	// same or more resolved.
@@ -864,9 +878,19 @@ func (md *BareRootMetadataV3) UnrefBytes() uint64 {
 	return md.WriterMetadata.UnrefBytes
 }
 
+// MDRefBytes implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) MDRefBytes() uint64 {
+	return md.WriterMetadata.MDRefBytes
+}
+
 // DiskUsage implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) DiskUsage() uint64 {
 	return md.WriterMetadata.DiskUsage
+}
+
+// MDDiskUsage implements the BareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) MDDiskUsage() uint64 {
+	return md.WriterMetadata.MDDiskUsage
 }
 
 // SetRefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
@@ -879,9 +903,19 @@ func (md *BareRootMetadataV3) SetUnrefBytes(unrefBytes uint64) {
 	md.WriterMetadata.UnrefBytes = unrefBytes
 }
 
+// SetMDRefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetMDRefBytes(mdRefBytes uint64) {
+	md.WriterMetadata.MDRefBytes = mdRefBytes
+}
+
 // SetDiskUsage implements the MutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) SetDiskUsage(diskUsage uint64) {
 	md.WriterMetadata.DiskUsage = diskUsage
+}
+
+// SetMDDiskUsage implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetMDDiskUsage(mdDiskUsage uint64) {
+	md.WriterMetadata.MDDiskUsage = mdDiskUsage
 }
 
 // AddRefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
@@ -894,9 +928,19 @@ func (md *BareRootMetadataV3) AddUnrefBytes(unrefBytes uint64) {
 	md.WriterMetadata.UnrefBytes += unrefBytes
 }
 
+// AddMDRefBytes implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AddMDRefBytes(mdRefBytes uint64) {
+	md.WriterMetadata.MDRefBytes += mdRefBytes
+}
+
 // AddDiskUsage implements the MutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) AddDiskUsage(diskUsage uint64) {
 	md.WriterMetadata.DiskUsage += diskUsage
+}
+
+// AddMDDiskUsage implements the MutableBareRootMetadata interface for BareRootMetadataV3.
+func (md *BareRootMetadataV3) AddMDDiskUsage(mdDiskUsage uint64) {
+	md.WriterMetadata.MDDiskUsage += mdDiskUsage
 }
 
 // RevisionNumber implements the BareRootMetadata interface for BareRootMetadataV3.

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -40,7 +40,7 @@ func putBlockDisk(
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
-	bCtx := kbfsblock.MakeFirstContext(uid1)
+	bCtx := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
@@ -58,7 +58,7 @@ func addBlockDiskRef(
 
 	uid1 := keybase1.MakeTestUID(1)
 	uid2 := keybase1.MakeTestUID(2)
-	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce)
+	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce, keybase1.BlockType_DATA)
 	err = s.addReference(bID, bCtx2, "")
 	require.NoError(t, err)
 	return bCtx2
@@ -141,7 +141,7 @@ func TestBlockDiskStoreArchiveNonExistentReference(t *testing.T) {
 
 	uid1 := keybase1.MakeTestUID(1)
 
-	bCtx := kbfsblock.MakeFirstContext(uid1)
+	bCtx := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -151,7 +151,7 @@ func putBlockData(
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
-	bCtx := kbfsblock.MakeFirstContext(uid1)
+	bCtx := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
@@ -174,7 +174,7 @@ func addBlockRef(
 
 	uid1 := keybase1.MakeTestUID(1)
 	uid2 := keybase1.MakeTestUID(2)
-	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce)
+	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce, keybase1.BlockType_DATA)
 	err = j.addReference(ctx, bID, bCtx2)
 	require.NoError(t, err)
 	require.Equal(t, oldLength+1, getBlockJournalLength(t, j))
@@ -233,7 +233,7 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
-	bCtx := kbfsblock.MakeFirstContext(uid1)
+	bCtx := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
@@ -301,7 +301,7 @@ func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
 
 	uid1 := keybase1.MakeTestUID(1)
 
-	bCtx := kbfsblock.MakeFirstContext(uid1)
+	bCtx := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
@@ -1094,7 +1094,7 @@ func TestBlockJournalByteCounters(t *testing.T) {
 	// first.
 
 	uid1 := keybase1.MakeTestUID(1)
-	bCtx3 := kbfsblock.MakeFirstContext(uid1)
+	bCtx3 := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 	serverHalf3, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -318,7 +318,8 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	id, _, readyBlockData, err := bops.Ready(ctx, kmd1, block)
 	require.NoError(t, err)
 
-	bCtx := kbfsblock.MakeFirstContext(keybase1.MakeTestUID(1))
+	bCtx := kbfsblock.MakeFirstContext(
+		keybase1.MakeTestUID(1), keybase1.BlockType_DATA)
 	err = config.bserver.Put(ctx, tlfID, id, bCtx,
 		readyBlockData.buf, readyBlockData.serverHalf)
 	require.NoError(t, err)
@@ -347,7 +348,8 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 	id, _, _, err := bops.Ready(ctx, kmd, &FileBlock{})
 	require.NoError(t, err)
 
-	bCtx := kbfsblock.MakeFirstContext(keybase1.MakeTestUID(1))
+	bCtx := kbfsblock.MakeFirstContext(
+		keybase1.MakeTestUID(1), keybase1.BlockType_DATA)
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
 		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
@@ -387,7 +389,8 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 	id, _, readyBlockData, err := bops.Ready(ctx, kmd, &FileBlock{})
 	require.NoError(t, err)
 
-	bCtx := kbfsblock.MakeFirstContext(keybase1.MakeTestUID(1))
+	bCtx := kbfsblock.MakeFirstContext(
+		keybase1.MakeTestUID(1), keybase1.BlockType_DATA)
 	err = config.bserver.Put(ctx, tlfID, id, bCtx,
 		readyBlockData.buf, readyBlockData.serverHalf)
 	require.NoError(t, err)
@@ -414,7 +417,8 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	id, _, readyBlockData, err := bops.Ready(ctx, kmd, &FileBlock{})
 	require.NoError(t, err)
 
-	bCtx := kbfsblock.MakeFirstContext(keybase1.MakeTestUID(1))
+	bCtx := kbfsblock.MakeFirstContext(
+		keybase1.MakeTestUID(1), keybase1.BlockType_DATA)
 	err = config.bserver.Put(ctx, tlfID, id, bCtx,
 		readyBlockData.buf, readyBlockData.serverHalf)
 	require.NoError(t, err)
@@ -482,7 +486,8 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 	decodeErr := errors.New("could not decode")
 	badDecoder.putError(readyBlockData.buf, decodeErr)
 
-	bCtx := kbfsblock.MakeFirstContext(keybase1.MakeTestUID(1))
+	bCtx := kbfsblock.MakeFirstContext(
+		keybase1.MakeTestUID(1), keybase1.BlockType_DATA)
 	err = config.bserver.Put(ctx, tlfID, id, bCtx,
 		readyBlockData.buf, readyBlockData.serverHalf)
 	require.NoError(t, err)
@@ -519,7 +524,8 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	id, _, readyBlockData, err := bops.Ready(ctx, kmd, &FileBlock{})
 	require.NoError(t, err)
 
-	bCtx := kbfsblock.MakeFirstContext(keybase1.MakeTestUID(1))
+	bCtx := kbfsblock.MakeFirstContext(
+		keybase1.MakeTestUID(1), keybase1.BlockType_DATA)
 	err = config.bserver.Put(ctx, tlfID, id, bCtx,
 		readyBlockData.buf, readyBlockData.serverHalf)
 	require.NoError(t, err)

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
@@ -64,6 +65,7 @@ func makeRandomBlockPointer(t *testing.T) BlockPointer {
 			"fake creator",
 			"fake writer",
 			kbfsblock.RefNonce{0xb},
+			keybase1.BlockType_DATA,
 		),
 	}
 }

--- a/libkbfs/block_types_test.go
+++ b/libkbfs/block_types_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -18,6 +19,7 @@ func makeFakeBlockContext(t *testing.T) kbfsblock.Context {
 		"fake creator",
 		"fake writer",
 		kbfsblock.RefNonce{0xb},
+		keybase1.BlockType_DATA,
 	)
 }
 

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -283,10 +284,14 @@ func makeBlockIDCombo(id kbfsblock.ID, context kbfsblock.Context) keybase1.Block
 	return keybase1.BlockIdCombo{
 		BlockHash: id.String(),
 		ChargedTo: context.GetCreator(),
+		BlockType: context.GetBlockType(),
 	}
 }
 
 func makeBlockReference(id kbfsblock.ID, context kbfsblock.Context) keybase1.BlockReference {
+	if context.GetBlockType() == keybase1.BlockType_MD {
+		panic(fmt.Sprintf("Can't make a reference for md block %s", id))
+	}
 	return keybase1.BlockReference{
 		Bid: makeBlockIDCombo(id, context),
 		// The actual writer to modify quota for.

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -6,7 +6,6 @@ package libkbfs
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -289,9 +288,8 @@ func makeBlockIDCombo(id kbfsblock.ID, context kbfsblock.Context) keybase1.Block
 }
 
 func makeBlockReference(id kbfsblock.ID, context kbfsblock.Context) keybase1.BlockReference {
-	if context.GetBlockType() == keybase1.BlockType_MD {
-		panic(fmt.Sprintf("Can't make a reference for md block %s", id))
-	}
+	// Block references to MD blocks are allowed, because they can be
+	// deleted in the case of an MD put failing.
 	return keybase1.BlockReference{
 		Bid: makeBlockIDCombo(id, context),
 		// The actual writer to modify quota for.

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -78,7 +78,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	b := newBlockServerRemoteWithClient(codec, nil, log, &fc)
 
 	tlfID := tlf.FakeID(2, false)
-	bCtx := kbfsblock.MakeFirstContext(currentUID)
+	bCtx := kbfsblock.MakeFirstContext(currentUID, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	nonce, err := kbfsblock.MakeRefNonce()
 	require.NoError(t, err)
 	bCtx2 := kbfsblock.MakeContext(
-		currentUID, keybase1.MakeTestUID(2), nonce)
+		currentUID, keybase1.MakeTestUID(2), nonce, keybase1.BlockType_DATA)
 	err = b.AddBlockReference(ctx, tlfID, bID, bCtx2)
 	require.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 	f := func(ctx context.Context) error {
 		bID := kbfsblock.FakeID(1)
 		tlfID := tlf.FakeID(2, false)
-		bCtx := kbfsblock.MakeFirstContext(currentUID)
+		bCtx := kbfsblock.MakeFirstContext(currentUID, keybase1.BlockType_DATA)
 		data := []byte{1, 2, 3, 4}
 		serverHalf := kbfscrypto.MakeBlockCryptKeyServerHalf(
 			[32]byte{0x1})

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2921,7 +2921,9 @@ func (cr *ConflictResolver) calculateResolutionUsage(ctx context.Context,
 	blocksToDelete []kbfsblock.ID, err error) {
 	md.SetRefBytes(0)
 	md.SetUnrefBytes(0)
+	md.SetMDRefBytes(0)
 	md.SetDiskUsage(mostRecentMergedMD.DiskUsage())
+	md.SetMDDiskUsage(mostRecentMergedMD.MDDiskUsage())
 
 	// Track the refs and unrefs in a set, to ensure no duplicates
 	refs := make(map[BlockPointer]bool)

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -641,10 +641,11 @@ func (fd *fileData) createIndirectBlock(
 			{
 				BlockInfo: BlockInfo{
 					BlockPointer: BlockPointer{
-						ID:         newID,
-						KeyGen:     fd.kmd.LatestKeyGeneration(),
-						DataVer:    dver,
-						Context:    kbfsblock.MakeFirstContext(fd.uid),
+						ID:      newID,
+						KeyGen:  fd.kmd.LatestKeyGeneration(),
+						DataVer: dver,
+						Context: kbfsblock.MakeFirstContext(
+							fd.uid, fd.rootBlockPointer().GetBlockType()),
 						DirectType: fd.rootBlockPointer().DirectType,
 					},
 					EncodedSize: 0,
@@ -744,10 +745,11 @@ func (fd *fileData) newRightBlock(
 		}
 
 		newPtr := BlockPointer{
-			ID:         newRID,
-			KeyGen:     fd.kmd.LatestKeyGeneration(),
-			DataVer:    dver,
-			Context:    kbfsblock.MakeFirstContext(fd.uid),
+			ID:      newRID,
+			KeyGen:  fd.kmd.LatestKeyGeneration(),
+			DataVer: dver,
+			Context: kbfsblock.MakeFirstContext(
+				fd.uid, fd.rootBlockPointer().GetBlockType()),
 			DirectType: IndirectBlock,
 		}
 
@@ -1571,7 +1573,8 @@ func (fd *fileData) readyHelper(ctx context.Context, id tlf.ID,
 			}
 
 			newInfo, _, readyBlockData, err := ReadyBlock(
-				ctx, bcache, bops, fd.crypto, fd.kmd, pb.pblock, fd.uid)
+				ctx, bcache, bops, fd.crypto, fd.kmd, pb.pblock, fd.uid,
+				fd.rootBlockPointer().GetBlockType())
 			if err != nil {
 				return nil, err
 			}
@@ -1836,10 +1839,11 @@ func (fd *fileData) deepCopy(ctx context.Context, dataVer DataVer) (
 					// when readied, since the child block pointers
 					// will have changed.
 					newPtr := BlockPointer{
-						ID:         newID,
-						KeyGen:     fd.kmd.LatestKeyGeneration(),
-						DataVer:    dataVer,
-						Context:    kbfsblock.MakeFirstContext(fd.uid),
+						ID:      newID,
+						KeyGen:  fd.kmd.LatestKeyGeneration(),
+						DataVer: dataVer,
+						Context: kbfsblock.MakeFirstContext(
+							fd.uid, fd.rootBlockPointer().GetBlockType()),
 						DirectType: IndirectBlock,
 					}
 					pblock.IPtrs[i].BlockPointer = newPtr
@@ -1869,8 +1873,9 @@ func (fd *fileData) deepCopy(ctx context.Context, dataVer DataVer) (
 		KeyGen:  fd.kmd.LatestKeyGeneration(),
 		DataVer: dataVer,
 		Context: kbfsblock.Context{
-			Creator:  fd.uid,
-			RefNonce: kbfsblock.ZeroRefNonce,
+			Creator:   fd.uid,
+			RefNonce:  kbfsblock.ZeroRefNonce,
+			BlockType: fd.rootBlockPointer().GetBlockType(),
 		},
 		DirectType: IndirectBlock,
 	}

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -1872,11 +1872,8 @@ func (fd *fileData) deepCopy(ctx context.Context, dataVer DataVer) (
 		ID:      newID,
 		KeyGen:  fd.kmd.LatestKeyGeneration(),
 		DataVer: dataVer,
-		Context: kbfsblock.Context{
-			Creator:   fd.uid,
-			RefNonce:  kbfsblock.ZeroRefNonce,
-			BlockType: fd.rootBlockPointer().GetBlockType(),
-		},
+		Context: kbfsblock.MakeFirstContext(
+			fd.uid, fd.rootBlockPointer().GetBlockType()),
 		DirectType: IndirectBlock,
 	}
 	fd.log.CDebugf(ctx, "Deep copied indirect file %s: %v -> %v",

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1735,7 +1735,8 @@ func (fbo *folderBlockOps) revertSyncInfoAfterRecoverableError(
 // ReadyBlock is a thin wrapper around BlockOps.Ready() that handles
 // checking for duplicates.
 func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
-	crypto cryptoPure, kmd KeyMetadata, block Block, uid keybase1.UID) (
+	crypto cryptoPure, kmd KeyMetadata, block Block, uid keybase1.UID,
+	bType keybase1.BlockType) (
 	info BlockInfo, plainSize int, readyBlockData ReadyBlockData, err error) {
 	var ptr BlockPointer
 	directType := IndirectBlock
@@ -1777,8 +1778,9 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 			DataVer:    block.DataVersion(),
 			DirectType: directType,
 			Context: kbfsblock.Context{
-				Creator:  uid,
-				RefNonce: kbfsblock.ZeroRefNonce,
+				Creator:   uid,
+				RefNonce:  kbfsblock.ZeroRefNonce,
+				BlockType: bType,
 			},
 		}
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1777,11 +1777,7 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 			KeyGen:     kmd.LatestKeyGeneration(),
 			DataVer:    block.DataVersion(),
 			DirectType: directType,
-			Context: kbfsblock.Context{
-				Creator:   uid,
-				RefNonce:  kbfsblock.ZeroRefNonce,
-				BlockType: bType,
-			},
+			Context:    kbfsblock.MakeFirstContext(uid, bType),
 		}
 	}
 
@@ -1886,7 +1882,7 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 		md.SetRefBytes(si.refBytes)
 		md.AddDiskUsage(si.refBytes)
 		md.SetUnrefBytes(si.unrefBytes)
-		md.SetMDRefBytes(0) // this will be calculated a-new
+		md.SetMDRefBytes(0) // this will be calculated anew
 		md.SetDiskUsage(md.DiskUsage() - si.unrefBytes)
 		syncState.newIndirectFileBlockPtrs = append(
 			syncState.newIndirectFileBlockPtrs, si.op.Refs()...)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1886,6 +1886,7 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 		md.SetRefBytes(si.refBytes)
 		md.AddDiskUsage(si.refBytes)
 		md.SetUnrefBytes(si.unrefBytes)
+		md.SetMDRefBytes(0) // this will be calculated a-new
 		md.SetDiskUsage(md.DiskUsage() - si.unrefBytes)
 		syncState.newIndirectFileBlockPtrs = append(
 			syncState.newIndirectFileBlockPtrs, si.op.Refs()...)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1772,10 +1772,11 @@ func (bps *blockPutState) DeepCopy() *blockPutState {
 
 func (fbo *folderBranchOps) readyBlockMultiple(ctx context.Context,
 	kmd KeyMetadata, currBlock Block, uid keybase1.UID,
-	bps *blockPutState) (info BlockInfo, plainSize int, err error) {
+	bps *blockPutState, bType keybase1.BlockType) (
+	info BlockInfo, plainSize int, err error) {
 	info, plainSize, readyBlockData, err :=
 		ReadyBlock(ctx, fbo.config.BlockCache(), fbo.config.BlockOps(),
-			fbo.config.Crypto(), kmd, currBlock, uid, keybase1.BlockType_DATA)
+			fbo.config.Crypto(), kmd, currBlock, uid, bType)
 	if err != nil {
 		return
 	}
@@ -1865,20 +1866,20 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		return err
 	}
 	for info := range infos {
-		md.AddRefBytes(uint64(info.EncodedSize))
-		md.AddDiskUsage(uint64(info.EncodedSize))
+		md.AddMDRefBytes(uint64(info.EncodedSize))
+		md.AddMDDiskUsage(uint64(info.EncodedSize))
 	}
 	fbo.log.CDebugf(ctx, "%d unembedded child blocks", len(infos))
 
 	// Ready the top block.
 	info, _, err := fbo.readyBlockMultiple(
-		ctx, md.ReadOnly(), block, uid, bps)
+		ctx, md.ReadOnly(), block, uid, bps, keybase1.BlockType_MD)
 	if err != nil {
 		return err
 	}
 
-	md.AddRefBytes(uint64(info.EncodedSize))
-	md.AddDiskUsage(uint64(info.EncodedSize))
+	md.AddMDRefBytes(uint64(info.EncodedSize))
+	md.AddMDDiskUsage(uint64(info.EncodedSize))
 	md.data.cachedChanges = *changes
 	changes.Info = info
 	changes.Ops = nil
@@ -1927,7 +1928,7 @@ func (fbo *folderBranchOps) syncBlock(
 	now := fbo.nowUnixNano()
 	for len(newPath.path) < len(dir.path)+1 {
 		info, plainSize, err := fbo.readyBlockMultiple(
-			ctx, md.ReadOnly(), currBlock, uid, bps)
+			ctx, md.ReadOnly(), currBlock, uid, bps, keybase1.BlockType_DATA)
 		if err != nil {
 			return path{}, DirEntry{}, nil, err
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1163,7 +1163,8 @@ func ResetRootBlock(ctx context.Context, config Config,
 	newDblock := NewDirBlock()
 	info, plainSize, readyBlockData, err :=
 		ReadyBlock(ctx, config.BlockCache(), config.BlockOps(),
-			config.Crypto(), rmd.ReadOnly(), newDblock, currentUID)
+			config.Crypto(), rmd.ReadOnly(), newDblock, currentUID,
+			keybase1.BlockType_DATA)
 	if err != nil {
 		return nil, BlockInfo{}, ReadyBlockData{}, err
 	}
@@ -1774,7 +1775,7 @@ func (fbo *folderBranchOps) readyBlockMultiple(ctx context.Context,
 	bps *blockPutState) (info BlockInfo, plainSize int, err error) {
 	info, plainSize, readyBlockData, err :=
 		ReadyBlock(ctx, fbo.config.BlockCache(), fbo.config.BlockOps(),
-			fbo.config.Crypto(), kmd, currBlock, uid)
+			fbo.config.Crypto(), kmd, currBlock, uid, keybase1.BlockType_DATA)
 	if err != nil {
 		return
 	}
@@ -1804,8 +1805,9 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		DataVer:    fbo.config.DataVersion(),
 		DirectType: DirectBlock,
 		Context: kbfsblock.Context{
-			Creator:  uid,
-			RefNonce: kbfsblock.ZeroRefNonce,
+			Creator:   uid,
+			RefNonce:  kbfsblock.ZeroRefNonce,
+			BlockType: keybase1.BlockType_MD,
 		},
 	}
 	file := path{fbo.folderBranch,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1805,11 +1805,7 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		KeyGen:     md.LatestKeyGeneration(),
 		DataVer:    fbo.config.DataVersion(),
 		DirectType: DirectBlock,
-		Context: kbfsblock.Context{
-			Creator:   uid,
-			RefNonce:  kbfsblock.ZeroRefNonce,
-			BlockType: keybase1.BlockType_MD,
-		},
+		Context:    kbfsblock.MakeFirstContext(uid, keybase1.BlockType_MD),
 	}
 	file := path{fbo.folderBranch,
 		[]pathNode{{ptr, fmt.Sprintf("<MD rev %d>", md.Revision())}}}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1751,12 +1751,16 @@ type BareRootMetadata interface {
 	LastModifyingWriter() keybase1.UID
 	// LastModifyingUser return the UID of the last user to modify the any of the metadata.
 	GetLastModifyingUser() keybase1.UID
-	// RefBytes returns the number of newly referenced bytes introduced by this revision of metadata.
+	// RefBytes returns the number of newly referenced bytes of data blocks introduced by this revision of metadata.
 	RefBytes() uint64
 	// UnrefBytes returns the number of newly unreferenced bytes introduced by this revision of metadata.
 	UnrefBytes() uint64
+	// MDRefBytes returns the number of newly referenced bytes of MD blocks introduced by this revision of metadata.
+	MDRefBytes() uint64
 	// DiskUsage returns the estimated disk usage for the folder as of this revision of metadata.
 	DiskUsage() uint64
+	// MDDiskUsage returns the estimated MD disk usage for the folder as of this revision of metadata.
+	MDDiskUsage() uint64
 	// RevisionNumber returns the revision number associated with this metadata structure.
 	RevisionNumber() MetadataRevision
 	// BID returns the per-device branch ID associated with this metadata revision.
@@ -1798,18 +1802,26 @@ type BareRootMetadata interface {
 type MutableBareRootMetadata interface {
 	BareRootMetadata
 
-	// SetRefBytes sets the number of newly referenced bytes introduced by this revision of metadata.
+	// SetRefBytes sets the number of newly referenced bytes of data blocks introduced by this revision of metadata.
 	SetRefBytes(refBytes uint64)
 	// SetUnrefBytes sets the number of newly unreferenced bytes introduced by this revision of metadata.
 	SetUnrefBytes(unrefBytes uint64)
+	// SetMDRefBytes sets the number of newly referenced bytes of MD blocks introduced by this revision of metadata.
+	SetMDRefBytes(mdRefBytes uint64)
 	// SetDiskUsage sets the estimated disk usage for the folder as of this revision of metadata.
 	SetDiskUsage(diskUsage uint64)
-	// AddRefBytes increments the number of newly referenced bytes introduced by this revision of metadata.
+	// SetMDDiskUsage sets the estimated MD disk usage for the folder as of this revision of metadata.
+	SetMDDiskUsage(mdDiskUsage uint64)
+	// AddRefBytes increments the number of newly referenced bytes of data blocks introduced by this revision of metadata.
 	AddRefBytes(refBytes uint64)
 	// AddUnrefBytes increments the number of newly unreferenced bytes introduced by this revision of metadata.
 	AddUnrefBytes(unrefBytes uint64)
+	// AddMDRefBytes increments the number of newly referenced bytes of MD blocks introduced by this revision of metadata.
+	AddMDRefBytes(mdRefBytes uint64)
 	// AddDiskUsage increments the estimated disk usage for the folder as of this revision of metadata.
 	AddDiskUsage(diskUsage uint64)
+	// AddMDDiskUsage increments the estimated MD disk usage for the folder as of this revision of metadata.
+	AddMDDiskUsage(mdDiskUsage uint64)
 	// ClearRekeyBit unsets any set rekey bit.
 	ClearRekeyBit()
 	// ClearWriterMetadataCopiedBit unsets any set writer metadata copied bit.

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -94,7 +94,7 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	blockServer := config.BlockServer()
 
 	uid1 := keybase1.MakeTestUID(1)
-	bCtx := kbfsblock.MakeFirstContext(uid1)
+	bCtx := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -115,7 +115,7 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	uid2 := keybase1.MakeTestUID(2)
 	nonce, err := kbfsblock.MakeRefNonce()
 	require.NoError(t, err)
-	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce)
+	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce, keybase1.BlockType_DATA)
 	err = blockServer.AddBlockReference(ctx, tlfID, bID, bCtx2)
 	require.NoError(t, err)
 

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -92,7 +93,7 @@ func TestJournalServerRestart(t *testing.T) {
 
 	// Put a block.
 
-	bCtx := kbfsblock.MakeFirstContext(uid)
+	bCtx := kbfsblock.MakeFirstContext(uid, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -164,7 +165,7 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 
 	// Put a block.
 
-	bCtx := kbfsblock.MakeFirstContext(uid)
+	bCtx := kbfsblock.MakeFirstContext(uid, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -268,7 +269,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	// Put a block under user 1.
 
-	bCtx1 := kbfsblock.MakeFirstContext(uid1)
+	bCtx1 := kbfsblock.MakeFirstContext(uid1, keybase1.BlockType_DATA)
 	data1 := []byte{1, 2, 3, 4}
 	bID1, err := kbfsblock.MakePermanentID(data1)
 	require.NoError(t, err)
@@ -314,7 +315,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	// Put a block under user 2.
 
-	bCtx2 := kbfsblock.MakeFirstContext(uid2)
+	bCtx2 := kbfsblock.MakeFirstContext(uid2, keybase1.BlockType_DATA)
 	data2 := []byte{1, 2, 3, 4, 5}
 	bID2, err := kbfsblock.MakePermanentID(data2)
 	require.NoError(t, err)
@@ -417,7 +418,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	uid := h.ResolvedWriters()[0]
 
 	// Access a TLF, which should create a journal automatically.
-	bCtx := kbfsblock.MakeFirstContext(uid)
+	bCtx := kbfsblock.MakeFirstContext(uid, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5105,7 +5105,7 @@ func TestSyncDirtyWithBlockChangePointerSuccess(t *testing.T) {
 		AnyTimes().Return(false)
 
 	// sync block
-	refBytes := uint64(1) // 1 new block changes block
+	refBytes := uint64(0) // block changes block don't count toward refBytes
 	var newRmd ImmutableRootMetadata
 	blocks := make([]kbfsblock.ID, 2)
 	expectedPath, lastCall := expectSyncBlock(t, config, nil, uid, id, "", p,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5171,6 +5171,16 @@ func (_mr *_MockBareRootMetadataRecorder) UnrefBytes() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnrefBytes")
 }
 
+func (_m *MockBareRootMetadata) MDRefBytes() uint64 {
+	ret := _m.ctrl.Call(_m, "MDRefBytes")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) MDRefBytes() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MDRefBytes")
+}
+
 func (_m *MockBareRootMetadata) DiskUsage() uint64 {
 	ret := _m.ctrl.Call(_m, "DiskUsage")
 	ret0, _ := ret[0].(uint64)
@@ -5179,6 +5189,16 @@ func (_m *MockBareRootMetadata) DiskUsage() uint64 {
 
 func (_mr *_MockBareRootMetadataRecorder) DiskUsage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskUsage")
+}
+
+func (_m *MockBareRootMetadata) MDDiskUsage() uint64 {
+	ret := _m.ctrl.Call(_m, "MDDiskUsage")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) MDDiskUsage() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MDDiskUsage")
 }
 
 func (_m *MockBareRootMetadata) RevisionNumber() MetadataRevision {
@@ -5587,6 +5607,16 @@ func (_mr *_MockMutableBareRootMetadataRecorder) UnrefBytes() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnrefBytes")
 }
 
+func (_m *MockMutableBareRootMetadata) MDRefBytes() uint64 {
+	ret := _m.ctrl.Call(_m, "MDRefBytes")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) MDRefBytes() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MDRefBytes")
+}
+
 func (_m *MockMutableBareRootMetadata) DiskUsage() uint64 {
 	ret := _m.ctrl.Call(_m, "DiskUsage")
 	ret0, _ := ret[0].(uint64)
@@ -5595,6 +5625,16 @@ func (_m *MockMutableBareRootMetadata) DiskUsage() uint64 {
 
 func (_mr *_MockMutableBareRootMetadataRecorder) DiskUsage() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskUsage")
+}
+
+func (_m *MockMutableBareRootMetadata) MDDiskUsage() uint64 {
+	ret := _m.ctrl.Call(_m, "MDDiskUsage")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) MDDiskUsage() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MDDiskUsage")
 }
 
 func (_m *MockMutableBareRootMetadata) RevisionNumber() MetadataRevision {
@@ -5746,12 +5786,28 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetUnrefBytes(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetUnrefBytes", arg0)
 }
 
+func (_m *MockMutableBareRootMetadata) SetMDRefBytes(mdRefBytes uint64) {
+	_m.ctrl.Call(_m, "SetMDRefBytes", mdRefBytes)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetMDRefBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMDRefBytes", arg0)
+}
+
 func (_m *MockMutableBareRootMetadata) SetDiskUsage(diskUsage uint64) {
 	_m.ctrl.Call(_m, "SetDiskUsage", diskUsage)
 }
 
 func (_mr *_MockMutableBareRootMetadataRecorder) SetDiskUsage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDiskUsage", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetMDDiskUsage(mdDiskUsage uint64) {
+	_m.ctrl.Call(_m, "SetMDDiskUsage", mdDiskUsage)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetMDDiskUsage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMDDiskUsage", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) AddRefBytes(refBytes uint64) {
@@ -5770,12 +5826,28 @@ func (_mr *_MockMutableBareRootMetadataRecorder) AddUnrefBytes(arg0 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddUnrefBytes", arg0)
 }
 
+func (_m *MockMutableBareRootMetadata) AddMDRefBytes(mdRefBytes uint64) {
+	_m.ctrl.Call(_m, "AddMDRefBytes", mdRefBytes)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) AddMDRefBytes(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddMDRefBytes", arg0)
+}
+
 func (_m *MockMutableBareRootMetadata) AddDiskUsage(diskUsage uint64) {
 	_m.ctrl.Call(_m, "AddDiskUsage", diskUsage)
 }
 
 func (_mr *_MockMutableBareRootMetadataRecorder) AddDiskUsage(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddDiskUsage", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) AddMDDiskUsage(mdDiskUsage uint64) {
+	_m.ctrl.Call(_m, "AddMDDiskUsage", mdDiskUsage)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) AddMDDiskUsage(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddMDDiskUsage", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) ClearRekeyBit() {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -379,6 +379,7 @@ func (md *RootMetadata) AddOp(o op) {
 func (md *RootMetadata) ClearBlockChanges() {
 	md.SetRefBytes(0)
 	md.SetUnrefBytes(0)
+	md.SetMDRefBytes(0)
 	md.data.Changes.sizeEstimate = 0
 	md.data.Changes.Info = BlockInfo{}
 	md.data.Changes.Ops = nil
@@ -548,9 +549,19 @@ func (md *RootMetadata) UnrefBytes() uint64 {
 	return md.bareMd.UnrefBytes()
 }
 
+// MDRefBytes wraps the respective method of the underlying BareRootMetadata for convenience.
+func (md *RootMetadata) MDRefBytes() uint64 {
+	return md.bareMd.MDRefBytes()
+}
+
 // DiskUsage wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) DiskUsage() uint64 {
 	return md.bareMd.DiskUsage()
+}
+
+// MDDiskUsage wraps the respective method of the underlying BareRootMetadata for convenience.
+func (md *RootMetadata) MDDiskUsage() uint64 {
+	return md.bareMd.MDDiskUsage()
 }
 
 // SetRefBytes wraps the respective method of the underlying BareRootMetadata for convenience.
@@ -563,9 +574,19 @@ func (md *RootMetadata) SetUnrefBytes(unrefBytes uint64) {
 	md.bareMd.SetUnrefBytes(unrefBytes)
 }
 
+// SetMDRefBytes wraps the respective method of the underlying BareRootMetadata for convenience.
+func (md *RootMetadata) SetMDRefBytes(mdRefBytes uint64) {
+	md.bareMd.SetMDRefBytes(mdRefBytes)
+}
+
 // SetDiskUsage wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) SetDiskUsage(diskUsage uint64) {
 	md.bareMd.SetDiskUsage(diskUsage)
+}
+
+// SetMDDiskUsage wraps the respective method of the underlying BareRootMetadata for convenience.
+func (md *RootMetadata) SetMDDiskUsage(mdDiskUsage uint64) {
+	md.bareMd.SetMDDiskUsage(mdDiskUsage)
 }
 
 // AddRefBytes wraps the respective method of the underlying BareRootMetadata for convenience.
@@ -578,9 +599,19 @@ func (md *RootMetadata) AddUnrefBytes(unrefBytes uint64) {
 	md.bareMd.AddUnrefBytes(unrefBytes)
 }
 
+// AddMDRefBytes wraps the respective method of the underlying BareRootMetadata for convenience.
+func (md *RootMetadata) AddMDRefBytes(mdRefBytes uint64) {
+	md.bareMd.AddMDRefBytes(mdRefBytes)
+}
+
 // AddDiskUsage wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) AddDiskUsage(diskUsage uint64) {
 	md.bareMd.AddDiskUsage(diskUsage)
+}
+
+// AddMDDiskUsage wraps the respective method of the underlying BareRootMetadata for convenience.
+func (md *RootMetadata) AddMDDiskUsage(mdDiskUsage uint64) {
+	md.bareMd.AddMDDiskUsage(mdDiskUsage)
 }
 
 // IsWriterMetadataCopiedSet wraps the respective method of the underlying BareRootMetadata for convenience.

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -157,7 +157,7 @@ func (c testTLFJournalConfig) makeBlock(data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
 	id, err := kbfsblock.MakePermanentID(data)
 	require.NoError(c.t, err)
-	bCtx := kbfsblock.MakeFirstContext(c.uid)
+	bCtx := kbfsblock.MakeFirstContext(c.uid, keybase1.BlockType_DATA)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(c.t, err)
 	return id, bCtx, serverHalf


### PR DESCRIPTION
Note this won't be merged until keybase/kbfs-server#217 is merged and deployed in production.

----

This PR differentiates data blocks and MD blocks, so that we can tell the bserver which is which.  The bserver will no longer charge for MD blocks.  I opted for what I considered the cleanest approach, which is just to store the type in the `kbfsblock.Context` (rather than passing it around explicitly between all the functions that would need it).

To avoid losing information, I also decided to store the bytes associated with the MD in the MD update itself, to aid with debugging or introspection in the future.

Suggested review order:
* `kbfsblock`
* `libkbfs/bserver_remote.go`
* `folder_block_ops.go`, `folder_branch_ops.go`, and `state_checker.go`.
* Everything else is basically boiler plate for adding the new MD bytes fields.

Issue: KBFS-1900