### PR TITLE
Fix byte count leak on duplicate puts

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -128,8 +128,10 @@ func (s backpressureDiskLimiter) beforeBlockPut(
 	return s.s.Acquire(ctx, blockBytes)
 }
 
-func (s backpressureDiskLimiter) onBlockPutFail(blockBytes int64) {
-	s.s.Release(blockBytes)
+func (s backpressureDiskLimiter) afterBlockPut(blockBytes int64, putData bool) {
+	if !putData {
+		s.s.Release(blockBytes)
+	}
 }
 
 func (s backpressureDiskLimiter) onBlockDelete(blockBytes int64) {

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -126,8 +126,9 @@ func putBlockData(
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
+	putData, err := j.putData(ctx, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
+	require.True(t, putData)
 
 	require.Equal(t, oldLength+1, getBlockJournalLength(t, j))
 
@@ -207,15 +208,17 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
+	putData, err := j.putData(ctx, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
+	require.True(t, putData)
 
 	require.Equal(t, int64(len(data)), j.getStoredBytes())
 	require.Equal(t, int64(len(data)), j.getUnflushedBytes())
 
 	// Put a second time.
-	err = j.putData(ctx, bID, bCtx, data, serverHalf)
+	putData, err = j.putData(ctx, bID, bCtx, data, serverHalf)
 	require.NoError(t, err)
+	require.False(t, putData)
 
 	require.Equal(t, oldLength+2, getBlockJournalLength(t, j))
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -80,9 +80,12 @@ type diskLimiter interface {
 	beforeBlockPut(ctx context.Context, blockBytes int64,
 		log logger.Logger) (int64, error)
 
-	// onBlockPutFail is called if putting a block of the given
-	// size (which must be > 0) fails.
-	onBlockPutFail(blockBytes int64)
+	// afterBlockPut is called after putting a block of the given
+	// size (which must match the corresponding call to
+	// beforeBlockPut). putData reflects whether or not the data
+	// was actually put; if it's false, it's either because of an
+	// error or because the block already existed.
+	afterBlockPut(blockBytes int64, putData bool)
 
 	// onBlockDelete is called after deleting a block of the given
 	// number of bytes of disk space, which must be >=

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -50,8 +50,10 @@ func (s semaphoreDiskLimiter) beforeBlockPut(
 	return s.s.Acquire(ctx, blockBytes)
 }
 
-func (s semaphoreDiskLimiter) onBlockPutFail(blockBytes int64) {
-	s.s.Release(blockBytes)
+func (s semaphoreDiskLimiter) afterBlockPut(blockBytes int64, putData bool) {
+	if !putData {
+		s.s.Release(blockBytes)
+	}
 }
 
 func (s semaphoreDiskLimiter) onBlockDelete(blockBytes int64) {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1493,9 +1493,7 @@ func (j *tlfJournal) putBlockData(
 
 	var putData bool
 	defer func() {
-		if !putData {
-			j.diskLimiter.onBlockPutFail(bufLen)
-		}
+		j.diskLimiter.afterBlockPut(bufLen, putData)
 	}()
 
 	j.journalLock.Lock()

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1491,8 +1491,9 @@ func (j *tlfJournal) putBlockData(
 		return err
 	}
 
+	var putData bool
 	defer func() {
-		if err != nil {
+		if !putData {
 			j.diskLimiter.onBlockPutFail(bufLen)
 		}
 	}()
@@ -1505,7 +1506,8 @@ func (j *tlfJournal) putBlockData(
 
 	storedBytesBefore := j.blockJournal.getStoredBytes()
 
-	err = j.blockJournal.putData(ctx, id, blockCtx, buf, serverHalf)
+	putData, err = j.blockJournal.putData(
+		ctx, id, blockCtx, buf, serverHalf)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1512,13 +1512,14 @@ func (j *tlfJournal) putBlockData(
 
 	storedBytesAfter := j.blockJournal.getStoredBytes()
 
-	// Either the stored bytes increased by `bufLen`, or stayed the
-	// same because the already existed.
-	if storedBytesAfter != (storedBytesBefore+bufLen) &&
-		storedBytesBefore != storedBytesAfter {
+	if putData && storedBytesAfter != (storedBytesBefore+bufLen) {
 		panic(fmt.Sprintf(
-			"storedBytes changed from %d to %d, but bufLen is %d",
+			"storedBytes changed from %d to %d, but %d bytes of data was put",
 			storedBytesBefore, storedBytesAfter, bufLen))
+	} else if !putData && storedBytesBefore != storedBytesAfter {
+		panic(fmt.Sprintf(
+			"storedBytes changed from %d to %d, but data was not put",
+			storedBytesBefore, storedBytesAfter))
 	}
 
 	j.config.Reporter().NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{


### PR DESCRIPTION
We forget to release bytes if a duplicate put happens.