### PR TITLE
conflict_resolver: don't unref the original half of a resOp update

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3457,8 +3457,7 @@ func (cr *ConflictResolver) syncBlocks(ctx context.Context, lState *lockState,
 					resOp.AddUpdate(update.Unref, update.Ref)
 				} else if !isMostRecent {
 					cr.log.CDebugf(ctx, "Unrefing an update from old resOp: "+
-						"%v and %v", update.Unref, update.Ref)
-					newOps = addUnrefToFinalResOp(newOps, update.Unref)
+						"%v (original=%v)", update.Ref, update.Unref)
 					newOps = addUnrefToFinalResOp(newOps, update.Ref)
 				}
 			}


### PR DESCRIPTION
If we unref the original, then a subsequent CR over the resulting `resolutionOp` will think the chain has been deleted, and the ops related to that chain won't get included in the resolution.

Issue: KBFS-1979