### PR TITLE
libkbfs: Pass username+uid to identify instead of only uid

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -177,7 +177,7 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	return nil
 }
 
-// identifyUserToChan calls identifyUID and plugs the result into the error channnel.
+// identifyUserToChan calls identifyUser and plugs the result into the error channnel.
 func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier, name libkb.NormalizedUsername, uid keybase1.UID,
 	isPublic bool, errChan chan error) {

--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -91,17 +91,20 @@ func makeNugAndTIForTest() (testNormalizedUsernameGetter, *testIdentifier) {
 			},
 		}
 }
+
+func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UID]libkb.NormalizedUsername {
+	return (map[keybase1.UID]libkb.NormalizedUsername)(g)
+}
+
 func TestIdentify(t *testing.T) {
 	nug, ti := makeNugAndTIForTest()
 
 	uids := make(map[keybase1.UID]bool, len(nug))
-	uidList := make([]keybase1.UID, 0, len(nug))
 	for u := range nug {
 		uids[u] = true
-		uidList = append(uidList, u)
 	}
 
-	err := identifyUserListForTLF(context.Background(), nug, ti, uidList, false)
+	err := identifyUsersForTLF(context.Background(), nug, ti, nug.uidMap(), nil, false)
 	require.NoError(t, err)
 	require.Equal(t, uids, ti.identifiedUids)
 }
@@ -116,21 +119,16 @@ func TestIdentifyAlternativeBehaviors(t *testing.T) {
 		},
 	}
 
-	uidList := make([]keybase1.UID, 0, len(nug))
-	for u := range nug {
-		uidList = append(uidList, u)
-	}
-
 	ctx, err := makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	require.NoError(t, err)
-	err = identifyUserListForTLF(ctx, nug, ti, uidList, false)
+	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
 	require.Error(t, err)
 
 	ctx, err = makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_GUI)
 	require.NoError(t, err)
-	err = identifyUserListForTLF(ctx, nug, ti, uidList, false)
+	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
 	require.NoError(t, err)
 	tb := getExtendedIdentify(ctx).getTlfBreakAndClose()
 	require.Len(t, tb.Breaks, 1)

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -67,6 +67,16 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 	return ok
 }
 
+// ResolvedReadersMap returns a map of resolved readers from uid to usernames.
+func (h TlfHandle) ResolvedReadersMap() map[keybase1.UID]libkb.NormalizedUsername {
+	return h.resolvedReaders
+}
+
+// ResolvedWritersMap returns a map of resolved writers from uid to usernames.
+func (h TlfHandle) ResolvedWritersMap() map[keybase1.UID]libkb.NormalizedUsername {
+	return h.resolvedWriters
+}
+
 func (h TlfHandle) unsortedResolvedWriters() []keybase1.UID {
 	if len(h.resolvedWriters) == 0 {
 		return nil


### PR DESCRIPTION
Pass the username to the identify routines rather than using only uid and getting the username based on that.