### PR TITLE
folder_branch_ops: wait for CR if on a pending squash branch

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -852,6 +852,9 @@ func (j *tlfJournal) flushBlockEntries(
 		return 0, maxMDRevToFlush, nil
 	}
 
+	j.log.CDebugf(ctx, "Flushing %d blocks, up to rev %d",
+		len(entries.puts.blockStates), maxMDRevToFlush)
+
 	// TODO: fill this in for logging/error purposes.
 	var tlfName CanonicalTlfName
 	err = flushBlockEntries(ctx, j.log, j.delegateBlockServer,


### PR DESCRIPTION
Continuous user writes can prevent CR for completing.  CR does lock the `mdWriterLock` on its second attempt to squash a branch, but by then dozens or hundreds more writes could have completed, leading to very large branches which take longer to flush.

Instead, this commit just delays writes until CR completes, to help the common case where the user is issuing writes one-at-a-time.  This limits the number of revisions involved in a squash branch to whatever the `tlfJournal` decides it should be.  In performance testing, this seems to save about 10-15% in foreground time on the Go source benchmark, presumably due to smaller squashes being faster.

Also a new log message to help debugging squash sizes.

Issue: KBFS-1927