### PR TITLE
[KBFS-2014] Add new traceLogger type

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -26,6 +26,7 @@ type blockOpsConfig interface {
 // requests to the block server.
 type BlockOpsStandard struct {
 	config blockOpsConfig
+	log    traceLogger
 	queue  *blockRetrievalQueue
 }
 
@@ -42,6 +43,7 @@ func NewBlockOpsStandard(config blockOpsConfig,
 	q := newBlockRetrievalQueue(queueSize, qConfig)
 	bops := &BlockOpsStandard{
 		config: config,
+		log:    traceLogger{config.MakeLogger("")},
 		queue:  q,
 	}
 	return bops
@@ -65,8 +67,14 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 		}
 	}
 
+	b.log.LazyTrace(ctx, "Requesting %s", blockPtr)
+
 	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd, blockPtr, block, lifetime)
-	return <-errCh
+	err := <-errCh
+
+	b.log.LazyTrace(ctx, "Request fulfilled for %s (err=%v)", blockPtr, err)
+
+	return err
 }
 
 // GetEncodedSize implements the BlockOps interface for

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -67,12 +67,12 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 		}
 	}
 
-	b.log.LazyTrace(ctx, "Requesting %s", blockPtr.ID)
+	b.log.LazyTrace(ctx, "BOps: Requesting %s", blockPtr.ID)
 
 	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd, blockPtr, block, lifetime)
 	err := <-errCh
 
-	b.log.LazyTrace(ctx, "Request fulfilled for %s (err=%v)", blockPtr.ID, err)
+	b.log.LazyTrace(ctx, "BOps: Request fulfilled for %s (err=%v)", blockPtr.ID, err)
 
 	return err
 }

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -67,12 +67,12 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 		}
 	}
 
-	b.log.LazyTrace(ctx, "Requesting %s", blockPtr)
+	b.log.LazyTrace(ctx, "Requesting %s", blockPtr.ID)
 
 	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd, blockPtr, block, lifetime)
 	err := <-errCh
 
-	b.log.LazyTrace(ctx, "Request fulfilled for %s (err=%v)", blockPtr, err)
+	b.log.LazyTrace(ctx, "Request fulfilled for %s (err=%v)", blockPtr.ID, err)
 
 	return err
 }

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/keybase/backoff"
 	"github.com/keybase/client/go/libkb"
-	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -41,7 +40,7 @@ const (
 // MDServerRemote is an implementation of the MDServer interface.
 type MDServerRemote struct {
 	config        Config
-	log           logger.Logger
+	log           traceLogger
 	mdSrvAddr     string
 	connOpts      rpc.ConnectionOpts
 	rpcLogFactory *libkb.RPCLogFactory
@@ -90,7 +89,7 @@ func NewMDServerRemote(config Config, srvAddr string,
 	mdServer := &MDServerRemote{
 		config:        config,
 		observers:     make(map[tlf.ID]chan<- error),
-		log:           config.MakeLogger(""),
+		log:           traceLogger{config.MakeLogger("")},
 		mdSrvAddr:     srvAddr,
 		rpcLogFactory: rpcLogFactory,
 		rekeyTimer:    time.NewTimer(MdServerBackgroundRekeyPeriod),
@@ -441,11 +440,22 @@ func (md *MDServerRemote) signalObserverLocked(observerChan chan<- error, id tlf
 // Helper used to retrieve metadata blocks from the MD server.
 func (md *MDServerRemote) get(ctx context.Context, id tlf.ID,
 	handle *tlf.Handle, bid BranchID, mStatus MergeStatus,
-	start, stop MetadataRevision) (tlf.ID, []*RootMetadataSigned, error) {
+	start, stop MetadataRevision) (tlfID tlf.ID, rmdses []*RootMetadataSigned, err error) {
 	// figure out which args to send
 	if id == tlf.NullID && handle == nil {
 		panic("nil tlf.ID and handle passed into MDServerRemote.get")
 	}
+	var reqStr string
+	if id != tlf.NullID {
+		reqStr = fmt.Sprintf("%s", id)
+	} else {
+		reqStr = fmt.Sprintf("%s", handle)
+	}
+	md.log.LazyTrace(ctx, "MDServer: get %s %s %d-%d", reqStr, bid, start, stop)
+	defer func() {
+		md.log.LazyTrace(ctx, "MDServer: get %s %s %d-%d done (err=%v)", reqStr, bid, start, stop, err)
+	}()
+
 	arg := keybase1.GetMetadataArg{
 		StartRevision: start.Number(),
 		StopRevision:  stop.Number(),
@@ -454,7 +464,6 @@ func (md *MDServerRemote) get(ctx context.Context, id tlf.ID,
 		LogTags:       nil,
 	}
 
-	var err error
 	if id == tlf.NullID {
 		arg.FolderHandle, err = md.config.Codec().Encode(handle)
 		if err != nil {
@@ -477,7 +486,7 @@ func (md *MDServerRemote) get(ctx context.Context, id tlf.ID,
 	}
 
 	// deserialize blocks
-	rmdses := make([]*RootMetadataSigned, len(response.MdBlocks))
+	rmdses = make([]*RootMetadataSigned, len(response.MdBlocks))
 	for i, block := range response.MdBlocks {
 		ver, max := MetadataVer(block.Version), md.config.MetadataVersion()
 		rmds, err := DecodeRootMetadataSigned(
@@ -531,7 +540,12 @@ func (md *MDServerRemote) GetRange(ctx context.Context, id tlf.ID,
 
 // Put implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
-	extra ExtraMetadata) error {
+	extra ExtraMetadata) (err error) {
+	md.log.LazyTrace(ctx, "MDServer: put %s %d", rmds.MD.TlfID(), rmds.MD.RevisionNumber())
+	defer func() {
+		md.log.LazyTrace(ctx, "MDServer: put %s %d done (err=%v)", rmds.MD.TlfID(), rmds.MD.RevisionNumber(), err)
+	}()
+
 	// encode MD block
 	rmdsBytes, err := EncodeRootMetadataSigned(md.config.Codec(), rmds)
 	if err != nil {
@@ -587,7 +601,11 @@ func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
 }
 
 // PruneBranch implements the MDServer interface for MDServerRemote.
-func (md *MDServerRemote) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error {
+func (md *MDServerRemote) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) (err error) {
+	md.log.LazyTrace(ctx, "MDServer: prune %s %s", id, bid)
+	defer func() {
+		md.log.LazyTrace(ctx, "MDServer: prune %s %s (err=%v)", id, bid, err)
+	}()
 	arg := keybase1.PruneBranchArg{
 		FolderID: id.String(),
 		BranchID: bid.String(),
@@ -736,24 +754,35 @@ func (md *MDServerRemote) RegisterForUpdate(ctx context.Context, id tlf.ID,
 
 // TruncateLock implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) TruncateLock(ctx context.Context, id tlf.ID) (
-	bool, error) {
+	locked bool, err error) {
+	md.log.LazyTrace(ctx, "MDServer: TruncateLock %s", id)
+	defer func() {
+		md.log.LazyTrace(ctx, "MDServer: TruncateLock %s (err=%v)", id, err)
+	}()
 	return md.getClient().TruncateLock(ctx, id.String())
 }
 
 // TruncateUnlock implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) TruncateUnlock(ctx context.Context, id tlf.ID) (
-	bool, error) {
+	unlocked bool, err error) {
+	md.log.LazyTrace(ctx, "MDServer: TruncateLock %s", id)
+	defer func() {
+		md.log.LazyTrace(ctx, "MDServer: TruncateLock %s (err=%v)", id, err)
+	}()
 	return md.getClient().TruncateUnlock(ctx, id.String())
 }
 
 // GetLatestHandleForTLF implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (
-	tlf.Handle, error) {
+	handle tlf.Handle, err error) {
+	md.log.LazyTrace(ctx, "MDServer: GetLatestHandle %s", id)
+	defer func() {
+		md.log.LazyTrace(ctx, "MDServer: GetLatestHandle %s (err=%v)", id, err)
+	}()
 	buf, err := md.getClient().GetLatestFolderHandle(ctx, id.String())
 	if err != nil {
 		return tlf.Handle{}, err
 	}
-	var handle tlf.Handle
 	if err := md.config.Codec().Decode(buf, &handle); err != nil {
 		return tlf.Handle{}, err
 	}
@@ -844,6 +873,11 @@ func (md *MDServerRemote) GetTLFCryptKeyServerHalf(ctx context.Context,
 	serverHalfID TLFCryptKeyServerHalfID,
 	cryptKey kbfscrypto.CryptPublicKey) (
 	serverHalf kbfscrypto.TLFCryptKeyServerHalf, err error) {
+	md.log.LazyTrace(ctx, "KeyServer: GetTLFCryptKeyServerHalf %s", serverHalfID)
+	defer func() {
+		md.log.LazyTrace(ctx, "KeyServer: GetTLFCryptKeyServerHalf %s (err=%v)", serverHalfID, err)
+	}()
+
 	// encode the ID
 	idBytes, err := md.config.Codec().Encode(serverHalfID)
 	if err != nil {
@@ -872,7 +906,12 @@ func (md *MDServerRemote) GetTLFCryptKeyServerHalf(ctx context.Context,
 
 // PutTLFCryptKeyServerHalves is an implementation of the KeyServer interface.
 func (md *MDServerRemote) PutTLFCryptKeyServerHalves(ctx context.Context,
-	keyServerHalves UserDeviceKeyServerHalves) error {
+	keyServerHalves UserDeviceKeyServerHalves) (err error) {
+	md.log.LazyTrace(ctx, "KeyServer: PutTLFCryptKeyServerHalves %v", keyServerHalves)
+	defer func() {
+		md.log.LazyTrace(ctx, "KeyServer: PutTLFCryptKeyServerHalves %v (err=%v)", keyServerHalves, err)
+	}()
+
 	// flatten out the map into an array
 	var keyHalves []keybase1.KeyHalf
 	for user, deviceMap := range keyServerHalves {
@@ -900,7 +939,12 @@ func (md *MDServerRemote) PutTLFCryptKeyServerHalves(ctx context.Context,
 // DeleteTLFCryptKeyServerHalf is an implementation of the KeyServer interface.
 func (md *MDServerRemote) DeleteTLFCryptKeyServerHalf(ctx context.Context,
 	uid keybase1.UID, key kbfscrypto.CryptPublicKey,
-	serverHalfID TLFCryptKeyServerHalfID) error {
+	serverHalfID TLFCryptKeyServerHalfID) (err error) {
+	md.log.LazyTrace(ctx, "KeyServer: DeleteTLFCryptKeyServerHalf %s %s", uid, serverHalfID)
+	defer func() {
+		md.log.LazyTrace(ctx, "KeyServer: DeleteTLFCryptKeyServerHalf %s %s done (err=%v)", uid, serverHalfID, err)
+	}()
+
 	// encode the ID
 	idBytes, err := md.config.Codec().Encode(serverHalfID)
 	if err != nil {
@@ -969,7 +1013,11 @@ func (md *MDServerRemote) backgroundRekeyChecker(ctx context.Context) {
 // GetKeyBundles implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 	tlf tlf.ID, wkbID TLFWriterKeyBundleID, rkbID TLFReaderKeyBundleID) (
-	*TLFWriterKeyBundleV3, *TLFReaderKeyBundleV3, error) {
+	wkb *TLFWriterKeyBundleV3, rkb *TLFReaderKeyBundleV3, err error) {
+	md.log.LazyTrace(ctx, "KeyServer: GetKeyBundles %s %s %s", tlf, wkbID, rkbID)
+	defer func() {
+		md.log.LazyTrace(ctx, "KeyServer: GetKeyBundles %s %s %s done (err=%v)", tlf, wkbID, rkbID, err)
+	}()
 
 	arg := keybase1.GetKeyBundlesArg{
 		FolderID:       tlf.String(),
@@ -982,7 +1030,6 @@ func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 		return nil, nil, err
 	}
 
-	var wkb *TLFWriterKeyBundleV3
 	if response.WriterBundle.Bundle != nil {
 		if response.WriterBundle.Version != int(SegregatedKeyBundlesVer) {
 			err = fmt.Errorf("Unsupported writer bundle version: %d",
@@ -1006,7 +1053,6 @@ func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 		}
 	}
 
-	var rkb *TLFReaderKeyBundleV3
 	if response.ReaderBundle.Bundle != nil {
 		if response.ReaderBundle.Version != int(SegregatedKeyBundlesVer) {
 			err = fmt.Errorf("Unsupported reader bundle version: %d",

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -246,7 +246,7 @@ func (md *MDServerRemote) resetAuth(
 			if err := md.getFoldersForRekey(ctx, c); err != nil {
 				md.log.CWarningf(ctx, "getFoldersForRekey failed with %v", err)
 			}
-			md.log.CDebugf(ctx,
+			md.deferLog.CDebugf(ctx,
 				"requested list of folders for rekey")
 		}()
 	}

--- a/libkbfs/trace_logger.go
+++ b/libkbfs/trace_logger.go
@@ -1,0 +1,26 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/trace"
+)
+
+type traceLogger struct {
+	logger.Logger
+}
+
+// TODO: Override logger.Logger functions to trace log statements if
+// the right options are turned on.
+
+func (tl traceLogger) LazyTrace(
+	ctx context.Context, format string, args ...interface{}) {
+	if tr, ok := trace.FromContext(ctx); ok {
+		tr.LazyPrintf(format, args...)
+	}
+}


### PR DESCRIPTION
Use it to add tracing for remote BlockServer
and MDServer. Also add tracing to BlockOps.