### PR TITLE
kbfs_ops: include unflushed bytes in usage bytes for status

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -678,6 +678,9 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		if err != nil {
 			return KBFSStatus{}, nil, err
 		}
+		if usageBytes >= 0 {
+			usageBytes += status.UnflushedBytes
+		}
 	}
 
 	return KBFSStatus{


### PR DESCRIPTION
Otherwise, when the disk limiter triggers an "over quota" error
notification, and the user does a `du`, they could seem to still be
under the limit.