### PR TITLE
util: add log tags from RPC if available

### DIFF
--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -48,28 +48,6 @@ func MakeRandomRequestID() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
-// LogTagsFromContextToMap parses log tags from the context into a map of strings.
-func LogTagsFromContextToMap(ctx context.Context) (tags map[string]string) {
-	if ctx == nil {
-		return tags
-	}
-	logTags, ok := logger.LogTagsFromContext(ctx)
-	if !ok || len(logTags) == 0 {
-		return tags
-	}
-	tags = make(map[string]string)
-	for key, tag := range logTags {
-		if v := ctx.Value(key); v != nil {
-			if value, ok := v.(fmt.Stringer); ok {
-				tags[tag] = value.String()
-			} else if value, ok := v.(string); ok {
-				tags[tag] = value
-			}
-		}
-	}
-	return tags
-}
-
 // BoolForString returns false if trimmed string is "" (empty), "0", "false", or "no"
 func BoolForString(s string) bool {
 	s = strings.TrimSpace(s)

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -81,6 +81,8 @@ const (
 
 func ctxWithRandomIDReplayable(ctx context.Context, tagKey interface{},
 	tagName string, log logger.Logger) context.Context {
+	ctx = logger.ConvertRPCTagsToLogTags(ctx)
+
 	id, err := MakeRandomRequestID()
 	if err != nil && log != nil {
 		log.Warning("Couldn't generate a random request ID: %v", err)

--- a/vendor/github.com/keybase/client/go/logger/standard.go
+++ b/vendor/github.com/keybase/client/go/logger/standard.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	logging "github.com/keybase/go-logging"
 	"golang.org/x/net/context"
 
@@ -61,6 +62,35 @@ func NewContextWithLogTags(
 func LogTagsFromContext(ctx context.Context) (CtxLogTags, bool) {
 	logTags, ok := ctx.Value(CtxLogTagsKey).(CtxLogTags)
 	return logTags, ok
+}
+
+// LogTagsFromContextRPC is a wrapper around LogTagsFromContext
+// that simply casts the result to the type expected by
+// rpc.Connection.
+func LogTagsFromContextRPC(ctx context.Context) (map[interface{}]string, bool) {
+	tags, ok := LogTagsFromContext(ctx)
+	return map[interface{}]string(tags), ok
+}
+
+// ConvertRPCTagsToLogTags takes any RPC tags in the context and makes
+// them log tags.  It uses the string representation of the tag key,
+// rather than the original uniquely typed key, since the latter isn't
+// available in the RPC tags.
+func ConvertRPCTagsToLogTags(ctx context.Context) context.Context {
+	rpcTags, ok := rpc.RpcTagsFromContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	tags := make(CtxLogTags)
+	for key, value := range rpcTags {
+		// The map key should be a proper unique type, but that's not
+		// passed along in the RPC so just use the string key.
+		tags[key] = key
+		ctx = context.WithValue(ctx, key, value)
+	}
+	ctx = context.WithValue(ctx, rpc.CtxRpcTagsKey, nil)
+	return NewContextWithLogTags(ctx, tags)
 }
 
 type ExternalLogger interface {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -165,10 +165,10 @@
 			"revisionTime": "2017-03-20T19:37:17Z"
 		},
 		{
-			"checksumSHA1": "3ijtWRJkPFOXXKvlswIdSmwhjXk=",
+			"checksumSHA1": "jAH6LB6sSSp+Vxx/bTBE5DtocGo=",
 			"path": "github.com/keybase/client/go/logger",
-			"revision": "5374606c314d5a66e9f726d473e4d78429c22c1f",
-			"revisionTime": "2017-02-22T19:32:43Z"
+			"revision": "f59fbd24c1d4d05b4b02763385ceff7f064614c9",
+			"revisionTime": "2017-03-21T16:41:32Z"
 		},
 		{
 			"checksumSHA1": "O1Q0NBB6o1mj4A+1uk1xgf7nw+c=",


### PR DESCRIPTION
If the service makes any RPC calls to us with debug tags included, this will add them to the context as log tags.  However, right now I don't think it sets any tags during calls (not chat-related calls, anyway).