### PR TITLE
cr_chains: various fixes needed for KBFS-2076

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -975,7 +975,8 @@ func (ccs *crChains) copyOpAndRevertUnrefsToOriginals(currOp op) op {
 	return newOp
 }
 
-// changeOriginal converts the original of a chain to a different original.
+// changeOriginal converts the original of a chain to a different
+// original, which originated in some other branch.
 func (ccs *crChains) changeOriginal(oldOriginal BlockPointer,
 	newOriginal BlockPointer) error {
 	chain, ok := ccs.byOriginal[oldOriginal]
@@ -998,7 +999,8 @@ func (ccs *crChains) changeOriginal(oldOriginal BlockPointer,
 	}
 	if _, ok := ccs.createdOriginals[oldOriginal]; ok {
 		delete(ccs.createdOriginals, oldOriginal)
-		ccs.createdOriginals[newOriginal] = true
+		// We're swapping in an original made on some other branch, so
+		// it shouldn't go in the `createdOriginals` map.
 	}
 	if ri, ok := ccs.renamedOriginals[oldOriginal]; ok {
 		delete(ccs.renamedOriginals, oldOriginal)

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -243,6 +243,11 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 
 	parentOriginal, ok := chains.originals[parentDir]
 	if !ok {
+		if chains.isDeleted(parentDir) {
+			// If the parent's been deleted, it doesn't matter whether
+			// we find the type or not.
+			return nil
+		}
 		return NoChainFoundError{parentDir}
 	}
 

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -991,11 +991,6 @@ func (ccs *crChains) changeOriginal(oldOriginal BlockPointer,
 	chain.original = newOriginal
 	ccs.byOriginal[newOriginal] = chain
 	ccs.originals[oldOriginal] = newOriginal
-	if chain.mostRecent == oldOriginal {
-		chain.mostRecent = newOriginal
-		delete(ccs.byMostRecent, oldOriginal)
-		ccs.byMostRecent[newOriginal] = chain
-	}
 
 	if _, ok := ccs.deletedOriginals[oldOriginal]; ok {
 		delete(ccs.deletedOriginals, oldOriginal)


### PR DESCRIPTION
A few issues found while preparing KBFS-2076 (these will be tested in the final PR in this series):

* When merging an unmerged file with a merged one in a non-conflicting way (for example, because two directories of the same name were created simultaneously and need to be merged), `changeOriginal` should only update the "original" pointer on the chain, not the "most recent" pointer, which should remain whatever it was in the unmerged branch until CR finishes.
* Also, `changeOriginal` doesn't imply that the unmerged branch created the original; it was actually created in the merged branch!
* When trying to find the type of a directory entry and the entry doesn't exist, give up gracefully if it's already been deleted (by some later operation), since we don't really need to know the type and it's no use erroring in that case.

Issue: KBFS-2076