### PR TITLE
Fix bad disk block cache merge

### DIFF
--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -312,6 +312,9 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 				ctx, "Get id=%s tlf=%s context=%s sz=%d err=%v",
 				id, tlfID, context, size, err)
 		} else {
+			if b.config.DiskBlockCache() != nil {
+				go b.config.DiskBlockCache().Put(ctx, tlfID, id, buf, serverHalf)
+			}
 			b.deferLog.CDebugf(
 				ctx, "Get id=%s tlf=%s context=%s sz=%d",
 				id, tlfID, context, size)


### PR DESCRIPTION
Need a quick thumb on this before the builds start tomorrow; disk cache won't save any blocks without it. I think I messed up a merge somewhere and `git rerere` got too aggressive.