### PR TITLE
tlf_journal: mark first revision as already squashed

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1401,7 +1401,11 @@ func (fbo *folderBranchOps) initMDLocked(
 		return err
 	}
 
-	// finally, write out the new metadata
+	// Finally, write out the new metadata.  TODO: if journaling is
+	// enabled, we should bypass it here, so we don't have to worry
+	// about delayed conflicts (since this is essentially a rekey, and
+	// we always bypass the journal for rekeys).  The caller will have
+	// to intelligently deal with a conflict.
 	mdID, err := fbo.config.MDOps().Put(ctx, md)
 	if err != nil {
 		return err

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -296,7 +296,8 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	err = jServer.Enable(ctx, id, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
-	rmd := makeMDForJournalMDOpsTest(t, config, id, h, MetadataRevision(1))
+	rmd := makeMDForJournalMDOpsTest(t, config, id, h, MetadataRevision(2))
+	rmd.SetPrevRoot(fakeMdID(1))
 	rmd.SetBranchID(FakeBranchID(1))
 
 	_, err = mdOps.PutUnmerged(ctx, rmd)


### PR DESCRIPTION
So that we won't run conflict resolution on it while squashing, before
it is flushed.

Issue: KBFS-2048
Issue: keybase/client#6339