### PR TITLE
mdserver_remote: don't treat random errors as NoCurrentSessionErrors

### DIFF
--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -432,13 +432,9 @@ func (k *KeybaseServiceBase) CurrentSession(ctx context.Context, sessionID int) 
 
 	res, err := k.sessionClient.CurrentSession(ctx, sessionID)
 	if err != nil {
-		if ncs := (NoCurrentSessionError{}); err.Error() ==
-			NoCurrentSessionExpectedError {
-			// Use an error with a proper OS error code attached to
-			// it.  TODO: move ErrNoSession from client/go/service to
-			// client/go/libkb, so we can use types for the check
-			// above.
-			err = ncs
+		if _, ok := err.(libkb.NoSessionError); ok {
+			// Use an error with a proper OS error code attached to it.
+			err = NoCurrentSessionError{}
 		}
 		return SessionInfo{}, err
 	}

--- a/vendor/github.com/keybase/client/go/chat/types/interfaces.go
+++ b/vendor/github.com/keybase/client/go/chat/types/interfaces.go
@@ -1,4 +1,4 @@
-package interfaces
+package types
 
 import (
 	"github.com/keybase/client/go/protocol/chat1"
@@ -11,6 +11,13 @@ type Offlinable interface {
 	IsOffline() bool
 	Connected(ctx context.Context)
 	Disconnected(ctx context.Context)
+}
+
+type TLFInfoSource interface {
+	Lookup(ctx context.Context, tlfName string, vis chat1.TLFVisibility) (*TLFInfo, error)
+	CryptKeys(ctx context.Context, tlfName string) (keybase1.GetTLFCryptKeysRes, error)
+	PublicCanonicalTLFNameAndID(ctx context.Context, tlfName string) (keybase1.CanonicalTLFNameAndIDWithBreaks, error)
+	CompleteAndCanonicalizePrivateTlfName(ctx context.Context, tlfName string) (res keybase1.CanonicalTLFNameAndIDWithBreaks, err error)
 }
 
 type ConversationSource interface {
@@ -27,7 +34,7 @@ type ConversationSource interface {
 	TransformSupersedes(ctx context.Context, convID chat1.ConversationID, uid gregor1.UID, msgs []chat1.MessageUnboxed, finalizeInfo *chat1.ConversationFinalizeInfo) ([]chat1.MessageUnboxed, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
-	SetTlfInterface(func() keybase1.TlfInterface)
+	SetTLFInfoSource(tlfInfoSource TLFInfoSource)
 }
 
 type MessageDeliverer interface {
@@ -66,5 +73,5 @@ type InboxSource interface {
 		convIDs []chat1.ConversationID, finalizeInfo chat1.ConversationFinalizeInfo) ([]chat1.ConversationLocal, error)
 
 	SetRemoteInterface(func() chat1.RemoteInterface)
-	SetTlfInterface(func() keybase1.TlfInterface)
+	SetTLFInfoSource(tlfInfoSource TLFInfoSource)
 }

--- a/vendor/github.com/keybase/client/go/chat/types/types.go
+++ b/vendor/github.com/keybase/client/go/chat/types/types.go
@@ -1,0 +1,12 @@
+package types
+
+import (
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+type TLFInfo struct {
+	ID               chat1.TLFID
+	CanonicalName    string
+	IdentifyFailures []keybase1.TLFIdentifyFailure
+}

--- a/vendor/github.com/keybase/client/go/libkb/globals.go
+++ b/vendor/github.com/keybase/client/go/libkb/globals.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	chatinterfaces "github.com/keybase/client/go/chat/interfaces"
+	chattypes "github.com/keybase/client/go/chat/types"
 	logger "github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	clockwork "github.com/keybase/clockwork"
@@ -101,9 +101,9 @@ type GlobalContext struct {
 	uchMu               *sync.Mutex          // protects the UserChangedHandler array
 	UserChangedHandlers []UserChangedHandler // a list of handlers that deal generically with userchanged events
 
-	InboxSource      chatinterfaces.InboxSource        // source of remote inbox entries for chat
-	ConvSource       chatinterfaces.ConversationSource // source of remote message bodies for chat
-	MessageDeliverer chatinterfaces.MessageDeliverer   // background message delivery service
+	InboxSource      chattypes.InboxSource        // source of remote inbox entries for chat
+	ConvSource       chattypes.ConversationSource // source of remote message bodies for chat
+	MessageDeliverer chattypes.MessageDeliverer   // background message delivery service
 
 	// Can be overloaded by tests to get an improvement in performance
 	NewTriplesec func(pw []byte, salt []byte) (Triplesec, error)

--- a/vendor/github.com/keybase/client/go/protocol/chat1/chat_ui.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/chat_ui.go
@@ -64,8 +64,8 @@ type ChatInboxFailedArg struct {
 }
 
 type ChatThreadCachedArg struct {
-	SessionID int        `codec:"sessionID" json:"sessionID"`
-	Thread    ThreadView `codec:"thread" json:"thread"`
+	SessionID int         `codec:"sessionID" json:"sessionID"`
+	Thread    *ThreadView `codec:"thread,omitempty" json:"thread,omitempty"`
 }
 
 type ChatThreadFullArg struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -135,9 +135,9 @@
 			"revisionTime": "2017-02-13T21:07:17Z"
 		},
 		{
-			"checksumSHA1": "gLinqeOpvTWSGUlxrFbvsc016Oc=",
-			"path": "github.com/keybase/client/go/chat/interfaces",
-			"revision": "66b4b1333325587c1161b18c2b462b3d1781696e",
+			"checksumSHA1": "/M69Gv5ANGm5un2FLnBTEVuKsxI=",
+			"path": "github.com/keybase/client/go/chat/types",
+			"revision": "dec61b18d5ccccc63a14100393675b7edd249f43",
 			"revisionTime": "2017-03-20T19:37:17Z"
 		},
 		{
@@ -159,9 +159,9 @@
 			"revisionTime": "2017-02-13T21:07:17Z"
 		},
 		{
-			"checksumSHA1": "izAKnxnWAKBhfisFveXwWSd1Gz4=",
+			"checksumSHA1": "OU+qaJCZkbBMoQYamhJ4HhWS7c8=",
 			"path": "github.com/keybase/client/go/libkb",
-			"revision": "66b4b1333325587c1161b18c2b462b3d1781696e",
+			"revision": "dec61b18d5ccccc63a14100393675b7edd249f43",
 			"revisionTime": "2017-03-20T19:37:17Z"
 		},
 		{
@@ -177,9 +177,9 @@
 			"revisionTime": "2017-02-13T21:07:17Z"
 		},
 		{
-			"checksumSHA1": "vTm7HH3hzSzdG1MiYsUPYqpLm6c=",
+			"checksumSHA1": "LsKwdzQMatyS/SbuGP7TF+DbCvc=",
 			"path": "github.com/keybase/client/go/protocol/chat1",
-			"revision": "66b4b1333325587c1161b18c2b462b3d1781696e",
+			"revision": "dec61b18d5ccccc63a14100393675b7edd249f43",
 			"revisionTime": "2017-03-20T19:37:17Z"
 		},
 		{
@@ -191,7 +191,7 @@
 		{
 			"checksumSHA1": "wjqppOFQQ4pKglfjqa0ehgI8lvY=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "66b4b1333325587c1161b18c2b462b3d1781696e",
+			"revision": "dec61b18d5ccccc63a14100393675b7edd249f43",
 			"revisionTime": "2017-03-20T19:37:17Z"
 		},
 		{


### PR DESCRIPTION
If the service gives us some other error message when getting the session (as opposed to `libkb.NoSessionError`), we should retry the connection after a delay using the rpc connection's retry logic.

This also fixes up logging in `MDServerRemote` to be more consistent with the rest of the package.

Also, it re-vendors client to get the most up-to-date content hashes (previously, we had vendored from an unmerged branch).

Issue: KBFS-2031