### PR TITLE
folder_branch_ops: save old block pointers in the blockPutState

### DIFF
--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -1684,6 +1684,7 @@ func (fd *fileData) readyHelper(ctx context.Context, id tlf.ID,
 
 			bps.addNewBlock(
 				newInfo.BlockPointer, pb.pblock, readyBlockData, syncFunc)
+			bps.saveOldPtr(ptr)
 
 			parentPB.pblock.IPtrs[parentPB.childIndex].BlockInfo = newInfo
 			oldPtrs[newInfo] = ptr

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1899,6 +1899,8 @@ func (bps *blockPutState) addNewBlock(
 		blockState{blockPtr, block, readyBlockData, syncedCb, zeroPtr})
 }
 
+// saveOldPtr stores the given BlockPointer as the old (pre-readied)
+// pointer for the most recent blockState.
 func (bps *blockPutState) saveOldPtr(oldPtr BlockPointer) {
 	bps.blockStates[len(bps.blockStates)-1].oldPtr = oldPtr
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1824,6 +1824,7 @@ type blockState struct {
 	block          Block
 	readyBlockData ReadyBlockData
 	syncedCb       func() error
+	oldPtr         BlockPointer
 }
 
 func (fbo *folderBranchOps) Stat(ctx context.Context, node Node) (
@@ -1891,10 +1892,15 @@ func newBlockPutState(length int) *blockPutState {
 // complete (whether or not the put resulted in an error).  Currently
 // it will not be called if the block is never put (due to an earlier
 // error).
-func (bps *blockPutState) addNewBlock(blockPtr BlockPointer, block Block,
+func (bps *blockPutState) addNewBlock(
+	blockPtr BlockPointer, block Block,
 	readyBlockData ReadyBlockData, syncedCb func() error) {
 	bps.blockStates = append(bps.blockStates,
-		blockState{blockPtr, block, readyBlockData, syncedCb})
+		blockState{blockPtr, block, readyBlockData, syncedCb, zeroPtr})
+}
+
+func (bps *blockPutState) saveOldPtr(oldPtr BlockPointer) {
+	bps.blockStates[len(bps.blockStates)-1].oldPtr = oldPtr
 }
 
 func (bps *blockPutState) mergeOtherBps(other *blockPutState) {

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -273,8 +273,10 @@ func (fup folderUpdatePrepper) prepUpdateForPath(
 
 		if prevIdx < 0 {
 			md.AddUpdate(md.data.Dir.BlockInfo, info)
+			bps.saveOldPtr(md.data.Dir.BlockPointer)
 		} else if prevDe, ok := prevDblock.Children[currName]; ok {
 			md.AddUpdate(prevDe.BlockInfo, info)
+			bps.saveOldPtr(prevDe.BlockPointer)
 		} else {
 			// this is a new block
 			md.AddRefBlock(info)
@@ -433,7 +435,8 @@ func (fup folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 			}
 		}
 
-		// TODO: fix mtime and ctime?
+		// Assume the mtime/ctime are already fixed up in the blocks
+		// in the lbc.
 		_, _, bps, err := fup.prepUpdateForPath(
 			ctx, lState, uid, newMD, block,
 			*node.mergedPath.parentPath(), node.mergedPath.tailName(),


### PR DESCRIPTION
Track the pre-ready block pointers in the blockPutState, so that in a
future commit SyncAll can figure out how to call `UpdatePointers` for
blocks that haven't yet been synced (and were given random
BlockPointers when they were created).

Issue: KBFS-2076