### PR TITLE
tlf_journal: limit squash size by estimate of the unsquashed bytes

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -868,8 +868,7 @@ func (c *ConfigLocal) journalizeBcaches(jServer *JournalServer) error {
 	// server.  Since this doesn't rely directly on the network,
 	// there's no need for an adaptive sync buffer size, so we
 	// always set the min and max to the same thing.
-	maxSyncBufferSize :=
-		int64(MaxBlockSizeBytesDefault * maxParallelBlockPuts * 2)
+	maxSyncBufferSize := int64(ForcedBranchSquashBytesThresholdDefault)
 	log := c.MakeLogger("DBCJ")
 	journalCache := NewDirtyBlockCacheStandard(c.clock, log,
 		maxSyncBufferSize, maxSyncBufferSize, maxSyncBufferSize)

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1450,3 +1450,25 @@ func (j *mdJournal) resolveAndClear(
 
 	return mdID, nil
 }
+
+// markLatestAsLocalSquash marks the head revision as a local squash,
+// without the need to go through resolveAndClear.  It's assumed that
+// the caller already guaranteed that there is no more than 1
+// non-local-squash at the end of the journal.
+func (j *mdJournal) markLatestAsLocalSquash(ctx context.Context) error {
+	if j.branchID != NullBranchID {
+		return errors.Errorf("Can't mark latest as local squash when on a "+
+			"branch (bid=%s)", j.branchID)
+	}
+
+	entry, exists, err := j.j.getLatestEntry()
+	if err != nil {
+		return err
+	}
+	if !exists || entry.IsLocalSquash {
+		return nil
+	}
+
+	entry.IsLocalSquash = true
+	return j.j.replaceHead(entry)
+}

--- a/test/journal_test.go
+++ b/test/journal_test.go
@@ -381,7 +381,7 @@ func TestJournalCoalescingBasicCreates(t *testing.T) {
 	var busyWork []fileOp
 	var reads []fileOp
 	listing := m{"^a$": "DIR"}
-	iters := libkbfs.ForcedBranchSquashThreshold + 1
+	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
 	unflushedPaths := []string{"alice,bob"}
 	for i := 0; i < iters; i++ {
 		name := fmt.Sprintf("a%d", i)
@@ -428,7 +428,7 @@ func TestJournalCoalescingCreatesPlusCR(t *testing.T) {
 	var busyWork []fileOp
 	var reads []fileOp
 	listing := m{"^a$": "DIR", "^b$": "DIR"}
-	iters := libkbfs.ForcedBranchSquashThreshold + 1
+	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
 	unflushedPaths := []string{"alice,bob"}
 	for i := 0; i < iters; i++ {
 		name := fmt.Sprintf("a%d", i)
@@ -493,7 +493,7 @@ func TestJournalCoalescingCreatesPlusCR(t *testing.T) {
 // get coalesced together.
 func TestJournalCoalescingWrites(t *testing.T) {
 	var busyWork []fileOp
-	iters := libkbfs.ForcedBranchSquashThreshold + 1
+	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
 	var contents string
 	for i := 0; i < iters; i++ {
 		contents += fmt.Sprintf("hello%d", i)
@@ -537,7 +537,7 @@ func TestJournalCoalescingWrites(t *testing.T) {
 // coalesced together.
 func TestJournalCoalescingMixedOperations(t *testing.T) {
 	var busyWork []fileOp
-	iters := libkbfs.ForcedBranchSquashThreshold + 1
+	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
 	for i := 0; i < iters; i++ {
 		name := fmt.Sprintf("a%d", i)
 		busyWork = append(busyWork, mkfile(name, "hello"), rm(name))
@@ -619,7 +619,7 @@ func TestJournalCoalescingMixedOperations(t *testing.T) {
 // coalesced together.
 func TestJournalCoalescingNoChanges(t *testing.T) {
 	var busyWork []fileOp
-	iters := libkbfs.ForcedBranchSquashThreshold + 1
+	iters := libkbfs.ForcedBranchSquashRevThreshold + 1
 	for i := 0; i < iters; i++ {
 		name := fmt.Sprintf("a%d", i)
 		busyWork = append(busyWork, mkfile(name, "hello"), rm(name))


### PR DESCRIPTION
If each revision has lots of big blocks, we want to limit the size of
a squash by bytes as well, not just the number of revisions.

This commit does that by tracking an estimate of the number of bytes
that will be in the squash (though it doesn't account for blocks that
will be deleted and not flushed as part of the squash).  If there is
at least one revision with more than a threshold of bytes associated
with it (currently set to 25MB, or about 2 parallel rounds of flushing
max-sized blocks), it will convert it to a squash branch.

If there's only one revision with that many bytes, it can directly be
turned into a squash branch, without the need for CR at all.

Issue: KBFS-1927