### PR TITLE
folder_branch_ops: fix rm'd dirty dirs and rm -rf performance

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2987,6 +2987,7 @@ func (fbo *folderBranchOps) unrefEntryLocked(ctx context.Context,
 	}
 
 	unrefsToAdd := make(map[BlockPointer]bool)
+	fbo.prepper.cacheBlockInfos([]BlockInfo{de.BlockInfo})
 	unrefsToAdd[de.BlockPointer] = true
 	// construct a path for the child so we can unlink with it.
 	childPath := dir.ChildPath(name, de.BlockPointer)
@@ -3005,6 +3006,7 @@ func (fbo *folderBranchOps) unrefEntryLocked(ctx context.Context,
 		} else if err != nil {
 			return err
 		}
+		fbo.prepper.cacheBlockInfos(blockInfos)
 		for _, blockInfo := range blockInfos {
 			unrefsToAdd[blockInfo.BlockPointer] = true
 		}

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -138,24 +138,25 @@ func (fbsk *folderBranchStatusKeeper) addNode(m map[NodeID]Node, n Node) bool {
 	return true
 }
 
-func (fbsk *folderBranchStatusKeeper) rmNode(m map[NodeID]Node, n Node) {
+func (fbsk *folderBranchStatusKeeper) rmNode(m map[NodeID]Node, n Node) bool {
 	fbsk.dataMutex.Lock()
 	defer fbsk.dataMutex.Unlock()
 	id := n.GetID()
 	_, ok := m[id]
 	if !ok {
-		return
+		return false
 	}
 	delete(m, id)
 	fbsk.signalChangeLocked()
+	return true
 }
 
 func (fbsk *folderBranchStatusKeeper) addDirtyNode(n Node) bool {
 	return fbsk.addNode(fbsk.dirtyNodes, n)
 }
 
-func (fbsk *folderBranchStatusKeeper) rmDirtyNode(n Node) {
-	fbsk.rmNode(fbsk.dirtyNodes, n)
+func (fbsk *folderBranchStatusKeeper) rmDirtyNode(n Node) bool {
+	return fbsk.rmNode(fbsk.dirtyNodes, n)
 }
 
 // dataMutex should be taken by the caller


### PR DESCRIPTION
This PR does two things:

1. Removes dirty nodes when the entry is removed. A removed dir entry is also removed from the deCache, which means it will never be synced.  Removed files still go through the sync process, so that their state is cleared.
2. Caches block infos during a cached `rmOp`. Otherwise the prepper will fetch all the blocks in order to find out the sizes, which could take a long time and would block writes and leave dirty paths around during the entire download process, until the SyncAll finishes.

The test makes sure extraneous blocks are fetched, and the dirty paths are all cleaned up.

Issue: KBFS-2161