### PR TITLE
fs: don't sync files on close, only on explicit fsync or background sync

### DIFF
--- a/libdokan/file.go
+++ b/libdokan/file.go
@@ -68,8 +68,6 @@ func (f *File) Cleanup(ctx context.Context, fi *dokan.FileInfo) {
 	if f.refcount.Decrease() {
 		f.folder.fs.log.CDebugf(ctx, "Forgetting file node")
 		f.folder.forgetNode(ctx, f.node)
-		// TODO this should not be needed in future.
-		f.folder.fs.config.KBFSOps().Sync(ctx, f.node)
 	}
 }
 

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -403,6 +403,7 @@ func testOneCreateThenRead(t *testing.T, p string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 	const input = "hello, world\n"
 	if _, err := io.WriteString(f, input); err != nil {
@@ -466,7 +467,7 @@ func TestReadUnflushed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { syncAndClose(t, f) }()
+	defer syncAndClose(t, f)
 	const input = "hello, world\n"
 	if _, err := io.WriteString(f, input); err != nil {
 		t.Fatalf("write error: %v", err)
@@ -841,7 +842,7 @@ func TestWriteThenRename(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
-	defer func() { syncAndClose(t, f) }()
+	defer syncAndClose(t, f)
 
 	// write to the file
 	const input = "hello, world\n"
@@ -903,7 +904,8 @@ func TestWriteThenRenameCrossDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
-	defer func() { syncAndClose(t, f) }()
+	// Call in a closure since `f` is overridden below.
+	defer syncAndClose(t, f)
 
 	// write to the file
 	const input = "hello, world\n"
@@ -1041,6 +1043,7 @@ func TestRemoveFileWhileOpenWriting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	if err := ioutil.Remove(p); err != nil {
@@ -1488,6 +1491,7 @@ func TestFsync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 	const input = "hello, world\n"
 	if _, err := io.WriteString(f, input); err != nil {
@@ -2346,6 +2350,7 @@ func TestInvalidateRenameToUncachedDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	{
@@ -2728,7 +2733,7 @@ func TestSimpleCRConflictOnOpenFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { syncAndClose(t, f1) }()
+	defer syncAndClose(t, f1)
 
 	const input1 = "hello"
 	{
@@ -2747,7 +2752,7 @@ func TestSimpleCRConflictOnOpenFiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { syncAndClose(t, f2) }()
+	defer syncAndClose(t, f2)
 
 	const input2 = "ohell"
 	{
@@ -2917,7 +2922,7 @@ func TestSimpleCRConflictOnOpenMergedFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { syncAndClose(t, f1) }()
+	defer syncAndClose(t, f1)
 
 	const input1 = "hello"
 	{
@@ -2940,7 +2945,7 @@ func TestSimpleCRConflictOnOpenMergedFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { syncAndClose(t, f2) }()
+	defer syncAndClose(t, f2)
 
 	const input2 = "ohell"
 	{

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -570,6 +570,7 @@ func testOneCreateThenRead(t *testing.T, p string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 	const input = "hello, world\n"
 	if _, err := io.WriteString(f, input); err != nil {
@@ -1226,6 +1227,7 @@ func TestRemoveFileWhileOpenSetEx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	if err := ioutil.Remove(p); err != nil {
@@ -1270,6 +1272,7 @@ func TestRemoveFileWhileOpenWritingInTLFRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	if err := ioutil.Remove(p); err != nil {
@@ -1310,6 +1313,7 @@ func TestRemoveFileWhileOpenWritingInSubDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	if err := ioutil.Remove(p); err != nil {
@@ -1350,6 +1354,7 @@ func TestRenameOverFileWhileOpenWritingInDifferentDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
+	// Call in a closure since `f1` is overridden below.
 	defer func() { syncAndClose(t, f1) }()
 
 	p2 := path.Join(mnt.Dir, PrivateName, "jdoe", "mynewfile")
@@ -1401,6 +1406,7 @@ func TestRenameOverFileWhileOpenWritingInSameSubDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot create file: %v", err)
 	}
+	// Call in a closure since `f1` is overridden below.
 	defer func() { syncAndClose(t, f1) }()
 
 	p2 := path.Join(dirPath, "mynewfile")
@@ -1453,6 +1459,7 @@ func TestRemoveFileWhileOpenReading(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot open file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	if err := ioutil.Remove(p); err != nil {
@@ -1508,6 +1515,7 @@ func TestRemoveFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot open file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	p2 := path.Join(mnt2.Dir, PrivateName, "user1,user2", "myfile")
@@ -1574,6 +1582,7 @@ func TestRenameOverFileWhileOpenReadingAcrossMounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot open file: %v", err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	p2Other := path.Join(mnt2.Dir, PrivateName, "user1,user2", "other")
@@ -2052,6 +2061,7 @@ func TestFsync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 	const input = "hello, world\n"
 	if _, err := io.WriteString(f, input); err != nil {
@@ -2952,6 +2962,7 @@ func TestInvalidateRenameToUncachedDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Call in a closure since `f` is overridden below.
 	defer func() { syncAndClose(t, f) }()
 
 	{

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -81,7 +81,7 @@ const (
 	maxMDsAtATime = 10
 	// Time between checks for dirty files to flush, in case Sync is
 	// never called.
-	secondsBetweenBackgroundFlushes = 10
+	secondsBetweenBackgroundFlushes = 1
 	// Cap the number of times we retry after a recoverable error
 	maxRetriesOnRecoverableErrors = 10
 	// When the number of dirty bytes exceeds this level, force a sync.
@@ -5232,7 +5232,7 @@ func (fbo *folderBranchOps) backgroundFlusher(betweenFlushes time.Duration) {
 					return context.WithValue(ctx, CtxBackgroundSyncKey, "1")
 				})
 
-			if sameDirtyRefCount >= 10 {
+			if sameDirtyRefCount >= 100 {
 				// If the local journal is full, we might not be able to
 				// make progress until more data is flushed to the
 				// servers, so just warn here rather than just an outright

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -5307,7 +5307,11 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 	go ops.backgroundFlusher(1 * time.Millisecond)
 
 	// Make sure we get the notification
-	<-c
+	select {
+	case <-c:
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for signal")
+	}
 
 	// Make sure we get a sync even if we overwrite (not extend) the file
 	data[1] = 0


### PR DESCRIPTION
Also, reduce the background sync period to 1 second, since we can't rely on closes to sync the data anymore.

Note that this PR changes our durability guarantees a bit, because now if the user doesn't call fsync, there is up to a second after the user closes the file where KBFS can crash and lose the writes that have buffered in memory.  I think this is fine, since applications should know that fsyncs are required for data durability.  But please think critically about this PR and let me know if this is a bad idea.

This improves perceived performance for single file writes by a fair amount, but not for batch file writes, as shown below.  That's because it still blocks the foreground process while doing the same number of syncs, they're just shifted a bit.

```
Sync-on-close, 1 byte file in root dir:

real	0m0.017s
user	0m0.000s
sys	0m0.000s

No sync-on-close, 1 byte file in root dir:

real	0m0.005s
user	0m0.000s
sys	0m0.000s


Sync-on-close, `cp -r go/test .`:

real	0m24.450s
user	0m0.020s
sys	0m0.076s


No sync-on-close, `cp -r go/test .`:

real	0m22.924s
user	0m0.016s
sys	0m0.068s
```

Issue: KBFS-2072