### PR TITLE
ops: small truncate fixes

### DIFF
--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -1248,9 +1248,9 @@ func invertOpForLocalNotifications(oldOp op) (newOp op, err error) {
 			return nil, err
 		}
 	case *GCOp:
-		newOp = op
+		newOp = newGCOp(op.LatestRev)
 	case *resolutionOp:
-		newOp = op
+		newOp = newResolutionOp()
 	}
 
 	// Now reverse all the block updates.  Don't bother with bare Refs

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -867,10 +867,7 @@ func addToCollapsedWriteRange(writes []WriteRange,
 			// Truncate past the last write.
 			return append(head, wNew)
 		} else if mid[0].isTruncate() {
-			// Min truncate wins
-			if mid[0].Off < wNew.Off {
-				return append(head, mid[0])
-			}
+			// Later truncates always win.
 			return append(head, wNew)
 		} else if mid[0].Off < wNew.Off {
 			return append(head, WriteRange{

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -659,6 +659,11 @@ func TestOpsCollapseWriteRange(t *testing.T) {
 				}
 			} else {
 				op.addTruncate(off)
+				if lastByteIsTruncate && lastByte < off {
+					for k := lastByte; k < off; k++ {
+						file[k] = true // zero-fill
+					}
+				}
 				for k := off; k < fileSize; k++ {
 					file[k] = false
 				}
@@ -710,7 +715,7 @@ func TestCollapseWriteRangeWithLaterTruncate(t *testing.T) {
 	so := &syncOp{}
 	so.Writes = []WriteRange{{Off: 400, Len: 0}}
 	got := so.collapseWriteRange([]WriteRange{{Off: 0, Len: 0}})
-	expected := []WriteRange{{Off: 400, Len: 0}}
+	expected := []WriteRange{{Off: 0, Len: 400}, {Off: 400, Len: 0}}
 	require.True(t, reflect.DeepEqual(got, expected),
 		"Bad write collapse, got=%v, expected=%v", got, expected)
 }

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -706,6 +706,15 @@ func TestOpsCollapseWriteRange(t *testing.T) {
 	}
 }
 
+func TestCollapseWriteRangeWithLaterTruncate(t *testing.T) {
+	so := &syncOp{}
+	so.Writes = []WriteRange{{Off: 400, Len: 0}}
+	got := so.collapseWriteRange([]WriteRange{{Off: 0, Len: 0}})
+	expected := []WriteRange{{Off: 400, Len: 0}}
+	require.True(t, reflect.DeepEqual(got, expected),
+		"Bad write collapse, got=%v, expected=%v", got, expected)
+}
+
 func ExamplecoalesceWrites() {
 	fmt.Println(coalesceWrites(
 		[]WriteRange{{Off: 7, Len: 5}, {Off: 18, Len: 10},


### PR DESCRIPTION
* When collapsing writes, the later truncate always wins.
* When inverting ops, make copies of gcOps and resolutionOps, otherwise we're setting ourselves up for trouble.

Issue: KBFS-2076