### PR TITLE
process reachability notifications from the service, and plug MDServer into them

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1274,6 +1274,10 @@ type MDServer interface {
 	GetKeyBundles(ctx context.Context, tlfID tlf.ID,
 		wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
 		*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error)
+
+	// CheckReachability is called when the Keybase service sends a notification
+	// that network connectivity has changed.
+	CheckReachability(ctx context.Context)
 }
 
 type mdServerLocal interface {

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -273,10 +273,11 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 	// recursion.
 	c := keybase1.NotifyCtlClient{Cli: rawClient}
 	err := c.SetNotifications(ctx, keybase1.NotificationChannels{
-		Session:     true,
-		Paperkeys:   true,
-		Keyfamily:   true,
-		Kbfsrequest: true,
+		Session:      true,
+		Paperkeys:    true,
+		Keyfamily:    true,
+		Kbfsrequest:  true,
+		Reachability: true,
 	})
 	if err != nil {
 		return err

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -248,6 +248,7 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 		keybase1.NotifyPaperKeyProtocol(k),
 		keybase1.NotifyFSRequestProtocol(k),
 		keybase1.TlfKeysProtocol(k),
+		keybase1.ReachabilityProtocol(k),
 	}
 
 	// Add simplefs if set

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -272,6 +272,7 @@ func (k *KeybaseServiceBase) KeyfamilyChanged(ctx context.Context,
 // ReachabilityChanged implements keybase1.ReachabiltyInterface
 func (k *KeybaseServiceBase) ReachabilityChanged(ctx context.Context,
 	reachability keybase1.Reachability) error {
+	k.log.CDebugf(ctx, "CheckReachability invoked: %v", reachability)
 	k.config.MDServer().CheckReachability(ctx)
 	return nil
 }

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -269,7 +269,7 @@ func (k *KeybaseServiceBase) KeyfamilyChanged(ctx context.Context,
 	return nil
 }
 
-// ReachabilityChanged implements keybase1.ReachabiltyInterface
+// ReachabilityChanged implements keybase1.ReachabiltyInterface.
 func (k *KeybaseServiceBase) ReachabilityChanged(ctx context.Context,
 	reachability keybase1.Reachability) error {
 	k.log.CDebugf(ctx, "CheckReachability invoked: %v", reachability)
@@ -277,12 +277,12 @@ func (k *KeybaseServiceBase) ReachabilityChanged(ctx context.Context,
 	return nil
 }
 
-// StartReachability implements keybase1.ReachabilityInterface
+// StartReachability implements keybase1.ReachabilityInterface.
 func (k *KeybaseServiceBase) StartReachability(ctx context.Context) (res keybase1.Reachability, err error) {
 	return k.CheckReachability(ctx)
 }
 
-// CheckReachability implements keybase1.ReachabilityInterface
+// CheckReachability implements keybase1.ReachabilityInterface.
 func (k *KeybaseServiceBase) CheckReachability(ctx context.Context) (res keybase1.Reachability, err error) {
 	res.Reachable = keybase1.Reachable_NO
 	if k.config.MDServer().IsConnected() {

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -269,6 +269,27 @@ func (k *KeybaseServiceBase) KeyfamilyChanged(ctx context.Context,
 	return nil
 }
 
+// ReachabilityChanged implements keybase1.ReachabiltyInterface
+func (k *KeybaseServiceBase) ReachabilityChanged(ctx context.Context,
+	reachability keybase1.Reachability) error {
+	k.config.MDServer().CheckReachability(ctx)
+	return nil
+}
+
+// StartReachability implements keybase1.ReachabilityInterface
+func (k *KeybaseServiceBase) StartReachability(ctx context.Context) (res keybase1.Reachability, err error) {
+	return k.CheckReachability(ctx)
+}
+
+// CheckReachability implements keybase1.ReachabilityInterface
+func (k *KeybaseServiceBase) CheckReachability(ctx context.Context) (res keybase1.Reachability, err error) {
+	res.Reachable = keybase1.Reachable_NO
+	if k.config.MDServer().IsConnected() {
+		res.Reachable = keybase1.Reachable_YES
+	}
+	return res, nil
+}
+
 // PaperKeyCached implements keybase1.NotifyPaperKeyInterface.
 func (k *KeybaseServiceBase) PaperKeyCached(ctx context.Context,
 	arg keybase1.PaperKeyCachedArg) error {

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -693,3 +693,8 @@ func (md *MDServerDisk) GetKeyBundles(ctx context.Context,
 
 	return tlfStorage.getKeyBundles(tlfID, wkbID, rkbID)
 }
+
+// CheckReachability implements the MDServer interface for MDServerDisk.
+func (md *MDServerDisk) CheckReachability(ctx context.Context) {
+
+}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -876,3 +876,8 @@ func (md *MDServerMemory) GetKeyBundles(ctx context.Context,
 	}
 	return wkb, rkb, nil
 }
+
+// CheckReachability implements the MDServer interface for MDServerMemory.
+func (md *MDServerMemory) CheckReachability(ctx context.Context) {
+
+}

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -391,14 +391,13 @@ func (md *MDServerRemote) ShouldRetryOnConnect(err error) bool {
 // CheckReachability implements the MDServer interface.
 func (md *MDServerRemote) CheckReachability(ctx context.Context) {
 	conn, err := net.DialTimeout("tcp", md.mdSrvAddr, MdServerPingTimeout)
-	if conn != nil {
-		conn.Close()
-		return
-	}
 	if err != nil {
 		md.log.CDebugf(ctx,
 			"MDServerRemote: CheckReachability(): failed to connect, reconnecting: %s", err.Error())
 		md.initNewConnection()
+	}
+	if conn != nil {
+		conn.Close()
 	}
 }
 

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -385,6 +386,20 @@ func (md *MDServerRemote) ShouldRetry(name string, err error) bool {
 func (md *MDServerRemote) ShouldRetryOnConnect(err error) bool {
 	_, inputCanceled := err.(libkb.InputCanceledError)
 	return !inputCanceled
+}
+
+// CheckReachability implements the MDServer interface.
+func (md *MDServerRemote) CheckReachability(ctx context.Context) {
+	conn, err := net.DialTimeout("tcp", md.mdSrvAddr, MdServerPingTimeout)
+	if conn != nil {
+		conn.Close()
+		return
+	}
+	if err != nil {
+		md.log.CDebugf(ctx,
+			"MDServerRemote: CheckReachability(): failed to connect, reconnecting: %s", err.Error())
+		md.initNewConnection()
+	}
 }
 
 // Signal errors and clear any registered observers.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4,6 +4,8 @@
 package libkbfs
 
 import (
+	time "time"
+
 	gomock "github.com/golang/mock/gomock"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
@@ -14,7 +16,6 @@ import (
 	tlf "github.com/keybase/kbfs/tlf"
 	go_metrics "github.com/rcrowley/go-metrics"
 	context "golang.org/x/net/context"
-	time "time"
 )
 
 // Mock of dataVersioner interface
@@ -3436,8 +3437,16 @@ func (_m *MockMDServer) CheckForRekeys(ctx context.Context) <-chan error {
 	return ret0
 }
 
+func (_m *MockMDServer) CheckReachability(ctx context.Context) {
+
+}
+
 func (_mr *_MockMDServerRecorder) CheckForRekeys(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckForRekeys", arg0)
+}
+
+func (_m *_MockMDServerRecorder) CheckReachability(ctx context.Context) {
+
 }
 
 func (_m *MockMDServer) TruncateLock(ctx context.Context, id tlf.ID) (bool, error) {
@@ -3632,6 +3641,10 @@ func (_m *MockmdServerLocal) CheckForRekeys(ctx context.Context) <-chan error {
 
 func (_mr *_MockmdServerLocalRecorder) CheckForRekeys(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckForRekeys", arg0)
+}
+
+func (_m *_MockmdServerLocalRecorder) CheckReachability(ctx context.Context) {
+
 }
 
 func (_m *MockmdServerLocal) TruncateLock(ctx context.Context, id tlf.ID) (bool, error) {


### PR DESCRIPTION
The patch does the following:

1.) Implements the `keybase1.ReachabilityProtocol` for the MDServer.
2.) When receiving a `ReachabilityChanged` notification from the service, then we do a basic test (`DialWithTimeout`), to see if we can still reach the MDServer at the network level.

`ReachabilityChanged` is triggered from an OS level update indicating the network state has changed in some way. The service currently uses it to be aggressive about dropping the Gregor connection in response to these updates, and this patch extends that same behavior to MDServer.