### PR TITLE
libkbfs: don't send read/write notifications for invalid paths

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -292,7 +292,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 
 	bops := fbo.config.BlockOps()
 
-	if notifyPath.isValid() {
+	if notifyPath.isValidForNotification() {
 		fbo.config.Reporter().Notify(ctx, readNotification(notifyPath, false))
 		defer fbo.config.Reporter().Notify(ctx,
 			readNotification(notifyPath, true))

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3638,9 +3638,11 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 		return true, err
 	}
 
-	// notify the daemon that a write is being performed
-	fbo.config.Reporter().Notify(ctx, writeNotification(file, false))
-	defer fbo.config.Reporter().Notify(ctx, writeNotification(file, true))
+	if file.isValidForNotification() {
+		// notify the daemon that a write is being performed
+		fbo.config.Reporter().Notify(ctx, writeNotification(file, false))
+		defer fbo.config.Reporter().Notify(ctx, writeNotification(file, true))
+	}
 
 	// Filled in by doBlockPuts below.
 	var blocksToRemove []BlockPointer

--- a/libkbfs/path.go
+++ b/libkbfs/path.go
@@ -86,6 +86,17 @@ func (p path) isValid() bool {
 	return true
 }
 
+// isValidForNotification() returns true if the path has at least one
+// node (for the root), and the first element of the path is non-empty
+// and does not start with "<", which indicates an unnotifiable path.
+func (p path) isValidForNotification() bool {
+	if !p.isValid() {
+		return false
+	}
+
+	return len(p.path[0].Name) > 0 && !strings.HasPrefix(p.path[0].Name, "<")
+}
+
 // hasValidParent() returns true if this path is valid and
 // parentPath() is a valid path.
 func (p path) hasValidParent() bool {


### PR DESCRIPTION
Otherwise the user can get flooded with notifications during CR (and
also potentially when reading big unembedded block changes).

Issue: KBFS-1972