### PR TITLE
folder_block_ops: fixes need for dir op batching

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1102,32 +1102,6 @@ func (fbo *folderBlockOps) SetAttrInDirEntryInCache(lState *lockState,
 	})
 }
 
-// ClearCachedAddsAndRemoves clears out any cached directory entry
-// adds and removes for the given dir.
-func (fbo *folderBlockOps) ClearCachedAdd(
-	lState *lockState, dir path, name string) {
-	fbo.blockLock.Lock(lState)
-	defer fbo.blockLock.Unlock(lState)
-	cacheEntry, ok := fbo.deCache[dir.tailRef()]
-	if !ok {
-		return
-	}
-
-	delete(cacheEntry.adds, name)
-	delete(cacheEntry.addedSyms, name)
-
-	// If the entry is totally empty, we can just delete it.
-	if !cacheEntry.dirEntry.IsInitialized() &&
-		cacheEntry.dirEntry.Mtime == 0 && cacheEntry.dirEntry.Ctime == 0 &&
-		len(cacheEntry.adds) == 0 && len(cacheEntry.dels) == 0 &&
-		len(cacheEntry.addedSyms) == 0 {
-		delete(fbo.deCache, dir.tailRef())
-		return
-	}
-
-	fbo.deCache[dir.tailRef()] = cacheEntry
-}
-
 // ClearCachedRef clears any info from the cache for the given block
 // reference, if it's not still dirty.  Returns false if the reference
 // wasn't cleared because it is still dirty.

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1074,15 +1074,22 @@ func (fbo *folderBlockOps) SetAttrInDirEntryInCache(lState *lockState,
 	undoAdd := fbo.addDirEntryInCacheLocked(
 		lState, *p.parentPath(), p.tailName(), newDe)
 
+	// TODO(KBFS-2076): Uncomment below (see comment in undo function).
 	// Update the actual attribute in the deCache.
-	cacheEntry, ok := fbo.deCache[newDe.Ref()]
-	cacheEntryCopy := cacheEntry.deepCopy()
+	// cacheEntry, ok := fbo.deCache[newDe.Ref()]
+	_, ok := fbo.deCache[newDe.Ref()]
+	// cacheEntryCopy := cacheEntry.deepCopy()
 	fbo.setCachedAttrLocked(
 		lState, newDe.Ref(), attr, &newDe,
 		true /* create the deCache entry if it doesn't exist yet */)
 	return fbo.wrapWithBlockLock(func() {
 		if ok {
-			fbo.deCache[newDe.Ref()] = cacheEntryCopy
+			// TODO(KBFS-2076): Uncomment below.  Before KBFS-2076,
+			// the undo shouldn't restore attributes that are set in
+			// an entry that was created by a write, since it is
+			// always called even after a successfully-synced setattr
+			// call.
+			//fbo.deCache[newDe.Ref()] = cacheEntryCopy
 		} else {
 			delete(fbo.deCache, newDe.Ref())
 		}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1017,7 +1017,7 @@ func (fbo *folderBlockOps) RenameDirEntryInCache(lState *lockState,
 	}
 	undoAdd := fbo.addDirEntryInCacheLocked(lState, newParent, newName, newDe)
 	undoRm := fbo.removeDirEntryInCacheLocked(
-		lState, oldParent, oldName, DirEntry{})
+		lState, oldParent, oldName, replacedDe)
 
 	// If there's already an entry for the target, only update the
 	// Ctime on a rename.

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1386,12 +1386,13 @@ func (fbo *folderBlockOps) getDirtyParentAndEntryLocked(ctx context.Context,
 // directory. file must have a valid parent. Use GetDirtyEntry() if
 // you only need the DirEntry.
 func (fbo *folderBlockOps) GetDirtyParentAndEntry(
-	ctx context.Context, lState *lockState, kmd KeyMetadata, file path) (
+	ctx context.Context, lState *lockState, kmd KeyMetadata, file path,
+	rtype blockReqType) (
 	*DirBlock, DirEntry, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	return fbo.getDirtyParentAndEntryLocked(
-		ctx, lState, kmd, file, blockRead, false)
+		ctx, lState, kmd, file, rtype, false)
 }
 
 // file must have a valid parent.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4421,7 +4421,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 				continue
 			}
 			parentPath := p.parentPath()
-			parentNode := fbo.nodeCache.Get(parentPath.tailPointer().Ref())
+			parentNode := fbo.nodeCache.Get(parentPath.tailRef())
 			if parentNode != nil {
 				changes = append(changes, NodeChange{
 					Node:       parentNode,
@@ -4449,7 +4449,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 					"Couldn't get the dir entry for %s/%v: %+v",
 					p, p.tailPointer(), err)
 			}
-			_ = fbo.nodeCache.Unlink(p.tailPointer().Ref(), p, de)
+			_ = fbo.nodeCache.Unlink(p.tailRef(), p, de)
 		}
 		if len(changes) == 0 {
 			return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2580,10 +2580,16 @@ func (fbo *folderBranchOps) createEntryLocked(
 			fbo.status.rmDirtyNode(dir)
 		}
 		fbo.dirOps = fbo.dirOps[:len(fbo.dirOps)-1]
-		dirCacheUndoFn(lState)
+		if dirCacheUndoFn != nil {
+			dirCacheUndoFn(lState)
+		}
 	}
 	// Until KBFS-2076 is done, always clear out the cached dir data.
-	defer func() { cleanupFn() }()
+	defer func() {
+		if cleanupFn != nil {
+			cleanupFn()
+		}
+	}()
 
 	de, err = fbo.syncBlockAndFinalizeLocked(
 		ctx, lState, md, newBlock, dirPath, name, entryType,
@@ -2599,7 +2605,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 		fbo.log.CDebugf(ctx, "Clearing dirty entries before applying new "+
 			"updates for exclusive write")
 		cleanupFn()
-		cleanupFn = func() {}
+		cleanupFn = nil
 		err = fbo.getAndApplyMDUpdates(ctx, lState, fbo.applyMDUpdatesLocked)
 		if err != nil {
 			return nil, DirEntry{}, err
@@ -2885,7 +2891,9 @@ func (fbo *folderBranchOps) createLinkLocked(
 			fbo.status.rmDirtyNode(dir)
 		}
 		fbo.dirOps = fbo.dirOps[:len(fbo.dirOps)-1]
-		dirCacheUndoFn(lState)
+		if dirCacheUndoFn != nil {
+			dirCacheUndoFn(lState)
+		}
 	}()
 
 	_, err = fbo.syncBlockAndFinalizeLocked(
@@ -3022,7 +3030,9 @@ func (fbo *folderBranchOps) removeEntryLocked(ctx context.Context,
 			fbo.status.rmDirtyNode(dir)
 		}
 		fbo.dirOps = fbo.dirOps[:len(fbo.dirOps)-1]
-		dirCacheUndoFn(lState)
+		if dirCacheUndoFn != nil {
+			dirCacheUndoFn(lState)
+		}
 	}()
 
 	// sync the parent directory
@@ -3212,7 +3222,9 @@ func (fbo *folderBranchOps) renameLocked(
 			fbo.status.rmDirtyNode(n)
 		}
 		fbo.dirOps = fbo.dirOps[:len(fbo.dirOps)-1]
-		dirCacheUndoFn(lState)
+		if dirCacheUndoFn != nil {
+			dirCacheUndoFn(lState)
+		}
 	}()
 
 	// find the common ancestor
@@ -3549,7 +3561,9 @@ func (fbo *folderBranchOps) setExLocked(
 			fbo.status.rmDirtyNode(file)
 		}
 		fbo.dirOps = fbo.dirOps[:len(fbo.dirOps)-1]
-		dirCacheUndoFn(lState)
+		if dirCacheUndoFn != nil {
+			dirCacheUndoFn(lState)
+		}
 	}()
 
 	dblock.Children[filePath.tailName()] = de
@@ -3634,7 +3648,9 @@ func (fbo *folderBranchOps) setMtimeLocked(
 			fbo.status.rmDirtyNode(file)
 		}
 		fbo.dirOps = fbo.dirOps[:len(fbo.dirOps)-1]
-		dirCacheUndoFn(lState)
+		if dirCacheUndoFn != nil {
+			dirCacheUndoFn(lState)
+		}
 	}()
 
 	dblock.Children[filePath.tailName()] = de

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1807,7 +1807,6 @@ func (fbo *folderBranchOps) statEntry(ctx context.Context, node Node) (
 		if err != nil {
 			return DirEntry{}, err
 		}
-
 	} else {
 		// nodePath is just the root.
 		de = md.data.Dir

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3494,7 +3494,7 @@ func (fbo *folderBranchOps) setExLocked(
 	}
 
 	dblock, de, err := fbo.blocks.GetDirtyParentAndEntry(
-		ctx, lState, md.ReadOnly(), filePath)
+		ctx, lState, md.ReadOnly(), filePath, blockWrite)
 	if err != nil {
 		return err
 	}
@@ -3596,7 +3596,7 @@ func (fbo *folderBranchOps) setMtimeLocked(
 	}
 
 	dblock, de, err := fbo.blocks.GetDirtyParentAndEntry(
-		ctx, lState, md.ReadOnly(), filePath)
+		ctx, lState, md.ReadOnly(), filePath, blockWrite)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -125,16 +125,17 @@ func (fbsk *folderBranchStatusKeeper) setPermErr(err error) {
 	fbsk.signalChangeLocked()
 }
 
-func (fbsk *folderBranchStatusKeeper) addNode(m map[NodeID]Node, n Node) {
+func (fbsk *folderBranchStatusKeeper) addNode(m map[NodeID]Node, n Node) bool {
 	fbsk.dataMutex.Lock()
 	defer fbsk.dataMutex.Unlock()
 	id := n.GetID()
 	_, ok := m[id]
 	if ok {
-		return
+		return false
 	}
 	m[id] = n
 	fbsk.signalChangeLocked()
+	return true
 }
 
 func (fbsk *folderBranchStatusKeeper) rmNode(m map[NodeID]Node, n Node) {
@@ -149,8 +150,8 @@ func (fbsk *folderBranchStatusKeeper) rmNode(m map[NodeID]Node, n Node) {
 	fbsk.signalChangeLocked()
 }
 
-func (fbsk *folderBranchStatusKeeper) addDirtyNode(n Node) {
-	fbsk.addNode(fbsk.dirtyNodes, n)
+func (fbsk *folderBranchStatusKeeper) addDirtyNode(n Node) bool {
+	return fbsk.addNode(fbsk.dirtyNodes, n)
 }
 
 func (fbsk *folderBranchStatusKeeper) rmDirtyNode(n Node) {

--- a/libkbfs/path.go
+++ b/libkbfs/path.go
@@ -115,6 +115,12 @@ func (p path) tailPointer() BlockPointer {
 	return p.path[len(p.path)-1].BlockPointer
 }
 
+// tailRef returns the BlockRef of the final node in the Path.  Must
+// be called with a valid path.
+func (p path) tailRef() BlockRef {
+	return p.path[len(p.path)-1].Ref()
+}
+
 // DebugString returns a string representation of the path with all
 // branch and pointer information.
 func (p path) DebugString() string {


### PR DESCRIPTION
* Make cache/status changes undo-able
* Use the undo functions in folderBranchOps.
* Provide more control over whether to apply cached attributes when
  getting directory entries or not.

Issue: KBFS-2076