### PR TITLE
md_util: don't fetch unmerged MD range when the BID is null

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -114,20 +114,26 @@ func TestCRInput(t *testing.T) {
 	unmergedHead := MetadataRevision(5)
 	mergedHead := MetadataRevision(15)
 
-	cr.fbo.head = crMakeFakeRMD(unmergedHead, cr.fbo.bid)
+	crypto := MakeCryptoCommon(config.Codec())
+	bid, err := crypto.MakeRandomBranchID()
+	if err != nil {
+		t.Fatalf("Branch id err: %+v", bid)
+	}
+	cr.fbo.bid = bid
+	cr.fbo.head = crMakeFakeRMD(unmergedHead, bid)
 	cr.fbo.headStatus = headTrusted
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
-		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
-			crMakeFakeRMD(i, cr.fbo.bid), nil)
+		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, bid).Return(
+			crMakeFakeRMD(i, bid), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
-		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
-			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), branchPoint, cr.fbo.bid})
+		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, bid).Return(
+			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), branchPoint, bid})
 	}
 	config.mockMdops.EXPECT().GetUnmergedRange(gomock.Any(), cr.fbo.id(),
-		cr.fbo.bid, MetadataRevisionInitial, branchPoint).Return(nil, nil)
+		bid, MetadataRevisionInitial, branchPoint).Return(nil, nil)
 
 	for i := branchPoint; i <= mergedHead; i++ {
 		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, NullBranchID).Return(
@@ -170,19 +176,25 @@ func TestCRInputFracturedRange(t *testing.T) {
 	unmergedHead := MetadataRevision(5)
 	mergedHead := MetadataRevision(15)
 
-	cr.fbo.head = crMakeFakeRMD(unmergedHead, cr.fbo.bid)
+	crypto := MakeCryptoCommon(config.Codec())
+	bid, err := crypto.MakeRandomBranchID()
+	if err != nil {
+		t.Fatalf("Branch id err: %+v", bid)
+	}
+	cr.fbo.bid = bid
+	cr.fbo.head = crMakeFakeRMD(unmergedHead, bid)
 	cr.fbo.headStatus = headTrusted
 	// serve all the MDs from the cache
 	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes().Return(nil)
 	for i := unmergedHead; i >= branchPoint+1; i-- {
-		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(crMakeFakeRMD(i, cr.fbo.bid), nil)
+		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, bid).Return(crMakeFakeRMD(i, bid), nil)
 	}
 	for i := MetadataRevisionInitial; i <= branchPoint; i++ {
-		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, cr.fbo.bid).Return(
-			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), branchPoint, cr.fbo.bid})
+		config.mockMdcache.EXPECT().Get(cr.fbo.id(), i, bid).Return(
+			ImmutableRootMetadata{}, NoSuchMDError{cr.fbo.id(), branchPoint, bid})
 	}
 	config.mockMdops.EXPECT().GetUnmergedRange(gomock.Any(), cr.fbo.id(),
-		cr.fbo.bid, MetadataRevisionInitial, branchPoint).Return(nil, nil)
+		bid, MetadataRevisionInitial, branchPoint).Return(nil, nil)
 
 	skipCacheRevision := MetadataRevision(10)
 	for i := branchPoint; i <= mergedHead; i++ {

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -267,12 +267,19 @@ func getMergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 // and unmerged branch, between the merge point for that branch and
 // startRev (inclusive).  The returned MDs are the same instances that
 // are stored in the MD cache, so they should be modified with care.
+// If bid is NullBranchID, it returns an empty MD list.
 //
 // TODO: Accept a parameter to express that we want copies of the MDs
 // instead of the cached versions.
 func getUnmergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 	bid BranchID, startRev MetadataRevision) (
-	currHead MetadataRevision, unmergedRmds []ImmutableRootMetadata, err error) {
+	currHead MetadataRevision, unmergedRmds []ImmutableRootMetadata,
+	err error) {
+	if bid == NullBranchID {
+		// We're not really unmerged, so there's nothing to do.
+		return startRev, nil, nil
+	}
+
 	// We don't yet know about any revisions yet, so there's no range
 	// to get.
 	if startRev < MetadataRevisionInitial {

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -277,6 +277,9 @@ func getUnmergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 	err error) {
 	if bid == NullBranchID {
 		// We're not really unmerged, so there's nothing to do.
+		// TODO: require the caller to avoid making this call if the
+		// bid isn't set (and change the mdserver behavior in that
+		// case as well).
 		return startRev, nil, nil
 	}
 


### PR DESCRIPTION
A queued CR can run after the local branch is cleared.  When it asks
for the unmerged MDs, folderBranchOps simply calls
`getUnmergedMDUpdates()` with whatever the current BID is -- which is
`NullBranchID`.  This ends up serving merged updates out of the MD
cache, which results in self-conflicts.  Instead, if the BID is null,
always serve back an empty list.

Issue: KBFS-2023