### PR TITLE
kbpki_client: allow slack time when checking revoke times

### DIFF
--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -116,7 +116,7 @@ func TestKBPKIClientHasRevokedVerifyingKey(t *testing.T) {
 
 	// Something verified after the key was revoked
 	err = c.HasVerifyingKey(context.Background(), keybase1.MakeTestUID(1),
-		revokedKey, revokeTime.Add(10*time.Second))
+		revokedKey, revokeTime.Add(70*time.Second))
 	if err == nil {
 		t.Error("HasVerifyingKey unexpectedly succeeded")
 	}


### PR DESCRIPTION
The mdserver might still allow writes from an online device that's
just been revoked, until it hears about the revocation from the API
server.  One user has TLFs in this state, and our strict check here
means they can't read any data in it.

Eventually we should switch all these to Merkle roots, but that's a
much bigger project (and will also need some concept of slack anyway,
for the same reason).

Issue: keybase/client#6990