### PR TITLE
config_local: lower default cache size on 32-bit builds

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -213,12 +213,13 @@ func MakeLocalUsers(users []libkb.NormalizedUsername) []LocalUser {
 	return localUsers
 }
 
-// getDefaultCleanBlockCacheCapacity returns the default clean block cache
-// capacity. If we can get total RAM of the system, we cap at the smaller of
-// <1/4 of available memory> and <MaxBlockSizeBytesDefault * 1024>; otherwise,
+// getDefaultCleanBlockCacheCapacity returns the default clean block
+// cache capacity. If we can get total RAM of the system, we cap at
+// the smaller of <1/4 of available memory> and
+// <MaxBlockSizeBytesDefault * DefaultBlocksInMemCache>; otherwise,
 // fallback to latter.
 func getDefaultCleanBlockCacheCapacity() uint64 {
-	capacity := uint64(MaxBlockSizeBytesDefault) * 1024
+	capacity := uint64(MaxBlockSizeBytesDefault) * DefaultBlocksInMemCache
 	vmstat, err := mem.VirtualMemory()
 	if err == nil {
 		ramBased := vmstat.Total / 8

--- a/libkbfs/default_blocks_in_mem_cache_386.go
+++ b/libkbfs/default_blocks_in_mem_cache_386.go
@@ -1,0 +1,12 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build 386
+
+package libkbfs
+
+// DefaultBlocksInMemCache is the number of blocks we should keep in
+// the cache.  We turn this way down for 32-bit builds to avoid
+// overflowing the low memory limits.
+const DefaultBlocksInMemCache = 128

--- a/libkbfs/default_blocks_in_mem_cache_64bit.go
+++ b/libkbfs/default_blocks_in_mem_cache_64bit.go
@@ -1,0 +1,11 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// +build !386
+
+package libkbfs
+
+// DefaultBlocksInMemCache is the number of blocks we should keep in
+// the cache.
+const DefaultBlocksInMemCache = 1024


### PR DESCRIPTION
To avoid running into memory issues on Windows.

Issue: KBFS-2088