### PR TITLE
bserver_remote: add pings and disconnect on timeouts

### DIFF
--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -95,8 +95,9 @@ func (b *blockServerRemoteClientHandler) initNewConnection() {
 	}
 
 	b.conn = rpc.NewTLSConnection(
-		b.srvAddr, kbfscrypto.GetRootCerts(b.srvAddr), MDServerErrorUnwrapper{},
-		b, b.rpcLogFactory, b.log, b.connOpts)
+		b.srvAddr, kbfscrypto.GetRootCerts(b.srvAddr),
+		kbfsblock.BServerErrorUnwrapper{}, b, b.rpcLogFactory, b.log,
+		b.connOpts)
 	b.client = keybase1.BlockClient{Cli: b.conn.GetClient()}
 }
 

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -114,7 +114,7 @@ func (b *blockServerRemoteClientHandler) shutdown() {
 	}
 
 	// cancel the ping ticker
-	b.pinger.resetTicker(0)
+	b.pinger.cancelTicker()
 }
 
 func (b *blockServerRemoteClientHandler) getConn() *rpc.Connection {
@@ -197,7 +197,7 @@ func (b *blockServerRemoteClientHandler) OnConnectError(err error, wait time.Dur
 	if b.authToken != nil {
 		b.authToken.Shutdown()
 	}
-	b.pinger.resetTicker(0)
+	b.pinger.cancelTicker()
 	// TODO: it might make sense to show something to the user if this is
 	// due to authentication, for example.
 }
@@ -216,7 +216,7 @@ func (b *blockServerRemoteClientHandler) OnDisconnected(ctx context.Context,
 	if b.authToken != nil {
 		b.authToken.Shutdown()
 	}
-	b.pinger.resetTicker(0)
+	b.pinger.cancelTicker()
 }
 
 // ShouldRetry implements the ConnectionHandler interface.

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/keybase/backoff"
@@ -26,46 +27,130 @@ const (
 	BServerTokenExpireIn = 2 * 60 * 60 // 2 hours
 )
 
-type blockServerRemoteConfig interface {
-	diskBlockCacheGetter
-	codecGetter
-	signerGetter
-	currentSessionGetterGetter
-	logMaker
-}
-
-// BlockServerRemote implements the BlockServer interface and
-// represents a remote KBFS block server.
-type BlockServerRemote struct {
-	config     blockServerRemoteConfig
-	shutdownFn func()
-	putClient  keybase1.BlockInterface
-	getClient  keybase1.BlockInterface
-	log        logger.Logger
-	deferLog   logger.Logger
-	blkSrvAddr string
-
-	putAuthToken *kbfscrypto.AuthToken
-	getAuthToken *kbfscrypto.AuthToken
-}
-
-// Test that BlockServerRemote fully implements the BlockServer interface.
-var _ BlockServer = (*BlockServerRemote)(nil)
-
 // blockServerRemoteAuthTokenRefresher is a helper struct for
-// refreshing auth tokens.
+// refreshing auth tokens and managing connections.
 type blockServerRemoteClientHandler struct {
-	bs        *BlockServerRemote
-	name      string
-	authToken *kbfscrypto.AuthToken
-	client    keybase1.BlockInterface
+	name          string
+	log           logger.Logger
+	deferLog      logger.Logger
+	csg           currentSessionGetter
+	authToken     *kbfscrypto.AuthToken
+	srvAddr       string
+	connOpts      rpc.ConnectionOpts
+	rpcLogFactory *libkb.RPCLogFactory
+
+	connMu sync.RWMutex
+	conn   *rpc.Connection
+	client keybase1.BlockInterface
+
+	tickerMu     sync.Mutex
+	tickerCancel context.CancelFunc
+}
+
+func newBlockServerRemoteClientHandler(name string, log logger.Logger,
+	signer kbfscrypto.Signer, csg currentSessionGetter, srvAddr string,
+	rpcLogFactory *libkb.RPCLogFactory) *blockServerRemoteClientHandler {
+	deferLog := log.CloneWithAddedDepth(1)
+	b := &blockServerRemoteClientHandler{
+		name:          name,
+		log:           log,
+		deferLog:      deferLog,
+		csg:           csg,
+		srvAddr:       srvAddr,
+		rpcLogFactory: rpcLogFactory,
+	}
+
+	b.authToken = kbfscrypto.NewAuthToken(
+		signer, BServerTokenServer, BServerTokenExpireIn,
+		"libkbfs_bserver_remote", VersionString(), b)
+
+	constBackoff := backoff.NewConstantBackOff(RPCReconnectInterval)
+	b.connOpts = rpc.ConnectionOpts{
+		DontConnectNow:   true, // connect only on-demand
+		WrapErrorFunc:    libkb.WrapError,
+		TagsFunc:         libkb.LogTagsFromContext,
+		ReconnectBackoff: func() backoff.BackOff { return constBackoff },
+	}
+	b.initNewConnection()
+	return b
+}
+
+func (b *blockServerRemoteClientHandler) initNewConnection() {
+	b.connMu.Lock()
+	defer b.connMu.Unlock()
+
+	if b.conn != nil {
+		b.conn.Shutdown()
+	}
+
+	b.conn = rpc.NewTLSConnection(
+		b.srvAddr, kbfscrypto.GetRootCerts(b.srvAddr), MDServerErrorUnwrapper{},
+		b, b.rpcLogFactory, b.log, b.connOpts)
+	b.client = keybase1.BlockClient{Cli: b.conn.GetClient()}
+}
+
+func (b *blockServerRemoteClientHandler) shutdown() {
+	if b.authToken != nil {
+		b.authToken.Shutdown()
+	}
+
+	b.connMu.Lock()
+	defer b.connMu.Unlock()
+
+	if b.conn != nil {
+		b.conn.Shutdown()
+	}
+}
+
+func (b *blockServerRemoteClientHandler) getConn() *rpc.Connection {
+	b.connMu.RLock()
+	defer b.connMu.RUnlock()
+	return b.conn
+}
+
+func (b *blockServerRemoteClientHandler) getClient() keybase1.BlockInterface {
+	b.connMu.RLock()
+	defer b.connMu.RUnlock()
+	return b.client
+}
+
+// resetAuth is called to reset the authorization on a BlockServer
+// connection.
+func (b *blockServerRemoteClientHandler) resetAuth(
+	ctx context.Context, c keybase1.BlockInterface) (err error) {
+	defer func() {
+		b.deferLog.CDebugf(
+			ctx, "BlockServerRemote: resetAuth called, err: %#v", err)
+	}()
+
+	session, err := b.csg.GetCurrentSession(ctx)
+	if err != nil {
+		b.log.CDebugf(
+			ctx, "BlockServerRemote: User logged out, skipping resetAuth")
+		return nil
+	}
+
+	// request a challenge
+	challenge, err := c.GetSessionChallenge(ctx)
+	if err != nil {
+		return err
+	}
+
+	// get a new signature
+	signature, err := b.authToken.Sign(ctx, session.Name,
+		session.UID, session.VerifyingKey, challenge)
+	if err != nil {
+		return err
+	}
+
+	return c.AuthenticateSession(ctx, signature)
 }
 
 // RefreshAuthToken implements the AuthTokenRefreshHandler interface.
 func (b *blockServerRemoteClientHandler) RefreshAuthToken(
 	ctx context.Context) {
-	if err := b.bs.resetAuth(ctx, b.client, b.authToken); err != nil {
-		b.bs.log.CDebugf(ctx, "error refreshing auth token: %v", err)
+	if err := b.resetAuth(ctx, b.client); err != nil {
+		b.log.CDebugf(ctx, "error refreshing auth token: %v", err)
 	}
 }
 
@@ -81,13 +166,12 @@ func (b *blockServerRemoteClientHandler) OnConnect(ctx context.Context,
 	conn *rpc.Connection, client rpc.GenericClient, _ *rpc.Server) error {
 	// reset auth -- using client here would cause problematic recursion.
 	c := keybase1.BlockClient{Cli: client}
-	return b.bs.resetAuth(ctx, c, b.authToken)
+	return b.resetAuth(ctx, c)
 }
 
 // OnConnectError implements the ConnectionHandler interface.
 func (b *blockServerRemoteClientHandler) OnConnectError(err error, wait time.Duration) {
-	b.bs.log.Warning("connection error: %v; retrying in %s",
-		err, wait)
+	b.log.Warning("connection error: %v; retrying in %s", err, wait)
 	if b.authToken != nil {
 		b.authToken.Shutdown()
 	}
@@ -97,15 +181,14 @@ func (b *blockServerRemoteClientHandler) OnConnectError(err error, wait time.Dur
 
 // OnDoCommandError implements the ConnectionHandler interface.
 func (b *blockServerRemoteClientHandler) OnDoCommandError(err error, wait time.Duration) {
-	b.bs.log.Warning("DoCommand error: %v; retrying in %s",
-		err, wait)
+	b.log.Warning("DoCommand error: %v; retrying in %s", err, wait)
 }
 
 // OnDisconnected implements the ConnectionHandler interface.
 func (b *blockServerRemoteClientHandler) OnDisconnected(ctx context.Context,
 	status rpc.DisconnectStatus) {
 	if status == rpc.StartingNonFirstConnection {
-		b.bs.log.CWarningf(ctx, "disconnected")
+		b.log.CWarningf(ctx, "disconnected")
 	}
 	if b.authToken != nil {
 		b.authToken.Shutdown()
@@ -141,11 +224,36 @@ func (b *blockServerRemoteClientHandler) ShouldRetryOnConnect(err error) bool {
 
 var _ rpc.ConnectionHandler = (*blockServerRemoteClientHandler)(nil)
 
+type blockServerRemoteConfig interface {
+	diskBlockCacheGetter
+	codecGetter
+	signerGetter
+	currentSessionGetterGetter
+	logMaker
+}
+
+// BlockServerRemote implements the BlockServer interface and
+// represents a remote KBFS block server.
+type BlockServerRemote struct {
+	config     blockServerRemoteConfig
+	shutdownFn func()
+	putClient  keybase1.BlockInterface
+	getClient  keybase1.BlockInterface
+	log        logger.Logger
+	deferLog   logger.Logger
+	blkSrvAddr string
+
+	putConn *blockServerRemoteClientHandler
+	getConn *blockServerRemoteClientHandler
+}
+
+// Test that BlockServerRemote fully implements the BlockServer interface.
+var _ BlockServer = (*BlockServerRemote)(nil)
+
 // NewBlockServerRemote constructs a new BlockServerRemote for the
 // given address.
 func NewBlockServerRemote(config blockServerRemoteConfig,
-	signer kbfscrypto.Signer, blkSrvAddr string,
-	rpcLogFactory *libkb.RPCLogFactory) *BlockServerRemote {
+	blkSrvAddr string, rpcLogFactory *libkb.RPCLogFactory) *BlockServerRemote {
 	log := config.MakeLogger("BSR")
 	deferLog := log.CloneWithAddedDepth(1)
 	bs := &BlockServerRemote{
@@ -154,56 +262,20 @@ func NewBlockServerRemote(config blockServerRemoteConfig,
 		deferLog:   deferLog,
 		blkSrvAddr: blkSrvAddr,
 	}
-	bs.log.Debug("new instance server addr %s", blkSrvAddr)
-
-	// Use two separate auth tokens and clients -- one for writes and
-	// one for reads.  This allows small reads to avoid getting
-	// trapped behind large asynchronous writes.  TODO: use some real
-	// network QoS to achieve better prioritization within the actual
-	// network.
-	putClientHandler := &blockServerRemoteClientHandler{
-		bs:   bs,
-		name: "BlockServerRemotePut",
-	}
-	bs.putAuthToken = kbfscrypto.NewAuthToken(signer,
-		BServerTokenServer, BServerTokenExpireIn,
-		"libkbfs_bserver_remote", VersionString(), putClientHandler)
-	putClientHandler.authToken = bs.putAuthToken
-	getClientHandler := &blockServerRemoteClientHandler{
-		bs:   bs,
-		name: "BlockServerRemoteGet",
-	}
-	bs.getAuthToken = kbfscrypto.NewAuthToken(signer,
-		BServerTokenServer, BServerTokenExpireIn,
-		"libkbfs_bserver_remote", VersionString(), getClientHandler)
-	getClientHandler.authToken = bs.getAuthToken
-
-	constBackoff := backoff.NewConstantBackOff(RPCReconnectInterval)
-	opts := rpc.ConnectionOpts{
-		DontConnectNow: true, // connect only on-demand
-		WrapErrorFunc:  libkb.WrapError,
-		TagsFunc:       libkb.LogTagsFromContext,
-		// This constant backoff is safe to share between multiple connections,
-		// because it has no internal state. But beware: an exponential backoff
-		// shouldn't be shared.
-		ReconnectBackoff: func() backoff.BackOff { return constBackoff },
-	}
-	putConn := rpc.NewTLSConnection(blkSrvAddr,
-		kbfscrypto.GetRootCerts(blkSrvAddr),
-		kbfsblock.BServerErrorUnwrapper{}, putClientHandler,
-		rpcLogFactory, log, opts)
-	bs.putClient = keybase1.BlockClient{Cli: putConn.GetClient()}
-	putClientHandler.client = bs.putClient
-	getConn := rpc.NewTLSConnection(blkSrvAddr,
-		kbfscrypto.GetRootCerts(blkSrvAddr),
-		kbfsblock.BServerErrorUnwrapper{}, getClientHandler,
-		rpcLogFactory, log, opts)
-	bs.getClient = keybase1.BlockClient{Cli: getConn.GetClient()}
-	getClientHandler.client = bs.getClient
+	// Use two separate auth clients -- one for writes and one for
+	// reads.  This allows small reads to avoid getting trapped behind
+	// large asynchronous writes.  TODO: use some real network QoS to
+	// achieve better prioritization within the actual network.
+	bs.putConn = newBlockServerRemoteClientHandler(
+		"BlockServerRemotePut", log, config.Signer(),
+		config.currentSessionGetter(), blkSrvAddr, rpcLogFactory)
+	bs.getConn = newBlockServerRemoteClientHandler(
+		"BlockServerRemoteGet", log, config.Signer(),
+		config.currentSessionGetter(), blkSrvAddr, rpcLogFactory)
 
 	bs.shutdownFn = func() {
-		putConn.Shutdown()
-		getConn.Shutdown()
+		bs.putConn.shutdown()
+		bs.getConn.shutdown()
 	}
 	return bs
 }
@@ -214,10 +286,19 @@ func newBlockServerRemoteWithClient(config blockServerRemoteConfig,
 	log := config.MakeLogger("BSR")
 	deferLog := log.CloneWithAddedDepth(1)
 	bs := &BlockServerRemote{
-		config:    config,
-		putClient: client,
-		getClient: client,
-		deferLog:  deferLog,
+		config:   config,
+		log:      log,
+		deferLog: deferLog,
+		putConn: &blockServerRemoteClientHandler{
+			log:      log,
+			deferLog: deferLog,
+			client:   client,
+		},
+		getConn: &blockServerRemoteClientHandler{
+			log:      log,
+			deferLog: deferLog,
+			client:   client,
+		},
 	}
 	return bs
 }
@@ -227,46 +308,10 @@ func (b *BlockServerRemote) RemoteAddress() string {
 	return b.blkSrvAddr
 }
 
-// resetAuth is called to reset the authorization on a BlockServer
-// connection.
-func (b *BlockServerRemote) resetAuth(
-	ctx context.Context, c keybase1.BlockInterface,
-	authToken *kbfscrypto.AuthToken) (err error) {
-
-	defer func() {
-		b.log.Debug("BlockServerRemote: resetAuth called, err: %#v", err)
-	}()
-
-	session, err := b.config.currentSessionGetter().GetCurrentSession(ctx)
-	if err != nil {
-		b.log.Debug("BlockServerRemote: User logged out, skipping resetAuth")
-		return nil
-	}
-
-	// request a challenge
-	challenge, err := c.GetSessionChallenge(ctx)
-	if err != nil {
-		return err
-	}
-
-	// get a new signature
-	signature, err := authToken.Sign(ctx, session.Name,
-		session.UID, session.VerifyingKey, challenge)
-	if err != nil {
-		return err
-	}
-
-	return c.AuthenticateSession(ctx, signature)
-}
-
 // RefreshAuthToken implements the AuthTokenRefreshHandler interface.
 func (b *BlockServerRemote) RefreshAuthToken(ctx context.Context) {
-	if err := b.resetAuth(ctx, b.putClient, b.putAuthToken); err != nil {
-		b.log.CDebugf(ctx, "error refreshing put auth token: %v", err)
-	}
-	if err := b.resetAuth(ctx, b.getClient, b.getAuthToken); err != nil {
-		b.log.CDebugf(ctx, "error refreshing get auth token: %v", err)
-	}
+	b.putConn.RefreshAuthToken(ctx)
+	b.getConn.RefreshAuthToken(ctx)
 }
 
 func makeBlockIDCombo(id kbfsblock.ID, context kbfsblock.Context) keybase1.BlockIdCombo {
@@ -326,7 +371,7 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 		Folder: tlfID.String(),
 	}
 
-	res, err := b.getClient.GetBlock(ctx, arg)
+	res, err := b.getConn.getClient().GetBlock(ctx, arg)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}
@@ -369,7 +414,7 @@ func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 	}
 
 	// Handle OverQuota errors at the caller
-	return b.putClient.PutBlock(ctx, arg)
+	return b.putConn.getClient().PutBlock(ctx, arg)
 }
 
 // AddBlockReference implements the BlockServer interface for BlockServerRemote
@@ -388,7 +433,7 @@ func (b *BlockServerRemote) AddBlockReference(ctx context.Context, tlfID tlf.ID,
 	}()
 
 	// Handle OverQuota errors at the caller
-	return b.putClient.AddReference(ctx, keybase1.AddReferenceArg{
+	return b.putConn.getClient().AddReference(ctx, keybase1.AddReferenceArg{
 		Ref:    makeBlockReference(id, context),
 		Folder: tlfID.String(),
 	})
@@ -451,13 +496,13 @@ func (b *BlockServerRemote) batchDowngradeReferences(ctx context.Context,
 		var res keybase1.DowngradeReferenceRes
 		var err error
 		if archive {
-			res, err = b.putClient.ArchiveReferenceWithCount(ctx,
+			res, err = b.putConn.getClient().ArchiveReferenceWithCount(ctx,
 				keybase1.ArchiveReferenceWithCountArg{
 					Refs:   notDone,
 					Folder: tlfID.String(),
 				})
 		} else {
-			res, err = b.putClient.DelReferenceWithCount(ctx,
+			res, err = b.putConn.getClient().DelReferenceWithCount(ctx,
 				keybase1.DelReferenceWithCountArg{
 					Refs:   notDone,
 					Folder: tlfID.String(),
@@ -543,7 +588,7 @@ func (b *BlockServerRemote) getNotDone(all kbfsblock.ContextMap, doneRefs map[kb
 
 // GetUserQuotaInfo implements the BlockServer interface for BlockServerRemote
 func (b *BlockServerRemote) GetUserQuotaInfo(ctx context.Context) (info *kbfsblock.UserQuotaInfo, err error) {
-	res, err := b.getClient.GetUserQuotaInfo(ctx)
+	res, err := b.getConn.getClient().GetUserQuotaInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -555,10 +600,6 @@ func (b *BlockServerRemote) Shutdown(ctx context.Context) {
 	if b.shutdownFn != nil {
 		b.shutdownFn()
 	}
-	if b.getAuthToken != nil {
-		b.getAuthToken.Shutdown()
-	}
-	if b.putAuthToken != nil {
-		b.putAuthToken.Shutdown()
-	}
+	b.getConn.shutdown()
+	b.putConn.shutdown()
 }

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -272,8 +272,6 @@ type blockServerRemoteConfig interface {
 type BlockServerRemote struct {
 	config     blockServerRemoteConfig
 	shutdownFn func()
-	putClient  keybase1.BlockInterface
-	getClient  keybase1.BlockInterface
 	log        logger.Logger
 	deferLog   logger.Logger
 	blkSrvAddr string

--- a/libkbfs/connection_status.go
+++ b/libkbfs/connection_status.go
@@ -50,7 +50,13 @@ func (kcs *kbfsCurrentStatus) PushConnectionStatusChange(service string, err err
 	defer kcs.lock.Unlock()
 
 	if err != nil {
+		// Exit early if the service is already failed, to avoid an
+		// invalidation.
+		_, errExisted := kcs.failingServices[service]
 		kcs.failingServices[service] = err
+		if errExisted {
+			return
+		}
 	} else {
 		// Potentially exit early if nothing changes.
 		_, exist := kcs.failingServices[service]

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -354,8 +354,7 @@ func makeBlockServer(config Config, bserverAddr string,
 	}
 
 	log.Debug("Using remote bserver %s", bserverAddr)
-	return NewBlockServerRemote(config, config.Signer(), bserverAddr,
-		rpcLogFactory), nil
+	return NewBlockServerRemote(config, bserverAddr, rpcLogFactory), nil
 }
 
 // InitLog sets up logging switching to a log file if necessary.

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -32,6 +32,9 @@ const (
 	// MdServerDefaultPingIntervalSeconds is the default interval on which the
 	// client should contact the MD Server
 	MdServerDefaultPingIntervalSeconds = 10
+	// MdServerPingTimeout is how long to wait for a ping response
+	// before breaking the connection and trying to reconnect.
+	MdServerPingTimeout = 30 * time.Second
 )
 
 // MDServerRemote is an implementation of the MDServer interface.
@@ -245,7 +248,7 @@ func (md *MDServerRemote) resetAuth(
 func (md *MDServerRemote) RefreshAuthToken(ctx context.Context) {
 	md.log.CDebugf(ctx, "MDServerRemote: Refreshing auth token...")
 
-	_, err := md.resetAuth(ctx, md.client)
+	_, err := md.resetAuth(ctx, md.getClient())
 	switch err.(type) {
 	case nil:
 		md.log.CDebugf(ctx, "MDServerRemote: auth token refreshed")
@@ -264,8 +267,14 @@ func (md *MDServerRemote) RefreshAuthToken(ctx context.Context) {
 func (md *MDServerRemote) pingOnce(ctx context.Context) {
 	clock := md.config.Clock()
 	beforePing := clock.Now()
-	resp, err := md.client.Ping2(ctx)
-	if err != nil {
+	ctx, cancel := context.WithTimeout(ctx, MdServerPingTimeout)
+	defer cancel()
+	resp, err := md.getClient().Ping2(ctx)
+	if err == context.DeadlineExceeded {
+		md.log.CDebugf(ctx, "Ping timeout -- reinitializing connection")
+		md.initNewConnection()
+		return
+	} else if err != nil {
 		md.log.CDebugf(ctx, "MDServerRemote: ping error %s", err)
 		return
 	}
@@ -467,7 +476,7 @@ func (md *MDServerRemote) get(ctx context.Context, id tlf.ID,
 	}
 
 	// request
-	response, err := md.client.GetMetadata(ctx, arg)
+	response, err := md.getClient().GetMetadata(ctx, arg)
 	if err != nil {
 		return id, nil, err
 	}
@@ -585,7 +594,7 @@ func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
 		}
 	}
 
-	return md.client.PutMetadata(ctx, arg)
+	return md.getClient().PutMetadata(ctx, arg)
 }
 
 // PruneBranch implements the MDServer interface for MDServerRemote.
@@ -595,7 +604,7 @@ func (md *MDServerRemote) PruneBranch(ctx context.Context, id tlf.ID, bid Branch
 		BranchID: bid.String(),
 		LogTags:  nil,
 	}
-	return md.client.PruneBranch(ctx, arg)
+	return md.getClient().PruneBranch(ctx, arg)
 }
 
 // MetadataUpdate implements the MetadataUpdateProtocol interface.

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -46,6 +46,7 @@ type MDServerRemote struct {
 	rpcLogFactory *libkb.RPCLogFactory
 	authToken     *kbfscrypto.AuthToken
 	squelchRekey  bool
+	pinger        pinger
 
 	authenticatedMtx sync.Mutex
 	isAuthenticated  bool
@@ -93,6 +94,14 @@ func NewMDServerRemote(config Config, srvAddr string,
 		rpcLogFactory: rpcLogFactory,
 		rekeyTimer:    time.NewTimer(MdServerBackgroundRekeyPeriod),
 	}
+
+	mdServer.pinger = pinger{
+		name:    "MDServerRemote",
+		doPing:  mdServer.pingOnce,
+		timeout: MdServerPingTimeout,
+		log:     mdServer.log,
+	}
+
 	mdServer.authToken = kbfscrypto.NewAuthToken(config.Crypto(),
 		MdServerTokenServer, MdServerTokenExpireIn,
 		"libkbfs_mdserver_remote", VersionString(), mdServer)
@@ -174,7 +183,7 @@ func (md *MDServerRemote) OnConnect(ctx context.Context,
 	md.config.KBFSOps().PushConnectionStatusChange(MDServiceName, nil)
 
 	// start pinging
-	md.resetPingTicker(pingIntervalSeconds)
+	md.pinger.resetTicker(pingIntervalSeconds)
 	return nil
 }
 
@@ -266,8 +275,6 @@ func (md *MDServerRemote) RefreshAuthToken(ctx context.Context) {
 
 func (md *MDServerRemote) pingOnce(ctx context.Context) {
 	clock := md.config.Clock()
-	ctx, cancel := context.WithTimeout(ctx, MdServerPingTimeout)
-	defer cancel()
 	beforePing := clock.Now()
 	resp, err := md.getClient().Ping2(ctx)
 	if err == context.DeadlineExceeded {
@@ -301,44 +308,6 @@ func (md *MDServerRemote) pingOnce(ctx context.Context) {
 	}()
 }
 
-// Helper to reset a ping ticker.
-func (md *MDServerRemote) resetPingTicker(intervalSeconds int) {
-	md.tickerMu.Lock()
-	defer md.tickerMu.Unlock()
-
-	if md.tickerCancel != nil {
-		md.tickerCancel()
-		md.tickerCancel = nil
-	}
-	if intervalSeconds <= 0 {
-		return
-	}
-
-	md.log.CDebugf(context.TODO(),
-		"MDServerRemote: starting new ping ticker with interval %d",
-		intervalSeconds)
-
-	var ctx context.Context
-	ctx, md.tickerCancel = context.WithCancel(context.Background())
-	go func() {
-		// Ping right away to get the offset
-		md.pingOnce(ctx)
-
-		ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
-		for {
-			select {
-			case <-ticker.C:
-				md.pingOnce(ctx)
-
-			case <-ctx.Done():
-				md.log.CDebugf(ctx, "MDServerRemote: stopping ping ticker")
-				ticker.Stop()
-				return
-			}
-		}
-	}()
-}
-
 // OnConnectError implements the ConnectionHandler interface.
 func (md *MDServerRemote) OnConnectError(err error, wait time.Duration) {
 	md.log.CWarningf(context.TODO(),
@@ -346,7 +315,7 @@ func (md *MDServerRemote) OnConnectError(err error, wait time.Duration) {
 	// TODO: it might make sense to show something to the user if this is
 	// due to authentication, for example.
 	md.cancelObservers()
-	md.resetPingTicker(0)
+	md.pinger.resetTicker(0)
 	if md.authToken != nil {
 		md.authToken.Shutdown()
 	}
@@ -385,7 +354,7 @@ func (md *MDServerRemote) OnDisconnected(ctx context.Context,
 	md.authenticatedMtx.Unlock()
 
 	md.cancelObservers()
-	md.resetPingTicker(0)
+	md.pinger.resetTicker(0)
 	if md.authToken != nil {
 		md.authToken.Shutdown()
 	}
@@ -834,7 +803,7 @@ func (md *MDServerRemote) Shutdown() {
 	// cancel pending observers
 	md.cancelObservers()
 	// cancel the ping ticker
-	md.resetPingTicker(0)
+	md.pinger.resetTicker(0)
 	// cancel the auth token ticker
 	if md.authToken != nil {
 		md.authToken.Shutdown()

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -266,9 +266,9 @@ func (md *MDServerRemote) RefreshAuthToken(ctx context.Context) {
 
 func (md *MDServerRemote) pingOnce(ctx context.Context) {
 	clock := md.config.Clock()
-	beforePing := clock.Now()
 	ctx, cancel := context.WithTimeout(ctx, MdServerPingTimeout)
 	defer cancel()
+	beforePing := clock.Now()
 	resp, err := md.getClient().Ping2(ctx)
 	if err == context.DeadlineExceeded {
 		md.log.CDebugf(ctx, "Ping timeout -- reinitializing connection")

--- a/libkbfs/pinger.go
+++ b/libkbfs/pinger.go
@@ -1,0 +1,66 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
+)
+
+// pinger is a helper type that calls a given function periodically.
+type pinger struct {
+	name    string
+	doPing  func(ctx context.Context)
+	timeout time.Duration
+	log     logger.Logger
+
+	tickerMu     sync.Mutex
+	tickerCancel context.CancelFunc
+}
+
+func (p pinger) pingOnce(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+	p.doPing(ctx)
+}
+
+func (p pinger) resetTicker(intervalSeconds int) {
+	p.tickerMu.Lock()
+	defer p.tickerMu.Unlock()
+
+	if p.tickerCancel != nil {
+		p.tickerCancel()
+		p.tickerCancel = nil
+	}
+	if intervalSeconds <= 0 {
+		return
+	}
+
+	p.log.CDebugf(context.TODO(),
+		"%s: Starting new ping ticker with interval %d", p.name,
+		intervalSeconds)
+
+	var ctx context.Context
+	ctx, p.tickerCancel = context.WithCancel(context.Background())
+	go func() {
+		p.pingOnce(ctx)
+
+		ticker := time.NewTicker(time.Duration(intervalSeconds) * time.Second)
+		for {
+			select {
+			case <-ticker.C:
+				p.pingOnce(ctx)
+
+			case <-ctx.Done():
+				p.log.CDebugf(ctx, "%s: stopping ping ticker", p.name)
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+}

--- a/libkbfs/pinger.go
+++ b/libkbfs/pinger.go
@@ -23,13 +23,13 @@ type pinger struct {
 	tickerCancel context.CancelFunc
 }
 
-func (p pinger) pingOnce(ctx context.Context) {
+func (p *pinger) pingOnce(ctx context.Context) {
 	ctx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 	p.doPing(ctx)
 }
 
-func (p pinger) resetTicker(intervalSeconds int) {
+func (p *pinger) resetTicker(intervalSeconds int) {
 	p.tickerMu.Lock()
 	defer p.tickerMu.Unlock()
 

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -80,7 +80,7 @@ func MakeTestBlockServerOrBust(t logger.TestLogBackend,
 		return blockServer
 
 	case len(bserverAddr) != 0:
-		return NewBlockServerRemote(config, signer, bserverAddr, rpcLogFactory)
+		return NewBlockServerRemote(config, bserverAddr, rpcLogFactory)
 
 	default:
 		return NewBlockServerMemory(config.MakeLogger(""))
@@ -228,7 +228,7 @@ func configAsUserWithMode(config *ConfigLocal,
 	c.noBGFlush = config.noBGFlush
 
 	if s, ok := config.BlockServer().(*BlockServerRemote); ok {
-		blockServer := NewBlockServerRemote(c, c.Signer(), s.RemoteAddress(),
+		blockServer := NewBlockServerRemote(c, s.RemoteAddress(),
 			env.NewContext().NewRPCLogFactory())
 		c.SetBlockServer(blockServer)
 	} else {


### PR DESCRIPTION
Also add timeout disconnects for mdserver as well, factoring out a bit of common code.

Since bserver actually has two connections, this required a bit of refactoring of bserver connection handling as well.

This helps the case where a (Linux?) device loses its network (e.g., due to a suspend).  Normally it would take a long time (15-20 mins) for the TCP connections to figure out that they need to reconnect.  This brings that down to ~40s.

One downside is that `connection.go` now spams the log every 2 seconds while the device is offline, and before it wouldn't do that until the TCP connection noticed the disconnect.  We might want to suppress some of that logging in a future PR.

Issue: KBFS-1982