### PR TITLE
folderlist: force a fast forward on a new user login

### DIFF
--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -266,7 +266,7 @@ func clearFolderListCacheLoop(ctx context.Context, r *Root) {
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -279,5 +279,8 @@ func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUser
 	}()
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
+	}
+	if newUser != libkb.NormalizedUsername("") {
+		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -328,7 +328,7 @@ func (fl *FolderList) updateTlfName(ctx context.Context, oldName string,
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -339,5 +339,8 @@ func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUser
 	}()
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
+	}
+	if newUser != libkb.NormalizedUsername("") {
+		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2788,8 +2788,6 @@ func (fbo *folderBlockOps) fastForwardDirAndChildrenLocked(ctx context.Context,
 func (fbo *folderBlockOps) FastForwardAllNodes(ctx context.Context,
 	lState *lockState, md ReadOnlyRootMetadata) (
 	changes []NodeChange, err error) {
-	defer func() { fbo.log.CDebugf(ctx, "Fast-forward complete: %v", err) }()
-
 	// Take a hard lock through this whole process.  TODO: is there
 	// any way to relax this?  It could lead to file system operation
 	// timeouts, even on reads, if we hold it too long.
@@ -2802,6 +2800,7 @@ func (fbo *folderBlockOps) FastForwardAllNodes(ctx context.Context,
 		return nil, nil
 	}
 	fbo.log.CDebugf(ctx, "Fast-forwarding %d nodes", len(nodes))
+	defer func() { fbo.log.CDebugf(ctx, "Fast-forward complete: %v", err) }()
 
 	// Build a "tree" representation for each interesting path prefix.
 	children := make(map[string]map[pathNode]bool)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4800,6 +4800,36 @@ func (fbo *folderBranchOps) runUnlessShutdown(fn func(ctx context.Context) error
 	}
 }
 
+func (fbo *folderBranchOps) doFastForwardLocked(ctx context.Context,
+	lState *lockState, currHead ImmutableRootMetadata) error {
+	fbo.mdWriterLock.AssertLocked(lState)
+	fbo.headLock.AssertLocked(lState)
+
+	fbo.log.CDebugf(ctx, "Fast-forwarding from rev %d to rev %d",
+		fbo.latestMergedRevision, currHead.Revision())
+	changes, err := fbo.blocks.FastForwardAllNodes(
+		ctx, lState, currHead.ReadOnly())
+	if err != nil {
+		return err
+	}
+
+	err = fbo.setHeadSuccessorLocked(ctx, lState, currHead, true /*rebase*/)
+	if err != nil {
+		return err
+	}
+
+	// Invalidate all the affected nodes.
+	if len(changes) > 0 {
+		fbo.observers.batchChanges(ctx, changes)
+	}
+
+	// Reset the edit history.  TODO: notify any listeners that we've
+	// done this.
+	fbo.editHistory.Shutdown()
+	fbo.editHistory = NewTlfEditHistory(fbo.config, fbo, fbo.log)
+	return nil
+}
+
 func (fbo *folderBranchOps) maybeFastForward(ctx context.Context,
 	lState *lockState, lastUpdate time.Time, currUpdate time.Time) (
 	fastForwardDone bool, err error) {
@@ -4843,28 +4873,10 @@ func (fbo *folderBranchOps) maybeFastForward(ctx context.Context,
 		return false, nil
 	}
 
-	fbo.log.CDebugf(ctx, "Fast-forwarding from rev %d to rev %d",
-		fbo.latestMergedRevision, currHead.Revision())
-	changes, err := fbo.blocks.FastForwardAllNodes(
-		ctx, lState, currHead.ReadOnly())
+	err = fbo.doFastForwardLocked(ctx, lState, currHead)
 	if err != nil {
 		return false, err
 	}
-
-	err = fbo.setHeadSuccessorLocked(ctx, lState, currHead, true /*rebase*/)
-	if err != nil {
-		return false, err
-	}
-
-	// Invalidate all the affected nodes.
-	if len(changes) > 0 {
-		fbo.observers.batchChanges(ctx, changes)
-	}
-
-	// Reset the edit history.  TODO: notify any listeners that we've
-	// done this.
-	fbo.editHistory.Shutdown()
-	fbo.editHistory = NewTlfEditHistory(fbo.config, fbo, fbo.log)
 	return true, nil
 }
 
@@ -5556,6 +5568,47 @@ func (fbo *folderBranchOps) ClearPrivateFolderMD(ctx context.Context) {
 
 	fbo.head = ImmutableRootMetadata{}
 	fbo.latestMergedRevision = MetadataRevisionUninitialized
+}
+
+// ForceFastForward implements the KBFSOps interface for
+// folderBranchOps.
+func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
+	lState := makeFBOLockState()
+	fbo.headLock.RLock(lState)
+	defer fbo.headLock.RUnlock(lState)
+	if fbo.head != (ImmutableRootMetadata{}) {
+		// We're already up to date.
+		return
+	}
+
+	go func() {
+		ctx, cancelFunc := fbo.newCtxWithFBOID()
+		defer cancelFunc()
+
+		fbo.log.CDebugf(ctx, "Forcing a fast-forward")
+		currHead, err := fbo.config.MDOps().GetForTLF(ctx, fbo.id())
+		if err != nil {
+			fbo.log.CDebugf(ctx, "Fast-forward failed: %v", err)
+			return
+		}
+		fbo.log.CDebugf(ctx, "Current head is revision %d", currHead.Revision())
+
+		lState := makeFBOLockState()
+		fbo.mdWriterLock.Lock(lState)
+		defer fbo.mdWriterLock.Unlock(lState)
+		fbo.headLock.Lock(lState)
+		defer fbo.headLock.Unlock(lState)
+		if fbo.head != (ImmutableRootMetadata{}) {
+			// We're already up to date.
+			fbo.log.CDebugf(ctx, "Already up-to-date: %v", err)
+			return
+		}
+
+		err = fbo.doFastForwardLocked(ctx, lState, currHead)
+		if err != nil {
+			fbo.log.CDebugf(ctx, "Fast-forward failed: %v", err)
+		}
+	}()
 }
 
 // PushConnectionStatusChange pushes human readable connection status changes.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -317,6 +317,10 @@ type KBFSOps interface {
 	// ClearPrivateFolderMD clears any cached private folder metadata,
 	// e.g. on a logout.
 	ClearPrivateFolderMD(ctx context.Context)
+	// ForceFastForward forwards the nodes of all folders to their
+	// newest version, if the folder is not currently receiving
+	// updates.  It works asynchronously, so no error is returned.
+	ForceFastForward(ctx context.Context)
 }
 
 // KeybaseService is an interface for communicating with the keybase

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -150,6 +150,18 @@ func (fs *KBFSOpsStandard) ClearPrivateFolderMD(ctx context.Context) {
 	}
 }
 
+// ForceFastForward implements the KBFSOps interface for
+// KBFSOpsStandard.
+func (fs *KBFSOpsStandard) ForceFastForward(ctx context.Context) {
+	fs.opsLock.Lock()
+	defer fs.opsLock.Unlock()
+
+	fs.log.CDebugf(ctx, "Forcing fast-forwards for %d folders", len(fs.ops))
+	for _, fbo := range fs.ops {
+		fbo.ForceFastForward(ctx)
+	}
+}
+
 // GetFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetFavorites(ctx context.Context) (

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -781,6 +781,14 @@ func (_mr *_MockKBFSOpsRecorder) ClearPrivateFolderMD(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearPrivateFolderMD", arg0)
 }
 
+func (_m *MockKBFSOps) ForceFastForward(ctx context.Context) {
+	_m.ctrl.Call(_m, "ForceFastForward", ctx)
+}
+
+func (_mr *_MockKBFSOpsRecorder) ForceFastForward(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ForceFastForward", arg0)
+}
+
 // Mock of KeybaseService interface
 type MockKeybaseService struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
On a logout, we now reset the FBO TLF heads.  After the user re-logs
in, if FUSE still holds a reference to some node within the TLF, and
tries a read operation on it, it will fail with a "This request needs
MD write access, but doesn't have it.", because read operations aren't
normally allowed to set the head.

After a re-login, we want to invalidate any nodes that are still being
held, in the same way we do for fast-forwarding, and set the head, so
that the read operations don't need to.

Issue: KBFS-1923