### PR TITLE
folder_block_ops: set dedup DirectType correctly

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1768,6 +1768,8 @@ func ReadyBlock(ctx context.Context, bcache BlockCache, bops BlockOps,
 			return
 		}
 		ptr.SetWriter(uid)
+		// In case we're deduping an old pointer with an unknown block type.
+		ptr.DirectType = directType
 	} else {
 		ptr = BlockPointer{
 			ID:         id,


### PR DESCRIPTION
In case we're dedupping an old BlockPointer.

This can cause a panic on an indirect block where all child blocks are
old dedupped pointers, so none had their DirectTypes set correctly.

Issue: KBFS-1950