### PR TITLE
kbfs_ops: eliminate Sync() in favor of SyncAll()

### DIFF
--- a/kbfstool/write.go
+++ b/kbfstool/write.go
@@ -149,7 +149,7 @@ func writeHelper(ctx context.Context, config libkbfs.Config, args []string) (err
 		if *verbose {
 			fmt.Fprintf(os.Stderr, "Syncing %s\n", p)
 		}
-		err := kbfsOps.Sync(ctx, fileNode)
+		err := kbfsOps.SyncAll(ctx, fileNode.GetFolderBranch())
 		if err != nil {
 			return err
 		}

--- a/libdokan/file.go
+++ b/libdokan/file.go
@@ -76,7 +76,7 @@ func (f *File) FlushFileBuffers(ctx context.Context, fi *dokan.FileInfo) (err er
 	f.folder.fs.logEnter(ctx, "File FlushFileBuffers")
 	defer func() { f.folder.reportErr(ctx, libkbfs.WriteMode, err) }()
 
-	return f.folder.fs.config.KBFSOps().Sync(ctx, f.node)
+	return f.folder.fs.config.KBFSOps().SyncAll(ctx, f.node.GetFolderBranch())
 }
 
 // ReadFile for dokan reads.

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -2299,7 +2299,7 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 			ctx, myfile, []byte(input2), int64(len(input1))); err != nil {
 			t.Fatal(err)
 		}
-		if err := ops.Sync(ctx, myfile); err != nil {
+		if err := ops.SyncAll(ctx, myfile.GetFolderBranch()); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -173,7 +173,7 @@ var _ fs.NodeFsyncer = (*File)(nil)
 
 func (f *File) sync(ctx context.Context) error {
 	f.eiCache.destroy()
-	err := f.folder.fs.config.KBFSOps().Sync(ctx, f.node)
+	err := f.folder.fs.config.KBFSOps().SyncAll(ctx, f.node.GetFolderBranch())
 	if err != nil {
 		return err
 	}

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -2908,7 +2908,7 @@ func TestInvalidateAppendAcrossMounts(t *testing.T) {
 			ctx, myfile, []byte(input2), int64(len(input1))); err != nil {
 			t.Fatal(err)
 		}
-		if err := ops.Sync(ctx, myfile); err != nil {
+		if err := ops.SyncAll(ctx, myfile.GetFolderBranch()); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -1103,7 +1103,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't write: %v", err)
 	}
-	err = config2.KBFSOps().Sync(ctx, file2)
+	err = config2.KBFSOps().SyncAll(ctx, file2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't sync: %v", err)
 	}
@@ -1286,7 +1286,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't write file: %v", err)
 	}
-	err = config1.KBFSOps().Sync(ctx, file1)
+	err = config1.KBFSOps().SyncAll(ctx, file1.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't sync file: %v", err)
 	}
@@ -1297,7 +1297,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't write file: %v", err)
 	}
-	err = config2.KBFSOps().Sync(ctx, file2)
+	err = config2.KBFSOps().SyncAll(ctx, file2.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't sync file: %v", err)
 	}

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -247,7 +247,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't write file: %+v", err)
 	}
-	err = kbfsOps1.Sync(ctx, aNode1)
+	err = kbfsOps1.SyncAll(ctx, aNode1.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't sync file: %+v", err)
 	}
@@ -264,7 +264,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Couldn't write file: %+v", err)
 		}
-		err = kbfsOps1.Sync(ctx, node)
+		err = kbfsOps1.SyncAll(ctx, node.GetFolderBranch())
 		if err != nil {
 			t.Fatalf("Couldn't sync file: %+v", err)
 		}
@@ -363,7 +363,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't write file: %+v", err)
 	}
-	err = kbfsOps2.Sync(ctx, dNode)
+	err = kbfsOps2.SyncAll(ctx, dNode.GetFolderBranch())
 	if err != nil {
 		t.Fatalf("Couldn't write file: %+v", err)
 	}
@@ -393,7 +393,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	// Start the sync and wait for it to stall twice only.
 	errChan := make(chan error)
 	go func() {
-		errChan <- kbfsOps2.Sync(ctxStall, eNode)
+		errChan <- kbfsOps2.SyncAll(ctxStall, eNode.GetFolderBranch())
 	}()
 	<-onWriteStalledCh
 	<-onWriteStalledCh

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1639,6 +1639,9 @@ func (fbo *folderBlockOps) writeDataLocked(
 	// files.  TODO: combine `deCache` with `dirtyFiles` and
 	// `unrefCache`.
 	cacheEntry := fbo.deCache[file.tailPointer().Ref()]
+	now := fbo.nowUnixNano()
+	newDe.Mtime = now
+	newDe.Ctime = now
 	cacheEntry.dirEntry = newDe
 	fbo.deCache[file.tailPointer().Ref()] = cacheEntry
 
@@ -1751,6 +1754,9 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 		return WriteRange{}, nil, err
 	}
 	cacheEntry := fbo.deCache[file.tailPointer().Ref()]
+	now := fbo.nowUnixNano()
+	newDe.Mtime = now
+	newDe.Ctime = now
 	cacheEntry.dirEntry = newDe
 	fbo.deCache[file.tailPointer().Ref()] = cacheEntry
 
@@ -1851,6 +1857,9 @@ func (fbo *folderBlockOps) truncateLocked(
 
 	latestWrite := si.op.addTruncate(size)
 	cacheEntry := fbo.deCache[file.tailPointer().Ref()]
+	now := fbo.nowUnixNano()
+	newDe.Mtime = now
+	newDe.Ctime = now
 	cacheEntry.dirEntry = newDe
 	fbo.deCache[file.tailPointer().Ref()] = cacheEntry
 

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -272,14 +272,11 @@ func (fup folderUpdatePrepper) prepUpdateForPath(
 		}
 
 		if prevIdx < 0 {
-			fup.log.CDebugf(ctx, "update: %d -> %d", md.data.Dir.EncodedSize, info.EncodedSize)
 			md.AddUpdate(md.data.Dir.BlockInfo, info)
 		} else if prevDe, ok := prevDblock.Children[currName]; ok {
-			fup.log.CDebugf(ctx, "update: %d -> %d", prevDe.EncodedSize, info.EncodedSize)
 			md.AddUpdate(prevDe.BlockInfo, info)
 		} else {
 			// this is a new block
-			fup.log.CDebugf(ctx, "add: %d", info.EncodedSize)
 			md.AddRefBlock(info)
 		}
 

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -272,11 +272,14 @@ func (fup folderUpdatePrepper) prepUpdateForPath(
 		}
 
 		if prevIdx < 0 {
+			fup.log.CDebugf(ctx, "update: %d -> %d", md.data.Dir.EncodedSize, info.EncodedSize)
 			md.AddUpdate(md.data.Dir.BlockInfo, info)
 		} else if prevDe, ok := prevDblock.Children[currName]; ok {
+			fup.log.CDebugf(ctx, "update: %d -> %d", prevDe.EncodedSize, info.EncodedSize)
 			md.AddUpdate(prevDe.BlockInfo, info)
 		} else {
 			// this is a new block
+			fup.log.CDebugf(ctx, "add: %d", info.EncodedSize)
 			md.AddRefBlock(info)
 		}
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -285,12 +285,6 @@ type KBFSOps interface {
 	// the top-level folder.  If mtime is nil, it is a noop.  This is
 	// a remote-sync operation.
 	SetMtime(ctx context.Context, file Node, mtime *time.Time) error
-	// Sync flushes all outstanding writes and truncates for the given
-	// file to the KBFS servers, if the logged-in user has write
-	// permissions to the top-level folder.  If done through a file
-	// system interface, this may include modifications done via
-	// multiple file handles.  This is a remote-sync operation.
-	Sync(ctx context.Context, file Node) error
 	// SyncAll flushes all outstanding writes and truncates for any
 	// dirty files to the KBFS servers within the given folder, if the
 	// logged-in user has write permissions to the top-level folder.

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -213,7 +213,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	require.NoError(t, err)
 	checkStatus(t, ctx, kbfsOps2, false, userName1, []string{"u1,u2/a"},
 		rootNode2.GetFolderBranch(), "Node 2 (after write)")
-	err = kbfsOps2.Sync(ctx, fileNode2)
+	err = kbfsOps2.SyncAll(ctx, fileNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	// Now when user 1 tries to write to file 1 and sync, it will
@@ -222,7 +222,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	err = kbfsOps1.Write(ctx, fileNode1, data1, 0)
 	require.NoError(t, err)
 	// sync the file from u1 so that we get a clean exit state
-	err = kbfsOps1.Sync(ctx, fileNode1)
+	err = kbfsOps1.SyncAll(ctx, fileNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// Wait for the conflict to be detected.
@@ -287,7 +287,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	require.NoError(t, err)
 	checkStatus(t, ctx, kbfsOps2, false, userName1, []string{"u1,u2/a"},
 		rootNode2.GetFolderBranch(), "Node 2 (after write)")
-	err = kbfsOps2.Sync(ctx, fileNode2)
+	err = kbfsOps2.SyncAll(ctx, fileNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	// Now when user 1 tries to write to file 1 and sync, it will
@@ -300,7 +300,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	require.NoError(t, err)
 	checkStatus(t, ctx, kbfsOps1, false, userName1, []string{"u1,u2/a"},
 		rootNode1.GetFolderBranch(), "Node 1 (after write)")
-	err = kbfsOps1.Sync(ctx, fileNode1)
+	err = kbfsOps1.SyncAll(ctx, fileNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	checkStatus(t, ctx, kbfsOps1, true, userName1, nil,
@@ -423,7 +423,7 @@ func TestMultiUserWrite(t *testing.T) {
 	// a sync work when the writer is changing.
 	err = kbfsOps2.Write(ctx, fileNode2, data2, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, fileNode2)
+	err = kbfsOps2.SyncAll(ctx, fileNode2.GetFolderBranch())
 	require.NoError(t, err)
 	readAndCompareData(t, config2, ctx, name, data2, userName2)
 
@@ -431,7 +431,7 @@ func TestMultiUserWrite(t *testing.T) {
 	data3 := []byte{3}
 	err = kbfsOps2.Write(ctx, fileNode2, data3, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, fileNode2)
+	err = kbfsOps2.SyncAll(ctx, fileNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	readAndCompareData(t, config2, ctx, name, data3, userName2)
@@ -610,7 +610,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	data := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, fileB1, data, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, fileB1)
+	err = kbfsOps1.SyncAll(ctx, fileB1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 makes a few changes in the file
@@ -624,7 +624,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 		err = kbfsOps2.Write(ctx, fileB2, data, 0)
 		require.NoError(t, err)
 
-		err = kbfsOps2.Sync(ctx, fileB2)
+		err = kbfsOps2.SyncAll(ctx, fileB2.GetFolderBranch())
 		require.NoError(t, err)
 	}
 
@@ -692,14 +692,14 @@ func TestBasicCRFileConflict(t *testing.T) {
 	data1 := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, fileB1, data1, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, fileB1)
+	err = kbfsOps1.SyncAll(ctx, fileB1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 makes a new different file
 	data2 := []byte{5, 4, 3, 2, 1}
 	err = kbfsOps2.Write(ctx, fileB2, data2, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, fileB2)
+	err = kbfsOps2.SyncAll(ctx, fileB2.GetFolderBranch())
 	require.NoError(t, err)
 
 	// re-enable updates, and wait for CR to complete
@@ -781,7 +781,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	data2 := []byte{5, 4, 3, 2, 1}
 	err = kbfsOps2.Write(ctx, fileB2, data2, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, fileB2)
+	err = kbfsOps2.SyncAll(ctx, fileB2.GetFolderBranch())
 	require.NoError(t, err)
 
 	// re-enable updates, and wait for CR to complete
@@ -872,7 +872,7 @@ func TestCRDouble(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = kbfsOps2.Sync(syncCtx, fileNodeC)
+		err = kbfsOps2.SyncAll(syncCtx, fileNodeC.GetFolderBranch())
 		assert.Equal(t, context.Canceled, err)
 	}()
 	<-onSyncStalledCh
@@ -881,7 +881,7 @@ func TestCRDouble(t *testing.T) {
 	wg.Wait()
 
 	// Sync for real to clear out the dirty files.
-	err = kbfsOps2.Sync(ctx, fileNodeC)
+	err = kbfsOps2.SyncAll(ctx, fileNodeC.GetFolderBranch())
 	require.NoError(t, err)
 
 	// Do one CR.
@@ -1001,7 +1001,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	data1 := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, fileB1, data1, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, fileB1)
+	err = kbfsOps1.SyncAll(ctx, fileB1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 dev 2 should set the rekey bit
@@ -1018,7 +1018,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	data2 := []byte{5, 4, 3, 2, 1}
 	err = kbfsOps2.Write(ctx, fileB2, data2, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, fileB2)
+	err = kbfsOps2.SyncAll(ctx, fileB2.GetFolderBranch())
 	require.NoError(t, err)
 
 	// re-enable updates, and wait for CR to complete.
@@ -1142,7 +1142,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	data1 := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, fileB1, data1, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, fileB1)
+	err = kbfsOps1.SyncAll(ctx, fileB1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// re-enable updates, and wait for CR to complete.
@@ -1276,7 +1276,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		syncErr = kbfsOps2.Sync(syncCtx, fileNodeB)
+		syncErr = kbfsOps2.SyncAll(syncCtx, fileNodeB.GetFolderBranch())
 	}()
 	// Wait for 2 of the blocks and let them go
 	<-onSyncStalledCh
@@ -1311,7 +1311,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	}
 	err = kbfsOps2.Write(ctx, fileNodeB, data, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, fileNodeB)
+	err = kbfsOps2.SyncAll(ctx, fileNodeB.GetFolderBranch())
 	require.NoError(t, err)
 
 	c <- struct{}{}
@@ -1351,7 +1351,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	data := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, aNode1, data, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, aNode1)
+	err = kbfsOps1.SyncAll(ctx, aNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// look it up on user2
@@ -1369,14 +1369,14 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// User 1 truncates file a.
 	err = kbfsOps1.Truncate(ctx, aNode1, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, aNode1)
+	err = kbfsOps1.SyncAll(ctx, aNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 writes to the file, creating a conflict.
 	data2 := []byte{5, 4, 3, 2, 1}
 	err = kbfsOps2.Write(ctx, aNode2, data2, 0)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, aNode2)
+	err = kbfsOps2.SyncAll(ctx, aNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	onPutStalledCh, putUnstallCh, putCtx :=
@@ -1597,7 +1597,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	data := []byte{1, 2, 3, 4, 5}
 	err = kbfsOps1.Write(ctx, aNode1, data, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, aNode1)
+	err = kbfsOps1.SyncAll(ctx, aNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// look it up on user2
@@ -1615,7 +1615,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// User 1 truncates file a.
 	err = kbfsOps1.Truncate(ctx, aNode1, 0)
 	require.NoError(t, err)
-	err = kbfsOps1.Sync(ctx, aNode1)
+	err = kbfsOps1.SyncAll(ctx, aNode1.GetFolderBranch())
 	require.NoError(t, err)
 
 	// User 2 creates a file to start a conflict branch.

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -634,12 +634,6 @@ func (fs *KBFSOpsStandard) SetMtime(
 	return ops.SetMtime(ctx, file, mtime)
 }
 
-// Sync implements the KBFSOps interface for KBFSOpsStandard
-func (fs *KBFSOpsStandard) Sync(ctx context.Context, file Node) error {
-	ops := fs.getOpsByNode(ctx, file)
-	return ops.Sync(ctx, file)
-}
-
 // SyncAll implements the KBFSOps interface for KBFSOpsStandard
 func (fs *KBFSOpsStandard) SyncAll(
 	ctx context.Context, folderBranch FolderBranch) error {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4,8 +4,6 @@
 package libkbfs
 
 import (
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
@@ -16,6 +14,7 @@ import (
 	tlf "github.com/keybase/kbfs/tlf"
 	go_metrics "github.com/rcrowley/go-metrics"
 	context "golang.org/x/net/context"
+	time "time"
 )
 
 // Mock of dataVersioner interface
@@ -864,16 +863,6 @@ func (_m *MockKBFSOps) SetMtime(ctx context.Context, file Node, mtime *time.Time
 
 func (_mr *_MockKBFSOpsRecorder) SetMtime(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMtime", arg0, arg1, arg2)
-}
-
-func (_m *MockKBFSOps) Sync(ctx context.Context, file Node) error {
-	ret := _m.ctrl.Call(_m, "Sync", ctx, file)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockKBFSOpsRecorder) Sync(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Sync", arg0, arg1)
 }
 
 func (_m *MockKBFSOps) SyncAll(ctx context.Context, folderBranch FolderBranch) error {
@@ -3458,16 +3447,8 @@ func (_m *MockMDServer) CheckForRekeys(ctx context.Context) <-chan error {
 	return ret0
 }
 
-func (_m *MockMDServer) CheckReachability(ctx context.Context) {
-
-}
-
 func (_mr *_MockMDServerRecorder) CheckForRekeys(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckForRekeys", arg0)
-}
-
-func (_m *_MockMDServerRecorder) CheckReachability(ctx context.Context) {
-
 }
 
 func (_m *MockMDServer) TruncateLock(ctx context.Context, id tlf.ID) (bool, error) {
@@ -3550,6 +3531,14 @@ func (_m *MockMDServer) GetKeyBundles(ctx context.Context, tlfID tlf.ID, wkbID T
 
 func (_mr *_MockMDServerRecorder) GetKeyBundles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockMDServer) CheckReachability(ctx context.Context) {
+	_m.ctrl.Call(_m, "CheckReachability", ctx)
+}
+
+func (_mr *_MockMDServerRecorder) CheckReachability(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckReachability", arg0)
 }
 
 // Mock of mdServerLocal interface
@@ -3664,10 +3653,6 @@ func (_mr *_MockmdServerLocalRecorder) CheckForRekeys(arg0 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckForRekeys", arg0)
 }
 
-func (_m *_MockmdServerLocalRecorder) CheckReachability(ctx context.Context) {
-
-}
-
 func (_m *MockmdServerLocal) TruncateLock(ctx context.Context, id tlf.ID) (bool, error) {
 	ret := _m.ctrl.Call(_m, "TruncateLock", ctx, id)
 	ret0, _ := ret[0].(bool)
@@ -3748,6 +3733,14 @@ func (_m *MockmdServerLocal) GetKeyBundles(ctx context.Context, tlfID tlf.ID, wk
 
 func (_mr *_MockmdServerLocalRecorder) GetKeyBundles(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetKeyBundles", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockmdServerLocal) CheckReachability(ctx context.Context) {
+	_m.ctrl.Call(_m, "CheckReachability", ctx)
+}
+
+func (_mr *_MockmdServerLocalRecorder) CheckReachability(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckReachability", arg0)
 }
 
 func (_m *MockmdServerLocal) addNewAssertionForTest(uid keybase1.UID, newAssertion keybase1.SocialAssertion) error {

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -1252,6 +1252,8 @@ func invertOpForLocalNotifications(oldOp op) (newOp op, err error) {
 		}
 	case *GCOp:
 		newOp = op
+	case *resolutionOp:
+		newOp = op
 	}
 
 	// Now reverse all the block updates.  Don't bother with bare Refs

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -133,7 +133,7 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 	require.NoError(t, err)
 	err = kbfsOps.Write(ctx, fileNode, []byte{0}, 0)
 	require.NoError(t, err)
-	err = kbfsOps.Sync(ctx, fileNode)
+	err = kbfsOps.SyncAll(ctx, fileNode.GetFolderBranch())
 	require.NoError(t, err)
 	if i >= 70 {
 		edits[uid] = append(edits[uid], TlfEdit{
@@ -284,7 +284,7 @@ func TestLongTlfEditHistory(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps2.Write(ctx, editNode, []byte{1}, 1)
 	require.NoError(t, err)
-	err = kbfsOps2.Sync(ctx, editNode)
+	err = kbfsOps2.SyncAll(ctx, editNode.GetFolderBranch())
 	require.NoError(t, err)
 
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -544,7 +544,7 @@ func (k *SimpleFS) SimpleFSClose(ctx context.Context, opid keybase1.OpID) (err e
 	}
 	delete(k.handles, opid)
 	if h.node != nil {
-		err = k.config.KBFSOps().Sync(ctx, h.node)
+		err = k.config.KBFSOps().SyncAll(ctx, h.node.GetFolderBranch())
 	}
 	return err
 }
@@ -858,7 +858,7 @@ func (r *kbfsIO) Write(bs []byte) (int, error) {
 }
 
 func (r *kbfsIO) Close() error {
-	return r.sfs.config.KBFSOps().Sync(r.ctx, r.node)
+	return r.sfs.config.KBFSOps().SyncAll(r.ctx, r.node.GetFolderBranch())
 }
 
 func (r *kbfsIO) Type() keybase1.DirentType {


### PR DESCRIPTION
Syncing a single file doesn't make sense in a world where the
directory operation creating the file hasn't been synced yet.  The
simplest solution seems to be to not allow syncing a single file, and
requiring that all operations are synced together no matter what.

So this PR gets rid of Sync(), and makes all of its callers use
SyncAll() instead.

As part of this I got rid of a bunch of mock-based KBFSOps tests that
would have been a pain in the butt to adapt to SyncAll; the stuff they
covered is covered by other, higher-level tests now (those tests
predate the ability to end-to-end FS operations).

This depends on #909.

Issue: KBFS-2073