### PR TITLE
Cache journal ordinals in memory

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -170,11 +170,18 @@ func makeBlockJournal(
 	log logger.Logger) (*blockJournal, error) {
 	journalPath := filepath.Join(dir, "block_journal")
 	deferLog := log.CloneWithAddedDepth(1)
-	j := makeDiskJournal(
+	j, err := makeDiskJournal(
 		codec, journalPath, reflect.TypeOf(blockJournalEntry{}))
+	if err != nil {
+		return nil, err
+	}
+
 	gcJournalPath := deferredGCBlockJournalDir(dir)
-	gcj := makeDiskJournal(
+	gcj, err := makeDiskJournal(
 		codec, gcJournalPath, reflect.TypeOf(blockJournalEntry{}))
+	if err != nil {
+		return nil, err
+	}
 
 	storeDir := filepath.Join(dir, "blocks")
 	s := makeBlockDiskStore(codec, storeDir)
@@ -189,7 +196,7 @@ func makeBlockJournal(
 	}
 
 	// Get initial aggregate info.
-	err := kbfscodec.DeserializeFromFile(
+	err = kbfscodec.DeserializeFromFile(
 		codec, aggregateInfoPath(dir), &journal.aggregateInfo)
 	if !ioutil.IsNotExist(err) && err != nil {
 		return nil, err

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -310,6 +310,16 @@ func (j *blockJournal) length() uint64 {
 	return j.j.length()
 }
 
+func (j *blockJournal) next() (journalOrdinal, error) {
+	last, err := j.j.readLatestOrdinal()
+	if ioutil.IsNotExist(err) {
+		return 1, nil
+	} else if err != nil {
+		return 0, err
+	}
+	return last + 1, nil
+}
+
 func (j *blockJournal) end() (journalOrdinal, error) {
 	last, err := j.j.readLatestOrdinal()
 	if ioutil.IsNotExist(err) {
@@ -394,7 +404,7 @@ func (j *blockJournal) putData(
 		}
 	}()
 
-	next, err := j.end()
+	next, err := j.next()
 	if err != nil {
 		return false, err
 	}
@@ -436,7 +446,7 @@ func (j *blockJournal) addReference(
 		}
 	}()
 
-	next, err := j.end()
+	next, err := j.next()
 	if err != nil {
 		return err
 	}
@@ -467,7 +477,7 @@ func (j *blockJournal) archiveReferences(
 		}
 	}()
 
-	next, err := j.end()
+	next, err := j.next()
 	if err != nil {
 		return err
 	}

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -306,7 +306,7 @@ func (j *blockJournal) appendJournalEntry(
 	return ordinal, nil
 }
 
-func (j *blockJournal) length() (uint64, error) {
+func (j *blockJournal) length() uint64 {
 	return j.j.length()
 }
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -65,7 +65,7 @@ type blockJournal struct {
 	deferLog logger.Logger
 
 	// j is the main journal.
-	j diskJournal
+	j *diskJournal
 
 	// saveUntilMDFlush, when non-nil, prevents garbage collection
 	// of blocks. When removed, all the referenced blocks are
@@ -73,7 +73,7 @@ type blockJournal struct {
 	//
 	// TODO: We only really need to save a list of IDs, and not a
 	// full journal.
-	deferredGC diskJournal
+	deferredGC *diskJournal
 
 	// s stores all the block data. s should always reflect the
 	// state you get by replaying all the entries in j.
@@ -881,7 +881,7 @@ func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 
 func (j *blockJournal) ignoreBlocksAndMDRevMarkersInJournal(ctx context.Context,
 	idsToIgnore map[kbfsblock.ID]bool, rev MetadataRevision,
-	dj diskJournal) error {
+	dj *diskJournal) error {
 	first, err := dj.readEarliestOrdinal()
 	if ioutil.IsNotExist(err) {
 		return nil

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -313,7 +313,7 @@ func (j *blockJournal) length() uint64 {
 func (j *blockJournal) next() (journalOrdinal, error) {
 	last, err := j.j.readLatestOrdinal()
 	if ioutil.IsNotExist(err) {
-		return 1, nil
+		return firstValidJournalOrdinal, nil
 	} else if err != nil {
 		return 0, err
 	}

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -450,7 +450,7 @@ func TestBlockJournalFlush(t *testing.T) {
 		// Test that the end parameter is respected.
 		var partialEntries blockEntriesToFlush
 		var rev MetadataRevision
-		if end > 2 {
+		if end > firstValidJournalOrdinal+1 {
 			partialEntries, rev, err = j.getNextEntriesToFlush(ctx, end-1,
 				maxJournalBlockFlushBatchSize)
 			require.NoError(t, err)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -450,7 +450,7 @@ func TestBlockJournalFlush(t *testing.T) {
 		// Test that the end parameter is respected.
 		var partialEntries blockEntriesToFlush
 		var rev MetadataRevision
-		if end > 1 {
+		if end > 2 {
 			partialEntries, rev, err = j.getNextEntriesToFlush(ctx, end-1,
 				maxJournalBlockFlushBatchSize)
 			require.NoError(t, err)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -90,12 +90,6 @@ func TestSaturateAdd(t *testing.T) {
 	require.Equal(t, int64(0), x)
 }
 
-func getBlockJournalLength(t *testing.T, j *blockJournal) int {
-	len, err := j.length()
-	require.NoError(t, err)
-	return int(len)
-}
-
 func setupBlockJournalTest(t *testing.T) (
 	ctx context.Context, cancel context.CancelFunc, tempdir string,
 	log logger.Logger, j *blockJournal) {
@@ -126,7 +120,7 @@ func setupBlockJournalTest(t *testing.T) (
 
 	j, err = makeBlockJournal(ctx, codec, tempdir, log)
 	require.NoError(t, err)
-	require.Equal(t, 0, getBlockJournalLength(t, j))
+	require.Equal(t, uint64(0), j.length())
 
 	setupSucceeded = true
 	return ctx, cancel, tempdir, log, j
@@ -146,7 +140,7 @@ func teardownBlockJournalTest(t *testing.T, ctx context.Context,
 func putBlockData(
 	ctx context.Context, t *testing.T, j *blockJournal, data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
-	oldLength := getBlockJournalLength(t, j)
+	oldLength := j.length()
 
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -160,7 +154,7 @@ func putBlockData(
 	require.NoError(t, err)
 	require.True(t, putData)
 
-	require.Equal(t, oldLength+1, getBlockJournalLength(t, j))
+	require.Equal(t, oldLength+1, j.length())
 
 	return bID, bCtx, serverHalf
 }
@@ -168,7 +162,7 @@ func putBlockData(
 func addBlockRef(
 	ctx context.Context, t *testing.T, j *blockJournal,
 	bID kbfsblock.ID) kbfsblock.Context {
-	oldLength := getBlockJournalLength(t, j)
+	oldLength := j.length()
 
 	nonce, err := kbfsblock.MakeRefNonce()
 	require.NoError(t, err)
@@ -178,7 +172,7 @@ func addBlockRef(
 	bCtx2 := kbfsblock.MakeContext(uid1, uid2, nonce, keybase1.BlockType_DATA)
 	err = j.addReference(ctx, bID, bCtx2)
 	require.NoError(t, err)
-	require.Equal(t, oldLength+1, getBlockJournalLength(t, j))
+	require.Equal(t, oldLength+1, j.length())
 	return bCtx2
 }
 
@@ -214,7 +208,7 @@ func TestBlockJournalBasic(t *testing.T) {
 	j, err = makeBlockJournal(ctx, j.codec, tempdir, j.log)
 	require.NoError(t, err)
 
-	require.Equal(t, 2, getBlockJournalLength(t, j))
+	require.Equal(t, uint64(2), j.length())
 
 	// Make sure we get the same block for both refs.
 
@@ -228,7 +222,7 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 
 	data := []byte{1, 2, 3, 4}
 
-	oldLength := getBlockJournalLength(t, j)
+	oldLength := j.length()
 
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -251,7 +245,7 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, putData)
 
-	require.Equal(t, oldLength+2, getBlockJournalLength(t, j))
+	require.Equal(t, oldLength+2, j.length())
 
 	// Shouldn't count the block twice.
 	require.Equal(t, int64(len(data)), j.getStoredBytes())
@@ -290,7 +284,7 @@ func TestBlockJournalArchiveReferences(t *testing.T) {
 	err := j.archiveReferences(
 		ctx, kbfsblock.ContextMap{bID: {bCtx, bCtx2}})
 	require.NoError(t, err)
-	require.Equal(t, 3, getBlockJournalLength(t, j))
+	require.Equal(t, uint64(3), j.length())
 
 	// Get block should still succeed.
 	getAndCheckBlockData(ctx, t, j, bID, bCtx, data, serverHalf)
@@ -330,7 +324,7 @@ func TestBlockJournalRemoveReferences(t *testing.T) {
 		ctx, kbfsblock.ContextMap{bID: {bCtx, bCtx2}})
 	require.NoError(t, err)
 	require.Equal(t, map[kbfsblock.ID]int{bID: 0}, liveCounts)
-	require.Equal(t, 3, getBlockJournalLength(t, j))
+	require.Equal(t, uint64(3), j.length())
 
 	// Make sure the block data is inaccessible.
 	_, _, err = j.getDataWithContext(bID, bCtx)
@@ -524,9 +518,8 @@ func TestBlockJournalFlush(t *testing.T) {
 	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
 	require.IsType(t, kbfsblock.BServerErrorBlockNonExistent{}, err)
 
-	length, err := j.length()
-	require.NoError(t, err)
-	require.Zero(t, length)
+	length := j.length()
+	require.Equal(t, uint64(0), length)
 
 	// Make sure the ordinals and blocks are flushed.
 	testBlockJournalGCd(t, j)

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -45,7 +45,7 @@ type diskJournal struct {
 	entryType reflect.Type
 
 	// The journal must be considered empty when either
-	// earliestValid or latestValid is valse.
+	// earliestValid or latestValid is false.
 
 	earliestValid bool
 	earliest      journalOrdinal

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -174,7 +174,7 @@ func (j diskJournal) readLatestOrdinalFromDisk() (journalOrdinal, error) {
 // isValid bool, or an invalid journalOrdinal instead of an error.
 
 func (j diskJournal) readEarliestOrdinal() (journalOrdinal, error) {
-	if !j.earliestValid {
+	if j.empty() {
 		return journalOrdinal(0), errors.WithStack(os.ErrNotExist)
 	}
 	return j.earliest, nil
@@ -191,7 +191,7 @@ func (j *diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
 }
 
 func (j diskJournal) readLatestOrdinal() (journalOrdinal, error) {
-	if !j.latestValid {
+	if j.empty() {
 		return journalOrdinal(0), errors.WithStack(os.ErrNotExist)
 	}
 	return j.latest, nil

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -177,7 +177,9 @@ func (j *diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
 	if err != nil {
 		return err
 	}
-	return err
+	j.earliestValid = true
+	j.earliest = o
+	return nil
 }
 
 func (j diskJournal) readLatestOrdinal() (journalOrdinal, error) {
@@ -185,7 +187,13 @@ func (j diskJournal) readLatestOrdinal() (journalOrdinal, error) {
 }
 
 func (j *diskJournal) writeLatestOrdinal(o journalOrdinal) error {
-	return j.writeOrdinal(j.latestPath(), o)
+	err := j.writeOrdinal(j.latestPath(), o)
+	if err != nil {
+		return err
+	}
+	j.latestValid = true
+	j.latest = o
+	return nil
 }
 
 // clear completely removes the journal directory.
@@ -205,6 +213,11 @@ func (j *diskJournal) clear() error {
 	if err != nil {
 		return err
 	}
+
+	j.earliestValid = false
+	j.earliest = journalOrdinal(0)
+	j.latestValid = false
+	j.latest = journalOrdinal(0)
 
 	// j.dir will be recreated on the next call to
 	// writeJournalEntry (via kbfscodec.SerializeToFile), which

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -49,12 +49,13 @@ type diskJournal struct {
 
 // makeDiskJournal returns a new diskJournal for the given directory.
 func makeDiskJournal(
-	codec kbfscodec.Codec, dir string, entryType reflect.Type) diskJournal {
+	codec kbfscodec.Codec, dir string, entryType reflect.Type) (
+	diskJournal, error) {
 	return diskJournal{
 		codec:     codec,
 		dir:       dir,
 		entryType: entryType,
-	}
+	}, nil
 }
 
 // journalOrdinal is the ordinal used for naming journal entries.

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -46,6 +46,7 @@ type diskJournal struct {
 	dir       string
 	entryType reflect.Type
 
+	empty            bool
 	earliest, latest journalOrdinal
 }
 
@@ -57,18 +58,26 @@ func makeDiskJournal(
 		codec:     codec,
 		dir:       dir,
 		entryType: entryType,
+		empty:     true,
 	}
 
 	earliest, err := j.readEarliestOrdinalReal()
+	if ioutil.IsNotExist(err) {
+		return j, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	latest, err := j.readLatestOrdinalReal()
+	if ioutil.IsNotExist(err) {
+		return j, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 
+	j.empty = false
 	j.earliest = earliest
 	j.latest = latest
 

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -312,7 +312,10 @@ func (j *diskJournal) appendJournalEntry(
 		if o != nil {
 			next = *o
 		} else {
-			next = 0
+			// TODO: Define the zero journalOrdinal as
+			// invalid, once no existing journals use
+			// them.
+			next = 1
 		}
 	} else {
 		next = j.latest + 1

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -209,16 +209,16 @@ func (j *diskJournal) writeLatestOrdinal(o journalOrdinal) error {
 
 // clear completely removes the journal directory.
 func (j *diskJournal) clear() error {
-	// Clear ordinals first to reduce the chances of leaving the
-	// journal in a weird state if we crash in the middle of
-	// removing the files.
+	// Clear ordinals first to not leave the journal in a weird
+	// state if we crash in the middle of removing the files,
+	// assuming that file removal is atomic.
 	err := ioutil.Remove(j.earliestPath())
 	if err != nil {
 		return err
 	}
 
 	// If we crash here, on the next startup the journal will
-	// already be cnosidered to be empty.
+	// still be considered empty.
 
 	j.earliestValid = false
 	j.earliest = journalOrdinal(0)

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -50,8 +50,8 @@ type diskJournal struct {
 // makeDiskJournal returns a new diskJournal for the given directory.
 func makeDiskJournal(
 	codec kbfscodec.Codec, dir string, entryType reflect.Type) (
-	diskJournal, error) {
-	return diskJournal{
+	*diskJournal, error) {
+	return &diskJournal{
 		codec:     codec,
 		dir:       dir,
 		entryType: entryType,
@@ -102,7 +102,7 @@ func (j diskJournal) readOrdinal(path string) (journalOrdinal, error) {
 	return makeJournalOrdinal(string(buf))
 }
 
-func (j diskJournal) writeOrdinal(
+func (j *diskJournal) writeOrdinal(
 	path string, o journalOrdinal) error {
 	// Don't use ioutil.WriteFile because it truncates the file first,
 	// and if there's a crash it will leave the journal in an unknown
@@ -138,7 +138,7 @@ func (j diskJournal) readEarliestOrdinal() (
 	return j.readOrdinal(j.earliestPath())
 }
 
-func (j diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
+func (j *diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
 	return j.writeOrdinal(j.earliestPath(), o)
 }
 
@@ -146,12 +146,12 @@ func (j diskJournal) readLatestOrdinal() (journalOrdinal, error) {
 	return j.readOrdinal(j.latestPath())
 }
 
-func (j diskJournal) writeLatestOrdinal(o journalOrdinal) error {
+func (j *diskJournal) writeLatestOrdinal(o journalOrdinal) error {
 	return j.writeOrdinal(j.latestPath(), o)
 }
 
 // clear completely removes the journal directory.
-func (j diskJournal) clear() error {
+func (j *diskJournal) clear() error {
 	// Clear ordinals first to reduce the chances of leaving the
 	// journal in a weird state if we crash in the middle of
 	// removing the files.
@@ -177,7 +177,7 @@ func (j diskJournal) clear() error {
 // removeEarliest removes the earliest entry in the journal. If that
 // entry was the last one, clear() is also called, and true is
 // returned.
-func (j diskJournal) removeEarliest() (empty bool, err error) {
+func (j *diskJournal) removeEarliest() (empty bool, err error) {
 	earliestOrdinal, err := j.readEarliestOrdinal()
 	if err != nil {
 		return false, err
@@ -226,7 +226,7 @@ func (j diskJournal) readJournalEntry(o journalOrdinal) (interface{}, error) {
 	return entry.Elem().Interface(), nil
 }
 
-func (j diskJournal) writeJournalEntry(
+func (j *diskJournal) writeJournalEntry(
 	o journalOrdinal, entry interface{}) error {
 	entryType := reflect.TypeOf(entry)
 	if entryType != j.entryType {
@@ -245,7 +245,7 @@ func (j diskJournal) writeJournalEntry(
 // an error if *o is not the successor of the latest ordinal. If
 // successful, appendJournalEntry returns the ordinal of the
 // just-appended entry.
-func (j diskJournal) appendJournalEntry(
+func (j *diskJournal) appendJournalEntry(
 	o *journalOrdinal, entry interface{}) (journalOrdinal, error) {
 	// TODO: Consider caching the latest ordinal in memory instead
 	// of reading it from disk every time.

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -60,7 +60,7 @@ func makeDiskJournal(
 		entryType: entryType,
 	}
 
-	earliest, err := j.readEarliestOrdinalReal()
+	earliest, err := j.readEarliestOrdinalFromDisk()
 	if ioutil.IsNotExist(err) {
 		// Continue with j.earliestValid = false.
 	} else if err != nil {
@@ -70,7 +70,7 @@ func makeDiskJournal(
 		j.earliest = earliest
 	}
 
-	latest, err := j.readLatestOrdinalReal()
+	latest, err := j.readLatestOrdinalFromDisk()
 	if ioutil.IsNotExist(err) {
 		// Continue with j.latestValid = false.
 	} else if err != nil {
@@ -119,7 +119,7 @@ func (j diskJournal) journalEntryPath(o journalOrdinal) string {
 // latest ordinals. The read functions may return an error for which
 // ioutil.IsNotExist() returns true.
 
-func (j diskJournal) readOrdinal(path string) (journalOrdinal, error) {
+func (j diskJournal) readOrdinalFromDisk(path string) (journalOrdinal, error) {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {
 		return 0, err
@@ -127,8 +127,7 @@ func (j diskJournal) readOrdinal(path string) (journalOrdinal, error) {
 	return makeJournalOrdinal(string(buf))
 }
 
-func (j *diskJournal) writeOrdinal(
-	path string, o journalOrdinal) error {
+func (j *diskJournal) writeOrdinalToDisk(path string, o journalOrdinal) error {
 	// Don't use ioutil.WriteFile because it truncates the file first,
 	// and if there's a crash it will leave the journal in an unknown
 	// state.  TODO: it's technically possible a partial write could
@@ -158,12 +157,12 @@ func (j *diskJournal) writeOrdinal(
 	return nil
 }
 
-func (j diskJournal) readEarliestOrdinalReal() (journalOrdinal, error) {
-	return j.readOrdinal(j.earliestPath())
+func (j diskJournal) readEarliestOrdinalFromDisk() (journalOrdinal, error) {
+	return j.readOrdinalFromDisk(j.earliestPath())
 }
 
-func (j diskJournal) readLatestOrdinalReal() (journalOrdinal, error) {
-	return j.readOrdinal(j.latestPath())
+func (j diskJournal) readLatestOrdinalFromDisk() (journalOrdinal, error) {
+	return j.readOrdinalFromDisk(j.latestPath())
 }
 
 func (j diskJournal) readEarliestOrdinal() (journalOrdinal, error) {
@@ -174,7 +173,7 @@ func (j diskJournal) readEarliestOrdinal() (journalOrdinal, error) {
 }
 
 func (j *diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
-	err := j.writeOrdinal(j.earliestPath(), o)
+	err := j.writeOrdinalToDisk(j.earliestPath(), o)
 	if err != nil {
 		return err
 	}
@@ -191,7 +190,7 @@ func (j diskJournal) readLatestOrdinal() (journalOrdinal, error) {
 }
 
 func (j *diskJournal) writeLatestOrdinal(o journalOrdinal) error {
-	err := j.writeOrdinal(j.latestPath(), o)
+	err := j.writeOrdinalToDisk(j.latestPath(), o)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -169,7 +169,10 @@ func (j diskJournal) readLatestOrdinalReal() (journalOrdinal, error) {
 
 func (j diskJournal) readEarliestOrdinal() (
 	journalOrdinal, error) {
-	return j.readOrdinal(j.earliestPath())
+	if !j.earliestValid {
+		return journalOrdinal(0), errors.WithStack(os.ErrNotExist)
+	}
+	return j.earliest, nil
 }
 
 func (j *diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
@@ -183,7 +186,10 @@ func (j *diskJournal) writeEarliestOrdinal(o journalOrdinal) error {
 }
 
 func (j diskJournal) readLatestOrdinal() (journalOrdinal, error) {
-	return j.readOrdinal(j.latestPath())
+	if !j.latestValid {
+		return journalOrdinal(0), errors.WithStack(os.ErrNotExist)
+	}
+	return j.latest, nil
 }
 
 func (j *diskJournal) writeLatestOrdinal(o journalOrdinal) error {

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -158,8 +158,7 @@ func (j *diskJournal) writeOrdinal(
 	return nil
 }
 
-func (j diskJournal) readEarliestOrdinalReal() (
-	journalOrdinal, error) {
+func (j diskJournal) readEarliestOrdinalReal() (journalOrdinal, error) {
 	return j.readOrdinal(j.earliestPath())
 }
 
@@ -167,8 +166,7 @@ func (j diskJournal) readLatestOrdinalReal() (journalOrdinal, error) {
 	return j.readOrdinal(j.latestPath())
 }
 
-func (j diskJournal) readEarliestOrdinal() (
-	journalOrdinal, error) {
+func (j diskJournal) readEarliestOrdinal() (journalOrdinal, error) {
 	if !j.earliestValid {
 		return journalOrdinal(0), errors.WithStack(os.ErrNotExist)
 	}

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -370,15 +370,8 @@ func (j *diskJournal) move(newDir string) (oldDir string, err error) {
 }
 
 func (j diskJournal) length() (uint64, error) {
-	first, err := j.readEarliestOrdinal()
-	if ioutil.IsNotExist(err) {
+	if !j.earliestValid || !j.latestValid {
 		return 0, nil
-	} else if err != nil {
-		return 0, err
 	}
-	last, err := j.readLatestOrdinal()
-	if err != nil {
-		return 0, err
-	}
-	return uint64(last - first + 1), nil
+	return uint64(j.latest - j.earliest + 1), nil
 }

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -169,6 +169,10 @@ func (j diskJournal) readLatestOrdinalFromDisk() (journalOrdinal, error) {
 	return j.readOrdinalFromDisk(j.latestPath())
 }
 
+func (j diskJournal) empty() bool {
+	return !j.earliestValid || !j.latestValid
+}
+
 // TODO: Change {read,write}{Earliest,Latest}Ordinal() to
 // {get,set}{Earliest,Latest}Ordinal(), and have the getters return an
 // isValid bool, or an invalid journalOrdinal instead of an error.
@@ -359,10 +363,6 @@ func (j *diskJournal) move(newDir string) (oldDir string, err error) {
 	oldDir = j.dir
 	j.dir = newDir
 	return oldDir, nil
-}
-
-func (j diskJournal) empty() bool {
-	return !j.earliestValid || !j.latestValid
 }
 
 func (j diskJournal) length() uint64 {

--- a/libkbfs/disk_journal.go
+++ b/libkbfs/disk_journal.go
@@ -359,9 +359,9 @@ func (j *diskJournal) move(newDir string) (oldDir string, err error) {
 	return oldDir, nil
 }
 
-func (j diskJournal) length() (uint64, error) {
+func (j diskJournal) length() uint64 {
 	if !j.earliestValid || !j.latestValid {
-		return 0, nil
+		return 0
 	}
-	return uint64(j.latest - j.earliest + 1), nil
+	return uint64(j.latest - j.earliest + 1)
 }

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -35,7 +35,7 @@ func TestDiskJournalOrdinals(t *testing.T) {
 
 	readEarliest := func() (journalOrdinal, error) {
 		earliest, err := j.readEarliestOrdinal()
-		earliestReal, errReal := j.readEarliestOrdinalReal()
+		earliestReal, errReal := j.readEarliestOrdinalFromDisk()
 		require.Equal(t, earliestReal, earliest)
 		if ioutil.IsNotExist(err) && ioutil.IsNotExist(errReal) {
 			return earliest, err
@@ -47,7 +47,7 @@ func TestDiskJournalOrdinals(t *testing.T) {
 
 	readLatest := func() (journalOrdinal, error) {
 		latest, err := j.readLatestOrdinal()
-		latestReal, errReal := j.readLatestOrdinalReal()
+		latestReal, errReal := j.readLatestOrdinalFromDisk()
 		require.Equal(t, latestReal, latest)
 		if ioutil.IsNotExist(err) && ioutil.IsNotExist(errReal) {
 			return latest, err

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -81,13 +81,13 @@ func TestDiskJournalOrdinals(t *testing.T) {
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), o)
+	require.Equal(t, firstValidJournalOrdinal, o)
 
 	expectRange(1, 1)
 
 	o, err = j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(2), o)
+	require.Equal(t, firstValidJournalOrdinal+1, o)
 
 	expectRange(1, 2)
 
@@ -118,11 +118,11 @@ func TestDiskJournalClear(t *testing.T) {
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), o)
+	require.Equal(t, firstValidJournalOrdinal, o)
 
 	o, err = j.appendJournalEntry(nil, testJournalEntry{2})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(2), o)
+	require.Equal(t, firstValidJournalOrdinal+1, o)
 
 	err = j.clear()
 	require.NoError(t, err)
@@ -173,7 +173,7 @@ func TestDiskJournalMove(t *testing.T) {
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), o)
+	require.Equal(t, firstValidJournalOrdinal, o)
 
 	moveOldDir, err := j.move(newDir)
 	require.NoError(t, err)

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -65,31 +65,19 @@ func TestDiskJournalOrdinals(t *testing.T) {
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(0), o)
+	require.Equal(t, journalOrdinal(1), o)
 
 	earliest, err := readEarliest()
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(0), earliest)
+	require.Equal(t, journalOrdinal(1), earliest)
 
 	latest, err := readLatest()
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(0), latest)
+	require.Equal(t, journalOrdinal(1), latest)
 
 	o, err = j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), o)
-
-	earliest, err = readEarliest()
-	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(0), earliest)
-
-	latest, err = readLatest()
-	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), latest)
-
-	empty, err := j.removeEarliest()
-	require.NoError(t, err)
-	require.False(t, empty)
+	require.Equal(t, journalOrdinal(2), o)
 
 	earliest, err = readEarliest()
 	require.NoError(t, err)
@@ -97,7 +85,19 @@ func TestDiskJournalOrdinals(t *testing.T) {
 
 	latest, err = readLatest()
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), latest)
+	require.Equal(t, journalOrdinal(2), latest)
+
+	empty, err := j.removeEarliest()
+	require.NoError(t, err)
+	require.False(t, empty)
+
+	earliest, err = readEarliest()
+	require.NoError(t, err)
+	require.Equal(t, journalOrdinal(2), earliest)
+
+	latest, err = readLatest()
+	require.NoError(t, err)
+	require.Equal(t, journalOrdinal(2), latest)
 
 	err = j.clear()
 	require.NoError(t, err)
@@ -124,11 +124,11 @@ func TestDiskJournalClear(t *testing.T) {
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(0), o)
+	require.Equal(t, journalOrdinal(1), o)
 
 	o, err = j.appendJournalEntry(nil, testJournalEntry{2})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(1), o)
+	require.Equal(t, journalOrdinal(2), o)
 
 	err = j.clear()
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestDiskJournalMove(t *testing.T) {
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
-	require.Equal(t, journalOrdinal(0), o)
+	require.Equal(t, journalOrdinal(1), o)
 
 	moveOldDir, err := j.move(newDir)
 	require.NoError(t, err)

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -29,7 +29,9 @@ func TestDiskJournalClear(t *testing.T) {
 	}()
 
 	codec := kbfscodec.NewMsgpack()
-	j := makeDiskJournal(codec, tempdir, reflect.TypeOf(testJournalEntry{}))
+	j, err := makeDiskJournal(
+		codec, tempdir, reflect.TypeOf(testJournalEntry{}))
+	require.NoError(t, err)
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
@@ -58,7 +60,9 @@ func TestDiskJournalMoveEmpty(t *testing.T) {
 	newDir := oldDir + ".new"
 
 	codec := kbfscodec.NewMsgpack()
-	j := makeDiskJournal(codec, oldDir, reflect.TypeOf(testJournalEntry{}))
+	j, err := makeDiskJournal(
+		codec, oldDir, reflect.TypeOf(testJournalEntry{}))
+	require.NoError(t, err)
 	require.Equal(t, oldDir, j.dir)
 
 	moveOldDir, err := j.move(newDir)
@@ -79,7 +83,9 @@ func TestDiskJournalMove(t *testing.T) {
 	newDir := oldDir + ".new"
 
 	codec := kbfscodec.NewMsgpack()
-	j := makeDiskJournal(codec, oldDir, reflect.TypeOf(testJournalEntry{}))
+	j, err := makeDiskJournal(
+		codec, oldDir, reflect.TypeOf(testJournalEntry{}))
+	require.NoError(t, err)
 	require.Equal(t, oldDir, j.dir)
 
 	o, err := j.appendJournalEntry(nil, testJournalEntry{1})

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -20,6 +20,16 @@ type testJournalEntry struct {
 	I int
 }
 
+func requireEqualOrdinal(t *testing.T, o journalOrdinal, err error,
+	oDisk journalOrdinal, errDisk error) {
+	require.Equal(t, oDisk, o)
+	if ioutil.IsNotExist(err) && ioutil.IsNotExist(errDisk) {
+		return
+	}
+	require.NoError(t, err)
+	require.NoError(t, errDisk)
+}
+
 // TestDiskJournalOrdinals makes sure the in-memory ordinals stay in
 // sync with the on-disk ones.
 func TestDiskJournalOrdinals(t *testing.T) {
@@ -37,25 +47,15 @@ func TestDiskJournalOrdinals(t *testing.T) {
 
 	readEarliest := func() (journalOrdinal, error) {
 		earliest, err := j.readEarliestOrdinal()
-		earliestReal, errReal := j.readEarliestOrdinalFromDisk()
-		require.Equal(t, earliestReal, earliest)
-		if ioutil.IsNotExist(err) && ioutil.IsNotExist(errReal) {
-			return earliest, err
-		}
-		require.NoError(t, err)
-		require.NoError(t, errReal)
+		earliestDisk, errDisk := j.readEarliestOrdinalFromDisk()
+		requireEqualOrdinal(t, earliest, err, earliestDisk, errDisk)
 		return earliest, err
 	}
 
 	readLatest := func() (journalOrdinal, error) {
 		latest, err := j.readLatestOrdinal()
-		latestReal, errReal := j.readLatestOrdinalFromDisk()
-		require.Equal(t, latestReal, latest)
-		if ioutil.IsNotExist(err) && ioutil.IsNotExist(errReal) {
-			return latest, err
-		}
-		require.NoError(t, err)
-		require.NoError(t, errReal)
+		latestDisk, errDisk := j.readLatestOrdinalFromDisk()
+		requireEqualOrdinal(t, latest, err, latestDisk, errDisk)
 		return latest, err
 	}
 

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -83,19 +83,19 @@ func TestDiskJournalOrdinals(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, firstValidJournalOrdinal, o)
 
-	expectRange(1, 1)
+	expectRange(firstValidJournalOrdinal, firstValidJournalOrdinal)
 
 	o, err = j.appendJournalEntry(nil, testJournalEntry{1})
 	require.NoError(t, err)
 	require.Equal(t, firstValidJournalOrdinal+1, o)
 
-	expectRange(1, 2)
+	expectRange(firstValidJournalOrdinal, firstValidJournalOrdinal+1)
 
 	empty, err := j.removeEarliest()
 	require.NoError(t, err)
 	require.False(t, empty)
 
-	expectRange(2, 2)
+	expectRange(firstValidJournalOrdinal+1, firstValidJournalOrdinal+1)
 
 	err = j.clear()
 	require.NoError(t, err)

--- a/libkbfs/disk_journal_test.go
+++ b/libkbfs/disk_journal_test.go
@@ -87,6 +87,18 @@ func TestDiskJournalOrdinals(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, journalOrdinal(1), latest)
 
+	empty, err := j.removeEarliest()
+	require.NoError(t, err)
+	require.False(t, empty)
+
+	earliest, err = readEarliest()
+	require.NoError(t, err)
+	require.Equal(t, journalOrdinal(1), earliest)
+
+	latest, err = readLatest()
+	require.NoError(t, err)
+	require.Equal(t, journalOrdinal(1), latest)
+
 	err = j.clear()
 	require.NoError(t, err)
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -132,7 +132,7 @@ func (j mdIDJournal) readJournalEntry(r MetadataRevision) (
 
 // All functions below are public functions.
 
-func (j mdIDJournal) length() (uint64, error) {
+func (j mdIDJournal) length() uint64 {
 	return j.j.length()
 }
 

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -24,7 +24,7 @@ import (
 // TODO: Write unit tests for this. For now, we're relying on
 // md_journal.go's unit tests.
 type mdIDJournal struct {
-	j diskJournal
+	j *diskJournal
 }
 
 // An mdIDJournalEntry is an MdID and a boolean describing whether

--- a/libkbfs/md_id_journal.go
+++ b/libkbfs/md_id_journal.go
@@ -51,9 +51,13 @@ type mdIDJournalEntry struct {
 	codec.UnknownFieldSetHandler
 }
 
-func makeMdIDJournal(codec kbfscodec.Codec, dir string) mdIDJournal {
-	j := makeDiskJournal(codec, dir, reflect.TypeOf(mdIDJournalEntry{}))
-	return mdIDJournal{j}
+func makeMdIDJournal(codec kbfscodec.Codec, dir string) (mdIDJournal, error) {
+	j, err :=
+		makeDiskJournal(codec, dir, reflect.TypeOf(mdIDJournalEntry{}))
+	if err != nil {
+		return mdIDJournal{}, err
+	}
+	return mdIDJournal{j}, nil
 }
 
 func ordinalToRevision(o journalOrdinal) (MetadataRevision, error) {

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -992,16 +992,13 @@ func (j mdJournal) readLatestRevision() (MetadataRevision, error) {
 	return j.j.readLatestRevision()
 }
 
-func (j mdJournal) length() (uint64, error) {
+func (j mdJournal) length() uint64 {
 	return j.j.length()
 }
 
 func (j mdJournal) atLeastNNonLocalSquashes(
 	numNonLocalSquashes uint64) (bool, error) {
-	size, err := j.length()
-	if err != nil {
-		return false, err
-	}
+	size := j.length()
 	if size < numNonLocalSquashes {
 		return false, nil
 	}

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -221,9 +221,13 @@ func makeMDJournal(
 	mdVer MetadataVer, dir string,
 	log logger.Logger) (*mdJournal, error) {
 	journalDir := mdJournalPath(dir)
+	idJournal, err := makeMdIDJournal(codec, journalDir)
+	if err != nil {
+		return nil, err
+	}
 	return makeMDJournalWithIDJournal(
 		ctx, uid, key, codec, crypto, clock, tlfID, mdVer, dir,
-		makeMdIDJournal(codec, journalDir), log)
+		idJournal, log)
 }
 
 // The functions below are for building various paths.
@@ -654,7 +658,10 @@ func (j *mdJournal) convertToBranch(
 		}
 	}()
 
-	tempJournal := makeMdIDJournal(j.codec, journalTempDir)
+	tempJournal, err := makeMdIDJournal(j.codec, journalTempDir)
+	if err != nil {
+		return err
+	}
 
 	var prevID MdID
 
@@ -1440,7 +1447,10 @@ func (j *mdJournal) resolveAndClear(
 	// be cleaned up whenever the entire journal goes empty.
 
 	j.log.CDebugf(ctx, "Using temp dir %s for new IDs", idJournalTempDir)
-	otherIDJournal := makeMdIDJournal(j.codec, idJournalTempDir)
+	otherIDJournal, err := makeMdIDJournal(j.codec, idJournalTempDir)
+	if err != nil {
+		return MdID{}, err
+	}
 	defer func() {
 		j.log.CDebugf(ctx, "Removing temp dir %s", idJournalTempDir)
 		removeErr := ioutil.RemoveAll(idJournalTempDir)

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -354,7 +354,7 @@ func (s *mdServerTlfStorage) journalLength(bid BranchID) (uint64, error) {
 		return 0, nil
 	}
 
-	return j.length()
+	return j.length(), nil
 }
 
 func (s *mdServerTlfStorage) getForTLF(

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -206,7 +206,10 @@ func (s *mdServerTlfStorage) getOrCreateBranchJournalLocked(
 		return mdIDJournal{}, err
 	}
 
-	j = makeMdIDJournal(s.codec, dir)
+	j, err = makeMdIDJournal(s.codec, dir)
+	if err != nil {
+		return mdIDJournal{}, err
+	}
 	s.branchJournals[bid] = j
 	return j, nil
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1249,16 +1249,8 @@ func (j *tlfJournal) getJournalEntryCounts() (
 		return 0, 0, err
 	}
 
-	blockEntryCount, err = j.blockJournal.length()
-	if err != nil {
-		return 0, 0, err
-	}
-
-	mdEntryCount, err = j.mdJournal.length()
-	if err != nil {
-		return 0, 0, err
-	}
-
+	blockEntryCount = j.blockJournal.length()
+	mdEntryCount = j.mdJournal.length()
 	return blockEntryCount, mdEntryCount, nil
 }
 
@@ -1286,10 +1278,7 @@ func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 	if err != nil {
 		return TLFJournalStatus{}, err
 	}
-	blockEntryCount, err := j.blockJournal.length()
-	if err != nil {
-		return TLFJournalStatus{}, err
-	}
+	blockEntryCount := j.blockJournal.length()
 	lastFlushErr := ""
 	if j.lastFlushErr != nil {
 		lastFlushErr = j.lastFlushErr.Error()
@@ -1555,15 +1544,8 @@ func (j *tlfJournal) disable() (wasEnabled bool, err error) {
 		return false, err
 	}
 
-	blockEntryCount, err := j.blockJournal.length()
-	if err != nil {
-		return false, err
-	}
-
-	mdEntryCount, err := j.mdJournal.length()
-	if err != nil {
-		return false, err
-	}
+	blockEntryCount := j.blockJournal.length()
+	mdEntryCount := j.mdJournal.length()
 
 	// You can only disable an empty journal.
 	if blockEntryCount > 0 || mdEntryCount > 0 {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -494,7 +494,8 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
 			ctx, id, bCtx, data2, serverHalf)
 	}()
 
-	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 2)
+	numFlushed, rev, converted, err :=
+		tlfJournal.flushBlockEntries(ctx, firstValidJournalOrdinal+1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)
@@ -531,7 +532,8 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
 			ctx, id, bCtx, data2, serverHalf)
 	}()
 
-	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 2)
+	numFlushed, rev, converted, err :=
+		tlfJournal.flushBlockEntries(ctx, firstValidJournalOrdinal+1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -411,7 +411,8 @@ func testTLFJournalBlockOpBasic(t *testing.T, ver MetadataVer) {
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
-	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, converted, err :=
+		tlfJournal.flushBlockEntries(ctx, firstValidJournalOrdinal+1)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -494,7 +494,7 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
 			ctx, id, bCtx, data2, serverHalf)
 	}()
 
-	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 2)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)
@@ -531,7 +531,7 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
 			ctx, id, bCtx, data2, serverHalf)
 	}()
 
-	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 1)
+	numFlushed, rev, converted, err := tlfJournal.flushBlockEntries(ctx, 2)
 	require.NoError(t, err)
 	require.Equal(t, 1, numFlushed)
 	require.Equal(t, rev, MetadataRevisionUninitialized)


### PR DESCRIPTION
This makes it possible to not have to tediously
error-check on every ordinal get.

Start journals at 1 instead of 0, so that 0
may in the future be declared invalid.

This reduces the number of reads, also, which may
improve performance slightly (but that's not the main
focus).