### PR TITLE
tlf_journal: avoid reading/signing an MD for no reason

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1185,6 +1185,9 @@ func (j *tlfJournal) flushOneMDOp(
 
 	mdServer := j.config.MDServer()
 
+	// TODO: Do we need `end` at all, or can we just pass
+	// `maxMDRevToFlush+1` here?  The only argument for `end` is that
+	// it might help if the block and MD journals are out of sync.
 	mdID, rmds, extra, err := j.getNextMDEntryToFlush(ctx, end)
 	if err != nil {
 		return false, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1170,6 +1170,12 @@ func (j *tlfJournal) removeFlushedMDEntry(ctx context.Context,
 func (j *tlfJournal) flushOneMDOp(
 	ctx context.Context, end MetadataRevision,
 	maxMDRevToFlush MetadataRevision) (flushed bool, err error) {
+	if maxMDRevToFlush == MetadataRevisionUninitialized {
+		// Short-cut `getNextMDEntryToFlush`, which would otherwise read
+		// an MD from disk and sign it unnecessarily.
+		return false, nil
+	}
+
 	j.log.CDebugf(ctx, "Flushing one MD to server")
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
When there are still blocks remaining to be flushed for the earliest
MD in the journal, we don't need to bother reading it from disk and
signing it, just to decide we aren't going to flush it after all.  Not
sure if this helps performance much, but at least it cuts down log
spam a bit.