### PR TITLE
md_util: don't reembed block changes in minimal mode

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -744,3 +744,14 @@ const (
 	// layer (e.g., for chat on mobile).
 	InitMinimal
 )
+
+func (im InitMode) String() string {
+	switch im {
+	case InitDefault:
+		return InitDefaultString
+	case InitMinimal:
+		return InitMinimalString
+	default:
+		return "unknown"
+	}
+}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -744,7 +744,8 @@ func (fbo *folderBranchOps) setHeadLocked(
 
 	// Make sure that any unembedded block changes have been swapped
 	// back in.
-	if md.data.Changes.Info.BlockPointer != zeroPtr &&
+	if fbo.config.Mode() == InitDefault &&
+		md.data.Changes.Info.BlockPointer != zeroPtr &&
 		len(md.data.Changes.Ops) == 0 {
 		return errors.New("Must swap in block changes before setting head")
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1474,7 +1474,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 			md.Revision(), md.MergedStatus(), err)
 	}()
 
-	if md.IsReadable() {
+	if md.IsReadable() && fbo.config.Mode() != InitMinimal {
 		// We will prefetch this as on-demand so that it triggers downstream
 		// prefetches.
 		fbo.config.BlockOps().Prefetcher().PrefetchBlock(

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -57,7 +57,8 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	config := j.jServer.config
 	pmd, err := decryptMDPrivateData(ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(), config.KeyManager(),
-		uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.jServer.log)
+		config.Mode(), uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd,
+		j.jServer.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -695,8 +695,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	if !md.IsReadable() && len(md.GetSerializedPrivateMetadata()) > 0 {
 		pmd, err := decryptMDPrivateData(
 			ctx, km.config.Codec(), km.config.Crypto(),
-			km.config.BlockCache(), km.config.BlockOps(),
-			km, session.UID, md.GetSerializedPrivateMetadata(), md, md, km.log)
+			km.config.BlockCache(), km.config.BlockOps(), km, km.config.Mode(),
+			session.UID, md.GetSerializedPrivateMetadata(), md, md, km.log)
 		if err != nil {
 			return false, nil, err
 		}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -223,8 +223,8 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	pmd, err := decryptMDPrivateData(
 		ctx, md.config.Codec(), md.config.Crypto(),
 		md.config.BlockCache(), md.config.BlockOps(),
-		md.config.KeyManager(), uid, rmd.GetSerializedPrivateMetadata(),
-		rmd, rmd, md.log)
+		md.config.KeyManager(), md.config.Mode(), uid,
+		rmd.GetSerializedPrivateMetadata(), rmd, rmd, md.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1408,10 +1408,12 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		}
 		rmd := makeRootMetadata(brmd, ibrmd.extra, handle)
 
+		// Assume, since journal is running, that we're in default mode.
+		mode := InitDefault
 		pmd, err := decryptMDPrivateData(
 			ctx, j.config.Codec(), j.config.Crypto(),
 			j.config.BlockCache(), j.config.BlockOps(),
-			j.config.mdDecryptionKeyGetter(), j.uid,
+			j.config.mdDecryptionKeyGetter(), mode, j.uid,
 			rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.log)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Also don't prefetch the root dir block in minimal mode.

Basically this should avoid any bserver requests in minimal mode.

Issue: KBFS-2026