### PR TITLE
cr: merge new, truncated files

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -467,7 +467,7 @@ func createdFileWithConflictingWrite(unmergedChains, mergedChains *crChains,
 	}
 
 	// If the merged one is just a truncate, we can safely ignore
-	// the unmerged chain.
+	// the merged chain.
 	if len(mergedWriteRange) == 1 && mergedWriteRange[0].isTruncate() &&
 		mergedWriteRange[0].Off == 0 {
 		mergedChain.removeSyncOps()


### PR DESCRIPTION
A future commit will immediately truncate every newly-created file, in
order to mark it dirty.  To avoid unnecessary conflicts, we should
treat the same file name that's only been truncated as mergeable
everywhere in the CR code, not just during action computation.

Issue: KBFS-2076