### PR TITLE
md_journal: putMD should return the id even on a dup put

### DIFF
--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -481,7 +481,7 @@ func (j mdJournal) putMD(rmd BareRootMetadata) (MdID, error) {
 		return MdID{}, err
 	} else {
 		// Entry exists, so nothing else to do.
-		return MdID{}, nil
+		return id, nil
 	}
 
 	err = kbfscodec.SerializeToFileIfNotExist(


### PR DESCRIPTION
Otherwise the caller could use the nil ID, e.g. in branch conversion.

Issue: KBFS-1955