### PR TITLE
folder_branch_ops: include cached dir ops in SyncAll

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -387,7 +387,7 @@ type crChains struct {
 	// Pointers that should be explicitly cleaned up in the resolution.
 	toUnrefPointers map[BlockPointer]bool
 
-	// Pointers that should be explicitly *not* be cleaned up in the
+	// Pointers that should explicitly *not* be cleaned up in the
 	// resolution.
 	doNotUnrefPointers map[BlockPointer]bool
 

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -387,6 +387,10 @@ type crChains struct {
 	// Pointers that should be explicitly cleaned up in the resolution.
 	toUnrefPointers map[BlockPointer]bool
 
+	// Pointers that should be explicitly *not* be cleaned up in the
+	// resolution.
+	doNotUnrefPointers map[BlockPointer]bool
+
 	// Also keep the info for the most recent chain MD used to
 	// build these chains.
 	mostRecentChainMDInfo mostRecentChainMetadataInfo
@@ -731,6 +735,7 @@ func newCRChainsEmpty() *crChains {
 		renamedOriginals:    make(map[BlockPointer]renameInfo),
 		blockChangePointers: make(map[BlockPointer]bool),
 		toUnrefPointers:     make(map[BlockPointer]bool),
+		doNotUnrefPointers:  make(map[BlockPointer]bool),
 		originals:           make(map[BlockPointer]BlockPointer),
 	}
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -539,6 +539,11 @@ func (et EntryType) String() string {
 	return "<invalid EntryType>"
 }
 
+// IsFile returns whether or not this entry points to a file.
+func (et EntryType) IsFile() bool {
+	return et == File || et == Exec
+}
+
 // Excl indicates whether O_EXCL is set on a fuse call
 type Excl bool
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1247,14 +1247,16 @@ func (fbo *folderBlockOps) getOrCreateSyncInfoLocked(
 	return si, nil
 }
 
-// GetDirtyRefs returns a list of references of all known dirty
-// blocks.
-func (fbo *folderBlockOps) GetDirtyRefs(lState *lockState) []BlockRef {
+// GetDirtyFiles returns a list of references of all known dirty
+// files.
+func (fbo *folderBlockOps) GetDirtyFiles(lState *lockState) []BlockRef {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	var dirtyRefs []BlockRef
-	for ref := range fbo.deCache {
-		dirtyRefs = append(dirtyRefs, ref)
+	for ref, de := range fbo.deCache {
+		if de.dirEntry.IsInitialized() && de.dirEntry.Type.IsFile() {
+			dirtyRefs = append(dirtyRefs, ref)
+		}
 	}
 	return dirtyRefs
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1022,7 +1022,7 @@ func (fbo *folderBlockOps) updateWithDirtyEntriesLocked(ctx context.Context,
 	}
 
 	// Remove cached removals from the copy.
-	for k := range dirCacheEntry.adds {
+	for k := range dirCacheEntry.dels {
 		_, ok := dblock.Children[k]
 		if !ok {
 			continue

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1284,13 +1284,15 @@ func (fbo *folderBlockOps) getOrCreateSyncInfoLocked(
 	return si, nil
 }
 
-// GetDirtyFiles returns a list of references of all known dirty
+// GetDirtyFileBlockRefs returns a list of references of all known dirty
 // files.
-func (fbo *folderBlockOps) GetDirtyFiles(lState *lockState) []BlockRef {
+func (fbo *folderBlockOps) GetDirtyFileBlockRefs(lState *lockState) []BlockRef {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	var dirtyRefs []BlockRef
 	for ref := range fbo.deCache {
+		// A file is only dirty if it's been written to (and hence
+		// caused some block unrefs) but not been synced yet.
 		if _, ok := fbo.unrefCache[ref]; ok {
 			dirtyRefs = append(dirtyRefs, ref)
 		}
@@ -1298,9 +1300,9 @@ func (fbo *folderBlockOps) GetDirtyFiles(lState *lockState) []BlockRef {
 	return dirtyRefs
 }
 
-// GetDirtyDirs returns a list of references of all known dirty
+// GetDirtyDirBlockRefs returns a list of references of all known dirty
 // directories.
-func (fbo *folderBlockOps) GetDirtyDirs(lState *lockState) []BlockRef {
+func (fbo *folderBlockOps) GetDirtyDirBlockRefs(lState *lockState) []BlockRef {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	var dirtyRefs []BlockRef

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3683,8 +3683,8 @@ func (fbo *folderBranchOps) syncAllLocked(
 	ctx context.Context, lState *lockState) (err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	dirtyFiles := fbo.blocks.GetDirtyFiles(lState)
-	dirtyDirs := fbo.blocks.GetDirtyDirs(lState)
+	dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
+	dirtyDirs := fbo.blocks.GetDirtyDirBlockRefs(lState)
 	if len(dirtyFiles) == 0 && len(dirtyDirs) == 0 {
 		return nil
 	}
@@ -3737,6 +3737,8 @@ func (fbo *folderBranchOps) syncAllLocked(
 			})
 	}
 	defer func() {
+		// If the sync is successful, we can clear out all buffered
+		// directory operations.
 		if err == nil {
 			fbo.dirOps = nil
 		}
@@ -5007,7 +5009,7 @@ func (fbo *folderBranchOps) SyncFromServerForTesting(
 			}
 		}
 
-		dirtyFiles := fbo.blocks.GetDirtyFiles(lState)
+		dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
 		if len(dirtyFiles) > 0 {
 			for _, ref := range dirtyFiles {
 				fbo.log.CDebugf(ctx, "DeCache entry left: %v", ref)
@@ -5470,7 +5472,7 @@ func (fbo *folderBranchOps) backgroundFlusher(betweenFlushes time.Duration) {
 			}
 		}
 
-		dirtyFiles := fbo.blocks.GetDirtyFiles(lState)
+		dirtyFiles := fbo.blocks.GetDirtyFileBlockRefs(lState)
 		if len(dirtyFiles) == 0 {
 			sameDirtyFileCount = 0
 			continue

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -698,7 +698,7 @@ func (fup folderUpdatePrepper) updateResolutionUsageAndPointers(
 	}
 	deletedBlocks := make(map[BlockPointer]bool)
 	for ptr := range toUnref {
-		if ptr == zeroPtr {
+		if ptr == zeroPtr || unmergedChains.doNotUnrefPointers[ptr] {
 			// A zero pointer can sneak in from the unrefs field of a
 			// syncOp following a failed syncOp, via
 			// `unmergedChains.toUnrefPointers` after a chain collapse.
@@ -1095,7 +1095,8 @@ func (fup folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 		// Ignore it if it doesn't descend from an original block
 		// pointer or one created in the merged branch.
 		if _, ok := unmergedChains.originals[update.Unref]; !ok &&
-			unmergedChains.byOriginal[update.Unref] == nil &&
+			(unmergedChains.byOriginal[update.Unref] == nil ||
+				unmergedChains.isCreated(update.Unref)) &&
 			mergedChains.byMostRecent[update.Unref] == nil {
 			fup.log.CDebugf(ctx,
 				"Turning update from %v into just a ref for %v",

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -4919,3 +4919,312 @@ func TestKBFSOpsSyncAllTwoFiles(t *testing.T) {
 		t.Fatalf("Couldn't sync; %+v", err)
 	}
 }
+
+func TestKBFSOpsCreateSyncAll(t *testing.T) {
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
+	// TODO: Use kbfsTestShutdownNoMocks.
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+
+	// Manually create a file without actually syncing it.
+	// TODO(KBFS-2076) remove all this duplicated code.
+	rootNode := GetRootNodeOrBust(ctx, t, config, "alice,bob", false)
+
+	ops := getOps(config, rootNode.GetFolderBranch().Tlf)
+	name := "myfile"
+	var fileNode Node
+	{
+		rootDir := ops.nodeCache.PathFromNode(rootNode)
+		co, err := newCreateOp(name, rootDir.tailPointer(), File)
+		if err != nil {
+			t.Fatal(err)
+		}
+		newBlock := &FileBlock{}
+
+		newID, err := config.cryptoPure().MakeTemporaryBlockID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		session, err := config.KBPKI().GetCurrentSession(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newPtr := BlockPointer{
+			ID:         newID,
+			KeyGen:     1,
+			DataVer:    1,
+			DirectType: DirectBlock,
+			Context: kbfsblock.MakeFirstContext(
+				session.UID, keybase1.BlockType_DATA),
+		}
+		config.DirtyBlockCache().Put(ops.id(), newPtr, ops.branch(), newBlock)
+		co.AddRefBlock(newPtr)
+		fileNode, err = ops.nodeCache.GetOrCreate(newPtr, name, rootNode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		de := DirEntry{
+			BlockInfo: BlockInfo{
+				BlockPointer: newPtr,
+				EncodedSize:  0,
+			},
+			EntryInfo: EntryInfo{
+				Type: File,
+				Size: 0,
+			},
+		}
+		lState := makeFBOLockState()
+		ops.blocks.AddDirEntryInCache(lState, rootDir, name, de)
+		ops.dirOps = append(
+			ops.dirOps, cachedDirOp{co, []Node{rootNode, fileNode}})
+	}
+
+	// Write to A.
+	data := []byte{1}
+	kbfsOps := config.KBFSOps()
+	err := kbfsOps.Write(ctx, fileNode, data, 0)
+	if err != nil {
+		t.Fatalf("Couldn't write to file: %+v", err)
+	}
+
+	// Make sure we can see it before the sync happens.
+	_, ei, err := kbfsOps.Lookup(ctx, rootNode, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ei.Size != uint64(len(data)) {
+		t.Fatalf("Unexpected size: %d vs %d", ei.Size, len(data))
+	}
+
+	// Sync everything.
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync; %+v", err)
+	}
+
+	// Check that bob can see it.
+	config2 := ConfigAsUser(config, "bob")
+	defer CheckConfigAndShutdown(ctx, t, config2)
+
+	rootNodeBob := GetRootNodeOrBust(ctx, t, config2, "alice,bob", false)
+	fileNodeBob, _, err := config2.KBFSOps().Lookup(ctx, rootNodeBob, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotData := make([]byte, len(data))
+	_, err = config2.KBFSOps().Read(ctx, fileNodeBob, gotData, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(data, gotData) {
+		t.Fatalf("Data didn't match: %v vs %v", data, gotData)
+	}
+
+	if len(ops.blocks.deCache) > 0 {
+		t.Fatalf("%d unexpected deCache entries leftover",
+			len(ops.blocks.deCache))
+	}
+}
+
+func TestKBFSOpsRemoveSyncAll(t *testing.T) {
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
+	// TODO: Use kbfsTestShutdownNoMocks.
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+
+	rootNode := GetRootNodeOrBust(ctx, t, config, "alice,bob", false)
+	kbfsOps := config.KBFSOps()
+	name := "myfile"
+	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, name, false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %+v", err)
+	}
+
+	// Manually remove a file without actually syncing it.
+	// TODO(KBFS-2076) remove all this duplicated code.
+	ops := getOps(config, rootNode.GetFolderBranch().Tlf)
+	{
+		rootDir := ops.nodeCache.PathFromNode(rootNode)
+		ro, err := newRmOp(name, rootDir.tailPointer())
+		if err != nil {
+			t.Fatal(err)
+		}
+		ro.setFinalPath(rootDir)
+
+		filePath := ops.nodeCache.PathFromNode(fileNode)
+		ro.AddUnrefBlock(filePath.tailPointer())
+
+		lState := makeFBOLockState()
+		ops.blocks.RemoveDirEntryInCache(lState, rootDir, name)
+		ops.dirOps = append(ops.dirOps, cachedDirOp{ro, []Node{rootNode}})
+	}
+
+	// Make sure we can't see it before the sync happens.
+	children, err := kbfsOps.GetDirChildren(ctx, rootNode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != 0 {
+		t.Fatalf("Unexpected children: %v", children)
+	}
+
+	// Sync everything.
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync; %+v", err)
+	}
+
+	if len(ops.blocks.deCache) > 0 {
+		t.Fatalf("%d unexpected deCache entries leftover",
+			len(ops.blocks.deCache))
+	}
+}
+
+func TestKBFSOpsRenameSameDirSyncAll(t *testing.T) {
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
+	// TODO: Use kbfsTestShutdownNoMocks.
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+
+	rootNode := GetRootNodeOrBust(ctx, t, config, "alice,bob", false)
+	kbfsOps := config.KBFSOps()
+	name := "myfile"
+	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, name, false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %+v", err)
+	}
+
+	// Manually rename a file without actually syncing it.
+	// TODO(KBFS-2076) remove all this duplicated code.
+	newName := "myfile"
+	ops := getOps(config, rootNode.GetFolderBranch().Tlf)
+	{
+		rootDir := ops.nodeCache.PathFromNode(rootNode)
+		filePath := ops.nodeCache.PathFromNode(fileNode)
+
+		ro, err := newRenameOp(name, rootDir.tailPointer(), newName,
+			rootDir.tailPointer(), filePath.tailPointer(), File)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lState := makeFBOLockState()
+		dblock, err := ops.blocks.GetDirBlockForReading(
+			ctx, lState, ops.head, rootDir.tailPointer(), ops.branch(), rootDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_ = ops.blocks.RenameDirEntryInCache(
+			lState, rootDir, name, rootDir, newName, dblock.Children[name])
+		ops.dirOps = append(ops.dirOps, cachedDirOp{ro, []Node{rootNode}})
+	}
+
+	// Make sure we see the new name before the sync happens.
+	checkChild := func(config Config, rootNode Node) {
+		children, err := config.KBFSOps().GetDirChildren(ctx, rootNode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(children) != 1 {
+			t.Fatalf("Unexpected children: %v", children)
+		}
+		if _, ok := children[newName]; !ok {
+			t.Fatalf("Child %s missing: %v", newName, children)
+		}
+	}
+	checkChild(config, rootNode)
+
+	// Sync everything.
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync; %+v", err)
+	}
+
+	// Check that bob can see it.
+	config2 := ConfigAsUser(config, "bob")
+	defer CheckConfigAndShutdown(ctx, t, config2)
+
+	rootNodeBob := GetRootNodeOrBust(ctx, t, config2, "alice,bob", false)
+	checkChild(config2, rootNodeBob)
+
+	if len(ops.blocks.deCache) > 0 {
+		t.Fatalf("%d unexpected deCache entries leftover",
+			len(ops.blocks.deCache))
+	}
+}
+
+func TestKBFSOpsSetExSyncAll(t *testing.T) {
+	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, "alice", "bob")
+	// TODO: Use kbfsTestShutdownNoMocks.
+	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
+
+	rootNode := GetRootNodeOrBust(ctx, t, config, "alice,bob", false)
+	kbfsOps := config.KBFSOps()
+	name := "myfile"
+	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, name, false, NoExcl)
+	if err != nil {
+		t.Fatalf("Couldn't create file: %+v", err)
+	}
+
+	// Manually set the executability of a file without actually
+	// syncing it.  TODO(KBFS-2076) remove all this duplicated code.
+	ops := getOps(config, rootNode.GetFolderBranch().Tlf)
+	{
+		rootDir := ops.nodeCache.PathFromNode(rootNode)
+		filePath := ops.nodeCache.PathFromNode(fileNode)
+
+		sao, err := newSetAttrOp(name, rootDir.tailPointer(),
+			exAttr, filePath.tailPointer())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lState := makeFBOLockState()
+		dblock, err := ops.blocks.GetDirBlockForReading(
+			ctx, lState, ops.head, rootDir.tailPointer(), ops.branch(), rootDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		de := dblock.Children[name]
+		de.Type = Exec
+
+		_ = ops.blocks.SetAttrInDirEntryInCache(lState, filePath, de, sao.Attr)
+		ops.dirOps = append(ops.dirOps, cachedDirOp{sao, []Node{fileNode}})
+	}
+
+	// Make sure we can't see it before the sync happens.
+	checkChild := func(config Config, rootNode Node) {
+		children, err := config.KBFSOps().GetDirChildren(ctx, rootNode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(children) != 1 {
+			t.Fatalf("Unexpected children: %v", children)
+		}
+		if ei, ok := children[name]; !ok {
+			t.Fatalf("Child %s missing: %v", name, children)
+		} else if ei.Type != Exec {
+			t.Fatalf("Unexpected type: %s", ei.Type)
+		}
+	}
+	checkChild(config, rootNode)
+
+	// Sync everything.
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync; %+v", err)
+	}
+
+	// Check that bob can see it.
+	config2 := ConfigAsUser(config, "bob")
+	defer CheckConfigAndShutdown(ctx, t, config2)
+
+	//rootNodeBob := GetRootNodeOrBust(ctx, t, config2, "alice,bob", false)
+	//checkChild(config2, rootNodeBob)
+
+	if len(ops.blocks.deCache) > 0 {
+		t.Fatalf("%d unexpected deCache entries leftover",
+			len(ops.blocks.deCache))
+	}
+}

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -359,13 +359,11 @@ func (md *RootMetadata) AddUnrefBlock(info BlockInfo) {
 
 // AddUpdate adds the newly-updated block to the add block change list.
 func (md *RootMetadata) AddUpdate(oldInfo BlockInfo, newInfo BlockInfo) {
-	if oldInfo.EncodedSize > 0 {
-		md.AddUnrefBytes(uint64(oldInfo.EncodedSize))
-		md.AddRefBytes(uint64(newInfo.EncodedSize))
-		md.AddDiskUsage(uint64(newInfo.EncodedSize))
-		md.SetDiskUsage(md.DiskUsage() - uint64(oldInfo.EncodedSize))
-		md.data.Changes.AddUpdate(oldInfo.BlockPointer, newInfo.BlockPointer)
-	}
+	md.AddUnrefBytes(uint64(oldInfo.EncodedSize))
+	md.AddRefBytes(uint64(newInfo.EncodedSize))
+	md.AddDiskUsage(uint64(newInfo.EncodedSize))
+	md.SetDiskUsage(md.DiskUsage() - uint64(oldInfo.EncodedSize))
+	md.data.Changes.AddUpdate(oldInfo.BlockPointer, newInfo.BlockPointer)
 }
 
 // AddOp starts a new operation for this MD update.  Subsequent


### PR DESCRIPTION
This PR syncs any outstanding directory operations in a `SyncAll()` call -- but it doesn't actually turn it on in production.  It adds some manual hacky tests to make sure the right thing is happening for basic operations.  A future PR (for KBFS-2076) will have more extensive tests, and will probably remove the hacky ones.

Getting block accounting to work properly required a few scattered changes, I'll comment on those individually.

This depends on #920 (and #909).

Issue: KBFS-2074