### PR TITLE
mdserver_remote: use same connection in DoCommand handler

### DIFF
--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -707,10 +707,11 @@ func (md *MDServerRemote) RegisterForUpdate(ctx context.Context, id tlf.ID,
 
 	// register
 	var c chan error
-	err := md.getConn().DoCommand(ctx, "register", func(rawClient rpc.GenericClient) error {
+	conn := md.getConn()
+	err := conn.DoCommand(ctx, "register", func(rawClient rpc.GenericClient) error {
 		// set up the server to receive updates, since we may
 		// get disconnected between retries.
-		server := md.getConn().GetServer()
+		server := conn.GetServer()
 		err := server.Register(keybase1.MetadataUpdateProtocol(md))
 		if err != nil {
 			if _, ok := err.(rpc.AlreadyRegisteredError); !ok {


### PR DESCRIPTION
Calling `getConn()` within a `DoCommand` handler rpc function can
result in getting a different connection that the one `DoCommand` was
originally called on.  This new connection might not be initialized
yet, and so `conn.Server()` might return `nil`.

Instead, just use the same connection, since by the time the
`DoCommand` rpc function is invoke, we know the server will have been
set.  (The connection transport may have been shut down, but that
should error cleanly as we'd expect, and the caller can retry the RPC
over the new connection.)

Issue: KBFS-2130