### PR TITLE
[KBFS-1871] Limit journal disk usage to fraction of free space

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -36,8 +36,8 @@ type backpressureDiskLimiter struct {
 	backpressureMinThreshold float64
 	// backpressureMaxThreshold is M in the above.
 	backpressureMaxThreshold float64
-	// maxJournalByteUsage is k in the above.
-	maxJournalByteUsage float64
+	// maxJournalByteFrac is k in the above.
+	maxJournalByteFrac float64
 	// maxJournalBytes is L in the above.
 	maxJournalBytes int64
 	maxDelay        time.Duration
@@ -61,7 +61,7 @@ var _ diskLimiter = (*backpressureDiskLimiter)(nil)
 // given delay function, which is overridden in tests.
 func newBackpressureDiskLimiterWithFunctions(
 	log logger.Logger,
-	backpressureMinThreshold, backpressureMaxThreshold, maxJournalByteUsage float64,
+	backpressureMinThreshold, backpressureMaxThreshold, maxJournalByteFrac float64,
 	maxJournalBytes int64, maxDelay time.Duration,
 	delayFn func(context.Context, time.Duration) error,
 	freeBytesFn func() (int64, error)) (
@@ -79,13 +79,13 @@ func newBackpressureDiskLimiterWithFunctions(
 		return nil, errors.Errorf("1.0 < backpressureMaxThreshold=%f",
 			backpressureMaxThreshold)
 	}
-	if maxJournalByteUsage < 0.01 {
-		return nil, errors.Errorf("maxJournalByteUsage=%f < 0.01",
-			maxJournalByteUsage)
+	if maxJournalByteFrac < 0.01 {
+		return nil, errors.Errorf("maxJournalByteFrac=%f < 0.01",
+			maxJournalByteFrac)
 	}
-	if maxJournalByteUsage > 1.0 {
-		return nil, errors.Errorf("maxJournalByteUsage=%f > 1.0",
-			maxJournalByteUsage)
+	if maxJournalByteFrac > 1.0 {
+		return nil, errors.Errorf("maxJournalByteFrac=%f > 1.0",
+			maxJournalByteFrac)
 	}
 	freeBytes, err := freeBytesFn()
 	if err != nil {
@@ -93,7 +93,7 @@ func newBackpressureDiskLimiterWithFunctions(
 	}
 	bdl := &backpressureDiskLimiter{
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		maxJournalByteUsage, maxJournalBytes, maxDelay,
+		maxJournalByteFrac, maxJournalBytes, maxDelay,
 		delayFn, freeBytesFn, sync.Mutex{}, 0,
 		freeBytes, 0, kbfssync.NewSemaphore(),
 	}
@@ -140,12 +140,12 @@ func defaultGetFreeBytes(path string) (int64, error) {
 // with the given parameters.
 func newBackpressureDiskLimiter(
 	log logger.Logger,
-	backpressureMinThreshold, backpressureMaxThreshold, maxJournalByteUsage float64,
+	backpressureMinThreshold, backpressureMaxThreshold, maxJournalByteFrac float64,
 	maxJournalBytes int64, maxDelay time.Duration,
 	journalPath string) (*backpressureDiskLimiter, error) {
 	return newBackpressureDiskLimiterWithFunctions(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		maxJournalByteUsage, maxJournalBytes, maxDelay,
+		maxJournalByteFrac, maxJournalBytes, maxDelay,
 		defaultDoDelay, func() (int64, error) {
 			return defaultGetFreeBytes(journalPath)
 		})
@@ -163,7 +163,7 @@ func (bdl *backpressureDiskLimiter) getScaledFreeBytesWithoutJournalLocked() flo
 	// overflow.
 	journalBytesFloat := float64(bdl.journalBytes)
 	freeBytesFloat := float64(bdl.freeBytes)
-	return bdl.maxJournalByteUsage * (journalBytesFloat + freeBytesFloat)
+	return bdl.maxJournalByteFrac * (journalBytesFloat + freeBytesFloat)
 }
 
 // updateBytesSemaphoreMaxLocked must be called (under s.bytesLock)

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -216,9 +216,9 @@ func (bdl *backpressureDiskLimiter) calculateDelay(
 	journalBytesFloat := float64(journalBytes)
 	maxJournalBytesFloat := float64(bdl.maxJournalBytes)
 	// Set r to max(J/(k(J+F)), J/L).
-	r := math.Max(
-		journalBytesFloat/bdl.getScaledFreeBytesWithoutJournalLocked(),
-		journalBytesFloat/maxJournalBytesFloat)
+	r := journalBytesFloat / math.Min(
+		bdl.getScaledFreeBytesWithoutJournalLocked(),
+		maxJournalBytesFloat)
 
 	// We want the delay to be 0 if r <= m and the max delay if r
 	// >= M, so linearly interpolate the delay based on r.

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -30,7 +30,7 @@ func TestBackpressureConstructorError(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	fakeErr := errors.New("Fake error")
 	_, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 100, 8*time.Second, nil,
+		log, 0.1, 0.9, 0.25, 100, 8*time.Second, nil,
 		func() (int64, error) {
 			return 0, fakeErr
 		})
@@ -49,7 +49,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	var fakeFreeBytes int64 = 50
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 100, 8*time.Second, delayFn,
+		log, 0.1, 0.9, 0.25, 100, 8*time.Second, delayFn,
 		func() (int64, error) {
 			return fakeFreeBytes, nil
 		})
@@ -201,7 +201,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 func TestBackpressureDiskLimiterCalculateDelay(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 100, 8*time.Second,
+		log, 0.1, 0.9, 0.25, 100, 8*time.Second,
 		func(ctx context.Context, delay time.Duration) error {
 			return nil
 		},
@@ -237,7 +237,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 10*blockSize, 8*time.Second, delayFn,
+		log, 0.1, 0.9, 0.25, 10*blockSize, 8*time.Second, delayFn,
 		func() (int64, error) {
 			return math.MaxInt64, nil
 		})
@@ -319,7 +319,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, math.MaxInt64, 8*time.Second, delayFn,
+		log, 0.1, 0.9, 0.25, math.MaxInt64, 8*time.Second, delayFn,
 		func() (int64, error) {
 			if bdl == nil {
 				return diskSize, nil

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -321,7 +321,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 	}
 
 	const blockSize = 10
-	const diskSize = 100
+	const diskSize = 400
 
 	var bdl *backpressureDiskLimiter
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -209,7 +209,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 func TestBackpressureDiskLimiterCalculateDelay(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 100, 8*time.Second,
+		log, 0.1, 0.9, 0.25, math.MaxInt64, 8*time.Second,
 		func(ctx context.Context, delay time.Duration) error {
 			return nil
 		},
@@ -221,14 +221,14 @@ func TestBackpressureDiskLimiterCalculateDelay(t *testing.T) {
 	now := time.Now()
 
 	ctx := context.Background()
-	delay := bdl.calculateDelay(ctx, 50, 50, now)
+	delay := bdl.calculateDelay(ctx, 50, 350, now)
 	require.InEpsilon(t, float64(4), delay.Seconds(), 0.01)
 
 	deadline := now.Add(5 * time.Second)
 	ctx2, cancel2 := context.WithDeadline(ctx, deadline)
 	defer cancel2()
 
-	delay = bdl.calculateDelay(ctx2, 50, 50, now)
+	delay = bdl.calculateDelay(ctx2, 50, 350, now)
 	require.InEpsilon(t, float64(2), delay.Seconds(), 0.01)
 }
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -321,7 +321,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 	}
 
 	const blockSize = 8
-	const diskSize = 400
+	const diskSize = 320
 
 	var bdl *backpressureDiskLimiter
 
@@ -348,8 +348,8 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 		bdl.getLockedVarsForTest()
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(diskSize), freeBytes)
-	require.Equal(t, int64(100), bytesSemaphoreMax)
-	require.Equal(t, int64(100), bdl.bytesSemaphore.Count())
+	require.Equal(t, int64(80), bytesSemaphoreMax)
+	require.Equal(t, int64(80), bdl.bytesSemaphore.Count())
 
 	ctx := context.Background()
 
@@ -360,7 +360,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 			bdl.getLockedVarsForTest()
 		require.Equal(t, int64(bytesPut), journalBytes)
 		expectedFreeBytes := int64(diskSize - journalBytes)
-		expectedBytesSemaphoreMax := int64(100)
+		expectedBytesSemaphoreMax := int64(80)
 		expectedBytesSemaphore := expectedBytesSemaphoreMax - int64(bytesPut)
 		if before {
 			expectedBytesSemaphore -= blockSize
@@ -378,18 +378,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 
 	// The first two puts shouldn't encounter any backpressure...
 
-	for i := 0; i < 1; i++ {
-		_, err = bdl.beforeBlockPut(ctx, blockSize)
-		require.NoError(t, err)
-		require.Equal(t, 0*time.Second, lastDelay)
-		checkCounters(true)
-
-		bdl.afterBlockPut(ctx, blockSize, true)
-		bytesPut += blockSize
-		checkCounters(false)
-	}
-
-	for i := 0; i < 1; i++ {
+	for i := 0; i < 2; i++ {
 		_, err = bdl.beforeBlockPut(ctx, blockSize)
 		require.NoError(t, err)
 		require.Equal(t, 0*time.Second, lastDelay)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -917,10 +917,10 @@ func (c *ConfigLocal) EnableJournaling(
 	const backpressureMinThreshold = 0.5
 	const backpressureMaxThreshold = 0.95
 	// Cap journal usage to a quarter of the free space.
-	const maxJournalByteUsage = 0.25
+	const maxJournalByteFrac = 0.25
 	bdl, err := newBackpressureDiskLimiter(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		maxJournalByteUsage, journalDiskLimit,
+		maxJournalByteFrac, journalDiskLimit,
 		defaultDiskLimitMaxDelay, journalRoot)
 	if err != nil {
 		return err

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -917,10 +917,10 @@ func (c *ConfigLocal) EnableJournaling(
 	const backpressureMinThreshold = 0.5
 	const backpressureMaxThreshold = 0.95
 	// Cap journal usage to a quarter of the free space.
-	const journalPlusFreeBytesFraction = 0.25
+	const maxJournalByteUsage = 0.25
 	bdl, err := newBackpressureDiskLimiter(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		journalPlusFreeBytesFraction, journalDiskLimit,
+		maxJournalByteUsage, journalDiskLimit,
 		defaultDiskLimitMaxDelay, journalRoot)
 	if err != nil {
 		return err

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -916,9 +916,12 @@ func (c *ConfigLocal) EnableJournaling(
 	const journalDiskLimit int64 = 50 * 1024 * 1024 * 1024
 	const backpressureMinThreshold = 0.5
 	const backpressureMaxThreshold = 0.95
+	// Cap journal usage to a quarter of the free space.
+	const journalPlusFreeBytesFraction = 0.25
 	bdl, err := newBackpressureDiskLimiter(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		journalDiskLimit, defaultDiskLimitMaxDelay, journalRoot)
+		journalPlusFreeBytesFraction, journalDiskLimit,
+		defaultDiskLimitMaxDelay, journalRoot)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Set the default to 25%.

Also flesh out disk limiter tests.