### PR TITLE
[KBFS-1958] Make diskJournal.clear() nuke the journal dir

### DIFF
--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -37,8 +37,6 @@ import (
 //
 // TODO: Do all high-level operations atomically on the file-system
 // level.
-//
-// TODO: Make IO ops cancellable.
 type diskJournal struct {
 	codec     kbfscodec.Codec
 	dir       string

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -163,6 +163,9 @@ func (j diskJournal) clear() error {
 		return err
 	}
 
+	// j.dir will be recreated on the next call to
+	// writeJournalEntry (via kbfscodec.SerializeToFile), which
+	// must always come before any ordinal write.
 	return ioutil.RemoveAll(j.dir)
 }
 

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -149,6 +149,18 @@ func (j diskJournal) writeLatestOrdinal(o journalOrdinal) error {
 
 // clear completely removes the journal directory.
 func (j diskJournal) clear() error {
+	// Clear ordinals first to reduce the chances of leaving the
+	// journal in a weird state if we crash in the middle of
+	// removing the files.
+	err := ioutil.Remove(j.earliestPath())
+	if err != nil {
+		return err
+	}
+	err = ioutil.Remove(j.latestPath())
+	if err != nil {
+		return err
+	}
+
 	return ioutil.RemoveAll(j.dir)
 }
 

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -17,7 +17,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// diskJournal stores an ordered list of entries.
+// diskJournal stores an ordered list of entries in a directory, which
+// is assumed to not be used by anything else.
 //
 // The directory layout looks like:
 //

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -268,12 +268,11 @@ func (j diskJournal) appendJournalEntry(
 	return next, nil
 }
 
-// move moves the journal to the given directory, assuming it
-// exists. If the directory doesn't exist, an error is returned and
-// the journal directory remains the same.
+// move moves the journal to the given directory, which should share
+// the same parent directory as the current journal directory.
 func (j *diskJournal) move(newDir string) (oldDir string, err error) {
 	err = ioutil.Rename(j.dir, newDir)
-	if err != nil {
+	if err != nil && !ioutil.IsNotExist(err) {
 		return "", err
 	}
 	oldDir = j.dir

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -146,7 +146,7 @@ func (j diskJournal) writeLatestOrdinal(o journalOrdinal) error {
 	return j.writeOrdinal(j.latestPath(), o)
 }
 
-func (j diskJournal) clearOrdinals() error {
+func (j diskJournal) clear() error {
 	earliestOrdinal, err := j.readEarliestOrdinal()
 	if err != nil {
 		return err
@@ -189,7 +189,7 @@ func (j diskJournal) removeEarliest() (empty bool, err error) {
 	}
 
 	if earliestOrdinal == latestOrdinal {
-		err := j.clearOrdinals()
+		err := j.clear()
 		if err != nil {
 			return false, err
 		}

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -147,35 +147,9 @@ func (j diskJournal) writeLatestOrdinal(o journalOrdinal) error {
 	return j.writeOrdinal(j.latestPath(), o)
 }
 
+// clear completely removes the journal directory.
 func (j diskJournal) clear() error {
-	earliestOrdinal, err := j.readEarliestOrdinal()
-	if err != nil {
-		return err
-	}
-	latestOrdinal, err := j.readLatestOrdinal()
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.Remove(j.earliestPath())
-	if err != nil {
-		return err
-	}
-	err = ioutil.Remove(j.latestPath())
-	if err != nil {
-		return err
-	}
-
-	// Garbage-collect the old entries.  TODO: we'll eventually need a
-	// sweeper to clean up entries left behind if we crash right here.
-	for ordinal := earliestOrdinal; ordinal <= latestOrdinal; ordinal++ {
-		p := j.journalEntryPath(ordinal)
-		err = ioutil.Remove(p)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return ioutil.RemoveAll(j.dir)
 }
 
 func (j diskJournal) removeEarliest() (empty bool, err error) {

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -268,6 +268,9 @@ func (j diskJournal) appendJournalEntry(
 	return next, nil
 }
 
+// move moves the journal to the given directory, assuming it
+// exists. If the directory doesn't exist, an error is returned and
+// the journal directory remains the same.
 func (j *diskJournal) move(newDir string) (oldDir string, err error) {
 	err = ioutil.Rename(j.dir, newDir)
 	if err != nil {

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -176,8 +176,9 @@ func (j diskJournal) removeEarliest() (empty bool, err error) {
 		return false, err
 	}
 
-	// Garbage-collect the old entry.  TODO: we'll eventually need a
-	// sweeper to clean up entries left behind if we crash right here.
+	// Garbage-collect the old entry. If we crash here and leave
+	// behind an entry, it'll be cleaned up the next time clear()
+	// is called.
 	p := j.journalEntryPath(earliestOrdinal)
 	err = ioutil.Remove(p)
 	if err != nil {

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -154,6 +154,10 @@ func (j diskJournal) clear() error {
 	// Clear ordinals first to reduce the chances of leaving the
 	// journal in a weird state if we crash in the middle of
 	// removing the files.
+	//
+	// TODO: When we read ordinals into memory on startup, treat
+	// the absence of either ordinal as the journal being empty,
+	// so as to make clearing atomic.
 	err := ioutil.Remove(j.earliestPath())
 	if err != nil {
 		return err

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -39,6 +39,8 @@ import (
 // level.
 //
 // TODO: Make IO ops cancellable.
+//
+// TODO: Read ordinals into memory on startup.
 type diskJournal struct {
 	codec     kbfscodec.Codec
 	dir       string

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -37,6 +37,8 @@ import (
 //
 // TODO: Do all high-level operations atomically on the file-system
 // level.
+//
+// TODO: Make IO ops cancellable.
 type diskJournal struct {
 	codec     kbfscodec.Codec
 	dir       string

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -1,0 +1,43 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/keybase/kbfs/ioutil"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testJournalEntry struct {
+	I int
+}
+
+func TestDiskJournalClear(t *testing.T) {
+	tempdir, err := ioutil.TempDir(os.TempDir(), "disk_journal")
+	require.NoError(t, err)
+	defer func() {
+		err := ioutil.RemoveAll(tempdir)
+		assert.NoError(t, err)
+	}()
+
+	codec := kbfscodec.NewMsgpack()
+	j := makeDiskJournal(codec, tempdir, reflect.TypeOf(testJournalEntry{}))
+
+	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
+	require.NoError(t, err)
+	require.Equal(t, journalOrdinal(0), o)
+
+	o, err = j.appendJournalEntry(nil, testJournalEntry{2})
+	require.NoError(t, err)
+	require.Equal(t, journalOrdinal(1), o)
+
+	err = j.clear()
+	require.NoError(t, err)
+}

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -40,4 +40,7 @@ func TestDiskJournalClear(t *testing.T) {
 
 	err = j.clear()
 	require.NoError(t, err)
+
+	_, err = ioutil.Stat(tempdir)
+	require.True(t, ioutil.IsNotExist(err))
 }

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -129,12 +129,12 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	id, head, err := mdOps.GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
 	require.NotEqual(t, tlf.NullID, id)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(7), head.Revision())
 
 	head, err = mdOps.GetForTLF(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(7), head.Revision())
 
 	head, err = oldMDOps.GetForTLF(ctx, id)
@@ -146,12 +146,12 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	head, err = mdOps.GetForTLF(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(7), head.Revision())
 
 	head, err = oldMDOps.GetForTLF(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(7), head.Revision())
 
 	// (3) trigger a conflict
@@ -175,12 +175,12 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	head, err = mdOps.GetForTLF(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(8), head.Revision())
 
 	head, err = oldMDOps.GetForTLF(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(8), head.Revision())
 
 	// Find the branch ID.
@@ -190,12 +190,12 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	head, err = mdOps.GetUnmergedForTLF(ctx, id, bid)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(10), head.Revision())
 
 	_, head, err = mdOps.GetForHandle(ctx, h, Unmerged)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(10), head.Revision())
 	require.Equal(t, bid, head.BID())
 
@@ -215,7 +215,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	// (5) check for proper unmerged head
 	head, err = mdOps.GetUnmergedForTLF(ctx, id, bid)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(40), head.Revision())
 
 	// (6a) try to get unmerged range
@@ -251,7 +251,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	// (10) check for proper merged head
 	head, err = mdOps.GetForTLF(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, head)
+	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, MetadataRevision(8), head.Revision())
 
 	// (11) try to get merged range

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -244,6 +244,11 @@ func (j mdIDJournal) clearFrom(revision MetadataRevision) error {
 		return err
 	}
 
+	if revision < earliestRevision {
+		return errors.Errorf("Cannot call clearFrom with revision %s < %s",
+			revision, earliestRevision)
+	}
+
 	if revision == earliestRevision {
 		return j.clear()
 	}

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -17,6 +17,10 @@ import (
 // MdIDs (with possible other fields in the future) with sequential
 // MetadataRevisions for a single branch.
 //
+// Like diskJournal, this type assumes that the directory passed into
+// makeMdIDJournal isn't used by anything else, and that all
+// synchronization is done at a higher level.
+//
 // TODO: Write unit tests for this. For now, we're relying on
 // md_journal.go's unit tests.
 type mdIDJournal struct {

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -231,7 +231,7 @@ func (j mdIDJournal) removeEarliest() (empty bool, err error) {
 }
 
 func (j mdIDJournal) clear() error {
-	return j.j.clearOrdinals()
+	return j.j.clear()
 }
 
 func (j *mdIDJournal) move(newDir string) (oldDir string, err error) {

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -238,6 +238,8 @@ func (j mdIDJournal) clear() error {
 	return j.j.clear()
 }
 
+// Note that since diskJournal.move takes a pointer receiver, so must
+// this.
 func (j *mdIDJournal) move(newDir string) (oldDir string, err error) {
 	return j.j.move(newDir)
 }

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1431,10 +1431,10 @@ func (j *mdJournal) resolveAndClear(
 	// Set new journal to one with the new revision.
 	j.log.CDebugf(ctx, "Moved new journal from %s to %s",
 		otherIDJournalOldDir, dir)
-	*j, *otherJournal = *otherJournal, *j
 
-	// Transform the other journal into the old journal, so we can
-	// clear it out.
+	// Transform the other journal into the old journal and clear
+	// it out.
+	*j, *otherJournal = *otherJournal, *j
 	err = otherJournal.clear(ctx, bid)
 	if err != nil {
 		return MdID{}, err

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1240,7 +1240,7 @@ func (j *mdJournal) put(
 
 // clear removes all the journal entries, and deletes the
 // corresponding MD updates.  If the branch is a pending local squash,
-// it preserved the MD updates corresponding to the prefix of existing
+// it preserves the MD updates corresponding to the prefix of existing
 // local squashes, so they can be re-used in the newly-resolved
 // journal.
 func (j *mdJournal) clear(

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -857,11 +857,17 @@ func getMdID(ctx context.Context, mdserver MDServer, crypto cryptoPure,
 	return crypto.MakeMdID(rmdses[0].MD)
 }
 
-// clearHelper removes all the journal entries, and deletes the
-// corresponding MD updates.  If the branch is a pending local squash,
-// it preserves the MD updates corresponding to the prefix of existing
-// local squashes, so they can be re-used in the newly-resolved
-// journal.
+// clearHelper removes all the journal entries starting from
+// earliestBranchRevision and deletes the corresponding MD
+// updates. All MDs from earliestBranchRevision onwards must have
+// branch equal to the given one, which must not be NullBranchID. This
+// means that, if bid != PendingLocalSquashBranchID,
+// earliestBranchRevision must equal the earliest revision, and if bid
+// == PendingLocalSquashBranchID, earliestBranchRevision must equal
+// one past the last local squash revision. If the branch is a pending
+// local squash, it preserves the MD updates corresponding to the
+// prefix of existing local squashes, so they can be re-used in the
+// newly-resolved journal.
 func (j *mdJournal) clearHelper(ctx context.Context, bid BranchID,
 	earliestBranchRevision MetadataRevision) (err error) {
 	j.log.CDebugf(ctx, "Clearing journal for branch %s", bid)

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1389,6 +1389,7 @@ func (j *mdJournal) resolveAndClear(
 	// Put the local squashes back into the new journal, since they
 	// weren't part of the resolve.
 	if bid == PendingLocalSquashBranchID {
+		// TODO: Preserve earliest non-local squash revision.
 		for ; earliestRevision <= latestRevision; earliestRevision++ {
 			entry, err := j.j.readJournalEntry(earliestRevision)
 			if err != nil {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -830,6 +830,8 @@ func (j *mdJournal) removeFlushedEntry(
 		j.log.CDebugf(ctx,
 			"Journal is now empty; saving last MdID=%s", mdID)
 		j.lastMdID = mdID
+
+		// TODO: Nuke directory here.
 	}
 
 	// Garbage-collect the old entry.  TODO: we'll eventually need a

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -459,6 +459,7 @@ func testMDJournalPutCase3NonEmptyAppend(t *testing.T, ver MetadataVer) {
 
 	head, err := j.getHead(bid)
 	require.NoError(t, err)
+	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
 
 	md2 := makeMDForTest(t, ver, id, MetadataRevision(11), j.uid, signer, head.mdID)
 	md2.SetUnmerged()
@@ -484,6 +485,7 @@ func testMDJournalPutCase3NonEmptyReplace(t *testing.T, ver MetadataVer) {
 
 	head, err := j.getHead(bid)
 	require.NoError(t, err)
+	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
 
 	md.SetUnmerged()
 	md.SetBranchID(head.BID())

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -821,6 +821,9 @@ func testMDJournalBranchConversionPreservesUnknownFields(t *testing.T, ver Metad
 	flushAllMDs(t, ctx, signer, j)
 }
 
+// TODO: Write a test to test clearing a local squash branch with
+// master entries.
+
 func testMDJournalClear(t *testing.T, ver MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -932,7 +932,7 @@ func testMDJournalClearPendingWithMaster(t *testing.T, ver MetadataVer) {
 
 	length, err := j.length()
 	require.NoError(t, err)
-	require.Equal(t, mdCount, length)
+	require.Equal(t, uint64(mdCount), length)
 
 	head, err := j.getHead(bid)
 	require.NoError(t, err)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -924,11 +924,15 @@ func testMDJournalClearPendingWithMaster(t *testing.T, ver MetadataVer) {
 
 	bid := j.branchID
 
-	// Clearing the correct branch ID should clear the entire
-	// journal, and reset the branch ID.
+	// Clearing the correct branch ID should clear just the last
+	// half of the journal and reset the branch ID.
 	err = j.clear(ctx, bid)
 	require.NoError(t, err)
 	require.Equal(t, NullBranchID, j.branchID)
+
+	length, err := j.length()
+	require.NoError(t, err)
+	require.Equal(t, mdCount, length)
 
 	head, err := j.getHead(bid)
 	require.NoError(t, err)
@@ -936,7 +940,8 @@ func testMDJournalClearPendingWithMaster(t *testing.T, ver MetadataVer) {
 
 	head, err = j.getHead(NullBranchID)
 	require.NoError(t, err)
-	require.Equal(t, ImmutableBareRootMetadata{}, head)
+	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
+	require.Equal(t, NullBranchID, head.BID())
 }
 
 func testMDJournalRestart(t *testing.T, ver MetadataVer) {

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -943,6 +943,8 @@ func testMDJournalClearPendingWithMaster(t *testing.T, ver MetadataVer) {
 	head, err = j.getHead(NullBranchID)
 	require.NoError(t, err)
 	require.NotEqual(t, ImmutableBareRootMetadata{}, head)
+	require.Equal(t, firstRevision+MetadataRevision(mdCount-1),
+		head.RevisionNumber())
 	require.Equal(t, NullBranchID, head.BID())
 }
 


### PR DESCRIPTION
Make diskJournal.move work correctly even if the journal
directory doesn't exist yet.

Fix bug in mdJournal where clear() would remove revisions
from the master branch if the branch is the local pending
squash branch.