### PR TITLE
cr: fix rename op handling for local notifications

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2420,7 +2420,7 @@ func (cr *ConflictResolver) makeRevertedOps(ctx context.Context,
 					}
 					op = rop
 
-					// If this renames from a destination that's been
+					// If this renames from a source that's been
 					// deleted by a previous op, we should replace the
 					// delete with this.
 					for i, prevOp := range ops {

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2722,7 +2722,16 @@ func (cr *ConflictResolver) getOpsForLocalNotification(ctx context.Context,
 	[]op, error) {
 	dummyOp := newResolutionOp()
 	newPtrs := make(map[BlockPointer]bool)
-	for original, newMostRecent := range updates {
+	for mergedMostRecent, newMostRecent := range updates {
+		// `updates` contains the pointer updates needed for devices
+		// on the merged branch to update; we have to find the
+		// original of the entire branch to find the corresponding
+		// unmerged most recent.
+		original, err :=
+			mergedChains.originalFromMostRecentOrSame(mergedMostRecent)
+		if err != nil {
+			return nil, err
+		}
 		chain, ok := unmergedChains.byOriginal[original]
 		if ok {
 			// If this unmerged node was updated in the resolution,

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -218,29 +218,18 @@ func prependOpsToChain(mostRecent BlockPointer, chains *crChains,
 func crActionConvertSymlink(unmergedMostRecent BlockPointer,
 	mergedMostRecent BlockPointer, unmergedChain *crChain,
 	mergedChains *crChains, fromName string, toName string) error {
-	// If this was turned into a symlink, then we have to simulate
-	// rm/create at the beginning of the mergedOps list.
-	ro, err := newRmOp(fromName, mergedMostRecent)
-	if err != nil {
-		return err
-	}
-	// Add a fake unref so this rm doesn't get mistaken for one
-	// half of a rename operation.
-	ro.AddUnrefBlock(zeroPtr)
 	co, err := newCreateOp(toName, mergedMostRecent, Sym)
 	if err != nil {
 		return err
 	}
 
-	// If the chain already exists, just append the operations instead
-	// of prepending them.  We don't want to do any rms of nodes that
-	// the merged chain might also touch (e.g., a double rename
-	// situation).
+	// If the chain already exists, just append the operation instead
+	// of prepending them.
 	chain, ok := mergedChains.byMostRecent[mergedMostRecent]
 	if ok {
-		chain.ops = append(chain.ops, ro, co)
+		chain.ops = append(chain.ops, co)
 	} else {
-		err := prependOpsToChain(mergedMostRecent, mergedChains, ro, co)
+		err := prependOpsToChain(mergedMostRecent, mergedChains, co)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -353,9 +353,16 @@ func (cuea *copyUnmergedEntryAction) updateOps(unmergedMostRecent BlockPointer,
 			fixupNamesInOps(cuea.fromName, cuea.toName, unmergedChain.ops,
 				unmergedChains)
 
-		// We need a local rename notification if the name changed.
-		makeLocalRenameOpForCopyAction(mergedMostRecent, mergedBlock,
-			mergedChains, cuea.fromName, cuea.toName)
+		if cuea.unique || cuea.symPath != "" {
+			// If a directory was renamed locally, either because of a
+			// direct conflict or because it was turned into a
+			// symlink, we need to fake a merged rename op from the
+			// unmerged name to the merged name, before creating the
+			// symlink, so the local Node objects are updated
+			// correctly.
+			makeLocalRenameOpForCopyAction(mergedMostRecent, mergedBlock,
+				mergedChains, cuea.fromName, cuea.toName)
+		}
 	}
 
 	// If the target is a file that had child blocks, we need to
@@ -440,10 +447,6 @@ func (cuaa *copyUnmergedAttrAction) updateOps(unmergedMostRecent BlockPointer,
 		unmergedChain.ops =
 			fixupNamesInOps(cuaa.fromName, cuaa.toName, unmergedChain.ops,
 				unmergedChains)
-
-		// We need a local rename notification if the name changed.
-		makeLocalRenameOpForCopyAction(mergedMostRecent, mergedBlock,
-			mergedChains, cuaa.fromName, cuaa.toName)
 	}
 	return nil
 }

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -224,7 +224,10 @@ func crActionConvertSymlink(unmergedMostRecent BlockPointer,
 	}
 
 	// If the chain already exists, just append the operation instead
-	// of prepending them.
+	// of prepending them.  If there was something else at that
+	// location in the unmerged branch, it should be moved out of the
+	// way first by a `renameOp` (see
+	// `makeLocalRenameOpForCopyAction()`).
 	chain, ok := mergedChains.byMostRecent[mergedMostRecent]
 	if ok {
 		chain.ops = append(chain.ops, co)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5679,9 +5679,19 @@ func (fbo *folderBranchOps) finalizeResolutionLocked(ctx context.Context,
 		fbo.fbm.archiveUnrefBlocks(irmd.ReadOnly())
 	}
 
+	mdCopyWithLocalOps, err := md.deepCopy(fbo.config.Codec())
+	if err != nil {
+		return err
+	}
+	mdCopyWithLocalOps.data.Changes.Ops = newOps
+	irmdCopyWithLocalOps := MakeImmutableRootMetadata(
+		mdCopyWithLocalOps, session.VerifyingKey, mdID,
+		fbo.config.Clock().Now())
+
 	// notifyOneOp for every fixed-up merged op.
 	for _, op := range newOps {
-		err := fbo.notifyOneOpLocked(ctx, lState, op, irmd, false, nil)
+		err := fbo.notifyOneOpLocked(
+			ctx, lState, op, irmdCopyWithLocalOps, false, nil)
 		if err != nil {
 			return err
 		}

--- a/test/cr_basic_conflicts_test.go
+++ b/test/cr_basic_conflicts_test.go
@@ -761,7 +761,7 @@ func TestCrConflictMergedRenameSetMtimeFile(t *testing.T) {
 	)
 }
 
-// alice and both both rename the same file, causing a copy.,
+// alice and both both rename the same file, causing a copy.
 func TestCrConflictRenameSameFile(t *testing.T) {
 	test(t,
 		users("alice", "bob"),

--- a/test/cr_basic_conflicts_test.go
+++ b/test/cr_basic_conflicts_test.go
@@ -761,7 +761,7 @@ func TestCrConflictMergedRenameSetMtimeFile(t *testing.T) {
 	)
 }
 
-// alice and both both rename(the same file, causing a copy.),
+// alice and both both rename the same file, causing a copy.,
 func TestCrConflictRenameSameFile(t *testing.T) {
 	test(t,
 		users("alice", "bob"),
@@ -794,7 +794,7 @@ func TestCrConflictRenameSameFile(t *testing.T) {
 	)
 }
 
-// alice and both both rename(the same executable file, causing a copy.),
+// alice and both both rename the same executable file, causing a copy.
 func TestCrConflictRenameSameEx(t *testing.T) {
 	test(t,
 		users("alice", "bob"),
@@ -828,7 +828,7 @@ func TestCrConflictRenameSameEx(t *testing.T) {
 	)
 }
 
-// alice and both both rename(the same symlink.),
+// alice and both both rename the same symlink.
 func TestCrConflictRenameSameSymlink(t *testing.T) {
 	test(t,
 		skip("dokan", "Does not work with Dokan."),
@@ -863,7 +863,7 @@ func TestCrConflictRenameSameSymlink(t *testing.T) {
 	)
 }
 
-// alice and bob both rename(the same directory, causing a symlink to),
+// alice and bob both rename the same directory, causing a symlink to
 // be created.
 func TestCrConflictRenameSameDir(t *testing.T) {
 	test(t,
@@ -897,7 +897,7 @@ func TestCrConflictRenameSameDir(t *testing.T) {
 	)
 }
 
-// alice and bob both rename(the same directory, causing a symlink to),
+// alice and bob both rename the same directory, causing a symlink to
 // be created.
 func TestCrConflictRenameSameDirUpward(t *testing.T) {
 	test(t,
@@ -936,7 +936,7 @@ func TestCrConflictRenameSameDirUpward(t *testing.T) {
 	)
 }
 
-// alice and bob both rename(the same directory, causing a symlink to),
+// alice and bob both rename the same directory, causing a symlink to
 // be created.
 func TestCrConflictRenameSameDirMergedUpward(t *testing.T) {
 	test(t,
@@ -1203,7 +1203,7 @@ func TestCrConflictWriteFileDoubleWithExtensions(t *testing.T) {
 	)
 }
 
-// bob causes a rename(cycle with a conflict while unstaged),
+// bob causes a rename cycle with a conflict while unstaged.
 func TestCrRenameCycleWithConflict(t *testing.T) {
 	test(t,
 		users("alice", "bob"),
@@ -1242,7 +1242,7 @@ func TestCrRenameCycleWithConflict(t *testing.T) {
 	)
 }
 
-// bob causes a rename(cycle with two conflicts while unstaged),
+// bob causes a rename cycle with two conflicts while unstaged.
 func TestCrRenameCycleWithTwoConflicts(t *testing.T) {
 	test(t,
 		users("alice", "bob"),
@@ -1282,7 +1282,7 @@ func TestCrRenameCycleWithTwoConflicts(t *testing.T) {
 	)
 }
 
-// bob causes a rename(cycle with two conflicts while unstaged),
+// bob causes a rename cycle with two conflicts while unstaged.
 func TestCrRenameCycleWithConflictAndMergedDir(t *testing.T) {
 	test(t,
 		users("alice", "bob"),


### PR DESCRIPTION
#941 makes us depend more on the `NodeCache` when stat'ing files, and that ended up exposing some issues where CR was incorrectly generating local notification op lists that messed up the node cache.  Specifically, when there's a `renameOp` in the local notifications list, several things could have been wrong:

1. CR might also have an `rmOp` in the list for the source of the `renameOp`, and due to golang map reordering, the `rmOp` might come beforethe `renameOp` in the notification list.  This led to the node entry being unlinked before being moved.  This PR makes sure the `renameOp` always comes first in that situation.
2. Sometimes `folderBranchOps.notifyOneOpLocked` needs to use the pointers in the MD ops list to search for the new parent `Node` of a renamed file.  However, during CR, the MD contains the "official" ops list that goes in the folder master branch, while the local client is being notified via the local list of ops, which is different.  Make sure these ops are the ones that are passed to `notifyOneOpLocked`.
3. Sometimes CR needs to rename a local directory entry, either because of a direct conflict or because it's getting turned into a symlink due to a double-rename.  In some of those cases, we were neglecting to generate a local notification to reflect this rename, and the node cache wasn't getting properly updated.

Issue: KBFS-2076