### PR TITLE
[KBFS-1988] Create a param struct for the backpressure disk limiter

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -259,6 +259,38 @@ type backpressureDiskLimiter struct {
 
 var _ DiskLimiter = (*backpressureDiskLimiter)(nil)
 
+type backpressureDiskLimiterParams struct {
+	log logger.Logger
+	// minThreshold is the fraction of the available bytes/files
+	// at which we start to apply backpressure.
+	minThreshold float64
+	// maxThreshold is the fraction of the available bytes/files
+	// at which we max out on backpressure.
+	maxThreshold float64
+	// journalFrac is fraction of the available bytes/files that
+	// the journal is allowed to use.
+	journalFrac float64
+	// diskCacheFrac is the fraction of the available bytes/files
+	// that the disk cache is allowed to use.
+	diskCacheFrac float64
+	// byteLimit is absolute byte limit that the journal and the disk cache
+	// is allowed to use.
+	byteLimit int64
+	// fileLimit is absolute file limit that the journal and the
+	// disk cache is allowed to use.
+	fileLimit int64
+	// maxDelay is the maximum delay used for backpressure.
+	maxDelay time.Duration
+	// delayFn is a function that takes a context and a duration
+	// and returns after sleeping for that duration, or if the
+	// context is cancelled.
+	delayFn func(context.Context, time.Duration) error
+	// freeBytesAndFilesFn is a function that returns the current
+	// free bytes and files on the disk containing KBFS's storage
+	// directory.
+	freeBytesAndFilesFn func() (int64, int64, error)
+}
+
 // newBackpressureDiskLimiterWithFunctions constructs a new
 // backpressureDiskLimiter with the given parameters, and also the
 // given delay function, which is overridden in tests.

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -443,20 +443,6 @@ func defaultGetFreeBytesAndFiles(path string) (int64, int64, error) {
 	return int64(freeBytes), int64(freeFiles), nil
 }
 
-// newBackpressureDiskLimiter constructs a new backpressureDiskLimiter
-// with the given parameters.
-func newBackpressureDiskLimiter(log logger.Logger, backpressureMinThreshold,
-	backpressureMaxThreshold, journalFrac, diskCacheFrac float64, byteLimit,
-	fileLimit int64, maxDelay time.Duration, journalPath string) (
-	*backpressureDiskLimiter, error) {
-	return newBackpressureDiskLimiterWithFunctions(
-		log, backpressureMinThreshold, backpressureMaxThreshold,
-		journalFrac, diskCacheFrac, byteLimit, fileLimit, maxDelay,
-		defaultDoDelay, func() (int64, int64, error) {
-			return defaultGetFreeBytesAndFiles(journalPath)
-		})
-}
-
 type bdlSnapshot struct {
 	used  int64
 	free  int64

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -273,8 +273,8 @@ type backpressureDiskLimiterParams struct {
 	// diskCacheFrac is the fraction of the available bytes/files
 	// that the disk cache is allowed to use.
 	diskCacheFrac float64
-	// byteLimit is absolute byte limit that the journal and the disk cache
-	// is allowed to use.
+	// byteLimit is absolute byte limit that the journal and the
+	// disk cache is allowed to use.
 	byteLimit int64
 	// fileLimit is absolute file limit that the journal and the
 	// disk cache is allowed to use.
@@ -306,6 +306,9 @@ func newBackpressureDiskLimiterWithFunctions(log logger.Logger,
 	}
 	// byteLimit and fileLimit must be scaled by the proportion of the limit
 	// that the journal should consume.
+	//
+	// TODO: Need to use journalFrac/(journalFrac+diskCacheFrac)
+	// instead.
 	journalByteLimit := int64((float64(byteLimit) * journalFrac) + 0.5)
 	byteTracker, err := newBackpressureTracker(
 		backpressureMinThreshold, backpressureMaxThreshold,

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -282,11 +282,11 @@ type backpressureDiskLimiterParams struct {
 	maxDelay time.Duration
 	// delayFn is a function that takes a context and a duration
 	// and returns after sleeping for that duration, or if the
-	// context is cancelled.
+	// context is cancelled. Overridden for testing.
 	delayFn func(context.Context, time.Duration) error
 	// freeBytesAndFilesFn is a function that returns the current
 	// free bytes and files on the disk containing KBFS's storage
-	// directory.
+	// directory. Overridden for testing.
 	freeBytesAndFilesFn func() (int64, int64, error)
 }
 

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -153,6 +153,24 @@ func TestDefaultDoDelayCancel(t *testing.T) {
 	require.Equal(t, ctx.Err(), errors.Cause(err))
 }
 
+func makeTestBackpressureDiskLimiterParams() backpressureDiskLimiterParams {
+	return backpressureDiskLimiterParams{
+		minThreshold:  0.1,
+		maxThreshold:  0.9,
+		journalFrac:   0.25,
+		diskCacheFrac: 0.1,
+		byteLimit:     400,
+		fileLimit:     40,
+		maxDelay:      8 * time.Second,
+		delayFn: func(context.Context, time.Duration) error {
+			return nil
+		},
+		freeBytesAndFilesFn: func() (int64, int64, error) {
+			return math.MaxInt64, math.MaxInt64, nil
+		},
+	}
+}
+
 func TestBackpressureConstructorError(t *testing.T) {
 	log := logger.NewTestLogger(t)
 	fakeErr := errors.New("Fake error")

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -179,7 +179,7 @@ func TestBackpressureConstructorError(t *testing.T) {
 	params.freeBytesAndFilesFn = func() (int64, int64, error) {
 		return 0, 0, fakeErr
 	}
-	_, err := newBackpressureDiskLimiterWithParams(log, params)
+	_, err := newBackpressureDiskLimiter(log, params)
 	require.Equal(t, fakeErr, err)
 }
 
@@ -191,7 +191,7 @@ func TestBackpressureDiskLimiterBeforeBlockPut(t *testing.T) {
 	params := makeTestBackpressureDiskLimiterParams()
 	params.byteLimit = 88
 	params.fileLimit = 20
-	bdl, err := newBackpressureDiskLimiterWithParams(log, params)
+	bdl, err := newBackpressureDiskLimiter(log, params)
 	require.NoError(t, err)
 
 	availBytes, availFiles, err := bdl.beforeBlockPut(
@@ -212,7 +212,7 @@ func TestBackpressureDiskLimiterBeforeBlockPutError(t *testing.T) {
 	params := makeTestBackpressureDiskLimiterParams()
 	params.byteLimit = 40
 	params.fileLimit = 4
-	bdl, err := newBackpressureDiskLimiterWithParams(log, params)
+	bdl, err := newBackpressureDiskLimiter(log, params)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(
@@ -235,7 +235,7 @@ func TestBackpressureDiskLimiterGetDelay(t *testing.T) {
 	params := makeTestBackpressureDiskLimiterParams()
 	params.byteLimit = math.MaxInt64
 	params.fileLimit = math.MaxInt64
-	bdl, err := newBackpressureDiskLimiterWithParams(log, params)
+	bdl, err := newBackpressureDiskLimiter(log, params)
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -319,7 +319,7 @@ func testBackpressureDiskLimiterLargeDiskDelay(
 	params.byteLimit = byteLimit * 4
 	params.fileLimit = fileLimit * 4
 	params.delayFn = delayFn
-	bdl, err := newBackpressureDiskLimiterWithParams(log, params)
+	bdl, err := newBackpressureDiskLimiter(log, params)
 	require.NoError(t, err)
 
 	byteSnapshot, fileSnapshot := bdl.getSnapshotsForTest()
@@ -482,7 +482,7 @@ func TestBackpressureDiskLimiterJournalAndDiskCache(t *testing.T) {
 	params.freeBytesAndFilesFn = func() (int64, int64, error) {
 		return maxFreeBytes, math.MaxInt64, nil
 	}
-	bdl, err := newBackpressureDiskLimiterWithParams(log, params)
+	bdl, err := newBackpressureDiskLimiter(log, params)
 	require.NoError(t, err)
 
 	byteSnapshot, _ := bdl.getSnapshotsForTest()
@@ -647,7 +647,7 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 	params.fileLimit = math.MaxInt64
 	params.delayFn = delayFn
 	params.freeBytesAndFilesFn = getFreeBytesAndFilesFn
-	bdl, err := newBackpressureDiskLimiterWithParams(log, params)
+	bdl, err := newBackpressureDiskLimiter(log, params)
 	require.NoError(t, err)
 
 	byteSnapshot, fileSnapshot := bdl.getSnapshotsForTest()

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -946,10 +946,6 @@ func (c *ConfigLocal) journalizeBcaches(jServer *JournalServer) error {
 	return nil
 }
 
-// defaultDiskLimitMaxDelay is the maximum amount to delay a block
-// put.
-const defaultDiskLimitMaxDelay = 10 * time.Second
-
 // MakeDiskLimiter makes a DiskLimiter for use in journaling and disk caching.
 func (c *ConfigLocal) MakeDiskLimiter(configRoot string) (DiskLimiter, error) {
 	const (

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -948,27 +948,13 @@ func (c *ConfigLocal) journalizeBcaches(jServer *JournalServer) error {
 
 // MakeDiskLimiter makes a DiskLimiter for use in journaling and disk caching.
 func (c *ConfigLocal) MakeDiskLimiter(configRoot string) (DiskLimiter, error) {
-	const (
-		backpressureMinThreshold = 0.5
-		backpressureMaxThreshold = 0.95
-		// Cap journal usage to a 15% of free space.
-		journalByteLimitFrac = 0.15
-		// Cap disk cache usage to a 10% of free space.
-		diskCacheByteLimitFrac = 0.10
-		// Set the absolute filesystem byte limit to 200 GiB. This will be
-		// scaled by the various *Frac parameters.
-		byteLimit int64 = 200 * 1024 * 1024 * 1024
-		// Set the absolute file limit to 6 million for now.
-		fileLimit int64 = 6000000
-	)
+	params := makeDefaultBackpressureDiskLimiterParams(configRoot)
 	log := c.MakeLogger("")
-	log.Debug("Setting disk storage byte limit to %v", byteLimit)
+	log.Debug("Setting disk storage byte limit to %d and file limit to %d",
+		params.byteLimit, params.fileLimit)
 	os.MkdirAll(configRoot, 0700)
 	var err error
-	c.diskLimiter, err = newBackpressureDiskLimiter(log,
-		backpressureMinThreshold, backpressureMaxThreshold,
-		journalByteLimitFrac, diskCacheByteLimitFrac, byteLimit, fileLimit,
-		defaultDiskLimitMaxDelay, configRoot)
+	c.diskLimiter, err = newBackpressureDiskLimiterWithParams(log, params)
 	return c.diskLimiter, err
 }
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -954,7 +954,7 @@ func (c *ConfigLocal) MakeDiskLimiter(configRoot string) (DiskLimiter, error) {
 		params.byteLimit, params.fileLimit)
 	os.MkdirAll(configRoot, 0700)
 	var err error
-	c.diskLimiter, err = newBackpressureDiskLimiterWithParams(log, params)
+	c.diskLimiter, err = newBackpressureDiskLimiter(log, params)
 	return c.diskLimiter, err
 }
 

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -69,7 +69,7 @@ func newDiskBlockCacheStandardForTest(config *testDiskBlockCacheConfig,
 				return freeBytes, maxFiles, nil
 			},
 		}
-		limiter, err = newBackpressureDiskLimiterWithParams(
+		limiter, err = newBackpressureDiskLimiter(
 			config.MakeLogger(""), params)
 		if err != nil {
 			return nil, err

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -54,14 +54,23 @@ func newDiskBlockCacheStandardForTest(config *testDiskBlockCacheConfig,
 		return nil, err
 	}
 	if limiter == nil {
-		limiter, err = newBackpressureDiskLimiterWithFunctions(
-			config.MakeLogger(""), 0.5, 0.95, 0.25, 0.25,
-			testDiskBlockCacheMaxBytes, maxFiles, time.Second,
-			defaultDoDelay, func() (int64, int64, error) {
+		params := backpressureDiskLimiterParams{
+			minThreshold:  0.5,
+			maxThreshold:  0.95,
+			journalFrac:   0.25,
+			diskCacheFrac: 0.25,
+			byteLimit:     testDiskBlockCacheMaxBytes,
+			fileLimit:     maxFiles,
+			maxDelay:      time.Second,
+			delayFn:       defaultDoDelay,
+			freeBytesAndFilesFn: func() (int64, int64, error) {
 				// hackity hackeroni: simulate the disk cache taking up space.
 				freeBytes := maxBytes - int64(cache.currBytes)
 				return freeBytes, maxFiles, nil
-			})
+			},
+		}
+		limiter, err = newBackpressureDiskLimiterWithParams(
+			config.MakeLogger(""), params)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -475,7 +475,7 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.DiskLimiter.onJournalEnable(ctx, math.MaxInt64-6, 0)
+	tlfJournal.diskLimiter.onJournalEnable(ctx, math.MaxInt64-6, 0)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
 
@@ -512,7 +512,7 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.DiskLimiter.onJournalEnable(
+	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, 0, math.MaxInt64-2*filesPerBlockMax+1)
 
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4})
@@ -550,7 +550,7 @@ func testTLFJournalBlockOpDiskLimitDuplicate(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.DiskLimiter.onJournalEnable(
+	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-8, math.MaxInt64-2*filesPerBlockMax)
 
 	data := []byte{1, 2, 3, 4}
@@ -575,7 +575,7 @@ func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.DiskLimiter.onJournalEnable(ctx, math.MaxInt64, 0)
+	tlfJournal.diskLimiter.onJournalEnable(ctx, math.MaxInt64, 0)
 
 	ctx2, cancel2 := context.WithCancel(ctx)
 	cancel2()
@@ -592,7 +592,7 @@ func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.DiskLimiter.onJournalEnable(
+	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64, math.MaxInt64-1)
 	config.dlTimeout = 3 * time.Microsecond
 
@@ -615,7 +615,7 @@ func testTLFJournalBlockOpDiskLimitPutFailure(t *testing.T, ver MetadataVer) {
 	defer teardownTLFJournalTest(
 		tempdir, config, ctx, cancel, tlfJournal, delegate)
 
-	tlfJournal.DiskLimiter.onJournalEnable(
+	tlfJournal.diskLimiter.onJournalEnable(
 		ctx, math.MaxInt64-6, math.MaxInt64-filesPerBlockMax)
 
 	data := []byte{1, 2, 3, 4}


### PR DESCRIPTION
I'll be adding more params for quota limits, and this is already getting
quite unwieldy.

Add a few more comments.