### PR TITLE
folder_block_ops: fill in UID whenever a BlockPointer is made

### DIFF
--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
@@ -93,6 +94,11 @@ func (b *BlockServerMemory) Get(ctx context.Context, tlfID tlf.ID,
 
 func validateBlockPut(
 	id kbfsblock.ID, context kbfsblock.Context, buf []byte) error {
+	var emptyUID keybase1.UID
+	if context.GetCreator() == emptyUID {
+		return fmt.Errorf("Can't Put() a block %v with an empty UID", id)
+	}
+
 	if context.GetCreator() != context.GetWriter() {
 		return fmt.Errorf("Can't Put() a block with creator=%s != writer=%s",
 			context.GetCreator(), context.GetWriter())

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -640,7 +640,10 @@ func (fbo *folderBlockOps) DeepCopyFile(
 	// so only a read lock is needed.
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	var uid keybase1.UID // Data reads don't depend on the uid.
+	_, uid, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return BlockPointer{}, nil, err
+	}
 	fd := fbo.newFileDataWithCache(lState, file, uid, kmd, dirtyBcache)
 	return fd.deepCopy(ctx, dataVer)
 }
@@ -650,7 +653,10 @@ func (fbo *folderBlockOps) UndupChildrenInCopy(ctx context.Context,
 	dirtyBcache DirtyBlockCache, topBlock *FileBlock) ([]BlockInfo, error) {
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
-	var uid keybase1.UID // Data reads don't depend on the uid.
+	_, uid, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
 	fd := fbo.newFileDataWithCache(lState, file, uid, kmd, dirtyBcache)
 	return fd.undupChildrenInCopy(ctx, fbo.config.BlockCache(),
 		fbo.config.BlockOps(), bps, topBlock)
@@ -661,7 +667,10 @@ func (fbo *folderBlockOps) ReadyNonLeafBlocksInCopy(ctx context.Context,
 	dirtyBcache DirtyBlockCache, topBlock *FileBlock) ([]BlockInfo, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	var uid keybase1.UID // Data reads don't depend on the uid.
+	_, uid, err := fbo.config.KBPKI().GetCurrentUserInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
 	fd := fbo.newFileDataWithCache(lState, file, uid, kmd, dirtyBcache)
 	return fd.readyNonLeafBlocksInCopy(ctx, fbo.config.BlockCache(),
 		fbo.config.BlockOps(), bps, topBlock)


### PR DESCRIPTION
Otherwise the context could look empty.

Issue: KBFS-1971