### PR TITLE
cr_chains: check createdOriginals for parent dir in identifyType

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -258,6 +258,14 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 
 	parentOriginal, ok := chains.originals[parentDir]
 	if !ok {
+		// If the parent dir was created as part of a squash/batch,
+		// there might not be any update for it, and so it might not
+		// appear in the `originals` map.  In that case, we can use
+		// the original.
+		parentOriginal = parentDir
+		ok = chains.createdOriginals[parentDir]
+	}
+	if !ok {
 		if chains.isDeleted(parentDir) {
 			// If the parent's been deleted, it doesn't matter whether
 			// we find the type or not.

--- a/test/cr_simple_test.go
+++ b/test/cr_simple_test.go
@@ -159,6 +159,39 @@ func TestCrUnmergedSetMtime(t *testing.T) {
 	)
 }
 
+// bob sets the mtime on a file while unstaged
+func TestCrUnmergedSetMtimeInNewDir(t *testing.T) {
+	targetMtime := time.Now().Add(1 * time.Minute)
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			mkfile("a/b", "hello"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			write("a/c", "world"),
+		),
+		as(bob, noSync(),
+			mkdir("d"),
+			mkdir("d/e"),
+			setmtime("d/e", targetMtime),
+			reenableUpdates(),
+			lsdir("a/", m{"b": "FILE", "c": "FILE"}),
+			read("a/c", "world"),
+			lsdir("d/", m{"e": "DIR"}),
+			mtime("d/e", targetMtime),
+		),
+		as(alice,
+			lsdir("a/", m{"b": "FILE", "c": "FILE"}),
+			read("a/c", "world"),
+			lsdir("d/", m{"e": "DIR"}),
+			mtime("d/e", targetMtime),
+		),
+	)
+}
+
 // bob sets the mtime on a moved file while unstaged
 func TestCrUnmergedSetMtimeOnMovedFile(t *testing.T) {
 	targetMtime := time.Now().Add(1 * time.Minute)

--- a/test/cr_simple_test.go
+++ b/test/cr_simple_test.go
@@ -159,7 +159,8 @@ func TestCrUnmergedSetMtime(t *testing.T) {
 	)
 }
 
-// bob sets the mtime on a file while unstaged
+// bob sets the mtime on a file in a newly-created directory while
+// unstaged.  Regression test for KBFS-2162.
 func TestCrUnmergedSetMtimeInNewDir(t *testing.T) {
 	targetMtime := time.Now().Add(1 * time.Minute)
 	test(t,


### PR DESCRIPTION
If the parent dir was created as part of a squash/batch, there might not be any update for it, and so it might not appear in the `originals` map.  In that case, we can use the original.

The new test reproduces the failure without the `crChains` fix.

Issue: KBFS-2162