### PR TITLE
folder_branch_ops: limit background batch sizes, and make batch values more configurable

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -44,6 +44,10 @@ const (
 	qrMinHeadAgeDefault = 24 * time.Hour
 	// tlfValidDurationDefault is the default for tlf validity before redoing identify.
 	tlfValidDurationDefault = 6 * time.Hour
+	// bgFlushDirOpThresholdDefault is the default for how many
+	// directory operations should be batched together in a single
+	// background flush.
+	bgFlushDirOpBatchSizeDefault = 20
 )
 
 // ConfigLocal implements the Config interface using purely local
@@ -98,6 +102,11 @@ type ConfigLocal struct {
 
 	// tlfValidDuration is the time TLFs are valid before redoing identification.
 	tlfValidDuration time.Duration
+
+	// bgFlushDirOpBatchSizeDefault indicates how many directory
+	// operations should be batched together in a single background
+	// flush.
+	bgFlushDirOpBatchSize int
 
 	// metadataVersion is the version to use when creating new metadata.
 	metadataVersion MetadataVer
@@ -271,6 +280,7 @@ func NewConfigLocal(mode InitMode, loggerFn func(module string) logger.Logger,
 	}
 
 	config.tlfValidDuration = tlfValidDurationDefault
+	config.bgFlushDirOpBatchSize = bgFlushDirOpBatchSizeDefault
 	config.metadataVersion = defaultClientMetadataVer
 
 	return config
@@ -879,6 +889,20 @@ func (c *ConfigLocal) SetTLFValidDuration(r time.Duration) {
 // TLFValidDuration implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) TLFValidDuration() time.Duration {
 	return c.tlfValidDuration
+}
+
+// SetBGFlushDirOpBatchSize implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) SetBGFlushDirOpBatchSize(s int) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.bgFlushDirOpBatchSize = s
+}
+
+// BGFlushDirOpBatchSize implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) BGFlushDirOpBatchSize() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.bgFlushDirOpBatchSize
 }
 
 // Shutdown implements the Config interface for ConfigLocal.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -106,9 +106,8 @@ type ConfigLocal struct {
 	// tlfValidDuration is the time TLFs are valid before redoing identification.
 	tlfValidDuration time.Duration
 
-	// bgFlushDirOpBatchSizeDefault indicates how many directory
-	// operations should be batched together in a single background
-	// flush.
+	// bgFlushDirOpBatchSize indicates how many directory operations
+	// should be batched together in a single background flush.
 	bgFlushDirOpBatchSize int
 
 	// bgFlushPeriod indicates how long to wait for a batch to fill up

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5457,20 +5457,20 @@ func (fbo *folderBranchOps) backgroundFlusher() {
 
 		if doSelect {
 			// Wait until we really have a write waiting.
-			forced := false
+			doWait := true
 			select {
 			case <-fbo.syncNeededChan:
 				if fbo.getCachedDirOpsCount(lState) >=
 					fbo.config.BGFlushDirOpBatchSize() {
-					forced = true
+					doWait = false
 				}
 			case <-fbo.forceSyncChan:
-				forced = true
+				doWait = false
 			case <-fbo.shutdownChan:
 				return
 			}
 
-			if !forced {
+			if doWait {
 				timer := time.NewTimer(fbo.config.BGFlushPeriod())
 				// Loop until either a tick's worth of time passes,
 				// the batch size of directory ops is full, a sync is

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -167,8 +167,8 @@ func DefaultInitParams(ctx Context) InitParams {
 		},
 		TLFJournalBackgroundWorkStatus: TLFJournalBackgroundWorkEnabled,
 		StorageRoot:                    ctx.GetDataDir(),
-		BGFlushPeriod:                  1 * time.Second,
-		BGFlushDirOpBatchSize:          20,
+		BGFlushPeriod:                  bgFlushPeriodDefault,
+		BGFlushDirOpBatchSize:          bgFlushDirOpBatchSizeDefault,
 		Mode: InitDefaultString,
 	}
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1641,6 +1641,14 @@ type Config interface {
 	TLFValidDuration() time.Duration
 	// SetTLFValidDuration sets TLFValidDuration.
 	SetTLFValidDuration(time.Duration)
+
+	// BGFlushDirOpBatchSize returns the directory op batch size for
+	// background flushes.
+	BGFlushDirOpBatchSize() int
+	// SetBGFlushDirOpBatchSize sets the directory op batch size for
+	// background flushes.
+	SetBGFlushDirOpBatchSize(s int)
+
 	// Shutdown is called to free config resources.
 	Shutdown(context.Context) error
 	// CheckStateOnShutdown tells the caller whether or not it is safe

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1649,6 +1649,13 @@ type Config interface {
 	// background flushes.
 	SetBGFlushDirOpBatchSize(s int)
 
+	// BGFlushPeriod returns how long to wait for a batch to fill up
+	// before syncing a set of changes to the servers.
+	BGFlushPeriod() time.Duration
+	// SetBGFlushPeriod sets how long to wait for a batch to fill up
+	// before syncing a set of changes to the servers.
+	SetBGFlushPeriod(p time.Duration)
+
 	// Shutdown is called to free config resources.
 	Shutdown(context.Context) error
 	// CheckStateOnShutdown tells the caller whether or not it is safe

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -4479,7 +4479,8 @@ func TestKBFSOpsBackgroundFlush(t *testing.T) {
 
 	// start the background flusher
 	ops := getOps(config, rootNode.GetFolderBranch().Tlf)
-	go ops.backgroundFlusher(1 * time.Millisecond)
+	config.SetBGFlushPeriod(1 * time.Millisecond)
+	go ops.backgroundFlusher()
 
 	// Make sure we get the notification
 	select {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5091,6 +5091,24 @@ func (_mr *_MockConfigRecorder) SetBGFlushDirOpBatchSize(arg0 interface{}) *gomo
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBGFlushDirOpBatchSize", arg0)
 }
 
+func (_m *MockConfig) BGFlushPeriod() int {
+	ret := _m.ctrl.Call(_m, "BGFlushPeriod")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) BGFlushPeriod() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BGFlushPeriod")
+}
+
+func (_m *MockConfig) SetBGFlushPeriod(s int) {
+	_m.ctrl.Call(_m, "SetBGFlushPeriod", s)
+}
+
+func (_mr *_MockConfigRecorder) SetBGFlushPeriod(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBGFlushPeriod", arg0)
+}
+
 func (_m *MockConfig) Shutdown(_param0 context.Context) error {
 	ret := _m.ctrl.Call(_m, "Shutdown", _param0)
 	ret0, _ := ret[0].(error)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5073,6 +5073,24 @@ func (_mr *_MockConfigRecorder) SetTLFValidDuration(arg0 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetTLFValidDuration", arg0)
 }
 
+func (_m *MockConfig) BGFlushDirOpBatchSize() int {
+	ret := _m.ctrl.Call(_m, "BGFlushDirOpBatchSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+func (_mr *_MockConfigRecorder) BGFlushDirOpBatchSize() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "BGFlushDirOpBatchSize")
+}
+
+func (_m *MockConfig) SetBGFlushDirOpBatchSize(s int) {
+	_m.ctrl.Call(_m, "SetBGFlushDirOpBatchSize", s)
+}
+
+func (_mr *_MockConfigRecorder) SetBGFlushDirOpBatchSize(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetBGFlushDirOpBatchSize", arg0)
+}
+
 func (_m *MockConfig) Shutdown(_param0 context.Context) error {
 	ret := _m.ctrl.Call(_m, "Shutdown", _param0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
This changes the background flusher to flush either a) after a certain amount of time has passed since the last write, or b) after a certain number of directory operations have been buffered.  This should have no effect since we don't currently buffer directory operations (that's what the next PR in the series will do.)

It also makes both these values configurable from the command line, to make performance testing easier.

Issue: KBFS-2075