### PR TITLE
Capture range variable in runTestsOverMetadataVers

### DIFF
--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -63,6 +63,7 @@ func runTestOverMetadataVers(
 func runTestsOverMetadataVers(t *testing.T, prefix string,
 	fs []func(t *testing.T, ver MetadataVer)) {
 	for _, f := range fs {
+		f := f // capture range variable.
 		name := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 		i := strings.LastIndex(name, prefix)
 		if i >= 0 {


### PR DESCRIPTION
Otherwise, if we have parallel tests, this wouldn't work
properly.