### PR TITLE
check for branch conversion while flushing blocks

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -590,6 +590,18 @@ func (be blockEntriesToFlush) revIsLocalSquash(rev MetadataRevision) bool {
 	return false
 }
 
+func (be blockEntriesToFlush) markFlushingBlockIDs(ids map[kbfsblock.ID]bool) {
+	for _, bs := range be.puts.blockStates {
+		ids[bs.blockPtr.ID] = true
+	}
+}
+
+func (be blockEntriesToFlush) clearFlushingBlockIDs(ids map[kbfsblock.ID]bool) {
+	for _, bs := range be.puts.blockStates {
+		delete(ids, bs.blockPtr.ID)
+	}
+}
+
 // Only entries with ordinals less than the given ordinal (assumed to
 // be <= latest ordinal + 1) are returned.  Also returns the maximum
 // MD revision that can be merged after the returned entries are

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -581,6 +581,15 @@ func (be blockEntriesToFlush) flushNeeded() bool {
 	return be.length() > 0
 }
 
+func (be blockEntriesToFlush) revIsLocalSquash(rev MetadataRevision) bool {
+	for _, entry := range be.other {
+		if entry.Op == mdRevMarkerOp && entry.Revision == rev {
+			return entry.Unignorable
+		}
+	}
+	return false
+}
+
 // Only entries with ordinals less than the given ordinal (assumed to
 // be <= latest ordinal + 1) are returned.  Also returns the maximum
 // MD revision that can be merged after the returned entries are

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1311,8 +1311,12 @@ type BlockServer interface {
 		contexts kbfsblock.ContextMap) error
 
 	// IsUnflushed returns whether a given block is being queued
-	// locally for later flushing to another block server.
-	IsUnflushed(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID) (bool, error)
+	// locally for later flushing to another block server.  If the
+	// block is currently being flushed to the server, this should
+	// return `true`, so that the caller will try to clean it up from
+	// the server if it's no longer needed.
+	IsUnflushed(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID) (
+		bool, error)
 
 	// Shutdown is called to shutdown a BlockServer connection.
 	Shutdown(ctx context.Context)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -866,6 +866,21 @@ func (j *tlfJournal) flushBlockEntries(
 
 	// TODO: fill this in for logging/error purposes.
 	var tlfName CanonicalTlfName
+
+	// TODO: launch this in a goroutine. Alongside make another
+	// goroutine that listens for MD puts and checks the size of the
+	// MD journal, and converts to a local squash branch if it gets
+	// too large.  While the 2nd goroutine is waiting, it should exit
+	// immediately as soon as the 1st one finishes, but if it is
+	// already working on a conversion it should finish that work.
+	//
+	// If the 2nd goroutine makes a branch, foreground writes could
+	// trigger CR while blocks are still being flushed.  This can't
+	// usually happen, because flushing is paused while CR is
+	// happening.  flush() has to make sure to restart its loop if a
+	// branch conversion happened during the block flushing, in order
+	// to get the new MD journal end, but I can't think of anything
+	// else that could go wrong...
 	err = flushBlockEntries(ctx, j.log, j.delegateBlockServer,
 		j.config.BlockCache(), j.config.Reporter(),
 		j.tlfID, tlfName, entries)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -930,6 +930,8 @@ func (j *tlfJournal) flushBlockEntries(
 	})
 	converted = false
 	eg.Go(func() error {
+		// We might need to run multiple conversions during a single
+		// batch of block flushes, so loop until the batch finishes.
 		for {
 			select {
 			case <-j.needBranchCheckCh:

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1088,6 +1088,12 @@ func (j *tlfJournal) convertMDsToBranchIfOverThreshold(ctx context.Context,
 			if err != nil {
 				return false, err
 			}
+
+			err = j.blockJournal.markLatestRevMarkerAsUnignorable()
+			if err != nil {
+				return false, err
+			}
+
 			j.unsquashedBytes = 0
 			return true, nil
 		}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -411,10 +411,11 @@ func testTLFJournalBlockOpBasic(t *testing.T, ver MetadataVer) {
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
-	numFlushed, rev, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)
+	require.False(t, converted)
 }
 
 func testTLFJournalBlockOpBusyPause(t *testing.T, ver MetadataVer) {
@@ -493,10 +494,11 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
 			ctx, id, bCtx, data2, serverHalf)
 	}()
 
-	numFlushed, rev, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)
+	require.False(t, converted)
 
 	// Fake an MD flush.
 	md := config.makeMD(MetadataRevisionInitial, MdID{})
@@ -529,10 +531,11 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
 			ctx, id, bCtx, data2, serverHalf)
 	}()
 
-	numFlushed, rev, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)
+	require.False(t, converted)
 
 	// Fake an MD flush.
 	md := config.makeMD(MetadataRevisionInitial, MdID{})


### PR DESCRIPTION
Currently, we flush blocks in batches of 25, and only then check for squashability.   An arbitrary number of MD revisions can build up during that time, especially if the flushing is slow.  When squashing does happen, the result will be huge, and require flushing even MORE blocks before the squashed MD is finally pushed, which is the point at which other clients can see the revision.

Not only does this delay other clients from seeing your changes, but it also makes them more likely to start QR and needlessly start conflicting with the writing device.  Also, since we don't delete blocks until the MD is flushed, it means the journal can stay large for longer, leading to unnecessary backpressure and semaphore blocking, which can lead to user-visible errors in the form of timeouts.

Instead, this PR checks for squashability in parallel to the blocks flushing.  This is a somewhat big change from before, because it means CR can run while the journal isn't paused.  Some changes needed to make this work:

* Blocks that are currently flushing should be conservatively considered "flushed", so that CR will unreference them as part of its resolution.
* If branch conversion happens during the flush, the `flush()` loop must take care to fix up `maxMDRevToFlush` and `mdEnd`, since they may have changed in unusual ways.

Issue: KBFS-1927