### PR TITLE
[KBFS-1920] Disk Cache Limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ kbfsfuse/kbfs_key/
 kbfsfuse/kbfs_md/
 kbfsfuse/revision
 *.test
+
+**/vim-go-test-compile

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -251,7 +251,7 @@ type backpressureDiskLimiter struct {
 	byteTracker, fileTracker *backpressureTracker
 }
 
-var _ diskLimiter = (*backpressureDiskLimiter)(nil)
+var _ DiskLimiter = (*backpressureDiskLimiter)(nil)
 
 // newBackpressureDiskLimiterWithFunctions constructs a new
 // backpressureDiskLimiter with the given parameters, and also the

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -249,6 +249,7 @@ type backpressureDiskLimiter struct {
 	// actual semaphore itself.
 	lock                     sync.RWMutex
 	byteTracker, fileTracker *backpressureTracker
+	diskCacheByteTracker     *backpressureTracker
 }
 
 var _ DiskLimiter = (*backpressureDiskLimiter)(nil)
@@ -256,10 +257,9 @@ var _ DiskLimiter = (*backpressureDiskLimiter)(nil)
 // newBackpressureDiskLimiterWithFunctions constructs a new
 // backpressureDiskLimiter with the given parameters, and also the
 // given delay function, which is overridden in tests.
-func newBackpressureDiskLimiterWithFunctions(
-	log logger.Logger,
-	backpressureMinThreshold, backpressureMaxThreshold, limitFrac float64,
-	byteLimit, fileLimit int64, maxDelay time.Duration,
+func newBackpressureDiskLimiterWithFunctions(log logger.Logger,
+	backpressureMinThreshold, backpressureMaxThreshold, journalFrac,
+	diskCacheFrac float64, byteLimit, fileLimit int64, maxDelay time.Duration,
 	delayFn func(context.Context, time.Duration) error,
 	freeBytesAndFilesFn func() (int64, int64, error)) (
 	*backpressureDiskLimiter, error) {
@@ -267,21 +267,28 @@ func newBackpressureDiskLimiterWithFunctions(
 	if err != nil {
 		return nil, err
 	}
+	// byteLimit and fileLimit must be scaled by the proportion of the limit
+	// that the journal should consume.
+	journalByteLimit := int64((float64(byteLimit) * journalFrac) + 0.5)
 	byteTracker, err := newBackpressureTracker(
 		backpressureMinThreshold, backpressureMaxThreshold,
-		limitFrac, byteLimit, freeBytes)
+		journalFrac, journalByteLimit, freeBytes)
 	if err != nil {
 		return nil, err
 	}
+	journalFileLimit := int64((float64(fileLimit) * journalFrac) + 0.5)
 	fileTracker, err := newBackpressureTracker(
 		backpressureMinThreshold, backpressureMaxThreshold,
-		limitFrac, fileLimit, freeFiles)
+		journalFrac, journalFileLimit, freeFiles)
 	if err != nil {
 		return nil, err
 	}
+	diskCacheByteLimit := int64((float64(byteLimit) * diskCacheFrac) + 0.5)
+	diskCacheByteTracker, err := newBackpressureTracker(
+		1.0, 1.0, diskCacheFrac, diskCacheByteLimit, freeBytes)
 	bdl := &backpressureDiskLimiter{
 		log, maxDelay, delayFn, freeBytesAndFilesFn, sync.RWMutex{},
-		byteTracker, fileTracker,
+		byteTracker, fileTracker, diskCacheByteTracker,
 	}
 	return bdl, nil
 }
@@ -322,14 +329,13 @@ func defaultGetFreeBytesAndFiles(path string) (int64, int64, error) {
 
 // newBackpressureDiskLimiter constructs a new backpressureDiskLimiter
 // with the given parameters.
-func newBackpressureDiskLimiter(
-	log logger.Logger,
-	backpressureMinThreshold, backpressureMaxThreshold, limitFrac float64,
-	byteLimit, fileLimit int64, maxDelay time.Duration,
-	journalPath string) (*backpressureDiskLimiter, error) {
+func newBackpressureDiskLimiter(log logger.Logger, backpressureMinThreshold,
+	backpressureMaxThreshold, journalFrac, diskCacheFrac float64, byteLimit,
+	fileLimit int64, maxDelay time.Duration, journalPath string) (
+	*backpressureDiskLimiter, error) {
 	return newBackpressureDiskLimiterWithFunctions(
 		log, backpressureMinThreshold, backpressureMaxThreshold,
-		limitFrac, byteLimit, fileLimit, maxDelay,
+		journalFrac, diskCacheFrac, byteLimit, fileLimit, maxDelay,
 		defaultDoDelay, func() (int64, int64, error) {
 			return defaultGetFreeBytesAndFiles(journalPath)
 		})

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -492,7 +492,7 @@ func (bdl *backpressureDiskLimiter) beforeDiskBlockCachePut(
 	ctx context.Context, blockBytes, diskBlockCacheBytes int64) (
 	availableBytes int64, err error) {
 	if blockBytes == 0 {
-		// Better to return an error than to panic in Acquire.
+		// Better to return an error than to panic in ForceAcquire.
 		return 0, errors.New("backpressureDiskLimiter.beforeDiskBlockCachePut" +
 			" called with 0 blockBytes")
 	}
@@ -500,7 +500,7 @@ func (bdl *backpressureDiskLimiter) beforeDiskBlockCachePut(
 	defer bdl.lock.Unlock()
 	freeBytes, freeFiles, err := bdl.freeBytesAndFilesFn()
 	if err != nil {
-		return
+		return 0, err
 	}
 	bdl.byteTracker.updateFree(freeBytes)
 	bdl.fileTracker.updateFree(freeFiles)

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -383,16 +383,15 @@ func (bdl *backpressureDiskLimiter) onJournalDisable(
 	bdl.updateFreeLocked()
 }
 
-func (bdl *backpressureDiskLimiter) onDiskCacheEnable(ctx context.Context,
-	diskCacheBytes int64) (availableBytes int64) {
+func (bdl *backpressureDiskLimiter) onDiskBlockCacheEnable(ctx context.Context,
+	diskCacheBytes int64) {
 	bdl.lock.Lock()
 	defer bdl.lock.Unlock()
-	availableBytes = bdl.diskCacheByteTracker.onEnable(diskCacheBytes)
+	bdl.diskCacheByteTracker.onEnable(diskCacheBytes)
 	bdl.updateFreeLocked()
-	return availableBytes
 }
 
-func (bdl *backpressureDiskLimiter) onDiskCacheDisable(ctx context.Context,
+func (bdl *backpressureDiskLimiter) onDiskBlockCacheDisable(ctx context.Context,
 	diskCacheBytes int64) {
 	bdl.lock.Lock()
 	defer bdl.lock.Unlock()

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -469,6 +469,30 @@ func (bdl *backpressureDiskLimiter) onBlocksDelete(
 	bdl.fileTracker.onBlocksDelete(blockFiles)
 }
 
+func (bdl *backpressureDiskLimiter) onDiskBlockCacheDelete(
+	ctx context.Context, blockBytes int64) {
+	if blockBytes == 0 {
+		return
+	}
+	bdl.lock.Lock()
+	defer bdl.lock.Unlock()
+	bdl.byteTracker.onBlockDelete(blockBytes)
+}
+
+func (bdl *backpressureDiskLimiter) beforeDiskBlockCachePut(
+	ctx context.Context, blockBytes int64) (availableBytes int64, err error) {
+	if blockBytes == 0 {
+		// Better to return an error than to panic in Acquire.
+		return bdl.byteTracker.semaphore.Count(),
+			errors.New("backpressureDiskLimiter.beforeDiskBlockCachePut" +
+				" called with 0 blockBytes")
+	}
+	bdl.lock.Lock()
+	defer bdl.lock.Unlock()
+	// TODO: finish
+	return 0, nil
+}
+
 type backpressureDiskLimiterStatus struct {
 	Type string
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -211,8 +211,8 @@ func TestBackpressureDiskLimiterBeforeBlockPutError(t *testing.T) {
 	require.Equal(t, int64(10), availBytes)
 	require.Equal(t, int64(1), availFiles)
 
-	require.Equal(t, int64(10), bdl.byteTracker.semaphore.Count())
-	require.Equal(t, int64(1), bdl.fileTracker.semaphore.Count())
+	require.Equal(t, int64(10), bdl.journalByteTracker.semaphore.Count())
+	require.Equal(t, int64(1), bdl.journalFileTracker.semaphore.Count())
 }
 
 // TestBackpressureDiskLimiterGetDelay tests the delay calculation,
@@ -236,11 +236,11 @@ func TestBackpressureDiskLimiterGetDelay(t *testing.T) {
 		bdl.lock.Lock()
 		defer bdl.lock.Unlock()
 		// byteDelayScale should be 25/(.25(350 + 25)) = 0.267.
-		bdl.byteTracker.used = 25
-		bdl.byteTracker.free = 350
+		bdl.journalByteTracker.used = 25
+		bdl.journalByteTracker.free = 350
 		// fileDelayScale should by 50/(.25(350 + 50)) = 0.5.
-		bdl.fileTracker.used = 50
-		bdl.fileTracker.free = 350
+		bdl.journalFileTracker.used = 50
+		bdl.journalFileTracker.free = 350
 	}()
 
 	ctx := context.Background()
@@ -487,8 +487,8 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 		// When called in subsequent times from
 		// beforeBlockPut, simulate the journal taking up
 		// space.
-		return diskBytes - bdl.byteTracker.used,
-			diskFiles - bdl.fileTracker.used, nil
+		return diskBytes - bdl.journalByteTracker.used,
+			diskFiles - bdl.journalFileTracker.used, nil
 	}
 
 	log := logger.NewTestLogger(t)

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -31,7 +31,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 	// Increase U by 10, so that increases sM by 0.25*10 = 2.5, so
 	// sM is now 52.
 
-	avail := bt.onJournalEnable(10)
+	avail := bt.onEnable(10)
 	require.Equal(t, int64(42), avail)
 
 	require.Equal(t, int64(10), bt.used)
@@ -42,7 +42,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 	// Decrease U by 9, so that decreases sM by 0.25*9 = 2.25, so
 	// sM is back to 50.
 
-	bt.onJournalDisable(9)
+	bt.onDisable(9)
 
 	require.Equal(t, int64(1), bt.used)
 	require.Equal(t, int64(200), bt.free)
@@ -52,7 +52,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 	// Increase U by 440, so that increases sM by 0.25*110 = 110,
 	// so sM maxes out at 100, and semaphore should go negative.
 
-	avail = bt.onJournalEnable(440)
+	avail = bt.onEnable(440)
 	require.Equal(t, int64(-341), avail)
 
 	require.Equal(t, int64(441), bt.used)
@@ -62,7 +62,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 
 	// Now revert that increase.
 
-	bt.onJournalDisable(440)
+	bt.onDisable(440)
 
 	require.Equal(t, int64(1), bt.used)
 	require.Equal(t, int64(200), bt.free)
@@ -70,7 +70,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 	require.Equal(t, int64(49), bt.semaphore.Count())
 
 	// This should be a no-op.
-	avail = bt.onJournalEnable(0)
+	avail = bt.onEnable(0)
 	require.Equal(t, int64(49), avail)
 
 	require.Equal(t, int64(1), bt.used)
@@ -79,7 +79,7 @@ func TestBackpressureTrackerCounters(t *testing.T) {
 	require.Equal(t, int64(49), bt.semaphore.Count())
 
 	// So should this.
-	bt.onJournalDisable(0)
+	bt.onDisable(0)
 
 	require.Equal(t, int64(1), bt.used)
 	require.Equal(t, int64(200), bt.free)

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -157,7 +157,7 @@ func TestBackpressureConstructorError(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	fakeErr := errors.New("Fake error")
 	_, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 100, 10, 8*time.Second, nil,
+		log, 0.1, 0.9, 0.25, 0.1, 400, 40, 8*time.Second, nil,
 		func() (int64, int64, error) {
 			return 0, 0, fakeErr
 		})
@@ -170,7 +170,7 @@ func TestBackpressureConstructorError(t *testing.T) {
 func TestBackpressureDiskLimiterBeforeBlockPut(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 22, 5, 8*time.Second,
+		log, 0.1, 0.9, 0.25, 0.1, 88, 20, 8*time.Second,
 		func(ctx context.Context, delay time.Duration) error {
 			return nil
 		},
@@ -193,7 +193,7 @@ func TestBackpressureDiskLimiterBeforeBlockPut(t *testing.T) {
 func TestBackpressureDiskLimiterBeforeBlockPutError(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, 10, 1, 8*time.Second,
+		log, 0.1, 0.9, 0.25, 0.1, 40, 4, 8*time.Second,
 		func(ctx context.Context, delay time.Duration) error {
 			return nil
 		},
@@ -220,7 +220,7 @@ func TestBackpressureDiskLimiterBeforeBlockPutError(t *testing.T) {
 func TestBackpressureDiskLimiterGetDelay(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, math.MaxInt64, math.MaxInt64,
+		log, 0.1, 0.9, 0.25, 0.1, math.MaxInt64, math.MaxInt64,
 		8*time.Second,
 		func(ctx context.Context, delay time.Duration) error {
 			return nil
@@ -307,7 +307,7 @@ func testBackpressureDiskLimiterLargeDiskDelay(
 
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, byteLimit, fileLimit,
+		log, 0.1, 0.9, 0.25, 0.1, byteLimit*4, fileLimit*4,
 		8*time.Second, delayFn,
 		func() (int64, int64, error) {
 			return math.MaxInt64, math.MaxInt64, nil
@@ -493,7 +493,7 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 
 	log := logger.NewTestLogger(t)
 	bdl, err := newBackpressureDiskLimiterWithFunctions(
-		log, 0.1, 0.9, 0.25, math.MaxInt64, math.MaxInt64,
+		log, 0.1, 0.9, 0.25, 0.1, math.MaxInt64, math.MaxInt64,
 		8*time.Second, delayFn, getFreeBytesAndFilesFn)
 	require.NoError(t, err)
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -931,19 +931,23 @@ func (c *ConfigLocal) MakeDiskLimiter(configRoot string) (DiskLimiter, error) {
 	const (
 		backpressureMinThreshold = 0.5
 		backpressureMaxThreshold = 0.95
-		// Cap filesystem usage to a quarter of the free space.
-		byteLimitFrac = 0.25
-		// Set the absolute filesystem byte limit to 50 GiB for now.
-		byteLimit int64 = 50 * 1024 * 1024 * 1024
-		// Set the absolute file limit to 1.5 million for now.
-		fileLimit int64 = 1500000
+		// Cap journal usage to a 15% of free space.
+		journalByteLimitFrac = 0.15
+		// Cap disk cache usage to a 10% of free space.
+		diskCacheByteLimitFrac = 0.10
+		// Set the absolute filesystem byte limit to 200 GiB. This will be
+		// scaled by the various *Frac parameters.
+		byteLimit int64 = 200 * 1024 * 1024 * 1024
+		// Set the absolute file limit to 6 million for now.
+		fileLimit int64 = 6000000
 	)
 	log := c.MakeLogger("")
 	log.Debug("Setting disk storage byte limit to %v", byteLimit)
 	os.MkdirAll(configRoot, 0700)
 	var err error
-	c.diskLimiter, err = newBackpressureDiskLimiter(log, backpressureMinThreshold,
-		backpressureMaxThreshold, byteLimitFrac, byteLimit, fileLimit,
+	c.diskLimiter, err = newBackpressureDiskLimiter(log,
+		backpressureMinThreshold, backpressureMaxThreshold,
+		journalByteLimitFrac, diskCacheByteLimitFrac, byteLimit, fileLimit,
 		defaultDiskLimitMaxDelay, configRoot)
 	return c.diskLimiter, err
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -909,10 +909,10 @@ func (c *ConfigLocal) journalizeBcaches(jServer *JournalServer) error {
 // put.
 const defaultDiskLimitMaxDelay = 10 * time.Second
 
-// EnableJournaling creates a JournalServer and attaches it to
+// enableJournaling creates a JournalServer and attaches it to
 // this config. journalRoot must be non-empty. Errors returned are
 // non-fatal.
-func (c *ConfigLocal) EnableJournaling(
+func (c *ConfigLocal) enableJournaling(
 	ctx context.Context, journalRoot string,
 	bws TLFJournalBackgroundWorkStatus) (diskLimiter, error) {
 	jServer, err := GetJournalServer(c)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1025,9 +1025,10 @@ func (c *ConfigLocal) EnableJournaling(
 func (c *ConfigLocal) SetDiskBlockCache(dbc DiskBlockCache) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	ctx := context.TODO()
 	if c.diskBlockCache != nil {
-		// TODO: disable old one
+		c.diskBlockCache.Shutdown(ctx)
 	}
 	c.diskBlockCache = dbc
-	// TODO: enable new one
+	c.diskLimiter.onDiskBlockCacheEnable(ctx, dbc.Size())
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -991,12 +991,11 @@ func (c *ConfigLocal) EnableJournaling(
 // EnableDiskBlockCache creates and enables a new disk block cache.
 func (c *ConfigLocal) EnableDiskBlockCache(ctx context.Context,
 	diskCacheRoot string, limiter diskBlockCacheLimiter) (err error) {
-	// TODO: use limiter
 	// Don't lock because:
 	// 1) This happens while constructing the config, and thus no goroutines
 	//	  are contending for access yet.
 	// 2) It'll deadlock with uses of c's methods.
 	c.diskBlockCache, err = newDiskBlockCacheStandard(c, diskCacheRoot,
-		defaultDiskBlockCacheMaxBytes)
+		defaultDiskBlockCacheMaxBytes, limiter)
 	return err
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -956,7 +956,7 @@ func (c *ConfigLocal) MakeDiskLimiter(configRoot string) (DiskLimiter, error) {
 // this config. journalRoot must be non-empty. Errors returned are
 // non-fatal.
 func (c *ConfigLocal) EnableJournaling(
-	ctx context.Context, journalRoot string, limiter DiskLimiter,
+	ctx context.Context, journalRoot string,
 	bws TLFJournalBackgroundWorkStatus) error {
 	jServer, err := GetJournalServer(c)
 	if err == nil {
@@ -978,8 +978,8 @@ func (c *ConfigLocal) EnableJournaling(
 		return err
 	}
 
-	if limiter == nil {
-		limiter, err = c.MakeDiskLimiter(journalRoot)
+	if c.DiskLimiter() == nil {
+		_, err = c.MakeDiskLimiter(journalRoot)
 		if err != nil {
 			return err
 		}
@@ -987,7 +987,7 @@ func (c *ConfigLocal) EnableJournaling(
 
 	jServer = makeJournalServer(c, log, journalRoot, c.BlockCache(),
 		c.DirtyBlockCache(), c.BlockServer(), c.MDOps(), branchListener,
-		flushListener, limiter)
+		flushListener)
 
 	c.SetBlockServer(jServer.blockServer())
 	c.SetMDOps(jServer.mdOps())
@@ -1025,5 +1025,9 @@ func (c *ConfigLocal) EnableJournaling(
 func (c *ConfigLocal) SetDiskBlockCache(dbc DiskBlockCache) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
+	if c.diskBlockCache != nil {
+		// TODO: disable old one
+	}
 	c.diskBlockCache = dbc
+	// TODO: enable new one
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -972,17 +972,10 @@ func (c *ConfigLocal) EnableJournaling(
 	branchListener := c.KBFSOps().(branchChangeListener)
 	flushListener := c.KBFSOps().(mdFlushListener)
 
-	// The backpressure disk limiter needs the dir to exist first.
+	// Make sure the journal root exists.
 	err = ioutil.MkdirAll(journalRoot, 0700)
 	if err != nil {
 		return err
-	}
-
-	if c.DiskLimiter() == nil {
-		_, err = c.MakeDiskLimiter(journalRoot)
-		if err != nil {
-			return err
-		}
 	}
 
 	jServer = makeJournalServer(c, log, journalRoot, c.BlockCache(),

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -909,12 +909,12 @@ func (c *ConfigLocal) journalizeBcaches(jServer *JournalServer) error {
 // put.
 const defaultDiskLimitMaxDelay = 10 * time.Second
 
-// enableJournaling creates a JournalServer and attaches it to
+// EnableJournaling creates a JournalServer and attaches it to
 // this config. journalRoot must be non-empty. Errors returned are
 // non-fatal.
-func (c *ConfigLocal) enableJournaling(
+func (c *ConfigLocal) EnableJournaling(
 	ctx context.Context, journalRoot string,
-	bws TLFJournalBackgroundWorkStatus) (diskLimiter, error) {
+	bws TLFJournalBackgroundWorkStatus) (DiskLimiter, error) {
 	jServer, err := GetJournalServer(c)
 	if err == nil {
 		// Journaling shouldn't be enabled twice for the same

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -415,6 +415,7 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 				// space.
 				continue
 			}
+			break
 		}
 		err = cache.blockDb.Put(blockKey, entry, nil)
 		if err != nil {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -417,9 +417,12 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 			if bytesAvailable >= 0 {
 				break
 			}
-			_, _, err = cache.evictLocked(ctx, defaultNumBlocksToEvict)
+			numRemoved, _, err := cache.evictLocked(ctx, defaultNumBlocksToEvict)
 			if err != nil {
 				return err
+			}
+			if numRemoved == 0 {
+				return errors.New("couldn't evict any more blocks from the disk cache")
 			}
 		}
 		err = cache.blockDb.Put(blockKey, entry, nil)

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -415,6 +415,10 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 				// space.
 				continue
 			}
+			// If the limiter has made space, don't loop, even if we haven't
+			// verified that there are enough bytes available. The block cache
+			// isn't taking up its own limit, so while we might cause
+			// backpressure for the journal, we're still meeting our limit.
 			break
 		}
 		err = cache.blockDb.Put(blockKey, entry, nil)

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -131,7 +131,7 @@ func newDiskBlockCacheStandardFromStorage(config diskBlockCacheConfig,
 	if err != nil {
 		return nil, err
 	}
-	return &DiskBlockCacheStandard{
+	cache = &DiskBlockCacheStandard{
 		config:     config,
 		limiter:    limiter,
 		maxBlockID: maxBlockID.Bytes(),
@@ -141,7 +141,12 @@ func newDiskBlockCacheStandardFromStorage(config diskBlockCacheConfig,
 		blockDb:    blockDb,
 		metaDb:     metaDb,
 		tlfDb:      tlfDb,
-	}, nil
+	}
+	err = cache.syncBlockCountsFromDb()
+	if err != nil {
+		return nil, err
+	}
+	return cache, nil
 }
 
 func versionPathFromVersion(dirPath string, version uint64) string {
@@ -232,16 +237,8 @@ func newDiskBlockCacheStandard(config diskBlockCacheConfig, dirPath string,
 			tlfStorage.Close()
 		}
 	}()
-	cache, err = newDiskBlockCacheStandardFromStorage(config, blockStorage,
+	return newDiskBlockCacheStandardFromStorage(config, blockStorage,
 		metadataStorage, tlfStorage, limiter)
-	if err != nil {
-		return nil, err
-	}
-	err = cache.syncBlockCountsFromDb()
-	if err != nil {
-		return nil, err
-	}
-	return cache, nil
 }
 
 func (cache *DiskBlockCacheStandard) syncBlockCountsFromDb() error {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -86,6 +86,10 @@ func openLevelDB(stor storage.Storage) (db *leveldb.DB, err error) {
 	return db, err
 }
 
+func diskBlockCacheRootFromStorageRoot(storageRoot string) string {
+	return filepath.Join(storageRoot, "kbfs_block_cache")
+}
+
 // newDiskBlockCacheStandardFromStorage creates a new *DiskBlockCacheStandard
 // with the passed-in storage.Storage interfaces as storage layers for each
 // cache.

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -448,6 +448,13 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 	return cache.updateMetadataLocked(ctx, tlfID, blockKey, int(encodedLen))
 }
 
+// Size implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Size() int64 {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	return int64(cache.currBytes)
+}
+
 // deleteLocked deletes a set of blocks from the disk block cache.
 func (cache *DiskBlockCacheStandard) deleteLocked(ctx context.Context,
 	blockEntries []diskBlockCacheDeleteKey) (numRemoved int, sizeRemoved int64, err error) {
@@ -661,4 +668,5 @@ func (cache *DiskBlockCacheStandard) Shutdown(ctx context.Context) {
 		cache.log.CWarningf(ctx, "Error closing blockDb: %+v", err)
 	}
 	cache.metaDb = nil
+	cache.config.DiskLimiter().onDiskBlockCacheDisable(ctx, int64(cache.currBytes))
 }

--- a/libkbfs/disk_block_cache_helper.go
+++ b/libkbfs/disk_block_cache_helper.go
@@ -3,7 +3,6 @@ package libkbfs
 import (
 	"time"
 
-	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
@@ -25,7 +24,6 @@ type diskBlockCacheDeleteKey struct {
 // diskBlockCacheMetadata packages the metadata needed to make decisions on
 // cache eviction.
 type diskBlockCacheMetadata struct {
-	codec.UnknownFieldSet
 	// the TLF ID for the block
 	TlfID tlf.ID
 	// the last time the block was used

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -354,8 +354,14 @@ func TestDiskBlockCacheLimit(t *testing.T) {
 	}
 
 	t.Log("Set the cache maximum bytes to the current total.")
-	cache.maxBytes = cache.currBytes
-	currBytes := cache.maxBytes
+	const (
+		cacheLimitFactor        int64 = 2
+		backpressureStartFactor       = 2
+		limiterFactor                 = cacheLimitFactor * backpressureStartFactor
+	)
+	cache.limiter.(*backpressureDiskLimiter).byteTracker.limit =
+		int64(cache.currBytes) * limiterFactor
+	currBytes := cache.currBytes
 
 	t.Log("Add a block to the cache. Verify that blocks were evicted.")
 	blockID, blockEncoded, serverHalf := setupBlockForDiskCache(t, config)

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -48,7 +48,7 @@ func newDiskBlockCacheStandardForTest(config diskBlockCacheConfig,
 		return nil, err
 	}
 	cache.limiter, err = newBackpressureDiskLimiterWithFunctions(
-		config.MakeLogger(""), 0.5, 0.95, 0.25,
+		config.MakeLogger(""), 0.5, 0.95, 0.15, 0.1,
 		int64(testDiskBlockCacheMaxBytes*8), maxFiles, time.Second,
 		defaultDoDelay, func() (int64, int64, error) {
 			// hackity hackeroni

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -58,10 +58,13 @@ func newDiskBlockCacheStandardForTest(config *testDiskBlockCacheConfig,
 			config.MakeLogger(""), 0.5, 0.95, 0.25, 0.25,
 			testDiskBlockCacheMaxBytes, maxFiles, time.Second,
 			defaultDoDelay, func() (int64, int64, error) {
-				// hackity hackeroni
+				// hackity hackeroni: simulate the disk cache taking up space.
 				freeBytes := maxBytes - int64(cache.currBytes)
 				return freeBytes, maxFiles, nil
 			})
+		if err != nil {
+			return nil, err
+		}
 	}
 	config.limiter = limiter
 	if err != nil {

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -49,11 +49,11 @@ type diskLimiter interface {
 	afterBlockPut(ctx context.Context,
 		blockBytes, blockFiles int64, putData bool)
 
-	// onBlockDelete is called after deleting a block of the given
+	// onBlocksDelete is called after deleting blocks of the given
 	// byte and file count, both of which must be >= 0. (Deleting
 	// a block with either zero byte or zero file count shouldn't
 	// happen, but may as well let it go through.)
-	onBlockDelete(ctx context.Context, blockBytes, blockFiles int64)
+	onBlocksDelete(ctx context.Context, blockBytes, blockFiles int64)
 
 	// getStatus returns an object that's marshallable into JSON
 	// for use in displaying status.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -12,12 +12,21 @@ type diskBlockCacheLimiter interface {
 	// beforeDiskBlockCachePut is called by the disk block cache before putting
 	// a block into the cache. It returns the total number of available bytes.
 	beforeDiskBlockCachePut(ctx context.Context, blockBytes int64) (
-		bytesAvailable int64, err error)
+		availableBytes int64, err error)
 
 	// afterDiskBlockCachePut is called by the disk block cache after putting
 	// a block into the cache. It returns how many bytes it acquired.
 	afterDiskBlockCachePut(ctx context.Context, blockBytes int64,
 		putData bool)
+
+	// onDiskCacheEnable is called when the disk block cache is enabled to
+	// begin accounting for its blocks.
+	onDiskCacheEnable(ctx context.Context, cacheBytes int64) (
+		availableBytes int64)
+
+	// onDiskCacheDisable is called when the disk block cache is disabled to
+	// stop accounting for its blocks.
+	onDiskCacheDisable(ctx context.Context, cacheBytes int64)
 }
 
 // DiskLimiter is an interface for limiting disk usage.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -11,8 +11,8 @@ type diskBlockCacheLimiter interface {
 
 	// beforeDiskBlockCachePut is called by the disk block cache before putting
 	// a block into the cache. It returns how many bytes it acquired.
-	beforeDiskBlockCachePut(ctx context.Context, blockBytes,
-		diskBlockCacheBytes int64) (bytesAvailable int64, err error)
+	beforeDiskBlockCachePut(ctx context.Context, blockBytes int64) (
+		bytesAvailable int64, err error)
 }
 
 // DiskLimiter is an interface for limiting disk usage.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -19,14 +19,13 @@ type diskBlockCacheLimiter interface {
 	afterDiskBlockCachePut(ctx context.Context, blockBytes int64,
 		putData bool)
 
-	// onDiskCacheEnable is called when the disk block cache is enabled to
+	// onDiskBlockCacheEnable is called when the disk block cache is enabled to
 	// begin accounting for its blocks.
-	onDiskCacheEnable(ctx context.Context, cacheBytes int64) (
-		availableBytes int64)
+	onDiskBlockCacheEnable(ctx context.Context, cacheBytes int64)
 
-	// onDiskCacheDisable is called when the disk block cache is disabled to
+	// onDiskBlockCacheDisable is called when the disk block cache is disabled to
 	// stop accounting for its blocks.
-	onDiskCacheDisable(ctx context.Context, cacheBytes int64)
+	onDiskBlockCacheDisable(ctx context.Context, cacheBytes int64)
 }
 
 // DiskLimiter is an interface for limiting disk usage.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -10,9 +10,14 @@ type diskBlockCacheLimiter interface {
 	onDiskBlockCacheDelete(ctx context.Context, blockBytes int64)
 
 	// beforeDiskBlockCachePut is called by the disk block cache before putting
-	// a block into the cache. It returns how many bytes it acquired.
+	// a block into the cache. It returns the total number of available bytes.
 	beforeDiskBlockCachePut(ctx context.Context, blockBytes int64) (
 		bytesAvailable int64, err error)
+
+	// afterDiskBlockCachePut is called by the disk block cache after putting
+	// a block into the cache. It returns how many bytes it acquired.
+	afterDiskBlockCachePut(ctx context.Context, blockBytes int64,
+		putData bool)
 }
 
 // DiskLimiter is an interface for limiting disk usage.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -1,0 +1,58 @@
+package libkbfs
+
+import (
+	"golang.org/x/net/context"
+)
+
+// diskLimiter is an interface for limiting disk usage.
+type diskLimiter interface {
+	// onJournalEnable is called when initializing a TLF journal
+	// with that journal's current disk usage. Both journalBytes
+	// and journalFiles must be >= 0. The updated available byte
+	// and file count must be returned.
+	onJournalEnable(
+		ctx context.Context, journalBytes, journalFiles int64) (
+		availableBytes, availableFiles int64)
+
+	// onJournalDisable is called when shutting down a TLF journal
+	// with that journal's current disk usage. Both journalBytes
+	// and journalFiles must be >= 0.
+	onJournalDisable(ctx context.Context, journalBytes, journalFiles int64)
+
+	// beforeBlockPut is called before putting a block of the
+	// given byte and file count, both of which must be > 0. It
+	// may block, but must return immediately with a
+	// (possibly-wrapped) ctx.Err() if ctx is cancelled. The
+	// updated available byte and file count must be returned,
+	// even if err is non-nil.
+	beforeBlockPut(ctx context.Context,
+		blockBytes, blockFiles int64) (
+		availableBytes, availableFiles int64, err error)
+
+	// afterBlockPut is called after putting a block of the given
+	// byte and file count, which must match the corresponding call to
+	// beforeBlockPut. putData reflects whether or not the data
+	// was actually put; if it's false, it's either because of an
+	// error or because the block already existed.
+	afterBlockPut(ctx context.Context,
+		blockBytes, blockFiles int64, putData bool)
+
+	// onBlockDelete is called after deleting a block of the given
+	// byte and file count, both of which must be >= 0. (Deleting
+	// a block with either zero byte or zero file count shouldn't
+	// happen, but may as well let it go through.)
+	onBlockDelete(ctx context.Context, blockBytes, blockFiles int64)
+
+	// onDiskBlockCacheDelete is called by the disk block cache after deleting
+	// blocks from the cache.
+	onDiskBlockCacheDelete(ctx context.Context, blockBytes int64)
+
+	// beforeDiskBlockCachePut is called by the disk block cache before putting
+	// a block into the cache. It returns how many bytes it acquired.
+	beforeDiskBlockCachePut(ctx context.Context, blockBytes int64) (
+		bytesAcquired int64, err error)
+
+	// getStatus returns an object that's marshallable into JSON
+	// for use in displaying status.
+	getStatus() interface{}
+}

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -15,8 +15,8 @@ type diskBlockCacheLimiter interface {
 		diskBlockCacheBytes int64) (bytesAvailable int64, err error)
 }
 
-// diskLimiter is an interface for limiting disk usage.
-type diskLimiter interface {
+// DiskLimiter is an interface for limiting disk usage.
+type DiskLimiter interface {
 	diskBlockCacheLimiter
 	// onJournalEnable is called when initializing a TLF journal
 	// with that journal's current disk usage. Both journalBytes

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -504,7 +504,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 
 	config.SetBlockServer(bserv)
 
-	limiter, err := config.MakeDiskLimiter(params.StorageRoot)
+	_, err = config.MakeDiskLimiter(params.StorageRoot)
 	if err != nil {
 		log.Warning("Could not initialize disk limiter: %+v", err)
 		return nil, err
@@ -514,14 +514,14 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 	if params.EnableJournal {
 		journalRoot := filepath.Join(params.StorageRoot, "kbfs_journal")
 		err = config.EnableJournaling(context.Background(), journalRoot,
-			limiter, params.TLFJournalBackgroundWorkStatus)
+			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {
 			log.Warning("Could not initialize journal server: %+v", err)
 		}
 	}
 	if params.EnableDiskCache {
 		dbc, err := newDiskBlockCacheStandard(config,
-			diskBlockCacheRootFromStorageRoot(params.StorageRoot), limiter)
+			diskBlockCacheRootFromStorageRoot(params.StorageRoot))
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)
 			// TODO: Make this error less fatal later.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -537,7 +537,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
 	if len(params.WriteJournalRoot) != 0 {
-		limiter, err = config.EnableJournaling(context.Background(),
+		err = config.EnableJournaling(context.Background(),
 			params.WriteJournalRoot, limiter,
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -521,8 +521,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 	}
 	if params.EnableDiskCache {
 		dbc, err := newDiskBlockCacheStandard(config,
-			diskBlockCacheRootFromStorageRoot(params.StorageRoot),
-			defaultDiskBlockCacheMaxBytes, limiter)
+			diskBlockCacheRootFromStorageRoot(params.StorageRoot), limiter)
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)
 			// TODO: Make this error less fatal later.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -403,7 +403,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 			lg.Configure("", true, "")
 		}
 		return lg
-	})
+	}, params.StorageRoot)
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.Debug("overriding default clean block cache capacity from %d to %d",
@@ -520,14 +520,15 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 		}
 	}
 	if params.EnableDiskCache {
-		diskCacheRoot := filepath.Join(params.StorageRoot, "kbfs_block_cache")
-		err := config.EnableDiskBlockCache(context.TODO(),
-			diskCacheRoot, limiter)
+		dbc, err := newDiskBlockCacheStandard(config,
+			diskBlockCacheRootFromStorageRoot(params.StorageRoot),
+			defaultDiskBlockCacheMaxBytes, limiter)
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)
 			// TODO: Make this error less fatal later.
 			return nil, err
 		}
+		config.SetDiskBlockCache(dbc)
 	}
 
 	return config, nil

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -66,25 +66,23 @@ type InitParams struct {
 
 	// TLFJournalBackgroundWorkStatus is the status to use to
 	// pass into JournalServer.enableJournaling. Only has an effect when
-	// WriteJournalRoot is non-empty.
+	// EnableJournal is non-empty.
 	TLFJournalBackgroundWorkStatus TLFJournalBackgroundWorkStatus
-
-	// WriteJournalRoot, if non-empty, points to a path to a local
-	// directory to put write journals in. If non-empty, enables
-	// write journaling to be turned on for TLFs.
-	WriteJournalRoot string
 
 	// CreateSimpleFSInstance creates a SimpleFSInterface from config.
 	// If this is nil then simplefs will be omitted in the rpc api.
 	CreateSimpleFSInstance func(Config) keybase1.SimpleFSInterface
 
-	// DiskCacheRoot, if non-empty, points to a path to a local directory to
-	// put the block cache database. If non-default, enables disk caching.
-	DiskCacheRoot string
-	// EnableDiskCache toggles whether the disk cache is enabled in the default
-	// data directory. Note that specifying a non-default DiskCacheRoot
-	// overrides this setting.
+	// EnableJournal enables journaling.
+	EnableJournal bool
+
+	// EnableDiskCache toggles whether the disk cache is enabled in the
+	// StorageRoot data directory.
 	EnableDiskCache bool
+
+	// StorageRoot, if non-empty, points to a local directory to put its local
+	// databases for things like the journal or disk cache.
+	StorageRoot string
 }
 
 // defaultBServer returns the default value for the -bserver flag.
@@ -147,8 +145,7 @@ func DefaultInitParams(ctx Context) InitParams {
 			MaxKeepFiles: 3,
 		},
 		TLFJournalBackgroundWorkStatus: TLFJournalBackgroundWorkEnabled,
-		WriteJournalRoot:               filepath.Join(ctx.GetDataDir(), "kbfs_journal"),
-		DiskCacheRoot:                  filepath.Join(ctx.GetDataDir(), "kbfs_block_cache"),
+		StorageRoot:                    ctx.GetDataDir(),
 	}
 }
 
@@ -172,10 +169,10 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
 	// The default is to *DELETE* old log files for kbfs.
 	flags.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
-	flags.StringVar(&params.WriteJournalRoot, "write-journal-root", defaultParams.WriteJournalRoot, "If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	flags.Uint64Var(&params.CleanBlockCacheCapacity, "clean-bcache-cap", defaultParams.CleanBlockCacheCapacity, "If non-zero, specify the capacity of clean block cache. If zero, the capacity is set based on system RAM.")
-	flags.StringVar(&params.DiskCacheRoot, "disk-cache-root", defaultParams.DiskCacheRoot, "(EXPERIMENTAL) If non-empty, permits a block database to be saved in the specified directory.")
-	flags.BoolVar(&params.EnableDiskCache, "enable-disk-cache", false, "(EXPERIMENTAL) Enables the disk cache for the default data directory.")
+	flags.StringVar(&params.StorageRoot, "storage-root", defaultParams.StorageRoot, "Specifies where Keybase will store its local databases for the journal and disk cache.")
+	flags.BoolVar(&params.EnableDiskCache, "enable-disk-cache", false, "(EXPERIMENTAL) Enables the disk cache for the directory specified by -storage-root.")
+	flags.BoolVar(&params.EnableJournal, "enable-journal", true, "Enables write journaling for TLFs.")
 
 	// No real need to enable setting
 	// params.TLFJournalBackgroundWorkStatus via a flag.
@@ -183,29 +180,6 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 
 	flags.IntVar((*int)(&params.MetadataVersion), "md-version", int(defaultParams.MetadataVersion), "Metadata version to use when creating new metadata")
 	return &params
-}
-
-// TODO: Add a server endpoint to get this data.
-var adminFeatureList = map[keybase1.UID]bool{
-	"23260c2ce19420f97b58d7d95b68ca00": true, // Chris Coyne "chris"
-	"dbb165b7879fe7b1174df73bed0b9500": true, // Max Krohn, "max"
-	"ef2e49961eddaa77094b45ed635cfc00": true, // Jeremy Stribling, "strib"
-	"41b1f75fb55046d370608425a3208100": true, // Jack O'Connor, "oconnor663"
-	"9403ede05906b942fd7361f40a679500": true, // Jinyang Li, "jinyang"
-	"b7c2eaddcced7727bcb229751d91e800": true, // Gabriel Handford, "gabrielh"
-	"1563ec26dc20fd162a4f783551141200": true, // Patrick Crosby, "patrick"
-	"ebbe1d99410ab70123262cf8dfc87900": true, // Fred Akalin, "akalin"
-	"8bc0fd2f5fefd30d3ec04452600f4300": true, // Andy Alness, "alness"
-	"e0b4166c9c839275cf5633ff65c3e819": true, // Chris Nojima, "chrisnojima"
-	"d95f137b3b4a3600bc9e39350adba819": true, // Cécile Boucheron, "cecileb"
-	"4c230ae8d2f922dc2ccc1d2f94890700": true, // Marco Polo, "marcopolo"
-	"237e85db5d939fbd4b84999331638200": true, // Chris Ball, "cjb"
-	"69da56f622a2ac750b8e590c3658a700": true, // John Zila, "jzila"
-	"673a740cd20fb4bd348738b16d228219": true, // Steve Sanders, "zanderz"
-	"95e88f2087e480cae28f08d81554bc00": true, // Mike Maxim, "mikem"
-	"5c2ef2d4eddd2381daa681ac1a901519": true, // Max Goodman, "chromakode"
-	"08abe80bd2da8984534b2d8f7b12c700": true, // Song Gao, "songgao"
-	"eb08cb06e608ea41bd893946445d7919": true, // Miles Steele, "mlsteele"
 }
 
 // GetRemoteUsageString returns a string describing the flags to use
@@ -530,27 +504,25 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 
 	config.SetBlockServer(bserv)
 
-	limiter, err := config.MakeDiskLimiter(params.WriteJournalRoot)
+	limiter, err := config.MakeDiskLimiter(params.StorageRoot)
 	if err != nil {
+		log.Warning("Could not initialize disk limiter: %+v", err)
 		return nil, err
 	}
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
-	if len(params.WriteJournalRoot) != 0 {
-		err = config.EnableJournaling(context.Background(),
-			params.WriteJournalRoot, limiter,
-			params.TLFJournalBackgroundWorkStatus)
+	if params.EnableJournal {
+		journalRoot := filepath.Join(params.StorageRoot, "kbfs_journal")
+		err = config.EnableJournaling(context.Background(), journalRoot,
+			limiter, params.TLFJournalBackgroundWorkStatus)
 		if err != nil {
 			log.Warning("Could not initialize journal server: %+v", err)
 		}
 	}
-	defaultParams := DefaultInitParams(ctx)
-	// Only enable the disk block cache if the user has explicitly specified a
-	// caching root directory, or enabled caching in the default directory.
-	if len(params.DiskCacheRoot) != 0 && (params.EnableDiskCache ||
-		params.DiskCacheRoot != defaultParams.DiskCacheRoot) {
+	if params.EnableDiskCache {
+		diskCacheRoot := filepath.Join(params.StorageRoot, "kbfs_block_cache")
 		err := config.EnableDiskBlockCache(context.TODO(),
-			params.DiskCacheRoot, limiter)
+			diskCacheRoot, limiter)
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)
 			// TODO: Make this error less fatal later.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -65,7 +65,7 @@ type InitParams struct {
 	LogFileConfig logger.LogFileConfig
 
 	// TLFJournalBackgroundWorkStatus is the status to use to
-	// pass into JournalServer.EnableJournaling. Only has an effect when
+	// pass into JournalServer.enableJournaling. Only has an effect when
 	// WriteJournalRoot is non-empty.
 	TLFJournalBackgroundWorkStatus TLFJournalBackgroundWorkStatus
 
@@ -511,7 +511,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 	// -mdserver point to local implementations.
 	var limiter diskLimiter
 	if len(params.WriteJournalRoot) != 0 {
-		limiter, err = config.EnableJournaling(
+		limiter, err = config.enableJournaling(
 			context.Background(), params.WriteJournalRoot,
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -509,8 +509,9 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
+	var limiter diskLimiter
 	if len(params.WriteJournalRoot) != 0 {
-		err := config.EnableJournaling(
+		limiter, err = config.EnableJournaling(
 			context.Background(), params.WriteJournalRoot,
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {
@@ -522,8 +523,8 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 	// caching root directory, or enabled caching in the default directory.
 	if len(params.DiskCacheRoot) != 0 && (params.EnableDiskCache ||
 		params.DiskCacheRoot != defaultParams.DiskCacheRoot) {
-		err := config.EnableDiskBlockCache(context.TODO(),
-			params.DiskCacheRoot)
+		err = config.EnableDiskBlockCache(context.TODO(),
+			params.DiskCacheRoot, limiter)
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)
 			// TODO: Make this error less fatal later.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -509,9 +509,9 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
-	var limiter diskLimiter
+	var limiter DiskLimiter
 	if len(params.WriteJournalRoot) != 0 {
-		limiter, err = config.enableJournaling(
+		limiter, err = config.EnableJournaling(
 			context.Background(), params.WriteJournalRoot,
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -172,7 +172,7 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 	flags.Var(SizeFlag{&params.LogFileConfig.MaxSize}, "log-file-max-size", "Maximum size of a log file before rotation")
 	// The default is to *DELETE* old log files for kbfs.
 	flags.IntVar(&params.LogFileConfig.MaxKeepFiles, "log-file-max-keep-files", defaultParams.LogFileConfig.MaxKeepFiles, "Maximum number of log files for this service, older ones are deleted. 0 for infinite.")
-	flags.StringVar(&params.WriteJournalRoot, "write-journal-root", defaultParams.WriteJournalRoot, "(EXPERIMENTAL) If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
+	flags.StringVar(&params.WriteJournalRoot, "write-journal-root", defaultParams.WriteJournalRoot, "If non-empty, permits write journals to be turned on for TLFs which will be put in the given directory")
 	flags.Uint64Var(&params.CleanBlockCacheCapacity, "clean-bcache-cap", defaultParams.CleanBlockCacheCapacity, "If non-zero, specify the capacity of clean block cache. If zero, the capacity is set based on system RAM.")
 	flags.StringVar(&params.DiskCacheRoot, "disk-cache-root", defaultParams.DiskCacheRoot, "(EXPERIMENTAL) If non-empty, permits a block database to be saved in the specified directory.")
 	flags.BoolVar(&params.EnableDiskCache, "enable-disk-cache", false, "(EXPERIMENTAL) Enables the disk cache for the default data directory.")
@@ -183,6 +183,29 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 
 	flags.IntVar((*int)(&params.MetadataVersion), "md-version", int(defaultParams.MetadataVersion), "Metadata version to use when creating new metadata")
 	return &params
+}
+
+// TODO: Add a server endpoint to get this data.
+var adminFeatureList = map[keybase1.UID]bool{
+	"23260c2ce19420f97b58d7d95b68ca00": true, // Chris Coyne "chris"
+	"dbb165b7879fe7b1174df73bed0b9500": true, // Max Krohn, "max"
+	"ef2e49961eddaa77094b45ed635cfc00": true, // Jeremy Stribling, "strib"
+	"41b1f75fb55046d370608425a3208100": true, // Jack O'Connor, "oconnor663"
+	"9403ede05906b942fd7361f40a679500": true, // Jinyang Li, "jinyang"
+	"b7c2eaddcced7727bcb229751d91e800": true, // Gabriel Handford, "gabrielh"
+	"1563ec26dc20fd162a4f783551141200": true, // Patrick Crosby, "patrick"
+	"ebbe1d99410ab70123262cf8dfc87900": true, // Fred Akalin, "akalin"
+	"8bc0fd2f5fefd30d3ec04452600f4300": true, // Andy Alness, "alness"
+	"e0b4166c9c839275cf5633ff65c3e819": true, // Chris Nojima, "chrisnojima"
+	"d95f137b3b4a3600bc9e39350adba819": true, // Cécile Boucheron, "cecileb"
+	"4c230ae8d2f922dc2ccc1d2f94890700": true, // Marco Polo, "marcopolo"
+	"237e85db5d939fbd4b84999331638200": true, // Chris Ball, "cjb"
+	"69da56f622a2ac750b8e590c3658a700": true, // John Zila, "jzila"
+	"673a740cd20fb4bd348738b16d228219": true, // Steve Sanders, "zanderz"
+	"95e88f2087e480cae28f08d81554bc00": true, // Mike Maxim, "mikem"
+	"5c2ef2d4eddd2381daa681ac1a901519": true, // Max Goodman, "chromakode"
+	"08abe80bd2da8984534b2d8f7b12c700": true, // Song Gao, "songgao"
+	"eb08cb06e608ea41bd893946445d7919": true, // Miles Steele, "mlsteele"
 }
 
 // GetRemoteUsageString returns a string describing the flags to use
@@ -507,12 +530,15 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 
 	config.SetBlockServer(bserv)
 
+	limiter, err := config.MakeDiskLimiter(params.WriteJournalRoot)
+	if err != nil {
+		return nil, err
+	}
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
-	var limiter DiskLimiter
 	if len(params.WriteJournalRoot) != 0 {
-		limiter, err = config.EnableJournaling(
-			context.Background(), params.WriteJournalRoot,
+		limiter, err = config.EnableJournaling(context.Background(),
+			params.WriteJournalRoot, limiter,
 			params.TLFJournalBackgroundWorkStatus)
 		if err != nil {
 			log.Warning("Could not initialize journal server: %+v", err)
@@ -523,7 +549,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn, l
 	// caching root directory, or enabled caching in the default directory.
 	if len(params.DiskCacheRoot) != 0 && (params.EnableDiskCache ||
 		params.DiskCacheRoot != defaultParams.DiskCacheRoot) {
-		err = config.EnableDiskBlockCache(context.TODO(),
+		err := config.EnableDiskBlockCache(context.TODO(),
 			params.DiskCacheRoot, limiter)
 		if err != nil {
 			log.Warning("Could not initialize disk cache: %+v", err)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -63,6 +63,10 @@ type diskBlockCacheGetter interface {
 	DiskBlockCache() DiskBlockCache
 }
 
+type diskBlockCacheSetter interface {
+	SetDiskBlockCache(DiskBlockCache)
+}
+
 type clockGetter interface {
 	Clock() Clock
 }
@@ -1492,6 +1496,7 @@ type Config interface {
 	signerGetter
 	currentSessionGetterGetter
 	diskBlockCacheGetter
+	diskBlockCacheSetter
 	clockGetter
 	diskLimiterGetter
 	KBFSOps() KBFSOps
@@ -1586,6 +1591,9 @@ type Config interface {
 
 	// ResetCaches clears and re-initializes all data and key caches.
 	ResetCaches()
+
+	// StorageRoot returns the path to the storage root for this config.
+	StorageRoot() string
 
 	// MetricsRegistry may be nil, which should be interpreted as
 	// not using metrics at all. (i.e., as if UseNilMetrics were

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -842,6 +842,8 @@ type DiskBlockCache interface {
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
 	// DeleteByTLF deletes some blocks from the disk cache.
 	DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) (numRemoved int, sizeRemoved int64, err error)
+	// Size returns the size in bytes of the disk cache.
+	Size() int64
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -841,7 +841,7 @@ type DiskBlockCache interface {
 	Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte,
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
 	// DeleteByTLF deletes some blocks from the disk cache.
-	DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) error
+	DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) (numRemoved int, sizeRemoved int64, err error)
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -67,6 +67,10 @@ type clockGetter interface {
 	Clock() Clock
 }
 
+type diskLimiterGetter interface {
+	DiskLimiter() DiskLimiter
+}
+
 // Block just needs to be (de)serialized using msgpack
 type Block interface {
 	dataVersioner
@@ -1489,6 +1493,7 @@ type Config interface {
 	currentSessionGetterGetter
 	diskBlockCacheGetter
 	clockGetter
+	diskLimiterGetter
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -52,7 +52,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 		}
 	}()
 
-	_, err = config.enableJournaling(
+	_, err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -52,10 +52,10 @@ func setupJournalBlockServerTest(t *testing.T) (
 		}
 	}()
 
-	limiter, err := config.MakeDiskLimiter(tempdir)
+	_, err = config.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
-		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -52,7 +52,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 		}
 	}()
 
-	err = config.EnableJournaling(
+	_, err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -52,8 +52,10 @@ func setupJournalBlockServerTest(t *testing.T) (
 		}
 	}()
 
+	limiter, err := config.MakeDiskLimiter(tempdir)
+	require.NoError(t, err)
 	_, err = config.EnableJournaling(
-		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -52,7 +52,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 		}
 	}()
 
-	_, err = config.EnableJournaling(
+	_, err = config.enableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -54,7 +54,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 
 	limiter, err := config.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
-	_, err = config.EnableJournaling(
+	err = config.EnableJournaling(
 		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -53,7 +53,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	oldMDOps = config.MDOps()
 	limiter, err := config.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
-	_, err = config.EnableJournaling(
+	err = config.EnableJournaling(
 		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -51,7 +51,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	oldMDOps = config.MDOps()
-	_, err = config.EnableJournaling(
+	_, err = config.enableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -51,10 +51,10 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	oldMDOps = config.MDOps()
-	limiter, err := config.MakeDiskLimiter(tempdir)
+	_, err = config.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
-		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
 	// Turn off listeners to avoid background MD pushes for CR.

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -51,7 +51,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	oldMDOps = config.MDOps()
-	err = config.EnableJournaling(
+	_, err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -51,7 +51,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	oldMDOps = config.MDOps()
-	_, err = config.enableJournaling(
+	_, err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -51,8 +51,10 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	oldMDOps = config.MDOps()
+	limiter, err := config.MakeDiskLimiter(tempdir)
+	require.NoError(t, err)
 	_, err = config.EnableJournaling(
-		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
 	// Turn off listeners to avoid background MD pushes for CR.

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -18,29 +18,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// TODO: Add a server endpoint to get this data.
-var adminFeatureList = map[keybase1.UID]bool{
-	"23260c2ce19420f97b58d7d95b68ca00": true, // Chris Coyne "chris"
-	"dbb165b7879fe7b1174df73bed0b9500": true, // Max Krohn, "max"
-	"ef2e49961eddaa77094b45ed635cfc00": true, // Jeremy Stribling, "strib"
-	"41b1f75fb55046d370608425a3208100": true, // Jack O'Connor, "oconnor663"
-	"9403ede05906b942fd7361f40a679500": true, // Jinyang Li, "jinyang"
-	"b7c2eaddcced7727bcb229751d91e800": true, // Gabriel Handford, "gabrielh"
-	"1563ec26dc20fd162a4f783551141200": true, // Patrick Crosby, "patrick"
-	"ebbe1d99410ab70123262cf8dfc87900": true, // Fred Akalin, "akalin"
-	"8bc0fd2f5fefd30d3ec04452600f4300": true, // Andy Alness, "alness"
-	"e0b4166c9c839275cf5633ff65c3e819": true, // Chris Nojima, "chrisnojima"
-	"d95f137b3b4a3600bc9e39350adba819": true, // Cécile Boucheron, "cecileb"
-	"4c230ae8d2f922dc2ccc1d2f94890700": true, // Marco Polo, "marcopolo"
-	"237e85db5d939fbd4b84999331638200": true, // Chris Ball, "cjb"
-	"69da56f622a2ac750b8e590c3658a700": true, // John Zila, "jzila"
-	"673a740cd20fb4bd348738b16d228219": true, // Steve Sanders, "zanderz"
-	"95e88f2087e480cae28f08d81554bc00": true, // Mike Maxim, "mikem"
-	"5c2ef2d4eddd2381daa681ac1a901519": true, // Max Goodman, "chromakode"
-	"08abe80bd2da8984534b2d8f7b12c700": true, // Song Gao, "songgao"
-	"eb08cb06e608ea41bd893946445d7919": true, // Miles Steele, "mlsteele"
-}
-
 type journalServerConfig struct {
 	// EnableAuto, if true, means the user has explicitly set its
 	// value. If false, then either the user turned it on and then

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -141,7 +141,7 @@ type JournalServer struct {
 	onBranchChange          branchChangeListener
 	onMDFlush               mdFlushListener
 
-	diskLimiter diskLimiter
+	DiskLimiter DiskLimiter
 
 	// Protects all fields below.
 	lock                sync.RWMutex
@@ -157,7 +157,7 @@ func makeJournalServer(
 	config Config, log logger.Logger, dir string,
 	bcache BlockCache, dirtyBcache DirtyBlockCache, bserver BlockServer,
 	mdOps MDOps, onBranchChange branchChangeListener,
-	onMDFlush mdFlushListener, diskLimiter diskLimiter) *JournalServer {
+	onMDFlush mdFlushListener, DiskLimiter DiskLimiter) *JournalServer {
 	if len(dir) == 0 {
 		panic("journal root path string unexpectedly empty")
 	}
@@ -173,7 +173,7 @@ func makeJournalServer(
 		onBranchChange:          onBranchChange,
 		onMDFlush:               onMDFlush,
 		tlfJournals:             make(map[tlf.ID]*tlfJournal),
-		diskLimiter:             diskLimiter,
+		DiskLimiter:             DiskLimiter,
 	}
 	jServer.dirtyOpsDone = sync.NewCond(&jServer.lock)
 	return &jServer
@@ -437,7 +437,7 @@ func (j *JournalServer) enableLocked(
 	tlfJournal, err := makeTLFJournal(
 		ctx, j.currentUID, j.currentVerifyingKey, tlfDir,
 		tlfID, tlfJournalConfigAdapter{j.config}, j.delegateBlockServer,
-		bws, nil, j.onBranchChange, j.onMDFlush, j.diskLimiter)
+		bws, nil, j.onBranchChange, j.onMDFlush, j.DiskLimiter)
 	if err != nil {
 		return err
 	}
@@ -653,7 +653,7 @@ func (j *JournalServer) Status(
 		StoredBytes:         totalStoredBytes,
 		StoredFiles:         totalStoredFiles,
 		UnflushedBytes:      totalUnflushedBytes,
-		DiskLimiterStatus:   j.diskLimiter.getStatus(),
+		DiskLimiterStatus:   j.DiskLimiter.getStatus(),
 	}, tlfIDs
 }
 

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -18,6 +18,29 @@ import (
 	"golang.org/x/net/context"
 )
 
+// TODO: Add a server endpoint to get this data.
+var adminFeatureList = map[keybase1.UID]bool{
+	"23260c2ce19420f97b58d7d95b68ca00": true, // Chris Coyne "chris"
+	"dbb165b7879fe7b1174df73bed0b9500": true, // Max Krohn, "max"
+	"ef2e49961eddaa77094b45ed635cfc00": true, // Jeremy Stribling, "strib"
+	"41b1f75fb55046d370608425a3208100": true, // Jack O'Connor, "oconnor663"
+	"9403ede05906b942fd7361f40a679500": true, // Jinyang Li, "jinyang"
+	"b7c2eaddcced7727bcb229751d91e800": true, // Gabriel Handford, "gabrielh"
+	"1563ec26dc20fd162a4f783551141200": true, // Patrick Crosby, "patrick"
+	"ebbe1d99410ab70123262cf8dfc87900": true, // Fred Akalin, "akalin"
+	"8bc0fd2f5fefd30d3ec04452600f4300": true, // Andy Alness, "alness"
+	"e0b4166c9c839275cf5633ff65c3e819": true, // Chris Nojima, "chrisnojima"
+	"d95f137b3b4a3600bc9e39350adba819": true, // Cécile Boucheron, "cecileb"
+	"4c230ae8d2f922dc2ccc1d2f94890700": true, // Marco Polo, "marcopolo"
+	"237e85db5d939fbd4b84999331638200": true, // Chris Ball, "cjb"
+	"69da56f622a2ac750b8e590c3658a700": true, // John Zila, "jzila"
+	"673a740cd20fb4bd348738b16d228219": true, // Steve Sanders, "zanderz"
+	"95e88f2087e480cae28f08d81554bc00": true, // Mike Maxim, "mikem"
+	"5c2ef2d4eddd2381daa681ac1a901519": true, // Max Goodman, "chromakode"
+	"08abe80bd2da8984534b2d8f7b12c700": true, // Song Gao, "songgao"
+	"eb08cb06e608ea41bd893946445d7919": true, // Miles Steele, "mlsteele"
+}
+
 type journalServerConfig struct {
 	// EnableAuto, if true, means the user has explicitly set its
 	// value. If false, then either the user turned it on and then
@@ -86,51 +109,6 @@ type branchChangeListener interface {
 // avoid deadlocks.
 type mdFlushListener interface {
 	onMDFlush(tlf.ID, BranchID, MetadataRevision)
-}
-
-// diskLimiter is an interface for limiting disk usage.
-type diskLimiter interface {
-	// onJournalEnable is called when initializing a TLF journal
-	// with that journal's current disk usage. Both journalBytes
-	// and journalFiles must be >= 0. The updated available byte
-	// and file count must be returned.
-	onJournalEnable(
-		ctx context.Context, journalBytes, journalFiles int64) (
-		availableBytes, availableFiles int64)
-
-	// onJournalDisable is called when shutting down a TLF journal
-	// with that journal's current disk usage. Both journalBytes
-	// and journalFiles must be >= 0.
-	onJournalDisable(ctx context.Context, journalBytes, journalFiles int64)
-
-	// beforeBlockPut is called before putting a block of the
-	// given byte and file count, both of which must be > 0. It
-	// may block, but must return immediately with a
-	// (possibly-wrapped) ctx.Err() if ctx is cancelled. The
-	// updated available byte and file count must be returned,
-	// even if err is non-nil.
-	beforeBlockPut(ctx context.Context,
-		blockBytes, blockFiles int64) (
-		availableBytes, availableFiles int64, err error)
-
-	// afterBlockPut is called after putting a block of the given
-	// byte and file count, which must match the corresponding call to
-	// beforeBlockPut. putData reflects whether or not the data
-	// was actually put; if it's false, it's either because of an
-	// error or because the block already existed.
-	afterBlockPut(ctx context.Context,
-		blockBytes, blockFiles int64, putData bool)
-
-	// onBlocksDelete is called after deleting one or more blocks
-	// of the given total byte and file count, both of which must
-	// be >= 0. (Deleting a block with either zero byte or zero
-	// file count shouldn't happen, but may as well let it go
-	// through.)
-	onBlocksDelete(ctx context.Context, blockBytes, blockFiles int64)
-
-	// getStatus returns an object that's marshallable into JSON
-	// for use in displaying status.
-	getStatus() interface{}
 }
 
 // TODO: JournalServer isn't really a server, although it can create

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -53,10 +53,10 @@ func setupJournalServerTest(t *testing.T) (
 		}
 	}()
 
-	limiter, err := config.MakeDiskLimiter(tempdir)
+	_, err = config.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
-		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)
@@ -120,8 +120,7 @@ func TestJournalServerRestart(t *testing.T) {
 	jServer = makeJournalServer(
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
-		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil,
-		jServer.DiskLimiter)
+		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(
@@ -442,8 +441,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	jServer = makeJournalServer(
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
-		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil,
-		jServer.DiskLimiter)
+		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -53,8 +53,10 @@ func setupJournalServerTest(t *testing.T) (
 		}
 	}()
 
+	limiter, err := config.MakeDiskLimiter(tempdir)
+	require.NoError(t, err)
 	_, err = config.EnableJournaling(
-		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
 	require.NoError(t, err)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -53,7 +53,7 @@ func setupJournalServerTest(t *testing.T) (
 		}
 	}()
 
-	_, err = config.enableJournaling(
+	_, err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)
@@ -119,7 +119,7 @@ func TestJournalServerRestart(t *testing.T) {
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil,
-		jServer.diskLimiter)
+		jServer.DiskLimiter)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(
@@ -441,7 +441,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil,
-		jServer.diskLimiter)
+		jServer.DiskLimiter)
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -55,7 +55,7 @@ func setupJournalServerTest(t *testing.T) (
 
 	limiter, err := config.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
-	_, err = config.EnableJournaling(
+	err = config.EnableJournaling(
 		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -53,7 +53,7 @@ func setupJournalServerTest(t *testing.T) (
 		}
 	}()
 
-	err = config.EnableJournaling(
+	_, err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -53,7 +53,7 @@ func setupJournalServerTest(t *testing.T) (
 		}
 	}()
 
-	_, err = config.EnableJournaling(
+	_, err = config.enableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -172,10 +172,10 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 		err := ioutil.RemoveAll(tempdir)
 		assert.NoError(t, err)
 	}()
-	limiter, err := config1.MakeDiskLimiter(tempdir)
+	_, err = config1.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config1.EnableJournaling(
-		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err := GetJournalServer(config1)
 	require.NoError(t, err)
@@ -231,9 +231,11 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 
 	// now re-login u1
 	config1B := ConfigAsUser(config1, userName1)
+	_, err = config1B.MakeDiskLimiter(tempdir)
+	require.NoError(t, err)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
 	err = config1B.EnableJournaling(
-		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config1B)
 	require.NoError(t, err)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -174,7 +174,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	}()
 	limiter, err := config1.MakeDiskLimiter(tempdir)
 	require.NoError(t, err)
-	_, err = config1.EnableJournaling(
+	err = config1.EnableJournaling(
 		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err := GetJournalServer(config1)
@@ -232,7 +232,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	// now re-login u1
 	config1B := ConfigAsUser(config1, userName1)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
-	_, err = config1B.EnableJournaling(
+	err = config1B.EnableJournaling(
 		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config1B)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -172,7 +172,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 		err := ioutil.RemoveAll(tempdir)
 		assert.NoError(t, err)
 	}()
-	err = config1.EnableJournaling(
+	_, err = config1.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err := GetJournalServer(config1)
@@ -230,7 +230,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	// now re-login u1
 	config1B := ConfigAsUser(config1, userName1)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
-	err = config1B.EnableJournaling(
+	_, err = config1B.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config1B)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -172,7 +172,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 		err := ioutil.RemoveAll(tempdir)
 		assert.NoError(t, err)
 	}()
-	_, err = config1.enableJournaling(
+	_, err = config1.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err := GetJournalServer(config1)
@@ -230,7 +230,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	// now re-login u1
 	config1B := ConfigAsUser(config1, userName1)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
-	_, err = config1B.enableJournaling(
+	_, err = config1B.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config1B)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -172,8 +172,10 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 		err := ioutil.RemoveAll(tempdir)
 		assert.NoError(t, err)
 	}()
+	limiter, err := config1.MakeDiskLimiter(tempdir)
+	require.NoError(t, err)
 	_, err = config1.EnableJournaling(
-		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err := GetJournalServer(config1)
 	require.NoError(t, err)
@@ -231,7 +233,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	config1B := ConfigAsUser(config1, userName1)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
 	_, err = config1B.EnableJournaling(
-		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, limiter, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config1B)
 	require.NoError(t, err)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -172,7 +172,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 		err := ioutil.RemoveAll(tempdir)
 		assert.NoError(t, err)
 	}()
-	_, err = config1.EnableJournaling(
+	_, err = config1.enableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err := GetJournalServer(config1)
@@ -230,7 +230,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	// now re-login u1
 	config1B := ConfigAsUser(config1, userName1)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
-	_, err = config1B.EnableJournaling(
+	_, err = config1B.enableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
 	require.NoError(t, err)
 	jServer, err = GetJournalServer(config1B)

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -57,7 +57,7 @@ func serviceLoggedIn(ctx context.Context, config Config, name string,
 	if config.DiskBlockCache() == nil && adminFeatureList[session.UID] {
 		dbc, err := newDiskBlockCacheStandard(config,
 			diskBlockCacheRootFromStorageRoot(config.StorageRoot()),
-			defaultDiskBlockCacheMaxBytes, config.DiskLimiter())
+			config.DiskLimiter())
 		if err == nil {
 			config.SetDiskBlockCache(dbc)
 		}

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -56,8 +56,7 @@ func serviceLoggedIn(ctx context.Context, config Config, name string,
 	}
 	if config.DiskBlockCache() == nil && adminFeatureList[session.UID] {
 		dbc, err := newDiskBlockCacheStandard(config,
-			diskBlockCacheRootFromStorageRoot(config.StorageRoot()),
-			config.DiskLimiter())
+			diskBlockCacheRootFromStorageRoot(config.StorageRoot()))
 		if err == nil {
 			config.SetDiskBlockCache(dbc)
 		}

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -4,7 +4,33 @@
 
 package libkbfs
 
-import "golang.org/x/net/context"
+import (
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+// TODO: Add a server endpoint to get this data.
+var adminFeatureList = map[keybase1.UID]bool{
+	"23260c2ce19420f97b58d7d95b68ca00": true, // Chris Coyne "chris"
+	"dbb165b7879fe7b1174df73bed0b9500": true, // Max Krohn, "max"
+	"ef2e49961eddaa77094b45ed635cfc00": true, // Jeremy Stribling, "strib"
+	"41b1f75fb55046d370608425a3208100": true, // Jack O'Connor, "oconnor663"
+	"9403ede05906b942fd7361f40a679500": true, // Jinyang Li, "jinyang"
+	"b7c2eaddcced7727bcb229751d91e800": true, // Gabriel Handford, "gabrielh"
+	"1563ec26dc20fd162a4f783551141200": true, // Patrick Crosby, "patrick"
+	"ebbe1d99410ab70123262cf8dfc87900": true, // Fred Akalin, "akalin"
+	"8bc0fd2f5fefd30d3ec04452600f4300": true, // Andy Alness, "alness"
+	"e0b4166c9c839275cf5633ff65c3e819": true, // Chris Nojima, "chrisnojima"
+	"d95f137b3b4a3600bc9e39350adba819": true, // Cécile Boucheron, "cecileb"
+	"4c230ae8d2f922dc2ccc1d2f94890700": true, // Marco Polo, "marcopolo"
+	"237e85db5d939fbd4b84999331638200": true, // Chris Ball, "cjb"
+	"69da56f622a2ac750b8e590c3658a700": true, // John Zila, "jzila"
+	"673a740cd20fb4bd348738b16d228219": true, // Steve Sanders, "zanderz"
+	"95e88f2087e480cae28f08d81554bc00": true, // Mike Maxim, "mikem"
+	"5c2ef2d4eddd2381daa681ac1a901519": true, // Max Goodman, "chromakode"
+	"08abe80bd2da8984534b2d8f7b12c700": true, // Song Gao, "songgao"
+	"eb08cb06e608ea41bd893946445d7919": true, // Miles Steele, "mlsteele"
+}
 
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
@@ -26,6 +52,14 @@ func serviceLoggedIn(ctx context.Context, config Config, name string,
 		if err != nil {
 			log.CWarningf(ctx,
 				"Failed to enable existing journals: %v", err)
+		}
+	}
+	if config.DiskBlockCache() == nil && adminFeatureList[session.UID] {
+		dbc, err := newDiskBlockCacheStandard(config,
+			diskBlockCacheRootFromStorageRoot(config.StorageRoot()),
+			defaultDiskBlockCacheMaxBytes, config.DiskLimiter())
+		if err == nil {
+			config.SetDiskBlockCache(dbc)
 		}
 	}
 

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -57,6 +57,24 @@ func (sdl semaphoreDiskLimiter) onJournalDisable(
 	}
 }
 
+func (sdl semaphoreDiskLimiter) onDiskCacheEnable(
+	ctx context.Context, diskCacheBytes int64) (
+	availableBytes int64) {
+	if diskCacheBytes != 0 {
+		availableBytes = sdl.byteSemaphore.ForceAcquire(diskCacheBytes)
+	} else {
+		availableBytes = sdl.byteSemaphore.Count()
+	}
+	return availableBytes
+}
+
+func (sdl semaphoreDiskLimiter) onDiskCacheDisable(
+	ctx context.Context, diskCacheBytes int64) {
+	if diskCacheBytes != 0 {
+		sdl.byteSemaphore.Release(diskCacheBytes)
+	}
+}
+
 func (sdl semaphoreDiskLimiter) beforeBlockPut(
 	ctx context.Context, blockBytes, blockFiles int64) (
 	availableBytes, availableFiles int64, err error) {

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -109,15 +109,12 @@ func (sdl semaphoreDiskLimiter) onDiskBlockCacheDelete(ctx context.Context,
 }
 
 func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,
-	blockBytes, diskBlockCacheBytes int64) (bytesAcquired int64, err error) {
+	blockBytes, diskBlockCacheBytes int64) (availableBytes int64, err error) {
 	if blockBytes == 0 {
-		return 0, nil
+		return 0, errors.New("semaphoreDiskLimiter.beforeDiskBlockCachePut" +
+			" called with 0 blockBytes")
 	}
-	availableBytes, err := sdl.byteSemaphore.Acquire(ctx, blockBytes)
-	if err != nil {
-		return availableBytes, err
-	}
-	return availableBytes, nil
+	return sdl.byteSemaphore.ForceAcquire(blockBytes), nil
 }
 
 type semaphoreDiskLimiterStatus struct {

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -117,6 +117,13 @@ func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,
 	return sdl.byteSemaphore.ForceAcquire(blockBytes), nil
 }
 
+func (sdl semaphoreDiskLimiter) afterDiskBlockCachePut(ctx context.Context,
+	blockBytes int64, putData bool) {
+	if !putData {
+		sdl.byteSemaphore.Release(blockBytes)
+	}
+}
+
 type semaphoreDiskLimiterStatus struct {
 	Type string
 

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -103,6 +103,23 @@ func (sdl semaphoreDiskLimiter) onBlocksDelete(
 	}
 }
 
+func (sdl semaphoreDiskLimiter) onDiskBlockCacheDelete(ctx context.Context,
+	blockBytes int64) {
+	sdl.onBlockDelete(ctx, blockBytes, 0)
+}
+
+func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,
+	blockBytes int64) (bytesAcquired int64, err error) {
+	if blockBytes == 0 {
+		return 0, nil
+	}
+	availableBytes, err := sdl.byteSemaphore.Acquire(ctx, blockBytes)
+	if err != nil {
+		return availableBytes, err
+	}
+	return availableBytes, nil
+}
+
 type semaphoreDiskLimiterStatus struct {
 	Type string
 

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -109,7 +109,7 @@ func (sdl semaphoreDiskLimiter) onDiskBlockCacheDelete(ctx context.Context,
 }
 
 func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,
-	blockBytes int64) (bytesAcquired int64, err error) {
+	blockBytes, diskBlockCacheBytes int64) (bytesAcquired int64, err error) {
 	if blockBytes == 0 {
 		return 0, nil
 	}

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -57,18 +57,14 @@ func (sdl semaphoreDiskLimiter) onJournalDisable(
 	}
 }
 
-func (sdl semaphoreDiskLimiter) onDiskCacheEnable(
-	ctx context.Context, diskCacheBytes int64) (
-	availableBytes int64) {
+func (sdl semaphoreDiskLimiter) onDiskBlockCacheEnable(
+	ctx context.Context, diskCacheBytes int64) {
 	if diskCacheBytes != 0 {
-		availableBytes = sdl.byteSemaphore.ForceAcquire(diskCacheBytes)
-	} else {
-		availableBytes = sdl.byteSemaphore.Count()
+		sdl.byteSemaphore.ForceAcquire(diskCacheBytes)
 	}
-	return availableBytes
 }
 
-func (sdl semaphoreDiskLimiter) onDiskCacheDisable(
+func (sdl semaphoreDiskLimiter) onDiskBlockCacheDisable(
 	ctx context.Context, diskCacheBytes int64) {
 	if diskCacheBytes != 0 {
 		sdl.byteSemaphore.Release(diskCacheBytes)

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -105,7 +105,7 @@ func (sdl semaphoreDiskLimiter) onBlocksDelete(
 
 func (sdl semaphoreDiskLimiter) onDiskBlockCacheDelete(ctx context.Context,
 	blockBytes int64) {
-	sdl.onBlockDelete(ctx, blockBytes, 0)
+	sdl.onBlocksDelete(ctx, blockBytes, 0)
 }
 
 func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -19,7 +19,7 @@ type semaphoreDiskLimiter struct {
 	fileSemaphore *kbfssync.Semaphore
 }
 
-var _ diskLimiter = semaphoreDiskLimiter{}
+var _ DiskLimiter = semaphoreDiskLimiter{}
 
 func newSemaphoreDiskLimiter(byteLimit, fileLimit int64) semaphoreDiskLimiter {
 	byteSemaphore := kbfssync.NewSemaphore()

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -109,7 +109,7 @@ func (sdl semaphoreDiskLimiter) onDiskBlockCacheDelete(ctx context.Context,
 }
 
 func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,
-	blockBytes, diskBlockCacheBytes int64) (availableBytes int64, err error) {
+	blockBytes int64) (availableBytes int64, err error) {
 	if blockBytes == 0 {
 		return 0, errors.New("semaphoreDiskLimiter.beforeDiskBlockCachePut" +
 			" called with 0 blockBytes")

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -50,7 +50,7 @@ func fakeMdID(b byte) MdID {
 //
 // TODO: Move more common code here.
 func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
-	config := NewConfigLocal(loggerFn)
+	config := NewConfigLocal(loggerFn, "")
 
 	bops := NewBlockOpsStandard(config,
 		testBlockRetrievalWorkerQueueSize)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -195,7 +195,7 @@ type tlfJournal struct {
 	// Invariant: this tlfJournal acquires exactly
 	// blockJournal.getStoredBytes() and
 	// blockJournal.getStoredFiles() until shutdown.
-	diskLimiter diskLimiter
+	DiskLimiter DiskLimiter
 
 	// All the channels below are used as simple on/off
 	// signals. They're buffered for one object, and all sends are
@@ -277,7 +277,7 @@ func makeTLFJournal(
 	dir string, tlfID tlf.ID, config tlfJournalConfig,
 	delegateBlockServer BlockServer, bws TLFJournalBackgroundWorkStatus,
 	bwDelegate tlfJournalBWDelegate, onBranchChange branchChangeListener,
-	onMDFlush mdFlushListener, diskLimiter diskLimiter) (
+	onMDFlush mdFlushListener, DiskLimiter DiskLimiter) (
 	*tlfJournal, error) {
 	if uid == keybase1.UID("") {
 		return nil, errors.New("Empty user")
@@ -347,7 +347,7 @@ func makeTLFJournal(
 		onBranchChange:       onBranchChange,
 		onMDFlush:            onMDFlush,
 		forcedSquashByBytes:  ForcedBranchSquashBytesThresholdDefault,
-		diskLimiter:          diskLimiter,
+		DiskLimiter:          DiskLimiter,
 		hasWorkCh:            make(chan struct{}, 1),
 		needPauseCh:          make(chan struct{}, 1),
 		needResumeCh:         make(chan struct{}, 1),
@@ -383,7 +383,7 @@ func makeTLFJournal(
 	// Do this only once we're sure we won't error.
 	storedBytes := j.blockJournal.getStoredBytes()
 	storedFiles := j.blockJournal.getStoredFiles()
-	availableBytes, availableFiles := j.diskLimiter.onJournalEnable(
+	availableBytes, availableFiles := j.DiskLimiter.onJournalEnable(
 		ctx, storedBytes, storedFiles)
 
 	go j.doBackgroundWorkLoop(bws, backoff.NewExponentialBackOff())
@@ -1132,7 +1132,7 @@ func (j *tlfJournal) doOnMDFlush(ctx context.Context,
 		return err
 	}
 
-	j.diskLimiter.onBlocksDelete(ctx, removedBytes, removedFiles)
+	j.DiskLimiter.onBlocksDelete(ctx, removedBytes, removedFiles)
 
 	j.journalLock.Lock()
 	defer j.journalLock.Unlock()
@@ -1548,7 +1548,7 @@ func (j *tlfJournal) shutdown(ctx context.Context) {
 	// shut-down journals against the disk limit.
 	storedBytes := j.blockJournal.getStoredBytes()
 	storedFiles := j.blockJournal.getStoredFiles()
-	j.diskLimiter.onJournalDisable(ctx, storedBytes, storedFiles)
+	j.DiskLimiter.onJournalDisable(ctx, storedBytes, storedFiles)
 
 	// Make further accesses error out.
 	j.blockJournal = nil
@@ -1669,7 +1669,7 @@ func (j *tlfJournal) putBlockData(
 	defer cancel()
 
 	bufLen := int64(len(buf))
-	availableBytes, availableFiles, err := j.diskLimiter.beforeBlockPut(
+	availableBytes, availableFiles, err := j.DiskLimiter.beforeBlockPut(
 		acquireCtx, bufLen, filesPerBlockMax)
 	switch errors.Cause(err) {
 	case nil:
@@ -1685,7 +1685,7 @@ func (j *tlfJournal) putBlockData(
 
 	var putData bool
 	defer func() {
-		j.diskLimiter.afterBlockPut(
+		j.DiskLimiter.afterBlockPut(
 			ctx, bufLen, filesPerBlockMax, putData)
 	}()
 

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -475,7 +475,7 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.diskLimiter.onJournalEnable(ctx, math.MaxInt64-6, 0)
+	tlfJournal.DiskLimiter.onJournalEnable(ctx, math.MaxInt64-6, 0)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
 
@@ -512,7 +512,7 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.diskLimiter.onJournalEnable(
+	tlfJournal.DiskLimiter.onJournalEnable(
 		ctx, 0, math.MaxInt64-2*filesPerBlockMax+1)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
@@ -550,7 +550,7 @@ func testTLFJournalBlockOpDiskLimitDuplicate(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.diskLimiter.onJournalEnable(
+	tlfJournal.DiskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-8, math.MaxInt64-2*filesPerBlockMax)
 
 	data := []byte{1, 2, 3, 4}
@@ -575,7 +575,7 @@ func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.diskLimiter.onJournalEnable(ctx, math.MaxInt64, 0)
+	tlfJournal.DiskLimiter.onJournalEnable(ctx, math.MaxInt64, 0)
 
 	ctx2, cancel2 := context.WithCancel(ctx)
 	cancel2()
@@ -592,7 +592,7 @@ func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.diskLimiter.onJournalEnable(
+	tlfJournal.DiskLimiter.onJournalEnable(
 		ctx, math.MaxInt64, math.MaxInt64-1)
 	config.dlTimeout = 3 * time.Microsecond
 
@@ -615,7 +615,7 @@ func testTLFJournalBlockOpDiskLimitPutFailure(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.diskLimiter.onJournalEnable(
+	tlfJournal.DiskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-6, math.MaxInt64-filesPerBlockMax)
 
 	data := []byte{1, 2, 3, 4}

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -567,13 +567,12 @@ func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 		e.tb.Logf("Journal directory: %s", e.journalDir)
 		for i, c := range cfgs {
 			journalRoot := filepath.Join(jdir, users[i].String())
-			limiter, err := c.MakeDiskLimiter(journalRoot)
+			_, err = c.MakeDiskLimiter(journalRoot)
 			if err != nil {
 				panic(fmt.Sprintf("No disk limiter for %d: %+v", i, err))
 			}
 			c.EnableJournaling(context.Background(),
-				journalRoot, limiter,
-				libkbfs.TLFJournalBackgroundWorkEnabled)
+				journalRoot, libkbfs.TLFJournalBackgroundWorkEnabled)
 			jServer, err := libkbfs.GetJournalServer(c)
 			if err != nil {
 				panic(fmt.Sprintf("No journal server for %d: %+v", i, err))

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -566,8 +566,13 @@ func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 		e.journalDir = jdir
 		e.tb.Logf("Journal directory: %s", e.journalDir)
 		for i, c := range cfgs {
+			journalRoot := filepath.Join(jdir, users[i].String())
+			limiter, err := c.MakeDiskLimiter(journalRoot)
+			if err != nil {
+				panic(fmt.Sprintf("No disk limiter for %d: %+v", i, err))
+			}
 			c.EnableJournaling(context.Background(),
-				filepath.Join(jdir, users[i].String()),
+				journalRoot, limiter,
 				libkbfs.TLFJournalBackgroundWorkEnabled)
 			jServer, err := libkbfs.GetJournalServer(c)
 			if err != nil {

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -80,12 +80,12 @@ func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 		for name, c := range userMap {
 			config := c.(*libkbfs.ConfigLocal)
 			journalRoot := filepath.Join(jdir, name.String())
-			limiter, err := config.MakeDiskLimiter(journalRoot)
+			_, err = config.MakeDiskLimiter(journalRoot)
 			if err != nil {
 				panic(fmt.Sprintf("No disk limiter for %s: %+v", name, err))
 			}
 			config.EnableJournaling(context.Background(), journalRoot,
-				limiter, libkbfs.TLFJournalBackgroundWorkEnabled)
+				libkbfs.TLFJournalBackgroundWorkEnabled)
 			jServer, err := libkbfs.GetJournalServer(config)
 			if err != nil {
 				panic(fmt.Sprintf("No journal server for %s: %+v", name, err))

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -79,10 +79,13 @@ func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 		k.tb.Logf("Journal directory: %s", k.journalDir)
 		for name, c := range userMap {
 			config := c.(*libkbfs.ConfigLocal)
-			config.EnableJournaling(
-				context.Background(),
-				filepath.Join(jdir, name.String()),
-				libkbfs.TLFJournalBackgroundWorkEnabled)
+			journalRoot := filepath.Join(jdir, name.String())
+			limiter, err := config.MakeDiskLimiter(journalRoot)
+			if err != nil {
+				panic(fmt.Sprintf("No disk limiter for %s: %+v", name, err))
+			}
+			config.EnableJournaling(context.Background(), journalRoot,
+				limiter, libkbfs.TLFJournalBackgroundWorkEnabled)
 			jServer, err := libkbfs.GetJournalServer(config)
 			if err != nil {
 				panic(fmt.Sprintf("No journal server for %s: %+v", name, err))


### PR DESCRIPTION
This PR adds the ability for the journal's `diskLimiter` to also work with the `DiskBlockCacheStandard`. The limit function is as follows:

* min(20GB, 0.1 * free space on drive)

In practice the disk cache will only hit 20GB when the user has >=200GB of available space. We can ship future builds where this will be a tunable parameter.