### PR TITLE
vendor in changes to copy RPC tags out of context, instead of re-using array

### DIFF
--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
@@ -192,9 +192,6 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			return err
 		}
 		conn = tls.Client(baseConn, config)
-		if err := conn.(*tls.Conn).Handshake(); err != nil {
-			return err
-		}
 
 		// Disable SIGPIPE on platforms that require it (Darwin). See sigpipe_bsd.go.
 		return DisableSigPipe(baseConn)

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/connection.go
@@ -192,6 +192,9 @@ func (ct *ConnectionTransportTLS) Dial(ctx context.Context) (
 			return err
 		}
 		conn = tls.Client(baseConn, config)
+		if err := conn.(*tls.Conn).Handshake(); err != nil {
+			return err
+		}
 
 		// Disable SIGPIPE on platforms that require it (Darwin). See sigpipe_bsd.go.
 		return DisableSigPipe(baseConn)

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/context.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/context.go
@@ -1,8 +1,6 @@
 package rpc
 
-import (
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 // CtxRpcKey is a type defining the context key for the RPC context
 type CtxRpcKey int
@@ -21,16 +19,23 @@ func AddRpcTagsToContext(ctx context.Context, logTagsToAdd CtxRpcTags) context.C
 	currTags, ok := RpcTagsFromContext(ctx)
 	if !ok {
 		currTags = make(CtxRpcTags)
-		ctx = context.WithValue(ctx, CtxRpcTagsKey, currTags)
 	}
 	for key, tag := range logTagsToAdd {
 		currTags[key] = tag
 	}
-	return ctx
+
+	return context.WithValue(ctx, CtxRpcTagsKey, currTags)
 }
 
 // RpcTagsFromContext returns the tags being passed along with the given context.
 func RpcTagsFromContext(ctx context.Context) (CtxRpcTags, bool) {
 	logTags, ok := ctx.Value(CtxRpcTagsKey).(CtxRpcTags)
-	return logTags, ok
+	if ok {
+		ret := make(CtxRpcTags)
+		for k, v := range logTags {
+			ret[k] = v
+		}
+		return ret, true
+	}
+	return nil, false
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -293,10 +293,10 @@
 			"revisionTime": "2016-12-08T01:54:25Z"
 		},
 		{
-			"checksumSHA1": "h5M/0X8u48IKcVyFg/bTBt2Q/EY=",
+			"checksumSHA1": "VJXG0sarqZdiW3yV0WdtOMv3aRo=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "ed0755654131895e6bdaa3fbd828a35f4c8db799",
-			"revisionTime": "2017-03-30T19:15:56Z"
+			"revision": "a78b83e7f6a00a4840651615fff80f34144dce9c",
+			"revisionTime": "2017-04-26T21:05:15Z"
 		},
 		{
 			"checksumSHA1": "vecRkvbIBGmLUxH37v899JcgjO4=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -293,10 +293,10 @@
 			"revisionTime": "2016-12-08T01:54:25Z"
 		},
 		{
-			"checksumSHA1": "d2oUixwR6P1/pDb7NEu/cFmCKJc=",
+			"checksumSHA1": "h5M/0X8u48IKcVyFg/bTBt2Q/EY=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "68da9ff2336b22c496aa52a9e63f2589d7d4495e",
-			"revisionTime": "2017-04-03T19:16:51Z"
+			"revision": "ed0755654131895e6bdaa3fbd828a35f4c8db799",
+			"revisionTime": "2017-03-30T19:15:56Z"
 		},
 		{
 			"checksumSHA1": "vecRkvbIBGmLUxH37v899JcgjO4=",


### PR DESCRIPTION
Otherwise if two goroutines are trying to modify these log tags, then you can get concurrent map access panics.