### PR TITLE
[KBFS-2014] Only do tracing when debug server is enabled

### DIFF
--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -453,18 +453,18 @@ var _ DirInterface = (*Dir)(nil)
 // Access implements the fs.NodeAccesser interface for File. See comment for
 // File.Access for more details.
 func (d *Dir) Access(ctx context.Context, r *fuse.AccessRequest) (err error) {
-	ctx = d.folder.fs.maybeStartTrace(
+	ctx = d.folder.fs.config.MaybeStartTrace(
 		ctx, "Dir.Access", d.node.GetBasename())
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	return d.folder.access(ctx, r)
 }
 
 // Attr implements the fs.Node interface for Dir.
 func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) (err error) {
-	ctx = d.folder.fs.maybeStartTrace(
+	ctx = d.folder.fs.config.MaybeStartTrace(
 		ctx, "Dir.Attr", d.node.GetBasename())
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Attr")
 	defer func() { d.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
@@ -497,9 +497,9 @@ func (d *Dir) attr(ctx context.Context, a *fuse.Attr) (err error) {
 
 // Lookup implements the fs.NodeRequestLookuper interface for Dir.
 func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (node fs.Node, err error) {
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Lookup",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Lookup",
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Lookup %s", req.Name)
 	defer func() { d.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
@@ -593,9 +593,9 @@ func getEXCLFromCreateRequest(req *fuse.CreateRequest) libkbfs.Excl {
 
 // Create implements the fs.NodeCreater interface for Dir.
 func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (node fs.Node, handle fs.Handle, err error) {
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Create",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Create",
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Create %s", req.Name)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
@@ -632,9 +632,9 @@ func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.Cr
 // Mkdir implements the fs.NodeMkdirer interface for Dir.
 func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 	node fs.Node, err error) {
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Mkdir",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Mkdir",
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Mkdir %s", req.Name)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
@@ -662,10 +662,10 @@ func (d *Dir) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (
 // Symlink implements the fs.NodeSymlinker interface for Dir.
 func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 	node fs.Node, err error) {
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Symlink",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Symlink",
 		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
 			req.NewName, req.Target))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Symlink %s -> %s",
 		req.NewName, req.Target)
@@ -693,10 +693,10 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (
 // Rename implements the fs.NodeRenamer interface for Dir.
 func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 	newDir fs.Node) (err error) {
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Rename",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Rename",
 		fmt.Sprintf("%s %s -> %s", d.node.GetBasename(),
 			req.OldName, req.NewName))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Rename %s -> %s",
 		req.OldName, req.NewName)
@@ -746,9 +746,9 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest,
 
 // Remove implements the fs.NodeRemover interface for Dir.
 func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Remove",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Remove",
 		fmt.Sprintf("%s %s", d.node.GetBasename(), req.Name))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir Remove %s", req.Name)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
@@ -777,9 +777,9 @@ func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
 
 // ReadDirAll implements the fs.NodeReadDirAller interface for Dir.
 func (d *Dir) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err error) {
-	ctx = d.folder.fs.maybeStartTrace(
+	ctx = d.folder.fs.config.MaybeStartTrace(
 		ctx, "Dir.ReadDirAll", d.node.GetBasename())
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir ReadDirAll")
 	defer func() { d.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
@@ -814,9 +814,9 @@ func (d *Dir) Forget() {
 // Setattr implements the fs.NodeSetattrer interface for Dir.
 func (d *Dir) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) (err error) {
 	valid := req.Valid
-	ctx = d.folder.fs.maybeStartTrace(ctx, "Dir.Setattr",
+	ctx = d.folder.fs.config.MaybeStartTrace(ctx, "Dir.Setattr",
 		fmt.Sprintf("%s %s", d.node.GetBasename(), valid))
-	defer func() { d.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { d.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	d.folder.fs.log.CDebugf(ctx, "Dir SetAttr %s", valid)
 	defer func() { d.folder.reportErr(ctx, libkbfs.WriteMode, err) }()

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -77,9 +77,9 @@ func (f *File) fillAttrWithMode(
 
 // Attr implements the fs.Node interface for File.
 func (f *File) Attr(ctx context.Context, a *fuse.Attr) (err error) {
-	ctx = f.folder.fs.maybeStartTrace(
+	ctx = f.folder.fs.config.MaybeStartTrace(
 		ctx, "File.Attr", f.node.GetBasename())
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.log.CDebugf(ctx, "File Attr")
 	defer func() { f.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
@@ -124,9 +124,9 @@ var _ fs.NodeAccesser = (*File)(nil)
 // success, which makes it think the file is executable, yielding a "Unix
 // executable" UTI.
 func (f *File) Access(ctx context.Context, r *fuse.AccessRequest) (err error) {
-	ctx = f.folder.fs.maybeStartTrace(
+	ctx = f.folder.fs.config.MaybeStartTrace(
 		ctx, "File.Access", f.node.GetBasename())
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	if int(r.Uid) != os.Getuid() &&
 		// Finder likes to use UID 0 for some operations. osxfuse already allows
@@ -183,9 +183,9 @@ func (f *File) sync(ctx context.Context) error {
 
 // Fsync implements the fs.NodeFsyncer interface for File.
 func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
-	ctx = f.folder.fs.maybeStartTrace(
+	ctx = f.folder.fs.config.MaybeStartTrace(
 		ctx, "File.Fsync", f.node.GetBasename())
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.log.CDebugf(ctx, "File Fsync")
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
@@ -209,9 +209,9 @@ func (f *File) Read(ctx context.Context, req *fuse.ReadRequest,
 	resp *fuse.ReadResponse) (err error) {
 	off := req.Offset
 	sz := cap(resp.Data)
-	ctx = f.folder.fs.maybeStartTrace(ctx, "File.Read",
+	ctx = f.folder.fs.config.MaybeStartTrace(ctx, "File.Read",
 		fmt.Sprintf("%s off=%d sz=%d", f.node.GetBasename(), off, sz))
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.log.CDebugf(ctx, "File Read off=%d sz=%d", off, sz)
 	defer func() { f.folder.reportErr(ctx, libkbfs.ReadMode, err) }()
@@ -231,9 +231,9 @@ var _ fs.HandleWriter = (*File)(nil)
 func (f *File) Write(ctx context.Context, req *fuse.WriteRequest,
 	resp *fuse.WriteResponse) (err error) {
 	sz := len(req.Data)
-	ctx = f.folder.fs.maybeStartTrace(ctx, "File.Write",
+	ctx = f.folder.fs.config.MaybeStartTrace(ctx, "File.Write",
 		fmt.Sprintf("%s sz=%d", f.node.GetBasename(), sz))
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.log.CDebugf(ctx, "File Write sz=%d ", sz)
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
@@ -251,9 +251,9 @@ var _ fs.HandleFlusher = (*File)(nil)
 
 // Flush implements the fs.HandleFlusher interface for File.
 func (f *File) Flush(ctx context.Context, req *fuse.FlushRequest) (err error) {
-	ctx = f.folder.fs.maybeStartTrace(
+	ctx = f.folder.fs.config.MaybeStartTrace(
 		ctx, "File.Flush", f.node.GetBasename())
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.log.CDebugf(ctx, "File Flush")
 	// I'm not sure about the guarantees from KBFSOps, so we don't
@@ -276,9 +276,9 @@ var _ fs.NodeSetattrer = (*File)(nil)
 func (f *File) Setattr(ctx context.Context, req *fuse.SetattrRequest,
 	resp *fuse.SetattrResponse) (err error) {
 	valid := req.Valid
-	ctx = f.folder.fs.maybeStartTrace(ctx, "File.SetAttr",
+	ctx = f.folder.fs.config.MaybeStartTrace(ctx, "File.SetAttr",
 		fmt.Sprintf("%s %s", f.node.GetBasename(), valid))
-	defer func() { f.folder.fs.maybeFinishTrace(ctx, err) }()
+	defer func() { f.folder.fs.config.MaybeFinishTrace(ctx, err) }()
 
 	f.folder.fs.log.CDebugf(ctx, "File SetAttr %s", valid)
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -292,35 +292,6 @@ func (f *FS) WithContext(ctx context.Context) context.Context {
 	return ctx
 }
 
-func (f *FS) maybeStartTrace(
-	ctx context.Context, family, title string) context.Context {
-	f.debugServerLock.RLock()
-	defer f.debugServerLock.RUnlock()
-	if !f.debugServerEnabledLocked() {
-		// Debug server isn't enabled, so no need to trace
-		// anything.
-		//
-		// TODO: Perhaps enable turning on tracing
-		// independently from the debug server, and maybe a
-		// add a way to adjust trace detail.
-		return ctx
-	}
-
-	tr := trace.New(family, title)
-	ctx = trace.NewContext(ctx, tr)
-	return ctx
-}
-
-func (f *FS) maybeFinishTrace(ctx context.Context, err error) {
-	if tr, ok := trace.FromContext(ctx); ok {
-		if err != nil {
-			tr.LazyPrintf("err=%+v", err)
-			tr.SetError()
-		}
-		tr.Finish()
-	}
-}
-
 // Serve FS. Will block.
 func (f *FS) Serve(ctx context.Context) error {
 	srv := fs.New(f.conn, &fs.Config{

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -193,6 +193,8 @@ func (f *FS) enableDebugServer(ctx context.Context, port uint16) error {
 		f.log.Debug("Debug http server ended with %+v", err)
 	}(f.debugServer, f.debugServerListener)
 
+	f.config.SetTraceOptions(true)
+
 	return nil
 }
 
@@ -215,6 +217,8 @@ func (f *FS) disableDebugServer(ctx context.Context) error {
 	// it returns an error.
 	f.debugServer.Addr = ""
 	f.debugServerListener = nil
+
+	f.config.SetTraceOptions(false)
 
 	return err
 }

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -153,8 +153,8 @@ func (f *FS) enableDebugServer(ctx context.Context, port uint16) error {
 	defer f.debugServerLock.Unlock()
 
 	// Note that f.debugServer may be nil if f was created via
-	// makeFS. But we shouldn't be calling this function then
-	// anyway.
+	// makeFS. But in that case we shouldn't be calling this
+	// function then anyway.
 	if f.debugServer.Addr != "" {
 		return errors.Errorf("Debug server already enabled at %s",
 			f.debugServer.Addr)
@@ -198,8 +198,8 @@ func (f *FS) disableDebugServer(ctx context.Context) error {
 	defer f.debugServerLock.Unlock()
 
 	// Note that f.debugServer may be nil if f was created via
-	// makeFS. But we shouldn't be calling this function then
-	// anyway.
+	// makeFS. But in that case we shouldn't be calling this
+	// function then anyway.
 	if f.debugServer.Addr == "" {
 		return errors.New("Debug server already disabled")
 	}

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -69,7 +69,8 @@ func makeTraceHandler(renderFn func(http.ResponseWriter, *http.Request, bool)) f
 	}
 }
 
-// NewFS creates an FS
+// NewFS creates an FS. Note that this isn't the only constructor; see
+// makeFS in libfuse/mount_test.go.
 func NewFS(config libkbfs.Config, conn *fuse.Conn, debug bool, platformParams PlatformParams) *FS {
 	log := config.MakeLogger("kbfsfuse")
 	// We need extra depth for errors, so that we can report the line
@@ -148,6 +149,12 @@ func (tkal tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 }
 
 func (f *FS) debugServerEnabledLocked() bool {
+	// This can happen in libfuse tests; see makeFS in
+	// libfuse/mount_test.go.
+	if f.debugServer == nil {
+		return false
+	}
+
 	return len(f.debugServer.Addr) > 0
 }
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -147,11 +147,15 @@ func (tkal tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	return tc, nil
 }
 
+func (f *FS) debugServerEnabledLocked() error {
+	return len(f.debugServer.Addr) > 0
+}
+
 func (f *FS) enableDebugServer(ctx context.Context, port uint16) error {
 	f.debugServerLock.Lock()
 	defer f.debugServerLock.Unlock()
 
-	if f.debugServer.Addr != "" {
+	if f.debugServerEnabledLocked() {
 		return errors.Errorf("Debug server already enabled at %s",
 			f.debugServer.Addr)
 	}
@@ -189,7 +193,7 @@ func (f *FS) disableDebugServer(ctx context.Context) error {
 	f.debugServerLock.Lock()
 	defer f.debugServerLock.Unlock()
 
-	if f.debugServer.Addr == "" {
+	if !f.debugServerEnabledLocked() {
 		return errors.New("Debug server already disabled")
 	}
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -843,6 +843,7 @@ func (c *ConfigLocal) SetTraceOptions(enabled bool) {
 	c.traceEnabled = enabled
 }
 
+// MaybeStartTrace implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) MaybeStartTrace(
 	ctx context.Context, family, title string) context.Context {
 	traceEnabled := func() bool {
@@ -859,6 +860,7 @@ func (c *ConfigLocal) MaybeStartTrace(
 	return ctx
 }
 
+// MaybeFinishTrace implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) MaybeFinishTrace(ctx context.Context, err error) {
 	if tr, ok := trace.FromContext(ctx); ok {
 		if err != nil {

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -83,6 +83,9 @@ type ConfigLocal struct {
 	rekeyQueue   RekeyQueue
 	storageRoot  string
 
+	traceLock    sync.RWMutex
+	traceEnabled bool
+
 	qrPeriod                       time.Duration
 	qrUnrefAge                     time.Duration
 	qrMinHeadAge                   time.Duration
@@ -830,6 +833,20 @@ func (c *ConfigLocal) RekeyQueue() RekeyQueue {
 // SetMetricsRegistry implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) SetMetricsRegistry(r metrics.Registry) {
 	c.registry = r
+}
+
+// SetTraceOptions implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) SetTraceOptions(enabled bool) {
+	c.traceLock.Lock()
+	defer c.traceLock.Unlock()
+	c.traceEnabled = enabled
+}
+
+// TraceOptions implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) TraceOptions() (enabled bool) {
+	c.traceLock.RLock()
+	defer c.traceLock.RUnlock()
+	return c.traceEnabled
 }
 
 // SetTLFValidDuration implements the Config interface for ConfigLocal.

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -150,7 +150,11 @@ func (cr *ConflictResolver) cancelExistingLocked(ci conflictInput) bool {
 
 func (cr *ConflictResolver) maybeStartTrace(
 	ctx context.Context, family, title string) context.Context {
-	// TODO: Obey tracing options when we add them.
+	traceEnabled := cr.config.TraceOptions()
+	if !traceEnabled {
+		return ctx
+	}
+
 	tr := trace.New(family, title)
 	ctx = trace.NewContext(ctx, tr)
 	return ctx

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -17,7 +17,6 @@ import (
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfssync"
 	"golang.org/x/net/context"
-	"golang.org/x/net/trace"
 )
 
 // CtxCRTagKey is the type used for unique context tags related to
@@ -146,28 +145,6 @@ func (cr *ConflictResolver) cancelExistingLocked(ci conflictInput) bool {
 		cr.currCancel()
 	}
 	return true
-}
-
-func (cr *ConflictResolver) maybeStartTrace(
-	ctx context.Context, family, title string) context.Context {
-	traceEnabled := cr.config.TraceOptions()
-	if !traceEnabled {
-		return ctx
-	}
-
-	tr := trace.New(family, title)
-	ctx = trace.NewContext(ctx, tr)
-	return ctx
-}
-
-func (cr *ConflictResolver) maybeFinishTrace(ctx context.Context, err error) {
-	if tr, ok := trace.FromContext(ctx); ok {
-		if err != nil {
-			tr.LazyPrintf("err=%+v", err)
-			tr.SetError()
-		}
-		tr.Finish()
-	}
 }
 
 // processInput processes conflict resolution jobs from the given
@@ -2969,9 +2946,9 @@ func (e CRWrapError) Error() string {
 
 func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	var err error
-	ctx = cr.maybeStartTrace(ctx, "CR.doResolve",
+	ctx = cr.config.MaybeStartTrace(ctx, "CR.doResolve",
 		fmt.Sprintf("%s %+v", cr.fbo.folderBranch, ci))
-	defer func() { cr.maybeFinishTrace(ctx, err) }()
+	defer func() { cr.config.MaybeFinishTrace(ctx, err) }()
 	cr.log.CDebugf(ctx, "Starting conflict resolution with input %+v", ci)
 	lState := makeFBOLockState()
 	defer func() {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1611,6 +1611,12 @@ type Config interface {
 	// objects, which is to use the default registry.
 	MetricsRegistry() metrics.Registry
 	SetMetricsRegistry(metrics.Registry)
+
+	// TraceOptions gets the options for tracing (via x/net/trace).
+	TraceOptions() (enabled bool)
+	// SetTraceOptions set the options for tracing (via x/net/trace).
+	SetTraceOptions(enabled bool)
+
 	// TLFValidDuration is the time TLFs are valid before identification needs to be redone.
 	TLFValidDuration() time.Duration
 	// SetTLFValidDuration sets TLFValidDuration.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1488,8 +1488,15 @@ type ConflictRenamer interface {
 		string, error)
 }
 
+// Tracer maybe adds traces to contexts.
 type Tracer interface {
+	// MaybeStartTrace, if tracing is on, returns a new context
+	// based on the given one with an attached trace made with the
+	// given family and title. Otherwise, it returns the given
+	// context unchanged.
 	MaybeStartTrace(ctx context.Context, family, title string) context.Context
+	// MaybeFinishTrace, finishes the trace attached to the given
+	// context, if any.
 	MaybeFinishTrace(ctx context.Context, err error)
 }
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1488,6 +1488,11 @@ type ConflictRenamer interface {
 		string, error)
 }
 
+type Tracer interface {
+	MaybeStartTrace(ctx context.Context, family, title string) context.Context
+	MaybeFinishTrace(ctx context.Context, err error)
+}
+
 // Config collects all the singleton instance instantiations needed to
 // run KBFS in one place.  The methods below are self-explanatory and
 // do not require comments.
@@ -1506,6 +1511,7 @@ type Config interface {
 	diskBlockCacheSetter
 	clockGetter
 	diskLimiterGetter
+	Tracer
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI
@@ -1612,8 +1618,6 @@ type Config interface {
 	MetricsRegistry() metrics.Registry
 	SetMetricsRegistry(metrics.Registry)
 
-	// TraceOptions gets the options for tracing (via x/net/trace).
-	TraceOptions() (enabled bool)
 	// SetTraceOptions set the options for tracing (via x/net/trace).
 	SetTraceOptions(enabled bool)
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4262,6 +4262,45 @@ func (_mr *_MockConflictRenamerRecorder) ConflictRename(arg0, arg1, arg2 interfa
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ConflictRename", arg0, arg1, arg2)
 }
 
+// Mock of Tracer interface
+type MockTracer struct {
+	ctrl     *gomock.Controller
+	recorder *_MockTracerRecorder
+}
+
+// Recorder for MockTracer (not exported)
+type _MockTracerRecorder struct {
+	mock *MockTracer
+}
+
+func NewMockTracer(ctrl *gomock.Controller) *MockTracer {
+	mock := &MockTracer{ctrl: ctrl}
+	mock.recorder = &_MockTracerRecorder{mock}
+	return mock
+}
+
+func (_m *MockTracer) EXPECT() *_MockTracerRecorder {
+	return _m.recorder
+}
+
+func (_m *MockTracer) MaybeStartTrace(ctx context.Context, family string, title string) context.Context {
+	ret := _m.ctrl.Call(_m, "MaybeStartTrace", ctx, family, title)
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+func (_mr *_MockTracerRecorder) MaybeStartTrace(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaybeStartTrace", arg0, arg1, arg2)
+}
+
+func (_m *MockTracer) MaybeFinishTrace(ctx context.Context, err error) {
+	_m.ctrl.Call(_m, "MaybeFinishTrace", ctx, err)
+}
+
+func (_mr *_MockTracerRecorder) MaybeFinishTrace(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaybeFinishTrace", arg0, arg1)
+}
+
 // Mock of Config interface
 type MockConfig struct {
 	ctrl     *gomock.Controller
@@ -4419,6 +4458,24 @@ func (_m *MockConfig) DiskLimiter() DiskLimiter {
 
 func (_mr *_MockConfigRecorder) DiskLimiter() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DiskLimiter")
+}
+
+func (_m *MockConfig) MaybeStartTrace(ctx context.Context, family string, title string) context.Context {
+	ret := _m.ctrl.Call(_m, "MaybeStartTrace", ctx, family, title)
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) MaybeStartTrace(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaybeStartTrace", arg0, arg1, arg2)
+}
+
+func (_m *MockConfig) MaybeFinishTrace(ctx context.Context, err error) {
+	_m.ctrl.Call(_m, "MaybeFinishTrace", ctx, err)
+}
+
+func (_mr *_MockConfigRecorder) MaybeFinishTrace(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MaybeFinishTrace", arg0, arg1)
 }
 
 func (_m *MockConfig) KBFSOps() KBFSOps {
@@ -4961,16 +5018,6 @@ func (_m *MockConfig) SetMetricsRegistry(_param0 go_metrics.Registry) {
 
 func (_mr *_MockConfigRecorder) SetMetricsRegistry(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMetricsRegistry", arg0)
-}
-
-func (_m *MockConfig) TraceOptions() bool {
-	ret := _m.ctrl.Call(_m, "TraceOptions")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-func (_mr *_MockConfigRecorder) TraceOptions() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "TraceOptions")
 }
 
 func (_m *MockConfig) SetTraceOptions(enabled bool) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4963,6 +4963,24 @@ func (_mr *_MockConfigRecorder) SetMetricsRegistry(arg0 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMetricsRegistry", arg0)
 }
 
+func (_m *MockConfig) TraceOptions() bool {
+	ret := _m.ctrl.Call(_m, "TraceOptions")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) TraceOptions() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TraceOptions")
+}
+
+func (_m *MockConfig) SetTraceOptions(enabled bool) {
+	_m.ctrl.Call(_m, "SetTraceOptions", enabled)
+}
+
+func (_mr *_MockConfigRecorder) SetTraceOptions(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTraceOptions", arg0)
+}
+
 func (_m *MockConfig) TLFValidDuration() time.Duration {
 	ret := _m.ctrl.Call(_m, "TLFValidDuration")
 	ret0, _ := ret[0].(time.Duration)


### PR DESCRIPTION
That way we don't have to worry much about the performance
impact of tracing.

Also move all the trace logic into Config, so that ConflictResolver
(and anything not attached to FUSE requests) can obey tracing
options.