### PR TITLE
folder_branch_ops: don't ref/unref pointers within same MD

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2889,6 +2889,10 @@ func (fbo *folderBranchOps) CreateLink(
 func (fbo *folderBranchOps) unrefEntry(ctx context.Context,
 	lState *lockState, md *RootMetadata, dir path, de DirEntry,
 	name string) error {
+	if de.Type == Sym {
+		return nil
+	}
+
 	md.AddUnrefBlock(de.BlockInfo)
 	// construct a path for the child so we can unlink with it.
 	childPath := dir.ChildPath(name, de.BlockPointer)


### PR DESCRIPTION
This is a no-op until a later PR cached directory ops in `fbo.dirOps`.

Issue: KBFS-2076