### PR TITLE
bare_root_metadata_v3: don't error if MDDiskUsage looks bad

### DIFF
--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -494,7 +494,11 @@ func (md *BareRootMetadataV3) CheckValidSuccessor(
 	if !nextMd.IsWriterMetadataCopiedSet() {
 		expectedMDUsage += nextMd.MDRefBytes()
 	}
-	if nextMd.MDDiskUsage() != expectedMDUsage {
+	// Add an exception for the case where MDRefBytes is equal, since
+	// it probably indicates an older client just copied the previous
+	// MDRefBytes value as an unknown field.
+	if nextMd.MDDiskUsage() != expectedMDUsage &&
+		md.MDRefBytes() != nextMd.MDRefBytes() {
 		return MDDiskUsageMismatch{
 			expectedDiskUsage: expectedMDUsage,
 			actualDiskUsage:   nextMd.MDDiskUsage(),


### PR DESCRIPTION
As long as the MDRefBytes fields are the same, it probably means that
an old client just copied the value as an unknown field from an MD
written by a new client.