### PR TITLE
folder_block_manager: push gcOps even when no blocks are deleted

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2443,6 +2443,9 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 	}
 
 	md.AddOp(gco)
+	// TODO: if the revision number of this new commit is sequential
+	// with `LatestRev`, we can probably change this to
+	// `gco.LatestRev+1`.
 	md.SetLastGCRevision(gco.LatestRev)
 
 	bps, err := fbo.maybeUnembedAndPutBlocks(ctx, md)


### PR DESCRIPTION
This indicates to other devices (and future restarts of this device)
that there's no need to scan that MD range again looking for blocks to
delete.  This can happen for example when there's a range of gcOps
already at the tail of the TLF's history.

Also, we can avoid QR completely if the head consists of a gcOp that
deleted blocks all the way up to the head's parent revision.

Issue: KBFS-1922