### PR TITLE
libdokan: don't report GetDiskFreeSpace errors

### DIFF
--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -164,7 +164,6 @@ func (f *FS) GetDiskFreeSpace(ctx context.Context) (freeSpace dokan.FreeSpace, e
 	_, usageBytes, limitBytes, err := f.quotaUsage.Get(
 		ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
 	if err != nil {
-		f.log.CDebugf(ctx, "Getting quota usage error: %v", err)
 		return dokan.FreeSpace{}, errToDokan(err)
 	}
 	free := uint64(limitBytes - usageBytes)

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -151,7 +151,16 @@ func (f *FS) GetDiskFreeSpace(ctx context.Context) (freeSpace dokan.FreeSpace, e
 			FreeBytesAvailable:     dummyFreeSpace,
 		}, nil
 	}
-	defer func() { f.reportErr(ctx, libkbfs.ReadMode, err) }()
+	defer func() {
+		if err == nil {
+			f.log.CDebugf(ctx, "Request complete")
+		} else {
+			// Don't report the error (perhaps resulting in a user
+			// notification) since this method is mostly called by the
+			// OS and not because of a user action.
+			f.log.CDebugf(ctx, err.Error())
+		}
+	}()
 	_, usageBytes, limitBytes, err := f.quotaUsage.Get(
 		ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
 	if err != nil {


### PR DESCRIPTION
This function is usually called by the OS/desktop, not the user, so it
doesn't make sense to show an error notification (usually a "read
timeout -- send your logs" type of message) for this.

Issue: KBFS-2103