### PR TITLE
folder_branch_ops: SyncFromServer loops on merged rev error

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -582,6 +582,8 @@ func (fbo *folderBranchOps) setBranchIDLocked(lState *lockState, bid BranchID) {
 }
 
 var errNoFlushedRevisions = errors.New("No flushed MDs yet")
+var errNoMergedRevWhileStaged = errors.New(
+	"Cannot find most recent merged revision while staged")
 
 // getJournalPredecessorRevision returns the revision that precedes
 // the current journal head if journaling enabled and there are
@@ -607,8 +609,7 @@ func (fbo *folderBranchOps) getJournalPredecessorRevision(ctx context.Context) (
 	}
 
 	if jStatus.BranchID != NullBranchID.String() {
-		return MetadataRevisionUninitialized,
-			errors.New("Cannot find most recent merged revision while staged")
+		return MetadataRevisionUninitialized, errNoMergedRevWhileStaged
 	}
 
 	if jStatus.RevisionStart == MetadataRevisionUninitialized {
@@ -4897,6 +4898,8 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 				}
 			}
 			if _, isUnmerged := err.(UnmergedError); isUnmerged {
+				continue
+			} else if err == errNoMergedRevWhileStaged {
 				continue
 			}
 			return err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -989,13 +989,13 @@ func (j *tlfJournal) convertMDsToBranchLocked(
 	}
 	j.unsquashedBytes = 0
 
+	if j.onBranchChange != nil {
+		j.onBranchChange.onTLFBranchChange(j.tlfID, bid)
+	}
+
 	// Pause while on a conflict branch.
 	if doSignal {
 		j.pause(journalPauseConflict)
-	}
-
-	if j.onBranchChange != nil {
-		j.onBranchChange.onTLFBranchChange(j.tlfID, bid)
 	}
 
 	return nil


### PR DESCRIPTION
Something changed where `getAndApplyMDUpdates()` can now return the "Cannot find most recent merged revision while staged" if the journal becomes staged, rather than the `UnmergedError`.  We still need to continue waiting for CR in that case.

Also, on conflict in `tlfJournal`, signal branch change before pausing. If we pause first, then there's a race where folderBranchOps.SyncFromServerForTesting will finish waiting for the journal and then not have anything to CR because the branch change hasn't happened yet.

Issue: KBFS-2017