### PR TITLE
[KBFS-2037] Disk Cache Status

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -75,6 +75,9 @@ type DiskBlockCacheStandard struct {
 
 var _ DiskBlockCache = (*DiskBlockCacheStandard)(nil)
 
+// DiskBlockCacheStatus represents the status of the disk cache.
+type DiskBlockCacheStatus struct{}
+
 // openLevelDB opens or recovers a leveldb.DB with a passed-in storage.Storage
 // as its underlying storage layer.
 func openLevelDB(stor storage.Storage) (db *leveldb.DB, err error) {
@@ -786,6 +789,11 @@ func (cache *DiskBlockCacheStandard) evictLocked(ctx context.Context,
 	}
 
 	return cache.evictSomeBlocks(ctx, numBlocks, blockIDs)
+}
+
+// Status implements the DiskBlockCache interface for DiskBlockCacheStandard.
+func (cache *DiskBlockCacheStandard) Status() *DiskBlockCacheStatus {
+	return &DiskBlockCacheStatus{}
 }
 
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheStandard.

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -50,7 +50,8 @@ type KBFSStatus struct {
 	UsageBytes      int64
 	LimitBytes      int64
 	FailingServices map[string]error
-	JournalServer   *JournalServerStatus `json:",omitempty"`
+	JournalServer   *JournalServerStatus  `json:",omitempty"`
+	DiskCacheStatus *DiskBlockCacheStatus `json:",omitempty"`
 }
 
 // StatusUpdate is a dummy type used to indicate status has been updated.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -849,6 +849,8 @@ type DiskBlockCache interface {
 		hasPrefetched bool) error
 	// Size returns the size in bytes of the disk cache.
 	Size() int64
+	// Status returns the current status of the disk cache.
+	Status() *DiskBlockCacheStatus
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -683,6 +683,12 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		}
 	}
 
+	dbc := fs.config.DiskBlockCache()
+	var dbcStatus *DiskBlockCacheStatus
+	if dbc != nil {
+		dbcStatus = dbc.Status()
+	}
+
 	return KBFSStatus{
 		CurrentUser:     session.Name.String(),
 		IsConnected:     fs.config.MDServer().IsConnected(),
@@ -690,6 +696,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		LimitBytes:      limitBytes,
 		FailingServices: failures,
 		JournalServer:   jServerStatus,
+		DiskCacheStatus: dbcStatus,
 	}, ch, err
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2331,6 +2331,16 @@ func (_mr *_MockDiskBlockCacheRecorder) Size() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Size")
 }
 
+func (_m *MockDiskBlockCache) Status() *DiskBlockCacheStatus {
+	ret := _m.ctrl.Call(_m, "Status")
+	ret0, _ := ret[0].(*DiskBlockCacheStatus)
+	return ret0
+}
+
+func (_mr *_MockDiskBlockCacheRecorder) Status() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
+}
+
 func (_m *MockDiskBlockCache) Shutdown(ctx context.Context) {
 	_m.ctrl.Call(_m, "Shutdown", ctx)
 }

--- a/vendor/github.com/rcrowley/go-metrics/README.md
+++ b/vendor/github.com/rcrowley/go-metrics/README.md
@@ -21,6 +21,9 @@ g := metrics.NewGauge()
 metrics.Register("bar", g)
 g.Update(47)
 
+r := NewRegistry()
+g := metrics.NewRegisteredFunctionalGauge("cache-evictions", r, func() int64 { return cache.getEvictionsCount() })
+
 s := metrics.NewExpDecaySample(1028, 0.015) // or metrics.NewUniformSample(1028)
 h := metrics.NewHistogram(s)
 metrics.Register("baz", h)
@@ -32,6 +35,15 @@ m.Mark(47)
 
 t := metrics.NewTimer()
 metrics.Register("bang", t)
+t.Time(func() {})
+t.Update(47)
+```
+
+Register() is not threadsafe. For threadsafe metric registration use
+GetOrRegister:
+
+```
+t := metrics.GetOrRegisterTimer("account.create.latency", nil)
 t.Time(func() {})
 t.Update(47)
 ```
@@ -67,7 +79,7 @@ issues [#121](https://github.com/rcrowley/go-metrics/issues/121) and
 [#124](https://github.com/rcrowley/go-metrics/issues/124) for progress and details.
 
 ```go
-import "github.com/rcrowley/go-metrics/influxdb"
+import "github.com/vrischmann/go-metrics-influxdb"
 
 go influxdb.Influxdb(metrics.DefaultRegistry, 10e9, &influxdb.Config{
     Host:     "127.0.0.1:8086",
@@ -103,6 +115,19 @@ import "github.com/rcrowley/go-metrics/stathat"
 go stathat.Stathat(metrics.DefaultRegistry, 10e9, "example@example.com")
 ```
 
+Maintain all metrics along with expvars at `/debug/metrics`:
+
+This uses the same mechanism as [the official expvar](http://golang.org/pkg/expvar/)
+but exposed under `/debug/metrics`, which shows a json representation of all your usual expvars
+as well as all your go-metrics.
+
+
+```go
+import "github.com/rcrowley/go-metrics/exp"
+
+exp.Exp(metrics.DefaultRegistry)
+```
+
 Installation
 ------------
 
@@ -124,3 +149,5 @@ Clients are available for the following destinations:
 * Librato - [https://github.com/mihasya/go-metrics-librato](https://github.com/mihasya/go-metrics-librato)
 * Graphite - [https://github.com/cyberdelia/go-metrics-graphite](https://github.com/cyberdelia/go-metrics-graphite)
 * InfluxDB - [https://github.com/vrischmann/go-metrics-influxdb](https://github.com/vrischmann/go-metrics-influxdb)
+* Ganglia - [https://github.com/appscode/metlia](https://github.com/appscode/metlia)
+* Prometheus - [https://github.com/deathowl/go-metrics-prometheus](https://github.com/deathowl/go-metrics-prometheus)

--- a/vendor/github.com/rcrowley/go-metrics/json.go
+++ b/vendor/github.com/rcrowley/go-metrics/json.go
@@ -81,3 +81,7 @@ func WriteJSON(r Registry, d time.Duration, w io.Writer) {
 func WriteJSONOnce(r Registry, w io.Writer) {
 	json.NewEncoder(w).Encode(r)
 }
+
+func (p *PrefixedRegistry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.underlying)
+}

--- a/vendor/github.com/rcrowley/go-metrics/log.go
+++ b/vendor/github.com/rcrowley/go-metrics/log.go
@@ -1,17 +1,20 @@
 package metrics
 
 import (
-	"log"
 	"time"
 )
 
-func Log(r Registry, freq time.Duration, l *log.Logger) {
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+func Log(r Registry, freq time.Duration, l Logger) {
 	LogScaled(r, freq, time.Nanosecond, l)
 }
 
 // Output each metric in the given registry periodically using the given
 // logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
-func LogScaled(r Registry, freq time.Duration, scale time.Duration, l *log.Logger) {
+func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 

--- a/vendor/github.com/rcrowley/go-metrics/registry.go
+++ b/vendor/github.com/rcrowley/go-metrics/registry.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 )
 
@@ -166,12 +167,34 @@ func NewPrefixedChildRegistry(parent Registry, prefix string) Registry {
 
 // Call the given function for each registered metric.
 func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
-	r.underlying.Each(fn)
+	wrappedFn := func(prefix string) func(string, interface{}) {
+		return func(name string, iface interface{}) {
+			if strings.HasPrefix(name, prefix) {
+				fn(name, iface)
+			} else {
+				return
+			}
+		}
+	}
+
+	baseRegistry, prefix := findPrefix(r, "")
+	baseRegistry.Each(wrappedFn(prefix))
+}
+
+func findPrefix(registry Registry, prefix string) (Registry, string) {
+	switch r := registry.(type) {
+	case *PrefixedRegistry:
+		return findPrefix(r.underlying, r.prefix+prefix)
+	case *StandardRegistry:
+		return r, prefix
+	}
+	return nil, ""
 }
 
 // Get the metric by the given name or nil if none is registered.
 func (r *PrefixedRegistry) Get(name string) interface{} {
-	return r.underlying.Get(name)
+	realName := r.prefix + name
+	return r.underlying.Get(realName)
 }
 
 // Gets an existing metric or registers the given one.

--- a/vendor/github.com/rcrowley/go-metrics/runtime.go
+++ b/vendor/github.com/rcrowley/go-metrics/runtime.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"runtime"
+	"runtime/pprof"
 	"time"
 )
 
@@ -39,6 +40,7 @@ var (
 		}
 		NumCgoCall   Gauge
 		NumGoroutine Gauge
+		NumThread    Gauge
 		ReadMemStats Timer
 	}
 	frees       uint64
@@ -46,6 +48,8 @@ var (
 	mallocs     uint64
 	numGC       uint32
 	numCgoCalls int64
+
+	threadCreateProfile = pprof.Lookup("threadcreate")
 )
 
 // Capture new values for the Go runtime statistics exported in
@@ -134,6 +138,8 @@ func CaptureRuntimeMemStatsOnce(r Registry) {
 	numCgoCalls = currentNumCgoCalls
 
 	runtimeMetrics.NumGoroutine.Update(int64(runtime.NumGoroutine()))
+
+	runtimeMetrics.NumThread.Update(int64(threadCreateProfile.Count()))
 }
 
 // Register runtimeMetrics for the Go runtime statistics exported in runtime and
@@ -169,6 +175,7 @@ func RegisterRuntimeMemStats(r Registry) {
 	runtimeMetrics.MemStats.TotalAlloc = NewGauge()
 	runtimeMetrics.NumCgoCall = NewGauge()
 	runtimeMetrics.NumGoroutine = NewGauge()
+	runtimeMetrics.NumThread = NewGauge()
 	runtimeMetrics.ReadMemStats = NewTimer()
 
 	r.Register("runtime.MemStats.Alloc", runtimeMetrics.MemStats.Alloc)
@@ -200,5 +207,6 @@ func RegisterRuntimeMemStats(r Registry) {
 	r.Register("runtime.MemStats.TotalAlloc", runtimeMetrics.MemStats.TotalAlloc)
 	r.Register("runtime.NumCgoCall", runtimeMetrics.NumCgoCall)
 	r.Register("runtime.NumGoroutine", runtimeMetrics.NumGoroutine)
+	r.Register("runtime.NumThread", runtimeMetrics.NumThread)
 	r.Register("runtime.ReadMemStats", runtimeMetrics.ReadMemStats)
 }

--- a/vendor/github.com/rcrowley/go-metrics/sample.go
+++ b/vendor/github.com/rcrowley/go-metrics/sample.go
@@ -33,7 +33,7 @@ type Sample interface {
 // priority reservoir.  See Cormode et al's "Forward Decay: A Practical Time
 // Decay Model for Streaming Systems".
 //
-// <http://www.research.att.com/people/Cormode_Graham/library/publications/CormodeShkapenyukSrivastavaXu09.pdf>
+// <http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf>
 type ExpDecaySample struct {
 	alpha         float64
 	count         int64
@@ -300,6 +300,13 @@ func SamplePercentiles(values int64Slice, ps []float64) []float64 {
 type SampleSnapshot struct {
 	count  int64
 	values []int64
+}
+
+func NewSampleSnapshot(count int64, values []int64) *SampleSnapshot {
+	return &SampleSnapshot{
+		count:  count,
+		values: values,
+	}
 }
 
 // Clear panics.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -375,9 +375,10 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
+			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "7839c01b09d2b1d7068034e5fe6e423f6ac5be22",
-			"revisionTime": "2015-11-29T16:13:40-08:00"
+			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
+			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
 			"checksumSHA1": "zJZyxS96XiEnDJSZkWwXtktziRY=",


### PR DESCRIPTION
This PR creates some metrics to track disk cache trends, in addition to reporting overall status (max bytes, current bytes, num blocks). Combined with the disk cache status reported inside the disk limiter, this should give us a very complete pictures of what's going on in the cache.

Please review #913 first.