### PR TITLE
Add comments to timedProfileFile

### DIFF
--- a/libfuse/profilelist.go
+++ b/libfuse/profilelist.go
@@ -66,8 +66,6 @@ func (f timedProfileFile) Attr(ctx context.Context, a *fuse.Attr) error {
 	return nil
 }
 
-var _ fs.Handle = timedProfileFile{}
-
 var _ fs.NodeOpener = timedProfileFile{}
 
 func (f timedProfileFile) Open(ctx context.Context,

--- a/libfuse/profilelist.go
+++ b/libfuse/profilelist.go
@@ -75,7 +75,10 @@ func (f timedProfileFile) Open(ctx context.Context,
 	// timeout.
 	//
 	// The downside is that there's no easy way to start capturing
-	// a profile and then interrupt when done.
+	// a profile and then interrupt when done. But even if we try
+	// and stream the profile data, one problem is that the CPU
+	// profile is, at least as of go 1.8, buffered until it's
+	// stopped anyway, so we'd run into timeouts.
 	var buf bytes.Buffer
 	err := f.profile.Start(&buf)
 	if err != nil {

--- a/libfuse/profilelist.go
+++ b/libfuse/profilelist.go
@@ -70,6 +70,12 @@ var _ fs.NodeOpener = timedProfileFile{}
 
 func (f timedProfileFile) Open(ctx context.Context,
 	req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
+	// Blocking here until the profile is done is weird, but has a
+	// nice side effect of being exempt from the macOS FUSE
+	// timeout.
+	//
+	// The downside is that there's no easy way to start capturing
+	// a profile and then interrupt when done.
 	var buf bytes.Buffer
 	err := f.profile.Start(&buf)
 	if err != nil {
@@ -79,8 +85,7 @@ func (f timedProfileFile) Open(ctx context.Context,
 	select {
 	case <-time.After(f.duration):
 	case <-ctx.Done():
-		// Don't return an error and fall through, so we
-		// return the partial profile data.
+		return nil, ctx.Err()
 	}
 
 	f.profile.Stop()

--- a/libfuse/special_read_file.go
+++ b/libfuse/special_read_file.go
@@ -40,8 +40,6 @@ func (f *SpecialReadFile) Attr(ctx context.Context, a *fuse.Attr) error {
 	return nil
 }
 
-var _ fs.Handle = (*SpecialReadFile)(nil)
-
 var _ fs.NodeOpener = (*SpecialReadFile)(nil)
 
 // Open implements the fs.NodeOpener interface for SpecialReadFile.


### PR DESCRIPTION
I tried to make the profile data streamable,
but ran into problems. Turns out the current
way has a nice effect of being immune to
OSXFUSE timeouts, anyway. Document all that.

Also remove unneeded type assertions.