### PR TITLE
test: call SyncAll after every `as` block

### DIFF
--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -390,6 +390,10 @@ func as(user username, fops ...fileOp) optionOp {
 			desc, err := runFileOp(ctx, fop)
 			ctx.expectSuccess(desc, err)
 		}
+
+		// Sync everything to disk after this round of operations.
+		err := ctx.engine.SyncAll(ctx.user, ctx.tlfName, ctx.tlfIsPublic)
+		ctx.expectSuccess("SyncAll", err)
 	}
 }
 

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -392,8 +392,10 @@ func as(user username, fops ...fileOp) optionOp {
 		}
 
 		// Sync everything to disk after this round of operations.
-		err := ctx.engine.SyncAll(ctx.user, ctx.tlfName, ctx.tlfIsPublic)
-		ctx.expectSuccess("SyncAll", err)
+		if !ctx.noSyncInit {
+			err := ctx.engine.SyncAll(ctx.user, ctx.tlfName, ctx.tlfIsPublic)
+			ctx.expectSuccess("SyncAll", err)
+		}
 	}
 }
 

--- a/test/engine.go
+++ b/test/engine.go
@@ -87,6 +87,9 @@ type Engine interface {
 	// GetMtime is called by the test harness as the given user to get
 	// the mtime of the given file.
 	GetMtime(u User, file Node) (mtime time.Time, err error)
+	// SyncAll is called by the test harness as the given user to
+	// flush all writes buffered in memory to disk.
+	SyncAll(u User, tlfName string, isPublic bool) (err error)
 
 	// All functions below don't take nodes so that they can be
 	// run before any real FS operations.

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -501,6 +501,19 @@ func (*fsEngine) GetMtime(u User, file Node) (mtime time.Time, err error) {
 	return fi.ModTime(), err
 }
 
+// SyncAll implements the Engine interface.
+func (e *fsEngine) SyncAll(
+	user User, tlfName string, isPublic bool) (err error) {
+	u := user.(*fsUser)
+	path := buildTlfPath(u, tlfName, isPublic)
+	f, err := os.OpenFile(path, os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Sync()
+}
+
 func fiTypeString(fi os.FileInfo) string {
 	m := fi.Mode()
 	switch {

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -518,7 +518,8 @@ func (e *fsEngine) SyncAll(
 	}
 	// Sadly golang doesn't support syncing on a directory handle, so
 	// we have to hack it by syncing directly with the KBFSOps
-	// instance.
+	// instance.  TODO: implement a `.kbfs_sync_all` file to be used
+	// here, or maybe use a direct OS syscall?
 	return u.config.KBFSOps().SyncAll(ctx, dir.GetFolderBranch())
 }
 

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -439,6 +439,21 @@ func (k *LibKBFS) SetMtime(u User, file Node, mtime time.Time) (err error) {
 	return kbfsOps.SetMtime(ctx, file.(libkbfs.Node), &mtime)
 }
 
+// SyncAll implements the Engine interface.
+func (k *LibKBFS) SyncAll(
+	u User, tlfName string, isPublic bool) (err error) {
+	config := u.(*libkbfs.ConfigLocal)
+
+	ctx, cancel := k.newContext(u)
+	defer cancel()
+	dir, err := getRootNode(ctx, config, tlfName, isPublic)
+	if err != nil {
+		return err
+	}
+
+	return config.KBFSOps().SyncAll(ctx, dir.GetFolderBranch())
+}
+
 // GetMtime implements the Engine interface.
 func (k *LibKBFS) GetMtime(u User, file Node) (mtime time.Time, err error) {
 	config := u.(*libkbfs.ConfigLocal)

--- a/test/sbs_test.go
+++ b/test/sbs_test.go
@@ -23,6 +23,7 @@ func TestTlfNameChangePrivate(t *testing.T) {
 		),
 		as(charlie,
 			expectError(initRoot(), "charlie does not have read access to directory /keybase/private/alice,bob,charlie@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("charlie", "charlie@twitter"),
@@ -54,6 +55,7 @@ func TestTlfNameChangePrivateWithoutObservation(t *testing.T) {
 		inPrivateTlf("alice,bob@twitter"),
 		as(bob,
 			expectError(initRoot(), "bob does not have read access to directory /keybase/private/alice,bob@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("bob", "bob@twitter"),
@@ -77,6 +79,7 @@ func TestSBSNewlyResolvedWritersPrivate(t *testing.T) {
 		as(bob,
 			expectError(mkfile("foo.txt", "hello world"),
 				"bob does not have read access to directory /keybase/private/alice,bob@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("bob", "bob@twitter"),
@@ -106,11 +109,13 @@ func TestTlfNameChangePublic(t *testing.T) {
 			read("alice.txt", "hello charlie"),
 			expectError(mkfile("bob.txt", "hello alice & charlie"),
 				"bob does not have write access to directory /keybase/public/alice,charlie@twitter"),
+			noSync(),
 		),
 		as(charlie,
 			read("alice.txt", "hello charlie"),
 			expectError(mkfile("charlie.txt", "hello alice"),
 				"charlie does not have write access to directory /keybase/public/alice,charlie@twitter"),
+			noSync(),
 			disableUpdates(),
 		),
 
@@ -170,7 +175,7 @@ func TestTlfNameChangePublicWithoutObservation(t *testing.T) {
 	test(t,
 		users("alice", "bob", "charlie"),
 		inPublicTlf("alice,charlie@twitter"),
-		as(charlie), // no-op to initialize the SBS folder
+		as(charlie, noSync()), // no-op to initialize the SBS folder
 		addNewAssertion("charlie", "charlie@twitter"),
 
 		inPublicTlfNonCanonical(
@@ -196,6 +201,7 @@ func TestSBSNewlyResolvedWritersPublic(t *testing.T) {
 		as(charlie,
 			expectError(mkfile("foo.txt", "hello world"),
 				"charlie does not have write access to directory /keybase/public/alice,charlie@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("charlie", "charlie@twitter"),
@@ -278,6 +284,7 @@ func TestSBSPromoteReaderToWriter(t *testing.T) {
 			read("alice.txt", "hello bob"),
 			expectError(mkfile("bob.txt", "hello alice"),
 				"bob does not have write access to directory /keybase/private/alice,bob@twitter#bob"),
+			noSync(),
 		),
 
 		addNewAssertion("bob", "bob@twitter"),
@@ -320,6 +327,7 @@ func TestSBSOnlyUnresolvedWriter(t *testing.T) {
 		as(alice,
 			expectError(mkfile("foo.txt", "hello world"),
 				"alice does not have read access to directory /keybase/private/alice@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("alice", "alice@twitter"),
@@ -348,9 +356,11 @@ func TestSBSMultipleResolutions(t *testing.T) {
 		),
 		as(bob,
 			expectError(initRoot(), "bob does not have read access to directory /keybase/private/alice,bob@twitter,charlie@twitter"),
+			noSync(),
 		),
 		as(charlie,
 			expectError(initRoot(), "charlie does not have read access to directory /keybase/private/alice,bob@twitter,charlie@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("bob", "bob@twitter"),
@@ -371,6 +381,7 @@ func TestSBSMultipleResolutions(t *testing.T) {
 		),
 		as(charlie,
 			expectError(initRoot(), "charlie does not have read access to directory /keybase/private/alice,bob,charlie@twitter"),
+			noSync(),
 		),
 
 		inPrivateTlf("alice,bob,charlie@twitter"),
@@ -386,6 +397,7 @@ func TestSBSMultipleResolutions(t *testing.T) {
 		),
 		as(charlie,
 			expectError(initRoot(), "charlie does not have read access to directory /keybase/private/alice,bob,charlie@twitter"),
+			noSync(),
 		),
 
 		addNewAssertion("charlie", "charlie@twitter"),
@@ -455,6 +467,7 @@ func TestSBSConflicts(t *testing.T) {
 		),
 		as(charlie,
 			expectError(initRoot(), "charlie does not have read access to directory /keybase/private/alice,bob,charlie@twitter"),
+			noSync(),
 		),
 
 		inPrivateTlf("alice,bob@twitter,charlie@twitter"),
@@ -463,9 +476,11 @@ func TestSBSConflicts(t *testing.T) {
 		),
 		as(bob,
 			expectError(initRoot(), "bob does not have read access to directory /keybase/private/alice,bob@twitter,charlie@twitter"),
+			noSync(),
 		),
 		as(charlie,
 			expectError(initRoot(), "charlie does not have read access to directory /keybase/private/alice,bob@twitter,charlie@twitter"),
+			noSync(),
 		),
 
 		inPrivateTlf("alice,bob,charlie"),


### PR DESCRIPTION
A coming PR will require that `SyncAll` is called before directory changes are visible to other users, so this makes that invisible to DSL tests by automatically doing it at the end of every `as` block.

Issue: KBFS-2076