### PR TITLE
tests: add `SyncAll` calls to a bunch of tests that modify directories

### DIFF
--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -1826,7 +1826,7 @@ func TestInvalidateDataOnWrite(t *testing.T) {
 	defer libkbfs.CleanupCancellationDelayer(ctx)
 	config := libkbfs.MakeTestConfigOrBust(t, "jdoe", "wsmith")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config)
+	mnt1, _, cancelFn1 := makeFS(t, ctx, config)
 	defer mnt1.Close()
 	defer cancelFn1()
 	mnt2, fs2, cancelFn2 := makeFSE(t, ctx, config, 'U')
@@ -2182,7 +2182,7 @@ func TestInvalidateAcrossMounts(t *testing.T) {
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1",
 		"user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 
@@ -2455,7 +2455,7 @@ func TestUnstageFile(t *testing.T) {
 	defer libkbfs.CleanupCancellationDelayer(ctx)
 	config1 := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config1)
-	mnt1, _, cancelFn1 := makeFS(t, ctx, config1)
+	mnt1, fs1, cancelFn1 := makeFS(t, ctx, config1)
 	defer mnt1.Close()
 	defer cancelFn1()
 

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -37,9 +37,17 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 	if err != nil {
 		t.Fatalf("Couldn't create dir: %+v", err)
 	}
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync all: %v", err)
+	}
 	err = kbfsOps.RemoveDir(ctx, rootNode, "a")
 	if err != nil {
 		t.Fatalf("Couldn't remove dir: %+v", err)
+	}
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync all: %v", err)
 	}
 
 	// Wait for outstanding archives
@@ -83,6 +91,10 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 	_, _, err = kbfsOps.CreateDir(ctx, rootNode, "b")
 	if err != nil {
 		t.Fatalf("Couldn't create dir: %+v", err)
+	}
+	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync all: %v", err)
 	}
 
 	preQR2Blocks, err := bserverLocal.getAllRefsForTest(
@@ -165,9 +177,17 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Couldn't create dir: %+v", err)
 		}
+		err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+		if err != nil {
+			t.Fatalf("Couldn't sync all: %v", err)
+		}
 		err = kbfsOps.RemoveDir(ctx, rootNode, "a")
 		if err != nil {
 			t.Fatalf("Couldn't remove dir: %+v", err)
+		}
+		err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+		if err != nil {
+			t.Fatalf("Couldn't sync all: %v", err)
 		}
 	}
 
@@ -307,6 +327,10 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't remove file: %+v", err)
 	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	// Wait for outstanding archives
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
@@ -359,6 +383,10 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 	err = kbfsOps2.Write(ctx, dNode, otherData, 0)
 	if err != nil {
 		t.Fatalf("Couldn't write file: %+v", err)
@@ -378,6 +406,10 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	eNode, _, err := kbfsOps2.CreateFile(ctx, rootNode2, "e", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create dir: %+v", err)
+	}
+	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 	err = kbfsOps2.Write(ctx, eNode, data, 0)
 	if err != nil {
@@ -697,9 +729,17 @@ func TestQuotaReclamationGCOpsForGCOps(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Couldn't create dir: %+v", err)
 		}
+		err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+		if err != nil {
+			t.Fatalf("Couldn't sync all: %v", err)
+		}
 		err = kbfsOps.RemoveDir(ctx, rootNode, "a")
 		if err != nil {
 			t.Fatalf("Couldn't remove dir: %+v", err)
+		}
+		err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+		if err != nil {
+			t.Fatalf("Couldn't sync all: %v", err)
 		}
 	}
 	clock.Add(2 * config.QuotaReclamationMinUnrefAge())

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -704,7 +704,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 		fbo.setBranchIDLocked(lState, md.BID())
 		// Use uninitialized for the merged branch; the unmerged
 		// revision is enough to trigger conflict resolution.
-		fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
+		fbo.cr.Resolve(ctx, md.Revision(), MetadataRevisionUninitialized)
 	} else if md.MergedStatus() == Merged {
 		journalEnabled := TLFJournalEnabled(fbo.config, fbo.id())
 		if journalEnabled {
@@ -2196,7 +2196,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 	// Call Resolve() after the head is set, to make sure it fetches
 	// the correct unmerged MD range during resolution.
 	if doResolve {
-		fbo.cr.Resolve(md.Revision(), resolveMergedRev)
+		fbo.cr.Resolve(ctx, md.Revision(), resolveMergedRev)
 	}
 	return nil
 }
@@ -2277,7 +2277,7 @@ func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 	if rebased {
 		bid := md.BID()
 		fbo.setBranchIDLocked(lState, bid)
-		fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
+		fbo.cr.Resolve(ctx, md.Revision(), MetadataRevisionUninitialized)
 	}
 
 	md.loadCachedBlockChanges(ctx, nil, fbo.log)
@@ -2364,7 +2364,7 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 	if rebased {
 		bid := md.BID()
 		fbo.setBranchIDLocked(lState, bid)
-		fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
+		fbo.cr.Resolve(ctx, md.Revision(), MetadataRevisionUninitialized)
 	}
 
 	fbo.headLock.Lock(lState)
@@ -4508,7 +4508,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			if fbo.head != (ImmutableRootMetadata{}) {
 				unmergedRev = fbo.head.Revision()
 			}
-			fbo.cr.Resolve(unmergedRev, latestMerged.Revision())
+			fbo.cr.Resolve(ctx, unmergedRev, latestMerged.Revision())
 		}
 		return UnmergedError{}
 	}
@@ -5805,7 +5805,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 
 	// Kick off conflict resolution and set the head to the correct branch.
 	fbo.setBranchIDLocked(lState, newBID)
-	fbo.cr.Resolve(md.Revision(), MetadataRevisionUninitialized)
+	fbo.cr.Resolve(ctx, md.Revision(), MetadataRevisionUninitialized)
 
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -912,6 +912,10 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
 
@@ -921,6 +925,10 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
@@ -982,6 +990,10 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	// add a third device for user 2
 	config2Dev3 := ConfigAsUser(config1, u2)
@@ -1028,6 +1040,10 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "d", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	// this device should be able to read now
@@ -1146,6 +1162,10 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver MetadataVer) 
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2Dev2)
@@ -1235,6 +1255,10 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver MetadataVer) {
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	t.Log("User 2 adds a device")
 	// The configs don't share a Keybase Daemon so we have to do it in all
@@ -1279,6 +1303,10 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver MetadataVer) {
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps2Dev2.SyncAll(ctx, root2dev2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	t.Log("User 1 syncs from the server")
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
@@ -1320,6 +1348,10 @@ func testKeyManagerReaderRekey(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	t.Log("User 1 adds a device")
@@ -1413,6 +1445,10 @@ func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	t.Log("User 2 adds a device")
@@ -1517,6 +1553,10 @@ func testKeyManagerRekeyBit(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
@@ -1683,6 +1723,10 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver Metadat
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2Dev2)
@@ -1764,6 +1808,10 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver Metadat
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps2Dev2.SyncAll(ctx, root2Dev2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	// device 1 should still work
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
@@ -1828,6 +1876,10 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
@@ -1909,6 +1961,10 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
 	}
+	err = kbfsOps2.SyncAll(ctx, rootNode2Dev2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
+	}
 
 	// device 1 should be able to read the new file
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
@@ -1949,6 +2005,10 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
@@ -2045,6 +2105,10 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2Dev2, "b", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps2.SyncAll(ctx, rootNode2Dev2.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 }
 
@@ -2189,6 +2253,10 @@ func testKeyManagerRekeyMinimal(t *testing.T, ver MetadataVer) {
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	if err != nil {
 		t.Fatalf("Couldn't create file: %+v", err)
+	}
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	if err != nil {
+		t.Fatalf("Couldn't sync file: %+v", err)
 	}
 
 	// Device 2 is in default mode, so we can check that the rekey

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -391,12 +391,16 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	require.NoError(t, err)
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	require.NoError(t, err)
 
 	kbfsOps2 := config2.KBFSOps()
 	err = kbfsOps2.SyncFromServerForTesting(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	require.NoError(t, err)
+	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -60,6 +60,10 @@ func TestRekeyQueueBasic(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Couldn't create file: %v", err)
 		}
+		err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+		if err != nil {
+			t.Fatalf("Couldn't sync all: %v", err)
+		}
 	}
 
 	// Create a new device for user 2

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -482,7 +482,7 @@ func RestartCRForTesting(baseCtx context.Context, config Config,
 	// Start a resolution for anything we've missed.
 	lState := makeFBOLockState()
 	if !ops.isMasterBranch(lState) {
-		ops.cr.Resolve(ops.getCurrMDRevision(lState),
+		ops.cr.Resolve(baseCtx, ops.getCurrMDRevision(lState),
 			MetadataRevisionUninitialized)
 	}
 	return nil

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -53,12 +53,16 @@ func TestBasicTlfEditHistory(t *testing.T) {
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 	require.NoError(t, err)
+	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
+	require.NoError(t, err)
 
 	kbfsOps2 := config2.KBFSOps()
 	err = kbfsOps2.SyncFromServerForTesting(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	_, _, err = kbfsOps2.CreateFile(ctx, rootNode2, "b", false, NoExcl)
+	require.NoError(t, err)
+	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
 	err = kbfsOps1.SyncFromServerForTesting(ctx, rootNode1.GetFolderBranch())
@@ -109,6 +113,8 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 	if i%(len(createRemainders)*2) == createRemainders[uid] {
 		_, _, err := kbfsOps.CreateDir(ctx, rootNode, fmt.Sprintf("dir%d", i))
 		require.NoError(t, err)
+		err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
+		require.NoError(t, err)
 	}
 
 	if i%len(createRemainders) == createRemainders[uid] {
@@ -116,6 +122,8 @@ func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 		fileName := fmt.Sprintf("file%d", i)
 		_, _, err := kbfsOps.CreateFile(ctx, rootNode,
 			fileName, false, NoExcl)
+		require.NoError(t, err)
+		err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 		require.NoError(t, err)
 		if i >= 70 {
 			edits[uid] = append(edits[uid], TlfEdit{
@@ -182,6 +190,8 @@ func TestLongTlfEditHistory(t *testing.T) {
 	for ; i < 50; i++ {
 		_, _, err := kbfsOps1.CreateFile(ctx, rootNode1,
 			fmt.Sprintf("file%d", i), false, NoExcl)
+		require.NoError(t, err)
+		err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
This will be needed once we turn on the feature in a future PR.  Note that this PR doesn't update *every* test, especially the complicated ones in `kbfs_cr_test.go` and `kbfs_ops_concur_test.go`, because those will require a bit more work than just a simple call to `SyncAll`.