### PR TITLE
folder_block_ops: use Nodes for reading, not paths

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1769,15 +1769,17 @@ func (fbo *folderBlockOps) newFileDataWithCache(lState *lockState,
 // offset. It returns the number of bytes read and nil, or 0 and the
 // error if there was one.
 func (fbo *folderBlockOps) Read(
-	ctx context.Context, lState *lockState, kmd KeyMetadata, file path,
+	ctx context.Context, lState *lockState, kmd KeyMetadata, file Node,
 	dest []byte, off int64) (int64, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 
-	fbo.log.CDebugf(ctx, "Reading from %v", file.tailPointer())
+	filePath := fbo.nodeCache.PathFromNode(file)
+
+	fbo.log.CDebugf(ctx, "Reading from %v", filePath.tailPointer())
 
 	var uid keybase1.UID // Data reads don't depend on the uid.
-	fd := fbo.newFileData(lState, file, uid, kmd)
+	fd := fbo.newFileData(lState, filePath, uid, kmd)
 	return fd.read(ctx, dest, off)
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3280,12 +3280,12 @@ func (fbo *folderBranchOps) Read(
 		return 0, err
 	}
 
-	filePath, err := fbo.pathFromNodeForRead(file)
-	if err != nil {
-		return 0, err
-	}
-
 	{
+		filePath, err := fbo.pathFromNodeForRead(file)
+		if err != nil {
+			return 0, err
+		}
+
 		// It seems git isn't handling EINTR from some of its read calls (likely
 		// fread), which causes it to get corrupted data (which leads to coredumps
 		// later) when a read system call on pack files gets interrupted. This
@@ -3320,8 +3320,10 @@ func (fbo *folderBranchOps) Read(
 			return err
 		}
 
+		// Read using the `file` Node, not `filePath`, since the path
+		// could change until we take `blockLock` for reading.
 		bytesRead, err = fbo.blocks.Read(
-			ctx, lState, md.ReadOnly(), filePath, dest, off)
+			ctx, lState, md.ReadOnly(), file, dest, off)
 		return err
 	})
 	if err != nil {

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -2495,7 +2495,9 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	// Now u2 reads using the node it just looked up, and should see
 	// the right data.
 	gotData := make([]byte, len(data))
-	go func() { <-beforePathsCalled; <-afterPathCalled }() // Read needs a path lookup too.
+	// Read needs a path lookup too, so revert the node cache.
+	ops2.nodeCache = snc.NodeCache
+	ops2.blocks.nodeCache = snc.NodeCache
 	nr, err := kbfsOps2.Read(ctx, fileNodeA2, gotData, 0)
 	if err != nil {
 		t.Errorf("Couldn't read data: %v", err)


### PR DESCRIPTION
Since the caller would have gotten the path without holding
`blockLock`, which means it could have changed between then and now.

Issue: KBFS-2155