### PR TITLE
govendor updates from client

### DIFF
--- a/vendor/github.com/keybase/client/go/libkb/errors.go
+++ b/vendor/github.com/keybase/client/go/libkb/errors.go
@@ -1266,11 +1266,14 @@ func (e IdentifyFailedError) Error() string {
 //=============================================================================
 
 type IdentifySummaryError struct {
+	username string
 	problems []string
 }
 
 func (e IdentifySummaryError) Error() string {
-	return fmt.Sprintf("%s", strings.Join(e.problems, "; "))
+	return fmt.Sprintf("failed to identify %q: %s",
+		e.username,
+		strings.Join(e.problems, "; "))
 }
 
 func (e IdentifySummaryError) IsImmediateFail() (chat1.OutboxErrorType, bool) {

--- a/vendor/github.com/keybase/client/go/libkb/globals.go
+++ b/vendor/github.com/keybase/client/go/libkb/globals.go
@@ -117,6 +117,7 @@ type GlobalTestOptions struct {
 }
 
 func (g *GlobalContext) GetLog() logger.Logger          { return g.Log }
+func (g *GlobalContext) GetVDebugLog() *VDebugLog       { return g.VDL }
 func (g *GlobalContext) GetAPI() API                    { return g.API }
 func (g *GlobalContext) GetExternalAPI() ExternalAPI    { return g.XAPI }
 func (g *GlobalContext) GetServerURI() string           { return g.Env.GetServerURI() }

--- a/vendor/github.com/keybase/client/go/libkb/identify_outcome.go
+++ b/vendor/github.com/keybase/client/go/libkb/identify_outcome.go
@@ -225,12 +225,12 @@ func (i IdentifyOutcome) GetErrorAndWarnings(strict bool) (warnings Warnings, er
 
 	if ntf := i.NumTrackFailures(); ntf > 0 {
 		probs = append(probs,
-			fmt.Sprintf("%d track component%s failed",
+			fmt.Sprintf("%d followed proof%s failed",
 				ntf, GiveMeAnS(ntf)))
 	}
 
 	if len(probs) > 0 {
-		err = IdentifySummaryError{probs}
+		err = IdentifySummaryError{i.Username, probs}
 	}
 
 	return warnings, err

--- a/vendor/github.com/keybase/client/go/libkb/interfaces.go
+++ b/vendor/github.com/keybase/client/go/libkb/interfaces.go
@@ -449,6 +449,11 @@ type LogContext interface {
 	GetLog() logger.Logger
 }
 
+type VLogContext interface {
+	LogContext
+	GetVDebugLog() *VDebugLog
+}
+
 // APIContext defines methods for accessing API server
 type APIContext interface {
 	GetAPI() API

--- a/vendor/github.com/keybase/client/go/libkb/locktab.go
+++ b/vendor/github.com/keybase/client/go/libkb/locktab.go
@@ -10,7 +10,7 @@ import (
 
 type NamedLock struct {
 	sync.Mutex
-	lctx   LogContext
+	lctx   VLogContext
 	refs   int
 	name   string
 	parent *LockTable
@@ -25,12 +25,12 @@ func (l *NamedLock) decref() {
 }
 
 func (l *NamedLock) Release(ctx context.Context) {
-	l.lctx.GetLog().CDebugf(ctx, "+ LockTable.Release(%s)", l.name)
+	l.lctx.GetVDebugLog().CLogf(ctx, VLog1, "+ LockTable.Release(%s)", l.name)
 	l.Unlock()
 	l.parent.Lock()
 	l.decref()
 	if l.refs == 0 {
-		l.lctx.GetLog().CDebugf(ctx, "| LockTable.unref(%s)", l.name)
+		l.lctx.GetVDebugLog().CLogf(ctx, VLog1, "| LockTable.unref(%s)", l.name)
 		delete(l.parent.locks, l.name)
 	}
 	l.parent.Unlock()
@@ -48,7 +48,7 @@ func (t *LockTable) init() {
 	}
 }
 
-func (t *LockTable) AcquireOnName(ctx context.Context, g LogContext, s string) (ret *NamedLock) {
+func (t *LockTable) AcquireOnName(ctx context.Context, g VLogContext, s string) (ret *NamedLock) {
 	g.GetLog().CDebugf(ctx, "+ LockTable.Lock(%s)", s)
 	t.Lock()
 	t.init()
@@ -59,6 +59,6 @@ func (t *LockTable) AcquireOnName(ctx context.Context, g LogContext, s string) (
 	ret.incref()
 	t.Unlock()
 	ret.Lock()
-	g.GetLog().CDebugf(ctx, "- LockTable.Lock(%s)", s)
+	g.GetVDebugLog().CLogf(ctx, VLog1, "- LockTable.Lock(%s)", s)
 	return ret
 }

--- a/vendor/github.com/keybase/client/go/libkb/notify_router.go
+++ b/vendor/github.com/keybase/client/go/libkb/notify_router.go
@@ -250,8 +250,9 @@ func (n *NotifyRouter) HandleTrackingChanged(uid keybase1.UID, username string, 
 		return
 	}
 	arg := keybase1.TrackingChangedArg{
-		Uid:      uid,
-		Username: username,
+		Uid:        uid,
+		Username:   username,
+		IsTracking: isTracking,
 	}
 	// For all connections we currently have open...
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {

--- a/vendor/github.com/keybase/client/go/libkb/resolve.go
+++ b/vendor/github.com/keybase/client/go/libkb/resolve.go
@@ -89,7 +89,7 @@ func (r *Resolver) ResolveFullExpressionWithBody(ctx context.Context, input stri
 }
 
 func (r *Resolver) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {
-	defer r.G().CTrace(ctx, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
+	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
 
 	var expr AssertionExpression
 	expr, res.err = AssertionParseAndOnly(r.G().MakeAssertionContext(), input)
@@ -105,7 +105,7 @@ func (r *Resolver) resolveFullExpression(ctx context.Context, input string, with
 }
 
 func (r *Resolver) getFromDiskCache(ctx context.Context, key string) (ret *ResolveResult) {
-	defer r.G().CTraceOK(ctx, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
+	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
 	var uid keybase1.UID
 	found, err := r.G().LocalDb.GetInto(&uid, resolveDbKey(key))
 	r.Stats.diskGets++
@@ -154,7 +154,7 @@ func (r *Resolver) resolveURL(ctx context.Context, au AssertionURL, input string
 }
 
 func (r *Resolver) resolveURLViaServerLookup(ctx context.Context, au AssertionURL, input string, withBody bool) (res ResolveResult) {
-	defer r.G().CTrace(ctx, fmt.Sprintf("Resolver#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
+	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
 
 	var key, val string
 	var ares *APIRes
@@ -270,7 +270,7 @@ func (r *Resolver) Shutdown() {
 }
 
 func (r *Resolver) getFromMemCache(ctx context.Context, key string) (ret *ResolveResult) {
-	defer r.G().CTraceOK(ctx, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
+	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
 	if r.cache == nil {
 		return nil
 	}

--- a/vendor/github.com/keybase/client/go/libkb/util.go
+++ b/vendor/github.com/keybase/client/go/libkb/util.go
@@ -430,12 +430,25 @@ func (g *GlobalContext) Trace(msg string, f func() error) func() {
 	return Trace(g.Log, msg, f)
 }
 
+func (g *GlobalContext) ExitTrace(msg string, f func() error) func() {
+	return func() { g.Log.Debug("| %s -> %s", msg, ErrToOk(f())) }
+}
+
 func (g *GlobalContext) CTrace(ctx context.Context, msg string, f func() error) func() {
 	return CTrace(ctx, g.Log, msg, f)
 }
 
+func (g *GlobalContext) CVTrace(ctx context.Context, lev VDebugLevel, msg string, f func() error) func() {
+	g.VDL.CLogf(ctx, lev, "+ %s", msg)
+	return func() { g.VDL.CLogf(ctx, lev, "- %s -> %v", msg, ErrToOk(f())) }
+}
+
 func (g *GlobalContext) CTraceTimed(ctx context.Context, msg string, f func() error) func() {
 	return CTraceTimed(ctx, g.Log, msg, f, g.Clock())
+}
+
+func (g *GlobalContext) ExitTraceOK(msg string, f func() bool) func() {
+	return func() { g.Log.Debug("| %s -> %v", msg, f()) }
 }
 
 func (g *GlobalContext) TraceOK(msg string, f func() bool) func() {
@@ -444,6 +457,12 @@ func (g *GlobalContext) TraceOK(msg string, f func() bool) func() {
 
 func (g *GlobalContext) CTraceOK(ctx context.Context, msg string, f func() bool) func() {
 	return CTraceOK(ctx, g.Log, msg, f)
+}
+
+func (g *GlobalContext) CVTraceOK(ctx context.Context, lev VDebugLevel, msg string, f func() bool) func() {
+	g.VDL.CLogf(ctx, lev, "+ %s", msg)
+	return func() { g.VDL.CLogf(ctx, lev, "- %s -> %v", msg, f()) }
+
 }
 
 // SplitByRunes splits string by runes

--- a/vendor/github.com/keybase/client/go/libkb/vdebug.go
+++ b/vendor/github.com/keybase/client/go/libkb/vdebug.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
 )
 
 // VDebugLog is a "Verbose" debug logger; enable it if you really
@@ -36,6 +37,14 @@ func (v *VDebugLog) Log(lev VDebugLevel, fs string, args ...interface{}) {
 		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
 		fs = prfx + fs
 		v.log.Debug(fs, args...)
+	}
+}
+
+func (v *VDebugLog) CLogf(ctx context.Context, lev VDebugLevel, fs string, args ...interface{}) {
+	if lev <= v.lev {
+		prfx := fmt.Sprintf("{VDL:%d} ", int(lev))
+		fs = prfx + fs
+		v.log.CDebugf(ctx, fs, args...)
 	}
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/chat1/common.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/common.go
@@ -186,6 +186,8 @@ type ConversationMetadata struct {
 	Visibility     TLFVisibility             `codec:"visibility" json:"visibility"`
 	Status         ConversationStatus        `codec:"status" json:"status"`
 	FinalizeInfo   *ConversationFinalizeInfo `codec:"finalizeInfo,omitempty" json:"finalizeInfo,omitempty"`
+	Supersedes     []ConversationMetadata    `codec:"supersedes" json:"supersedes"`
+	SupersededBy   []ConversationMetadata    `codec:"supersededBy" json:"supersededBy"`
 	ActiveList     []gregor1.UID             `codec:"activeList" json:"activeList"`
 }
 
@@ -196,11 +198,9 @@ type ConversationReaderInfo struct {
 }
 
 type Conversation struct {
-	Metadata     ConversationMetadata    `codec:"metadata" json:"metadata"`
-	ReaderInfo   *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
-	Supersedes   []ConversationMetadata  `codec:"supersedes" json:"supersedes"`
-	SupersededBy []ConversationMetadata  `codec:"supersededBy" json:"supersededBy"`
-	MaxMsgs      []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
+	Metadata   ConversationMetadata    `codec:"metadata" json:"metadata"`
+	ReaderInfo *ConversationReaderInfo `codec:"readerInfo,omitempty" json:"readerInfo,omitempty"`
+	MaxMsgs    []MessageBoxed          `codec:"maxMsgs" json:"maxMsgs"`
 }
 
 type MessageServerHeader struct {

--- a/vendor/github.com/keybase/client/go/protocol/chat1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/extras.go
@@ -350,3 +350,21 @@ func ConvertMessageBodyV1ToV2(v1 MessageBodyV1) (MessageBody, error) {
 	return MessageBody{}, fmt.Errorf("ConvertMessageBodyV1ToV2: unhandled message type %v", t)
 }
 */
+
+func NewConversationErrorLocal(
+	message string,
+	remoteConv Conversation,
+	permanent bool,
+	unverifiedTLFName string,
+	typ ConversationErrorType,
+	rekeyInfo *ConversationErrorRekey,
+) *ConversationErrorLocal {
+	return &ConversationErrorLocal{
+		Typ:               typ,
+		Message:           message,
+		RemoteConv:        remoteConv,
+		Permanent:         permanent,
+		UnverifiedTLFName: unverifiedTLFName,
+		RekeyInfo:         rekeyInfo,
+	}
+}

--- a/vendor/github.com/keybase/client/go/protocol/chat1/local.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/local.go
@@ -1186,6 +1186,7 @@ type MessageUnboxedError struct {
 	ErrMsg      string                  `codec:"errMsg" json:"errMsg"`
 	MessageID   MessageID               `codec:"messageID" json:"messageID"`
 	MessageType MessageType             `codec:"messageType" json:"messageType"`
+	Ctime       gregor1.Time            `codec:"ctime" json:"ctime"`
 }
 
 type MessageUnboxed struct {
@@ -1322,11 +1323,12 @@ func (e ConversationErrorType) String() string {
 }
 
 type ConversationErrorLocal struct {
-	Typ        ConversationErrorType   `codec:"typ" json:"typ"`
-	Message    string                  `codec:"message" json:"message"`
-	RemoteConv Conversation            `codec:"remoteConv" json:"remoteConv"`
-	Permanent  bool                    `codec:"permanent" json:"permanent"`
-	RekeyInfo  *ConversationErrorRekey `codec:"rekeyInfo,omitempty" json:"rekeyInfo,omitempty"`
+	Typ               ConversationErrorType   `codec:"typ" json:"typ"`
+	Message           string                  `codec:"message" json:"message"`
+	RemoteConv        Conversation            `codec:"remoteConv" json:"remoteConv"`
+	Permanent         bool                    `codec:"permanent" json:"permanent"`
+	UnverifiedTLFName string                  `codec:"unverifiedTLFName" json:"unverifiedTLFName"`
+	RekeyInfo         *ConversationErrorRekey `codec:"rekeyInfo,omitempty" json:"rekeyInfo,omitempty"`
 }
 
 type ConversationErrorRekey struct {
@@ -1341,8 +1343,8 @@ type ConversationLocal struct {
 	Error            *ConversationErrorLocal       `codec:"error,omitempty" json:"error,omitempty"`
 	Info             ConversationInfoLocal         `codec:"info" json:"info"`
 	ReaderInfo       ConversationReaderInfo        `codec:"readerInfo" json:"readerInfo"`
-	Supersedes       []ConversationID              `codec:"supersedes" json:"supersedes"`
-	SupersededBy     []ConversationID              `codec:"supersededBy" json:"supersededBy"`
+	Supersedes       []ConversationMetadata        `codec:"supersedes" json:"supersedes"`
+	SupersededBy     []ConversationMetadata        `codec:"supersededBy" json:"supersededBy"`
 	MaxMessages      []MessageUnboxed              `codec:"maxMessages" json:"maxMessages"`
 	IsEmpty          bool                          `codec:"isEmpty" json:"isEmpty"`
 	IdentifyFailures []keybase1.TLFIdentifyFailure `codec:"identifyFailures" json:"identifyFailures"`

--- a/vendor/github.com/keybase/client/go/protocol/chat1/notify.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/notify.go
@@ -47,9 +47,10 @@ func (e ChatActivityType) String() string {
 }
 
 type IncomingMessage struct {
-	Message MessageUnboxed     `codec:"message" json:"message"`
-	ConvID  ConversationID     `codec:"convID" json:"convID"`
-	Conv    *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	Message    MessageUnboxed     `codec:"message" json:"message"`
+	ConvID     ConversationID     `codec:"convID" json:"convID"`
+	Conv       *ConversationLocal `codec:"conv,omitempty" json:"conv,omitempty"`
+	Pagination *Pagination        `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
 
 type ReadMessageInfo struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -138,68 +138,68 @@
 		{
 			"checksumSHA1": "5FZdIGpE5Mi16d6cIDiZb4x50Xo=",
 			"path": "github.com/keybase/client/go/auth",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "XLuIsEwolQy0HYCl0qkqcgCkSFQ=",
 			"path": "github.com/keybase/client/go/externals",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "wXT+Sk5B8Al1PyMczAzCrzYwZAc=",
 			"path": "github.com/keybase/client/go/gregor",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "YqnSB+btAlX7OQRnlTe6fnbn0fw=",
 			"path": "github.com/keybase/client/go/kex2",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
-			"checksumSHA1": "26+c/OUezV0RSoom1Dof7DpjSnM=",
+			"checksumSHA1": "J9apl3RyroeLg+6sHuH9n5eNkKc=",
 			"path": "github.com/keybase/client/go/libkb",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "E/jcLlFO2tb1pXUxMPxc5YRmc4M=",
 			"path": "github.com/keybase/client/go/logger",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "O1Q0NBB6o1mj4A+1uk1xgf7nw+c=",
 			"path": "github.com/keybase/client/go/protocol",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
-			"checksumSHA1": "pwNwOQjv9ibjGvayqed0Mjn457o=",
+			"checksumSHA1": "MZ9+1yUPlpI/OwDJ0SqtDs4UyKg=",
 			"path": "github.com/keybase/client/go/protocol/chat1",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "uGXPG5Atdb80jZ/5cg+CkWlHlt8=",
 			"path": "github.com/keybase/client/go/protocol/gregor1",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "90p9joLcyYEYBCMBY2xF/8eYAAM=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "aUMkkGW8nO2sf+UxAMxnmVbDbzU=",
 			"path": "github.com/keybase/client/go/pvl",
-			"revision": "59de178067291a35923a2ffc8543de7529e94525",
-			"revisionTime": "2017-02-06T17:08:05Z"
+			"revision": "804b64589ed62d7e5530153c4434a2fc0caccbac",
+			"revisionTime": "2017-02-08T16:43:02Z"
 		},
 		{
 			"checksumSHA1": "qtfSDF71FbCm7kTNKdraxOpU7wY=",


### PR DESCRIPTION
This brings in changes in how IdentifySummaryErrors are
exported/imported, without which we'll garble them in transit.

r? @strib 

@cjb @maxtaco I should've merged this last night, and right now
the errors that roundtrip through kbfs will get garbled. We might
need to restart the build after this goes in?