### PR TITLE
folder_branch_ops: always clear the CR branch on a branch change

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -519,6 +519,10 @@ func (fbo *folderBranchOps) isMasterBranchLocked(lState *lockState) bool {
 func (fbo *folderBranchOps) setBranchIDLocked(lState *lockState, bid BranchID) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
+	if fbo.bid != bid {
+		fbo.cr.BeginNewBranch()
+	}
+
 	fbo.bid = bid
 	if bid == NullBranchID {
 		fbo.status.setCRSummary(nil, nil)
@@ -5385,7 +5389,6 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 
 	// Kick off conflict resolution and set the head to the correct branch.
 	fbo.setBranchIDLocked(lState, newBID)
-	fbo.cr.BeginNewBranch()
 	fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
 
 	fbo.headLock.Lock(lState)


### PR DESCRIPTION
This fixes a race where, if FBO learns about the new branch when doing
a put (rather than through a onTLFBranchChange callback from the
journal), it wouldn't reset the input state in CR.  This causes CR to
ignore the any inputs with a revision number less than the last one it
processed, and it will cease to perform squashing until the revision
number gets back to where it was before.  But, if there are no new
writes, this will never happen, and journal flushing will remain
paused.

Instead, just clear that input state on every branch change.

Issue: KBFS-1969