### PR TITLE
fix routine leak in rekey_queue

### DIFF
--- a/libkbfs/rekey_queue.go
+++ b/libkbfs/rekey_queue.go
@@ -74,17 +74,23 @@ func NewRekeyQueueStandard(config Config) (rkq *RekeyQueueStandard) {
 // branch ops while conforming to the rater limiter.
 func (rkq *RekeyQueueStandard) start(ctx context.Context) {
 	go func() {
-		for id := range rkq.queue {
-			if err := rkq.limiter.Wait(ctx); err != nil {
-				rkq.log.Debug("Waiting on rate limiter for tlf=%v error: %v", id, err)
+		for {
+			select {
+			case id := <-rkq.queue:
+				if err := rkq.limiter.Wait(ctx); err != nil {
+					rkq.log.Debug("Waiting on rate limiter error: %v", err)
+					return
+				}
+				rkq.config.KBFSOps().RequestRekey(context.Background(), id)
+				func(id tlf.ID) {
+					rkq.mu.Lock()
+					defer rkq.mu.Unlock()
+					delete(rkq.pendings, id)
+				}(id)
+			case err := <-ctx.Done():
+				rkq.log.Debug("%v", err)
 				return
 			}
-			rkq.config.KBFSOps().RequestRekey(context.Background(), id)
-			func(id tlf.ID) {
-				rkq.mu.Lock()
-				defer rkq.mu.Unlock()
-				delete(rkq.pendings, id)
-			}(id)
 		}
 	}()
 }

--- a/libkbfs/rekey_queue.go
+++ b/libkbfs/rekey_queue.go
@@ -78,7 +78,7 @@ func (rkq *RekeyQueueStandard) start(ctx context.Context) {
 			select {
 			case id := <-rkq.queue:
 				if err := rkq.limiter.Wait(ctx); err != nil {
-					rkq.log.Debug("Waiting on rate limiter error: %v", err)
+					rkq.log.Debug("Waiting on rate limiter for tlf=%v error: %v", id, err)
 					return
 				}
 				rkq.config.KBFSOps().RequestRekey(context.Background(), id)

--- a/libkbfs/rekey_queue.go
+++ b/libkbfs/rekey_queue.go
@@ -88,7 +88,7 @@ func (rkq *RekeyQueueStandard) start(ctx context.Context) {
 					delete(rkq.pendings, id)
 				}(id)
 			case err := <-ctx.Done():
-				rkq.log.Debug("%v", err)
+				rkq.log.Debug("Rekey queue background routine context done: %v", err)
 				return
 			}
 		}


### PR DESCRIPTION
I tested locally using `gops` to make sure there wasn't any left-over routines after `test()` returned. Thanks for discovering this!