### PR TITLE
folder_branch_ops: disallow dir ops in unlinked directories

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -194,9 +194,21 @@ type WriteUnsupportedError struct {
 	Filename string
 }
 
-// Error implements the error interface for WriteAccessError
+// Error implements the error interface for WriteUnsupportedError
 func (e WriteUnsupportedError) Error() string {
 	return fmt.Sprintf("Writing to %s is unsupported", e.Filename)
+}
+
+// UnsupportedOpInUnlinkedDirError indicates an error when trying to
+// create a file.
+type UnsupportedOpInUnlinkedDirError struct {
+	Dirpath string
+}
+
+// Error implements the error interface for UnsupportedOpInUnlinkedDirError.
+func (e UnsupportedOpInUnlinkedDirError) Error() string {
+	return fmt.Sprintf(
+		"Operation is unsupported in unlinked directory %s", e.Dirpath)
 }
 
 // NewReadAccessError constructs a ReadAccessError for the given

--- a/libkbfs/errors_fuse.go
+++ b/libkbfs/errors_fuse.go
@@ -60,6 +60,14 @@ func (e WriteUnsupportedError) Errno() fuse.Errno {
 	return fuse.Errno(syscall.ENOENT)
 }
 
+var _ fuse.ErrorNumber = UnsupportedOpInUnlinkedDirError{}
+
+// Errno implements the fuse.ErrorNumber interface for
+// UnsupportedOpInUnlinkedDirError.
+func (e UnsupportedOpInUnlinkedDirError) Errno() fuse.Errno {
+	return fuse.Errno(syscall.ENOENT)
+}
+
 var _ fuse.ErrorNumber = NeedSelfRekeyError{}
 
 // Errno implements the fuse.ErrorNumber interface for

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3409,12 +3409,17 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 	require.Equal(t, "test_user/a/b", status.DirtyPaths[0])
 
 	// Now remove b, and make sure a/b is no longer dirty.
-	err = kbfsOps.RemoveEntry(ctx, nodeA, "b")
+	err = kbfsOps.RemoveDir(ctx, nodeA, "b")
 	require.NoError(t, err)
 	status, _, err = kbfsOps.FolderStatus(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
 	require.Len(t, status.DirtyPaths, 1)
 	require.Equal(t, "test_user/a", status.DirtyPaths[0])
+
+	// Also make sure we can no longer create anything in the removed
+	// directory.
+	_, _, err = kbfsOps.CreateDir(ctx, nodeB, "d")
+	require.IsType(t, UnsupportedOpInUnlinkedDirError{}, errors.Cause(err))
 
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)


### PR DESCRIPTION
This doesn't seem useful, and will just confuse our dir entry cache.

Issue: KBFS-2161