### PR TITLE
file_data: set direct type correctly on new level of indirection

### DIFF
--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -645,7 +645,7 @@ func (fd *fileData) createIndirectBlock(
 						KeyGen:     fd.kmd.LatestKeyGeneration(),
 						DataVer:    dver,
 						Context:    kbfsblock.MakeFirstContext(fd.uid),
-						DirectType: IndirectBlock,
+						DirectType: fd.rootBlockPointer().DirectType,
 					},
 					EncodedSize: 0,
 				},
@@ -709,6 +709,11 @@ func (fd *fileData) newRightBlock(
 		// The old top block needs to be cached under its new ID if it
 		// was indirect.
 		if len(parentBlocks) > 0 {
+			dType := DirectBlock
+			if parentBlocks[0].pblock.IsInd {
+				dType = IndirectBlock
+			}
+			newTopBlock.IPtrs[0].DirectType = dType
 			ptr := newTopBlock.IPtrs[0].BlockPointer
 			err = fd.cacher(ptr, parentBlocks[0].pblock)
 			if err != nil {


### PR DESCRIPTION
When making a new level of indirection, we were incorrectly setting
the DirectType of the first iptr of the new level -- it should have
the same type as the original top block, before the level was created.

In practice, this didn't cause any issues, because when the DirectType
should have been DirectBlock, it's always dirtied and the block type
recalculated anyway.  So this is just a cleanup to make things more
clear.

Issue: KBFS-1950