### PR TITLE
root_metadata: set the writer MD copied bit for finalized MDs

### DIFF
--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -1089,6 +1089,9 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(
 	}
 	// Set the final flag.
 	newBareMd.SetFinalBit()
+	// Set the copied bit, so that clients don't take the ops and byte
+	// counts in it seriously.
+	newBareMd.SetWriterMetadataCopiedBit()
 	// Increment revision but keep the PrevRoot --
 	// We want the client to be able to verify the signature by masking out the final
 	// bit, decrementing the revision, and nulling out the finalized extension info.
@@ -1141,6 +1144,7 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 		// things allowed to change in the finalized metadata
 		// block.
 		mutableMdCopy.ClearFinalBit()
+		mutableMdCopy.ClearWriterMetadataCopiedBit()
 		mutableMdCopy.SetRevision(md.RevisionNumber() - 1)
 		mutableMdCopy.SetFinalizedInfo(nil)
 		md = mutableMdCopy


### PR DESCRIPTION
Otherwise clients reject it, since the MD usage doesn't match up, and
could try to re-apply operations in it to the node cache.

Issue: KBFS-1976