### PR TITLE
disk_journal: overwrite ordinal files without truncating them

### DIFF
--- a/ioutil/ioutil_wrap.go
+++ b/ioutil/ioutil_wrap.go
@@ -49,7 +49,7 @@ func TempDir(dir, prefix string) (name string, err error) {
 	if err != nil {
 		return "", errors.Wrapf(err,
 			"failed to make temp dir in %q with prefix %q",
-			name, err)
+			dir, prefix)
 	}
 	return name, nil
 }

--- a/ioutil/os_wrap.go
+++ b/ioutil/os_wrap.go
@@ -10,6 +10,16 @@ import (
 	"github.com/pkg/errors"
 )
 
+// OpenFile wraps OpenFile from "os".
+func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
+	f, err := os.OpenFile(name, flag, perm)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %q", name)
+	}
+
+	return f, nil
+}
+
 // Lstat wraps Lstat from "os".
 func Lstat(name string) (os.FileInfo, error) {
 	info, err := os.Lstat(name)


### PR DESCRIPTION
Otherwise a crash at the wrong moment can lead to an empty EARLIEST or
LATEST file.

Ideally this would be done using an atomic rename, instead of an
overwrite, but there seems to be a big (~25%) performance penalty for
that.

Issue: KBFS-1887