### PR TITLE
Allow identify skip

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -964,6 +964,8 @@ func (fbo *folderBranchOps) identifyOnce(
 		len(ei.getTlfBreakAndClose().Breaks) > 0 {
 		fbo.log.CDebugf(ctx,
 			"Identify finished with no error but broken proof warnings")
+	} else if ei.behavior == keybase1.TLFIdentifyBehavior_CHAT_SKIP {
+		fbo.log.CDebugf(ctx, "Identify skipped")
 	} else {
 		fbo.log.CDebugf(ctx, "Identify finished successfully")
 		fbo.identifyDone = true

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -156,6 +156,13 @@ func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
 func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier, username libkb.NormalizedUsername,
 	uid keybase1.UID, isPublic bool) error {
+
+	// check to see if identify should be skipped altogether
+	ei := getExtendedIdentify(ctx)
+	if ei.behavior == keybase1.TLFIdentifyBehavior_CHAT_SKIP {
+		return nil
+	}
+
 	var reason string
 	if isPublic {
 		reason = "You accessed a public folder."

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -156,8 +156,7 @@ func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
 func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier, username libkb.NormalizedUsername,
 	uid keybase1.UID, isPublic bool) error {
-
-	// check to see if identify should be skipped altogether
+	// Check to see if identify should be skipped altogether.
 	ei := getExtendedIdentify(ctx)
 	if ei.behavior == keybase1.TLFIdentifyBehavior_CHAT_SKIP {
 		return nil

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/tlf_keys.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/tlf_keys.go
@@ -17,6 +17,7 @@ const (
 	TLFIdentifyBehavior_CHAT_GUI_STRICT TLFIdentifyBehavior = 3
 	TLFIdentifyBehavior_KBFS_REKEY      TLFIdentifyBehavior = 4
 	TLFIdentifyBehavior_KBFS_QR         TLFIdentifyBehavior = 5
+	TLFIdentifyBehavior_CHAT_SKIP       TLFIdentifyBehavior = 6
 )
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
@@ -26,6 +27,7 @@ var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
 	"CHAT_GUI_STRICT": 3,
 	"KBFS_REKEY":      4,
 	"KBFS_QR":         5,
+	"CHAT_SKIP":       6,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
@@ -35,6 +37,7 @@ var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	3: "CHAT_GUI_STRICT",
 	4: "KBFS_REKEY",
 	5: "KBFS_QR",
+	6: "CHAT_SKIP",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -189,10 +189,10 @@
 			"revisionTime": "2017-02-13T21:07:17Z"
 		},
 		{
-			"checksumSHA1": "wjqppOFQQ4pKglfjqa0ehgI8lvY=",
+			"checksumSHA1": "8Wj3jbO91/QMwOIQ1y7UMWLEPvU=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "dec61b18d5ccccc63a14100393675b7edd249f43",
-			"revisionTime": "2017-03-20T19:37:17Z"
+			"revision": "d4d7d442b9489d28bbbfde61907013944d5780c7",
+			"revisionTime": "2017-03-23T14:38:16Z"
 		},
 		{
 			"checksumSHA1": "aUMkkGW8nO2sf+UxAMxnmVbDbzU=",


### PR DESCRIPTION
This adds a new keybase1.IdentifyBehavior, CHAT_SKIP.  If present, KBFS will skip identify calls.  Service only sets this in the case of GetTLFCryptKeys where it does the identifies.

cc @mmaxim 