### PR TITLE
config_local: increase the min head age for QR on other devices

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -36,8 +36,10 @@ const (
 	qrPeriodDefault = 1 * time.Minute
 	// How long must something be unreferenced before we reclaim it?
 	qrUnrefAgeDefault = 1 * time.Minute
-	// How old must the most recent revision be before we run QR?
-	qrMinHeadAgeDefault = 5 * time.Minute
+	// How old must the most recent TLF revision be before another
+	// device can run QR on that TLF?  This is large, to avoid
+	// unnecessary conflicts on the TLF between devices.
+	qrMinHeadAgeDefault = 24 * time.Hour
 	// tlfValidDurationDefault is the default for tlf validity before redoing identify.
 	tlfValidDurationDefault = 6 * time.Hour
 )


### PR DESCRIPTION
This increases the time for another device to start QRing a TLF, after
one device writes to it.  The problem is that someone could write to a
journal, and then go offline for a while with items still unflushed.
If another device runs QR in the meantime, it will cause an
unnecessary conflict.

(Obviously CR still needs to work well in that case, in case the other
device does a _real_ write instead of just a QR write, but there's no
need to impose that extra burden if we don't have to.)

As long as the writing device is still online, it will be the one
doing QR on the TLF.

Issue: KBFS-1986