### PR TITLE
[KBFS-1870] Add backpressure based on file count

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -236,11 +236,10 @@ type backpressureDiskLimiter struct {
 	delayFn             func(context.Context, time.Duration) error
 	freeBytesAndFilesFn func() (int64, int64, error)
 
-	// lock protects freeX, journalX, xSemaphoreMax, and the
-	// (implicit) maximum value of xSemaphore (== xSemaphoreMax),
-	// where x = Bytes or Files.
-	lock sync.RWMutex
-
+	// lock protects everything in the trackers, including the
+	// (implicit) maximum values of the semaphores, but not the
+	// actual semaphore itself.
+	lock                     sync.RWMutex
 	byteTracker, fileTracker *backpressureTracker
 }
 

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -328,20 +328,23 @@ func newBackpressureDiskLimiter(
 		})
 }
 
-func (bdl *backpressureDiskLimiter) getLockedByteVarsForTest() (
-	journalBytes, freeBytes, byteSemaphoreMax, byteSemaphoreCount int64) {
-	bdl.lock.Lock()
-	defer bdl.lock.Unlock()
-	return bdl.byteTracker.used, bdl.byteTracker.free,
-		bdl.byteTracker.semaphoreMax, bdl.byteTracker.semaphore.Count()
+type bdlSnapshot struct {
+	used  int64
+	free  int64
+	max   int64
+	count int64
 }
 
-func (bdl *backpressureDiskLimiter) getLockedFileVarsForTest() (
-	journalFiles, freeFiles, fileSemaphoreMax, fileSemaphoreCount int64) {
-	bdl.lock.Lock()
-	defer bdl.lock.Unlock()
-	return bdl.fileTracker.used, bdl.fileTracker.free,
-		bdl.fileTracker.semaphoreMax, bdl.fileTracker.semaphore.Count()
+func (bdl *backpressureDiskLimiter) getSnapshotsForTest() (
+	byteSnapshot, fileSnapshot bdlSnapshot) {
+	bdl.lock.RLock()
+	defer bdl.lock.RUnlock()
+	return bdlSnapshot{bdl.byteTracker.used, bdl.byteTracker.free,
+			bdl.byteTracker.semaphoreMax,
+			bdl.byteTracker.semaphore.Count()},
+		bdlSnapshot{bdl.fileTracker.used, bdl.fileTracker.free,
+			bdl.fileTracker.semaphoreMax,
+			bdl.fileTracker.semaphore.Count()}
 }
 
 func (bdl *backpressureDiskLimiter) onJournalEnable(

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -328,7 +328,7 @@ func newBackpressureDiskLimiter(
 		})
 }
 
-func (bdl *backpressureDiskLimiter) getLockedVarsForTest() (
+func (bdl *backpressureDiskLimiter) getLockedByteVarsForTest() (
 	journalBytes int64, freeBytes int64, byteSemaphoreMax int64) {
 	bdl.lock.Lock()
 	defer bdl.lock.Unlock()

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -329,10 +329,19 @@ func newBackpressureDiskLimiter(
 }
 
 func (bdl *backpressureDiskLimiter) getLockedByteVarsForTest() (
-	journalBytes int64, freeBytes int64, byteSemaphoreMax int64) {
+	journalBytes, freeBytes, byteSemaphoreMax, byteSemaphoreCount int64) {
 	bdl.lock.Lock()
 	defer bdl.lock.Unlock()
-	return bdl.byteTracker.used, bdl.byteTracker.free, bdl.byteTracker.semaphoreMax
+	return bdl.byteTracker.used, bdl.byteTracker.free,
+		bdl.byteTracker.semaphoreMax, bdl.byteTracker.semaphore.Count()
+}
+
+func (bdl *backpressureDiskLimiter) getLockedFileVarsForTest() (
+	journalFiles, freeFiles, fileSemaphoreMax, fileSemaphoreCount int64) {
+	bdl.lock.Lock()
+	defer bdl.lock.Unlock()
+	return bdl.fileTracker.used, bdl.fileTracker.free,
+		bdl.fileTracker.semaphoreMax, bdl.fileTracker.semaphore.Count()
 }
 
 // updateBytesSemaphoreMaxLocked must be called (under s.lock)

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -47,6 +47,8 @@ type backpressureDiskLimiter struct {
 	// byteLimit is L in the above.
 	byteLimit int64
 
+	fileLimit int64
+
 	maxDelay    time.Duration
 	delayFn     func(context.Context, time.Duration) error
 	freeBytesFn func() (int64, error)
@@ -71,7 +73,7 @@ var _ diskLimiter = (*backpressureDiskLimiter)(nil)
 func newBackpressureDiskLimiterWithFunctions(
 	log logger.Logger,
 	backpressureMinThreshold, backpressureMaxThreshold, byteLimitFrac float64,
-	byteLimit int64, maxDelay time.Duration,
+	byteLimit, fileLimit int64, maxDelay time.Duration,
 	delayFn func(context.Context, time.Duration) error,
 	freeBytesFn func() (int64, error)) (
 	*backpressureDiskLimiter, error) {
@@ -102,7 +104,7 @@ func newBackpressureDiskLimiterWithFunctions(
 	}
 	bdl := &backpressureDiskLimiter{
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		byteLimitFrac, byteLimit, maxDelay,
+		byteLimitFrac, byteLimit, fileLimit, maxDelay,
 		delayFn, freeBytesFn, sync.Mutex{}, 0,
 		freeBytes, 0, kbfssync.NewSemaphore(),
 	}
@@ -150,11 +152,11 @@ func defaultGetFreeBytes(path string) (int64, error) {
 func newBackpressureDiskLimiter(
 	log logger.Logger,
 	backpressureMinThreshold, backpressureMaxThreshold, byteLimitFrac float64,
-	byteLimit int64, maxDelay time.Duration,
+	byteLimit, fileLimit int64, maxDelay time.Duration,
 	journalPath string) (*backpressureDiskLimiter, error) {
 	return newBackpressureDiskLimiterWithFunctions(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		byteLimitFrac, byteLimit, maxDelay,
+		byteLimitFrac, byteLimit, fileLimit, maxDelay,
 		defaultDoDelay, func() (int64, error) {
 			return defaultGetFreeBytes(journalPath)
 		})

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -192,22 +192,22 @@ type backpressureTrackerStatus struct {
 	MinThreshold float64
 	MaxThreshold float64
 	LimitFrac    float64
-	FixedLimit   float64
+	Limit        int64
 
 	// Raw numbers.
-	Used      float64
-	Free      float64
-	Limit     float64
-	Available float64
+	Used  int64
+	Free  int64
+	Max   int64
+	Count int64
 }
 
 func (bt *backpressureTracker) getStatus() backpressureTrackerStatus {
 	freeFrac := bt.freeFrac()
 	delayScale := bt.delayScale()
 
-	limit := float64(bt.semaphoreMax)
-	available := float64(bt.semaphore.Count())
-	usageFrac := 1 - available/limit
+	max := bt.semaphoreMax
+	count := bt.semaphore.Count()
+	usageFrac := 1 - float64(count)/float64(max)
 
 	return backpressureTrackerStatus{
 		FreeFrac:   freeFrac,
@@ -217,12 +217,12 @@ func (bt *backpressureTracker) getStatus() backpressureTrackerStatus {
 		MinThreshold: bt.minThreshold,
 		MaxThreshold: bt.maxThreshold,
 		LimitFrac:    bt.limitFrac,
-		FixedLimit:   float64(bt.limit),
+		Limit:        bt.limit,
 
-		Used:      float64(bt.used),
-		Free:      float64(bt.free),
-		Limit:     limit,
-		Available: available,
+		Used:  bt.used,
+		Free:  bt.free,
+		Max:   max,
+		Count: count,
 	}
 }
 

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -359,7 +359,9 @@ func (bdl *backpressureDiskLimiter) onJournalDisable(
 
 func (bdl *backpressureDiskLimiter) getDelayLocked(
 	ctx context.Context, now time.Time) time.Duration {
-	delayScale := bdl.byteTracker.delayScale()
+	byteDelayScale := bdl.byteTracker.delayScale()
+	fileDelayScale := bdl.fileTracker.delayScale()
+	delayScale := math.Max(byteDelayScale, fileDelayScale)
 
 	// Set maxDelay to min(bdl.maxDelay, time until deadline - 1s).
 	maxDelay := bdl.maxDelay

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -451,7 +451,7 @@ func (bdl *backpressureDiskLimiter) beforeBlockPut(
 	}()
 
 	availableFiles, err = bdl.fileTracker.beforeBlockPut(ctx, blockFiles)
-	return availableFiles, availableFiles, err
+	return availableBytes, availableFiles, err
 }
 
 func (bdl *backpressureDiskLimiter) afterBlockPut(

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -34,6 +34,9 @@ import (
 // which is equivalent to
 //
 //   m <= U/min(k(U+F), L) <= M.
+//
+// Note that this type doesn't do any locking, so it's the caller's
+// responsibility to do so.
 type backpressureTracker struct {
 	// minThreshold is m in the above.
 	minThreshold float64

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -414,9 +414,10 @@ func (bdl *backpressureDiskLimiter) beforeBlockPut(
 
 		delay := bdl.getDelayLocked(ctx, time.Now())
 		if delay > 0 {
-			bdl.log.CDebugf(ctx, "Delaying block put of %d bytes by %f s ("+
-				"journalBytes=%d freeBytes=%d)",
-				blockBytes, delay.Seconds(), journalBytes, freeBytes)
+			bdl.log.CDebugf(ctx, "Delaying block put of %d bytes and %d files by %f s ("+
+				"freeBytes=%d, freeFiles=%d)",
+				blockBytes, blockFiles,
+				delay.Seconds(), freeBytes, freeFiles)
 		}
 
 		return delay, nil

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -414,9 +414,11 @@ func (bdl *backpressureDiskLimiter) beforeBlockPut(
 		delay := bdl.getDelayLocked(ctx, time.Now())
 		if delay > 0 {
 			bdl.log.CDebugf(ctx, "Delaying block put of %d bytes and %d files by %f s ("+
-				"freeBytes=%d, freeFiles=%d)",
-				blockBytes, blockFiles,
-				delay.Seconds(), freeBytes, freeFiles)
+				"journalBytes=%d, freeBytes=%d, "+
+				"journalFiles=%d, freeFiles=%d)",
+				blockBytes, blockFiles, delay.Seconds(),
+				bdl.byteTracker.used, freeBytes,
+				bdl.fileTracker.used, freeFiles)
 		}
 
 		return delay, nil

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -91,9 +91,9 @@ func newBackpressureTracker(minThreshold, maxThreshold, limitFrac float64,
 	return bt, nil
 }
 
-// max returns the resource limit, taking into account the amount of
-// free resources left. This is min(k(U+F), L).
-func (bt backpressureTracker) max() float64 {
+// currLimit returns the resource limit, taking into account the
+// amount of free resources left. This is min(k(U+F), L).
+func (bt backpressureTracker) currLimit() float64 {
 	// Calculate k(U+F), converting to float64 first to avoid
 	// overflow, although losing some precision in the process.
 	usedFloat := float64(bt.used)
@@ -103,7 +103,7 @@ func (bt backpressureTracker) max() float64 {
 }
 
 func (bt backpressureTracker) freeFrac() float64 {
-	return float64(bt.used) / bt.max()
+	return float64(bt.used) / bt.currLimit()
 }
 
 // delayScale returns a number between 0 and 1, which should be
@@ -123,7 +123,7 @@ func (bt backpressureTracker) delayScale() float64 {
 // updateSemaphoreMax must be called whenever bt.used or bt.free
 // changes.
 func (bt *backpressureTracker) updateSemaphoreMax() {
-	newMax := int64(bt.max())
+	newMax := int64(bt.currLimit())
 	delta := newMax - bt.semaphoreMax
 	// These operations are adjusting the *maximum* value of
 	// bt.semaphore.

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -438,6 +438,12 @@ func (bdl *backpressureDiskLimiter) beforeBlockPut(
 	if err != nil {
 		return availableFiles, bdl.fileTracker.semaphore.Count(), err
 	}
+	defer func() {
+		if err != nil {
+			bdl.byteTracker.afterBlockPut(blockBytes, false)
+		}
+	}()
+
 	availableFiles, err = bdl.fileTracker.beforeBlockPut(ctx, blockFiles)
 	return availableFiles, availableFiles, err
 }

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -442,6 +442,7 @@ func (bdl *backpressureDiskLimiter) beforeBlockPut(
 	defer func() {
 		if err != nil {
 			bdl.byteTracker.afterBlockPut(blockBytes, false)
+			availableBytes = bdl.byteTracker.semaphore.Count()
 		}
 	}()
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -399,12 +399,12 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 	switch testType {
 	case byteTest:
 		// Make bytes be the bottleneck.
-		diskBytes = 10 * blockBytes
-		diskFiles = 100 * blockFiles
+		diskBytes = 40 * blockBytes
+		diskFiles = 400 * blockFiles
 	case fileTest:
 		// Make files be the bottleneck.
-		diskBytes = 100 * blockBytes
-		diskFiles = 10 * blockFiles
+		diskBytes = 400 * blockBytes
+		diskFiles = 40 * blockFiles
 	default:
 		panic(fmt.Sprintf("unknown test type %s", testType))
 	}
@@ -455,13 +455,13 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 			used:  bytesPut,
 			free:  diskBytes - bytesPut,
 			max:   diskBytes / 4,
-			count: diskBytes/4 - bytesPut/4,
+			count: diskBytes/4 - bytesPut - blockBytes,
 		}, byteSnapshot, "i=%d", i)
 		require.Equal(t, bdlSnapshot{
 			used:  filesPut,
 			free:  diskFiles - filesPut,
 			max:   diskFiles / 4,
-			count: diskFiles/4 - filesPut/4,
+			count: diskFiles/4 - filesPut - blockFiles,
 		}, fileSnapshot, "i=%d", i)
 	}
 
@@ -473,13 +473,13 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 			used:  bytesPut,
 			free:  diskBytes - bytesPut + blockBytes,
 			max:   diskBytes/4 + blockBytes/4,
-			count: diskBytes/4 + blockBytes/4 - bytesPut/4,
+			count: diskBytes/4 + blockBytes/4 - bytesPut,
 		}, byteSnapshot, "i=%d", i)
 		require.Equal(t, bdlSnapshot{
 			used:  filesPut,
 			free:  diskFiles - filesPut + blockFiles,
 			max:   diskFiles/4 + blockFiles/4,
-			count: diskFiles/4 + blockFiles/4 - filesPut/4,
+			count: diskFiles/4 + blockFiles/4 - filesPut,
 		}, fileSnapshot, "i=%d", i)
 	}
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -30,7 +30,7 @@ func TestBackpressureConstructorError(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	fakeErr := errors.New("Fake error")
 	_, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 100, 8*time.Second, nil,
+		log, 0.1, 0.9, 0.25, 100, 10, 8*time.Second, nil,
 		func() (int64, error) {
 			return 0, fakeErr
 		})
@@ -49,7 +49,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	var fakeFreeBytes int64 = 200
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 100, 8*time.Second, delayFn,
+		log, 0.1, 0.9, 0.25, 100, 10, 8*time.Second, delayFn,
 		func() (int64, error) {
 			return fakeFreeBytes, nil
 		})
@@ -209,7 +209,8 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 func TestBackpressureDiskLimiterCalculateDelay(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, math.MaxInt64, 8*time.Second,
+		log, 0.1, 0.9, 0.25, math.MaxInt64, math.MaxInt64,
+		8*time.Second,
 		func(ctx context.Context, delay time.Duration) error {
 			return nil
 		},
@@ -250,7 +251,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 10*blockSize, 8*time.Second, delayFn,
+		log, 0.1, 0.9, 0.25, 10*blockSize, 10, 8*time.Second, delayFn,
 		func() (int64, error) {
 			return math.MaxInt64, nil
 		})
@@ -368,8 +369,8 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, math.MaxInt64, 8*time.Second, delayFn,
-		getFreeBytesFn)
+		log, 0.1, 0.9, 0.25, math.MaxInt64, math.MaxInt64,
+		8*time.Second, delayFn, getFreeBytesFn)
 	require.NoError(t, err)
 
 	journalBytes, freeBytes, byteSemaphoreMax :=

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -18,7 +18,8 @@ import (
 // TestBackpressureTrackerCounters checks that the tracker's counters
 // are updated properly for each public method.
 func TestBackpressureTrackerCounters(t *testing.T) {
-	bt := newBackpressureTracker(0.1, 0.9, 0.25, 100, 200)
+	bt, err := newBackpressureTracker(0.1, 0.9, 0.25, 100, 200)
+	require.NoError(t, err)
 
 	// semaphoreMax = min(k(U+F), L) = min(0.25(0+200), 100) = 50.
 	require.Equal(t, int64(0), bt.used)
@@ -88,7 +89,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 
 	bt.updateFree(400)
 
-	avail, err := bt.beforeBlockPut(context.Background(), 10)
+	avail, err = bt.beforeBlockPut(context.Background(), 10)
 	require.NoError(t, err)
 	require.Equal(t, int64(89), avail)
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -225,14 +225,14 @@ func TestBackpressureDiskLimiterCalculateDelay(t *testing.T) {
 	// TODO: Clean up.
 	bdl.byteTracker.used = 50
 	bdl.byteTracker.free = 350
-	delay := bdl.calculateDelayLocked(ctx, now)
+	delay := bdl.getDelayLocked(ctx, now)
 	require.InEpsilon(t, float64(4), delay.Seconds(), 0.01)
 
 	deadline := now.Add(5 * time.Second)
 	ctx2, cancel2 := context.WithDeadline(ctx, deadline)
 	defer cancel2()
 
-	delay = bdl.calculateDelayLocked(ctx2, now)
+	delay = bdl.getDelayLocked(ctx2, now)
 	require.InEpsilon(t, float64(2), delay.Seconds(), 0.01)
 }
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -228,7 +228,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 	require.NoError(t, err)
 
 	journalBytes, freeBytes, byteSemaphoreMax :=
-		bdl.getLockedVarsForTest()
+		bdl.getLockedByteVarsForTest()
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(math.MaxInt64), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
@@ -240,7 +240,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 
 	checkCountersAfterBeforeBlockPut := func() {
 		journalBytes, freeBytes, byteSemaphoreMax =
-			bdl.getLockedVarsForTest()
+			bdl.getLockedByteVarsForTest()
 		require.Equal(t, int64(bytesPut), journalBytes)
 		require.Equal(t, int64(math.MaxInt64), freeBytes)
 		require.Equal(t, int64(100), byteSemaphoreMax)
@@ -250,7 +250,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 
 	checkCountersAfterBlockPut := func() {
 		journalBytes, freeBytes, byteSemaphoreMax =
-			bdl.getLockedVarsForTest()
+			bdl.getLockedByteVarsForTest()
 		require.Equal(t, int64(bytesPut), journalBytes)
 		require.Equal(t, int64(math.MaxInt64), freeBytes)
 		require.Equal(t, int64(100), byteSemaphoreMax)
@@ -298,7 +298,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 	// This does the same thing as checkCountersAfterBlockPut(),
 	// but only by coincidence; contrast with similar block in
 	// TestBackpressureDiskLimiterSmallDisk below.
-	journalBytes, freeBytes, byteSemaphoreMax = bdl.getLockedVarsForTest()
+	journalBytes, freeBytes, byteSemaphoreMax = bdl.getLockedByteVarsForTest()
 	require.Equal(t, int64(bytesPut), journalBytes)
 	require.Equal(t, int64(math.MaxInt64), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
@@ -344,7 +344,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 	require.NoError(t, err)
 
 	journalBytes, freeBytes, byteSemaphoreMax :=
-		bdl.getLockedVarsForTest()
+		bdl.getLockedByteVarsForTest()
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(diskSize), freeBytes)
 	require.Equal(t, int64(80), byteSemaphoreMax)
@@ -356,7 +356,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 
 	checkCountersAfterBeforeBlockPut := func() {
 		journalBytes, freeBytes, byteSemaphoreMax =
-			bdl.getLockedVarsForTest()
+			bdl.getLockedByteVarsForTest()
 		require.Equal(t, int64(bytesPut), journalBytes)
 		require.Equal(t, int64(diskSize-journalBytes), freeBytes)
 		require.Equal(t, int64(80), byteSemaphoreMax)
@@ -366,7 +366,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 
 	checkCountersAfterBlockPut := func() {
 		journalBytes, freeBytes, byteSemaphoreMax =
-			bdl.getLockedVarsForTest()
+			bdl.getLockedByteVarsForTest()
 		require.Equal(t, int64(bytesPut), journalBytes)
 		// freeBytes is only updated on beforeBlockPut, so we
 		// have to compensate for that.
@@ -416,7 +416,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 	require.Equal(t, 8*time.Second, lastDelay)
 
 	journalBytes, freeBytes, byteSemaphoreMax =
-		bdl.getLockedVarsForTest()
+		bdl.getLockedByteVarsForTest()
 	require.Equal(t, int64(bytesPut), journalBytes)
 	require.Equal(t, int64(diskSize-journalBytes), freeBytes)
 	require.Equal(t, int64(80), byteSemaphoreMax)

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -61,7 +61,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(50), byteSemaphoreMax)
-	require.Equal(t, int64(50), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(50), bdl.byteTracker.semaphore.Count())
 
 	ctx := context.Background()
 
@@ -76,7 +76,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(10), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(52), byteSemaphoreMax)
-	require.Equal(t, int64(42), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(42), bdl.byteTracker.semaphore.Count())
 
 	// Decrease J by 9, so that decreases bSM by 0.25*9 = 2.25, so
 	// bSM is back to 50.
@@ -88,7 +88,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(1), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(50), byteSemaphoreMax)
-	require.Equal(t, int64(49), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(49), bdl.byteTracker.semaphore.Count())
 
 	// Increase J by 440, so that increases bSM by 0.25*110 = 110,
 	// so bSM maxes out at 100, and byteSemaphore should do negative.
@@ -101,7 +101,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(441), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(-341), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(-341), bdl.byteTracker.semaphore.Count())
 
 	// Now revert that increase.
 
@@ -112,7 +112,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(1), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(50), byteSemaphoreMax)
-	require.Equal(t, int64(49), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(49), bdl.byteTracker.semaphore.Count())
 
 	// This should be a no-op.
 	availBytes, _ = bdl.onJournalEnable(ctx, 0, 0)
@@ -123,7 +123,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(1), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(50), byteSemaphoreMax)
-	require.Equal(t, int64(49), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(49), bdl.byteTracker.semaphore.Count())
 
 	// So should this.
 	bdl.onJournalDisable(ctx, 0, 0)
@@ -133,7 +133,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(1), journalBytes)
 	require.Equal(t, int64(200), freeBytes)
 	require.Equal(t, int64(50), byteSemaphoreMax)
-	require.Equal(t, int64(49), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(49), bdl.byteTracker.semaphore.Count())
 
 	// Add more free bytes and put a block successfully.
 
@@ -148,7 +148,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(1), journalBytes)
 	require.Equal(t, int64(400), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(89), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(89), bdl.byteTracker.semaphore.Count())
 
 	bdl.afterBlockPut(ctx, 10, 0, true)
 
@@ -157,7 +157,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(11), journalBytes)
 	require.Equal(t, int64(400), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(89), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(89), bdl.byteTracker.semaphore.Count())
 
 	// Then try to put a block but fail it.
 
@@ -170,7 +170,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(11), journalBytes)
 	require.Equal(t, int64(400), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(80), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(80), bdl.byteTracker.semaphore.Count())
 
 	bdl.afterBlockPut(ctx, 9, 0, false)
 
@@ -179,7 +179,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(11), journalBytes)
 	require.Equal(t, int64(400), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(89), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(89), bdl.byteTracker.semaphore.Count())
 
 	// Finally, delete a block.
 
@@ -190,7 +190,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(400), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(100), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(100), bdl.byteTracker.semaphore.Count())
 
 	// This should be a no-op.
 	bdl.onBlockDelete(ctx, 0, 0)
@@ -200,7 +200,7 @@ func TestBackpressureDiskLimiterCounters(t *testing.T) {
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(400), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(100), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(100), bdl.byteTracker.semaphore.Count())
 }
 
 // TestBackpressureDiskLimiterCalculateDelay tests the delay
@@ -262,7 +262,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(math.MaxInt64), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(100), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(100), bdl.byteTracker.semaphore.Count())
 
 	ctx := context.Background()
 
@@ -275,7 +275,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 		require.Equal(t, int64(math.MaxInt64), freeBytes)
 		require.Equal(t, int64(100), byteSemaphoreMax)
 		require.Equal(t, int64(100-bytesPut-blockSize),
-			bdl.byteSemaphore.Count())
+			bdl.byteTracker.semaphore.Count())
 	}
 
 	checkCountersAfterBlockPut := func() {
@@ -285,7 +285,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 		require.Equal(t, int64(math.MaxInt64), freeBytes)
 		require.Equal(t, int64(100), byteSemaphoreMax)
 		require.Equal(t, int64(100-bytesPut),
-			bdl.byteSemaphore.Count())
+			bdl.byteTracker.semaphore.Count())
 	}
 
 	// The first two puts shouldn't encounter any backpressure...
@@ -332,7 +332,7 @@ func TestBackpressureDiskLimiterLargeDiskDelay(t *testing.T) {
 	require.Equal(t, int64(bytesPut), journalBytes)
 	require.Equal(t, int64(math.MaxInt64), freeBytes)
 	require.Equal(t, int64(100), byteSemaphoreMax)
-	require.Equal(t, int64(100-bytesPut), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(100-bytesPut), bdl.byteTracker.semaphore.Count())
 }
 
 // TestBackpressureDiskLimiterSmallDiskDelay checks the delays when
@@ -364,7 +364,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 		// When called in subsequent times from
 		// beforeBlockPut, simulate the journal taking up
 		// space.
-		return diskSize - bdl.journalBytes, math.MaxInt64, nil
+		return diskSize - bdl.byteTracker.used, math.MaxInt64, nil
 	}
 
 	log := logger.NewTestLogger(t)
@@ -378,7 +378,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 	require.Equal(t, int64(0), journalBytes)
 	require.Equal(t, int64(diskSize), freeBytes)
 	require.Equal(t, int64(80), byteSemaphoreMax)
-	require.Equal(t, int64(80), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(80), bdl.byteTracker.semaphore.Count())
 
 	ctx := context.Background()
 
@@ -391,7 +391,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 		require.Equal(t, int64(diskSize-journalBytes), freeBytes)
 		require.Equal(t, int64(80), byteSemaphoreMax)
 		require.Equal(t, int64(80-bytesPut-blockSize),
-			bdl.byteSemaphore.Count())
+			bdl.byteTracker.semaphore.Count())
 	}
 
 	checkCountersAfterBlockPut := func() {
@@ -405,7 +405,7 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 		expectedBytesSemaphore := expectedBytesSemaphoreMax - int64(bytesPut)
 		require.Equal(t, expectedFreeBytes, freeBytes)
 		require.Equal(t, expectedBytesSemaphoreMax, byteSemaphoreMax)
-		require.Equal(t, expectedBytesSemaphore, bdl.byteSemaphore.Count())
+		require.Equal(t, expectedBytesSemaphore, bdl.byteTracker.semaphore.Count())
 	}
 
 	// The first two puts shouldn't encounter any backpressure...
@@ -450,5 +450,5 @@ func TestBackpressureDiskLimiterSmallDisk(t *testing.T) {
 	require.Equal(t, int64(bytesPut), journalBytes)
 	require.Equal(t, int64(diskSize-journalBytes), freeBytes)
 	require.Equal(t, int64(80), byteSemaphoreMax)
-	require.Equal(t, int64(80-bytesPut), bdl.byteSemaphore.Count())
+	require.Equal(t, int64(80-bytesPut), bdl.byteTracker.semaphore.Count())
 }

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -261,13 +261,14 @@ func testBackpressureDiskLimiterLargeDiskDelay(
 		return nil
 	}
 
-	// Set up parameters so that semaphoreMax always has value 100
-	// when called in beforeBlockPut, and every block put (of size
-	// 0.1 * 100 = 10) beyond the min threshold leads to an
-	// increase in timeout of 1 second up to the max.
-
 	const blockBytes = 100
 	const blockFiles = 10
+
+	// Set the bottleneck, based on the test type; i.e. set
+	// parameters so that semaphoreMax for the bottleneck always
+	// has value 10 * blockX when called in beforeBlockPut, and
+	// every block put beyond the min threshold leads to an
+	// increase in timeout of 1 second up to the max.
 	var byteLimit, fileLimit int64
 	switch testType {
 	case byteTest:
@@ -417,14 +418,16 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 		return nil
 	}
 
-	// Set up parameters so that semaphoreMax always has value 80
-	// when called in beforeBlockPut, and every block put (of size
-	// 0.1 * 80 = 8) beyond the min threshold leads to an increase
-	// in timeout of 1 second up to the max.
-
 	const blockBytes = 80
 	const blockFiles = 8
+
+	// Set the bottleneck, based on the test type; i.e. set
+	// parameters so that semaphoreMax for the bottleneck always
+	// has value 10 * blockX when called in beforeBlockPut, and
+	// every block put beyond the min threshold leads to an
+	// increase in timeout of 1 second up to the max.
 	var diskBytes, diskFiles int64
+	// Multiply by 4 to compensate for the 0.25 limitFrac.
 	switch testType {
 	case byteTest:
 		// Make bytes be the bottleneck.

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -222,14 +222,17 @@ func TestBackpressureDiskLimiterCalculateDelay(t *testing.T) {
 	now := time.Now()
 
 	ctx := context.Background()
-	delay := bdl.calculateDelay(ctx, 50, 350, now)
+	// TODO: Clean up.
+	bdl.byteTracker.used = 50
+	bdl.byteTracker.free = 350
+	delay := bdl.calculateDelayLocked(ctx, now)
 	require.InEpsilon(t, float64(4), delay.Seconds(), 0.01)
 
 	deadline := now.Add(5 * time.Second)
 	ctx2, cancel2 := context.WithDeadline(ctx, deadline)
 	defer cancel2()
 
-	delay = bdl.calculateDelay(ctx2, 50, 350, now)
+	delay = bdl.calculateDelayLocked(ctx2, now)
 	require.InEpsilon(t, float64(2), delay.Seconds(), 0.01)
 }
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -183,8 +183,10 @@ func TestBackpressureDiskLimiterGetDelay(t *testing.T) {
 	func() {
 		bdl.lock.Lock()
 		defer bdl.lock.Unlock()
-		bdl.byteTracker.used = 500
-		bdl.byteTracker.free = 3500
+		// byteDelayScale should be 25/(.25(350 + 25)) = 0.267.
+		bdl.byteTracker.used = 25
+		bdl.byteTracker.free = 350
+		// fileDelayScale should by 50/(.25(350 + 50)) = 0.5.
 		bdl.fileTracker.used = 50
 		bdl.fileTracker.free = 350
 	}()

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -915,10 +915,11 @@ func (c *ConfigLocal) EnableJournaling(
 	const journalByteLimitFrac = 0.25
 	// Set the absolute journal byte limit to 50 GiB for now.
 	const journalByteLimit int64 = 50 * 1024 * 1024 * 1024
-	// TODO: Also limit the inode count.
+	// Set the absolute journal file limit to 1.5 million for now.
+	const journalFileLimit int64 = 1500000
 	bdl, err := newBackpressureDiskLimiter(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		journalByteLimitFrac, journalByteLimit,
+		journalByteLimitFrac, journalByteLimit, journalFileLimit,
 		defaultDiskLimitMaxDelay, journalRoot)
 	if err != nil {
 		return err

--- a/libkbfs/disk_limits_test.go
+++ b/libkbfs/disk_limits_test.go
@@ -12,13 +12,14 @@ import (
 )
 
 // TestDiskLimits checks that getDiskLimits() doesn't return an error,
-// and returns a non-zero value. This assumes that the partition with
-// the root directory actually has free space, which may fail in
+// and returns non-zero values. This assumes that the partition with
+// the root directory actually has free space/files, which may fail in
 // certain weird configs.
 func TestDiskLimits(t *testing.T) {
-	availableBytes, err := getDiskLimits("/")
+	availableBytes, availableFiles, err := getDiskLimits("/")
 	require.NoError(t, err)
 	require.NotEqual(t, uint64(0), availableBytes)
+	require.NotEqual(t, uint64(0), availableFiles)
 }
 
 // TestDiskLimitsNonExistentFile checks that getDiskLimits() returns
@@ -26,7 +27,7 @@ func TestDiskLimits(t *testing.T) {
 // doesn't exist.
 func TestDiskLimitsNonExistentFile(t *testing.T) {
 	// Of course, we're assuming this file doesn't exist.
-	_, err := getDiskLimits("/non-existent-file")
+	_, _, err := getDiskLimits("/non-existent-file")
 	require.True(t, ioutil.IsNotExist(err))
 }
 

--- a/libkbfs/disk_limits_unix.go
+++ b/libkbfs/disk_limits_unix.go
@@ -13,19 +13,16 @@ import (
 
 // getDiskLimits gets the disk limits for the logical disk containing
 // the given path.
-//
-// TODO: Also return available files.
-func getDiskLimits(path string) (availableBytes uint64, err error) {
+func getDiskLimits(path string) (
+	availableBytes, availableFiles uint64, err error) {
 	var stat unix.Statfs_t
 	err = unix.Statfs(path, &stat)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, 0, errors.WithStack(err)
 	}
 
 	// Bavail is the free block count for an unprivileged user.
 	availableBytes = stat.Bavail * uint64(stat.Bsize)
-
-	// TODO: Use stat.Ffree to return availableFiles.
-
-	return availableBytes, nil
+	availableFiles = stat.Ffree
+	return availableBytes, availableFiles, nil
 }

--- a/libkbfs/disk_limits_windows.go
+++ b/libkbfs/disk_limits_windows.go
@@ -5,17 +5,17 @@
 package libkbfs
 
 import (
+	"math"
 	"unsafe"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 )
 
-// getDiskLimits gets a diskLimits object for the logical disk
-// containing the given path.
-//
-// TODO: Also return available files.
-func getDiskLimits(path string) (availableBytes uint64, err error) {
+// getDiskLimits gets the disk limits for the logical disk containing
+// the given path.
+func getDiskLimits(path string) (
+	availableBytes, availableFiles uint64, err error) {
 	pathPtr, err := windows.UTF16PtrFromString(path)
 	if err != nil {
 		return 0, errors.WithStack(err)
@@ -38,5 +38,7 @@ func getDiskLimits(path string) (availableBytes uint64, err error) {
 	// the filesystem type. Detect the filesystem type and use
 	// that to determine and return availableFiles.
 
-	return availableBytes, nil
+	// For now, assume all FSs on Windows are NTFS, or have
+	// similarly large file limits.
+	return availableBytes, math.MaxInt64, nil
 }

--- a/libkbfs/disk_limits_windows.go
+++ b/libkbfs/disk_limits_windows.go
@@ -18,7 +18,7 @@ func getDiskLimits(path string) (
 	availableBytes, availableFiles uint64, err error) {
 	pathPtr, err := windows.UTF16PtrFromString(path)
 	if err != nil {
-		return 0, errors.WithStack(err)
+		return 0, 0, errors.WithStack(err)
 	}
 
 	dll := windows.NewLazySystemDLL("kernel32.dll")
@@ -28,7 +28,7 @@ func getDiskLimits(path string) (
 	// err is always non-nil, but meaningful only when r1 == 0
 	// (which signifies function failure).
 	if r1 == 0 {
-		return 0, errors.WithStack(err)
+		return 0, 0, errors.WithStack(err)
 	} else {
 		err = nil
 	}

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -15,63 +15,88 @@ import (
 const defaultAvailableFiles = math.MaxInt64
 
 // semaphoreDiskLimiter is an implementation of diskLimiter that uses
-// semaphores to limit the byte usage.
-//
-// TODO: Also do limiting based on file counts.
+// semaphores to limit the byte and file usage.
 type semaphoreDiskLimiter struct {
 	byteLimit     int64
 	byteSemaphore *kbfssync.Semaphore
+	fileLimit     int64
+	fileSemaphore *kbfssync.Semaphore
 }
 
 var _ diskLimiter = semaphoreDiskLimiter{}
 
-func newSemaphoreDiskLimiter(byteLimit int64) semaphoreDiskLimiter {
+func newSemaphoreDiskLimiter(byteLimit, fileLimit int64) semaphoreDiskLimiter {
 	byteSemaphore := kbfssync.NewSemaphore()
 	byteSemaphore.Release(byteLimit)
-	return semaphoreDiskLimiter{byteLimit, byteSemaphore}
+	fileSemaphore := kbfssync.NewSemaphore()
+	fileSemaphore.Release(fileLimit)
+	return semaphoreDiskLimiter{
+		byteLimit, byteSemaphore, fileLimit, fileSemaphore,
+	}
 }
 
 func (sdl semaphoreDiskLimiter) onJournalEnable(
 	ctx context.Context, journalBytes, journalFiles int64) (
 	availableBytes, availableFiles int64) {
-	if journalBytes == 0 {
-		return sdl.byteSemaphore.Count(), defaultAvailableFiles
+	if journalBytes != 0 {
+		availableBytes = sdl.byteSemaphore.ForceAcquire(journalBytes)
+	} else {
+		availableBytes = sdl.byteSemaphore.Count()
 	}
-	availableBytes = sdl.byteSemaphore.ForceAcquire(journalBytes)
-	return availableBytes, defaultAvailableFiles
+	if journalFiles != 0 {
+		availableFiles = sdl.fileSemaphore.ForceAcquire(journalFiles)
+	} else {
+		availableFiles = sdl.fileSemaphore.Count()
+	}
+	return availableBytes, availableFiles
 }
 
 func (sdl semaphoreDiskLimiter) onJournalDisable(
 	ctx context.Context, journalBytes, journalFiles int64) {
-	if journalBytes > 0 {
+	if journalBytes != 0 {
 		sdl.byteSemaphore.Release(journalBytes)
+	}
+	if journalFiles != 0 {
+		sdl.fileSemaphore.Release(journalFiles)
 	}
 }
 
 func (sdl semaphoreDiskLimiter) beforeBlockPut(
 	ctx context.Context, blockBytes, blockFiles int64) (
 	availableBytes, availableFiles int64, err error) {
+	// Better to return an error than to panic in Acquire.
 	if blockBytes == 0 {
-		// Better to return an error than to panic in Acquire.
-		return sdl.byteSemaphore.Count(), defaultAvailableFiles, errors.New(
+		return sdl.byteSemaphore.Count(), sdl.fileSemaphore.Count(), errors.New(
 			"semaphore.DiskLimiter.beforeBlockPut called with 0 blockBytes")
+	}
+	if blockFiles == 0 {
+		return sdl.byteSemaphore.Count(), sdl.fileSemaphore.Count(), errors.New(
+			"semaphore.DiskLimiter.beforeBlockPut called with 0 blockFiles")
 	}
 
 	availableBytes, err = sdl.byteSemaphore.Acquire(ctx, blockBytes)
-	return availableBytes, defaultAvailableFiles, err
+	if err != nil {
+		return availableBytes, sdl.fileSemaphore.Count(), err
+	}
+	availableFiles, err = sdl.fileSemaphore.Acquire(ctx, blockFiles)
+	return availableBytes, availableFiles, err
 }
 
 func (sdl semaphoreDiskLimiter) afterBlockPut(
 	ctx context.Context, blockBytes, blockFiles int64, putData bool) {
 	if !putData {
 		sdl.byteSemaphore.Release(blockBytes)
+		sdl.fileSemaphore.Release(blockFiles)
 	}
 }
 
 func (sdl semaphoreDiskLimiter) onBlockDelete(
 	ctx context.Context, blockBytes, blockFiles int64) {
-	if blockBytes > 0 {
+	if blockBytes != 0 {
 		sdl.byteSemaphore.Release(blockBytes)
+	}
+	if blockFiles != 0 {
+		sdl.fileSemaphore.Release(blockFiles)
 	}
 }
 
@@ -79,11 +104,14 @@ type semaphoreDiskLimiterStatus struct {
 	Type string
 
 	// Derived numbers.
-	UsageFrac float64
+	ByteUsageFrac float64
+	FileUsageFrac float64
 
 	// Raw numbers.
-	LimitMB     float64
-	AvailableMB float64
+	LimitMB        float64
+	AvailableMB    float64
+	LimitFiles     float64
+	AvailableFiles float64
 }
 
 func (sdl semaphoreDiskLimiter) getStatus() interface{} {
@@ -91,14 +119,21 @@ func (sdl semaphoreDiskLimiter) getStatus() interface{} {
 
 	limitMB := float64(sdl.byteLimit) / MB
 	availableMB := float64(sdl.byteSemaphore.Count()) / MB
-	usageFrac := 1 - availableMB/limitMB
+	byteUsageFrac := 1 - availableMB/limitMB
+
+	limitFiles := float64(sdl.fileLimit) / MB
+	availableFiles := float64(sdl.fileSemaphore.Count()) / MB
+	fileUsageFrac := 1 - availableFiles/limitFiles
 
 	return semaphoreDiskLimiterStatus{
 		Type: "SemaphoreDiskLimiter",
 
-		UsageFrac: usageFrac,
+		ByteUsageFrac: byteUsageFrac,
+		FileUsageFrac: fileUsageFrac,
 
-		LimitMB:     limitMB,
-		AvailableMB: availableMB,
+		LimitMB:        limitMB,
+		AvailableMB:    availableMB,
+		LimitFiles:     limitFiles,
+		AvailableFiles: availableFiles,
 	}
 }

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -74,6 +74,13 @@ func (sdl semaphoreDiskLimiter) beforeBlockPut(
 	if err != nil {
 		return availableBytes, sdl.fileSemaphore.Count(), err
 	}
+	defer func() {
+		if err != nil {
+			sdl.byteSemaphore.Release(blockBytes)
+			availableBytes = sdl.byteSemaphore.Count()
+		}
+	}()
+
 	availableFiles, err = sdl.fileSemaphore.Acquire(ctx, blockFiles)
 	return availableBytes, availableFiles, err
 }

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -5,14 +5,10 @@
 package libkbfs
 
 import (
-	"math"
-
 	"github.com/keybase/kbfs/kbfssync"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
-
-const defaultAvailableFiles = math.MaxInt64
 
 // semaphoreDiskLimiter is an implementation of diskLimiter that uses
 // semaphores to limit the byte and file usage.

--- a/libkbfs/semaphore_disk_limiter_test.go
+++ b/libkbfs/semaphore_disk_limiter_test.go
@@ -19,6 +19,7 @@ import (
 // semaphore times out.
 func TestSemaphoreDiskLimiterBeforeBlockPutError(t *testing.T) {
 	sdl := newSemaphoreDiskLimiter(10, 1)
+
 	ctx, cancel := context.WithTimeout(
 		context.Background(), 3*time.Millisecond)
 	defer cancel()

--- a/libkbfs/semaphore_disk_limiter_test.go
+++ b/libkbfs/semaphore_disk_limiter_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackpressureTrackerCounters checks that the tracker's counters
+// are updated properly for each public method.
+func TestSemaphoreDiskLimiterBeforeBlockPutError(t *testing.T) {
+	sdl := newSemaphoreDiskLimiter(10, 1)
+	ctx, cancel := context.WithTimeout(
+		context.Background(), 3*time.Millisecond)
+	defer cancel()
+	availBytes, availFiles, err := sdl.beforeBlockPut(ctx, 10, 2)
+	require.Equal(t, ctx.Err(), errors.Cause(err))
+	require.Equal(t, int64(10), availBytes)
+	require.Equal(t, int64(1), availFiles)
+}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -262,7 +262,8 @@ func setupTLFJournalTest(
 
 	delegateBlockServer := NewBlockServerMemory(log)
 
-	diskLimitSemaphore := newSemaphoreDiskLimiter(math.MaxInt64)
+	diskLimitSemaphore := newSemaphoreDiskLimiter(
+		math.MaxInt64, math.MaxInt64)
 	tlfJournal, err = makeTLFJournal(ctx, uid, verifyingKey,
 		tempdir, config.tlfID, config, delegateBlockServer,
 		bwStatus, delegate, nil, nil, diskLimitSemaphore)


### PR DESCRIPTION
Basically, do what we're doing for bytes, but also with file counts.

Get available file count for Linux from Statfs, but not for Windows
(since NTFS has effectively an unlimited file count).

Set a hard limit of 1.5 million files (based on KBFS-1749).