### PR TITLE
libkbfs: fix deCache to update timestamps better, and store unlinked DirEntrys in the NodeCache

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1027,7 +1027,7 @@ func (fbo *folderBlockOps) ClearCachedDirEntry(lState *lockState, dir path) {
 	// in there as well.)
 }
 
-func (fbo *folderBlockOps) updateDirtyEntryLocked(
+func (fbo *folderBlockOps) updateDirtyEntryFromCacheLocked(
 	ctx context.Context, lState *lockState, de DirEntry) (
 	updated bool, newDe DirEntry) {
 	fbo.blockLock.AssertAnyLocked(lState)
@@ -1133,7 +1133,7 @@ func (fbo *folderBlockOps) updateWithDirtyEntriesLocked(ctx context.Context,
 			continue
 		}
 
-		doUpdate, newDe := fbo.updateDirtyEntryLocked(ctx, lState, v)
+		doUpdate, newDe := fbo.updateDirtyEntryFromCacheLocked(ctx, lState, v)
 		if !doUpdate {
 			continue
 		}
@@ -1233,7 +1233,7 @@ func (fbo *folderBlockOps) getDirtyParentAndEntryLocked(ctx context.Context,
 			}
 			de = fbo.nodeCache.UnlinkedDirEntry(node)
 			// It's possible the unlinked file has been updated.
-			_, de = fbo.updateDirtyEntryLocked(ctx, lState, de)
+			_, de = fbo.updateDirtyEntryFromCacheLocked(ctx, lState, de)
 		} else {
 			return nil, DirEntry{}, NoSuchNameError{name}
 		}
@@ -1298,7 +1298,7 @@ func (fbo *folderBlockOps) UpdateDirtyEntry(
 	ctx context.Context, lState *lockState, de DirEntry) DirEntry {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	_, newDe := fbo.updateDirtyEntryLocked(ctx, lState, de)
+	_, newDe := fbo.updateDirtyEntryFromCacheLocked(ctx, lState, de)
 	return newDe
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -131,8 +131,8 @@ type deCacheEntry struct {
 	// been added to the DirBlock for the BlockPointer that maps to
 	// this struct.
 	adds map[string]BlockPointer
-	// dels are the name that have been removed from the DirBlock
-	// for the BlockPointer that maps to this struct.
+	// dels is a set of the names that have been removed from the
+	// DirBlock for the BlockPointer that maps to this struct.
 	dels map[string]bool
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -906,6 +906,11 @@ func (fbo *folderBlockOps) RenameDirEntryInCache(lState *lockState,
 	newDe DirEntry) (deleteTargetDirEntry bool) {
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
+	if newParent.tailPointer() == oldParent.tailPointer() &&
+		oldName == newName {
+		// Noop
+		return false
+	}
 	fbo.addDirEntryInCacheLocked(lState, newParent, newName, newDe)
 	fbo.removeDirEntryInCacheLocked(lState, oldParent, oldName)
 	// If there's already an entry for the target, only update the

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4108,15 +4108,13 @@ func (fbo *folderBranchOps) searchForNode(ctx context.Context,
 	return n, nil
 }
 
-func (fbo *folderBranchOps) unlinkFromCache(
-	op op, unlinkPath path, unlinkDe DirEntry) error {
-
-	return nil
-}
-
 func (fbo *folderBranchOps) getUnlinkPathBeforeUpdatingPointers(
 	ctx context.Context, lState *lockState, md ReadOnlyRootMetadata, op op) (
 	unlinkPath path, unlinkDe DirEntry, toUnlink bool, err error) {
+	if len(md.data.Changes.Ops) == 0 {
+		return path{}, DirEntry{}, false, errors.New("md needs at least one op")
+	}
+
 	var node Node
 	var childName string
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1818,6 +1818,7 @@ func (fbo *folderBranchOps) statEntry(ctx context.Context, node Node) (
 	} else {
 		// nodePath is just the root.
 		de = md.data.Dir
+		de = fbo.blocks.UpdateDirtyEntry(ctx, lState, de)
 	}
 
 	return de, nil
@@ -2555,14 +2556,18 @@ func (fbo *folderBranchOps) createEntryLocked(
 	if err != nil {
 		return nil, DirEntry{}, err
 	}
+
+	now := fbo.nowUnixNano()
 	de := DirEntry{
 		BlockInfo: BlockInfo{
 			BlockPointer: newPtr,
 			EncodedSize:  0,
 		},
 		EntryInfo: EntryInfo{
-			Type: entryType,
-			Size: 0,
+			Type:  entryType,
+			Size:  0,
+			Mtime: now,
+			Ctime: now,
 		},
 	}
 	fbo.blocks.AddDirEntryInCache(lState, dirPath, name, de)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1802,7 +1802,7 @@ func (fbo *folderBranchOps) statEntry(ctx context.Context, node Node) (
 	}
 
 	if nodePath.hasValidParent() {
-		de, err = fbo.blocks.GetDirtyEntry(
+		de, err = fbo.blocks.GetDirtyEntryEvenIfDeleted(
 			ctx, lState, md.ReadOnly(), nodePath)
 		if err != nil {
 			return DirEntry{}, err

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1694,6 +1694,9 @@ type NodeCache interface {
 	// already that shouldn't be reflected in the cached path.
 	// Returns whether a node was actually updated.
 	Unlink(ref BlockRef, oldPath path) bool
+	// IsUnlinked returns whether `Unlink` has been called for the
+	// reference behind this node.
+	IsUnlinked(node Node) bool
 	// PathFromNode creates the path up to a given Node.
 	PathFromNode(node Node) path
 	// AllNodes returns the complete set of nodes currently in the cache.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1693,10 +1693,14 @@ type NodeCache interface {
 	// because the caller may have made changes to the parent nodes
 	// already that shouldn't be reflected in the cached path.
 	// Returns whether a node was actually updated.
-	Unlink(ref BlockRef, oldPath path) bool
+	Unlink(ref BlockRef, oldPath path, oldDe DirEntry) bool
 	// IsUnlinked returns whether `Unlink` has been called for the
 	// reference behind this node.
 	IsUnlinked(node Node) bool
+	// UnlinkedDirEntry returns a pointer to a modifiable directory
+	// entry if `Unlink` has been called for the reference behind this
+	// node.
+	UnlinkedDirEntry(node Node) DirEntry
 	// PathFromNode creates the path up to a given Node.
 	PathFromNode(node Node) path
 	// AllNodes returns the complete set of nodes currently in the cache.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1049,7 +1049,7 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 	}
 	node := pathNode{makeBP(rootID, rmd, config, u), "p"}
 	aNode := pathNode{makeBP(aID, rmd, config, u), "a"}
-	bNode := pathNode{makeBP(bID, rmd, config, u), "b"}
+	bNode := pathNode{dirBlock.Children["b"].BlockPointer, "b"}
 	p := path{FolderBranch{Tlf: id}, []pathNode{node, aNode, bNode}}
 	n := nodeFromPath(t, ops, p)
 
@@ -3604,7 +3604,8 @@ func TestKBFSOpsRenameSameDirSyncAll(t *testing.T) {
 		}
 
 		_ = ops.blocks.RenameDirEntryInCache(
-			lState, rootDir, name, rootDir, newName, dblock.Children[name])
+			lState, rootDir, name, rootDir, newName, dblock.Children[name],
+			DirEntry{})
 		ops.dirOps = append(ops.dirOps, cachedDirOp{ro, []Node{rootNode}})
 	}
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3545,7 +3545,7 @@ func TestKBFSOpsRemoveSyncAll(t *testing.T) {
 		ro.AddUnrefBlock(filePath.tailPointer())
 
 		lState := makeFBOLockState()
-		ops.blocks.RemoveDirEntryInCache(lState, rootDir, name)
+		ops.blocks.RemoveDirEntryInCache(lState, rootDir, name, DirEntry{})
 		ops.dirOps = append(ops.dirOps, cachedDirOp{ro, []Node{rootNode}})
 	}
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3584,7 +3584,7 @@ func TestKBFSOpsRenameSameDirSyncAll(t *testing.T) {
 
 	// Manually rename a file without actually syncing it.
 	// TODO(KBFS-2076) remove all this duplicated code.
-	newName := "myfile"
+	newName := "myfile2"
 	ops := getOps(config, rootNode.GetFolderBranch().Tlf)
 	{
 		rootDir := ops.nodeCache.PathFromNode(rootNode)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5191,14 +5191,14 @@ func (_mr *_MockNodeCacheRecorder) Move(arg0, arg1, arg2 interface{}) *gomock.Ca
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Move", arg0, arg1, arg2)
 }
 
-func (_m *MockNodeCache) Unlink(ref BlockRef, oldPath path) bool {
-	ret := _m.ctrl.Call(_m, "Unlink", ref, oldPath)
+func (_m *MockNodeCache) Unlink(ref BlockRef, oldPath path, oldDe DirEntry) bool {
+	ret := _m.ctrl.Call(_m, "Unlink", ref, oldPath, oldDe)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-func (_mr *_MockNodeCacheRecorder) Unlink(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unlink", arg0, arg1)
+func (_mr *_MockNodeCacheRecorder) Unlink(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unlink", arg0, arg1, arg2)
 }
 
 func (_m *MockNodeCache) IsUnlinked(node Node) bool {
@@ -5209,6 +5209,16 @@ func (_m *MockNodeCache) IsUnlinked(node Node) bool {
 
 func (_mr *_MockNodeCacheRecorder) IsUnlinked(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsUnlinked", arg0)
+}
+
+func (_m *MockNodeCache) UnlinkedDirEntry(node Node) DirEntry {
+	ret := _m.ctrl.Call(_m, "UnlinkedDirEntry", node)
+	ret0, _ := ret[0].(DirEntry)
+	return ret0
+}
+
+func (_mr *_MockNodeCacheRecorder) UnlinkedDirEntry(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "UnlinkedDirEntry", arg0)
 }
 
 func (_m *MockNodeCache) PathFromNode(node Node) path {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5201,6 +5201,16 @@ func (_mr *_MockNodeCacheRecorder) Unlink(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Unlink", arg0, arg1)
 }
 
+func (_m *MockNodeCache) IsUnlinked(node Node) bool {
+	ret := _m.ctrl.Call(_m, "IsUnlinked", node)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+func (_mr *_MockNodeCacheRecorder) IsUnlinked(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsUnlinked", arg0)
+}
+
 func (_m *MockNodeCache) PathFromNode(node Node) path {
 	ret := _m.ctrl.Call(_m, "PathFromNode", node)
 	ret0, _ := ret[0].(path)

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -16,6 +16,7 @@ type nodeCore struct {
 	cache    *nodeCacheStandard
 	// used only when parent is nil (the object has been unlinked)
 	cachedPath path
+	cachedDe   DirEntry
 }
 
 func newNodeCore(ptr BlockPointer, name string, parent *nodeStandard,

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -232,10 +232,29 @@ func (ncs *nodeCacheStandard) Unlink(ref BlockRef, oldPath path) bool {
 		return false
 	}
 
+	if entry.core.cachedPath.isValid() {
+		// Already unlinked!
+		return true
+	}
+
 	entry.core.cachedPath = oldPath
 	entry.core.parent = nil
 	entry.core.pathNode.Name = ""
 	return true
+}
+
+// IsUnlinked implements the NodeCache interface for
+// nodeCacheStandard.
+func (ncs *nodeCacheStandard) IsUnlinked(node Node) bool {
+	ncs.lock.RLock()
+	defer ncs.lock.RUnlock()
+
+	ns, ok := node.(*nodeStandard)
+	if !ok {
+		return false
+	}
+
+	return ns.core.cachedPath.isValid()
 }
 
 // PathFromNode implements the NodeCache interface for nodeCacheStandard.

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -214,7 +214,8 @@ func (ncs *nodeCacheStandard) Move(
 }
 
 // Unlink implements the NodeCache interface for nodeCacheStandard.
-func (ncs *nodeCacheStandard) Unlink(ref BlockRef, oldPath path) bool {
+func (ncs *nodeCacheStandard) Unlink(
+	ref BlockRef, oldPath path, oldDe DirEntry) bool {
 	if ref == (BlockRef{}) {
 		return false
 	}
@@ -238,6 +239,7 @@ func (ncs *nodeCacheStandard) Unlink(ref BlockRef, oldPath path) bool {
 	}
 
 	entry.core.cachedPath = oldPath
+	entry.core.cachedDe = oldDe
 	entry.core.parent = nil
 	entry.core.pathNode.Name = ""
 	return true
@@ -255,6 +257,20 @@ func (ncs *nodeCacheStandard) IsUnlinked(node Node) bool {
 	}
 
 	return ns.core.cachedPath.isValid()
+}
+
+// UnlinkedDirEntry implements the NodeCache interface for
+// nodeCacheStandard.
+func (ncs *nodeCacheStandard) UnlinkedDirEntry(node Node) DirEntry {
+	ncs.lock.RLock()
+	defer ncs.lock.RUnlock()
+
+	ns, ok := node.(*nodeStandard)
+	if !ok {
+		return DirEntry{}
+	}
+
+	return ns.core.cachedDe
 }
 
 // PathFromNode implements the NodeCache interface for nodeCacheStandard.

--- a/libkbfs/node_cache_test.go
+++ b/libkbfs/node_cache_test.go
@@ -278,7 +278,8 @@ func TestNodeCacheUnlink(t *testing.T) {
 	childPtr2 := path2[2].BlockPointer
 
 	// unlink child2
-	found := ncs.Unlink(childPtr2.Ref(), ncs.PathFromNode(childNode2))
+	found := ncs.Unlink(
+		childPtr2.Ref(), ncs.PathFromNode(childNode2), DirEntry{})
 	if !found {
 		t.Fatalf("Couldn't unlink")
 	}
@@ -301,7 +302,8 @@ func TestNodeCacheUnlinkParent(t *testing.T) {
 	childPtr1 := path2[1].BlockPointer
 
 	// unlink node 2's parent
-	found := ncs.Unlink(childPtr1.Ref(), ncs.PathFromNode(childNode1))
+	found := ncs.Unlink(
+		childPtr1.Ref(), ncs.PathFromNode(childNode1), DirEntry{})
 	if !found {
 		t.Fatalf("Couldn't unlink")
 	}
@@ -325,7 +327,8 @@ func TestNodeCacheUnlinkThenRelink(t *testing.T) {
 	childPtr2 := path2[2].BlockPointer
 
 	// unlink child2
-	found := ncs.Unlink(childPtr2.Ref(), ncs.PathFromNode(childNode2))
+	found := ncs.Unlink(
+		childPtr2.Ref(), ncs.PathFromNode(childNode2), DirEntry{})
 	if !found {
 		t.Fatalf("Couldn't unlink")
 	}


### PR DESCRIPTION
This PR does two somewhat related things that are needed for the rest of KBFS-2076:

1. It updates the parent mtime/ctime on creates and removes, and stores those changes in the `deCache`.  These changes need to be applied when looking up the directory in the future.  But we might not want to replace the entire `DirEntry` because our cached copy might not have a proper `BlockPointer` or other important data, so update carefully.
2. When a file is unlinked, there might still be a handle lying around for it in some application.  That handle still has a right to the node's DirEntry.  Previously we were storing it in the `deCache`, so a) it would only survive until the next `SyncAll`, even though the handle might live past that, and b) when processing directory adds, we might end up using the new DirEntry for an entry that was renamed over the one we had the handle for.  Instead, this stores the DirEntry alongside the `Node` object itself that's associated with the handle, so we can't lose track of it before the handle itself goes away.

Issue: KBFS-2076