### PR TITLE
[KBFS-2168] Fix TestSemaphoreDiskLimiterBlockBasic flake

### DIFF
--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -55,10 +55,10 @@ func (s *Semaphore) tryAcquire(n int64) (<-chan struct{}, int64) {
 // Acquire blocks until it is possible to atomically subtract n (which
 // must be positive) from the resource count without causing it to go
 // negative, and then returns the updated resource count and nil. If
-// the given context is canceled first, it instead does not change the
-// resource count, and returns the resource count at the time it
-// blocked (which is necessarily less than n), and a wrapped
-// ctx.Err().
+// the given context is canceled or times out first, it instead does
+// not change the resource count, and returns the resource count at
+// the time it blocked (which is necessarily less than n), and a
+// wrapped ctx.Err().
 func (s *Semaphore) Acquire(ctx context.Context, n int64) (int64, error) {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))

--- a/libkbfs/backpressure_disk_limiter_test.go
+++ b/libkbfs/backpressure_disk_limiter_test.go
@@ -420,7 +420,7 @@ func TestDefaultDoDelayCancel(t *testing.T) {
 	cancel()
 
 	err := defaultDoDelay(ctx, individualTestTimeout)
-	require.Equal(t, ctx.Err(), errors.Cause(err))
+	require.Equal(t, context.Canceled, errors.Cause(err))
 }
 
 func makeTestBackpressureDiskLimiterParams() backpressureDiskLimiterParams {
@@ -494,7 +494,7 @@ func TestBackpressureDiskLimiterBeforeBlockPutByteError(t *testing.T) {
 	cancel()
 
 	availBytes, availFiles, err := bdl.beforeBlockPut(ctx, 11, 1)
-	require.Equal(t, ctx.Err(), errors.Cause(err))
+	require.Equal(t, context.Canceled, errors.Cause(err))
 	require.Equal(t, int64(10), availBytes)
 	require.Equal(t, int64(1), availFiles)
 
@@ -521,7 +521,7 @@ func TestBackpressureDiskLimiterBeforeBlockPutFileError(t *testing.T) {
 	cancel()
 
 	availBytes, availFiles, err := bdl.beforeBlockPut(ctx, 10, 2)
-	require.Equal(t, ctx.Err(), errors.Cause(err))
+	require.Equal(t, context.Canceled, errors.Cause(err))
 	require.Equal(t, int64(10), availBytes)
 	require.Equal(t, int64(1), availFiles)
 
@@ -798,7 +798,7 @@ func testBackpressureDiskLimiterLargeDiskDelay(
 	cancel2()
 	availBytes, availFiles, err := bdl.beforeBlockPut(
 		ctx2, blockBytes, blockFiles)
-	require.Equal(t, ctx2.Err(), errors.Cause(err))
+	require.Equal(t, context.Canceled, errors.Cause(err))
 	require.Equal(t, 8*time.Second, lastDelay)
 
 	// This does the same thing as checkCountersAfterBlockPut(),
@@ -961,7 +961,7 @@ func TestBackpressureDiskLimiterJournalAndDiskCache(t *testing.T) {
 	cancel2()
 	availBytes, _, err := bdl.beforeBlockPut(
 		ctx2, blockBytes, 1)
-	require.Equal(t, ctx2.Err(), errors.Cause(err))
+	require.Equal(t, context.Canceled, errors.Cause(err))
 	require.Equal(t, 8*time.Second, lastDelay)
 
 	// This does the same thing as checkCountersAfterBlockPut(),
@@ -1147,7 +1147,7 @@ func testBackpressureDiskLimiterSmallDiskDelay(
 	cancel2()
 	availBytes, availFiles, err :=
 		bdl.beforeBlockPut(ctx2, blockBytes, blockFiles)
-	require.Equal(t, ctx2.Err(), errors.Cause(err))
+	require.Equal(t, context.Canceled, errors.Cause(err))
 	require.Equal(t, 8*time.Second, lastDelay)
 
 	expectedByteCount := diskBytes/4 - bytesPut

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5496,7 +5496,7 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 					// No need to lock here, since `cancelUpdates` is
 					// only set within this same goroutine.
 					fbo.cancelUpdates()
-					return ctx.Err()
+					return context.Canceled
 				case MDServerErrorCannotReadFinalizedTLF:
 					fbo.log.CDebugf(ctx, "Abandoning updates since we can't "+
 						"read the finalized metadata for this TLF: %+v", err)
@@ -5510,7 +5510,7 @@ func (fbo *folderBranchOps) registerAndWaitForUpdates() {
 					// No need to lock here, since `cancelUpdates` is
 					// only set within this same goroutine.
 					fbo.cancelUpdates()
-					return ctx.Err()
+					return context.Canceled
 				}
 				select {
 				case <-ctx.Done():

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1328,7 +1328,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	}()
 
 	err = kbfsOps.SyncAll(ctx2, fileNode.GetFolderBranch())
-	if err != ctx2.Err() {
+	if err != context.Canceled {
 		t.Errorf("Sync did not get canceled error: %v", err)
 	}
 	if nowNBlocks != prevNBlocks+2 {

--- a/libkbfs/semaphore_disk_limiter_test.go
+++ b/libkbfs/semaphore_disk_limiter_test.go
@@ -16,12 +16,10 @@ import (
 func TestSemaphoreDiskLimiterBlockBasic(t *testing.T) {
 	sdl := newSemaphoreDiskLimiter(10, 2, 12)
 
-	ctx, cancel := context.WithTimeout(
-		context.Background(), 3*time.Millisecond)
-	defer cancel()
+	ctx := context.Background()
 
 	availBytes, availFiles, err := sdl.beforeBlockPut(ctx, 9, 1)
-	require.Equal(t, ctx.Err(), errors.Cause(err))
+	require.NoError(t, err)
 	require.Equal(t, int64(1), availBytes)
 	require.Equal(t, int64(1), availFiles)
 
@@ -72,7 +70,7 @@ func TestSemaphoreDiskLimiterBeforeBlockPutError(t *testing.T) {
 	defer cancel()
 
 	availBytes, availFiles, err := sdl.beforeBlockPut(ctx, 10, 2)
-	require.Equal(t, ctx.Err(), errors.Cause(err))
+	require.Equal(t, context.DeadlineExceeded, errors.Cause(err))
 	require.Equal(t, int64(10), availBytes)
 	require.Equal(t, int64(1), availFiles)
 

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -239,8 +239,10 @@ func (k *SimpleFS) doCopy(ctx context.Context, srcPath, destPath keybase1.Path) 
 
 func copyWithCancellation(ctx context.Context, dst io.Writer, src io.Reader) error {
 	for {
-		if err := ctx.Err(); err != nil {
+		select {
+		case <-ctx.Done():
 			return err
+		default:
 		}
 		_, err := io.CopyN(dst, src, 64*1024)
 		if err == io.EOF {
@@ -265,8 +267,10 @@ func (k *SimpleFS) SimpleFSCopyRecursive(ctx context.Context,
 
 			var paths = []pathPair{{src: arg.Src, dest: arg.Dest}}
 			for len(paths) > 0 {
-				if err := ctx.Err(); err != nil {
+				select {
+				case <-ctx.Done():
 					return err
+				default:
 				}
 				// wrap in a function for defers.
 				err = func() error {

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -241,7 +241,7 @@ func copyWithCancellation(ctx context.Context, dst io.Writer, src io.Reader) err
 	for {
 		select {
 		case <-ctx.Done():
-			return err
+			return ctx.Err()
 		default:
 		}
 		_, err := io.CopyN(dst, src, 64*1024)
@@ -269,7 +269,7 @@ func (k *SimpleFS) SimpleFSCopyRecursive(ctx context.Context,
 			for len(paths) > 0 {
 				select {
 				case <-ctx.Done():
-					return err
+					return ctx.Err()
 				default:
 				}
 				// wrap in a function for defers.


### PR DESCRIPTION
ctx.Err() is only defined after ctx.Done() is closed,
and in practice it's nil before then.

Audit other misuses of ctx.Err().