### PR TITLE
tlf_journal: don't override non-nil errors after block flush

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -880,7 +880,7 @@ func (j *tlfJournal) flushBlockEntries(
 	defer func() {
 		if !cleared {
 			clearErr := j.clearFlushingBlockIDs(entries)
-			if err != nil {
+			if err == nil {
 				err = clearErr
 			}
 		}


### PR DESCRIPTION
Issue: KBFS-1982