### PR TITLE
tlf_journal: check MD server for conflicts during flush

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -909,8 +909,8 @@ func (j *tlfJournal) flushBlockEntries(
 	// end, and we need to make sure `maxMDRevToFlush` is still valid.
 	eg.Go(func() error {
 		defer convertCancel()
-		return flushBlockEntries(groupCtx, j.log, j.deferLog, j.delegateBlockServer,
-			j.config.BlockCache(), j.config.Reporter(),
+		return flushBlockEntries(groupCtx, j.log, j.deferLog,
+			j.delegateBlockServer, j.config.BlockCache(), j.config.Reporter(),
 			j.tlfID, tlfName, entries)
 	})
 	converted = false

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -828,8 +828,8 @@ func (e errTLFJournalNotEmpty) Error() string {
 }
 
 func (j *tlfJournal) checkServerForConflicts(ctx context.Context) error {
-	if time.Since(j.lastServerMDCheck) < tlfJournalServerMDCheckInterval ||
-		!j.config.MDServer().IsConnected() {
+	durSinceCheck := j.config.Clock().Now().Sub(j.lastServerMDCheck)
+	if durSinceCheck < tlfJournalServerMDCheckInterval {
 		return nil
 	}
 
@@ -855,9 +855,9 @@ func (j *tlfJournal) checkServerForConflicts(ctx context.Context) error {
 
 	j.log.CDebugf(ctx, "Checking the MD server for the latest revision; "+
 		"next MD revision in the journal is %d", nextMDToFlush)
-	// TODO: implement a lighterweight server RPC that just returns
-	// the latest revision number, so we don't have to fetch the
-	// entire MD?
+	// TODO(KBFS-2186): implement a lighterweight server RPC that just
+	// returns the latest revision number, so we don't have to fetch
+	// the entire MD?
 	currHead, err := j.config.MDServer().GetForTLF(
 		ctx, j.tlfID, NullBranchID, Merged)
 	if err != nil {


### PR DESCRIPTION
If we have a lot of blocks to flush from the journal, we should check
the MD server periodically to see if the next MD we're going to flush
would result in a conflict.

Specifically, if we have already once done CR locally, we might have a
huge set of blocks to flush, and only one MD to flush at the very end.
If we wait to the end to find out if there's a conflict, it could take
a long time for the remote changes (written by another device) to be
reflected in the local view of the TLF.  If instead we force CR
earlier, those changes will become visible earlier.

Issue: KBFS-2106