### PR TITLE
[KBFS-2001] Skip Retrieval Workers for Items in the Disk Cache

### DIFF
--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfshash"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 )
 
 type blockContainer struct {
@@ -242,6 +243,18 @@ func (b *BlockCacheStandard) makeRoomForSize(size uint64, lifetime BlockCacheLif
 func (b *BlockCacheStandard) PutWithPrefetch(
 	ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime,
 	hasPrefetched bool) (err error) {
+	// Just in case we tried to cache a block type that shouldn't be cached,
+	// return an error. This is an insurance check. That said, this got rid of
+	// a flake in TestSBSConflicts, so we should still look for the underlying
+	// error.
+	switch block.(type) {
+	case *DirBlock:
+	case *FileBlock:
+	case *CommonBlock:
+		return errors.New("attempted to Put a common block")
+	default:
+		return errors.Errorf("attempted to Put an unknown block type %T", block)
+	}
 
 	var wasInCache bool
 
@@ -251,7 +264,8 @@ func (b *BlockCacheStandard) PutWithPrefetch(
 
 	case TransientEntry:
 		// If it's the right type of block, store the hash -> ID mapping.
-		if fBlock, isFileBlock := block.(*FileBlock); b.ids != nil && isFileBlock && !fBlock.IsInd {
+		if fBlock, isFileBlock := block.(*FileBlock); b.ids != nil &&
+			isFileBlock && !fBlock.IsInd {
 
 			key := idCacheKey{tlf, fBlock.GetHash()}
 			// zero out the refnonce, it doesn't matter

--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -264,10 +264,10 @@ func (b *BlockCacheStandard) PutWithPrefetch(
 		// We could use `cleanTransient.Contains()`, but that wouldn't update
 		// the LRU time. By using `Get`, we make it less likely that another
 		// goroutine will evict this block before we can `Put` it again.
-		var block interface{}
-		block, wasInCache = b.cleanTransient.Get(ptr.ID)
+		var bc interface{}
+		bc, wasInCache = b.cleanTransient.Get(ptr.ID)
 		if wasInCache {
-			hasPrefetched = (hasPrefetched || block.(blockContainer).hasPrefetched)
+			hasPrefetched = (hasPrefetched || bc.(blockContainer).hasPrefetched)
 		}
 		// Cache it later, once we know there's room
 

--- a/libkbfs/block_getter.go
+++ b/libkbfs/block_getter.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 
 	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"golang.org/x/net/context"
 )
 
 // blockGetter provides the API for the block retrieval worker to obtain blocks.
 type blockGetter interface {
 	getBlock(context.Context, KeyMetadata, BlockPointer, Block) error
+	assembleBlock(context.Context, KeyMetadata, BlockPointer, Block, []byte,
+		kbfscrypto.BlockCryptKeyServerHalf) error
 }
 
 // realBlockGetter obtains real blocks using the APIs available in Config.
@@ -40,4 +43,11 @@ func (bg *realBlockGetter) getBlock(ctx context.Context, kmd KeyMetadata, blockP
 	return assembleBlock(
 		ctx, bg.config.keyGetter(), bg.config.Codec(), bg.config.cryptoPure(),
 		kmd, blockPtr, block, buf, blockServerHalf)
+}
+
+func (bg *realBlockGetter) assembleBlock(ctx context.Context,
+	kmd KeyMetadata, ptr BlockPointer, block Block, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
+	return assembleBlock(ctx, bg.config.keyGetter(), bg.config.Codec(),
+		bg.config.cryptoPure(), kmd, ptr, block, buf, serverHalf)
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -193,6 +193,11 @@ func (b *BlockOpsStandard) Prefetcher() Prefetcher {
 	return b.queue.Prefetcher()
 }
 
+// Prefetcher implements the BlockOps interface for BlockOpsStandard.
+func (b *BlockOpsStandard) BlockRetriever() blockRetriever {
+	return b.queue
+}
+
 // Shutdown implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) Shutdown() {
 	b.queue.Shutdown()

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -19,6 +19,7 @@ type blockOpsConfig interface {
 	codecGetter
 	cryptoPureGetter
 	keyGetterGetter
+	diskBlockCacheGetter
 }
 
 // BlockOpsStandard implements the BlockOps interface by relaying

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -193,8 +193,8 @@ func (b *BlockOpsStandard) Prefetcher() Prefetcher {
 	return b.queue.Prefetcher()
 }
 
-// Prefetcher implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) BlockRetriever() blockRetriever {
+// BlockRetriever implements the BlockOps interface for BlockOpsStandard.
+func (b *BlockOpsStandard) BlockRetriever() BlockRetriever {
 	return b.queue
 }
 

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -83,6 +83,7 @@ type testBlockOpsConfig struct {
 	bserver BlockServer
 	cp      cryptoPure
 	cache   BlockCache
+	diskBlockCacheGetter
 }
 
 var _ blockOpsConfig = (*testBlockOpsConfig)(nil)
@@ -113,7 +114,8 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	bserver := NewBlockServerMemory(lm.MakeLogger(""))
 	crypto := MakeCryptoCommon(codecGetter.Codec())
 	cache := NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity())
-	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache}
+	dbcg := newTestDiskBlockCacheGetter(t)
+	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, dbcg}
 }
 
 // TestBlockOpsReadySuccess checks that BlockOpsStandard.Ready()

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -114,8 +114,7 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	bserver := NewBlockServerMemory(lm.MakeLogger(""))
 	crypto := MakeCryptoCommon(codecGetter.Codec())
 	cache := NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity())
-	dbcg := newTestDiskBlockCacheGetter(t)
-	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, dbcg}
+	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, nil}
 }
 
 // TestBlockOpsReadySuccess checks that BlockOpsStandard.Ready()

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -114,7 +114,8 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	bserver := NewBlockServerMemory(lm.MakeLogger(""))
 	crypto := MakeCryptoCommon(codecGetter.Codec())
 	cache := NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity())
-	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, nil}
+	dbcg := newTestDiskBlockCacheGetter(t, nil)
+	return testBlockOpsConfig{codecGetter, lm, bserver, crypto, cache, dbcg}
 }
 
 // TestBlockOpsReadySuccess checks that BlockOpsStandard.Ready()

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -6,12 +6,12 @@ package libkbfs
 
 import (
 	"container/heap"
-	"errors"
 	"io"
 	"reflect"
 	"sync"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -200,7 +200,9 @@ func (brq *blockRetrievalQueue) CacheAndPrefetch(ptr BlockPointer, block Block,
 }
 
 // Request submits a block request to the queue.
-func (brq *blockRetrievalQueue) Request(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
+func (brq *blockRetrievalQueue) Request(ctx context.Context,
+	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
+	lifetime BlockCacheLifetime) <-chan error {
 	// Only continue if we haven't been shut down
 	ch := make(chan error, 1)
 	select {
@@ -225,13 +227,12 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context, priority int, kmd K
 	for {
 		br, exists := brq.ptrs[bpLookup]
 		if !exists {
-			// Attempt to retrieve the block from the cache. This
-			// might be a specific type where the request blocks are
-			// CommonBlocks, but that direction can Set correctly. The
-			// cache will never have CommonBlocks.  TODO: verify that
-			// the returned lifetime here matches `lifetime` (which
-			// should always be TransientEntry, since a PermanentEntry
-			// would have been served directly from the cache
+			// Attempt to retrieve the block from the cache. This might be a
+			// specific type where the request blocks are CommonBlocks, but
+			// that direction can Set correctly. The cache will never have
+			// CommonBlocks.  TODO: verify that the returned lifetime here
+			// matches `lifetime` (which should always be TransientEntry, since
+			// a PermanentEntry would have been served directly from the cache
 			// elsewhere)?
 			cachedBlock, hasPrefetched, _, err :=
 				brq.config.BlockCache().GetWithPrefetch(ptr)

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -25,6 +25,7 @@ type blockRetrievalPartialConfig interface {
 	dataVersioner
 	logMaker
 	blockCacher
+	diskBlockCacheGetter
 }
 
 type blockRetrievalConfig interface {

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -237,8 +237,8 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 		return NoSuchBlockError{ptr.ID}
 	}
 
-	// TODO: once the DiskBlockCache knows about
-	// hasPrefetched, pipe that through here.
+	// TODO: once the DiskBlockCache knows about hasPrefetched, pipe that
+	// through here.
 	brq.CacheAndPrefetch(ptr, cachedBlock, kmd, priority, lifetime, false)
 	return nil
 }
@@ -261,8 +261,7 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	}
 
 	// Check caches before locking the mutex.
-	err := brq.checkCaches(ctx, priority, kmd, ptr, block,
-		lifetime)
+	err := brq.checkCaches(ctx, priority, kmd, ptr, block, lifetime)
 	if err == nil {
 		ch <- nil
 		return ch

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -121,7 +121,7 @@ type blockRetrievalQueue struct {
 	prefetcher Prefetcher
 }
 
-var _ blockRetriever = (*blockRetrievalQueue)(nil)
+var _ BlockRetriever = (*blockRetrievalQueue)(nil)
 
 // newBlockRetrievalQueue creates a new block retrieval queue. The numWorkers
 // parameter determines how many workers can concurrently call Work (more than

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -29,7 +29,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter) *testBlockRetriev
 		newTestLogMaker(t),
 		NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity()),
 		bg,
-		newTestDiskBlockCacheGetter(t),
+		nil,
 	}
 }
 

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -20,6 +20,7 @@ type testBlockRetrievalConfig struct {
 	logMaker
 	testCache BlockCache
 	bg        blockGetter
+	diskBlockCacheGetter
 }
 
 func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter) *testBlockRetrievalConfig {
@@ -28,6 +29,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter) *testBlockRetriev
 		newTestLogMaker(t),
 		NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity()),
 		bg,
+		newTestDiskBlockCacheGetter(t),
 	}
 }
 

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -29,7 +29,7 @@ func newTestBlockRetrievalConfig(t *testing.T, bg blockGetter) *testBlockRetriev
 		newTestLogMaker(t),
 		NewBlockCacheStandard(10, getDefaultCleanBlockCacheCapacity()),
 		bg,
-		nil,
+		newTestDiskBlockCacheGetter(t, nil),
 	}
 }
 

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -83,6 +84,12 @@ func (bg *fakeBlockGetter) getBlock(ctx context.Context, kmd KeyMetadata, blockP
 			return ctx.Err()
 		}
 	}
+}
+
+func (bg *fakeBlockGetter) assembleBlock(ctx context.Context,
+	kmd KeyMetadata, ptr BlockPointer, block Block, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
+	return errors.New("Not implemented")
 }
 
 func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -377,7 +377,8 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 	context kbfsblock.Context) (
 	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	// TODO: do this in parallel.
-	if b.config.DiskBlockCache() != nil {
+	dbc := b.config.DiskBlockCache()
+	if dbc != nil {
 		buf, serverHalf, err = b.config.DiskBlockCache().Get(ctx, tlfID, id)
 		if err == nil {
 			return
@@ -390,8 +391,8 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 				ctx, "Get id=%s tlf=%s context=%s sz=%d err=%v",
 				id, tlfID, context, size, err)
 		} else {
-			if b.config.DiskBlockCache() != nil {
-				go b.config.DiskBlockCache().Put(ctx, tlfID, id, buf, serverHalf)
+			if dbc != nil {
+				go dbc.Put(ctx, tlfID, id, buf, serverHalf)
 			}
 			b.deferLog.CDebugf(
 				ctx, "Get id=%s tlf=%s context=%s sz=%d",
@@ -421,8 +422,9 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	bContext kbfsblock.Context, buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
-	if b.config.DiskBlockCache() != nil {
-		go b.config.DiskBlockCache().Put(ctx, tlfID, id, buf, serverHalf)
+	dbc := b.config.DiskBlockCache()
+	if dbc != nil {
+		go dbc.Put(ctx, tlfID, id, buf, serverHalf)
 	}
 	size := len(buf)
 	defer func() {

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -376,14 +376,6 @@ func makeBlockReference(id kbfsblock.ID, context kbfsblock.Context) keybase1.Blo
 func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context) (
 	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
-	// TODO: do this in parallel.
-	dbc := b.config.DiskBlockCache()
-	if dbc != nil {
-		buf, serverHalf, err = b.config.DiskBlockCache().Get(ctx, tlfID, id)
-		if err == nil {
-			return
-		}
-	}
 	size := -1
 	defer func() {
 		if err != nil {
@@ -391,6 +383,7 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 				ctx, "Get id=%s tlf=%s context=%s sz=%d err=%v",
 				id, tlfID, context, size, err)
 		} else {
+			dbc := b.config.DiskBlockCache()
 			if dbc != nil {
 				go dbc.Put(ctx, tlfID, id, buf, serverHalf)
 			}

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -383,13 +383,13 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 				ctx, "Get id=%s tlf=%s context=%s sz=%d err=%v",
 				id, tlfID, context, size, err)
 		} else {
+			b.deferLog.CDebugf(
+				ctx, "Get id=%s tlf=%s context=%s sz=%d",
+				id, tlfID, context, size)
 			dbc := b.config.DiskBlockCache()
 			if dbc != nil {
 				go dbc.Put(ctx, tlfID, id, buf, serverHalf)
 			}
-			b.deferLog.CDebugf(
-				ctx, "Get id=%s tlf=%s context=%s sz=%d",
-				id, tlfID, context, size)
 		}
 	}()
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -903,8 +903,9 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 	if err != nil {
 		errorList = append(errorList, err)
 	}
-	if c.DiskBlockCache() != nil {
-		c.DiskBlockCache().Shutdown(ctx)
+	dbc := c.DiskBlockCache()
+	if dbc != nil {
+		dbc.Shutdown(ctx)
 	}
 
 	if len(errorList) == 1 {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -465,9 +465,9 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 	return cache.updateMetadataLocked(ctx, tlfID, blockKey, int(encodedLen))
 }
 
-// UpdateMetadata implements the DiskBlockCache interface for
+// UpdateLRUTime implements the DiskBlockCache interface for
 // DiskBlockCacheStandard.
-func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
+func (cache *DiskBlockCacheStandard) UpdateLRUTime(ctx context.Context,
 	blockID kbfsblock.ID) (err error) {
 	var md diskBlockCacheMetadata
 	defer func() {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -468,11 +468,16 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 // UpdateMetadata implements the DiskBlockCache interface for
 // DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID) error {
+	blockID kbfsblock.ID) (err error) {
+	var md diskBlockCacheMetadata
+	defer func() {
+		cache.log.CDebugf(ctx, "Cache UpdateMetadata id=%s entrySize=%d "+
+			"err=%+v", blockID, md.BlockSize, err)
+	}()
 	// Only obtain a read lock because this happens on Get, not on Put.
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
-	md, err := cache.getMetadata(blockID)
+	md, err = cache.getMetadata(blockID)
 	if err != nil {
 		return NoSuchBlockError{blockID}
 	}

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -471,7 +471,7 @@ func (cache *DiskBlockCacheStandard) UpdateLRUTime(ctx context.Context,
 	blockID kbfsblock.ID) (err error) {
 	var md diskBlockCacheMetadata
 	defer func() {
-		cache.log.CDebugf(ctx, "Cache UpdateMetadata id=%s entrySize=%d "+
+		cache.log.CDebugf(ctx, "Cache UpdateLRUTime id=%s entrySize=%d "+
 			"err=%+v", blockID, md.BlockSize, err)
 	}()
 	// Only obtain a read lock because this happens on Get, not on Put.

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -460,8 +460,9 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 // DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
 	blockID kbfsblock.ID) error {
-	cache.lock.Lock()
-	defer cache.lock.Unlock()
+	// Only obtain a read lock because this happens on Get, not on Put.
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
 	md, err := cache.getMetadata(blockID)
 	if err != nil {
 		return NoSuchBlockError{blockID}

--- a/libkbfs/disk_block_cache_helper.go
+++ b/libkbfs/disk_block_cache_helper.go
@@ -15,12 +15,6 @@ type diskBlockCacheEntry struct {
 	ServerHalf kbfscrypto.BlockCryptKeyServerHalf
 }
 
-// diskBlockCacheDeleteKey specifies a blockID and TLF pair to delete.
-type diskBlockCacheDeleteKey struct {
-	TlfID   tlf.ID
-	BlockID kbfsblock.ID
-}
-
 // diskBlockCacheMetadata packages the metadata needed to make decisions on
 // cache eviction.
 type diskBlockCacheMetadata struct {
@@ -34,7 +28,6 @@ type diskBlockCacheMetadata struct {
 
 // lruEntry is an entry for sorting LRU times
 type lruEntry struct {
-	TlfID   tlf.ID
 	BlockID kbfsblock.ID
 	Time    time.Time
 }
@@ -45,13 +38,13 @@ func (b blockIDsByTime) Len() int           { return len(b) }
 func (b blockIDsByTime) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
 func (b blockIDsByTime) Less(i, j int) bool { return b[i].Time.Before(b[j].Time) }
 
-func (b blockIDsByTime) ToBlockIDSlice(numBlocks int) []diskBlockCacheDeleteKey {
-	ids := make([]diskBlockCacheDeleteKey, 0, numBlocks)
+func (b blockIDsByTime) ToBlockIDSlice(numBlocks int) []kbfsblock.ID {
+	ids := make([]kbfsblock.ID, 0, numBlocks)
 	for _, entry := range b {
 		if len(ids) == numBlocks {
 			return ids
 		}
-		ids = append(ids, diskBlockCacheDeleteKey{entry.TlfID, entry.BlockID})
+		ids = append(ids, entry.BlockID)
 	}
 	return ids
 }

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -91,6 +91,19 @@ func initDiskBlockCacheTest(t *testing.T) (*DiskBlockCacheStandard,
 	return cache, config
 }
 
+type testDiskBlockCacheGetter struct {
+	dbc *DiskBlockCacheStandard
+}
+
+func (dbcg *testDiskBlockCacheGetter) DiskBlockCache() DiskBlockCache {
+	return dbcg.dbc
+}
+
+func newTestDiskBlockCacheGetter(t *testing.T) *testDiskBlockCacheGetter {
+	cache, _ := initDiskBlockCacheTest(t)
+	return &testDiskBlockCacheGetter{cache}
+}
+
 func shutdownDiskBlockCacheTest(cache DiskBlockCache) {
 	cache.Shutdown(context.Background())
 }

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -92,16 +92,16 @@ func initDiskBlockCacheTest(t *testing.T) (*DiskBlockCacheStandard,
 }
 
 type testDiskBlockCacheGetter struct {
-	dbc *DiskBlockCacheStandard
+	dbc DiskBlockCache
 }
 
 func (dbcg *testDiskBlockCacheGetter) DiskBlockCache() DiskBlockCache {
 	return dbcg.dbc
 }
 
-func newTestDiskBlockCacheGetter(t *testing.T) *testDiskBlockCacheGetter {
-	cache, _ := initDiskBlockCacheTest(t)
-	return &testDiskBlockCacheGetter{cache}
+func newTestDiskBlockCacheGetter(t *testing.T,
+	dbc DiskBlockCache) *testDiskBlockCacheGetter {
+	return &testDiskBlockCacheGetter{dbc}
 }
 
 func shutdownDiskBlockCacheTest(cache DiskBlockCache) {

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -177,9 +177,12 @@ func TestDiskBlockCacheDelete(t *testing.T) {
 		require.NoError(t, err)
 	}
 	tlf1 := tlf.FakeID(3, false)
-	block1Id, block1Encoded, block1ServerHalf := setupBlockForDiskCache(t, config)
-	block2Id, block2Encoded, block2ServerHalf := setupBlockForDiskCache(t, config)
-	block3Id, block3Encoded, block3ServerHalf := setupBlockForDiskCache(t, config)
+	block1Id, block1Encoded, block1ServerHalf := setupBlockForDiskCache(t,
+		config)
+	block2Id, block2Encoded, block2ServerHalf := setupBlockForDiskCache(t,
+		config)
+	block3Id, block3Encoded, block3ServerHalf := setupBlockForDiskCache(t,
+		config)
 
 	t.Log("Put three blocks into the cache.")
 	err := cache.Put(ctx, tlf1, block1Id, block1Encoded, block1ServerHalf)
@@ -190,8 +193,7 @@ func TestDiskBlockCacheDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Delete two of the blocks from the cache.")
-	_, _, err = cache.DeleteByTLF(ctx, tlf1, []kbfsblock.ID{
-		block1Id, block2Id})
+	_, _, err = cache.Delete(ctx, []kbfsblock.ID{block1Id, block2Id})
 	require.NoError(t, err)
 
 	t.Log("Verify that only the non-deleted block is still in the cache.")

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	testDiskBlockCacheMaxBytes int64 = 1 << 30
+	testDiskBlockCacheMaxBytes int64 = 1 << 20
 )
 
 type testDiskBlockCacheConfig struct {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -335,8 +335,8 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		fbo.config.BlockOps().Prefetcher().PrefetchAfterBlockRetrieved(
-			block, ptr, kmd, defaultOnDemandRequestPriority, lifetime,
+		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(
+			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
 			hasPrefetched)
 		return block, nil
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -313,8 +313,8 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 // This must be called only by get{File,Dir}BlockHelperLocked().
 func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 	lState *lockState, kmd KeyMetadata, ptr BlockPointer, branch BranchName,
-	newBlock makeNewBlock, lifetime BlockCacheLifetime, notifyPath path, rtype blockReqType) (
-	Block, error) {
+	newBlock makeNewBlock, lifetime BlockCacheLifetime, notifyPath path,
+	rtype blockReqType) (Block, error) {
 	if rtype != blockReadParallel {
 		fbo.blockLock.AssertAnyLocked(lState)
 	} else if lState != nil {
@@ -331,11 +331,12 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		return block, nil
 	}
 
-	if block, hasPrefetched, lifetime, err := fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
+	if block, hasPrefetched, lifetime, err :=
+		fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(
+		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(ctx,
 			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
 			hasPrefetched)
 		return block, nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1947,8 +1947,8 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		}
 		fblock, ok := block.(*FileBlock)
 		if !ok {
-			return nil, false,
-				errors.Errorf("Block for %s is not a file block", ptr)
+			return nil, false, errors.Errorf(
+				"Block for %s is not a file block. Block type: %T", ptr, block)
 		}
 		return fblock, true, nil
 	}
@@ -4165,7 +4165,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		}
 		diskCache := fbo.config.DiskBlockCache()
 		if diskCache != nil {
-			go diskCache.DeleteByTLF(ctx, md.TlfID(), idsToDelete)
+			go diskCache.Delete(ctx, idsToDelete)
 		}
 	case *resolutionOp:
 		// If there are any unrefs of blocks that have a node, this is an

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1948,7 +1948,7 @@ func (fbo *folderBranchOps) unembedBlockChanges(
 		fblock, ok := block.(*FileBlock)
 		if !ok {
 			return nil, false, errors.Errorf(
-				"Block for %s is not a file block. Block type: %T", ptr, block)
+				"Block for %s is not a file block, block type: %T", ptr, block)
 		}
 		return fblock, true, nil
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1090,10 +1090,9 @@ type Prefetcher interface {
 	// PrefetchAfterBlockRetrieved allows the prefetcher to trigger prefetches
 	// after a block has been retrieved. Whichever component is responsible for
 	// retrieving blocks will call this method once it's done retrieving a
-	// block. It caches if it has triggered a prefetch.
+	// block.
 	PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer,
-		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		hasPrefetched bool)
+		kmd KeyMetadata)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are
@@ -1142,6 +1141,9 @@ type BlockOps interface {
 
 	// TogglePrefetcher activates or deactivates the prefetcher.
 	TogglePrefetcher(ctx context.Context, enable bool) error
+
+	// BlockRetriever obtains the block retriever
+	BlockRetriever() blockRetriever
 
 	// Prefetcher retrieves this BlockOps' Prefetcher.
 	Prefetcher() Prefetcher

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1143,7 +1143,7 @@ type BlockOps interface {
 	TogglePrefetcher(ctx context.Context, enable bool) error
 
 	// BlockRetriever obtains the block retriever
-	BlockRetriever() blockRetriever
+	BlockRetriever() BlockRetriever
 
 	// Prefetcher retrieves this BlockOps' Prefetcher.
 	Prefetcher() Prefetcher
@@ -2025,4 +2025,15 @@ type RekeyFSM interface {
 	// RequestRekeyAndWaitForOneFinishEvent for more details.
 	listenOnEvent(
 		event rekeyEventType, callback func(RekeyEvent), repeatedly bool)
+}
+
+// BlockRetriever specifies how to retrieve blocks.
+type BlockRetriever interface {
+	// Request retrieves blocks asynchronously.
+	Request(ctx context.Context, priority int, kmd KeyMetadata,
+		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+	// CacheAndPrefetch caches a block along with its prefetch status, and then
+	// triggers prefetches as appropriate.
+	CacheAndPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
+		priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -843,9 +843,8 @@ type DiskBlockCache interface {
 	// Delete deletes some blocks from the disk cache.
 	Delete(ctx context.Context, blockIDs []kbfsblock.ID) (numRemoved int,
 		sizeRemoved int64, err error)
-	// UpdateMetadata updates the metadata for the given block, including
-	// setting the LRU time to now.
-	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID) error
+	// UpdateLRUTime updates the LRU time to Now() for a given block.
+	UpdateLRUTime(ctx context.Context, blockID kbfsblock.ID) error
 	// Size returns the size in bytes of the disk cache.
 	Size() int64
 	// Shutdown cleanly shuts down the disk block cache.
@@ -2038,6 +2037,7 @@ type BlockRetriever interface {
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
 	// CacheAndPrefetch caches a block along with its prefetch status, and then
 	// triggers prefetches as appropriate.
-	CacheAndPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
-		priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error
+	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
+		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
+		hasPrefetched bool) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -840,8 +840,9 @@ type DiskBlockCache interface {
 	// Put puts a block to the disk cache.
 	Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte,
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
-	// DeleteByTLF deletes some blocks from the disk cache.
-	DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) (numRemoved int, sizeRemoved int64, err error)
+	// Delete deletes some blocks from the disk cache.
+	Delete(ctx context.Context, blockIDs []kbfsblock.ID) (numRemoved int,
+		sizeRemoved int64, err error)
 	// UpdateMetadata updates the metadata for the given block, including
 	// setting the LRU time to now.
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -842,6 +842,9 @@ type DiskBlockCache interface {
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf) error
 	// DeleteByTLF deletes some blocks from the disk cache.
 	DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) (numRemoved int, sizeRemoved int64, err error)
+	// UpdateMetadata updates the metadata for the given block, including
+	// setting the LRU time to now.
+	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID) error
 	// Size returns the size in bytes of the disk cache.
 	Size() int64
 	// Shutdown cleanly shuts down the disk block cache.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -111,7 +111,7 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
 	brc := &testBlockRetrievalConfig{nil, newTestLogMaker(t),
-		config.BlockCache(), nil, nil}
+		config.BlockCache(), nil, newTestDiskBlockCacheGetter(t, nil)}
 	pre := newBlockPrefetcher(nil, brc)
 	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(pre)
 	// Ignore BlockRetriever calls

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -111,12 +111,12 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
 	brc := &testBlockRetrievalConfig{nil, newTestLogMaker(t),
-		config.BlockCache(), nil, newTestDiskBlockCacheGetter(t)}
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(
-		newBlockPrefetcher(nil, brc))
+		config.BlockCache(), nil, nil}
+	pre := newBlockPrefetcher(nil, brc)
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(pre)
 	// Ignore BlockRetriever calls
-	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(
-		newBlockRetrievalQueue(0, brc))
+	brq := newBlockRetrievalQueue(0, brc)
+	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -110,7 +110,13 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, newTestLogMaker(t), config.BlockCache(), nil, newTestDiskBlockCacheGetter(t)}))
+	brc := &testBlockRetrievalConfig{nil, newTestLogMaker(t),
+		config.BlockCache(), nil, newTestDiskBlockCacheGetter(t)}
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(
+		newBlockPrefetcher(nil, brc))
+	// Ignore BlockRetriever calls
+	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(
+		newBlockRetrievalQueue(0, brc))
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -110,7 +110,7 @@ func kbfsOpsInit(t *testing.T, changeMd bool) (mockCtrl *gomock.Controller,
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
 	// Ignore Prefetcher calls
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, newTestLogMaker(t), config.BlockCache(), nil}))
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(newBlockPrefetcher(nil, &testBlockRetrievalConfig{nil, newTestLogMaker(t), config.BlockCache(), nil, newTestDiskBlockCacheGetter(t)}))
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3261,9 +3261,9 @@ func (_mr *_MockBlockOpsRecorder) TogglePrefetcher(arg0, arg1 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TogglePrefetcher", arg0, arg1)
 }
 
-func (_m *MockBlockOps) BlockRetriever() blockRetriever {
+func (_m *MockBlockOps) BlockRetriever() BlockRetriever {
 	ret := _m.ctrl.Call(_m, "BlockRetriever")
-	ret0, _ := ret[0].(blockRetriever)
+	ret0, _ := ret[0].(BlockRetriever)
 	return ret0
 }
 
@@ -6463,4 +6463,45 @@ func (_m *MockRekeyFSM) listenOnEvent(event rekeyEventType, callback func(RekeyE
 
 func (_mr *_MockRekeyFSMRecorder) listenOnEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "listenOnEvent", arg0, arg1, arg2)
+}
+
+// Mock of BlockRetriever interface
+type MockBlockRetriever struct {
+	ctrl     *gomock.Controller
+	recorder *_MockBlockRetrieverRecorder
+}
+
+// Recorder for MockBlockRetriever (not exported)
+type _MockBlockRetrieverRecorder struct {
+	mock *MockBlockRetriever
+}
+
+func NewMockBlockRetriever(ctrl *gomock.Controller) *MockBlockRetriever {
+	mock := &MockBlockRetriever{ctrl: ctrl}
+	mock.recorder = &_MockBlockRetrieverRecorder{mock}
+	return mock
+}
+
+func (_m *MockBlockRetriever) EXPECT() *_MockBlockRetrieverRecorder {
+	return _m.recorder
+}
+
+func (_m *MockBlockRetriever) Request(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
+	ret := _m.ctrl.Call(_m, "Request", ctx, priority, kmd, ptr, block, lifetime)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+func (_mr *_MockBlockRetrieverRecorder) Request(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Request", arg0, arg1, arg2, arg3, arg4, arg5)
+}
+
+func (_m *MockBlockRetriever) CacheAndPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error {
+	ret := _m.ctrl.Call(_m, "CacheAndPrefetch", ptr, block, kmd, priority, lifetime, hasPrefetched)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockBlockRetrieverRecorder) CacheAndPrefetch(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CacheAndPrefetch", arg0, arg1, arg2, arg3, arg4, arg5)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2297,16 +2297,26 @@ func (_mr *_MockDiskBlockCacheRecorder) Put(arg0, arg1, arg2, arg3, arg4 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDiskBlockCache) DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) (int, int64, error) {
-	ret := _m.ctrl.Call(_m, "DeleteByTLF", ctx, tlfID, blockIDs)
+func (_m *MockDiskBlockCache) Delete(ctx context.Context, blockIDs []kbfsblock.ID) (int, int64, error) {
+	ret := _m.ctrl.Call(_m, "Delete", ctx, blockIDs)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockDiskBlockCacheRecorder) DeleteByTLF(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteByTLF", arg0, arg1, arg2)
+func (_mr *_MockDiskBlockCacheRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1)
+}
+
+func (_m *MockDiskBlockCache) UpdateLRUTime(ctx context.Context, blockID kbfsblock.ID) error {
+	ret := _m.ctrl.Call(_m, "UpdateLRUTime", ctx, blockID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) UpdateLRUTime(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UpdateLRUTime", arg0, arg1)
 }
 
 func (_m *MockDiskBlockCache) Size() int64 {
@@ -6496,12 +6506,12 @@ func (_mr *_MockBlockRetrieverRecorder) Request(arg0, arg1, arg2, arg3, arg4, ar
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Request", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockBlockRetriever) CacheAndPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error {
-	ret := _m.ctrl.Call(_m, "CacheAndPrefetch", ptr, block, kmd, priority, lifetime, hasPrefetched)
+func (_m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error {
+	ret := _m.ctrl.Call(_m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, hasPrefetched)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockBlockRetrieverRecorder) CacheAndPrefetch(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CacheAndPrefetch", arg0, arg1, arg2, arg3, arg4, arg5)
+func (_mr *_MockBlockRetrieverRecorder) CacheAndPrefetch(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CacheAndPrefetch", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -358,6 +358,97 @@ func (_mr *_MockdiskBlockCacheGetterRecorder) DiskBlockCache() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskBlockCache")
 }
 
+// Mock of diskBlockCacheSetter interface
+type MockdiskBlockCacheSetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockdiskBlockCacheSetterRecorder
+}
+
+// Recorder for MockdiskBlockCacheSetter (not exported)
+type _MockdiskBlockCacheSetterRecorder struct {
+	mock *MockdiskBlockCacheSetter
+}
+
+func NewMockdiskBlockCacheSetter(ctrl *gomock.Controller) *MockdiskBlockCacheSetter {
+	mock := &MockdiskBlockCacheSetter{ctrl: ctrl}
+	mock.recorder = &_MockdiskBlockCacheSetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockdiskBlockCacheSetter) EXPECT() *_MockdiskBlockCacheSetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockdiskBlockCacheSetter) SetDiskBlockCache(_param0 DiskBlockCache) {
+	_m.ctrl.Call(_m, "SetDiskBlockCache", _param0)
+}
+
+func (_mr *_MockdiskBlockCacheSetterRecorder) SetDiskBlockCache(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDiskBlockCache", arg0)
+}
+
+// Mock of clockGetter interface
+type MockclockGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockclockGetterRecorder
+}
+
+// Recorder for MockclockGetter (not exported)
+type _MockclockGetterRecorder struct {
+	mock *MockclockGetter
+}
+
+func NewMockclockGetter(ctrl *gomock.Controller) *MockclockGetter {
+	mock := &MockclockGetter{ctrl: ctrl}
+	mock.recorder = &_MockclockGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockclockGetter) EXPECT() *_MockclockGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockclockGetter) Clock() Clock {
+	ret := _m.ctrl.Call(_m, "Clock")
+	ret0, _ := ret[0].(Clock)
+	return ret0
+}
+
+func (_mr *_MockclockGetterRecorder) Clock() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Clock")
+}
+
+// Mock of diskLimiterGetter interface
+type MockdiskLimiterGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockdiskLimiterGetterRecorder
+}
+
+// Recorder for MockdiskLimiterGetter (not exported)
+type _MockdiskLimiterGetterRecorder struct {
+	mock *MockdiskLimiterGetter
+}
+
+func NewMockdiskLimiterGetter(ctrl *gomock.Controller) *MockdiskLimiterGetter {
+	mock := &MockdiskLimiterGetter{ctrl: ctrl}
+	mock.recorder = &_MockdiskLimiterGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockdiskLimiterGetter) EXPECT() *_MockdiskLimiterGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockdiskLimiterGetter) DiskLimiter() DiskLimiter {
+	ret := _m.ctrl.Call(_m, "DiskLimiter")
+	ret0, _ := ret[0].(DiskLimiter)
+	return ret0
+}
+
+func (_mr *_MockdiskLimiterGetterRecorder) DiskLimiter() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskLimiter")
+}
+
 // Mock of Block interface
 type MockBlock struct {
 	ctrl     *gomock.Controller
@@ -2206,22 +2297,34 @@ func (_mr *_MockDiskBlockCacheRecorder) Put(arg0, arg1, arg2, arg3, arg4 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockDiskBlockCache) Delete(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) error {
-	ret := _m.ctrl.Call(_m, "Delete", ctx, tlfID, blockIDs)
-	ret0, _ := ret[0].(error)
+func (_m *MockDiskBlockCache) DeleteByTLF(ctx context.Context, tlfID tlf.ID, blockIDs []kbfsblock.ID) (int, int64, error) {
+	ret := _m.ctrl.Call(_m, "DeleteByTLF", ctx, tlfID, blockIDs)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) DeleteByTLF(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DeleteByTLF", arg0, arg1, arg2)
+}
+
+func (_m *MockDiskBlockCache) Size() int64 {
+	ret := _m.ctrl.Call(_m, "Size")
+	ret0, _ := ret[0].(int64)
 	return ret0
 }
 
-func (_mr *_MockDiskBlockCacheRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Delete", arg0, arg1, arg2)
+func (_mr *_MockDiskBlockCacheRecorder) Size() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Size")
 }
 
-func (_m *MockDiskBlockCache) Shutdown() {
-	_m.ctrl.Call(_m, "Shutdown")
+func (_m *MockDiskBlockCache) Shutdown(ctx context.Context) {
+	_m.ctrl.Call(_m, "Shutdown", ctx)
 }
 
-func (_mr *_MockDiskBlockCacheRecorder) Shutdown() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown")
+func (_mr *_MockDiskBlockCacheRecorder) Shutdown(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Shutdown", arg0)
 }
 
 // Mock of cryptoPure interface
@@ -3054,12 +3157,12 @@ func (_mr *_MockPrefetcherRecorder) PrefetchBlock(arg0, arg1, arg2, arg3 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchBlock", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, hasPrefetched bool) {
-	_m.ctrl.Call(_m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd, priority, lifetime, hasPrefetched)
+func (_m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata) {
+	_m.ctrl.Call(_m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd)
 }
 
-func (_mr *_MockPrefetcherRecorder) PrefetchAfterBlockRetrieved(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchAfterBlockRetrieved", arg0, arg1, arg2, arg3, arg4, arg5)
+func (_mr *_MockPrefetcherRecorder) PrefetchAfterBlockRetrieved(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PrefetchAfterBlockRetrieved", arg0, arg1, arg2)
 }
 
 func (_m *MockPrefetcher) Shutdown() <-chan struct{} {
@@ -3156,6 +3259,16 @@ func (_m *MockBlockOps) TogglePrefetcher(ctx context.Context, enable bool) error
 
 func (_mr *_MockBlockOpsRecorder) TogglePrefetcher(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TogglePrefetcher", arg0, arg1)
+}
+
+func (_m *MockBlockOps) BlockRetriever() blockRetriever {
+	ret := _m.ctrl.Call(_m, "BlockRetriever")
+	ret0, _ := ret[0].(blockRetriever)
+	return ret0
+}
+
+func (_mr *_MockBlockOpsRecorder) BlockRetriever() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BlockRetriever")
 }
 
 func (_m *MockBlockOps) Prefetcher() Prefetcher {
@@ -4270,6 +4383,34 @@ func (_mr *_MockConfigRecorder) DiskBlockCache() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskBlockCache")
 }
 
+func (_m *MockConfig) SetDiskBlockCache(_param0 DiskBlockCache) {
+	_m.ctrl.Call(_m, "SetDiskBlockCache", _param0)
+}
+
+func (_mr *_MockConfigRecorder) SetDiskBlockCache(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetDiskBlockCache", arg0)
+}
+
+func (_m *MockConfig) Clock() Clock {
+	ret := _m.ctrl.Call(_m, "Clock")
+	ret0, _ := ret[0].(Clock)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) Clock() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Clock")
+}
+
+func (_m *MockConfig) DiskLimiter() DiskLimiter {
+	ret := _m.ctrl.Call(_m, "DiskLimiter")
+	ret0, _ := ret[0].(DiskLimiter)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) DiskLimiter() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskLimiter")
+}
+
 func (_m *MockConfig) KBFSOps() KBFSOps {
 	ret := _m.ctrl.Call(_m, "KBFSOps")
 	ret0, _ := ret[0].(KBFSOps)
@@ -4590,16 +4731,6 @@ func (_mr *_MockConfigRecorder) SetNotifier(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetNotifier", arg0)
 }
 
-func (_m *MockConfig) Clock() Clock {
-	ret := _m.ctrl.Call(_m, "Clock")
-	ret0, _ := ret[0].(Clock)
-	return ret0
-}
-
-func (_mr *_MockConfigRecorder) Clock() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Clock")
-}
-
 func (_m *MockConfig) SetClock(_param0 Clock) {
 	_m.ctrl.Call(_m, "SetClock", _param0)
 }
@@ -4728,6 +4859,16 @@ func (_mr *_MockConfigRecorder) SetRekeyWithPromptWaitTime(arg0 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRekeyWithPromptWaitTime", arg0)
 }
 
+func (_m *MockConfig) Mode() InitMode {
+	ret := _m.ctrl.Call(_m, "Mode")
+	ret0, _ := ret[0].(InitMode)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) Mode() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Mode")
+}
+
 func (_m *MockConfig) DelayedCancellationGracePeriod() time.Duration {
 	ret := _m.ctrl.Call(_m, "DelayedCancellationGracePeriod")
 	ret0, _ := ret[0].(time.Duration)
@@ -4782,6 +4923,16 @@ func (_m *MockConfig) ResetCaches() {
 
 func (_mr *_MockConfigRecorder) ResetCaches() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResetCaches")
+}
+
+func (_m *MockConfig) StorageRoot() string {
+	ret := _m.ctrl.Call(_m, "StorageRoot")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) StorageRoot() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "StorageRoot")
 }
 
 func (_m *MockConfig) MetricsRegistry() go_metrics.Registry {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -35,18 +35,11 @@ type prefetchRequest struct {
 	block    Block
 }
 
-// blockRetriever specifies a method for retrieving blocks asynchronously.
-type blockRetriever interface {
-	Request(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
-	CacheAndPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
-		priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error
-}
-
 type blockPrefetcher struct {
 	config prefetcherConfig
 	log    logger.Logger
 	// blockRetriever to retrieve blocks from the server
-	retriever blockRetriever
+	retriever BlockRetriever
 	// channel to synchronize prefetch requests with the prefetcher shutdown
 	progressCh chan prefetchRequest
 	// channel that is idempotently closed when a shutdown occurs
@@ -58,7 +51,7 @@ type blockPrefetcher struct {
 
 var _ Prefetcher = (*blockPrefetcher)(nil)
 
-func newBlockPrefetcher(retriever blockRetriever, config prefetcherConfig) *blockPrefetcher {
+func newBlockPrefetcher(retriever BlockRetriever, config prefetcherConfig) *blockPrefetcher {
 	p := &blockPrefetcher{
 		config:     config,
 		retriever:  retriever,

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -38,6 +38,8 @@ type prefetchRequest struct {
 // blockRetriever specifies a method for retrieving blocks asynchronously.
 type blockRetriever interface {
 	Request(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+	CacheAndPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
+		priority int, lifetime BlockCacheLifetime, hasPrefetched bool) error
 }
 
 type blockPrefetcher struct {
@@ -190,31 +192,7 @@ func (p *blockPrefetcher) PrefetchBlock(
 // PrefetchAfterBlockRetrieved implements the Prefetcher interface for
 // blockPrefetcher.
 func (p *blockPrefetcher) PrefetchAfterBlockRetrieved(
-	b Block, ptr BlockPointer, kmd KeyMetadata, priority int,
-	lifetime BlockCacheLifetime, hasPrefetched bool) {
-	if hasPrefetched {
-		// We discard the error because there's nothing we can do about it.
-		_ = p.config.BlockCache().PutWithPrefetch(ptr, kmd.TlfID(), b,
-			lifetime, true)
-		return
-	}
-	if priority < defaultOnDemandRequestPriority {
-		// Only on-demand or higher priority requests can trigger prefetches.
-		// We discard the error because there's nothing we can do about it.
-		_ = p.config.BlockCache().PutWithPrefetch(ptr, kmd.TlfID(), b,
-			lifetime, false)
-		return
-	}
-	// We must let the cache know at this point that we've prefetched.
-	// 1) To prevent any other Gets from prefetching.
-	// 2) To prevent prefetching if a cache Put fails, since prefetching if
-	//	  only useful when combined with the cache.
-	err := p.config.BlockCache().PutWithPrefetch(ptr, kmd.TlfID(), b,
-		lifetime, true)
-	if _, isCacheFullError := err.(cachePutCacheFullError); isCacheFullError {
-		p.log.CDebugf(context.TODO(), "Skipping prefetch because the cache is full")
-		return
-	}
+	b Block, ptr BlockPointer, kmd KeyMetadata) {
 	switch b := b.(type) {
 	case *FileBlock:
 		if b.IsInd {


### PR DESCRIPTION
* [x] Export `blockRetriever` to `BlockRetriever`, and allow accessing it from `BlockOps`.
* [x] Factor out the `PrefetchAfterBlockRetrieved` responsibility to `BlockRetriever` as `CacheAndPrefetch`.
* [x] `blockRetrievalQueue` is now responsible for handling caching, and `Prefetcher` is only responsible for prefetching.
* [x] Move `DiskBlockCache.Get` calls from `BlockServerRemote` to `blockRetrievalQueue`, and call them before a request is placed in the request queue.
* [x] Check memory and disk caches before locking the `blockRetrievalQueue` mutex, so we don't lock the whole retrieval subsystem based on I/O to the disk. `DiskBlockCache.Get` and `DiskBlockCache.UpdateMetadata` both only take a read lock on the disk cache, so other goroutines attempting `Get`s won't block unless there's a `DiskBlockCache.Put` or `DiskBlockCache.Delete`.