### PR TITLE
tlf_journal: bg work retrier shouldn't have a MaxElapsedTime

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -387,7 +387,9 @@ func makeTLFJournal(
 	availableBytes, availableFiles := j.diskLimiter.onJournalEnable(
 		ctx, storedBytes, unflushedBytes, storedFiles)
 
-	go j.doBackgroundWorkLoop(bws, backoff.NewExponentialBackOff())
+	retry := backoff.NewExponentialBackOff()
+	retry.MaxElapsedTime = 0
+	go j.doBackgroundWorkLoop(bws, retry)
 
 	// Signal work to pick up any existing journal entries.
 	j.signalWork()


### PR DESCRIPTION
Otherwise if a flush takes more than 15 minutes (entirely reasonable
if the user dumps a huge amount of data into the journal at once), and
then the flush hits a failure (e.g., connectivity issues), the journal
will never retry.  I don't see any reason to ever stop retrying.

Issue: KBFS-2101