### PR TITLE
Revert "libkbfs: Pass username+uid to identify instead of only uid"

### DIFF
--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -91,20 +91,17 @@ func makeNugAndTIForTest() (testNormalizedUsernameGetter, *testIdentifier) {
 			},
 		}
 }
-
-func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UID]libkb.NormalizedUsername {
-	return (map[keybase1.UID]libkb.NormalizedUsername)(g)
-}
-
 func TestIdentify(t *testing.T) {
 	nug, ti := makeNugAndTIForTest()
 
 	uids := make(map[keybase1.UID]bool, len(nug))
+	uidList := make([]keybase1.UID, 0, len(nug))
 	for u := range nug {
 		uids[u] = true
+		uidList = append(uidList, u)
 	}
 
-	err := identifyUsersForTLF(context.Background(), nug, ti, nug.uidMap(), nil, false)
+	err := identifyUserListForTLF(context.Background(), nug, ti, uidList, false)
 	require.NoError(t, err)
 	require.Equal(t, uids, ti.identifiedUids)
 }
@@ -119,16 +116,21 @@ func TestIdentifyAlternativeBehaviors(t *testing.T) {
 		},
 	}
 
+	uidList := make([]keybase1.UID, 0, len(nug))
+	for u := range nug {
+		uidList = append(uidList, u)
+	}
+
 	ctx, err := makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	require.NoError(t, err)
-	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
+	err = identifyUserListForTLF(ctx, nug, ti, uidList, false)
 	require.Error(t, err)
 
 	ctx, err = makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_GUI)
 	require.NoError(t, err)
-	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
+	err = identifyUserListForTLF(ctx, nug, ti, uidList, false)
 	require.NoError(t, err)
 	tb := getExtendedIdentify(ctx).getTlfBreakAndClose()
 	require.Len(t, tb.Breaks, 1)

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -67,16 +67,6 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 	return ok
 }
 
-// ResolvedReadersMap returns a map of resolved readers from uid to usernames.
-func (h TlfHandle) ResolvedReadersMap() map[keybase1.UID]libkb.NormalizedUsername {
-	return h.resolvedReaders
-}
-
-// ResolvedWritersMap returns a map of resolved writers from uid to usernames.
-func (h TlfHandle) ResolvedWritersMap() map[keybase1.UID]libkb.NormalizedUsername {
-	return h.resolvedWriters
-}
-
 func (h TlfHandle) unsortedResolvedWriters() []keybase1.UID {
 	if len(h.resolvedWriters) == 0 {
 		return nil


### PR DESCRIPTION
keybase/kbfs#832 was merged due to a misclick. Revert.