### PR TITLE
libkbfs: introduce SyncAll for syncing multiple files

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2847,7 +2847,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	updates, bps, blocksToDelete, err := cr.prepper.prepUpdateForPaths(
 		ctx, lState, md, unmergedChains, mergedChains,
 		mostRecentUnmergedMD, mostRecentMergedMD, resolvedPaths, lbc,
-		newFileBlocks, dirtyBcache)
+		newFileBlocks, dirtyBcache, true /* copy indirect files */)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2847,7 +2847,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	updates, bps, blocksToDelete, err := cr.prepper.prepUpdateForPaths(
 		ctx, lState, md, unmergedChains, mergedChains,
 		mostRecentUnmergedMD, mostRecentMergedMD, resolvedPaths, lbc,
-		newFileBlocks, dirtyBcache, true /* copy indirect files */)
+		newFileBlocks, dirtyBcache, prepFolderCopyIndirectFileBlocks)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -954,9 +954,15 @@ func (ccs *crChains) copyOpAndRevertUnrefsToOriginals(currOp op) op {
 		newOp = realOp
 	}
 	for _, unref := range unrefs {
-		original, ok := ccs.originals[*unref]
-		if ok {
-			*unref = original
+		ok := true
+		// Loop over the originals, since if `changeOriginal` was
+		// called, there might be a path of them.
+		for ok {
+			var original BlockPointer
+			original, ok = ccs.originals[*unref]
+			if ok {
+				*unref = original
+			}
 		}
 	}
 	return newOp

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3875,8 +3875,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	md.AddOp(newResolutionOp())
 	_, newBps, blocksToDelete, err := fbo.prepper.prepUpdateForPaths(
 		ctx, lState, md, syncChains, dummyHeadChains, tempIRMD, head,
-		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(),
-		prepFolderAlwaysUnrefUnflushedBlocks)
+		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(), 0)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4016,7 +4016,7 @@ func (fbo *folderBranchOps) notifyBatchLocked(
 
 	switch len(md.data.Changes.Ops) {
 	case 0:
-		return nil
+		panic("Unexpected empty ops change list in notifyBatchLocked")
 	case 1:
 		err := fbo.notifyOneOpLocked(
 			ctx, lState, md.data.Changes.Ops[0], md, false, afterUpdateFn)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3875,7 +3875,8 @@ func (fbo *folderBranchOps) syncAllLocked(
 	md.AddOp(newResolutionOp())
 	_, newBps, blocksToDelete, err := fbo.prepper.prepUpdateForPaths(
 		ctx, lState, md, syncChains, dummyHeadChains, tempIRMD, head,
-		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(), false)
+		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(),
+		prepFolderAlwaysUnrefUnflushedBlocks)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3907,7 +3907,8 @@ func (fbo *folderBranchOps) syncAllLocked(
 	md.AddOp(newResolutionOp())
 	_, newBps, blocksToDelete, err := fbo.prepper.prepUpdateForPaths(
 		ctx, lState, md, syncChains, dummyHeadChains, tempIRMD, head,
-		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(), 0)
+		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(),
+		prepFolderDontCopyIndirectFileBlocks)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3952,7 +3952,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 		ctx, lState, md, bps, NoExcl, afterUpdateFn)
 }
 
-// Sync implements the KBFSOps interface for folderBranchOps.
+// SyncAll implements the KBFSOps interface for folderBranchOps.
 func (fbo *folderBranchOps) SyncAll(
 	ctx context.Context, folderBranch FolderBranch) (err error) {
 	fbo.log.CDebugf(ctx, "SyncAll")
@@ -4014,7 +4014,7 @@ func (fbo *folderBranchOps) notifyBatchLocked(
 		// Only supply the afterUpdateFn for the first notification,
 		// which, in a multi-update batch, should be the resolution op
 		// with all the new pointer updates.
-		if i > 0 && md.data.Changes.Ops[0].(*resolutionOp) == nil {
+		if i == 1 && md.data.Changes.Ops[0].(*resolutionOp) == nil {
 			return errors.Errorf("First update in local batch is not a "+
 				"resolutionOp: %T", md.data.Changes.Ops[0])
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3875,7 +3875,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	md.AddOp(newResolutionOp())
 	_, newBps, blocksToDelete, err := fbo.prepper.prepUpdateForPaths(
 		ctx, lState, md, syncChains, dummyHeadChains, tempIRMD, head,
-		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache())
+		resolvedPaths, lbc, fileBlocks, fbo.config.DirtyBlockCache(), false)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3602,7 +3602,7 @@ type cleanupFn func(context.Context, *lockState, []BlockPointer, error)
 //   this function returns.  (That is, if `doSync` is false, and `stillDirty`
 //   is true, then the file has outstanding changes but the sync was vetoed for
 //   some other reason.)
-// * `fblock`: the top file block for the file being sync'd.
+// * `fblock`: the root file block for the file being sync'd.
 // * `lbc`: A local block cache consisting of a dirtied version of the parent
 //   directory for this file.
 // * `bps`: All the blocks that need to be put to the server.
@@ -3681,9 +3681,7 @@ func (fbo *folderBranchOps) syncLocked(ctx context.Context,
 	lState *lockState, file path) (stillDirty bool, err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	// Verify we have permission to write.  We do this after the dirty
-	// check because otherwise readers who sync clean files on close
-	// would get an error.
+	// Verify we have permission to write.
 	md, err := fbo.getMDForWriteLocked(ctx, lState)
 	if err != nil {
 		return false, err
@@ -3786,8 +3784,8 @@ func (fbo *folderBranchOps) syncAllLocked(
 	}
 
 	// Verify we have permission to write.  We do this after the dirty
-	// check because otherwise readers who sync clean files on close
-	// would get an error.
+	// check because otherwise readers who call syncAll would get an
+	// error.
 	md, err := fbo.getMDForWriteLocked(ctx, lState)
 	if err != nil {
 		return err

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -1156,7 +1156,8 @@ func (fup folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 				isDeleted := false
 				alreadyUpdated := false
 				if isMostRecent {
-					isDeleted = unmergedChains.isDeleted(chain.original)
+					isDeleted = unmergedChains.isDeleted(chain.original) ||
+						unmergedChains.toUnrefPointers[update.Ref]
 					_, alreadyUpdated = updates[chain.original]
 				}
 				if newBlocks[update.Ref] ||

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -1127,8 +1127,8 @@ func (fup folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 		}
 	}
 
-	newBlocks := make(map[BlockPointer]bool)
 	if len(unmergedChains.resOps) > 0 {
+		newBlocks := make(map[BlockPointer]bool)
 		for _, bs := range bps.blockStates {
 			newBlocks[bs.blockPtr] = true
 		}
@@ -1143,11 +1143,14 @@ func (fup folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 			// Updates go in the first one.
 			for _, update := range unmergedResOp.allUpdates() {
 				chain, isMostRecent := unmergedChains.byMostRecent[update.Ref]
+				isDeleted := false
 				alreadyUpdated := false
 				if isMostRecent {
+					isDeleted = unmergedChains.isDeleted(chain.original)
 					_, alreadyUpdated = updates[chain.original]
 				}
-				if newBlocks[update.Ref] || (isMostRecent && !alreadyUpdated) {
+				if newBlocks[update.Ref] ||
+					(isMostRecent && !isDeleted && !alreadyUpdated) {
 					fup.log.CDebugf(ctx, "Including update from old resOp: "+
 						"%v -> %v", update.Unref, update.Ref)
 					resOp.AddUpdate(update.Unref, update.Ref)

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -694,9 +694,7 @@ func (fup folderUpdatePrepper) updateResolutionUsageAndPointers(
 		}
 	}
 	for ptr := range unmergedChains.toUnrefPointers {
-		if !refs[ptr] && !unrefs[ptr] {
-			toUnref[ptr] = true
-		}
+		toUnref[ptr] = true
 	}
 	deletedBlocks := make(map[BlockPointer]bool)
 	for ptr := range toUnref {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -291,6 +291,13 @@ type KBFSOps interface {
 	// system interface, this may include modifications done via
 	// multiple file handles.  This is a remote-sync operation.
 	Sync(ctx context.Context, file Node) error
+	// SyncAll flushes all outstanding writes and truncates for any
+	// dirty files to the KBFS servers within the given folder, if the
+	// logged-in user has write permissions to the top-level folder.
+	// If done through a file system interface, this may include
+	// modifications done via multiple file handles.  This is a
+	// remote-sync operation.
+	SyncAll(ctx context.Context, folderBranch FolderBranch) error
 	// FolderStatus returns the status of a particular folder/branch, along
 	// with a channel that will be closed when the status has been
 	// updated (to eliminate the need for polling this method).

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -640,7 +640,7 @@ func (fs *KBFSOpsStandard) Sync(ctx context.Context, file Node) error {
 	return ops.Sync(ctx, file)
 }
 
-// Sync implements the KBFSOps interface for KBFSOpsStandard
+// SyncAll implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) SyncAll(
 	ctx context.Context, folderBranch FolderBranch) error {
 	ops := fs.getOps(ctx, folderBranch, FavoritesOpAdd)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -640,6 +640,13 @@ func (fs *KBFSOpsStandard) Sync(ctx context.Context, file Node) error {
 	return ops.Sync(ctx, file)
 }
 
+// Sync implements the KBFSOps interface for KBFSOpsStandard
+func (fs *KBFSOpsStandard) SyncAll(
+	ctx context.Context, folderBranch FolderBranch) error {
+	ops := fs.getOps(ctx, folderBranch, FavoritesOpAdd)
+	return ops.SyncAll(ctx, folderBranch)
+}
+
 // FolderStatus implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) FolderStatus(
 	ctx context.Context, folderBranch FolderBranch) (

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5714,3 +5714,42 @@ func TestForceFastForwardOnEmptyTLF(t *testing.T) {
 		t.Fatalf("Couldn't wait for fast forward: %+v", err)
 	}
 }
+
+func TestKBFSOpsSyncAllTwoFiles(t *testing.T) {
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "test_user")
+	// TODO: Use kbfsTestShutdownNoMocks.
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+
+	// create a file.
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+
+	kbfsOps := config.KBFSOps()
+	nodeA, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	nodeB, _, err := kbfsOps.CreateFile(ctx, rootNode, "b", false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %+v", err)
+	}
+
+	// Write to A.
+	data := []byte{1}
+	err = kbfsOps.Write(ctx, nodeA, data, 0)
+	if err != nil {
+		t.Fatalf("Couldn't write to file: %+v", err)
+	}
+
+	// Write to B.
+	data = []byte{2}
+	err = kbfsOps.Write(ctx, nodeB, data, 0)
+	if err != nil {
+		t.Fatalf("Couldn't write to file: %+v", err)
+	}
+
+	// Sync both.
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync; %+v", err)
+	}
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -876,6 +876,16 @@ func (_mr *_MockKBFSOpsRecorder) Sync(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Sync", arg0, arg1)
 }
 
+func (_m *MockKBFSOps) SyncAll(ctx context.Context, folderBranch FolderBranch) error {
+	ret := _m.ctrl.Call(_m, "SyncAll", ctx, folderBranch)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockKBFSOpsRecorder) SyncAll(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SyncAll", arg0, arg1)
+}
+
 func (_m *MockKBFSOps) FolderStatus(ctx context.Context, folderBranch FolderBranch) (FolderBranchStatus, <-chan StatusUpdate, error) {
 	ret := _m.ctrl.Call(_m, "FolderStatus", ctx, folderBranch)
 	ret0, _ := ret[0].(FolderBranchStatus)

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -340,7 +340,7 @@ func (k *LibKBFS) WriteFile(u User, file Node, data []byte, off int64, sync bool
 	if sync {
 		ctx, cancel := k.newContext(u)
 		defer cancel()
-		err = kbfsOps.Sync(ctx, file.(libkbfs.Node))
+		err = kbfsOps.SyncAll(ctx, file.(libkbfs.Node).GetFolderBranch())
 	}
 	return err
 }

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -357,17 +357,9 @@ func (k *LibKBFS) TruncateFile(u User, file Node, size uint64, sync bool) (err e
 	if sync {
 		ctx, cancel := k.newContext(u)
 		defer cancel()
-		err = kbfsOps.Sync(ctx, file.(libkbfs.Node))
+		err = kbfsOps.SyncAll(ctx, file.(libkbfs.Node).GetFolderBranch())
 	}
 	return err
-}
-
-// Sync implements the Engine interface.
-func (k *LibKBFS) Sync(u User, file Node) (err error) {
-	kbfsOps := u.(*libkbfs.ConfigLocal).KBFSOps()
-	ctx, cancel := k.newContext(u)
-	defer cancel()
-	return kbfsOps.Sync(ctx, file.(libkbfs.Node))
 }
 
 // ReadFile implements the Engine interface.


### PR DESCRIPTION
This PR introduces `KBFSOps.SyncAll`, which syncs _all_ dirty files together to the server in a single MD update.  Note that this PR does *not* enable `SyncAll` use by kbfsfuse yet, it is only used in tests right now.

This breaks up the original `folderBranchOps.SyncLocked` into two parts, so it can be used by `SyncAll`. `SyncAll` uses the chains and prepper code also used by CR to summarize a set of changes into a single MD update and sync them all together.

This ended up exposing some issues in conflict resolution, especially around how it deals with `resolutionOp`s and `syncOp`s that are part of a previous resolution.  I'll try to give some details about each one in PR comments.

Issue: KBFS-2069