### PR TITLE
mdserver_remote: reset auth status on disconnect

### DIFF
--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -351,6 +351,10 @@ func (md *MDServerRemote) OnDisconnected(ctx context.Context,
 		md.serverOffset = 0
 	}()
 
+	md.authenticatedMtx.Lock()
+	md.isAuthenticated = false
+	md.authenticatedMtx.Unlock()
+
 	md.cancelObservers()
 	md.resetPingTicker(0)
 	if md.authToken != nil {


### PR DESCRIPTION
If the device suspends for a while and comes back (without any new
keybase login events), the old mserver connection will disconnect
(resetting the background check-rekey timer to 60min) and it will
immediately try to reconnect.  But that reconnect won't call
`getFoldersForRekey` when it starts up, because `md.isAuthenticated`
is still `true`, even though we aren't really authenticated anymore.
This means that any rekey requests that came into the server while the
device was suspended won't get processed by the device for 60 minutes.

Instead, set `md.isAuthenticated` to false on a disconnect, so that
the reconnect will trigger a `getFoldersForRekey()` call.

Issue: keybase/client#5972