### PR TITLE
kbfsdokan: don't error out on non-force fs mount failure

### DIFF
--- a/libdokan/mounter.go
+++ b/libdokan/mounter.go
@@ -67,7 +67,7 @@ func (m *DefaultMounter) Mount(cfg *dokan.Config, log logger.Logger) error {
 		if m.force {
 			return err
 		}
-		log.Info("continuing after filesystem mount failure %s", err)
+		log.Info("continuing after filesystem mount failure %+v", err)
 	} else {
 		log.Info("Mounting the filesystem was a success!")
 	}

--- a/libdokan/mounter.go
+++ b/libdokan/mounter.go
@@ -64,9 +64,13 @@ func (m *DefaultMounter) Mount(cfg *dokan.Config, log logger.Logger) error {
 	}
 
 	if err != nil {
-		return err
+		if m.force {
+			return err
+		}
+		log.Info("continuing after filesystem mount failure %s", err)
+	} else {
+		log.Info("Mounting the filesystem was a success!")
 	}
-	log.Info("Mounting the filesystem was a success!")
 	return h.BlockTillDone()
 }
 


### PR DESCRIPTION
At least people will be able to chat and use simplefs if dokan goes all wonky.