### PR TITLE
errors: return ENOSPC error for disk limit timeout

### DIFF
--- a/libkbfs/errors_fuse.go
+++ b/libkbfs/errors_fuse.go
@@ -128,8 +128,18 @@ func (e NoSuchFolderListError) Errno() fuse.Errno {
 	return fuse.Errno(syscall.ENOENT)
 }
 
+var _ fuse.ErrorNumber = RenameAcrossDirsError{}
+
 // Errno implements the fuse.ErrorNumber interface for
 // RenameAcrossDirsError.
 func (e RenameAcrossDirsError) Errno() fuse.Errno {
 	return fuse.Errno(syscall.EXDEV)
+}
+
+var _ fuse.ErrorNumber = &ErrDiskLimitTimeout{}
+
+// Errno implements the fuse.ErrorNumber interface for
+// ErrDiskLimitTimeout.
+func (e *ErrDiskLimitTimeout) Errno() fuse.Errno {
+	return fuse.Errno(syscall.ENOSPC)
 }


### PR DESCRIPTION
So that users get a better error code than simply EIO (in addition to
a nice popup notification with more information).