### PR TITLE
block_journal: be sure to ignore all relevant MD markers

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -830,7 +830,8 @@ func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 }
 
 func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
-	idsToIgnore map[kbfsblock.ID]bool, dj diskJournal) error {
+	idsToIgnore map[kbfsblock.ID]bool, rev MetadataRevision,
+	dj diskJournal) error {
 	first, err := dj.readEarliestOrdinal()
 	if ioutil.IsNotExist(err) {
 		return nil
@@ -847,6 +848,7 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 	// Iterate backwards since the blocks to ignore are likely to be
 	// at the end of the journal.
 	ignored := 0
+	ignoredRev := false
 	// i is unsigned, so make sure to handle overflow when `first` is
 	// 0 by checking that it's less than `last`.  TODO: handle
 	// first==0 and last==maxuint?
@@ -894,12 +896,6 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 				}
 			}
 
-			// If we've ignored all of the block IDs in `idsToIgnore`,
-			// we can avoid iterating through the rest of the journal.
-			if len(idsToIgnore) == ignored {
-				return nil
-			}
-
 		case mdRevMarkerOp:
 			if e.Unignorable {
 				continue
@@ -910,6 +906,21 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 			if err != nil {
 				return err
 			}
+
+			// We must ignore all the way up to the MD marker that
+			// matches the revision of the squash, otherwise we may
+			// put the new squash MD before all the blocks have been
+			// put.
+			if e.Revision == rev {
+				ignoredRev = true
+			}
+		}
+
+		// If we've ignored all of the block IDs in `idsToIgnore`, and
+		// the earliest md marker we care about, we can avoid
+		// iterating through the rest of the journal.
+		if len(idsToIgnore) == ignored && ignoredRev {
+			return nil
 		}
 	}
 
@@ -917,13 +928,13 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 }
 
 func (j *blockJournal) ignoreBlocksAndMDRevMarkers(ctx context.Context,
-	blocksToIgnore []kbfsblock.ID) error {
+	blocksToIgnore []kbfsblock.ID, rev MetadataRevision) error {
 	idsToIgnore := make(map[kbfsblock.ID]bool)
 	for _, id := range blocksToIgnore {
 		idsToIgnore[id] = true
 	}
 
-	err := j.ignoreBlocksAndMDRevMarkersInJournal(ctx, idsToIgnore, j.j)
+	err := j.ignoreBlocksAndMDRevMarkersInJournal(ctx, idsToIgnore, rev, j.j)
 	if err != nil {
 		return err
 	}
@@ -933,7 +944,7 @@ func (j *blockJournal) ignoreBlocksAndMDRevMarkers(ctx context.Context,
 	}
 
 	return j.ignoreBlocksAndMDRevMarkersInJournal(
-		ctx, idsToIgnore, *j.saveUntilMDFlush)
+		ctx, idsToIgnore, rev, *j.saveUntilMDFlush)
 }
 
 func (j *blockJournal) saveBlocksUntilNextMDFlush() error {

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -687,7 +687,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	err = j.markMDRevision(ctx, rev, false)
 	require.NoError(t, err)
 
-	err = j.ignoreBlocksAndMDRevMarkers(ctx, []kbfsblock.ID{id2, id3})
+	err = j.ignoreBlocksAndMDRevMarkers(ctx, []kbfsblock.ID{id2, id3}, rev)
 	require.NoError(t, err)
 
 	blockServer := NewBlockServerMemory(log)
@@ -731,12 +731,19 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	// Put a few blocks
 	data1 := []byte{1, 2, 3}
 	bID1, _, _ := putBlockData(ctx, t, j, data1)
+
+	// Put a revision marker
+	rev := MetadataRevision(9)
+	firstRev := rev
+	err := j.markMDRevision(ctx, rev, false)
+	require.NoError(t, err)
+
 	data2 := []byte{4, 5, 6, 7}
 	bID2, _, _ := putBlockData(ctx, t, j, data2)
 
 	// Put a revision marker
-	rev := MetadataRevision(10)
-	err := j.markMDRevision(ctx, rev, false)
+	rev = MetadataRevision(10)
+	err = j.markMDRevision(ctx, rev, false)
 	require.NoError(t, err)
 
 	data3 := []byte{8, 9, 10, 11, 12}
@@ -754,7 +761,8 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	err = j.saveBlocksUntilNextMDFlush()
 	require.NoError(t, err)
 
-	err = j.ignoreBlocksAndMDRevMarkers(ctx, []kbfsblock.ID{bID2, bID3})
+	err = j.ignoreBlocksAndMDRevMarkers(
+		ctx, []kbfsblock.ID{bID2, bID3}, firstRev)
 	require.NoError(t, err)
 
 	blockServer := NewBlockServerMemory(log)
@@ -769,10 +777,10 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 		maxJournalBlockFlushBatchSize)
 	require.NoError(t, err)
 	require.Equal(t, MetadataRevisionUninitialized, gotRev)
-	require.Equal(t, 6, entries.length())
+	require.Equal(t, 7, entries.length())
 	require.Len(t, entries.puts.blockStates, 2)
 	require.Len(t, entries.adds.blockStates, 0)
-	require.Len(t, entries.other, 4)
+	require.Len(t, entries.other, 5)
 	require.Equal(t, bID1, entries.puts.blockStates[0].blockPtr.ID)
 	require.Equal(t, bID4, entries.puts.blockStates[1].blockPtr.ID)
 	err = flushBlockEntries(ctx, j.log, blockServer,
@@ -1073,7 +1081,8 @@ func TestBlockJournalUnflushedBytesIgnore(t *testing.T) {
 
 	requireSize(len(data1)+len(data2), len(data1)+len(data2))
 
-	err := j.ignoreBlocksAndMDRevMarkers(ctx, []kbfsblock.ID{bID1})
+	err := j.ignoreBlocksAndMDRevMarkers(
+		ctx, []kbfsblock.ID{bID1}, MetadataRevision(0))
 	require.NoError(t, err)
 
 	requireSize(len(data1)+len(data2), len(data2))

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1777,7 +1777,8 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	}
 
 	// Then go through and mark blocks and md rev markers for ignoring.
-	err = j.blockJournal.ignoreBlocksAndMDRevMarkers(ctx, blocksToDelete)
+	err = j.blockJournal.ignoreBlocksAndMDRevMarkers(ctx, blocksToDelete,
+		rmd.Revision())
 	if err != nil {
 		return MdID{}, false, err
 	}


### PR DESCRIPTION
Recently we added an optimization in `ignoreBlocksAndMDRevMarkers`
where we'd stop iterating through the journal once we found all the
blocks we were looking for.  Unfortunately we missed an edge case: say
we're squashing revisions 5-15 together into one new revision, 5.  If,
while resolving the squash, we aren't ignoring any blocks from the
original revision 5, we will exit the loop early and never set the
`Ignored` flag on the original md marker entry for revision 5.  When
the flusher sees that unignored marker, it will think it's done with
the blocks for revision 5 early, and put the MD before all the blocks
have been flushed!  At that point, if the client crashes, or if
another device tries to read the folder, they could fail trying to
read a non-existent block.

Instead, don't exit early until we find the md marker for the earliest
revision in the squash.

Issue: KBFS-1939