### PR TITLE
file_data: fixes for finding all the dirty blocks in a file

### DIFF
--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -163,6 +163,12 @@ func testFileDataLevelFromData(t *testing.T, maxBlockSize int64,
 			// dirty, due to hole shifting.
 			if holeShiftAfter > 0 && off >= holeShiftAfter {
 				dirty = true
+				// If this is the bottom-most parent block after a
+				// hole shift, its rightmost child will also be marked
+				// dirty.
+				if newLevels == 1 {
+					children[len(children)-1].dirty = true
+				}
 			}
 			newChild := testFileDataLevel{dirty, children, off, 0}
 			level = append(level, newChild)

--- a/test/truncate_test.go
+++ b/test/truncate_test.go
@@ -8,7 +8,7 @@ package test
 
 import "testing"
 
-// bob writes a non-conflicting file while unstaged
+// Test out various truncate scenarios.
 func TestSimpleTruncate(t *testing.T) {
 	const mb = 1024 * 1024
 	mzero := make([]byte, mb)
@@ -55,4 +55,40 @@ func TestSimpleTruncate(t *testing.T) {
 			preadBS("file", mdat3, 0),
 		),
 	)
+}
+
+func testTruncateLargeThenWriteToSmallerOffset(t *testing.T, dataLen int) {
+	data := make([]byte, dataLen)
+	for i := 0; i < len(data); i++ {
+		if i < 12 || (i >= 64 && i < 68) || (i >= dataLen-12) {
+			data[i] = byte(i)
+		}
+	}
+	test(t,
+		blockSize(20), blockChangeSize(100*1024), users("alice", "bob"),
+		as(alice,
+			mkfile("file", ""),
+			truncate("file", uint64(dataLen)),
+			// Write first block and sync.
+			writeBS("file", data[:12]),
+			// Write last block, don't sync yet.
+			pwriteBSSync("file", data[dataLen-12:], int64(dataLen-12), false),
+			// Then write a block in the middle somewhere, and do the sync.
+			pwriteBSSync("file", data[64:68], 64, true),
+		),
+		as(bob,
+			read("file", string(data)),
+		),
+	)
+}
+
+func TestTruncateLargeThenWriteToSmallerOffset(t *testing.T) {
+	testTruncateLargeThenWriteToSmallerOffset(
+		t, 10*12 /* 10 min-sized blocks */)
+}
+
+// Regression for KBFS-2091.
+func TestTruncateLargeThenWriteToSmallerOffsetWithHoles(t *testing.T) {
+	testTruncateLargeThenWriteToSmallerOffset(
+		t, 1024*1024 /* above the holes threshold */)
 }


### PR DESCRIPTION
KBFS-2091 hit a case where a randomly-generated `kbfsblock.ID` was synced as part of a file write to the servers.  That should be impossible; a synced `kbfsblock.ID` should always be a hash of its contents.  It turns out that `fileData.ready()` couldn't figure out that the corresponding block was dirty, and so it never encrypted the block and figured out the new ID.  This rendered the file unreadable and triggered missing block errors.

This affected large files which were written to in the middle of the file, rather than being appended to.  KBFS-2091 caught this issue with `zip` on macOS.

This PR contains two necessary fixes (and regression tests for them:
1. The code that hunted for dirty blocks (`getNextDirtyFileBlockAtOffset`) would do a depth-first search of the file tree, looking for a dirty block at or past a given offset.  However, if it went all the way down the path and hit a leaf without finding a dirty block, it would not continue onto the next cousin block on the next branch of the tree, it would just give up.  To fix this, I broke the function apart and made it recursive.
2. When shifting new data into an existing hole, we were correctly adjusting offsets and marking the parent blocks containing those changed offsets as dirty.  However, because the leaf nodes of the right-side parents weren't changing, we weren't marking them as dirty.  The problem was that `getNextDirtyFileBlockAtOffset` only returns paths to dirty _leaf_ nodes, and if the leaf wasn't dirty, it wouldn't return any of the parents either.  This fixes it by marking one of the leaves dirty (and unreferencing it).  This is a bit of a bummer because that ends up re-encoding and re-uploading it for no good reason, but I don't see an easy way around that at the moment.

KBFS-2091