### PR TITLE
folder_block_manager: suppress identifies and ignore finalized MDs

### DIFF
--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -1163,6 +1163,8 @@ func (fbm *folderBlockManager) reclaimQuotaInBackground() {
 			// want forced reclamations to hang.
 			timer.Stop()
 			timerChan = make(chan time.Time)
+			fbm.log.CDebugf(context.Background(),
+				"Permanently stopping QR due to error: %+v", err)
 		}
 	}
 }

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/backoff"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfssync"
 	"github.com/keybase/kbfs/tlf"
@@ -942,6 +943,15 @@ func (fbm *folderBlockManager) finalizeReclamation(ctx context.Context,
 	for _, id := range zeroRefCounts {
 		gco.AddUnrefBlock(BlockPointer{ID: id})
 	}
+
+	// For now, pretend to be a rekey so the service suppresses
+	// popups.  TODO: add a more specific behavior type for QR.
+	ctx, err := makeExtendedIdentify(
+		ctx, keybase1.TLFIdentifyBehavior_KBFS_REKEY)
+	if err != nil {
+		return err
+	}
+
 	fbm.log.CDebugf(ctx, "Finalizing reclamation %s with %d ptrs", gco,
 		len(ptrs))
 	// finalizeGCOp could wait indefinitely on locks, so run it in a


### PR DESCRIPTION
Chris saw some random tracker popups that were due to background QR trying to write MD to a finalized TLF.  Attack this in two ways:

* Suppress popups for QR -- right now piggyback on the KBFS_REKEY semantics as a quick fix to avoid changing the protocol.
* If a TLF is finalized, stop QR altogether.

Issue: KBFS-1962

cc: @maxtaco 

[Adding @songgao as a reviewer, since both @akalin-keybase and @jzila are out today.)