### PR TITLE
libkbfs: cache MD at the same time it's put to the server

### DIFF
--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -46,12 +46,17 @@ func mdForceQROne(
 
 	fmt.Printf("Putting revision %d...\n", rmdNext.Revision())
 
-	mdID, err := config.MDOps().Put(ctx, rmdNext)
+	session, err := config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("New MD has id %s\n", mdID)
+	newIrmd, err := config.MDOps().Put(ctx, rmdNext, session.VerifyingKey)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("New MD has revision %v\n", newIrmd.Revision())
 
 	return nil
 }

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -98,12 +98,17 @@ func mdResetOne(
 
 	fmt.Printf("Putting revision %d...\n", rmdNext.Revision())
 
-	mdID, err := config.MDOps().Put(ctx, rmdNext)
+	session, err := config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("New MD has id %s\n", mdID)
+	newIrmd, err := config.MDOps().Put(ctx, rmdNext, session.VerifyingKey)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("New MD has revision %d\n", newIrmd.Revision())
 
 	return nil
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1040,13 +1040,14 @@ type MDOps interface {
 	GetUnmergedRange(ctx context.Context, id tlf.ID, bid BranchID,
 		start, stop kbfsmd.Revision) ([]ImmutableRootMetadata, error)
 
-	// Put stores the metadata object for the given
-	// top-level folder.
-	Put(ctx context.Context, rmd *RootMetadata) (kbfsmd.ID, error)
+	// Put stores the metadata object for the given top-level folder.
+	Put(ctx context.Context, rmd *RootMetadata,
+		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
 
 	// PutUnmerged is the same as the above but for unmerged
 	// metadata history.
-	PutUnmerged(ctx context.Context, rmd *RootMetadata) (kbfsmd.ID, error)
+	PutUnmerged(ctx context.Context, rmd *RootMetadata,
+		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
 
 	// PruneBranch prunes all unmerged history for the given TLF
 	// branch.
@@ -1057,7 +1058,8 @@ type MDOps interface {
 	// are still in the local journal.  It also appends the given MD
 	// to the journal.
 	ResolveBranch(ctx context.Context, id tlf.ID, bid BranchID,
-		blocksToDelete []kbfsblock.ID, rmd *RootMetadata) (kbfsmd.ID, error)
+		blocksToDelete []kbfsblock.ID, rmd *RootMetadata,
+		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
 
 	// GetLatestHandleForTLF returns the server's idea of the latest handle for the TLF,
 	// which may not yet be reflected in the MD if the TLF hasn't been rekeyed since it

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1041,11 +1041,21 @@ type MDOps interface {
 		start, stop kbfsmd.Revision) ([]ImmutableRootMetadata, error)
 
 	// Put stores the metadata object for the given top-level folder.
+	// This also adds the resulting ImmutableRootMetadata object to
+	// the mdcache, if the Put is successful.  Note that constructing
+	// the ImmutableRootMetadata requires knowing the verifying key,
+	// which might not be the same as the local user's verifying key
+	// if the MD has been copied from a previous update.
 	Put(ctx context.Context, rmd *RootMetadata,
 		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
 
-	// PutUnmerged is the same as the above but for unmerged
-	// metadata history.
+	// PutUnmerged is the same as the above but for unmerged metadata
+	// history.  This also adds the resulting ImmutableRootMetadata
+	// object to the mdcache, if the PutUnmerged is successful.  Note
+	// that constructing the ImmutableRootMetadata requires knowing
+	// the verifying key, which might not be the same as the local
+	// user's verifying key if the MD has been copied from a previous
+	// update.
 	PutUnmerged(ctx context.Context, rmd *RootMetadata,
 		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
 
@@ -1055,8 +1065,13 @@ type MDOps interface {
 
 	// ResolveBranch prunes all unmerged history for the given TLF
 	// branch, and also deletes any blocks in `blocksToDelete` that
-	// are still in the local journal.  It also appends the given MD
-	// to the journal.
+	// are still in the local journal.  In addition, it appends the
+	// given MD to the journal.  This also adds the resulting
+	// ImmutableRootMetadata object to the mdcache, if the
+	// ResolveBranch is successful.  Note that constructing the
+	// ImmutableRootMetadata requires knowing the verifying key, which
+	// might not be the same as the local user's verifying key if the
+	// MD has been copied from a previous update.
 	ResolveBranch(ctx context.Context, id tlf.ID, bid BranchID,
 		blocksToDelete []kbfsblock.ID, rmd *RootMetadata,
 		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -296,7 +296,10 @@ func TestJournalServerRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
 
-	_, err = mdOps.Put(ctx, rmd)
+	session, err := config.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
+
+	_, err = mdOps.Put(ctx, rmd, session.VerifyingKey)
 	require.NoError(t, err)
 
 	// Simulate a restart.
@@ -305,8 +308,6 @@ func TestJournalServerRestart(t *testing.T) {
 		config, jServer.log, tempdir, jServer.delegateBlockCache,
 		jServer.delegateDirtyBlockCache,
 		jServer.delegateBlockServer, jServer.delegateMDOps, nil, nil)
-	session, err := config.KBPKI().GetCurrentSession(ctx)
-	require.NoError(t, err)
 	err = jServer.EnableExistingJournals(
 		ctx, session.UID, session.VerifyingKey, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -366,7 +367,10 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
 
-	_, err = mdOps.Put(ctx, rmd)
+	session, err := config.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
+
+	_, err = mdOps.Put(ctx, rmd, session.VerifyingKey)
 	require.NoError(t, err)
 
 	// Simulate a log out.
@@ -471,7 +475,10 @@ func TestJournalServerMultiUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
 
-	_, err = mdOps.Put(ctx, rmd1)
+	session, err := config.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
+
+	_, err = mdOps.Put(ctx, rmd1, session.VerifyingKey)
 	require.NoError(t, err)
 
 	// Log in user 2.
@@ -486,6 +493,9 @@ func TestJournalServerMultiUser(t *testing.T) {
 		ctx, config, "test_user2", TLFJournalBackgroundWorkPaused)
 
 	err = jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
+	require.NoError(t, err)
+
+	session, err = config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
 	// None of user 1's changes should be visible.
@@ -517,7 +527,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
 
-	_, err = mdOps.Put(ctx, rmd2)
+	_, err = mdOps.Put(ctx, rmd2, session.VerifyingKey)
 	require.NoError(t, err)
 
 	// Log out.

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -538,7 +538,6 @@ func testKBFSOpsGetRootNodeCreateNewSuccess(t *testing.T, public bool) {
 		gomock.Any(), id, gomock.Any()).Return(ImmutableRootMetadata{}, nil)
 	irmd := makeImmutableRMDForTest(t, config, rmd, kbfsmd.FakeID(1))
 	config.mockMdops.EXPECT().GetForTLF(gomock.Any(), id).Return(irmd, nil)
-	config.mockMdcache.EXPECT().Put(irmd).Return(nil)
 
 	ops := getOps(config, id)
 	assert.False(t, fboIdentityDone(ops))

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3020,26 +3020,26 @@ func (_mr *_MockMDOpsRecorder) GetUnmergedRange(arg0, arg1, arg2, arg3, arg4 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetUnmergedRange", arg0, arg1, arg2, arg3, arg4)
 }
 
-func (_m *MockMDOps) Put(ctx context.Context, rmd *RootMetadata) (kbfsmd.ID, error) {
-	ret := _m.ctrl.Call(_m, "Put", ctx, rmd)
-	ret0, _ := ret[0].(kbfsmd.ID)
+func (_m *MockMDOps) Put(ctx context.Context, rmd *RootMetadata, verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "Put", ctx, rmd, verifyingKey)
+	ret0, _ := ret[0].(ImmutableRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMDOpsRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1)
+func (_mr *_MockMDOpsRecorder) Put(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Put", arg0, arg1, arg2)
 }
 
-func (_m *MockMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata) (kbfsmd.ID, error) {
-	ret := _m.ctrl.Call(_m, "PutUnmerged", ctx, rmd)
-	ret0, _ := ret[0].(kbfsmd.ID)
+func (_m *MockMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata, verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "PutUnmerged", ctx, rmd, verifyingKey)
+	ret0, _ := ret[0].(ImmutableRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMDOpsRecorder) PutUnmerged(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutUnmerged", arg0, arg1)
+func (_mr *_MockMDOpsRecorder) PutUnmerged(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PutUnmerged", arg0, arg1, arg2)
 }
 
 func (_m *MockMDOps) PruneBranch(ctx context.Context, id tlf.ID, bid BranchID) error {
@@ -3052,15 +3052,15 @@ func (_mr *_MockMDOpsRecorder) PruneBranch(arg0, arg1, arg2 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PruneBranch", arg0, arg1, arg2)
 }
 
-func (_m *MockMDOps) ResolveBranch(ctx context.Context, id tlf.ID, bid BranchID, blocksToDelete []kbfsblock.ID, rmd *RootMetadata) (kbfsmd.ID, error) {
-	ret := _m.ctrl.Call(_m, "ResolveBranch", ctx, id, bid, blocksToDelete, rmd)
-	ret0, _ := ret[0].(kbfsmd.ID)
+func (_m *MockMDOps) ResolveBranch(ctx context.Context, id tlf.ID, bid BranchID, blocksToDelete []kbfsblock.ID, rmd *RootMetadata, verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error) {
+	ret := _m.ctrl.Call(_m, "ResolveBranch", ctx, id, bid, blocksToDelete, rmd, verifyingKey)
+	ret0, _ := ret[0].(ImmutableRootMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMDOpsRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResolveBranch", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockMDOpsRecorder) ResolveBranch(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ResolveBranch", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -475,26 +475,28 @@ func (m *stallingMDOps) GetUnmergedRange(ctx context.Context, id tlf.ID,
 	return mds, err
 }
 
-func (m *stallingMDOps) Put(ctx context.Context, md *RootMetadata) (
-	mdID kbfsmd.ID, err error) {
+func (m *stallingMDOps) Put(ctx context.Context, md *RootMetadata,
+	verifyingKey kbfscrypto.VerifyingKey) (
+	irmd ImmutableRootMetadata, err error) {
 	m.maybeStall(ctx, StallableMDPut)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
-		mdID, err = m.delegate.Put(ctx, md)
+		irmd, err = m.delegate.Put(ctx, md, verifyingKey)
 		m.maybeStall(ctx, StallableMDAfterPut)
 		return err
 	})
-	return mdID, err
+	return irmd, err
 }
 
-func (m *stallingMDOps) PutUnmerged(ctx context.Context, md *RootMetadata) (
-	mdID kbfsmd.ID, err error) {
+func (m *stallingMDOps) PutUnmerged(ctx context.Context, md *RootMetadata,
+	verifyingKey kbfscrypto.VerifyingKey) (
+	irmd ImmutableRootMetadata, err error) {
 	m.maybeStall(ctx, StallableMDPutUnmerged)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
-		mdID, err = m.delegate.PutUnmerged(ctx, md)
+		irmd, err = m.delegate.PutUnmerged(ctx, md, verifyingKey)
 		m.maybeStall(ctx, StallableMDAfterPutUnmerged)
 		return err
 	})
-	return mdID, err
+	return irmd, err
 }
 
 func (m *stallingMDOps) PruneBranch(
@@ -507,11 +509,13 @@ func (m *stallingMDOps) PruneBranch(
 
 func (m *stallingMDOps) ResolveBranch(
 	ctx context.Context, id tlf.ID, bid BranchID, blocksToDelete []kbfsblock.ID,
-	rmd *RootMetadata) (mdID kbfsmd.ID, err error) {
+	rmd *RootMetadata, verifyingKey kbfscrypto.VerifyingKey) (
+	irmd ImmutableRootMetadata, err error) {
 	m.maybeStall(ctx, StallableMDResolveBranch)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
-		mdID, err = m.delegate.ResolveBranch(ctx, id, bid, blocksToDelete, rmd)
+		irmd, err = m.delegate.ResolveBranch(
+			ctx, id, bid, blocksToDelete, rmd, verifyingKey)
 		return err
 	})
-	return mdID, err
+	return irmd, err
 }

--- a/test/journal_test.go
+++ b/test/journal_test.go
@@ -284,7 +284,6 @@ func TestJournalCrConflictUnmergedWriteMultiblockFile(t *testing.T) {
 // bob creates a conflicting file while running the journal, but then
 // its resolution also conflicts.
 func testJournalCrResolutionHitsConflict(t *testing.T, options []optionOp) {
-	t.Skip("Skipping while debugging, KBFS-2182")
 	test(t, append(options,
 		journal(),
 		users("alice", "bob"),


### PR DESCRIPTION
This PR fixes a nasty race:

1. folderBranchOps puts a new MD update X into the journal, but execution doesn't return immediately to FBO.
2. The journal, while flushing, notices a conflict, and converts the journal, including new update X, to a conflict branch. This updates all MDs in the cache with a new branch ID . . . except update X hasn't been put into the cache yet.
3. Execution returns to folderBranchOps, and update X gets put into the cache as a "merged" revision with a null BranchID.
4. Conflict resolution runs, and reads update X as one of the merged revisions, even though the real merged revision X was written by another device and should be fetched from the server.

To fix, I decided to put things in the cache under the same journal lock that puts things in the journal, so we can be guaranteed that branch conversion will catch all cached updates when a journal put doesn't fail with a conflict. This ended up requiring some changes to the MDOps interface so that an immutable RootMetadata could be created at the journal level, instead of in FBO.

The downside of this approach is that now we don't cache in memory MDs that have been fetched from the journal.  That seems ok, since they're present on disk anyway, and if they were written by us since restart, they should already be in the cache.

Issue: KBFS-2182