### PR TITLE
folder_block_ops: fix block accounting issues after a multiblock file fails to sync twice

### DIFF
--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -101,6 +101,10 @@ func (df *dirtyFile) updateNotYetSyncingBytes(newBytes int64) {
 	defer df.lock.Unlock()
 	df.notYetSyncingBytes += newBytes
 	if df.notYetSyncingBytes < 0 {
+		// It would be better if we didn't have this check, but it's
+		// hard for folderBlockOps to account correctly when bytes in
+		// a syncing block are overwritten, and then the write is
+		// deferred (see KBFS-2157).
 		df.notYetSyncingBytes = 0
 	}
 	df.dirtyBcache.UpdateUnsyncedBytes(df.path.Tlf, newBytes, false)

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -100,6 +100,9 @@ func (df *dirtyFile) updateNotYetSyncingBytes(newBytes int64) {
 	df.lock.Lock()
 	defer df.lock.Unlock()
 	df.notYetSyncingBytes += newBytes
+	if df.notYetSyncingBytes < 0 {
+		df.notYetSyncingBytes = 0
+	}
 	df.dirtyBcache.UpdateUnsyncedBytes(df.path.Tlf, newBytes, false)
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -103,11 +103,7 @@ func (si *syncInfo) removeReplacedBlock(ctx context.Context,
 				si.op.RefBlocks[i+1:]...)
 			for j, unref := range si.unrefs {
 				if unref.BlockPointer == ptr {
-					// Don't completely remove the unref,
-					// since it contains size info that we
-					// need to incorporate into the MD
-					// usage calculations.
-					si.unrefs[j].BlockPointer = zeroPtr
+					si.unrefs = append(si.unrefs[:j], si.unrefs[j+1:]...)
 				}
 			}
 			break

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2640,7 +2640,7 @@ func (fbo *folderBlockOps) StartSync(ctx context.Context,
 		return nil, nil, nil, syncState, err
 	}
 
-	lbc, err = fbo.makeLocalBcache(ctx, lState, md, file, syncState.savedSi,
+	lbc, err = fbo.makeLocalBcache(ctx, lState, md, file, syncState.si,
 		dirtyDe)
 	if err != nil {
 		return nil, nil, nil, syncState, err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5665,7 +5665,7 @@ func (fbo *folderBranchOps) backgroundFlusher() {
 			if err != nil {
 				// Just log the warning and keep trying to
 				// sync the rest of the dirty files.
-				fbo.log.CWarningf(ctx, "Couldn't sync all", err)
+				fbo.log.CWarningf(ctx, "Couldn't sync all: %+v", err)
 			}
 			return nil
 		})


### PR DESCRIPTION
`si.unrefs` holds blocks that need to be unreferenced as part of a sync. If a block was created as part of a sync, and put to the bserver, but the MD put failed and the block was then overwritten in the new MD revision that does make it to the mdserver, we would "remove" it from `si.unrefs` by zeroing out the pointer, but we'd keep around the block size info so that it can be properly accounted for.

However, now the `folderUpdatePrepper` explicitly looks up the size of each block, so that accounting is no longer needed, and we can entirely remove the block.  Furthermore, the `folderUpdatePrepper` doesn't like invalid block pointers, so this fixes an "Invalid block ref" error after sync fails a few times.

Also, load unrefs from the current si, not savedSi.  `savedSi` might contain unreferences that have been removed from `si`,because they were already replaced by the current sync.

This adds a regression test which fails with "Invalid block ref" without the other changes.

Issue: KBFS-2157