### PR TITLE
folder_branch_ops: the getMD first access call can return empty MD

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1210,3 +1210,14 @@ type FileTooBigForCRError struct {
 func (e FileTooBigForCRError) Error() string {
 	return fmt.Sprintf("Cannot complete CR because the file %s is too big", e.p)
 }
+
+// NoMergedMDError indicates that no MDs for this folder have been
+// created yet.
+type NoMergedMDError struct {
+	tlf tlf.ID
+}
+
+// Error implements the error interface for NoMergedMDError.
+func (e NoMergedMDError) Error() string {
+	return fmt.Sprintf("No MD yet for TLF %s", e.tlf)
+}


### PR DESCRIPTION
To indicate that the caller needs to initialize the TLF before using
it.  Other get calls don't need this property, since they are internal
to folderBranchOps, and it's assumed the TLF has already been created
by an outsider if they're called.

Issue: KBFS-1929