### PR TITLE
keybase_service_util: un-feature-flag disk block cache on login

### DIFF
--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -54,7 +54,7 @@ func serviceLoggedIn(ctx context.Context, config Config, name string,
 				"Failed to enable existing journals: %v", err)
 		}
 	}
-	if config.DiskBlockCache() == nil && adminFeatureList[session.UID] {
+	if config.DiskBlockCache() == nil {
 		dbc, err := newDiskBlockCacheStandard(config,
 			diskBlockCacheRootFromStorageRoot(config.StorageRoot()))
 		if err == nil {


### PR DESCRIPTION
If a non-admin user logged-in after KBFS initialized, they would never
get to use the disk block cache.