### PR TITLE
[KBFS-1977] Pad blocks with zeros instead of random data

### DIFF
--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -322,7 +322,7 @@ const padPrefixSize = 4
 // padBlock adds zero padding to an encoded block.
 func (c CryptoCommon) padBlock(block []byte) ([]byte, error) {
 	blockLen := uint32(len(block))
-	totalLen := powerOfTwoEqualOrGreater(blockLen)
+	totalLen := powerOfTwoEqualOrGreater(int(blockLen))
 
 	buf := make([]byte, padPrefixSize+totalLen)
 	binary.LittleEndian.PutUint32(buf, blockLen)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -333,18 +333,18 @@ func (c CryptoCommon) padBlock(block []byte) ([]byte, error) {
 
 // depadBlock extracts the actual block data from a padded block.
 func (c CryptoCommon) depadBlock(paddedBlock []byte) ([]byte, error) {
-	paddedLen := len(paddedBlock)
-	if paddedLen < padPrefixSize {
+	totalLen := len(paddedBlock)
+	if totalLen < padPrefixSize {
 		return nil, errors.WithStack(io.ErrUnexpectedEOF)
 	}
 
 	blockLen := binary.LittleEndian.Uint32(paddedBlock)
 	blockEndPos := int(blockLen + padPrefixSize)
 
-	if paddedLen < blockEndPos {
+	if totalLen < blockEndPos {
 		return nil, errors.WithStack(
 			PaddedBlockReadError{
-				ActualLen:   paddedLen,
+				ActualLen:   totalLen,
 				ExpectedLen: blockEndPos,
 			})
 	}

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"io"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -334,10 +335,7 @@ func (c CryptoCommon) padBlock(block []byte) ([]byte, error) {
 func (c CryptoCommon) depadBlock(paddedBlock []byte) ([]byte, error) {
 	paddedLen := len(paddedBlock)
 	if paddedLen < padPrefixSize {
-		return nil, errors.WithStack(PaddedBlockReadError{
-			ActualLen:   paddedLen,
-			ExpectedLen: padPrefixSize,
-		})
+		return nil, errors.WithStack(io.ErrUnexpectedEOF)
 	}
 
 	blockLen := binary.LittleEndian.Uint32(paddedBlock)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -319,7 +319,7 @@ func powerOfTwoEqualOrGreater(n int) int {
 
 const padPrefixSize = 4
 
-// padBlock adds random padding to an encoded block.
+// padBlock adds zero padding to an encoded block.
 func (c CryptoCommon) padBlock(block []byte) ([]byte, error) {
 	blockLen := uint32(len(block))
 	totalLen := powerOfTwoEqualOrGreater(blockLen)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -321,11 +321,10 @@ const padPrefixSize = 4
 
 // padBlock adds zero padding to an encoded block.
 func (c CryptoCommon) padBlock(block []byte) ([]byte, error) {
-	blockLen := uint32(len(block))
-	totalLen := powerOfTwoEqualOrGreater(int(blockLen))
+	totalLen := powerOfTwoEqualOrGreater(len(block))
 
 	buf := make([]byte, padPrefixSize+totalLen)
-	binary.LittleEndian.PutUint32(buf, blockLen)
+	binary.LittleEndian.PutUint32(buf, uint32(len(block)))
 
 	copy(buf[padPrefixSize:], block)
 	return buf, nil

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -588,8 +588,14 @@ func TestBlockEncryptedLen(t *testing.T) {
 func BenchmarkEncryptBlock(b *testing.B) {
 	c := MakeCryptoCommon(kbfscodec.NewMsgpack())
 
+	// Fill in the block with varying data to make sure not to
+	// trigger any encoding optimizations.
+	data := make([]byte, 512<<10)
+	for i := 0; i < len(data); i++ {
+		data[i] = byte(i)
+	}
 	block := FileBlock{
-		Contents: make([]byte, 512<<10),
+		Contents: data,
 	}
 	key := kbfscrypto.BlockCryptKey{}
 	for i := 0; i < b.N; i++ {

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -598,6 +598,8 @@ func BenchmarkEncryptBlock(b *testing.B) {
 		Contents: data,
 	}
 	key := kbfscrypto.BlockCryptKey{}
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c.EncryptBlock(&block, key)
 	}

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -584,3 +584,15 @@ func TestBlockEncryptedLen(t *testing.T) {
 		require.Equal(t, expectedLen, len(encBlock.EncryptedData))
 	}
 }
+
+func BenchmarkEncryptBlock(b *testing.B) {
+	c := MakeCryptoCommon(kbfscodec.NewMsgpack())
+
+	block := FileBlock{
+		Contents: make([]byte, 512<<10),
+	}
+	key := kbfscrypto.BlockCryptKey{}
+	for i := 0; i < b.N; i++ {
+		c.EncryptBlock(&block, key)
+	}
+}

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"testing/quick"
 
@@ -585,7 +586,7 @@ func TestBlockEncryptedLen(t *testing.T) {
 	}
 }
 
-func BenchmarkEncryptBlock(b *testing.B) {
+func benchmarkEncryptBlock(b *testing.B, blockSize int) {
 	c := MakeCryptoCommon(kbfscodec.NewMsgpack())
 
 	// Fill in the block with varying data to make sure not to
@@ -602,5 +603,22 @@ func BenchmarkEncryptBlock(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		c.EncryptBlock(&block, key)
+	}
+}
+
+func BenchmarkEncryptBlock(b *testing.B) {
+	blockSizes := []int{
+		0,
+		1024,
+		32 * 1024,
+		512 * 1024,
+	}
+	for _, blockSize := range blockSizes {
+		// Capture range variable.
+		blockSize := blockSize
+		b.Run(fmt.Sprintf("blockSize=%d", blockSize),
+			func(b *testing.B) {
+				benchmarkEncryptBlock(b, blockSize)
+			})
 	}
 }


### PR DESCRIPTION
This should save a chunk of CPU time.

Also write to a []byte directly during padding/unpadding
instead of using a bytes.Buffer.

Also add benchmark for block encryption.