### PR TITLE
libkbfs: small file_data and cr_chains fixes needed for dir op batching

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -433,6 +433,23 @@ func (ccs *crChains) addOp(ptr BlockPointer, op op) error {
 	return nil
 }
 
+// addNoopChain adds a new chain with no ops to the chains struct, if
+// that pointer isn't involved in any chains yet.
+func (ccs *crChains) addNoopChain(ptr BlockPointer) {
+	if _, ok := ccs.byMostRecent[ptr]; ok {
+		return
+	}
+	if _, ok := ccs.byOriginal[ptr]; ok {
+		return
+	}
+	if _, ok := ccs.originals[ptr]; ok {
+		return
+	}
+	chain := &crChain{original: ptr, mostRecent: ptr}
+	ccs.byOriginal[ptr] = chain
+	ccs.byMostRecent[ptr] = chain
+}
+
 func (ccs *crChains) makeChainForOp(op op) error {
 	// Ignore gc ops -- their unref semantics differ from the other
 	// ops.  Note that this only matters for old gcOps: new gcOps


### PR DESCRIPTION
* file_data: even 0-byte writes should dirty the top block.  This will be used in a later commit when 0-byte writes are used to mark newly-created files as dirty, to make sure they are synced.
* cr_chains: implement addNoopChain helper function. To be used by a later commit to introduce chains for blocks that have no real ops, but still need to be readied.