### PR TITLE
libkbfs: add minimal init mode 

### DIFF
--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	defaultBlockRetrievalWorkerQueueSize int = 100
-	defaultNumPrefetchWorkers            int = 1
+	minimalBlockRetrievalWorkerQueueSize int = 2
 	testBlockRetrievalWorkerQueueSize    int = 5
 	defaultOnDemandRequestPriority       int = 100
 )

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -643,6 +643,12 @@ func (c *ConfigLocal) DataVersion() DataVer {
 
 // DoBackgroundFlushes implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) DoBackgroundFlushes() bool {
+	if c.mode == InitMinimal {
+		// Don't do background flushes when in minimal mode, since
+		// there shouldn't be any data writes.
+		return false
+	}
+
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return !c.noBGFlush

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -895,7 +895,10 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 	c.BlockServer().Shutdown(ctx)
 	c.Crypto().Shutdown()
 	c.Reporter().Shutdown()
-	err = c.DirtyBlockCache().Shutdown()
+	dirtyBcache := c.DirtyBlockCache()
+	if dirtyBcache != nil {
+		err = dirtyBcache.Shutdown()
+	}
 	if err != nil {
 		errorList = append(errorList, err)
 	}

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -97,6 +97,8 @@ type ConfigLocal struct {
 
 	// metadataVersion is the version to use when creating new metadata.
 	metadataVersion MetadataVer
+
+	mode InitMode
 }
 
 var _ Config = (*ConfigLocal)(nil)
@@ -233,11 +235,12 @@ func getDefaultCleanBlockCacheCapacity() uint64 {
 //
 // TODO: Now that NewConfigLocal takes loggerFn, add more default
 // components.
-func NewConfigLocal(loggerFn func(module string) logger.Logger,
+func NewConfigLocal(mode InitMode, loggerFn func(module string) logger.Logger,
 	storageRoot string) *ConfigLocal {
 	config := &ConfigLocal{
 		loggerFn:    loggerFn,
 		storageRoot: storageRoot,
+		mode:        mode,
 	}
 	config.SetClock(wallClock{})
 	config.SetReporter(NewReporterSimple(config.Clock(), 10))
@@ -666,6 +669,11 @@ func (c *ConfigLocal) SetRekeyWithPromptWaitTime(d time.Duration) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	c.rwpWaitTime = d
+}
+
+// Mode implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) Mode() InitMode {
+	return c.mode
 }
 
 // DelayedCancellationGracePeriod implements the Config interface for ConfigLocal.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -747,6 +747,12 @@ func (c *ConfigLocal) resetCachesWithoutShutdown() DirtyBlockCache {
 	}
 	c.bcache = NewBlockCacheStandard(10000, capacity)
 
+	if c.mode == InitMinimal {
+		// No blocks will be dirtied in minimal mode, so don't bother
+		// with the dirty block cache.
+		return nil
+	}
+
 	oldDirtyBcache := c.dirtyBcache
 
 	// TODO: we should probably fail or re-schedule this reset if

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -95,7 +95,13 @@ func NewConflictResolver(
 		},
 	}
 
-	cr.startProcessing(BackgroundContextWithCancellationDelayer())
+	if config.Mode() != InitMinimal {
+		cr.startProcessing(BackgroundContextWithCancellationDelayer())
+	} else {
+		// No need to run CR if there won't be any data writes on this
+		// device.  (There may still be rekey writes, but we don't
+		// allow conflicts to happen in that case.)
+	}
 	return cr
 }
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -732,3 +732,15 @@ type RekeyResult struct {
 	DidRekey      bool
 	NeedsPaperKey bool
 }
+
+// InitMode indicates how KBFS should configure itself at runtime.
+type InitMode int
+
+const (
+	// InitDefault is the normal mode for when KBFS data will be read
+	// and written.
+	InitDefault InitMode = iota
+	// InitMinimal is for when KBFS will only be used as a MD lookup
+	// layer (e.g., for chat on mobile).
+	InitMinimal
+)

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -137,17 +137,18 @@ func newFolderBlockManager(config Config, fb FolderBranch,
 	// doesn't do possibly-racy-in-tests access to
 	// fbm.config.BlockOps().
 
-	if config.Mode() != InitMinimal {
-		go fbm.archiveBlocksInBackground()
-		go fbm.deleteBlocksInBackground()
-		if fb.Branch == MasterBranch {
-			go fbm.reclaimQuotaInBackground()
-		}
-	} else {
+	if config.Mode() == InitMinimal {
 		// If this device is in minimal mode and won't be doing any
 		// data writes, no need deal with block-level cleanup
 		// operations.  TODO: in the future it might still be useful
 		// to have e.g. mobile devices doing QR.
+		return fbm
+	}
+
+	go fbm.archiveBlocksInBackground()
+	go fbm.deleteBlocksInBackground()
+	if fb.Branch == MasterBranch {
+		go fbm.reclaimQuotaInBackground()
 	}
 	return fbm
 }

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -136,10 +136,18 @@ func newFolderBlockManager(config Config, fb FolderBranch,
 	// Pass in the BlockOps here so that the archive goroutine
 	// doesn't do possibly-racy-in-tests access to
 	// fbm.config.BlockOps().
-	go fbm.archiveBlocksInBackground()
-	go fbm.deleteBlocksInBackground()
-	if fb.Branch == MasterBranch {
-		go fbm.reclaimQuotaInBackground()
+
+	if config.Mode() != InitMinimal {
+		go fbm.archiveBlocksInBackground()
+		go fbm.deleteBlocksInBackground()
+		if fb.Branch == MasterBranch {
+			go fbm.reclaimQuotaInBackground()
+		}
+	} else {
+		// If this device is in minimal mode and won't be doing any
+		// data writes, no need deal with block-level cleanup
+		// operations.  TODO: in the future it might still be useful
+		// to have e.g. mobile devices doing QR.
 	}
 	return fbm
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -334,11 +334,11 @@ var _ fbmHelper = (*folderBranchOps)(nil)
 func newFolderBranchOps(config Config, fb FolderBranch,
 	bType branchType) *folderBranchOps {
 	var nodeCache NodeCache
-	if config.Mode() != InitMinimal {
-		nodeCache = newNodeCacheStandard(fb)
-	} else {
+	if config.Mode() == InitMinimal {
 		// If we're in minimal mode, let the block cache remain nil to
 		// ensure that the user doesn't try any data reads or writes.
+	} else {
+		nodeCache = newNodeCacheStandard(fb)
 	}
 
 	// make logger

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -460,9 +460,10 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 	case InitDefaultString:
 		// Already the default
 	case InitMinimalString:
+		log.Debug("Initializing in minimal mode")
 		mode = InitMinimal
 	default:
-		return nil, fmt.Errorf("Unexpected mode: %s", mode)
+		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}
 
 	config := NewConfigLocal(mode, func(module string) logger.Logger {

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -220,7 +220,8 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 		int(defaultParams.MetadataVersion),
 		"Metadata version to use when creating new metadata")
 	flags.StringVar(&params.Mode, "mode", InitDefaultString,
-		fmt.Sprintf("Init mode (%s or %s)", InitDefaultString,
+		fmt.Sprintf("Overall initialization mode for KBFS, indicating how "+
+			"heavy-weight it can be (%s or %s)", InitDefaultString,
 			InitMinimalString))
 
 	return &params
@@ -458,6 +459,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 	mode := InitDefault
 	switch params.Mode {
 	case InitDefaultString:
+		log.Debug("Initializing in default mode")
 		// Already the default
 	case InitMinimalString:
 		log.Debug("Initializing in minimal mode")

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -596,7 +596,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 	}
 	// TODO: Don't turn on journaling if either -bserver or
 	// -mdserver point to local implementations.
-	if params.EnableJournal {
+	if params.EnableJournal && config.Mode() != InitMinimal {
 		journalRoot := filepath.Join(params.StorageRoot, "kbfs_journal")
 		err = config.EnableJournaling(context.Background(), journalRoot,
 			params.TLFJournalBackgroundWorkStatus)

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -493,6 +493,8 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 	if config.Mode() == InitMinimal {
 		// In minimal mode, a few workers are still needed to fetch
 		// unembedded block changes in the MD updates, but not many.
+		// TODO: turn off the block retriever entirely as part of
+		// KBFS-2026, when block re-embedding is no longer required.
 		workers = minimalBlockRetrievalWorkerQueueSize
 	}
 	config.SetBlockOps(NewBlockOpsStandard(config, workers))

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1563,6 +1563,9 @@ type Config interface {
 	RekeyWithPromptWaitTime() time.Duration
 	SetRekeyWithPromptWaitTime(time.Duration)
 
+	// Mode indicates how KBFS is configured to run.
+	Mode() InitMode
+
 	// GracePeriod specifies a grace period for which a delayed cancellation
 	// waits before actual cancels the context. This is useful for giving
 	// critical portion of a slow remote operation some extra time to finish as

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -507,7 +507,9 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 		}
 	}
 
-	// Re-embed the block changes if it's needed.
+	// Re-embed the block changes if it's needed.  TODO: we don't need
+	// to do this in minimal mode, since there's no node cache
+	// (KBFS-2026).
 	err := reembedBlockChanges(
 		ctx, codec, bcache, bops, rmdWithKeys.TlfID(),
 		&pmd, rmdWithKeys, log)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -50,7 +50,7 @@ func fakeMdID(b byte) MdID {
 //
 // TODO: Move more common code here.
 func newConfigForTest(loggerFn func(module string) logger.Logger) *ConfigLocal {
-	config := NewConfigLocal(loggerFn, "")
+	config := NewConfigLocal(InitDefault, loggerFn, "")
 
 	bops := NewBlockOpsStandard(config,
 		testBlockRetrievalWorkerQueueSize)

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -175,11 +175,11 @@ func NewTlfEditHistory(config Config, fbo *folderBranchOps,
 		rmdsChan: make(chan []ImmutableRootMetadata, 100),
 		cancel:   cancel,
 	}
-	if config.Mode() != InitMinimal {
-		go teh.process(processCtx)
-	} else {
+	if config.Mode() == InitMinimal {
 		// No need to process updates in minimal mode. TODO: avoid
 		// rmdsChan memory overhead?
+	} else {
+		go teh.process(processCtx)
 	}
 	return teh
 }


### PR DESCRIPTION
Allow KBFS to be used in a "minimal" mode, which limits the number of background goroutines and eliminates some unnecessary functions when we know data reads and writes won't be happening (e.g., for mobile).  In particular:

* Limit the number of block workers to 2.  (For now we still need some block workers in case the MD head for a folder needs to download unembedded block changes.  I filed KBFS-2026 to fix that at some point.)
* Turn off CR, QR, and other background block processors.
* Turn off edit history updates.
* Turn off journaling.
* Turn off the dirty block cache.

Now, in minimal mode, the KBFS goroutines seem pretty minimal.

Issue: KBFS-1999
