### PR TITLE
[KBFS-2014] Add special file to enable/disable a debug HTTP server

### DIFF
--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -107,7 +107,9 @@ func start() *libfs.Error {
 }
 
 func main() {
-	http.ListenAndServe(":8080", nil)
+	go func() {
+		http.ListenAndServe(":8080", nil)
+	}()
 
 	err := start()
 	if err != nil {

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -9,8 +9,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net/http"
-	_ "net/http/pprof"
 	"os"
 
 	"bazil.org/fuse"
@@ -107,10 +105,6 @@ func start() *libfs.Error {
 }
 
 func main() {
-	go func() {
-		http.ListenAndServe(":8080", nil)
-	}()
-
 	err := start()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "kbfsfuse error: (%d) %s\n", err.Code, err.Message)

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -9,6 +9,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 
 	"bazil.org/fuse"
@@ -105,6 +107,8 @@ func start() *libfs.Error {
 }
 
 func main() {
+	http.ListenAndServe(":8080", nil)
+
 	err := start()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "kbfsfuse error: (%d) %s\n", err.Code, err.Message)

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -78,12 +78,12 @@ const EnableBlockPrefetchingFileName = ".kbfs_enable_block_prefetching"
 // prefetching-disabling file.  It's accessible anywhere outside a TLF.
 const DisableBlockPrefetchingFileName = ".kbfs_disable_block_prefetching"
 
-// EnableDebugServer is the name of the file to turn on the debug HTTP
-// server. It's accessible anywhere only from /kbfs.
+// EnableDebugServerFileName is the name of the file to turn on the
+// debug HTTP server. It's accessible anywhere only from /kbfs.
 const EnableDebugServerFileName = ".kbfs_enable_debug_server"
 
-// DisableDebugServer is the name of the file to turn on the debug HTTP
-// server. It's accessible anywhere only from /kbfs.
+// DisableDebugServerFileName is the name of the file to turn on the
+// debug HTTP server. It's accessible anywhere only from /kbfs.
 const DisableDebugServerFileName = ".kbfs_disable_debug_server"
 
 // EditHistoryName is the name of the KBFS TLF edit history file --

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -79,11 +79,11 @@ const EnableBlockPrefetchingFileName = ".kbfs_enable_block_prefetching"
 const DisableBlockPrefetchingFileName = ".kbfs_disable_block_prefetching"
 
 // EnableDebugServerFileName is the name of the file to turn on the
-// debug HTTP server. It's accessible anywhere only from /kbfs.
+// debug HTTP server. It's accessible anywhere outside a TLF.
 const EnableDebugServerFileName = ".kbfs_enable_debug_server"
 
 // DisableDebugServerFileName is the name of the file to turn on the
-// debug HTTP server. It's accessible anywhere only from /kbfs.
+// debug HTTP server. It's accessible anywhere outside a TLF.
 const DisableDebugServerFileName = ".kbfs_disable_debug_server"
 
 // EditHistoryName is the name of the KBFS TLF edit history file --

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -78,6 +78,14 @@ const EnableBlockPrefetchingFileName = ".kbfs_enable_block_prefetching"
 // prefetching-disabling file.  It's accessible anywhere outside a TLF.
 const DisableBlockPrefetchingFileName = ".kbfs_disable_block_prefetching"
 
+// EnableDebugServer is the name of the file to turn on the debug HTTP
+// server. It's accessible anywhere only from /kbfs.
+const EnableDebugServerFileName = ".kbfs_enable_debug_server"
+
+// DisableDebugServer is the name of the file to turn on the debug HTTP
+// server. It's accessible anywhere only from /kbfs.
+const DisableDebugServerFileName = ".kbfs_disable_debug_server"
+
 // EditHistoryName is the name of the KBFS TLF edit history file --
 // it can be reached anywhere within a top-level folder.
 const EditHistoryName = ".kbfs_edit_history"

--- a/libfuse/debug_server_file.go
+++ b/libfuse/debug_server_file.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Keybase Inc. All rights reserved.
+// Copyright 2017 Keybase Inc. All rights reserved.
 // Use of this source code is governed by a BSD
 // license that can be found in the LICENSE file.
 

--- a/libfuse/debug_server_file.go
+++ b/libfuse/debug_server_file.go
@@ -16,8 +16,8 @@ import (
 
 // DebugServerFile represents a write-only file where any write of at
 // least one byte triggers either disabling or enabling the debug
-// server. For enabling, the port number to listen on must be what is
-// written, e.g.
+// server. For enabling, the port number to listen on (with localhost)
+// must be what is written, e.g.
 //
 //   echo 8080 > /keybase/.kbfs_enable_debug_server
 //

--- a/libfuse/debug_server_file.go
+++ b/libfuse/debug_server_file.go
@@ -1,0 +1,58 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// DebugServerFile represents a write-only file where any write of at
+// least one byte triggers either disabling or enabling the debug
+// server.  It is mainly useful for testing.
+type DebugServerFile struct {
+	fs     *FS
+	enable bool
+}
+
+var _ fs.Node = (*DebugServerFile)(nil)
+
+// Attr implements the fs.Node interface for DebugServerFile.
+func (f *DebugServerFile) Attr(ctx context.Context, a *fuse.Attr) error {
+	a.Size = 0
+	a.Mode = 0222
+	return nil
+}
+
+var _ fs.Handle = (*DebugServerFile)(nil)
+
+var _ fs.HandleWriter = (*DebugServerFile)(nil)
+
+// Write implements the fs.HandleWriter interface for DebugServerFile.
+func (f *DebugServerFile) Write(ctx context.Context, req *fuse.WriteRequest,
+	resp *fuse.WriteResponse) (err error) {
+	f.fs.log.CDebugf(ctx, "DebugServerFile (enable: %t) Write", f.enable)
+	defer func() { f.fs.reportErr(ctx, libkbfs.WriteMode, err) }()
+	if len(req.Data) == 0 {
+		return nil
+	}
+
+	if f.enable {
+		err := f.fs.enableDebugServer(ctx)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := f.fs.disableDebugServer(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	resp.Size = len(req.Data)
+	return nil
+}

--- a/libfuse/debug_server_file.go
+++ b/libfuse/debug_server_file.go
@@ -5,6 +5,9 @@
 package libfuse
 
 import (
+	"strconv"
+	"strings"
+
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -37,12 +40,14 @@ func (f *DebugServerFile) Write(ctx context.Context, req *fuse.WriteRequest,
 	resp *fuse.WriteResponse) (err error) {
 	f.fs.log.CDebugf(ctx, "DebugServerFile (enable: %t) Write", f.enable)
 	defer func() { f.fs.reportErr(ctx, libkbfs.WriteMode, err) }()
-	if len(req.Data) == 0 {
-		return nil
-	}
-
 	if f.enable {
-		err := f.fs.enableDebugServer(ctx)
+		portStr := strings.TrimSpace(string(req.Data))
+		port, err := strconv.ParseUint(portStr, 10, 16)
+		if err != nil {
+			return err
+		}
+
+		err = f.fs.enableDebugServer(ctx, uint16(port))
 		if err != nil {
 			return err
 		}

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -179,6 +179,8 @@ func (f *FS) disableDebugServer(ctx context.Context) error {
 	err := f.debugServerListener.Close()
 	f.log.CDebugf(ctx, "Debug http server shutdown with %+v", err)
 
+	// Assume the close succeeds in stopping the server, even if
+	// it returns an error.
 	f.debugServer.Addr = ""
 	f.debugServerListener = nil
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -6,7 +6,7 @@ package libfuse
 
 import (
 	"net/http"
-	_ "net/http/pprof"
+	"net/http/pprof"
 	"os"
 	"runtime"
 	"strings"
@@ -60,9 +60,15 @@ func NewFS(config libkbfs.Config, conn *fuse.Conn, debug bool, platformParams Pl
 		errLog.Configure("", true, "")
 	}
 
+	serveMux := http.NewServeMux()
+	serveMux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
+	serveMux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	serveMux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	serveMux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	serveMux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
 	debugServer := &http.Server{
 		Addr:         ":8080",
-		Handler:      nil, // TODO: Fill in custom handler.
+		Handler:      serveMux,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -70,11 +70,14 @@ func NewFS(config libkbfs.Config, conn *fuse.Conn, debug bool, platformParams Pl
 	}
 
 	serveMux := http.NewServeMux()
+
+	// Replicate the default endpoints from pprof's init function.
 	serveMux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	serveMux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 	serveMux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
 	serveMux.Handle("/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
 	serveMux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+
 	// Leave Addr blank to be set in enableDebugServer() and
 	// disableDebugServer().
 	debugServer := &http.Server{

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -118,8 +118,8 @@ type tcpKeepAliveListener struct {
 	*net.TCPListener
 }
 
-func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
-	tc, err := ln.AcceptTCP()
+func (tkal tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := tkal.AcceptTCP()
 	if err != nil {
 		return
 	}

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -176,6 +176,8 @@ func (f *FS) disableDebugServer(ctx context.Context) error {
 
 	f.log.CDebugf(ctx, "Disabling debug http server at %s",
 		f.debugServer.Addr)
+	// TODO: Use f.debugServer.Close() or f.debugServer.Shutdown()
+	// when we switch to go 1.8.
 	err := f.debugServerListener.Close()
 	f.log.CDebugf(ctx, "Debug http server shutdown with %+v", err)
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -10,6 +10,7 @@ import (
 	"net/http/pprof"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -122,7 +123,7 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	return tc, nil
 }
 
-func (f *FS) enableDebugServer(ctx context.Context) error {
+func (f *FS) enableDebugServer(ctx context.Context, port uint16) error {
 	f.debugServerLock.Lock()
 	defer f.debugServerLock.Unlock()
 
@@ -131,7 +132,8 @@ func (f *FS) enableDebugServer(ctx context.Context) error {
 			f.debugServer.Addr)
 	}
 
-	addr := net.JoinHostPort("localhost", "8080")
+	addr := net.JoinHostPort("localhost",
+		strconv.FormatUint(uint64(port), 10))
 	f.log.CDebugf(ctx, "Enabling debug http server at %s", addr)
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -156,7 +156,7 @@ func (f *FS) enableDebugServer(ctx context.Context, port uint16) error {
 
 	// This seems racy because the spawned goroutine may be
 	// scheduled to run after disableDebugServer is called. But
-	// that's okay since Serve will error out immediately when
+	// that's okay since Serve will error out immediately after
 	// f.debugServerListener.Close() is called.
 	go func(server *http.Server, listener net.Listener) {
 		err := server.Serve(listener)

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -36,7 +36,9 @@ type FS struct {
 	// Protects debugServerListener and debugServer.addr.
 	debugServerLock     sync.Mutex
 	debugServerListener net.Listener
-	debugServer         *http.Server
+	// An HTTP server used for debugging. Normally off unless
+	// turned on via enableDebugServer().
+	debugServer *http.Server
 
 	notifications *libfs.FSNotifications
 

--- a/libfuse/profilelist.go
+++ b/libfuse/profilelist.go
@@ -70,20 +70,13 @@ var _ fs.NodeOpener = timedProfileFile{}
 
 func (f timedProfileFile) Open(ctx context.Context,
 	req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
-	// Blocking here until the profile is done is weird, but has a
-	// nice side effect of being exempt from the macOS FUSE
-	// timeout.
+	// TODO: Blocking here until the profile is done is
+	// weird. Blocking on read is better.
 	//
-	// The downside is that there's no easy way to start capturing
-	// a profile and then interrupt when done. But even if we try
-	// and stream the profile data, one problem is that the CPU
-	// profile is, at least as of go 1.8, buffered until it's
-	// stopped anyway, so we'd run into timeouts.
-	//
-	// TODO: Maybe keep around a special last_profile file to
-	// solve the problem above, which would also be useful in
-	// general, since you be able to save a profile even if you
-	// open it up with a tool.
+	// TODO: Maybe keep around a special last_profile file to be
+	// able to start capturing a profile and then interrupt when
+	// done, which would also be useful in general, since you be
+	// able to save a profile even if you open it up with a tool.
 	var buf bytes.Buffer
 	err := f.profile.Start(&buf)
 	if err != nil {

--- a/libfuse/special_files.go
+++ b/libfuse/special_files.go
@@ -59,6 +59,11 @@ func handleNonTLFSpecialFile(
 		return &PrefetchFile{fs: fs, enable: true}
 	case libfs.DisableBlockPrefetchingFileName:
 		return &PrefetchFile{fs: fs, enable: false}
+
+	case libfs.EnableDebugServerFileName:
+		return &DebugServerFile{fs: fs, enable: true}
+	case libfs.DisableDebugServerFileName:
+		return &DebugServerFile{fs: fs, enable: false}
 	}
 
 	return nil


### PR DESCRIPTION
We need this for the net/trace stuff, since exposing those endpoints
don't work as files (since they use query parameters).

Add net/pprof handlers to the debug server for now.