### PR TITLE
libkbfs: add a `BlockOps` method for just getting the size of a block, and use in CR

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -355,6 +355,10 @@ func (j *blockJournal) getData(id kbfsblock.ID) (
 	return j.s.getData(id)
 }
 
+func (j *blockJournal) getDataSize(id kbfsblock.ID) (int64, error) {
+	return j.s.getDataSize(id)
+}
+
 func (j *blockJournal) getStoredBytes() int64 {
 	return j.aggregateInfo.StoredBytes
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -90,12 +90,12 @@ func (b *BlockOpsStandard) GetEncodedSize(ctx context.Context, kmd KeyMetadata,
 	// to verify the BlockID.
 	block := NewCommonBlock()
 	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd,
-		blockPtr, block, TransientEntry)
+		blockPtr, block, NoCacheEntry)
 	err := <-errCh
 	if err != nil {
 		return 0, err
 	}
-	return block.(*CommonBlock).cachedEncodedSize, nil
+	return block.GetEncodedSize(), nil
 }
 
 // Ready implements the BlockOps interface for BlockOpsStandard.

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -68,6 +68,36 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 	return <-errCh
 }
 
+// GetEncodedSize implements the BlockOps interface for
+// BlockOpsStandard.
+func (b *BlockOpsStandard) GetEncodedSize(ctx context.Context, kmd KeyMetadata,
+	blockPtr BlockPointer) (uint32, error) {
+	// Check the journal explicitly first, so we don't get stuck in
+	// the block-fetching queue.
+	if journalBServer, ok := b.config.BlockServer().(journalBlockServer); ok {
+		size, found, err := journalBServer.getBlockSizeFromJournal(
+			kmd.TlfID(), blockPtr.ID)
+		if err != nil {
+			return 0, err
+		}
+		if found {
+			return size, nil
+		}
+	}
+
+	// Otherwise fetch the entire block from the server, since we
+	// can't trust the journal to report the size without being able
+	// to verify the BlockID.
+	block := NewCommonBlock()
+	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd,
+		blockPtr, block, TransientEntry)
+	err := <-errCh
+	if err != nil {
+		return 0, err
+	}
+	return block.(*CommonBlock).cachedEncodedSize, nil
+}
+
 // Ready implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) Ready(ctx context.Context, kmd KeyMetadata,
 	block Block) (id kbfsblock.ID, plainSize int, readyBlockData ReadyBlockData,

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -433,67 +433,6 @@ func (fbo *folderBlockOps) GetBlockForReading(ctx context.Context,
 		NewCommonBlock, NoCacheEntry, path{}, blockRead)
 }
 
-// GetBlocksForReading retrieves the blocks pointed to by ptrs, all of
-// which must be valid, either from the cache or from the server.  The
-// returned block may have a generic type (not DirBlock or FileBlock).
-//
-// The caller can specify a set of pointers using
-// `ignoreRecoverableForRemovalErrors` for which "recoverable" fetch
-// errors are tolerated.  In that case, the returned map will not have
-// an entry for any pointers in the
-// `ignoreRecoverableForRemovalErrors` set that hit such an error.
-//
-// This should be called for "internal" operations, like conflict
-// resolution and state checking, which don't know what kind of block
-// the pointers refer to.  The blocks will not be cached, if they
-// weren't in the cache already.
-func (fbo *folderBlockOps) GetBlocksForReading(ctx context.Context,
-	lState *lockState, kmd KeyMetadata, ptrs []BlockPointer,
-	ignoreRecoverableForRemovalErrors map[BlockPointer]bool,
-	branch BranchName) (map[BlockPointer]Block, error) {
-	fbo.blockLock.RLock(lState)
-	defer fbo.blockLock.RUnlock(lState)
-
-	blockResults := make([]Block, len(ptrs))
-	eg, groupCtx := errgroup.WithContext(ctx)
-	for i, ptr := range ptrs {
-		i, ptr := i, ptr
-		eg.Go(func() error {
-			block, err := fbo.getBlockHelperLocked(groupCtx, nil, kmd, ptr,
-				branch, NewCommonBlock, NoCacheEntry, path{}, blockReadParallel)
-			// TODO: we might be able to recover the size of the
-			// top-most block of a removed file using the merged
-			// directory entry, the same way we do in
-			// `folderBranchOps.unrefEntry`.
-			if isRecoverableBlockErrorForRemoval(err) &&
-				ignoreRecoverableForRemovalErrors[ptr] {
-				fbo.log.CDebugf(groupCtx, "Hit an ignorable, recoverable "+
-					"error for block %v: %v", ptr, err)
-				return nil
-			}
-
-			if err != nil {
-				return err
-			}
-			blockResults[i] = block
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return nil, err
-	}
-
-	blocks := make(map[BlockPointer]Block, len(ptrs))
-	for i, ptr := range ptrs {
-		block := blockResults[i]
-		if block != nil {
-			blocks[ptr] = block
-		}
-	}
-	return blocks, nil
-}
-
 // GetCleanEncodedBlocksSizeSum retrieves the sum of the encoded sizes
 // of the blocks pointed to by ptrs, all of which must be valid,
 // either from the cache or from the server.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1081,6 +1081,12 @@ type BlockOps interface {
 	Get(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
 		block Block, cacheLifetime BlockCacheLifetime) error
 
+	// GetEncodedSize gets the encoded size of the block associated
+	// with the given block pointer (which belongs to the TLF with the
+	// given key metadata).
+	GetEncodedSize(ctx context.Context, kmd KeyMetadata,
+		blockPtr BlockPointer) (uint32, error)
+
 	// Ready turns the given block (which belongs to the TLF with
 	// the given key metadata) into encoded (and encrypted) data,
 	// and calculates its ID and size, so that we can do a bunch

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2988,6 +2988,17 @@ func (_mr *_MockBlockOpsRecorder) Get(arg0, arg1, arg2, arg3, arg4 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Get", arg0, arg1, arg2, arg3, arg4)
 }
 
+func (_m *MockBlockOps) GetEncodedSize(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer) (uint32, error) {
+	ret := _m.ctrl.Call(_m, "GetEncodedSize", ctx, kmd, blockPtr)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockBlockOpsRecorder) GetEncodedSize(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetEncodedSize", arg0, arg1, arg2)
+}
+
 func (_m *MockBlockOps) Ready(ctx context.Context, kmd KeyMetadata, block Block) (kbfsblock.ID, int, ReadyBlockData, error) {
 	ret := _m.ctrl.Call(_m, "Ready", ctx, kmd, block)
 	ret0, _ := ret[0].(kbfsblock.ID)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1611,6 +1611,23 @@ func (j *tlfJournal) getBlockData(id kbfsblock.ID) (
 	return j.blockJournal.getData(id)
 }
 
+func (j *tlfJournal) getBlockSize(id kbfsblock.ID) (uint32, error) {
+	j.journalLock.RLock()
+	defer j.journalLock.RUnlock()
+	if err := j.checkEnabledLocked(); err != nil {
+		return 0, err
+	}
+
+	size, err := j.blockJournal.getDataSize(id)
+	if err != nil {
+		return 0, err
+	}
+	// Block sizes are restricted, but `size` is an int64 because
+	// that's what the OS gives us.  Convert it to a uint32. TODO:
+	// check this is safe?
+	return uint32(size), nil
+}
+
 // ErrDiskLimitTimeout is returned when putBlockData exceeds
 // diskLimitTimeout when trying to acquire bytes to put.
 type ErrDiskLimitTimeout struct {


### PR DESCRIPTION
During CR, we need to get the size of all blocks referenced and unreferenced, for block accounting purposes.  Previously, we were doing this by fetching all the blocks in parallel at once, keeping them all in memory until they are all fetched, and then calculating the sum.

Instead, we can just get the sum.  If the block is in the trusted local journal, we don't even have to read the block data from disk, we can just get the size from the file info.  If the block is on the server, we still have to download it since we can't trust the server, but we don't need to keep it in memory afterwards.

I haven't tested the performance improvements yet (will do soon), but it is an obvious win for memory usage during CR.

Issue: KBFS-1974