### PR TITLE
timeout mdserver ping much faster

### DIFF
--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -34,7 +34,7 @@ const (
 	MdServerDefaultPingIntervalSeconds = 10
 	// MdServerPingTimeout is how long to wait for a ping response
 	// before breaking the connection and trying to reconnect.
-	MdServerPingTimeout = 30 * time.Second
+	MdServerPingTimeout = 5 * time.Second
 )
 
 // MDServerRemote is an implementation of the MDServer interface.


### PR DESCRIPTION
The advantage of this quicker timeout is that KBFS is more responsive to changes in the network, and the client's connectivity to it. The hope is we hit this timeout, disconnect the connection, and then move this whole deal into the connection retry mechanic. For context, we use the same timing for Gregor (10 second loop, 5 second timeout) in the client.

If we can't even ping the MD server in 5 seconds, KBFS is likely majorly slow anyway.