### PR TITLE
libkbfs: Pass usernames from TLFs to identifies

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -196,6 +196,7 @@ func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
 	// TODO: limit the number of concurrent identifies?
 	// TODO: implement a version of errgroup with limited concurrency.
 	for uid, name := range users {
+		// Capture range variables.
 		uid, name := uid, name
 		eg.Go(func() error {
 			return identifyUser(ctx, nug, identifier, name, uid, public)
@@ -206,12 +207,14 @@ func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
 }
 
 // identifyUserList identifies the users in the given list.
+// Only use this when the usernames are not known - like when rekeying.
 func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID, public bool) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	// TODO: limit the number of concurrent identifies?
 	// TODO: implement concurrency limited version of errgroup.
 	for _, uid := range uids {
+		// Capture range variable.
 		uid := uid
 		eg.Go(func() error {
 			return identifyUID(ctx, nug, identifier, uid, public)

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -141,11 +141,18 @@ func getExtendedIdentify(ctx context.Context) (ei *extendedIdentify) {
 	}
 }
 
-func identifyUID(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uid keybase1.UID, isPublic bool) error {
+func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, uid keybase1.UID, isPublic bool) error {
 	username, err := nug.GetNormalizedUsername(ctx, uid)
 	if err != nil {
 		return err
 	}
+	return identifyUser(ctx, nug, identifier, username, uid, isPublic)
+}
+
+func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, username libkb.NormalizedUsername,
+	uid keybase1.UID, isPublic bool) error {
 	var reason string
 	if isPublic {
 		reason = "You accessed a public folder."
@@ -170,6 +177,34 @@ func identifyUID(ctx context.Context, nug normalizedUsernameGetter, identifier i
 	return nil
 }
 
+// identifyUserToChan calls identifyUser and plugs the result into the error channnel.
+func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, name libkb.NormalizedUsername, uid keybase1.UID,
+	isPublic bool, errChan chan error) {
+	errChan <- identifyUser(ctx, nug, identifier, name, uid, isPublic)
+}
+
+// identifyUsers identifies the users in the given maps.
+func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, writers, readers map[keybase1.UID]libkb.NormalizedUsername,
+	public bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	nitems := len(writers) + len(readers)
+	errChan := make(chan error, nitems)
+	// TODO: limit the number of concurrent identifies? Otherwise we can use
+	// errgroup.Group here.
+	for uid, name := range writers {
+		go identifyUserToChan(ctx, nug, identifier, name, uid, public, errChan)
+	}
+	for uid, name := range readers {
+		go identifyUserToChan(ctx, nug, identifier, name, uid, public, errChan)
+	}
+
+	return readUpToNErrors(nitems, errChan)
+}
+
 // identifyUserList identifies the users in the given list.
 func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID, public bool) error {
 	ctx, cancel := context.WithCancel(ctx)
@@ -185,26 +220,35 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identif
 		}(uid)
 	}
 
-	for i := 0; i < len(uids); i++ {
+	return readUpToNErrors(len(uids), errChan)
+}
+
+// readUpToNErrors reads up to n errors from an error channel and returns
+// the first non-nil error encountered or nil after reading n nils from
+// the channel.
+func readUpToNErrors(n int, errChan chan error) error {
+	for i := 0; i < n; i++ {
 		err := <-errChan
 		if err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
-func identifyUserListForTLF(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID, public bool) error {
+// identifyUsersForTLF is a helper for identifyHandle for easier testing.
+func identifyUsersForTLF(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, writers, readers map[keybase1.UID]libkb.NormalizedUsername,
+	public bool) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
 		ei := getExtendedIdentify(ctx)
-		return ei.makeTlfBreaksIfNeeded(ctx, len(uids))
+		return ei.makeTlfBreaksIfNeeded(ctx, len(writers)+len(readers))
 	})
 
 	eg.Go(func() error {
-		return identifyUserList(ctx, nug, identifier, uids, public)
+		return identifyUsers(ctx, nug, identifier, writers, readers, public)
 	})
 
 	return eg.Wait()
@@ -212,6 +256,6 @@ func identifyUserListForTLF(ctx context.Context, nug normalizedUsernameGetter, i
 
 // identifyHandle identifies the canonical names in the given handle.
 func identifyHandle(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, h *TlfHandle) error {
-	uids := append(h.ResolvedWriters(), h.ResolvedReaders()...)
-	return identifyUserListForTLF(ctx, nug, identifier, uids, h.IsPublic())
+	return identifyUsersForTLF(ctx, nug, identifier,
+		h.ResolvedWritersMap(), h.ResolvedReadersMap(), h.IsPublic())
 }

--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -104,7 +104,7 @@ func TestIdentify(t *testing.T) {
 		uids[u] = true
 	}
 
-	err := identifyUsersForTLF(context.Background(), nug, ti, nug.uidMap(), nil, false)
+	err := identifyUsersForTLF(context.Background(), nug, ti, nug.uidMap(), false)
 	require.NoError(t, err)
 	require.Equal(t, uids, ti.identifiedUids)
 }
@@ -122,13 +122,13 @@ func TestIdentifyAlternativeBehaviors(t *testing.T) {
 	ctx, err := makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	require.NoError(t, err)
-	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
+	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), false)
 	require.Error(t, err)
 
 	ctx, err = makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_GUI)
 	require.NoError(t, err)
-	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
+	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), false)
 	require.NoError(t, err)
 	tb := getExtendedIdentify(ctx).getTlfBreakAndClose()
 	require.Len(t, tb.Breaks, 1)

--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -91,17 +91,20 @@ func makeNugAndTIForTest() (testNormalizedUsernameGetter, *testIdentifier) {
 			},
 		}
 }
+
+func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UID]libkb.NormalizedUsername {
+	return (map[keybase1.UID]libkb.NormalizedUsername)(g)
+}
+
 func TestIdentify(t *testing.T) {
 	nug, ti := makeNugAndTIForTest()
 
 	uids := make(map[keybase1.UID]bool, len(nug))
-	uidList := make([]keybase1.UID, 0, len(nug))
 	for u := range nug {
 		uids[u] = true
-		uidList = append(uidList, u)
 	}
 
-	err := identifyUserListForTLF(context.Background(), nug, ti, uidList, false)
+	err := identifyUsersForTLF(context.Background(), nug, ti, nug.uidMap(), nil, false)
 	require.NoError(t, err)
 	require.Equal(t, uids, ti.identifiedUids)
 }
@@ -116,21 +119,16 @@ func TestIdentifyAlternativeBehaviors(t *testing.T) {
 		},
 	}
 
-	uidList := make([]keybase1.UID, 0, len(nug))
-	for u := range nug {
-		uidList = append(uidList, u)
-	}
-
 	ctx, err := makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_CLI)
 	require.NoError(t, err)
-	err = identifyUserListForTLF(ctx, nug, ti, uidList, false)
+	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
 	require.Error(t, err)
 
 	ctx, err = makeExtendedIdentify(context.Background(),
 		keybase1.TLFIdentifyBehavior_CHAT_GUI)
 	require.NoError(t, err)
-	err = identifyUserListForTLF(ctx, nug, ti, uidList, false)
+	err = identifyUsersForTLF(ctx, nug, ti, nug.uidMap(), nil, false)
 	require.NoError(t, err)
 	tb := getExtendedIdentify(ctx).getTlfBreakAndClose()
 	require.Len(t, tb.Breaks, 1)

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -67,6 +67,16 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 	return ok
 }
 
+// ResolvedReadersMap returns a map of resolved readers from uid to usernames.
+func (h TlfHandle) ResolvedReadersMap() map[keybase1.UID]libkb.NormalizedUsername {
+	return h.resolvedReaders
+}
+
+// ResolvedWritersMap returns a map of resolved writers from uid to usernames.
+func (h TlfHandle) ResolvedWritersMap() map[keybase1.UID]libkb.NormalizedUsername {
+	return h.resolvedWriters
+}
+
 func (h TlfHandle) unsortedResolvedWriters() []keybase1.UID {
 	if len(h.resolvedWriters) == 0 {
 		return nil

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -67,14 +67,17 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 	return ok
 }
 
-// ResolvedReadersMap returns a map of resolved readers from uid to usernames.
-func (h TlfHandle) ResolvedReadersMap() map[keybase1.UID]libkb.NormalizedUsername {
-	return h.resolvedReaders
-}
-
-// ResolvedWritersMap returns a map of resolved writers from uid to usernames.
-func (h TlfHandle) ResolvedWritersMap() map[keybase1.UID]libkb.NormalizedUsername {
-	return h.resolvedWriters
+// ResolvedUsersMap returns a map of resolved users from uid to usernames.
+func (h TlfHandle) ResolvedUsersMap() map[keybase1.UID]libkb.NormalizedUsername {
+	m := make(map[keybase1.UID]libkb.NormalizedUsername,
+		len(h.resolvedReaders)+len(h.resolvedWriters))
+	for k, v := range h.resolvedReaders {
+		m[k] = v
+	}
+	for k, v := range h.resolvedWriters {
+		m[k] = v
+	}
+	return m
 }
 
 func (h TlfHandle) unsortedResolvedWriters() []keybase1.UID {


### PR DESCRIPTION
Passes usernames from TLFs to identify calls rather than using just the UID.