### PR TITLE
block_ops: if a block is in the local journal, fetch it directly

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -26,7 +26,6 @@ type blockOpsConfig interface {
 type BlockOpsStandard struct {
 	config blockOpsConfig
 	queue  *blockRetrievalQueue
-	bg     *realBlockGetter
 }
 
 var _ BlockOps = (*BlockOpsStandard)(nil)
@@ -43,7 +42,6 @@ func NewBlockOpsStandard(config blockOpsConfig,
 	bops := &BlockOpsStandard{
 		config: config,
 		queue:  q,
-		bg:     bg,
 	}
 	return bops
 }
@@ -60,8 +58,9 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 			return err
 		}
 		if found {
-			return b.bg.assembleBlock(
-				ctx, kmd, blockPtr, block, data, serverHalf)
+			return assembleBlock(
+				ctx, b.config.keyGetter(), b.config.Codec(),
+				b.config.cryptoPure(), kmd, blockPtr, block, data, serverHalf)
 		}
 	}
 


### PR DESCRIPTION
Otherwise, the block could get stuck behind a full queue of prefetching requests, for no reason.

@jzila: it strikes me that the disk cache will have exactly the same problem -- might want to move that logic out of `BlockServerRemote.Get()` and put it in `BlockOps.Get()` instead.

Issue: KBFS-1981