### PR TITLE
bcache: fix some possible issues with accounting and with cache-fullness

### DIFF
--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -199,6 +199,8 @@ func (b *BlockCacheStandard) makeRoomForSize(size uint64, lifetime BlockCacheLif
 		b.bytesLock.Unlock()
 		doUnlock = false
 		if oldLen == b.cleanTransient.Len() {
+			doUnlock = true
+			b.bytesLock.Lock()
 			break
 		}
 		oldLen = b.cleanTransient.Len()


### PR DESCRIPTION
I saw some logs when `BlockCache.PutWithPrefetch()` was returning a `cachePutCacheFullError` on a transient put, when there should have been plenty of room in the cache to evict something else since there shouldn't have been many live permanent entries.  I can't tell exactly why this happened, but this PR fixes a few things I noticed while looking at the code:

* Don't let `cleanTotalBytes` wrap in any circumstance.  There is at least one known race that can result in undercounting bytes, so we want to make sure we never get into a situation where it will wrap the unsigned integer.
* When we can't make room for a permanent entry, make sure `makeRoomForSize` still holds the lock while updates `cleanTotalBytes`.
* If `folderBranchOps` does receive a `cachePutCacheFullError`, we should make sure that it happens _before_ we put the MD to the journal/server.  Otherwise the local client will be out of sync, and could self-conflict.

@jzila: let me know if you can think of any other reasons KBFS-1980 would have occurred.  I don't think the wrapping issue due to the `PutWithPrefetch` race is likely enough to have caused this, but these changes are probably worthwhile anyway...


Issue: KBFS-1980