### PR TITLE
simplefs: Move out simplefs to separate package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -302,6 +302,13 @@ def runNixTest(prefix) {
             sh './libfuse.test -test.timeout 2m'
         }
     }
+    tests[prefix+'simplefs'] = {
+        dir('simplefs') {
+            sh 'go test -i'
+            sh 'go test -c'
+            sh './simplefs.test -test.timeout 2m'
+        }
+    }
     tests[prefix+'test'] = {
         dir('test') {
             sh 'go test -i -tags fuse'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,6 +68,7 @@ build_script:
   - echo github.com/keybase/kbfs/tlf >> testlist.txt
   - echo github.com/keybase/kbfs/libkbfs >> testlist.txt
   - echo github.com/keybase/kbfs/libdokan >> testlist.txt
+  - echo github.com/keybase/kbfs/simplefs >> testlist.txt
   - echo github.com/keybase/kbfs/test >> testlist.txt
 # TODO: Run the below tests with env KEYBASE_TEST_BSERVER_ADDR=tempdir.
   - for /f %%i in (testlist.txt) do (appveyor AddTest %%i -Outcome Running -Framework gotest -Filename %%i & go test -timeout 5m %%i && appveyor UpdateTest %%i -Outcome Passed -Framework gotest -Filename %%i -Duration 0) || (appveyor UpdateTest %%i -Outcome Failed -Framework gotest -Filename %%i -Duration 0 & exit /b 1) 

--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/simplefs"
 	"golang.org/x/net/context"
 )
 
@@ -26,6 +27,9 @@ type StartOptions struct {
 
 // Start the filesystem
 func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
+	// Hook simplefs implementation in.
+	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
+
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {
 		return libfs.InitError(err.Error())

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/simplefs"
 	"golang.org/x/net/context"
 )
 
@@ -24,6 +25,9 @@ type StartOptions struct {
 
 // Start the filesystem
 func Start(mounter Mounter, options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
+	// Hook simplefs implementation in.
+	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
+
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {
 		return libfs.InitError(err.Error())

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1232,20 +1232,3 @@ type InvalidFavoritesOpError struct{}
 func (InvalidFavoritesOpError) Error() string {
 	return "invalid FavoritesOp"
 }
-
-// SimpleFSError wraps errors for SimpleFS
-type SimpleFSError struct {
-	reason string
-}
-
-// Error implements the error interface for SimpleFSError
-func (e SimpleFSError) Error() string { return e.reason }
-
-// ToStatus implements the keybase1.ToStatusAble interface for SimpleFSError
-func (e SimpleFSError) ToStatus() keybase1.Status {
-	return keybase1.Status{
-		Name: e.reason,
-		Code: int(keybase1.StatusCode_SCGeneric),
-		Desc: e.Error(),
-	}
-}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 )
 
 // InitParams contains the initialization parameters for Init(). It is
@@ -72,6 +73,10 @@ type InitParams struct {
 	// directory to put write journals in. If non-empty, enables
 	// write journaling to be turned on for TLFs.
 	WriteJournalRoot string
+
+	// CreateSimpleFSInstance creates a SimpleFSInterface from config.
+	// If this is nil then simplefs will be omitted in the rpc api.
+	CreateSimpleFSInstance func(Config) keybase1.SimpleFSInterface
 }
 
 // defaultBServer returns the default value for the -bserver flag.

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -24,7 +24,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 		if err != nil {
 			return nil, err
 		}
-		return NewKeybaseDaemonRPC(config, ctx, log, params.Debug), nil
+		return NewKeybaseDaemonRPC(config, ctx, log, params.Debug, params.CreateSimpleFSInstance), nil
 	}
 
 	users := []libkb.NormalizedUsername{

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -45,6 +45,10 @@ var _ keybase1.SimpleFSInterface = (*SimpleFS)(nil)
 
 // NewSimpleFS creates a new SimpleFS instance.
 func NewSimpleFS(config libkbfs.Config) keybase1.SimpleFSInterface {
+	return newSimpleFS(config)
+}
+
+func newSimpleFS(config libkbfs.Config) *SimpleFS {
 	log := config.MakeLogger("simplefs")
 	return &SimpleFS{
 		config:     config,

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -43,6 +43,7 @@ type handle struct {
 // make sure the interface is implemented
 var _ keybase1.SimpleFSInterface = (*SimpleFS)(nil)
 
+// NewSimpleFS creates a new SimpleFS instance.
 func NewSimpleFS(config libkbfs.Config) keybase1.SimpleFSInterface {
 	log := config.MakeLogger("simplefs")
 	return &SimpleFS{
@@ -515,7 +516,7 @@ func (k *SimpleFS) SimpleFSClose(ctx context.Context, opid keybase1.OpID) (err e
 // SimpleFSCheck - Check progress of pending operation
 func (k *SimpleFS) SimpleFSCheck(_ context.Context, opid keybase1.OpID) (keybase1.Progress, error) {
 	// TODO
-	return 0, SimpleFSError{"Not implemented"}
+	return 0, simpleFSError{"Not implemented"}
 }
 
 // SimpleFSGetOps - Get all the outstanding operations
@@ -769,7 +770,7 @@ func (k *SimpleFS) pathIO(ctx context.Context, path keybase1.Path,
 		}
 		return &localIO{f, det}, nil
 	}
-	return nil, SimpleFSError{"Invalid path type"}
+	return nil, simpleFSError{"Invalid path type"}
 }
 
 type kbfsIO struct {
@@ -900,21 +901,21 @@ func (k *SimpleFS) setResult(opid keybase1.OpID, val interface{}) {
 	k.lock.Unlock()
 }
 
-var errOnlyRemotePathSupported = SimpleFSError{"Only remote paths are supported for this operation"}
-var errInvalidRemotePath = SimpleFSError{"Invalid remote path"}
-var errNoSuchHandle = SimpleFSError{"No such handle"}
-var errNoResult = SimpleFSError{"Async result not found"}
+var errOnlyRemotePathSupported = simpleFSError{"Only remote paths are supported for this operation"}
+var errInvalidRemotePath = simpleFSError{"Invalid remote path"}
+var errNoSuchHandle = simpleFSError{"No such handle"}
+var errNoResult = simpleFSError{"Async result not found"}
 
-// SimpleFSError wraps errors for SimpleFS
-type SimpleFSError struct {
+// simpleFSError wraps errors for SimpleFS
+type simpleFSError struct {
 	reason string
 }
 
-// Error implements the error interface for SimpleFSError
-func (e SimpleFSError) Error() string { return e.reason }
+// Error implements the error interface for simpleFSError
+func (e simpleFSError) Error() string { return e.reason }
 
-// ToStatus implements the keybase1.ToStatusAble interface for SimpleFSError
-func (e SimpleFSError) ToStatus() keybase1.Status {
+// ToStatus implements the keybase1.ToStatusAble interface for simpleFSError
+func (e simpleFSError) ToStatus() keybase1.Status {
 	return keybase1.Status{
 		Name: e.reason,
 		Code: int(keybase1.StatusCode_SCGeneric),

--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 
-package libkbfs
+package simplefs
 
 import (
 	"context"
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/libkbfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -41,7 +42,7 @@ func deleteTempLocalPath(path keybase1.Path) {
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
-	sfs := newSimpleFS(MakeTestConfigOrBust(t, "jdoe"))
+	sfs := newSimpleFS(libkbfs.MakeTestConfigOrBust(t, "jdoe"))
 	defer closeSimpleFS(ctx, t, sfs)
 
 	// make a temp remote directory + files we will clean up later
@@ -97,7 +98,7 @@ func TestList(t *testing.T) {
 
 func TestCopyToLocal(t *testing.T) {
 	ctx := context.Background()
-	sfs := newSimpleFS(MakeTestConfigOrBust(t, "jdoe"))
+	sfs := newSimpleFS(libkbfs.MakeTestConfigOrBust(t, "jdoe"))
 	defer closeSimpleFS(ctx, t, sfs)
 
 	// make a temp remote directory + file(s) we will clean up later
@@ -134,7 +135,7 @@ func TestCopyToLocal(t *testing.T) {
 
 func TestCopyToRemote(t *testing.T) {
 	ctx := context.Background()
-	sfs := newSimpleFS(MakeTestConfigOrBust(t, "jdoe"))
+	sfs := newSimpleFS(libkbfs.MakeTestConfigOrBust(t, "jdoe"))
 	defer closeSimpleFS(ctx, t, sfs)
 
 	// make a temp remote directory + file(s) we will clean up later


### PR DESCRIPTION
As discussed on Slack.

The instance is passed through InitParams because the connection to service is created before a separate hypothetical SetSimpleFSImplementation could be created. With the current way the simplefs implementation can be present when the connection is opened.