### PR TITLE
folder_branch_ops: some tlfs can have an FBO without a head

### DIFF
--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -266,7 +266,7 @@ func clearFolderListCacheLoop(ctx context.Context, r *Root) {
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -279,5 +279,8 @@ func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUser
 	}()
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
+	}
+	if newUser != libkb.NormalizedUsername("") {
+		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -328,7 +328,7 @@ func (fl *FolderList) updateTlfName(ctx context.Context, oldName string,
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -339,5 +339,8 @@ func (fl *FolderList) userChanged(ctx context.Context, _, _ libkb.NormalizedUser
 	}()
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
+	}
+	if newUser != libkb.NormalizedUsername("") {
+		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2788,8 +2788,6 @@ func (fbo *folderBlockOps) fastForwardDirAndChildrenLocked(ctx context.Context,
 func (fbo *folderBlockOps) FastForwardAllNodes(ctx context.Context,
 	lState *lockState, md ReadOnlyRootMetadata) (
 	changes []NodeChange, err error) {
-	defer func() { fbo.log.CDebugf(ctx, "Fast-forward complete: %v", err) }()
-
 	// Take a hard lock through this whole process.  TODO: is there
 	// any way to relax this?  It could lead to file system operation
 	// timeouts, even on reads, if we hold it too long.
@@ -2802,6 +2800,7 @@ func (fbo *folderBlockOps) FastForwardAllNodes(ctx context.Context,
 		return nil, nil
 	}
 	fbo.log.CDebugf(ctx, "Fast-forwarding %d nodes", len(nodes))
+	defer func() { fbo.log.CDebugf(ctx, "Fast-forward complete: %v", err) }()
 
 	// Build a "tree" representation for each interesting path prefix.
 	children := make(map[string]map[pathNode]bool)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -307,8 +307,9 @@ type folderBranchOps struct {
 
 	editHistory *TlfEditHistory
 
-	branchChanges kbfssync.RepeatedWaitGroup
-	mdFlushes     kbfssync.RepeatedWaitGroup
+	branchChanges      kbfssync.RepeatedWaitGroup
+	mdFlushes          kbfssync.RepeatedWaitGroup
+	forcedFastForwards kbfssync.RepeatedWaitGroup
 }
 
 var _ KBFSOps = (*folderBranchOps)(nil)
@@ -5601,7 +5602,9 @@ func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
 		return
 	}
 
+	fbo.forcedFastForwards.Add(1)
 	go func() {
+		defer fbo.forcedFastForwards.Done()
 		ctx, cancelFunc := fbo.newCtxWithFBOID()
 		defer cancelFunc()
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -317,6 +317,10 @@ type KBFSOps interface {
 	// ClearPrivateFolderMD clears any cached private folder metadata,
 	// e.g. on a logout.
 	ClearPrivateFolderMD(ctx context.Context)
+	// ForceFastForward forwards the nodes of all folders to their
+	// newest version, if the folder is not currently receiving
+	// updates.  It works asynchronously, so no error is returned.
+	ForceFastForward(ctx context.Context)
 }
 
 // KeybaseService is an interface for communicating with the keybase

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -317,9 +317,10 @@ type KBFSOps interface {
 	// ClearPrivateFolderMD clears any cached private folder metadata,
 	// e.g. on a logout.
 	ClearPrivateFolderMD(ctx context.Context)
-	// ForceFastForward forwards the nodes of all folders to their
-	// newest version, if the folder is not currently receiving
-	// updates.  It works asynchronously, so no error is returned.
+	// ForceFastForward forwards the nodes of all folders that have
+	// been previously cleared with `ClearPrivateFolderMD` to their
+	// newest version.  It works asynchronously, so no error is
+	// returned.
 	ForceFastForward(ctx context.Context)
 }
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -150,6 +150,18 @@ func (fs *KBFSOpsStandard) ClearPrivateFolderMD(ctx context.Context) {
 	}
 }
 
+// ForceFastForward implements the KBFSOps interface for
+// KBFSOpsStandard.
+func (fs *KBFSOpsStandard) ForceFastForward(ctx context.Context) {
+	fs.opsLock.Lock()
+	defer fs.opsLock.Unlock()
+
+	fs.log.CDebugf(ctx, "Forcing fast-forwards for %d folders", len(fs.ops))
+	for _, fbo := range fs.ops {
+		fbo.ForceFastForward(ctx)
+	}
+}
+
 // GetFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetFavorites(ctx context.Context) (

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5646,3 +5646,34 @@ func TestGetTLFCryptKeysAfterFirstError(t *testing.T) {
 		t.Fatalf("Got unexpected error when creating TLF: %+v", err)
 	}
 }
+
+func TestForceFastForwardOnEmptyTLF(t *testing.T) {
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
+	// TODO: Use kbfsTestShutdownNoMocks.
+	defer kbfsTestShutdownNoMocksNoCheck(t, config, ctx, cancel)
+
+	// Look up bob's public folder.
+	h := parseTlfHandleOrBust(t, config, "bob", true)
+	_, _, err := config.KBFSOps().GetOrCreateRootNode(ctx, h, MasterBranch)
+	if _, ok := err.(WriteAccessError); !ok {
+		t.Fatalf("Unexpected err reading a public TLF: %+v", err)
+	}
+
+	// There's only one folder at this point.
+	kbfsOps := config.KBFSOps().(*KBFSOpsStandard)
+	kbfsOps.opsLock.RLock()
+	var ops *folderBranchOps
+	for _, fbo := range kbfsOps.ops {
+		ops = fbo
+		break
+	}
+	kbfsOps.opsLock.RUnlock()
+
+	// FastForward shouldn't do anything, since the TLF hasn't been
+	// cleared yet.
+	config.KBFSOps().ForceFastForward(ctx)
+	err = ops.forcedFastForwards.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Couldn't wait for fast forward: %+v", err)
+	}
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -781,6 +781,14 @@ func (_mr *_MockKBFSOpsRecorder) ClearPrivateFolderMD(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ClearPrivateFolderMD", arg0)
 }
 
+func (_m *MockKBFSOps) ForceFastForward(ctx context.Context) {
+	_m.ctrl.Call(_m, "ForceFastForward", ctx)
+}
+
+func (_mr *_MockKBFSOpsRecorder) ForceFastForward(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ForceFastForward", arg0)
+}
+
 // Mock of KeybaseService interface
 type MockKeybaseService struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
If there's a local journal for it, for example.

As an added measure, don't fast-forward a folder if it wasn't ever
cleared out in the first place.

Also, this reverts the previous revert of fast-forward forcing.  New code for review is in the latest two commits.

Issue: KBFS-1923