### PR TITLE
[KBFS-2018] Detect FSs that don't keep track of inodes

### DIFF
--- a/libkbfs/disk_limits_unix.go
+++ b/libkbfs/disk_limits_unix.go
@@ -7,6 +7,8 @@
 package libkbfs
 
 import (
+	"math"
+
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -23,6 +25,13 @@ func getDiskLimits(path string) (
 
 	// Bavail is the free block count for an unprivileged user.
 	availableBytes = stat.Bavail * uint64(stat.Bsize)
-	availableFiles = stat.Ffree
+	// Some filesystems, like btrfs, don't keep track of inodes.
+	// (See https://github.com/keybase/client/issues/6206 .) Use
+	// the total inode count to detect that case.
+	if stat.Files > 0 {
+		availableFiles = stat.Ffree
+	} else {
+		availableFiles = math.MaxInt64
+	}
 	return availableBytes, availableFiles, nil
 }


### PR DESCRIPTION
Return math.MaxInt64 for max inodes in that case.