### PR TITLE
[KBFS-1902] Initial Disk Caching Implementation

### DIFF
--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -8,41 +8,31 @@ import (
 	"io"
 	"testing"
 
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
-	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
 type testBlockRetrievalConfig struct {
-	testCodec kbfscodec.Codec
+	codecGetter
+	logMaker
 	testCache BlockCache
 	bg        blockGetter
-	t         *testing.T
 }
 
 func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter) *testBlockRetrievalConfig {
 	return &testBlockRetrievalConfig{
-		kbfscodec.NewMsgpack(),
+		newTestCodecGetter(),
+		newTestLogMaker(t),
 		NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity()),
 		bg,
-		t,
 	}
-}
-
-func (c *testBlockRetrievalConfig) Codec() kbfscodec.Codec {
-	return c.testCodec
 }
 
 func (c *testBlockRetrievalConfig) BlockCache() BlockCache {
 	return c.testCache
-}
-
-func (c *testBlockRetrievalConfig) MakeLogger(_ string) logger.Logger {
-	return logger.NewTestLogger(c.t)
 }
 
 func (c testBlockRetrievalConfig) DataVersion() DataVer {

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -348,7 +348,7 @@ func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 	bContext kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
 	if b.config.DiskBlockCache() != nil {
-		go b.config.DiskBlockCache().Put(context.TODO(), tlfID, id, buf, serverHalf)
+		go b.config.DiskBlockCache().Put(ctx, tlfID, id, buf, serverHalf)
 	}
 	size := len(buf)
 	defer func() {

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -27,6 +27,7 @@ const (
 )
 
 type blockServerRemoteConfig interface {
+	diskBlockCacheGetter
 	codecGetter
 	signerGetter
 	currentInfoGetterGetter
@@ -304,6 +305,13 @@ func makeBlockReference(id kbfsblock.ID, context kbfsblock.Context) keybase1.Blo
 func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context) (
 	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
+	// TODO: do this in parallel.
+	if b.config.DiskBlockCache() != nil {
+		buf, serverHalf, err = b.config.DiskBlockCache().Get(ctx, tlfID, id)
+		if err == nil {
+			return
+		}
+	}
 	size := -1
 	defer func() {
 		if err != nil {
@@ -337,23 +345,26 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 
 // Put implements the BlockServer interface for BlockServerRemote.
 func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context, buf []byte,
+	bContext kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	if b.config.DiskBlockCache() != nil {
+		go b.config.DiskBlockCache().Put(context.TODO(), tlfID, id, buf, serverHalf)
+	}
 	size := len(buf)
 	defer func() {
 		if err != nil {
 			b.deferLog.CWarningf(
 				ctx, "Put id=%s tlf=%s context=%s sz=%d err=%v",
-				id, tlfID, context, size, err)
+				id, tlfID, bContext, size, err)
 		} else {
 			b.deferLog.CDebugf(
 				ctx, "Put id=%s tlf=%s context=%s sz=%d",
-				id, tlfID, context, size)
+				id, tlfID, bContext, size)
 		}
 	}()
 
 	arg := keybase1.PutBlockArg{
-		Bid: makeBlockIDCombo(id, context),
+		Bid: makeBlockIDCombo(id, bContext),
 		// BlockKey is misnamed -- it contains just the server
 		// half.
 		BlockKey: serverHalf.String(),

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -29,7 +29,6 @@ const (
 type blockServerRemoteConfig interface {
 	diskBlockCacheGetter
 	codecGetter
-	signerGetter
 	currentInfoGetterGetter
 	logMaker
 }
@@ -143,7 +142,8 @@ var _ rpc.ConnectionHandler = (*blockServerRemoteClientHandler)(nil)
 
 // NewBlockServerRemote constructs a new BlockServerRemote for the
 // given address.
-func NewBlockServerRemote(config blockServerRemoteConfig, blkSrvAddr string,
+func NewBlockServerRemote(config blockServerRemoteConfig,
+	signer kbfscrypto.Signer, blkSrvAddr string,
 	rpcLogFactory *libkb.RPCLogFactory) *BlockServerRemote {
 	log := config.MakeLogger("BSR")
 	deferLog := log.CloneWithAddedDepth(1)
@@ -164,7 +164,7 @@ func NewBlockServerRemote(config blockServerRemoteConfig, blkSrvAddr string,
 		bs:   bs,
 		name: "BlockServerRemotePut",
 	}
-	bs.putAuthToken = kbfscrypto.NewAuthToken(config.Signer(),
+	bs.putAuthToken = kbfscrypto.NewAuthToken(signer,
 		BServerTokenServer, BServerTokenExpireIn,
 		"libkbfs_bserver_remote", VersionString(), putClientHandler)
 	putClientHandler.authToken = bs.putAuthToken
@@ -172,7 +172,7 @@ func NewBlockServerRemote(config blockServerRemoteConfig, blkSrvAddr string,
 		bs:   bs,
 		name: "BlockServerRemoteGet",
 	}
-	bs.getAuthToken = kbfscrypto.NewAuthToken(config.Signer(),
+	bs.getAuthToken = kbfscrypto.NewAuthToken(signer,
 		BServerTokenServer, BServerTokenExpireIn,
 		"libkbfs_bserver_remote", VersionString(), getClientHandler)
 	getClientHandler.authToken = bs.getAuthToken

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -14,7 +14,6 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/kbfsblock"
-	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -27,11 +26,17 @@ const (
 	BServerTokenExpireIn = 2 * 60 * 60 // 2 hours
 )
 
+type blockServerRemoteConfig interface {
+	codecGetter
+	signerGetter
+	currentInfoGetterGetter
+	logMaker
+}
+
 // BlockServerRemote implements the BlockServer interface and
 // represents a remote KBFS block server.
 type BlockServerRemote struct {
-	codec      kbfscodec.Codec
-	cig        currentInfoGetter
+	config     blockServerRemoteConfig
 	shutdownFn func()
 	putClient  keybase1.BlockInterface
 	getClient  keybase1.BlockInterface
@@ -137,13 +142,12 @@ var _ rpc.ConnectionHandler = (*blockServerRemoteClientHandler)(nil)
 
 // NewBlockServerRemote constructs a new BlockServerRemote for the
 // given address.
-func NewBlockServerRemote(codec kbfscodec.Codec, signer kbfscrypto.Signer,
-	cig currentInfoGetter, log logger.Logger, blkSrvAddr string,
+func NewBlockServerRemote(config blockServerRemoteConfig, blkSrvAddr string,
 	rpcLogFactory *libkb.RPCLogFactory) *BlockServerRemote {
+	log := config.MakeLogger("BSR")
 	deferLog := log.CloneWithAddedDepth(1)
 	bs := &BlockServerRemote{
-		codec:      codec,
-		cig:        cig,
+		config:     config,
 		log:        log,
 		deferLog:   deferLog,
 		blkSrvAddr: blkSrvAddr,
@@ -159,7 +163,7 @@ func NewBlockServerRemote(codec kbfscodec.Codec, signer kbfscrypto.Signer,
 		bs:   bs,
 		name: "BlockServerRemotePut",
 	}
-	bs.putAuthToken = kbfscrypto.NewAuthToken(signer,
+	bs.putAuthToken = kbfscrypto.NewAuthToken(config.Signer(),
 		BServerTokenServer, BServerTokenExpireIn,
 		"libkbfs_bserver_remote", VersionString(), putClientHandler)
 	putClientHandler.authToken = bs.putAuthToken
@@ -167,7 +171,7 @@ func NewBlockServerRemote(codec kbfscodec.Codec, signer kbfscrypto.Signer,
 		bs:   bs,
 		name: "BlockServerRemoteGet",
 	}
-	bs.getAuthToken = kbfscrypto.NewAuthToken(signer,
+	bs.getAuthToken = kbfscrypto.NewAuthToken(config.Signer(),
 		BServerTokenServer, BServerTokenExpireIn,
 		"libkbfs_bserver_remote", VersionString(), getClientHandler)
 	getClientHandler.authToken = bs.getAuthToken
@@ -202,16 +206,14 @@ func NewBlockServerRemote(codec kbfscodec.Codec, signer kbfscrypto.Signer,
 }
 
 // For testing.
-func newBlockServerRemoteWithClient(codec kbfscodec.Codec,
-	cig currentInfoGetter, log logger.Logger,
+func newBlockServerRemoteWithClient(config blockServerRemoteConfig,
 	client keybase1.BlockInterface) *BlockServerRemote {
+	log := config.MakeLogger("BSR")
 	deferLog := log.CloneWithAddedDepth(1)
 	bs := &BlockServerRemote{
-		codec:     codec,
-		cig:       cig,
+		config:    config,
 		putClient: client,
 		getClient: client,
-		log:       log,
 		deferLog:  deferLog,
 	}
 	return bs
@@ -232,7 +234,7 @@ func (b *BlockServerRemote) resetAuth(
 		b.log.Debug("BlockServerRemote: resetAuth called, err: %#v", err)
 	}()
 
-	_, _, err = b.cig.GetCurrentUserInfo(ctx)
+	_, _, err = b.config.currentInfoGetter().GetCurrentUserInfo(ctx)
 	if err != nil {
 		b.log.Debug("BlockServerRemote: User logged out, skipping resetAuth")
 		return nil
@@ -245,11 +247,11 @@ func (b *BlockServerRemote) resetAuth(
 	}
 
 	// get UID, deviceKID and normalized username
-	username, uid, err := b.cig.GetCurrentUserInfo(ctx)
+	username, uid, err := b.config.currentInfoGetter().GetCurrentUserInfo(ctx)
 	if err != nil {
 		return err
 	}
-	key, err := b.cig.GetCurrentVerifyingKey(ctx)
+	key, err := b.config.currentInfoGetter().GetCurrentVerifyingKey(ctx)
 	if err != nil {
 		return err
 	}
@@ -538,7 +540,7 @@ func (b *BlockServerRemote) GetUserQuotaInfo(ctx context.Context) (info *kbfsblo
 	if err != nil {
 		return nil, err
 	}
-	return kbfsblock.UserQuotaInfoDecode(res, b.codec)
+	return kbfsblock.UserQuotaInfoDecode(res, b.config.Codec())
 }
 
 // Shutdown implements the BlockServer interface for BlockServerRemote.

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -68,10 +68,11 @@ func (fc *fakeBServerClient) AddReference(ctx context.Context, arg keybase1.AddR
 }
 
 type testBlockServerRemoteConfig struct {
-	log        logger.Logger
-	codec      kbfscodec.Codec
-	signer     kbfscrypto.Signer
-	infoGetter currentInfoGetter
+	log            logger.Logger
+	codec          kbfscodec.Codec
+	signer         kbfscrypto.Signer
+	infoGetter     currentInfoGetter
+	diskBlockCache DiskBlockCache
 }
 
 var _ blockServerRemoteConfig = (*testBlockServerRemoteConfig)(nil)
@@ -92,6 +93,10 @@ func (c testBlockServerRemoteConfig) currentInfoGetter() currentInfoGetter {
 	return c.infoGetter
 }
 
+func (c testBlockServerRemoteConfig) DiskBlockCache() DiskBlockCache {
+	return c.diskBlockCache
+}
+
 // Test that putting a block, and getting it back, works
 func TestBServerRemotePutAndGet(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
@@ -100,7 +105,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	fc := fakeBServerClient{
 		entries: make(map[keybase1.BlockIdCombo]fakeBlockEntry),
 	}
-	config := testBlockServerRemoteConfig{log, codec, nil, nil}
+	config := testBlockServerRemoteConfig{log, codec, nil, nil, nil}
 	b := newBlockServerRemoteWithClient(config, &fc)
 
 	tlfID := tlf.FakeID(2, false)
@@ -142,7 +147,7 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 	currentUID := keybase1.MakeTestUID(1)
 	serverConn, conn := rpc.MakeConnectionForTest(t)
 	log := logger.NewTestLogger(t)
-	config := testBlockServerRemoteConfig{log, codec, nil, nil}
+	config := testBlockServerRemoteConfig{log, codec, nil, nil, nil}
 	b := newBlockServerRemoteWithClient(config,
 		keybase1.BlockClient{Cli: conn.GetClient()})
 

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -7,11 +7,9 @@ package libkbfs
 import (
 	"testing"
 
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/kbfsblock"
-	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
@@ -68,22 +66,14 @@ func (fc *fakeBServerClient) AddReference(ctx context.Context, arg keybase1.AddR
 }
 
 type testBlockServerRemoteConfig struct {
-	log            logger.Logger
-	codec          kbfscodec.Codec
+	codecGetter
+	logMaker
 	signer         kbfscrypto.Signer
 	infoGetter     currentInfoGetter
 	diskBlockCache DiskBlockCache
 }
 
 var _ blockServerRemoteConfig = (*testBlockServerRemoteConfig)(nil)
-
-func (c testBlockServerRemoteConfig) MakeLogger(_ string) logger.Logger {
-	return c.log
-}
-
-func (c testBlockServerRemoteConfig) Codec() kbfscodec.Codec {
-	return c.codec
-}
 
 func (c testBlockServerRemoteConfig) Signer() kbfscrypto.Signer {
 	return c.signer
@@ -99,13 +89,12 @@ func (c testBlockServerRemoteConfig) DiskBlockCache() DiskBlockCache {
 
 // Test that putting a block, and getting it back, works
 func TestBServerRemotePutAndGet(t *testing.T) {
-	codec := kbfscodec.NewMsgpack()
 	currentUID := keybase1.MakeTestUID(1)
-	log := logger.NewTestLogger(t)
 	fc := fakeBServerClient{
 		entries: make(map[keybase1.BlockIdCombo]fakeBlockEntry),
 	}
-	config := testBlockServerRemoteConfig{log, codec, nil, nil, nil}
+	config := testBlockServerRemoteConfig{newTestCodecGetter(),
+		newTestLogMaker(t), nil, nil, nil}
 	b := newBlockServerRemoteWithClient(config, &fc)
 
 	tlfID := tlf.FakeID(2, false)
@@ -143,11 +132,10 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 
 // If we cancel the RPC before the RPC returns, the call should error quickly.
 func TestBServerRemotePutCanceled(t *testing.T) {
-	codec := kbfscodec.NewMsgpack()
 	currentUID := keybase1.MakeTestUID(1)
 	serverConn, conn := rpc.MakeConnectionForTest(t)
-	log := logger.NewTestLogger(t)
-	config := testBlockServerRemoteConfig{log, codec, nil, nil, nil}
+	config := testBlockServerRemoteConfig{newTestCodecGetter(),
+		newTestLogMaker(t), nil, nil, nil}
 	b := newBlockServerRemoteWithClient(config,
 		keybase1.BlockClient{Cli: conn.GetClient()})
 

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -67,6 +67,31 @@ func (fc *fakeBServerClient) AddReference(ctx context.Context, arg keybase1.AddR
 	return nil
 }
 
+type testBlockServerRemoteConfig struct {
+	log        logger.Logger
+	codec      kbfscodec.Codec
+	signer     kbfscrypto.Signer
+	infoGetter currentInfoGetter
+}
+
+var _ blockServerRemoteConfig = (*testBlockServerRemoteConfig)(nil)
+
+func (c testBlockServerRemoteConfig) MakeLogger(_ string) logger.Logger {
+	return c.log
+}
+
+func (c testBlockServerRemoteConfig) Codec() kbfscodec.Codec {
+	return c.codec
+}
+
+func (c testBlockServerRemoteConfig) Signer() kbfscrypto.Signer {
+	return c.signer
+}
+
+func (c testBlockServerRemoteConfig) currentInfoGetter() currentInfoGetter {
+	return c.infoGetter
+}
+
 // Test that putting a block, and getting it back, works
 func TestBServerRemotePutAndGet(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
@@ -75,7 +100,8 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	fc := fakeBServerClient{
 		entries: make(map[keybase1.BlockIdCombo]fakeBlockEntry),
 	}
-	b := newBlockServerRemoteWithClient(codec, nil, log, &fc)
+	config := testBlockServerRemoteConfig{log, codec, nil, nil}
+	b := newBlockServerRemoteWithClient(config, &fc)
 
 	tlfID := tlf.FakeID(2, false)
 	bCtx := kbfsblock.MakeFirstContext(currentUID, keybase1.BlockType_DATA)
@@ -116,7 +142,8 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 	currentUID := keybase1.MakeTestUID(1)
 	serverConn, conn := rpc.MakeConnectionForTest(t)
 	log := logger.NewTestLogger(t)
-	b := newBlockServerRemoteWithClient(codec, nil, log,
+	config := testBlockServerRemoteConfig{log, codec, nil, nil}
+	b := newBlockServerRemoteWithClient(config,
 		keybase1.BlockClient{Cli: conn.GetClient()})
 
 	f := func(ctx context.Context) error {

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -862,7 +862,7 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 		errorList = append(errorList, err)
 	}
 	if c.DiskBlockCache() != nil {
-		c.DiskBlockCache().Shutdown()
+		c.DiskBlockCache().Shutdown(ctx)
 	}
 
 	if len(errorList) == 1 {

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -281,6 +281,13 @@ func (c *ConfigLocal) KBPKI() KBPKI {
 	return c.kbpki
 }
 
+// currentInfoGetter implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) currentInfoGetter() currentInfoGetter {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.kbpki
+}
+
 // SetKBPKI implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) SetKBPKI(k KBPKI) {
 	c.lock.Lock()
@@ -381,6 +388,13 @@ func (c *ConfigLocal) SetDirtyBlockCache(d DirtyBlockCache) {
 
 // Crypto implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) Crypto() Crypto {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.crypto
+}
+
+// Signer implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) Signer() kbfscrypto.Signer {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.crypto

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -93,6 +93,14 @@ func (cache *DiskBlockCacheStandard) Evict(ctx context.Context, tlfID tlf.ID,
 	if cache.isClosed {
 		return DiskCacheClosedError{"Evict"}
 	}
+	// Use kbfscrypto.MakeTemporaryID() to create a random hash ID. Then begin
+	// an interator into cache.lruDb.Range(b, nil) and iterate from there to
+	// get numBlocks * evictionConsiderationFactor block IDs.  We sort the
+	// resulting blocks by value (LRU time) and pick the minimum numBlocks. We
+	// put those block IDs into a leveldb.Batch for cache.blockDb via
+	// Batch.Delete(), then Write() that batch.
+	// NOTE: It is important that we store LRU times using a monotonic clock
+	// for this device. Use runtime.nanotime() for now.
 	return nil
 }
 

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -1,0 +1,30 @@
+package libkbfs
+
+import (
+	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/tlf"
+)
+
+// DiskBlockCacheStandard is the standard implementation for DiskBlockCache.
+type DiskBlockCacheStandard struct {
+}
+
+var _ DiskBlockCache = (*DiskBlockCacheStandard)(nil)
+
+// Get implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Get(tlfID tlf.ID, blockID kbfsblock.ID) (
+	Block, error) {
+	return nil, NoSuchBlockError{blockID}
+}
+
+// Put implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Put(tlfID tlf.ID, blockID kbfsblock.ID,
+	block Block) error {
+	return nil
+}
+
+// Delete implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Delete(tlfID tlf.ID, blockID kbfsblock.ID,
+) error {
+	return nil
+}

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -129,8 +129,9 @@ func getVersionedPathForDiskCache(dirPath string) (versionedDirPath string,
 			return "", err
 		}
 		if version < initialDiskCacheVersion {
-			return "", errors.Errorf("New disk cache version."+
-				" Delete the existing disk cache at path: %s", dirPath)
+			return "", errors.WithStack(
+				InvalidVersionError{fmt.Sprintf("New disk cache version."+
+					" Delete the existing disk cache at path: %s", dirPath)})
 		}
 		// Disk cache version is newer than we expect for this client. This is an
 		// error, and we shouldn't initialize the disk cache.

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -13,9 +13,10 @@ import (
 )
 
 const (
-	evictionConsiderationFactor uint   = 3
-	blockDbFilename             string = "diskCacheBlocks.leveldb"
-	lruDbFilename               string = "diskCacheLRU.leveldb"
+	defaultDiskBlockCacheMaxBytes uint64 = 10 * (1 << 30)
+	evictionConsiderationFactor   uint   = 3
+	blockDbFilename               string = "diskCacheBlocks.leveldb"
+	lruDbFilename                 string = "diskCacheLRU.leveldb"
 )
 
 type diskBlockCacheEntry struct {
@@ -133,6 +134,7 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 	if cache.isClosed {
 		return DiskCacheClosedError{"Put"}
 	}
+	// TODO: accounting
 	entry, err := cache.encodeBlockCacheEntry(buf, serverHalf)
 	blockBytes := blockID.Bytes()
 	err = cache.blockDb.Put(blockBytes, entry, nil)

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -104,14 +104,6 @@ func newDiskBlockCacheStandard(config diskBlockCacheConfig, dirPath string,
 		lruStorage, maxBytes)
 }
 
-func newDiskBlockCacheStandardForTest(config diskBlockCacheConfig,
-	maxBytes uint64) (*DiskBlockCacheStandard, error) {
-	blockStorage := storage.NewMemStorage()
-	lruStorage := storage.NewMemStorage()
-	return newDiskBlockCacheStandardFromStorage(config, blockStorage,
-		lruStorage, maxBytes)
-}
-
 // TODO: Fix getSizesLocked(), where leveldb.DB.SizeOf() currently doesn't work
 // for the full range. As it is right now, this is a very cheap operation,
 // since it just takes the beginning and end offsets from levelDB and returns

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -143,7 +143,7 @@ func (cache *DiskBlockCacheStandard) compactCachesLocked(ctx context.Context) {
 
 // lruKey generates an LRU cache key from a tlf.ID and a binary-encoded block
 // ID.
-func (_ *DiskBlockCacheStandard) lruKey(tlfID tlf.ID, blockKey []byte) []byte {
+func (*DiskBlockCacheStandard) lruKey(tlfID tlf.ID, blockKey []byte) []byte {
 	return append(tlfID.Bytes(), blockKey...)
 }
 
@@ -161,7 +161,7 @@ func (cache *DiskBlockCacheStandard) updateLruLocked(tlfID tlf.ID,
 }
 
 // timeFromBytes converts a value from the LRU cache into a time.Time.
-func (_ *DiskBlockCacheStandard) timeFromBytes(b []byte) (t time.Time, err error) {
+func (*DiskBlockCacheStandard) timeFromBytes(b []byte) (t time.Time, err error) {
 	err = t.UnmarshalBinary(b)
 	return t, err
 }

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -1,30 +1,104 @@
 package libkbfs
 
 import (
+	"path/filepath"
+	"sync"
+
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+const (
+	evictionConsiderationFactor uint   = 3
+	blockDbFilename             string = "diskCacheBlocks.leveldb"
+	lruDbFilename               string = "diskCacheLRU.leveldb"
 )
 
 // DiskBlockCacheStandard is the standard implementation for DiskBlockCache.
 type DiskBlockCacheStandard struct {
+	maxBytes uint64
+	// protects everything below
+	lock     sync.RWMutex
+	isClosed bool
+	blockDb  *leveldb.DB
+	lruDb    *leveldb.DB
 }
 
 var _ DiskBlockCache = (*DiskBlockCacheStandard)(nil)
 
+func newDiskBlockCacheStandard(dirPath string, maxBytes uint64) (
+	*DiskBlockCacheStandard, error) {
+	blockDbPath := filepath.Join(dirPath, blockDbFilename)
+	blockDb, err := leveldb.OpenFile(blockDbPath, leveldbOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	lruDbPath := filepath.Join(dirPath, lruDbFilename)
+	lruDb, err := leveldb.OpenFile(lruDbPath, leveldbOptions)
+	if err != nil {
+		blockDb.Close()
+		return nil, err
+	}
+	return &DiskBlockCacheStandard{
+		blockDb:  blockDb,
+		lruDb:    lruDb,
+		maxBytes: maxBytes,
+	}, nil
+}
+
 // Get implements the DiskBlockCache interface for DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) Get(tlfID tlf.ID, blockID kbfsblock.ID) (
 	Block, error) {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	if cache.isClosed {
+		return nil, DiskCacheClosedError{"Get"}
+	}
 	return nil, NoSuchBlockError{blockID}
 }
 
 // Put implements the DiskBlockCache interface for DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) Put(tlfID tlf.ID, blockID kbfsblock.ID,
 	block Block) error {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	if cache.isClosed {
+		return DiskCacheClosedError{"Put"}
+	}
 	return nil
 }
 
 // Delete implements the DiskBlockCache interface for DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) Delete(tlfID tlf.ID, blockID kbfsblock.ID,
 ) error {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	if cache.isClosed {
+		return DiskCacheClosedError{"Delete"}
+	}
 	return nil
+}
+
+// Evict implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Evict(tlfID tlf.ID, numBlocks int) error {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	if cache.isClosed {
+		return DiskCacheClosedError{"Evict"}
+	}
+	return nil
+}
+
+// Shutdown implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Shutdown() {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	if cache.isClosed {
+		return
+	}
+	cache.isClosed = true
+	cache.blockDb.Close()
+	cache.lruDb.Close()
 }

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+const (
+	testDiskBlockCacheMaxBytes uint64 = 1 << 20
+)
+
+type testDiskBlockCacheConfig struct {
+	codec kbfscodec.Codec
+	log   logger.Logger
+}
+
+func newTestDiskBlockCacheConfig(t *testing.T) testDiskBlockCacheConfig {
+	return testDiskBlockCacheConfig{
+		codec: kbfscodec.NewMsgpack(),
+		log:   logger.NewTestLogger(t),
+	}
+}
+
+func (c testDiskBlockCacheConfig) Codec() kbfscodec.Codec {
+	return c.codec
+}
+
+func (c testDiskBlockCacheConfig) MakeLogger(_ string) logger.Logger {
+	return c.log
+}
+
+func newDiskBlockCacheStandardForTest(config diskBlockCacheConfig,
+	maxBytes uint64) (*DiskBlockCacheStandard, error) {
+	blockStorage := storage.NewMemStorage()
+	lruStorage := storage.NewMemStorage()
+	return newDiskBlockCacheStandardFromStorage(config, blockStorage,
+		lruStorage, maxBytes)
+}
+
+func initDiskBlockCacheTest(t *testing.T) (DiskBlockCache,
+	testDiskBlockCacheConfig) {
+	config := newTestDiskBlockCacheConfig(t)
+	cache, err := newDiskBlockCacheStandardForTest(config,
+		testDiskBlockCacheMaxBytes)
+	require.NoError(t, err)
+	return cache, config
+}
+
+func shutdownDiskBlockCacheTest(cache DiskBlockCache) {
+	cache.Shutdown()
+}
+
+func TestDiskBlockCachePutAndGet(t *testing.T) {
+	cache, config := initDiskBlockCacheTest(t)
+	defer shutdownDiskBlockCacheTest(cache)
+
+	tlf1 := tlf.FakeID(0, false)
+	ptr1 := makeRandomBlockPointer(t)
+	block1 := makeFakeFileBlock(t, false)
+	block1Encoded, err := config.Codec().Encode(block1)
+	require.NoError(t, err)
+	block1ServerHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Log("Put a block into the cache.")
+	err = cache.Put(ctx, tlf1, ptr1.ID, block1Encoded, block1ServerHalf)
+	require.NoError(t, err)
+
+	t.Log("Get that block from the cache. Verify that it's the same.")
+	buf, serverHalf, err := cache.Get(ctx, tlf1, ptr1.ID)
+	require.NoError(t, err)
+	require.Equal(t, block1ServerHalf, serverHalf)
+	require.Equal(t, block1Encoded, buf)
+
+	t.Log("Attempt to Get a block from the cache that isn't there." +
+		" Verify that it fails.")
+	ptr2 := makeRandomBlockPointer(t)
+	buf, serverHalf, err = cache.Get(ctx, tlf1, ptr2.ID)
+	require.EqualError(t, err, NoSuchBlockError{ptr2.ID}.Error())
+	require.Equal(t, kbfscrypto.BlockCryptKeyServerHalf{}, serverHalf)
+	require.Nil(t, buf)
+}

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -8,9 +8,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfsblock"
-	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
@@ -23,23 +21,15 @@ const (
 )
 
 type testDiskBlockCacheConfig struct {
-	codec kbfscodec.Codec
-	log   logger.Logger
+	codecGetter
+	logMaker
 }
 
 func newTestDiskBlockCacheConfig(t *testing.T) testDiskBlockCacheConfig {
 	return testDiskBlockCacheConfig{
-		codec: kbfscodec.NewMsgpack(),
-		log:   logger.NewTestLogger(t),
+		newTestCodecGetter(),
+		newTestLogMaker(t),
 	}
-}
-
-func (c testDiskBlockCacheConfig) Codec() kbfscodec.Codec {
-	return c.codec
-}
-
-func (c testDiskBlockCacheConfig) MakeLogger(_ string) logger.Logger {
-	return c.log
 }
 
 func newDiskBlockCacheStandardForTest(config diskBlockCacheConfig,

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -23,12 +24,14 @@ const (
 type testDiskBlockCacheConfig struct {
 	codecGetter
 	logMaker
+	*testClockGetter
 }
 
 func newTestDiskBlockCacheConfig(t *testing.T) testDiskBlockCacheConfig {
 	return testDiskBlockCacheConfig{
 		newTestCodecGetter(),
 		newTestLogMaker(t),
+		newTestClockGetter(),
 	}
 }
 
@@ -80,6 +83,7 @@ func TestDiskBlockCachePutAndGet(t *testing.T) {
 	require.NoError(t, err)
 	putTime, err := cache.getLru(tlf1, block1Id)
 	require.NoError(t, err)
+	config.TestClock().Add(time.Second)
 
 	t.Log("Get that block from the cache. Verify that it's the same.")
 	buf, serverHalf, err := cache.Get(ctx, tlf1, block1Id)

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -53,7 +53,7 @@ func initDiskBlockCacheTest(t *testing.T) (*DiskBlockCacheStandard,
 }
 
 func shutdownDiskBlockCacheTest(cache DiskBlockCache) {
-	cache.Shutdown()
+	cache.Shutdown(context.Background())
 }
 
 func setupBlockForDiskCache(t *testing.T, config diskBlockCacheConfig) (
@@ -81,7 +81,7 @@ func TestDiskBlockCachePutAndGet(t *testing.T) {
 	t.Log("Put a block into the cache.")
 	err := cache.Put(ctx, tlf1, block1Id, block1Encoded, block1ServerHalf)
 	require.NoError(t, err)
-	putTime, err := cache.getLru(tlf1, block1Id)
+	putTime, err := cache.getLRU(tlf1, block1Id)
 	require.NoError(t, err)
 	config.TestClock().Add(time.Second)
 
@@ -92,7 +92,7 @@ func TestDiskBlockCachePutAndGet(t *testing.T) {
 	require.Equal(t, block1Encoded, buf)
 
 	t.Log("Verify that the Get updated the LRU time for the block.")
-	getTime, err := cache.getLru(tlf1, block1Id)
+	getTime, err := cache.getLRU(tlf1, block1Id)
 	require.NoError(t, err)
 	require.True(t, getTime.After(putTime))
 
@@ -105,7 +105,7 @@ func TestDiskBlockCachePutAndGet(t *testing.T) {
 	require.Nil(t, buf)
 
 	t.Log("Verify that the cache returns no LRU time for the missing block.")
-	_, err = cache.getLru(tlf1, ptr2.ID)
+	_, err = cache.getLRU(tlf1, ptr2.ID)
 	require.EqualError(t, err, errors.ErrNotFound.Error())
 }
 
@@ -144,8 +144,8 @@ func TestDiskBlockCacheDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Verify that the cache returns no LRU time for the missing blocks.")
-	_, err = cache.getLru(tlf1, block1Id)
+	_, err = cache.getLRU(tlf1, block1Id)
 	require.EqualError(t, err, errors.ErrNotFound.Error())
-	_, err = cache.getLru(tlf1, block2Id)
+	_, err = cache.getLRU(tlf1, block2Id)
 	require.EqualError(t, err, errors.ErrNotFound.Error())
 }

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1221,3 +1221,14 @@ type NoMergedMDError struct {
 func (e NoMergedMDError) Error() string {
 	return fmt.Sprintf("No MD yet for TLF %s", e.tlf)
 }
+
+// DiskCacheClosedError indicates that the disk cache has been
+// closed, and thus isn't accepting any more operations.
+type DiskCacheClosedError struct {
+	op string
+}
+
+// Error implements the error interface for DiskCacheClosedError.
+func (e DiskCacheClosedError) Error() string {
+	return fmt.Sprintf("Error performing %s operation: the disk cache is closed.", e.op)
+}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1230,5 +1230,5 @@ type DiskCacheClosedError struct {
 
 // Error implements the error interface for DiskCacheClosedError.
 func (e DiskCacheClosedError) Error() string {
-	return fmt.Sprintf("Error performing %s operation: the disk cache is closed.", e.op)
+	return fmt.Sprintf("Error performing %s operation: the disk cache is closed", e.op)
 }

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -510,6 +510,20 @@ func (e OutdatedVersionError) Error() string {
 		"Please use `keybase update check` to upgrade your software."
 }
 
+// InvalidVersionError indicates that we have encountered some new data version
+// we don't understand, and we don't know how to handle it.
+type InvalidVersionError struct {
+	msg string
+}
+
+// Error implements the error interface for InvalidVersionError.
+func (e InvalidVersionError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+	return "The version provided is not valid."
+}
+
 // InvalidKeyGenerationError indicates that an invalid key generation
 // was used.
 type InvalidKeyGenerationError struct {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3991,6 +3991,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 	case *GCOp:
 		// Unreferenced blocks in a GCOp mean that we shouldn't cache
 		// them anymore
+		fbo.log.CDebugf(ctx, "notifyOneOp: GCOp with latest rev %d and %d unref'd blocks", realOp.LatestRev, len(realOp.Unrefs()))
 		bcache := fbo.config.BlockCache()
 		idsToDelete := make([]kbfsblock.ID, 0, len(realOp.Unrefs()))
 		for _, ptr := range realOp.Unrefs() {
@@ -4000,8 +4001,9 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 					"Couldn't delete transient entry for %v: %v", ptr, err)
 			}
 		}
-		if fbo.config.DiskBlockCache() != nil {
-			go fbo.config.DiskBlockCache().Delete(ctx, md.TlfID(), idsToDelete)
+		diskCache := fbo.config.DiskBlockCache()
+		if diskCache != nil {
+			go diskCache.Delete(ctx, md.TlfID(), idsToDelete)
 		}
 	case *resolutionOp:
 		// If there are any unrefs of blocks that have a node, this is an

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3992,11 +3992,16 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		// Unreferenced blocks in a GCOp mean that we shouldn't cache
 		// them anymore
 		bcache := fbo.config.BlockCache()
+		idsToDelete := make([]kbfsblock.ID, 0, len(realOp.Unrefs()))
 		for _, ptr := range realOp.Unrefs() {
+			idsToDelete = append(idsToDelete, ptr.ID)
 			if err := bcache.DeleteTransient(ptr, fbo.id()); err != nil {
 				fbo.log.CDebugf(ctx,
 					"Couldn't delete transient entry for %v: %v", ptr, err)
 			}
+		}
+		if fbo.config.DiskBlockCache() != nil {
+			go fbo.config.DiskBlockCache().Delete(ctx, md.TlfID(), idsToDelete)
 		}
 	case *resolutionOp:
 		// If there are any unrefs of blocks that have a node, this is an

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -74,8 +74,12 @@ type InitParams struct {
 	WriteJournalRoot string
 
 	// DiskCacheRoot, if non-empty, points to a path to a local directory to
-	// put the block cache database. If non-empty, enables disk caching.
+	// put the block cache database. If non-default, enables disk caching.
 	DiskCacheRoot string
+	// EnableDiskCache toggles whether the disk cache is enabled in the default
+	// data directory. Note that specifying a non-default DiskCacheRoot
+	// overrides this setting.
+	EnableDiskCache bool
 }
 
 // defaultBServer returns the default value for the -bserver flag.
@@ -166,6 +170,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.StringVar(&params.WriteJournalRoot, "write-journal-root", defaultParams.WriteJournalRoot, "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	flags.Uint64Var(&params.CleanBlockCacheCapacity, "clean-bcache-cap", defaultParams.CleanBlockCacheCapacity, "If non-zero, specify the capacity of clean block cache. If zero, the capacity is set based on system RAM.")
 	flags.StringVar(&params.DiskCacheRoot, "disk-cache-root", defaultParams.DiskCacheRoot, "(EXPERIMENTAL) If non-empty, permits a block database to be saved in the specified directory.")
+	flags.BoolVar(&params.EnableDiskCache, "enable-disk-cache", false, "(EXPERIMENTAL) Enables the disk cache for the default data directory.")
 
 	// No real need to enable setting
 	// params.TLFJournalBackgroundWorkStatus via a flag.
@@ -506,7 +511,11 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 			log.Warning("Could not initialize journal server: %+v", err)
 		}
 	}
-	if len(params.DiskCacheRoot) != 0 {
+	defaultParams := DefaultInitParams(ctx)
+	// Only enable the disk block cache if the user has explicitly specified a
+	// caching root directory, or enabled caching in the default directory.
+	if len(params.DiskCacheRoot) != 0 && (params.EnableDiskCache ||
+		params.DiskCacheRoot != defaultParams.DiskCacheRoot) {
 		err := config.EnableDiskBlockCache(context.TODO(),
 			params.DiskCacheRoot)
 		if err != nil {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -305,7 +305,8 @@ func makeBlockServer(config Config, bserverAddr string,
 	}
 
 	log.Debug("Using remote bserver %s", bserverAddr)
-	return NewBlockServerRemote(config, bserverAddr, rpcLogFactory), nil
+	return NewBlockServerRemote(config, config.Signer(), bserverAddr,
+		rpcLogFactory), nil
 }
 
 // InitLog sets up logging switching to a log file if necessary.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -72,6 +72,10 @@ type InitParams struct {
 	// directory to put write journals in. If non-empty, enables
 	// write journaling to be turned on for TLFs.
 	WriteJournalRoot string
+
+	// DiskCacheRoot, if non-empty, points to a path to a local directory to
+	// put the block cache database. If non-empty, enables disk caching.
+	DiskCacheRoot string
 }
 
 // defaultBServer returns the default value for the -bserver flag.
@@ -135,6 +139,7 @@ func DefaultInitParams(ctx Context) InitParams {
 		},
 		TLFJournalBackgroundWorkStatus: TLFJournalBackgroundWorkEnabled,
 		WriteJournalRoot:               filepath.Join(ctx.GetDataDir(), "kbfs_journal"),
+		DiskCacheRoot:                  filepath.Join(ctx.GetDataDir(), "kbfs_block_cache"),
 	}
 }
 
@@ -160,6 +165,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
 	flags.StringVar(&params.WriteJournalRoot, "write-journal-root", defaultParams.WriteJournalRoot, "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	flags.Uint64Var(&params.CleanBlockCacheCapacity, "clean-bcache-cap", defaultParams.CleanBlockCacheCapacity, "If non-zero, specify the capacity of clean block cache. If zero, the capacity is set based on system RAM.")
+	flags.StringVar(&params.DiskCacheRoot, "disk-cache-root", defaultParams.DiskCacheRoot, "(EXPERIMENTAL) If non-empty, permits a block database to be saved in the specified directory.")
 
 	// No real need to enable setting
 	// params.TLFJournalBackgroundWorkStatus via a flag.
@@ -498,6 +504,13 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {
 			log.Warning("Could not initialize journal server: %+v", err)
+		}
+	}
+	if len(params.DiskCacheRoot) != 0 {
+		err := config.EnableDiskBlockCache(context.TODO(),
+			params.DiskCacheRoot)
+		if err != nil {
+			log.Warning("Could not initialize disk cache: %+v", err)
 		}
 	}
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -294,9 +294,7 @@ func makeBlockServer(config Config, bserverAddr string,
 	}
 
 	log.Debug("Using remote bserver %s", bserverAddr)
-	bserverLog := config.MakeLogger("BSR")
-	return NewBlockServerRemote(config.Codec(), config.Crypto(),
-		config.KBPKI(), bserverLog, bserverAddr, rpcLogFactory), nil
+	return NewBlockServerRemote(config, bserverAddr, rpcLogFactory), nil
 }
 
 // InitLog sets up logging switching to a log file if necessary.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -520,6 +520,8 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 			params.DiskCacheRoot)
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)
+			// TODO: Make this error less fatal later.
+			return nil, err
 		}
 	}
 

--- a/libkbfs/interface_test.go
+++ b/libkbfs/interface_test.go
@@ -34,3 +34,21 @@ func newTestLogMaker(t *testing.T) testLogMaker {
 func (lm testLogMaker) MakeLogger(_ string) logger.Logger {
 	return lm.log
 }
+
+type testClockGetter struct {
+	clock *TestClock
+}
+
+var _ clockGetter = (*testClockGetter)(nil)
+
+func newTestClockGetter() *testClockGetter {
+	return &testClockGetter{newTestClockNow()}
+}
+
+func (cg *testClockGetter) Clock() Clock {
+	return cg.clock
+}
+
+func (cg *testClockGetter) TestClock() *TestClock {
+	return cg.clock
+}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -815,6 +815,16 @@ type DirtyBlockCache interface {
 	Shutdown() error
 }
 
+// DiskBlockCache caches blocks to the disk.
+type DiskBlockCache interface {
+	// Get gets a block from the disk cache.
+	Get(tlfID tlf.ID, blockID kbfsblock.ID) (Block, error)
+	// Put puts a block to the disk cache.
+	Put(tlfID tlf.ID, blockID kbfsblock.ID, block Block) error
+	// Delete deletes a block from the disk cache.
+	Delete(tlfID tlf.ID, blockID kbfsblock.ID) error
+}
+
 // cryptoPure contains all methods of Crypto that don't depend on
 // implicit state, i.e. they're pure functions of the input.
 type cryptoPure interface {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -823,6 +823,8 @@ type DiskBlockCache interface {
 	Put(tlfID tlf.ID, blockID kbfsblock.ID, block Block) error
 	// Delete deletes a block from the disk cache.
 	Delete(tlfID tlf.ID, blockID kbfsblock.ID) error
+	// Evict evicts some number of blocks from the disk cache.
+	Evict(tlfID tlf.ID, numBlocks int) error
 }
 
 // cryptoPure contains all methods of Crypto that don't depend on

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -818,13 +818,17 @@ type DirtyBlockCache interface {
 // DiskBlockCache caches blocks to the disk.
 type DiskBlockCache interface {
 	// Get gets a block from the disk cache.
-	Get(tlfID tlf.ID, blockID kbfsblock.ID) (Block, error)
+	Get(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) (
+		[]byte, kbfscrypto.BlockCryptKeyServerHalf, error)
 	// Put puts a block to the disk cache.
-	Put(tlfID tlf.ID, blockID kbfsblock.ID, block Block) error
+	Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte,
+		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
 	// Delete deletes a block from the disk cache.
-	Delete(tlfID tlf.ID, blockID kbfsblock.ID) error
+	Delete(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) error
 	// Evict evicts some number of blocks from the disk cache.
-	Evict(tlfID tlf.ID, numBlocks int) error
+	Evict(ctx context.Context, tlfID tlf.ID, numBlocks int) error
+	// Shutdown cleanly shuts down the disk block cache.
+	Shutdown()
 }
 
 // cryptoPure contains all methods of Crypto that don't depend on

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -839,8 +839,8 @@ type DiskBlockCache interface {
 	// Put puts a block to the disk cache.
 	Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte,
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
-	// Delete deletes a block from the disk cache.
-	Delete(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) error
+	// Delete deletes some blocks from the disk cache.
+	Delete(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) error
 	// Evict evicts some number of blocks from the disk cache.
 	Evict(ctx context.Context, tlfID tlf.ID, numBlocks int) error
 	// Shutdown cleanly shuts down the disk block cache.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -59,6 +59,10 @@ type signerGetter interface {
 	Signer() kbfscrypto.Signer
 }
 
+type diskBlockCacheGetter interface {
+	DiskBlockCache() DiskBlockCache
+}
+
 // Block just needs to be (de)serialized using msgpack
 type Block interface {
 	dataVersioner
@@ -1486,6 +1490,7 @@ type Config interface {
 	cryptoGetter
 	signerGetter
 	currentInfoGetterGetter
+	diskBlockCacheGetter
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -841,8 +841,6 @@ type DiskBlockCache interface {
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
 	// Delete deletes some blocks from the disk cache.
 	Delete(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) error
-	// Evict evicts some number of blocks from the disk cache.
-	Evict(ctx context.Context, tlfID tlf.ID, numBlocks int) error
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown()
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -47,6 +47,18 @@ type cryptoPureGetter interface {
 	cryptoPure() cryptoPure
 }
 
+type cryptoGetter interface {
+	Crypto() Crypto
+}
+
+type currentInfoGetterGetter interface {
+	currentInfoGetter() currentInfoGetter
+}
+
+type signerGetter interface {
+	Signer() kbfscrypto.Signer
+}
+
 // Block just needs to be (de)serialized using msgpack
 type Block interface {
 	dataVersioner
@@ -1471,6 +1483,9 @@ type Config interface {
 	codecGetter
 	cryptoPureGetter
 	keyGetterGetter
+	cryptoGetter
+	signerGetter
+	currentInfoGetterGetter
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI
@@ -1488,7 +1503,6 @@ type Config interface {
 	SetBlockCache(BlockCache)
 	DirtyBlockCache() DirtyBlockCache
 	SetDirtyBlockCache(DirtyBlockCache)
-	Crypto() Crypto
 	SetCrypto(Crypto)
 	SetCodec(kbfscodec.Codec)
 	MDOps() MDOps

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -63,6 +63,10 @@ type diskBlockCacheGetter interface {
 	DiskBlockCache() DiskBlockCache
 }
 
+type clockGetter interface {
+	Clock() Clock
+}
+
 // Block just needs to be (de)serialized using msgpack
 type Block interface {
 	dataVersioner
@@ -1489,6 +1493,7 @@ type Config interface {
 	signerGetter
 	currentInfoGetterGetter
 	diskBlockCacheGetter
+	clockGetter
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI
@@ -1525,7 +1530,6 @@ type Config interface {
 	SetBlockSplitter(BlockSplitter)
 	Notifier() Notifier
 	SetNotifier(Notifier)
-	Clock() Clock
 	SetClock(Clock)
 	ConflictRenamer() ConflictRenamer
 	SetConflictRenamer(ConflictRenamer)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -846,7 +846,7 @@ type DiskBlockCache interface {
 	// Delete deletes some blocks from the disk cache.
 	Delete(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) error
 	// Shutdown cleanly shuts down the disk block cache.
-	Shutdown()
+	Shutdown(ctx context.Context)
 }
 
 // cryptoPure contains all methods of Crypto that don't depend on

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -110,7 +110,7 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, config.BlockCache(), nil, t}))
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, newTestLogMaker(t), config.BlockCache(), nil}))
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/leveldb.go
+++ b/libkbfs/leveldb.go
@@ -8,6 +8,7 @@ import "github.com/syndtr/goleveldb/leveldb/opt"
 
 var leveldbOptions = &opt.Options{
 	Compression: opt.NoCompression,
+	BlockSize:   1 << 16,
 	// Default max open file descriptors (ulimit -n) is 256 on OS
 	// X, and >=1024 on (most?) Linux machines. So set to a low
 	// number since we have multiple leveldb instances.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -234,6 +234,130 @@ func (_mr *_MockcryptoPureGetterRecorder) cryptoPure() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "cryptoPure")
 }
 
+// Mock of cryptoGetter interface
+type MockcryptoGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockcryptoGetterRecorder
+}
+
+// Recorder for MockcryptoGetter (not exported)
+type _MockcryptoGetterRecorder struct {
+	mock *MockcryptoGetter
+}
+
+func NewMockcryptoGetter(ctrl *gomock.Controller) *MockcryptoGetter {
+	mock := &MockcryptoGetter{ctrl: ctrl}
+	mock.recorder = &_MockcryptoGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockcryptoGetter) EXPECT() *_MockcryptoGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockcryptoGetter) Crypto() Crypto {
+	ret := _m.ctrl.Call(_m, "Crypto")
+	ret0, _ := ret[0].(Crypto)
+	return ret0
+}
+
+func (_mr *_MockcryptoGetterRecorder) Crypto() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Crypto")
+}
+
+// Mock of currentInfoGetterGetter interface
+type MockcurrentInfoGetterGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockcurrentInfoGetterGetterRecorder
+}
+
+// Recorder for MockcurrentInfoGetterGetter (not exported)
+type _MockcurrentInfoGetterGetterRecorder struct {
+	mock *MockcurrentInfoGetterGetter
+}
+
+func NewMockcurrentInfoGetterGetter(ctrl *gomock.Controller) *MockcurrentInfoGetterGetter {
+	mock := &MockcurrentInfoGetterGetter{ctrl: ctrl}
+	mock.recorder = &_MockcurrentInfoGetterGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockcurrentInfoGetterGetter) EXPECT() *_MockcurrentInfoGetterGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockcurrentInfoGetterGetter) currentInfoGetter() currentInfoGetter {
+	ret := _m.ctrl.Call(_m, "currentInfoGetter")
+	ret0, _ := ret[0].(currentInfoGetter)
+	return ret0
+}
+
+func (_mr *_MockcurrentInfoGetterGetterRecorder) currentInfoGetter() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "currentInfoGetter")
+}
+
+// Mock of signerGetter interface
+type MocksignerGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MocksignerGetterRecorder
+}
+
+// Recorder for MocksignerGetter (not exported)
+type _MocksignerGetterRecorder struct {
+	mock *MocksignerGetter
+}
+
+func NewMocksignerGetter(ctrl *gomock.Controller) *MocksignerGetter {
+	mock := &MocksignerGetter{ctrl: ctrl}
+	mock.recorder = &_MocksignerGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MocksignerGetter) EXPECT() *_MocksignerGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MocksignerGetter) Signer() kbfscrypto.Signer {
+	ret := _m.ctrl.Call(_m, "Signer")
+	ret0, _ := ret[0].(kbfscrypto.Signer)
+	return ret0
+}
+
+func (_mr *_MocksignerGetterRecorder) Signer() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Signer")
+}
+
+// Mock of diskBlockCacheGetter interface
+type MockdiskBlockCacheGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockdiskBlockCacheGetterRecorder
+}
+
+// Recorder for MockdiskBlockCacheGetter (not exported)
+type _MockdiskBlockCacheGetterRecorder struct {
+	mock *MockdiskBlockCacheGetter
+}
+
+func NewMockdiskBlockCacheGetter(ctrl *gomock.Controller) *MockdiskBlockCacheGetter {
+	mock := &MockdiskBlockCacheGetter{ctrl: ctrl}
+	mock.recorder = &_MockdiskBlockCacheGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockdiskBlockCacheGetter) EXPECT() *_MockdiskBlockCacheGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockdiskBlockCacheGetter) DiskBlockCache() DiskBlockCache {
+	ret := _m.ctrl.Call(_m, "DiskBlockCache")
+	ret0, _ := ret[0].(DiskBlockCache)
+	return ret0
+}
+
+func (_mr *_MockdiskBlockCacheGetterRecorder) DiskBlockCache() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskBlockCache")
+}
+
 // Mock of Block interface
 type MockBlock struct {
 	ctrl     *gomock.Controller
@@ -2106,6 +2230,67 @@ func (_m *MockDirtyBlockCache) Shutdown() error {
 }
 
 func (_mr *_MockDirtyBlockCacheRecorder) Shutdown() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
+}
+
+// Mock of DiskBlockCache interface
+type MockDiskBlockCache struct {
+	ctrl     *gomock.Controller
+	recorder *_MockDiskBlockCacheRecorder
+}
+
+// Recorder for MockDiskBlockCache (not exported)
+type _MockDiskBlockCacheRecorder struct {
+	mock *MockDiskBlockCache
+}
+
+func NewMockDiskBlockCache(ctrl *gomock.Controller) *MockDiskBlockCache {
+	mock := &MockDiskBlockCache{ctrl: ctrl}
+	mock.recorder = &_MockDiskBlockCacheRecorder{mock}
+	return mock
+}
+
+func (_m *MockDiskBlockCache) EXPECT() *_MockDiskBlockCacheRecorder {
+	return _m.recorder
+}
+
+func (_m *MockDiskBlockCache) Get(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
+	ret := _m.ctrl.Call(_m, "Get", ctx, tlfID, blockID)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(kbfscrypto.BlockCryptKeyServerHalf)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2)
+}
+
+func (_m *MockDiskBlockCache) Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
+	ret := _m.ctrl.Call(_m, "Put", ctx, tlfID, blockID, buf, serverHalf)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) Put(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3, arg4)
+}
+
+func (_m *MockDiskBlockCache) Delete(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) error {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, tlfID, blockIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+}
+
+func (_m *MockDiskBlockCache) Shutdown() {
+	_m.ctrl.Call(_m, "Shutdown")
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) Shutdown() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
 }
 
@@ -4104,6 +4289,46 @@ func (_mr *_MockConfigRecorder) keyGetter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "keyGetter")
 }
 
+func (_m *MockConfig) Crypto() Crypto {
+	ret := _m.ctrl.Call(_m, "Crypto")
+	ret0, _ := ret[0].(Crypto)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) Crypto() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Crypto")
+}
+
+func (_m *MockConfig) Signer() kbfscrypto.Signer {
+	ret := _m.ctrl.Call(_m, "Signer")
+	ret0, _ := ret[0].(kbfscrypto.Signer)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) Signer() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Signer")
+}
+
+func (_m *MockConfig) currentInfoGetter() currentInfoGetter {
+	ret := _m.ctrl.Call(_m, "currentInfoGetter")
+	ret0, _ := ret[0].(currentInfoGetter)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) currentInfoGetter() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "currentInfoGetter")
+}
+
+func (_m *MockConfig) DiskBlockCache() DiskBlockCache {
+	ret := _m.ctrl.Call(_m, "DiskBlockCache")
+	ret0, _ := ret[0].(DiskBlockCache)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) DiskBlockCache() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskBlockCache")
+}
+
 func (_m *MockConfig) KBFSOps() KBFSOps {
 	ret := _m.ctrl.Call(_m, "KBFSOps")
 	ret0, _ := ret[0].(KBFSOps)
@@ -4254,16 +4479,6 @@ func (_m *MockConfig) SetDirtyBlockCache(_param0 DirtyBlockCache) {
 
 func (_mr *_MockConfigRecorder) SetDirtyBlockCache(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDirtyBlockCache", arg0)
-}
-
-func (_m *MockConfig) Crypto() Crypto {
-	ret := _m.ctrl.Call(_m, "Crypto")
-	ret0, _ := ret[0].(Crypto)
-	return ret0
-}
-
-func (_mr *_MockConfigRecorder) Crypto() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Crypto")
 }
 
 func (_m *MockConfig) SetCrypto(_param0 Crypto) {

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -15,7 +15,6 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/env"
-	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfshash"
 	"github.com/pkg/errors"
@@ -65,26 +64,25 @@ func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
 
 // MakeTestBlockServerOrBust makes a block server from the given
 // arguments and environment variables.
-func MakeTestBlockServerOrBust(t logger.TestLogBackend, codec kbfscodec.Codec,
-	signer kbfscrypto.Signer, cig currentInfoGetter,
-	rpcLogFactory *libkb.RPCLogFactory, log logger.Logger) BlockServer {
+func MakeTestBlockServerOrBust(t logger.TestLogBackend,
+	config blockServerRemoteConfig, rpcLogFactory *libkb.RPCLogFactory,
+) BlockServer {
 	// see if a local remote server is specified
 	bserverAddr := os.Getenv(EnvTestBServerAddr)
 	switch {
 	case bserverAddr == TempdirServerAddr:
 		var err error
-		blockServer, err := NewBlockServerTempDir(codec, log)
+		blockServer, err := NewBlockServerTempDir(config.Codec(), config.MakeLogger(""))
 		if err != nil {
 			t.Fatal(err)
 		}
 		return blockServer
 
 	case len(bserverAddr) != 0:
-		return NewBlockServerRemote(codec, signer, cig,
-			log, bserverAddr, rpcLogFactory)
+		return NewBlockServerRemote(config, bserverAddr, rpcLogFactory)
 
 	default:
-		return NewBlockServerMemory(log)
+		return NewBlockServerMemory(config.MakeLogger(""))
 	}
 }
 
@@ -119,9 +117,8 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 	crypto := NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey)
 	config.SetCrypto(crypto)
 
-	blockServer := MakeTestBlockServerOrBust(t, config.Codec(),
-		config.Crypto(), config.KBPKI(),
-		env.NewContext().NewRPCLogFactory(), log)
+	blockServer := MakeTestBlockServerOrBust(t, config,
+		env.NewContext().NewRPCLogFactory())
 	config.SetBlockServer(blockServer)
 
 	// see if a local remote server is specified
@@ -232,9 +229,7 @@ func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *C
 	c.noBGFlush = config.noBGFlush
 
 	if s, ok := config.BlockServer().(*BlockServerRemote); ok {
-		bserverLog := config.MakeLogger("BSR")
-		blockServer := NewBlockServerRemote(c.Codec(), c.Crypto(),
-			c.KBPKI(), bserverLog, s.RemoteAddress(),
+		blockServer := NewBlockServerRemote(c, s.RemoteAddress(),
 			env.NewContext().NewRPCLogFactory())
 		c.SetBlockServer(blockServer)
 	} else {

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -65,8 +65,8 @@ func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
 // MakeTestBlockServerOrBust makes a block server from the given
 // arguments and environment variables.
 func MakeTestBlockServerOrBust(t logger.TestLogBackend,
-	config blockServerRemoteConfig, rpcLogFactory *libkb.RPCLogFactory,
-) BlockServer {
+	config blockServerRemoteConfig, signer kbfscrypto.Signer,
+	rpcLogFactory *libkb.RPCLogFactory) BlockServer {
 	// see if a local remote server is specified
 	bserverAddr := os.Getenv(EnvTestBServerAddr)
 	switch {
@@ -79,7 +79,7 @@ func MakeTestBlockServerOrBust(t logger.TestLogBackend,
 		return blockServer
 
 	case len(bserverAddr) != 0:
-		return NewBlockServerRemote(config, bserverAddr, rpcLogFactory)
+		return NewBlockServerRemote(config, signer, bserverAddr, rpcLogFactory)
 
 	default:
 		return NewBlockServerMemory(config.MakeLogger(""))
@@ -117,7 +117,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 	crypto := NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey)
 	config.SetCrypto(crypto)
 
-	blockServer := MakeTestBlockServerOrBust(t, config,
+	blockServer := MakeTestBlockServerOrBust(t, config, config.Signer(),
 		env.NewContext().NewRPCLogFactory())
 	config.SetBlockServer(blockServer)
 
@@ -229,7 +229,7 @@ func ConfigAsUser(config *ConfigLocal, loggedInUser libkb.NormalizedUsername) *C
 	c.noBGFlush = config.noBGFlush
 
 	if s, ok := config.BlockServer().(*BlockServerRemote); ok {
-		blockServer := NewBlockServerRemote(c, s.RemoteAddress(),
+		blockServer := NewBlockServerRemote(c, c.Signer(), s.RemoteAddress(),
 			env.NewContext().NewRPCLogFactory())
 		c.SetBlockServer(blockServer)
 	} else {

--- a/libkbfs/test_util.go
+++ b/libkbfs/test_util.go
@@ -1,0 +1,36 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/kbfscodec"
+)
+
+type testCodecGetter struct {
+	codec kbfscodec.Codec
+}
+
+func newTestCodecGetter() testCodecGetter {
+	return testCodecGetter{kbfscodec.NewMsgpack()}
+}
+
+func (cg testCodecGetter) Codec() kbfscodec.Codec {
+	return cg.codec
+}
+
+type testLogMaker struct {
+	log logger.Logger
+}
+
+func newTestLogMaker(t *testing.T) testLogMaker {
+	return testLogMaker{logger.NewTestLogger(t)}
+}
+
+func (lm testLogMaker) MakeLogger(_ string) logger.Logger {
+	return lm.log
+}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -220,10 +220,10 @@ func setupTLFJournalTest(
 		uid:          uid,
 		verifyingKey: verifyingKey,
 	}
-	log := logger.NewTestLogger(t)
-	mdserver, err := NewMDServerMemory(newTestMDServerLocalConfig(log, cig))
+	mdserver, err := NewMDServerMemory(newTestMDServerLocalConfig(t, cig))
 	require.NoError(t, err)
 
+	log := logger.NewTestLogger(t)
 	config = &testTLFJournalConfig{
 		t, log, tlf.FakeID(1, false), bsplitter, codec, crypto,
 		nil, nil, NewMDCacheStandard(10), ver,

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -70,11 +69,11 @@ func (d testBWDelegate) requireNextState(
 // testTLFJournalConfig is the config we pass to the tlfJournal, and
 // also contains some helper functions for testing.
 type testTLFJournalConfig struct {
+	codecGetter
+	logMaker
 	t            *testing.T
-	log          logger.Logger
 	tlfID        tlf.ID
 	splitter     BlockSplitter
-	codec        kbfscodec.Codec
 	crypto       CryptoLocal
 	bcache       BlockCache
 	bops         BlockOps
@@ -95,10 +94,6 @@ func (c testTLFJournalConfig) BlockSplitter() BlockSplitter {
 
 func (c testTLFJournalConfig) Clock() Clock {
 	return wallClock{}
-}
-
-func (c testTLFJournalConfig) Codec() kbfscodec.Codec {
-	return c.codec
 }
 
 func (c testTLFJournalConfig) Crypto() Crypto {
@@ -143,10 +138,6 @@ func (c testTLFJournalConfig) usernameGetter() normalizedUsernameGetter {
 
 func (c testTLFJournalConfig) MDServer() MDServer {
 	return c.mdserver
-}
-
-func (c testTLFJournalConfig) MakeLogger(module string) logger.Logger {
-	return c.log
 }
 
 func (c testTLFJournalConfig) diskLimitTimeout() time.Duration {
@@ -223,9 +214,8 @@ func setupTLFJournalTest(
 	mdserver, err := NewMDServerMemory(newTestMDServerLocalConfig(t, cig))
 	require.NoError(t, err)
 
-	log := logger.NewTestLogger(t)
 	config = &testTLFJournalConfig{
-		t, log, tlf.FakeID(1, false), bsplitter, codec, crypto,
+		newTestCodecGetter(), newTestLogMaker(t), t, tlf.FakeID(1, false), bsplitter, crypto,
 		nil, nil, NewMDCacheStandard(10), ver,
 		NewReporterSimple(newTestClockNow(), 10), uid, verifyingKey, ekg, nil, mdserver, defaultDiskLimitMaxDelay + time.Second,
 	}
@@ -260,7 +250,7 @@ func setupTLFJournalTest(
 		}
 	}()
 
-	delegateBlockServer := NewBlockServerMemory(log)
+	delegateBlockServer := NewBlockServerMemory(config.MakeLogger(""))
 
 	diskLimitSemaphore := newSemaphoreDiskLimiter(
 		math.MaxInt64, math.MaxInt64)

--- a/vendor/github.com/syndtr/goleveldb/leveldb/cache/cache.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/cache/cache.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Cacher provides interface to implements a caching functionality.
-// An implementation must be goroutine-safe.
+// An implementation must be safe for concurrent use.
 type Cacher interface {
 	// Capacity returns cache capacity.
 	Capacity() int
@@ -511,17 +511,11 @@ func (r *Cache) EvictAll() {
 	}
 }
 
-// Close closes the 'cache map' and releases all 'cache node'.
+// Close closes the 'cache map' and forcefully releases all 'cache node'.
 func (r *Cache) Close() error {
 	r.mu.Lock()
 	if !r.closed {
 		r.closed = true
-
-		if r.cacher != nil {
-			if err := r.cacher.Close(); err != nil {
-				return err
-			}
-		}
 
 		h := (*mNode)(r.mHead)
 		h.initBuckets()
@@ -541,10 +535,37 @@ func (r *Cache) Close() error {
 				for _, f := range n.onDel {
 					f()
 				}
+				n.onDel = nil
 			}
 		}
 	}
 	r.mu.Unlock()
+
+	// Avoid deadlock.
+	if r.cacher != nil {
+		if err := r.cacher.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CloseWeak closes the 'cache map' and evict all 'cache node' from cacher, but
+// unlike Close it doesn't forcefully releases 'cache node'.
+func (r *Cache) CloseWeak() error {
+	r.mu.Lock()
+	if !r.closed {
+		r.closed = true
+	}
+	r.mu.Unlock()
+
+	// Avoid deadlock.
+	if r.cacher != nil {
+		r.cacher.EvictAll()
+		if err := r.cacher.Close(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/vendor/github.com/syndtr/goleveldb/leveldb/comparer.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/comparer.go
@@ -6,7 +6,9 @@
 
 package leveldb
 
-import "github.com/syndtr/goleveldb/leveldb/comparer"
+import (
+	"github.com/syndtr/goleveldb/leveldb/comparer"
+)
 
 type iComparer struct {
 	ucmp comparer.Comparer
@@ -33,12 +35,12 @@ func (icmp *iComparer) Name() string {
 }
 
 func (icmp *iComparer) Compare(a, b []byte) int {
-	x := icmp.ucmp.Compare(internalKey(a).ukey(), internalKey(b).ukey())
+	x := icmp.uCompare(internalKey(a).ukey(), internalKey(b).ukey())
 	if x == 0 {
 		if m, n := internalKey(a).num(), internalKey(b).num(); m > n {
-			x = -1
+			return -1
 		} else if m < n {
-			x = 1
+			return 1
 		}
 	}
 	return x
@@ -46,30 +48,20 @@ func (icmp *iComparer) Compare(a, b []byte) int {
 
 func (icmp *iComparer) Separator(dst, a, b []byte) []byte {
 	ua, ub := internalKey(a).ukey(), internalKey(b).ukey()
-	dst = icmp.ucmp.Separator(dst, ua, ub)
-	if dst == nil {
-		return nil
+	dst = icmp.uSeparator(dst, ua, ub)
+	if dst != nil && len(dst) < len(ua) && icmp.uCompare(ua, dst) < 0 {
+		// Append earliest possible number.
+		return append(dst, keyMaxNumBytes...)
 	}
-	if len(dst) < len(ua) && icmp.uCompare(ua, dst) < 0 {
-		dst = append(dst, keyMaxNumBytes...)
-	} else {
-		// Did not close possibilities that n maybe longer than len(ub).
-		dst = append(dst, a[len(a)-8:]...)
-	}
-	return dst
+	return nil
 }
 
 func (icmp *iComparer) Successor(dst, b []byte) []byte {
 	ub := internalKey(b).ukey()
-	dst = icmp.ucmp.Successor(dst, ub)
-	if dst == nil {
-		return nil
+	dst = icmp.uSuccessor(dst, ub)
+	if dst != nil && len(dst) < len(ub) && icmp.uCompare(ub, dst) < 0 {
+		// Append earliest possible number.
+		return append(dst, keyMaxNumBytes...)
 	}
-	if len(dst) < len(ub) && icmp.uCompare(ub, dst) < 0 {
-		dst = append(dst, keyMaxNumBytes...)
-	} else {
-		// Did not close possibilities that n maybe longer than len(ub).
-		dst = append(dst, b[len(b)-8:]...)
-	}
-	return dst
+	return nil
 }

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db.go
@@ -53,14 +53,13 @@ type DB struct {
 	aliveSnaps, aliveIters int32
 
 	// Write.
-	writeC       chan *Batch
+	batchPool    sync.Pool
+	writeMergeC  chan writeMerge
 	writeMergedC chan bool
 	writeLockC   chan struct{}
 	writeAckC    chan error
 	writeDelay   time.Duration
 	writeDelayN  int
-	journalC     chan *Batch
-	journalAckC  chan error
 	tr           *Transaction
 
 	// Compaction.
@@ -94,12 +93,11 @@ func openDB(s *session) (*DB, error) {
 		// Snapshot
 		snapsList: list.New(),
 		// Write
-		writeC:       make(chan *Batch),
+		batchPool:    sync.Pool{New: newBatch},
+		writeMergeC:  make(chan writeMerge),
 		writeMergedC: make(chan bool),
 		writeLockC:   make(chan struct{}, 1),
 		writeAckC:    make(chan error),
-		journalC:     make(chan *Batch),
-		journalAckC:  make(chan error),
 		// Compaction
 		tcompCmdC:   make(chan cCmd),
 		tcompPauseC: make(chan chan<- struct{}),
@@ -144,10 +142,10 @@ func openDB(s *session) (*DB, error) {
 	if readOnly {
 		db.SetReadOnly()
 	} else {
-		db.closeW.Add(3)
+		db.closeW.Add(2)
 		go db.tCompaction()
 		go db.mCompaction()
-		go db.jWriter()
+		// go db.jWriter()
 	}
 
 	s.logf("db@open done T·%v", time.Since(start))
@@ -162,10 +160,10 @@ func openDB(s *session) (*DB, error) {
 // os.ErrExist error.
 //
 // Open will return an error with type of ErrCorrupted if corruption
-// detected in the DB. Corrupted DB can be recovered with Recover
-// function.
+// detected in the DB. Use errors.IsCorrupted to test whether an error is
+// due to corruption. Corrupted DB can be recovered with Recover function.
 //
-// The returned DB instance is goroutine-safe.
+// The returned DB instance is safe for concurrent use.
 // The DB must be closed after use, by calling Close method.
 func Open(stor storage.Storage, o *opt.Options) (db *DB, err error) {
 	s, err := newSession(stor, o)
@@ -202,13 +200,13 @@ func Open(stor storage.Storage, o *opt.Options) (db *DB, err error) {
 // os.ErrExist error.
 //
 // OpenFile uses standard file-system backed storage implementation as
-// desribed in the leveldb/storage package.
+// described in the leveldb/storage package.
 //
 // OpenFile will return an error with type of ErrCorrupted if corruption
-// detected in the DB. Corrupted DB can be recovered with Recover
-// function.
+// detected in the DB. Use errors.IsCorrupted to test whether an error is
+// due to corruption. Corrupted DB can be recovered with Recover function.
 //
-// The returned DB instance is goroutine-safe.
+// The returned DB instance is safe for concurrent use.
 // The DB must be closed after use, by calling Close method.
 func OpenFile(path string, o *opt.Options) (db *DB, err error) {
 	stor, err := storage.OpenFile(path, o.GetReadOnly())
@@ -229,7 +227,7 @@ func OpenFile(path string, o *opt.Options) (db *DB, err error) {
 // The DB must already exist or it will returns an error.
 // Also, Recover will ignore ErrorIfMissing and ErrorIfExist options.
 //
-// The returned DB instance is goroutine-safe.
+// The returned DB instance is safe for concurrent use.
 // The DB must be closed after use, by calling Close method.
 func Recover(stor storage.Storage, o *opt.Options) (db *DB, err error) {
 	s, err := newSession(stor, o)
@@ -255,10 +253,10 @@ func Recover(stor storage.Storage, o *opt.Options) (db *DB, err error) {
 // The DB must already exist or it will returns an error.
 // Also, Recover will ignore ErrorIfMissing and ErrorIfExist options.
 //
-// RecoverFile uses standard file-system backed storage implementation as desribed
+// RecoverFile uses standard file-system backed storage implementation as described
 // in the leveldb/storage package.
 //
-// The returned DB instance is goroutine-safe.
+// The returned DB instance is safe for concurrent use.
 // The DB must be closed after use, by calling Close method.
 func RecoverFile(path string, o *opt.Options) (db *DB, err error) {
 	stor, err := storage.OpenFile(path, false)
@@ -504,10 +502,11 @@ func (db *DB) recoverJournal() error {
 			checksum    = db.s.o.GetStrict(opt.StrictJournalChecksum)
 			writeBuffer = db.s.o.GetWriteBuffer()
 
-			jr    *journal.Reader
-			mdb   = memdb.New(db.s.icmp, writeBuffer)
-			buf   = &util.Buffer{}
-			batch = &Batch{}
+			jr       *journal.Reader
+			mdb      = memdb.New(db.s.icmp, writeBuffer)
+			buf      = &util.Buffer{}
+			batchSeq uint64
+			batchLen int
 		)
 
 		for _, fd := range fds {
@@ -526,7 +525,7 @@ func (db *DB) recoverJournal() error {
 			}
 
 			// Flush memdb and remove obsolete journal file.
-			if !ofd.Nil() {
+			if !ofd.Zero() {
 				if mdb.Len() > 0 {
 					if _, err := db.s.flushMemdb(rec, mdb, 0); err != nil {
 						fr.Close()
@@ -569,7 +568,8 @@ func (db *DB) recoverJournal() error {
 					fr.Close()
 					return errors.SetFd(err, fd)
 				}
-				if err := batch.memDecodeAndReplay(db.seq, buf.Bytes(), mdb); err != nil {
+				batchSeq, batchLen, err = decodeBatchToMem(buf.Bytes(), db.seq, mdb)
+				if err != nil {
 					if !strict && errors.IsCorrupted(err) {
 						db.s.logf("journal error: %v (skipped)", err)
 						// We won't apply sequence number as it might be corrupted.
@@ -581,7 +581,7 @@ func (db *DB) recoverJournal() error {
 				}
 
 				// Save sequence number.
-				db.seq = batch.seq + uint64(batch.Len())
+				db.seq = batchSeq + uint64(batchLen)
 
 				// Flush it if large enough.
 				if mdb.Size() >= writeBuffer {
@@ -624,7 +624,7 @@ func (db *DB) recoverJournal() error {
 	}
 
 	// Remove the last obsolete journal file.
-	if !ofd.Nil() {
+	if !ofd.Zero() {
 		db.s.stor.Remove(ofd)
 	}
 
@@ -661,9 +661,10 @@ func (db *DB) recoverJournalRO() error {
 		db.logf("journal@recovery RO·Mode F·%d", len(fds))
 
 		var (
-			jr    *journal.Reader
-			buf   = &util.Buffer{}
-			batch = &Batch{}
+			jr       *journal.Reader
+			buf      = &util.Buffer{}
+			batchSeq uint64
+			batchLen int
 		)
 
 		for _, fd := range fds {
@@ -703,7 +704,8 @@ func (db *DB) recoverJournalRO() error {
 					fr.Close()
 					return errors.SetFd(err, fd)
 				}
-				if err := batch.memDecodeAndReplay(db.seq, buf.Bytes(), mdb); err != nil {
+				batchSeq, batchLen, err = decodeBatchToMem(buf.Bytes(), db.seq, mdb)
+				if err != nil {
 					if !strict && errors.IsCorrupted(err) {
 						db.s.logf("journal error: %v (skipped)", err)
 						// We won't apply sequence number as it might be corrupted.
@@ -715,7 +717,7 @@ func (db *DB) recoverJournalRO() error {
 				}
 
 				// Save sequence number.
-				db.seq = batch.seq + uint64(batch.Len())
+				db.seq = batchSeq + uint64(batchLen)
 			}
 
 			fr.Close()
@@ -856,7 +858,7 @@ func (db *DB) Has(key []byte, ro *opt.ReadOptions) (ret bool, err error) {
 
 // NewIterator returns an iterator for the latest snapshot of the
 // underlying DB.
-// The returned iterator is not goroutine-safe, but it is safe to use
+// The returned iterator is not safe for concurrent use, but it is safe to use
 // multiple iterators concurrently, with each in a dedicated goroutine.
 // It is also safe to use an iterator concurrently with modifying its
 // underlying DB. The resultant key/value pairs are guaranteed to be
@@ -1062,6 +1064,8 @@ func (db *DB) Close() error {
 	if db.journal != nil {
 		db.journal.Close()
 		db.journalWriter.Close()
+		db.journal = nil
+		db.journalWriter = nil
 	}
 
 	if db.writeDelayN > 0 {
@@ -1077,15 +1081,11 @@ func (db *DB) Close() error {
 		if err1 := db.closer.Close(); err == nil {
 			err = err1
 		}
+		db.closer = nil
 	}
 
-	// NIL'ing pointers.
-	db.s = nil
-	db.mem = nil
-	db.frozenMem = nil
-	db.journal = nil
-	db.journalWriter = nil
-	db.closer = nil
+	// Clear memdbs.
+	db.clearMems()
 
 	return err
 }

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_compaction.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_compaction.go
@@ -96,7 +96,7 @@ noerr:
 			default:
 				goto haserr
 			}
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
 			return
 		}
 	}
@@ -113,7 +113,7 @@ haserr:
 				goto hasperr
 			default:
 			}
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
 			return
 		}
 	}
@@ -126,7 +126,7 @@ hasperr:
 		case db.writeLockC <- struct{}{}:
 			// Hold write lock, so that write won't pass-through.
 			db.compWriteLocking = true
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
 			if db.compWriteLocking {
 				// We should release the lock or Close will hang.
 				<-db.writeLockC
@@ -172,7 +172,7 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 		disableBackoff = db.s.o.GetDisableCompactionBackoff()
 	)
 	for n := 0; ; n++ {
-		// Check wether the DB is closed.
+		// Check whether the DB is closed.
 		if db.isClosed() {
 			db.logf("%s exiting", name)
 			db.compactionExitTransact()
@@ -195,7 +195,7 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 				db.logf("%s exiting (persistent error %q)", name, perr)
 				db.compactionExitTransact()
 			}
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
 			db.logf("%s exiting", name)
 			db.compactionExitTransact()
 		}
@@ -224,7 +224,7 @@ func (db *DB) compactionTransact(name string, t compactionTransactInterface) {
 			}
 			select {
 			case <-backoffT.C:
-			case _, _ = <-db.closeC:
+			case <-db.closeC:
 				db.logf("%s exiting", name)
 				db.compactionExitTransact()
 			}
@@ -288,7 +288,7 @@ func (db *DB) memCompaction() {
 	case <-db.compPerErrC:
 		close(resumeC)
 		resumeC = nil
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return
 	}
 
@@ -337,7 +337,7 @@ func (db *DB) memCompaction() {
 		select {
 		case <-resumeC:
 			close(resumeC)
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
 			return
 		}
 	}
@@ -378,7 +378,7 @@ func (b *tableCompactionBuilder) appendKV(key, value []byte) error {
 			select {
 			case ch := <-b.db.tcompPauseC:
 				b.db.pauseCompaction(ch)
-			case _, _ = <-b.db.closeC:
+			case <-b.db.closeC:
 				b.db.compactionExitTransact()
 			default:
 			}
@@ -643,7 +643,7 @@ func (db *DB) tableNeedCompaction() bool {
 func (db *DB) pauseCompaction(ch chan<- struct{}) {
 	select {
 	case ch <- struct{}{}:
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		db.compactionExitTransact()
 	}
 }
@@ -688,7 +688,7 @@ func (db *DB) compTrigger(compC chan<- cCmd) {
 	}
 }
 
-// This will trigger auto compation and/or wait for all compaction to be done.
+// This will trigger auto compaction and/or wait for all compaction to be done.
 func (db *DB) compTriggerWait(compC chan<- cCmd) (err error) {
 	ch := make(chan error)
 	defer close(ch)
@@ -697,14 +697,14 @@ func (db *DB) compTriggerWait(compC chan<- cCmd) (err error) {
 	case compC <- cAuto{ch}:
 	case err = <-db.compErrC:
 		return
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 	// Wait cmd.
 	select {
 	case err = <-ch:
 	case err = <-db.compErrC:
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 	return err
@@ -719,14 +719,14 @@ func (db *DB) compTriggerRange(compC chan<- cCmd, level int, min, max []byte) (e
 	case compC <- cRange{level, min, max, ch}:
 	case err := <-db.compErrC:
 		return err
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 	// Wait cmd.
 	select {
 	case err = <-ch:
 	case err = <-db.compErrC:
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 	return err
@@ -758,7 +758,7 @@ func (db *DB) mCompaction() {
 			default:
 				panic("leveldb: unknown command")
 			}
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
 			return
 		}
 	}
@@ -791,7 +791,7 @@ func (db *DB) tCompaction() {
 			case ch := <-db.tcompPauseC:
 				db.pauseCompaction(ch)
 				continue
-			case _, _ = <-db.closeC:
+			case <-db.closeC:
 				return
 			default:
 			}
@@ -806,7 +806,7 @@ func (db *DB) tCompaction() {
 			case ch := <-db.tcompPauseC:
 				db.pauseCompaction(ch)
 				continue
-			case _, _ = <-db.closeC:
+			case <-db.closeC:
 				return
 			}
 		}

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_snapshot.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_snapshot.go
@@ -59,7 +59,7 @@ func (db *DB) releaseSnapshot(se *snapshotElement) {
 	}
 }
 
-// Gets minimum sequence that not being snapshoted.
+// Gets minimum sequence that not being snapshotted.
 func (db *DB) minSeq() uint64 {
 	db.snapsMu.Lock()
 	defer db.snapsMu.Unlock()
@@ -131,7 +131,7 @@ func (snap *Snapshot) Has(key []byte, ro *opt.ReadOptions) (ret bool, err error)
 }
 
 // NewIterator returns an iterator for the snapshot of the underlying DB.
-// The returned iterator is not goroutine-safe, but it is safe to use
+// The returned iterator is not safe for concurrent use, but it is safe to use
 // multiple iterators concurrently, with each in a dedicated goroutine.
 // It is also safe to use an iterator concurrently with modifying its
 // underlying DB. The resultant key/value pairs are guaranteed to be

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_state.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_state.go
@@ -67,12 +67,11 @@ func (db *DB) sampleSeek(ikey internalKey) {
 }
 
 func (db *DB) mpoolPut(mem *memdb.DB) {
-	defer func() {
-		recover()
-	}()
-	select {
-	case db.memPool <- mem:
-	default:
+	if !db.isClosed() {
+		select {
+		case db.memPool <- mem:
+		default:
+		}
 	}
 }
 
@@ -100,7 +99,13 @@ func (db *DB) mpoolDrain() {
 			case <-db.memPool:
 			default:
 			}
-		case _, _ = <-db.closeC:
+		case <-db.closeC:
+			ticker.Stop()
+			// Make sure the pool is drained.
+			select {
+			case <-db.memPool:
+			case <-time.After(time.Second):
+			}
 			close(db.memPool)
 			return
 		}
@@ -148,24 +153,26 @@ func (db *DB) newMem(n int) (mem *memDB, err error) {
 func (db *DB) getMems() (e, f *memDB) {
 	db.memMu.RLock()
 	defer db.memMu.RUnlock()
-	if db.mem == nil {
+	if db.mem != nil {
+		db.mem.incref()
+	} else if !db.isClosed() {
 		panic("nil effective mem")
 	}
-	db.mem.incref()
 	if db.frozenMem != nil {
 		db.frozenMem.incref()
 	}
 	return db.mem, db.frozenMem
 }
 
-// Get frozen memdb.
+// Get effective memdb.
 func (db *DB) getEffectiveMem() *memDB {
 	db.memMu.RLock()
 	defer db.memMu.RUnlock()
-	if db.mem == nil {
+	if db.mem != nil {
+		db.mem.incref()
+	} else if !db.isClosed() {
 		panic("nil effective mem")
 	}
-	db.mem.incref()
 	return db.mem
 }
 
@@ -196,6 +203,14 @@ func (db *DB) dropFrozenMem() {
 	}
 	db.frozenJournalFd = storage.FileDesc{}
 	db.frozenMem.decref()
+	db.frozenMem = nil
+	db.memMu.Unlock()
+}
+
+// Clear mems ptr; used by DB.Close().
+func (db *DB) clearMems() {
+	db.memMu.Lock()
+	db.mem = nil
 	db.frozenMem = nil
 	db.memMu.Unlock()
 }

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_transaction.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_transaction.go
@@ -59,8 +59,8 @@ func (tr *Transaction) Has(key []byte, ro *opt.ReadOptions) (bool, error) {
 }
 
 // NewIterator returns an iterator for the latest snapshot of the transaction.
-// The returned iterator is not goroutine-safe, but it is safe to use multiple
-// iterators concurrently, with each in a dedicated goroutine.
+// The returned iterator is not safe for concurrent use, but it is safe to use
+// multiple iterators concurrently, with each in a dedicated goroutine.
 // It is also safe to use an iterator concurrently while writes to the
 // transaction. The resultant key/value pairs are guaranteed to be consistent.
 //
@@ -167,8 +167,8 @@ func (tr *Transaction) Write(b *Batch, wo *opt.WriteOptions) error {
 	if tr.closed {
 		return errTransactionDone
 	}
-	return b.decodeRec(func(i int, kt keyType, key, value []byte) error {
-		return tr.put(kt, key, value)
+	return b.replayInternal(func(i int, kt keyType, k, v []byte) error {
+		return tr.put(kt, k, v)
 	})
 }
 
@@ -179,7 +179,8 @@ func (tr *Transaction) setDone() {
 	<-tr.db.writeLockC
 }
 
-// Commit commits the transaction.
+// Commit commits the transaction. If error is not nil, then the transaction is
+// not committed, it can then either be retried or discarded.
 //
 // Other methods should not be called after transaction has been committed.
 func (tr *Transaction) Commit() error {
@@ -192,24 +193,27 @@ func (tr *Transaction) Commit() error {
 	if tr.closed {
 		return errTransactionDone
 	}
-	defer tr.setDone()
 	if err := tr.flush(); err != nil {
-		tr.discard()
+		// Return error, lets user decide either to retry or discard
+		// transaction.
 		return err
 	}
 	if len(tr.tables) != 0 {
 		// Committing transaction.
 		tr.rec.setSeqNum(tr.seq)
 		tr.db.compCommitLk.Lock()
-		defer tr.db.compCommitLk.Unlock()
+		tr.stats.startTimer()
+		var cerr error
 		for retry := 0; retry < 3; retry++ {
-			if err := tr.db.s.commit(&tr.rec); err != nil {
-				tr.db.logf("transaction@commit error R·%d %q", retry, err)
+			cerr = tr.db.s.commit(&tr.rec)
+			if cerr != nil {
+				tr.db.logf("transaction@commit error R·%d %q", retry, cerr)
 				select {
 				case <-time.After(time.Second):
-				case _, _ = <-tr.db.closeC:
+				case <-tr.db.closeC:
 					tr.db.logf("transaction@commit exiting")
-					return err
+					tr.db.compCommitLk.Unlock()
+					return cerr
 				}
 			} else {
 				// Success. Set db.seq.
@@ -217,9 +221,26 @@ func (tr *Transaction) Commit() error {
 				break
 			}
 		}
+		tr.stats.stopTimer()
+		if cerr != nil {
+			// Return error, lets user decide either to retry or discard
+			// transaction.
+			return cerr
+		}
+
+		// Update compaction stats. This is safe as long as we hold compCommitLk.
+		tr.db.compStats.addStat(0, &tr.stats)
+
 		// Trigger table auto-compaction.
 		tr.db.compTrigger(tr.db.tcompCmdC)
+		tr.db.compCommitLk.Unlock()
+
+		// Additionally, wait compaction when certain threshold reached.
+		// Ignore error, returns error only if transaction can't be committed.
+		tr.db.waitCompaction()
 	}
+	// Only mark as done if transaction committed successfully.
+	tr.setDone()
 	return nil
 }
 
@@ -245,10 +266,20 @@ func (tr *Transaction) Discard() {
 	tr.lk.Unlock()
 }
 
+func (db *DB) waitCompaction() error {
+	if db.s.tLen(0) >= db.s.o.GetWriteL0PauseTrigger() {
+		return db.compTriggerWait(db.tcompCmdC)
+	}
+	return nil
+}
+
 // OpenTransaction opens an atomic DB transaction. Only one transaction can be
-// opened at a time. Write will be blocked until the transaction is committed or
-// discarded.
-// The returned transaction handle is goroutine-safe.
+// opened at a time. Subsequent call to Write and OpenTransaction will be blocked
+// until in-flight transaction is committed or discarded.
+// The returned transaction handle is safe for concurrent use.
+//
+// Transaction is expensive and can overwhelm compaction, especially if
+// transaction size is small. Use with caution.
 //
 // The transaction must be closed once done, either by committing or discarding
 // the transaction.
@@ -263,7 +294,7 @@ func (db *DB) OpenTransaction() (*Transaction, error) {
 	case db.writeLockC <- struct{}{}:
 	case err := <-db.compPerErrC:
 		return nil, err
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return nil, ErrClosed
 	}
 
@@ -276,6 +307,11 @@ func (db *DB) OpenTransaction() (*Transaction, error) {
 		if _, err := db.rotateMem(0, true); err != nil {
 			return nil, err
 		}
+	}
+
+	// Wait compaction when certain threshold reached.
+	if err := db.waitCompaction(); err != nil {
+		return nil, err
 	}
 
 	tr := &Transaction{

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_util.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_util.go
@@ -62,7 +62,7 @@ func (db *DB) checkAndCleanFiles() error {
 		case storage.TypeManifest:
 			keep = fd.Num >= db.s.manifestFd.Num
 		case storage.TypeJournal:
-			if !db.frozenJournalFd.Nil() {
+			if !db.frozenJournalFd.Zero() {
 				keep = fd.Num >= db.frozenJournalFd.Num
 			} else {
 				keep = fd.Num >= db.journalFd.Num

--- a/vendor/github.com/syndtr/goleveldb/leveldb/db_write.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/db_write.go
@@ -14,35 +14,21 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
-func (db *DB) writeJournal(b *Batch) error {
-	w, err := db.journal.Next()
+func (db *DB) writeJournal(batches []*Batch, seq uint64, sync bool) error {
+	wr, err := db.journal.Next()
 	if err != nil {
 		return err
 	}
-	if _, err := w.Write(b.encode()); err != nil {
+	if err := writeBatchesWithHeader(wr, batches, seq); err != nil {
 		return err
 	}
 	if err := db.journal.Flush(); err != nil {
 		return err
 	}
-	if b.sync {
+	if sync {
 		return db.journalWriter.Sync()
 	}
 	return nil
-}
-
-func (db *DB) jWriter() {
-	defer db.closeW.Done()
-	for {
-		select {
-		case b := <-db.journalC:
-			if b != nil {
-				db.journalAckC <- db.writeJournal(b)
-			}
-		case _, _ = <-db.closeC:
-			return
-		}
-	}
 }
 
 func (db *DB) rotateMem(n int, wait bool) (mem *memDB, err error) {
@@ -69,24 +55,29 @@ func (db *DB) rotateMem(n int, wait bool) (mem *memDB, err error) {
 
 func (db *DB) flush(n int) (mdb *memDB, mdbFree int, err error) {
 	delayed := false
+	slowdownTrigger := db.s.o.GetWriteL0SlowdownTrigger()
+	pauseTrigger := db.s.o.GetWriteL0PauseTrigger()
 	flush := func() (retry bool) {
-		v := db.s.version()
-		defer v.release()
 		mdb = db.getEffectiveMem()
+		if mdb == nil {
+			err = ErrClosed
+			return false
+		}
 		defer func() {
 			if retry {
 				mdb.decref()
 				mdb = nil
 			}
 		}()
+		tLen := db.s.tLen(0)
 		mdbFree = mdb.Free()
 		switch {
-		case v.tLen(0) >= db.s.o.GetWriteL0SlowdownTrigger() && !delayed:
+		case tLen >= slowdownTrigger && !delayed:
 			delayed = true
 			time.Sleep(time.Millisecond)
 		case mdbFree >= n:
 			return false
-		case v.tLen(0) >= db.s.o.GetWriteL0PauseTrigger():
+		case tLen >= pauseTrigger:
 			delayed = true
 			err = db.compTriggerWait(db.tcompCmdC)
 			if err != nil {
@@ -123,159 +114,250 @@ func (db *DB) flush(n int) (mdb *memDB, mdbFree int, err error) {
 	return
 }
 
-// Write apply the given batch to the DB. The batch will be applied
-// sequentially.
-//
-// It is safe to modify the contents of the arguments after Write returns.
-func (db *DB) Write(b *Batch, wo *opt.WriteOptions) (err error) {
-	err = db.ok()
-	if err != nil || b == nil || b.Len() == 0 {
-		return
+type writeMerge struct {
+	sync       bool
+	batch      *Batch
+	keyType    keyType
+	key, value []byte
+}
+
+func (db *DB) unlockWrite(overflow bool, merged int, err error) {
+	for i := 0; i < merged; i++ {
+		db.writeAckC <- err
+	}
+	if overflow {
+		// Pass lock to the next write (that failed to merge).
+		db.writeMergedC <- false
+	} else {
+		// Release lock.
+		<-db.writeLockC
+	}
+}
+
+// ourBatch if defined should equal with batch.
+func (db *DB) writeLocked(batch, ourBatch *Batch, merge, sync bool) error {
+	// Try to flush memdb. This method would also trying to throttle writes
+	// if it is too fast and compaction cannot catch-up.
+	mdb, mdbFree, err := db.flush(batch.internalLen)
+	if err != nil {
+		db.unlockWrite(false, 0, err)
+		return err
+	}
+	defer mdb.decref()
+
+	var (
+		overflow bool
+		merged   int
+		batches  = []*Batch{batch}
+	)
+
+	if merge {
+		// Merge limit.
+		var mergeLimit int
+		if batch.internalLen > 128<<10 {
+			mergeLimit = (1 << 20) - batch.internalLen
+		} else {
+			mergeLimit = 128 << 10
+		}
+		mergeCap := mdbFree - batch.internalLen
+		if mergeLimit > mergeCap {
+			mergeLimit = mergeCap
+		}
+
+	merge:
+		for mergeLimit > 0 {
+			select {
+			case incoming := <-db.writeMergeC:
+				if incoming.batch != nil {
+					// Merge batch.
+					if incoming.batch.internalLen > mergeLimit {
+						overflow = true
+						break merge
+					}
+					batches = append(batches, incoming.batch)
+					mergeLimit -= incoming.batch.internalLen
+				} else {
+					// Merge put.
+					internalLen := len(incoming.key) + len(incoming.value) + 8
+					if internalLen > mergeLimit {
+						overflow = true
+						break merge
+					}
+					if ourBatch == nil {
+						ourBatch = db.batchPool.Get().(*Batch)
+						ourBatch.Reset()
+						batches = append(batches, ourBatch)
+					}
+					// We can use same batch since concurrent write doesn't
+					// guarantee write order.
+					ourBatch.appendRec(incoming.keyType, incoming.key, incoming.value)
+					mergeLimit -= internalLen
+				}
+				sync = sync || incoming.sync
+				merged++
+				db.writeMergedC <- true
+
+			default:
+				break merge
+			}
+		}
 	}
 
-	b.init(wo.GetSync() && !db.s.o.GetNoSync())
+	// Seq number.
+	seq := db.seq + 1
 
-	if b.size() > db.s.o.GetWriteBuffer() && !db.s.o.GetDisableLargeBatchTransaction() {
-		// Writes using transaction.
-		tr, err1 := db.OpenTransaction()
-		if err1 != nil {
-			return err1
+	// Write journal.
+	if err := db.writeJournal(batches, seq, sync); err != nil {
+		db.unlockWrite(overflow, merged, err)
+		return err
+	}
+
+	// Put batches.
+	for _, batch := range batches {
+		if err := batch.putMem(seq, mdb.DB); err != nil {
+			panic(err)
 		}
-		if err1 := tr.Write(b, wo); err1 != nil {
+		seq += uint64(batch.Len())
+	}
+
+	// Incr seq number.
+	db.addSeq(uint64(batchesLen(batches)))
+
+	// Rotate memdb if it's reach the threshold.
+	if batch.internalLen >= mdbFree {
+		db.rotateMem(0, false)
+	}
+
+	db.unlockWrite(overflow, merged, nil)
+	return nil
+}
+
+// Write apply the given batch to the DB. The batch records will be applied
+// sequentially. Write might be used concurrently, when used concurrently and
+// batch is small enough, write will try to merge the batches. Set NoWriteMerge
+// option to true to disable write merge.
+//
+// It is safe to modify the contents of the arguments after Write returns but
+// not before. Write will not modify content of the batch.
+func (db *DB) Write(batch *Batch, wo *opt.WriteOptions) error {
+	if err := db.ok(); err != nil || batch == nil || batch.Len() == 0 {
+		return err
+	}
+
+	// If the batch size is larger than write buffer, it may justified to write
+	// using transaction instead. Using transaction the batch will be written
+	// into tables directly, skipping the journaling.
+	if batch.internalLen > db.s.o.GetWriteBuffer() && !db.s.o.GetDisableLargeBatchTransaction() {
+		tr, err := db.OpenTransaction()
+		if err != nil {
+			return err
+		}
+		if err := tr.Write(batch, wo); err != nil {
 			tr.Discard()
-			return err1
+			return err
 		}
 		return tr.Commit()
 	}
 
-	// The write happen synchronously.
-	select {
-	case db.writeC <- b:
-		if <-db.writeMergedC {
-			return <-db.writeAckC
-		}
-		// Continue, the write lock already acquired by previous writer
-		// and handed out to us.
-	case db.writeLockC <- struct{}{}:
-	case err = <-db.compPerErrC:
-		return
-	case _, _ = <-db.closeC:
-		return ErrClosed
-	}
+	merge := !wo.GetNoWriteMerge() && !db.s.o.GetNoWriteMerge()
+	sync := wo.GetSync() && !db.s.o.GetNoSync()
 
-	merged := 0
-	danglingMerge := false
-	defer func() {
-		for i := 0; i < merged; i++ {
-			db.writeAckC <- err
-		}
-		if danglingMerge {
-			// Only one dangling merge at most, so this is safe.
-			db.writeMergedC <- false
-		} else {
-			<-db.writeLockC
-		}
-	}()
-
-	mdb, mdbFree, err := db.flush(b.size())
-	if err != nil {
-		return
-	}
-	defer mdb.decref()
-
-	// Calculate maximum size of the batch.
-	m := 1 << 20
-	if x := b.size(); x <= 128<<10 {
-		m = x + (128 << 10)
-	}
-	m = minInt(m, mdbFree)
-
-	// Merge with other batch.
-drain:
-	for b.size() < m && !b.sync {
+	// Acquire write lock.
+	if merge {
 		select {
-		case nb := <-db.writeC:
-			if b.size()+nb.size() <= m {
-				b.append(nb)
-				db.writeMergedC <- true
-				merged++
-			} else {
-				danglingMerge = true
-				break drain
+		case db.writeMergeC <- writeMerge{sync: sync, batch: batch}:
+			if <-db.writeMergedC {
+				// Write is merged.
+				return <-db.writeAckC
 			}
-		default:
-			break drain
-		}
-	}
-
-	// Set batch first seq number relative from last seq.
-	b.seq = db.seq + 1
-
-	// Write journal concurrently if it is large enough.
-	if b.size() >= (128 << 10) {
-		// Push the write batch to the journal writer
-		select {
-		case db.journalC <- b:
-			// Write into memdb
-			if berr := b.memReplay(mdb.DB); berr != nil {
-				panic(berr)
-			}
-		case err = <-db.compPerErrC:
-			return
-		case _, _ = <-db.closeC:
-			err = ErrClosed
-			return
-		}
-		// Wait for journal writer
-		select {
-		case err = <-db.journalAckC:
-			if err != nil {
-				// Revert memdb if error detected
-				if berr := b.revertMemReplay(mdb.DB); berr != nil {
-					panic(berr)
-				}
-				return
-			}
-		case _, _ = <-db.closeC:
-			err = ErrClosed
-			return
+			// Write is not merged, the write lock is handed to us. Continue.
+		case db.writeLockC <- struct{}{}:
+			// Write lock acquired.
+		case err := <-db.compPerErrC:
+			// Compaction error.
+			return err
+		case <-db.closeC:
+			// Closed
+			return ErrClosed
 		}
 	} else {
-		err = db.writeJournal(b)
-		if err != nil {
-			return
-		}
-		if berr := b.memReplay(mdb.DB); berr != nil {
-			panic(berr)
+		select {
+		case db.writeLockC <- struct{}{}:
+			// Write lock acquired.
+		case err := <-db.compPerErrC:
+			// Compaction error.
+			return err
+		case <-db.closeC:
+			// Closed
+			return ErrClosed
 		}
 	}
 
-	// Set last seq number.
-	db.addSeq(uint64(b.Len()))
+	return db.writeLocked(batch, nil, merge, sync)
+}
 
-	if b.size() >= mdbFree {
-		db.rotateMem(0, false)
+func (db *DB) putRec(kt keyType, key, value []byte, wo *opt.WriteOptions) error {
+	if err := db.ok(); err != nil {
+		return err
 	}
-	return
+
+	merge := !wo.GetNoWriteMerge() && !db.s.o.GetNoWriteMerge()
+	sync := wo.GetSync() && !db.s.o.GetNoSync()
+
+	// Acquire write lock.
+	if merge {
+		select {
+		case db.writeMergeC <- writeMerge{sync: sync, keyType: kt, key: key, value: value}:
+			if <-db.writeMergedC {
+				// Write is merged.
+				return <-db.writeAckC
+			}
+			// Write is not merged, the write lock is handed to us. Continue.
+		case db.writeLockC <- struct{}{}:
+			// Write lock acquired.
+		case err := <-db.compPerErrC:
+			// Compaction error.
+			return err
+		case <-db.closeC:
+			// Closed
+			return ErrClosed
+		}
+	} else {
+		select {
+		case db.writeLockC <- struct{}{}:
+			// Write lock acquired.
+		case err := <-db.compPerErrC:
+			// Compaction error.
+			return err
+		case <-db.closeC:
+			// Closed
+			return ErrClosed
+		}
+	}
+
+	batch := db.batchPool.Get().(*Batch)
+	batch.Reset()
+	batch.appendRec(kt, key, value)
+	return db.writeLocked(batch, batch, merge, sync)
 }
 
 // Put sets the value for the given key. It overwrites any previous value
-// for that key; a DB is not a multi-map.
+// for that key; a DB is not a multi-map. Write merge also applies for Put, see
+// Write.
 //
-// It is safe to modify the contents of the arguments after Put returns.
+// It is safe to modify the contents of the arguments after Put returns but not
+// before.
 func (db *DB) Put(key, value []byte, wo *opt.WriteOptions) error {
-	b := new(Batch)
-	b.Put(key, value)
-	return db.Write(b, wo)
+	return db.putRec(keyTypeVal, key, value, wo)
 }
 
-// Delete deletes the value for the given key.
+// Delete deletes the value for the given key. Delete will not returns error if
+// key doesn't exist. Write merge also applies for Delete, see Write.
 //
-// It is safe to modify the contents of the arguments after Delete returns.
+// It is safe to modify the contents of the arguments after Delete returns but
+// not before.
 func (db *DB) Delete(key []byte, wo *opt.WriteOptions) error {
-	b := new(Batch)
-	b.Delete(key)
-	return db.Write(b, wo)
+	return db.putRec(keyTypeDel, key, nil, wo)
 }
 
 func isMemOverlaps(icmp *iComparer, mem *memdb.DB, min, max []byte) bool {
@@ -304,12 +386,15 @@ func (db *DB) CompactRange(r util.Range) error {
 	case db.writeLockC <- struct{}{}:
 	case err := <-db.compPerErrC:
 		return err
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 
 	// Check for overlaps in memdb.
 	mdb := db.getEffectiveMem()
+	if mdb == nil {
+		return ErrClosed
+	}
 	defer mdb.decref()
 	if isMemOverlaps(db.s.icmp, mdb.DB, r.Start, r.Limit) {
 		// Memdb compaction.
@@ -341,7 +426,7 @@ func (db *DB) SetReadOnly() error {
 		db.compWriteLocking = true
 	case err := <-db.compPerErrC:
 		return err
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 
@@ -350,7 +435,7 @@ func (db *DB) SetReadOnly() error {
 	case db.compErrSetC <- ErrReadOnly:
 	case perr := <-db.compPerErrC:
 		return perr
-	case _, _ = <-db.closeC:
+	case <-db.closeC:
 		return ErrClosed
 	}
 

--- a/vendor/github.com/syndtr/goleveldb/leveldb/errors.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/errors.go
@@ -10,6 +10,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/errors"
 )
 
+// Common errors.
 var (
 	ErrNotFound         = errors.ErrNotFound
 	ErrReadOnly         = errors.New("leveldb: read-only mode")

--- a/vendor/github.com/syndtr/goleveldb/leveldb/errors/errors.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/errors/errors.go
@@ -15,6 +15,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
+// Common errors.
 var (
 	ErrNotFound    = New("leveldb: not found")
 	ErrReleased    = util.ErrReleased
@@ -34,11 +35,10 @@ type ErrCorrupted struct {
 }
 
 func (e *ErrCorrupted) Error() string {
-	if !e.Fd.Nil() {
+	if !e.Fd.Zero() {
 		return fmt.Sprintf("%v [file=%v]", e.Err, e.Fd)
-	} else {
-		return e.Err.Error()
 	}
+	return e.Err.Error()
 }
 
 // NewErrCorrupted creates new ErrCorrupted error.

--- a/vendor/github.com/syndtr/goleveldb/leveldb/iterator/iter.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/iterator/iter.go
@@ -21,13 +21,13 @@ var (
 // IteratorSeeker is the interface that wraps the 'seeks method'.
 type IteratorSeeker interface {
 	// First moves the iterator to the first key/value pair. If the iterator
-	// only contains one key/value pair then First and Last whould moves
+	// only contains one key/value pair then First and Last would moves
 	// to the same key/value pair.
 	// It returns whether such pair exist.
 	First() bool
 
 	// Last moves the iterator to the last key/value pair. If the iterator
-	// only contains one key/value pair then First and Last whould moves
+	// only contains one key/value pair then First and Last would moves
 	// to the same key/value pair.
 	// It returns whether such pair exist.
 	Last() bool
@@ -48,7 +48,7 @@ type IteratorSeeker interface {
 	Prev() bool
 }
 
-// CommonIterator is the interface that wraps common interator methods.
+// CommonIterator is the interface that wraps common iterator methods.
 type CommonIterator interface {
 	IteratorSeeker
 
@@ -71,14 +71,15 @@ type CommonIterator interface {
 
 // Iterator iterates over a DB's key/value pairs in key order.
 //
-// When encouter an error any 'seeks method' will return false and will
+// When encounter an error any 'seeks method' will return false and will
 // yield no key/value pairs. The error can be queried by calling the Error
 // method. Calling Release is still necessary.
 //
 // An iterator must be released after use, but it is not necessary to read
 // an iterator until exhaustion.
-// Also, an iterator is not necessarily goroutine-safe, but it is safe to use
-// multiple iterators concurrently, with each in a dedicated goroutine.
+// Also, an iterator is not necessarily safe for concurrent use, but it is
+// safe to use multiple iterators concurrently, with each in a dedicated
+// goroutine.
 type Iterator interface {
 	CommonIterator
 
@@ -98,7 +99,7 @@ type Iterator interface {
 //
 // ErrorCallbackSetter implemented by indexed and merged iterator.
 type ErrorCallbackSetter interface {
-	// SetErrorCallback allows set an error callback of the coresponding
+	// SetErrorCallback allows set an error callback of the corresponding
 	// iterator. Use nil to clear the callback.
 	SetErrorCallback(f func(err error))
 }

--- a/vendor/github.com/syndtr/goleveldb/leveldb/key.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/key.go
@@ -37,14 +37,14 @@ func (kt keyType) String() string {
 	case keyTypeVal:
 		return "v"
 	}
-	return "x"
+	return fmt.Sprintf("<invalid:%#x>", uint(kt))
 }
 
 // Value types encoded as the last component of internal keys.
 // Don't modify; this value are saved to disk.
 const (
-	keyTypeDel keyType = iota
-	keyTypeVal
+	keyTypeDel = keyType(0)
+	keyTypeVal = keyType(1)
 )
 
 // keyTypeSeek defines the keyType that should be passed when constructing an
@@ -79,11 +79,7 @@ func makeInternalKey(dst, ukey []byte, seq uint64, kt keyType) internalKey {
 		panic("leveldb: invalid type")
 	}
 
-	if n := len(ukey) + 8; cap(dst) < n {
-		dst = make([]byte, n)
-	} else {
-		dst = dst[:n]
-	}
+	dst = ensureBuffer(dst, len(ukey)+8)
 	copy(dst, ukey)
 	binary.LittleEndian.PutUint64(dst[len(ukey):], (seq<<8)|uint64(kt))
 	return internalKey(dst)
@@ -143,5 +139,5 @@ func (ik internalKey) String() string {
 	if ukey, seq, kt, err := parseInternalKey(ik); err == nil {
 		return fmt.Sprintf("%s,%s%d", shorten(string(ukey)), kt, seq)
 	}
-	return "<invalid>"
+	return fmt.Sprintf("<invalid:%#x>", []byte(ik))
 }

--- a/vendor/github.com/syndtr/goleveldb/leveldb/opt/options.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/opt/options.go
@@ -312,6 +312,11 @@ type Options struct {
 	// The default is false.
 	NoSync bool
 
+	// NoWriteMerge allows disabling write merge.
+	//
+	// The default is false.
+	NoWriteMerge bool
+
 	// OpenFilesCacher provides cache algorithm for open files caching.
 	// Specify NoCacher to disable caching algorithm.
 	//
@@ -543,6 +548,13 @@ func (o *Options) GetNoSync() bool {
 	return o.NoSync
 }
 
+func (o *Options) GetNoWriteMerge() bool {
+	if o == nil {
+		return false
+	}
+	return o.NoWriteMerge
+}
+
 func (o *Options) GetOpenFilesCacher() Cacher {
 	if o == nil || o.OpenFilesCacher == nil {
 		return DefaultOpenFilesCacher
@@ -629,6 +641,11 @@ func (ro *ReadOptions) GetStrict(strict Strict) bool {
 // WriteOptions holds the optional parameters for 'write operation'. The
 // 'write operation' includes Write, Put and Delete.
 type WriteOptions struct {
+	// NoWriteMerge allows disabling write merge.
+	//
+	// The default is false.
+	NoWriteMerge bool
+
 	// Sync is whether to sync underlying writes from the OS buffer cache
 	// through to actual disk, if applicable. Setting Sync can result in
 	// slower writes.
@@ -642,6 +659,13 @@ type WriteOptions struct {
 	//
 	// The default value is false.
 	Sync bool
+}
+
+func (wo *WriteOptions) GetNoWriteMerge() bool {
+	if wo == nil {
+		return false
+	}
+	return wo.NoWriteMerge
 }
 
 func (wo *WriteOptions) GetSync() bool {

--- a/vendor/github.com/syndtr/goleveldb/leveldb/session.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/session.go
@@ -18,7 +18,8 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/storage"
 )
 
-// ErrManifestCorrupted records manifest corruption.
+// ErrManifestCorrupted records manifest corruption. This error will be
+// wrapped with errors.ErrCorrupted.
 type ErrManifestCorrupted struct {
 	Field  string
 	Reason string
@@ -42,10 +43,11 @@ type session struct {
 	stSeqNum         uint64 // last mem compacted seq; need external synchronization
 
 	stor     storage.Storage
-	storLock storage.Lock
+	storLock storage.Locker
 	o        *cachedOptions
 	icmp     *iComparer
 	tops     *tOps
+	fileRef  map[int64]int
 
 	manifest       *journal.Writer
 	manifestWriter storage.Writer
@@ -68,6 +70,7 @@ func newSession(stor storage.Storage, o *opt.Options) (s *session, err error) {
 	s = &session{
 		stor:     stor,
 		storLock: storLock,
+		fileRef:  make(map[int64]int),
 	}
 	s.setOptions(o)
 	s.tops = newTableOps(s)
@@ -87,12 +90,12 @@ func (s *session) close() {
 	}
 	s.manifest = nil
 	s.manifestWriter = nil
-	s.stVersion = nil
+	s.setVersion(&version{s: s, closing: true})
 }
 
 // Release session lock.
 func (s *session) release() {
-	s.storLock.Release()
+	s.storLock.Unlock()
 }
 
 // Create a new database session; need external synchronization.

--- a/vendor/github.com/syndtr/goleveldb/leveldb/storage/file_storage.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/storage/file_storage.go
@@ -32,7 +32,7 @@ type fileStorageLock struct {
 	fs *fileStorage
 }
 
-func (lock *fileStorageLock) Release() {
+func (lock *fileStorageLock) Unlock() {
 	if lock.fs != nil {
 		lock.fs.mu.Lock()
 		defer lock.fs.mu.Unlock()
@@ -116,7 +116,7 @@ func OpenFile(path string, readOnly bool) (Storage, error) {
 	return fs, nil
 }
 
-func (fs *fileStorage) Lock() (Lock, error) {
+func (fs *fileStorage) Lock() (Locker, error) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
 	if fs.open < 0 {
@@ -323,7 +323,7 @@ func (fs *fileStorage) GetMeta() (fd FileDesc, err error) {
 		}
 	}
 	// Don't remove any files if there is no valid CURRENT file.
-	if fd.Nil() {
+	if fd.Zero() {
 		if cerr != nil {
 			err = cerr
 		} else {

--- a/vendor/github.com/syndtr/goleveldb/leveldb/storage/file_storage_nacl.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/storage/file_storage_nacl.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2012, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// +build nacl
+
+package storage
+
+import (
+	"os"
+	"syscall"
+)
+
+func newFileLock(path string, readOnly bool) (fl fileLock, err error) {
+	return nil, syscall.ENOTSUP
+}
+
+func setFileLock(f *os.File, readOnly, lock bool) error {
+	return syscall.ENOTSUP
+}
+
+func rename(oldpath, newpath string) error {
+	return syscall.ENOTSUP
+}
+
+func isErrInvalid(err error) bool {
+	return false
+}
+
+func syncDir(name string) error {
+	return syscall.ENOTSUP
+}

--- a/vendor/github.com/syndtr/goleveldb/leveldb/storage/mem_storage.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/storage/mem_storage.go
@@ -18,7 +18,7 @@ type memStorageLock struct {
 	ms *memStorage
 }
 
-func (lock *memStorageLock) Release() {
+func (lock *memStorageLock) Unlock() {
 	ms := lock.ms
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
@@ -43,7 +43,7 @@ func NewMemStorage() Storage {
 	}
 }
 
-func (ms *memStorage) Lock() (Lock, error) {
+func (ms *memStorage) Lock() (Locker, error) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 	if ms.slock != nil {
@@ -69,7 +69,7 @@ func (ms *memStorage) SetMeta(fd FileDesc) error {
 func (ms *memStorage) GetMeta() (FileDesc, error) {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
-	if ms.meta.Nil() {
+	if ms.meta.Zero() {
 		return FileDesc{}, os.ErrNotExist
 	}
 	return ms.meta, nil
@@ -78,7 +78,7 @@ func (ms *memStorage) GetMeta() (FileDesc, error) {
 func (ms *memStorage) List(ft FileType) ([]FileDesc, error) {
 	ms.mu.Lock()
 	var fds []FileDesc
-	for x, _ := range ms.files {
+	for x := range ms.files {
 		fd := unpackFile(x)
 		if fd.Type&ft != 0 {
 			fds = append(fds, fd)

--- a/vendor/github.com/syndtr/goleveldb/leveldb/storage/storage.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/storage/storage.go
@@ -11,12 +11,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-
-	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
+// FileType represent a file type.
 type FileType int
 
+// File types.
 const (
 	TypeManifest FileType = 1 << iota
 	TypeJournal
@@ -40,6 +40,7 @@ func (t FileType) String() string {
 	return fmt.Sprintf("<unknown:%d>", t)
 }
 
+// Common error.
 var (
 	ErrInvalidFile = errors.New("leveldb/storage: invalid file for argument")
 	ErrLocked      = errors.New("leveldb/storage: already locked")
@@ -55,11 +56,10 @@ type ErrCorrupted struct {
 }
 
 func (e *ErrCorrupted) Error() string {
-	if !e.Fd.Nil() {
+	if !e.Fd.Zero() {
 		return fmt.Sprintf("%v [file=%v]", e.Err, e.Fd)
-	} else {
-		return e.Err.Error()
 	}
+	return e.Err.Error()
 }
 
 // Syncer is the interface that wraps basic Sync method.
@@ -83,11 +83,12 @@ type Writer interface {
 	Syncer
 }
 
-type Lock interface {
-	util.Releaser
+// Locker is the interface that wraps Unlock method.
+type Locker interface {
+	Unlock()
 }
 
-// FileDesc is a file descriptor.
+// FileDesc is a 'file descriptor'.
 type FileDesc struct {
 	Type FileType
 	Num  int64
@@ -108,12 +109,12 @@ func (fd FileDesc) String() string {
 	}
 }
 
-// Nil returns true if fd == (FileDesc{}).
-func (fd FileDesc) Nil() bool {
+// Zero returns true if fd == (FileDesc{}).
+func (fd FileDesc) Zero() bool {
 	return fd == (FileDesc{})
 }
 
-// FileDescOk returns true if fd is a valid file descriptor.
+// FileDescOk returns true if fd is a valid 'file descriptor'.
 func FileDescOk(fd FileDesc) bool {
 	switch fd.Type {
 	case TypeManifest:
@@ -126,43 +127,44 @@ func FileDescOk(fd FileDesc) bool {
 	return fd.Num >= 0
 }
 
-// Storage is the storage. A storage instance must be goroutine-safe.
+// Storage is the storage. A storage instance must be safe for concurrent use.
 type Storage interface {
 	// Lock locks the storage. Any subsequent attempt to call Lock will fail
 	// until the last lock released.
-	// After use the caller should call the Release method.
-	Lock() (Lock, error)
+	// Caller should call Unlock method after use.
+	Lock() (Locker, error)
 
 	// Log logs a string. This is used for logging.
 	// An implementation may write to a file, stdout or simply do nothing.
 	Log(str string)
 
-	// SetMeta sets to point to the given fd, which then can be acquired using
-	// GetMeta method.
-	// SetMeta should be implemented in such way that changes should happened
+	// SetMeta store 'file descriptor' that can later be acquired using GetMeta
+	// method. The 'file descriptor' should point to a valid file.
+	// SetMeta should be implemented in such way that changes should happen
 	// atomically.
 	SetMeta(fd FileDesc) error
 
-	// GetManifest returns a manifest file.
-	// Returns os.ErrNotExist if meta doesn't point to any fd, or point to fd
-	// that doesn't exist.
+	// GetMeta returns 'file descriptor' stored in meta. The 'file descriptor'
+	// can be updated using SetMeta method.
+	// Returns os.ErrNotExist if meta doesn't store any 'file descriptor', or
+	// 'file descriptor' point to nonexistent file.
 	GetMeta() (FileDesc, error)
 
-	// List returns fds that match the given file types.
+	// List returns file descriptors that match the given file types.
 	// The file types may be OR'ed together.
 	List(ft FileType) ([]FileDesc, error)
 
-	// Open opens file with the given fd read-only.
+	// Open opens file with the given 'file descriptor' read-only.
 	// Returns os.ErrNotExist error if the file does not exist.
 	// Returns ErrClosed if the underlying storage is closed.
 	Open(fd FileDesc) (Reader, error)
 
-	// Create creates file with the given fd, truncate if already exist and
-	// opens write-only.
+	// Create creates file with the given 'file descriptor', truncate if already
+	// exist and opens write-only.
 	// Returns ErrClosed if the underlying storage is closed.
 	Create(fd FileDesc) (Writer, error)
 
-	// Remove removes file with the given fd.
+	// Remove removes file with the given 'file descriptor'.
 	// Returns ErrClosed if the underlying storage is closed.
 	Remove(fd FileDesc) error
 

--- a/vendor/github.com/syndtr/goleveldb/leveldb/table.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/table.go
@@ -434,7 +434,7 @@ func (t *tOps) close() {
 	t.bpool.Close()
 	t.cache.Close()
 	if t.bcache != nil {
-		t.bcache.Close()
+		t.bcache.CloseWeak()
 	}
 }
 

--- a/vendor/github.com/syndtr/goleveldb/leveldb/table/reader.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/table/reader.go
@@ -26,12 +26,15 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
+// Reader errors.
 var (
 	ErrNotFound       = errors.ErrNotFound
 	ErrReaderReleased = errors.New("leveldb/table: reader released")
 	ErrIterReleased   = errors.New("leveldb/table: iterator released")
 )
 
+// ErrCorrupted describes error due to corruption. This error will be wrapped
+// with errors.ErrCorrupted.
 type ErrCorrupted struct {
 	Pos    int64
 	Size   int64
@@ -61,7 +64,7 @@ type block struct {
 func (b *block) seek(cmp comparer.Comparer, rstart, rlimit int, key []byte) (index, offset int, err error) {
 	index = sort.Search(b.restartsLen-rstart-(b.restartsLen-rlimit), func(i int) bool {
 		offset := int(binary.LittleEndian.Uint32(b.data[b.restartsOffset+4*(rstart+i):]))
-		offset += 1                                 // shared always zero, since this is a restart point
+		offset++                                    // shared always zero, since this is a restart point
 		v1, n1 := binary.Uvarint(b.data[offset:])   // key length
 		_, n2 := binary.Uvarint(b.data[offset+n1:]) // value length
 		m := offset + n1 + n2
@@ -356,7 +359,7 @@ func (i *blockIter) Prev() bool {
 	i.value = nil
 	offset := i.block.restartOffset(ri)
 	if offset == i.offset {
-		ri -= 1
+		ri--
 		if ri < 0 {
 			i.dir = dirSOI
 			return false
@@ -783,8 +786,8 @@ func (r *Reader) getDataIterErr(dataBH blockHandle, slice *util.Range, verifyChe
 // table. And a nil Range.Limit is treated as a key after all keys in
 // the table.
 //
-// The returned iterator is not goroutine-safe and should be released
-// when not used.
+// The returned iterator is not safe for concurrent use and should be released
+// after use.
 //
 // Also read Iterator documentation of the leveldb/iterator package.
 func (r *Reader) NewIterator(slice *util.Range, ro *opt.ReadOptions) iterator.Iterator {
@@ -826,18 +829,21 @@ func (r *Reader) find(key []byte, filtered bool, ro *opt.ReadOptions, noValue bo
 
 	index := r.newBlockIter(indexBlock, nil, nil, true)
 	defer index.Release()
+
 	if !index.Seek(key) {
-		err = index.Error()
-		if err == nil {
+		if err = index.Error(); err == nil {
 			err = ErrNotFound
 		}
 		return
 	}
+
 	dataBH, n := decodeBlockHandle(index.Value())
 	if n == 0 {
 		r.err = r.newErrCorruptedBH(r.indexBH, "bad data block handle")
-		return
+		return nil, nil, r.err
 	}
+
+	// The filter should only used for exact match.
 	if filtered && r.filter != nil {
 		filterBlock, frel, ferr := r.getFilterBlock(true)
 		if ferr == nil {
@@ -847,30 +853,53 @@ func (r *Reader) find(key []byte, filtered bool, ro *opt.ReadOptions, noValue bo
 			}
 			frel.Release()
 		} else if !errors.IsCorrupted(ferr) {
-			err = ferr
+			return nil, nil, ferr
+		}
+	}
+
+	data := r.getDataIter(dataBH, nil, r.verifyChecksum, !ro.GetDontFillCache())
+	if !data.Seek(key) {
+		data.Release()
+		if err = data.Error(); err != nil {
+			return
+		}
+
+		// The nearest greater-than key is the first key of the next block.
+		if !index.Next() {
+			if err = index.Error(); err == nil {
+				err = ErrNotFound
+			}
+			return
+		}
+
+		dataBH, n = decodeBlockHandle(index.Value())
+		if n == 0 {
+			r.err = r.newErrCorruptedBH(r.indexBH, "bad data block handle")
+			return nil, nil, r.err
+		}
+
+		data = r.getDataIter(dataBH, nil, r.verifyChecksum, !ro.GetDontFillCache())
+		if !data.Next() {
+			data.Release()
+			if err = data.Error(); err == nil {
+				err = ErrNotFound
+			}
 			return
 		}
 	}
-	data := r.getDataIter(dataBH, nil, r.verifyChecksum, !ro.GetDontFillCache())
-	defer data.Release()
-	if !data.Seek(key) {
-		err = data.Error()
-		if err == nil {
-			err = ErrNotFound
-		}
-		return
-	}
-	// Don't use block buffer, no need to copy the buffer.
+
+	// Key doesn't use block buffer, no need to copy the buffer.
 	rkey = data.Key()
 	if !noValue {
 		if r.bpool == nil {
 			value = data.Value()
 		} else {
-			// Use block buffer, and since the buffer will be recycled, the buffer
-			// need to be copied.
+			// Value does use block buffer, and since the buffer will be
+			// recycled, it need to be copied.
 			value = append([]byte{}, data.Value()...)
 		}
 	}
+	data.Release()
 	return
 }
 
@@ -888,7 +917,7 @@ func (r *Reader) Find(key []byte, filtered bool, ro *opt.ReadOptions) (rkey, val
 	return r.find(key, filtered, ro, false)
 }
 
-// Find finds key that is greater than or equal to the given key.
+// FindKey finds key that is greater than or equal to the given key.
 // It returns ErrNotFound if the table doesn't contain such key.
 // If filtered is true then the nearest 'block' will be checked against
 // 'filter data' (if present) and will immediately return ErrNotFound if
@@ -987,7 +1016,7 @@ func (r *Reader) Release() {
 // NewReader creates a new initialized table reader for the file.
 // The fi, cache and bpool is optional and can be nil.
 //
-// The returned table reader instance is goroutine-safe.
+// The returned table reader instance is safe for concurrent use.
 func NewReader(f io.ReaderAt, size int64, fd storage.FileDesc, cache *cache.NamespaceGetter, bpool *util.BufferPool, o *opt.Options) (*Reader, error) {
 	if f == nil {
 		return nil, errors.New("leveldb/table: nil file")
@@ -1039,9 +1068,8 @@ func NewReader(f io.ReaderAt, size int64, fd storage.FileDesc, cache *cache.Name
 		if errors.IsCorrupted(err) {
 			r.err = err
 			return r, nil
-		} else {
-			return nil, err
 		}
+		return nil, err
 	}
 
 	// Set data end.
@@ -1086,9 +1114,8 @@ func NewReader(f io.ReaderAt, size int64, fd storage.FileDesc, cache *cache.Name
 			if errors.IsCorrupted(err) {
 				r.err = err
 				return r, nil
-			} else {
-				return nil, err
 			}
+			return nil, err
 		}
 		if r.filter != nil {
 			r.filterBlock, err = r.readFilterBlock(r.filterBH)

--- a/vendor/github.com/syndtr/goleveldb/leveldb/table/writer.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/table/writer.go
@@ -349,7 +349,7 @@ func (w *Writer) Close() error {
 
 // NewWriter creates a new initialized table writer for the file.
 //
-// Table writer is not goroutine-safe.
+// Table writer is not safe for concurrent use.
 func NewWriter(f io.Writer, o *opt.Options) *Writer {
 	w := &Writer{
 		writer:          f,

--- a/vendor/github.com/syndtr/goleveldb/leveldb/util.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/util.go
@@ -89,3 +89,10 @@ func (p fdSorter) Swap(i, j int) {
 func sortFds(fds []storage.FileDesc) {
 	sort.Sort(fdSorter(fds))
 }
+
+func ensureBuffer(b []byte, n int) []byte {
+	if cap(b) < n {
+		return make([]byte, n)
+	}
+	return b[:n]
+}

--- a/vendor/github.com/syndtr/goleveldb/leveldb/util/hash.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/util/hash.go
@@ -7,38 +7,38 @@
 package util
 
 import (
-	"bytes"
 	"encoding/binary"
 )
 
 // Hash return hash of the given data.
 func Hash(data []byte, seed uint32) uint32 {
 	// Similar to murmur hash
-	var m uint32 = 0xc6a4a793
-	var r uint32 = 24
-	h := seed ^ (uint32(len(data)) * m)
+	const (
+		m = uint32(0xc6a4a793)
+		r = uint32(24)
+	)
+	var (
+		h = seed ^ (uint32(len(data)) * m)
+		i int
+	)
 
-	buf := bytes.NewBuffer(data)
-	for buf.Len() >= 4 {
-		var w uint32
-		binary.Read(buf, binary.LittleEndian, &w)
-		h += w
+	for n := len(data) - len(data)%4; i < n; i += 4 {
+		h += binary.LittleEndian.Uint32(data[i:])
 		h *= m
 		h ^= (h >> 16)
 	}
 
-	rest := buf.Bytes()
-	switch len(rest) {
+	switch len(data) - i {
 	default:
 		panic("not reached")
 	case 3:
-		h += uint32(rest[2]) << 16
+		h += uint32(data[i+2]) << 16
 		fallthrough
 	case 2:
-		h += uint32(rest[1]) << 8
+		h += uint32(data[i+1]) << 8
 		fallthrough
 	case 1:
-		h += uint32(rest[0])
+		h += uint32(data[i])
 		h *= m
 		h ^= (h >> r)
 	case 0:

--- a/vendor/github.com/syndtr/goleveldb/leveldb/version.go
+++ b/vendor/github.com/syndtr/goleveldb/leveldb/version.go
@@ -34,43 +34,48 @@ type version struct {
 
 	cSeek unsafe.Pointer
 
-	ref int
-	// Succeeding version.
-	next *version
+	closing  bool
+	ref      int
+	released bool
 }
 
 func newVersion(s *session) *version {
 	return &version{s: s}
 }
 
+func (v *version) incref() {
+	if v.released {
+		panic("already released")
+	}
+
+	v.ref++
+	if v.ref == 1 {
+		// Incr file ref.
+		for _, tt := range v.levels {
+			for _, t := range tt {
+				v.s.addFileRef(t.fd, 1)
+			}
+		}
+	}
+}
+
 func (v *version) releaseNB() {
 	v.ref--
 	if v.ref > 0 {
 		return
-	}
-	if v.ref < 0 {
+	} else if v.ref < 0 {
 		panic("negative version ref")
-	}
-
-	nextTables := make(map[int64]bool)
-	for _, tt := range v.next.levels {
-		for _, t := range tt {
-			num := t.fd.Num
-			nextTables[num] = true
-		}
 	}
 
 	for _, tt := range v.levels {
 		for _, t := range tt {
-			num := t.fd.Num
-			if _, ok := nextTables[num]; !ok {
+			if v.s.addFileRef(t.fd, -1) == 0 {
 				v.s.tops.remove(t)
 			}
 		}
 	}
 
-	v.next.releaseNB()
-	v.next = nil
+	v.released = true
 }
 
 func (v *version) release() {
@@ -131,6 +136,10 @@ func (v *version) walkOverlapping(aux tFiles, ikey internalKey, f func(level int
 }
 
 func (v *version) get(aux tFiles, ikey internalKey, ro *opt.ReadOptions, noValue bool) (value []byte, tcomp bool, err error) {
+	if v.closing {
+		return nil, false, ErrClosed
+	}
+
 	ukey := ikey.ukey()
 
 	var (

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -384,85 +384,85 @@
 			"checksumSHA1": "npXqUwwwsY52sXJtpS673untmBo=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb",
 			"path": "github.com/syndtr/goleveldb/leveldb",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "BX+u3k6if9kZNYYqbL56gC48BAQ=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/cache",
 			"path": "github.com/syndtr/goleveldb/leveldb/cache",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "5KPgnvCPlR0ysDAqo6jApzRQ3tw=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/comparer",
 			"path": "github.com/syndtr/goleveldb/leveldb/comparer",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "Vpvz4qmbq/kz0SN95yt0tmSI7JE=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/errors",
 			"path": "github.com/syndtr/goleveldb/leveldb/errors",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "eqKeD6DS7eNCtxVYZEHHRKkyZrw=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/filter",
 			"path": "github.com/syndtr/goleveldb/leveldb/filter",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "cRn09EwfU3k2ZjvClHYmVFlakRY=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/iterator",
 			"path": "github.com/syndtr/goleveldb/leveldb/iterator",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "CMBbso8ZuG2kBGDL2Blf/wpeheU=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/journal",
 			"path": "github.com/syndtr/goleveldb/leveldb/journal",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "LshzRv+3spfwuHLepRxiyjf/3sQ=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/memdb",
 			"path": "github.com/syndtr/goleveldb/leveldb/memdb",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "MP/sSiEbzIN5M664sO4r9+dwzV4=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/opt",
 			"path": "github.com/syndtr/goleveldb/leveldb/opt",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "X+PA6Wrhhy5+nujN1TNOGWtd1RI=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/storage",
 			"path": "github.com/syndtr/goleveldb/leveldb/storage",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "4EGplyU1Q07vIczP2yZgKvjuYVA=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/table",
 			"path": "github.com/syndtr/goleveldb/leveldb/table",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"checksumSHA1": "kgGxCIF5+2SQj2rNVophj4a8jYs=",
 			"origin": "github.com/keybase/client/go/vendor/github.com/syndtr/goleveldb/leveldb/util",
 			"path": "github.com/syndtr/goleveldb/leveldb/util",
-			"revision": "a7c5ee4a843ee6e4ccf898ae9e5ad1dd301a358e",
-			"revisionTime": "2016-08-26T20:58:34Z"
+			"revision": "23851d93a2292dcc56e71a18ec9e0624d84a0f65",
+			"revisionTime": "2016-12-27T18:05:19+07:00"
 		},
 		{
 			"path": "github.com/vaughan0/go-ini",


### PR DESCRIPTION
This is KBFS-1902:
* [x] `DiskBlockCache` interface specified and added to `Config`.
* [x] `DiskBlockCacheStandard` implemented and plumbed through KBFS initialization.
* [x] `DiskBlockCacheStandard.Get` implemented and plumbed through `BlockServerRemote.Get`
* [x] `DiskBlockCacheStandard.Put` implemented and plumbed through `BlockServerRemote.Put`
* [x] `DiskBlockCacheStandard.Delete` implemented and plumbed through `folderBranchOps.notifyOneOpLocked` when the `op` is a `GCOp`.
    * `Delete` always performs compaction on both the `blockDb` and `lruDb`.
* [x] `DiskBlockCache.Evict` specified and an overview of the algorithm is specified in `DiskBlockCacheStandard`.
    * Currently it's only per-TLF eviction. Not sure how we'll decide which TLF to evict.
* [x] disk block cache basic manual tests performed successfully.
* [x] Basic unit tests for `DiskBlockCacheStandard` implemented.