### PR TITLE
folder_branch_ops: refuse lookups in unlinked directories

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1763,8 +1763,13 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
-		lState := makeFBOLockState()
+		if fbo.nodeCache.IsUnlinked(dir) {
+			fbo.log.CDebugf(ctx, "Refusing a lookup for unlinked directory %v",
+				fbo.nodeCache.PathFromNode(dir).tailPointer())
+			return NoSuchNameError{name}
+		}
 
+		lState := makeFBOLockState()
 		md, err := fbo.getMDForReadNeedIdentify(ctx, lState)
 		if err != nil {
 			return err

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -168,8 +168,8 @@ func (ncs *nodeCacheStandard) UpdatePointer(
 		return false
 	}
 
-	// Cannot update the pointer for an unlinked node
-	if len(entry.core.cachedPath.path) > 0 {
+	// Cannot update the pointer for an unlinked node.
+	if entry.core.cachedPath.isValid() {
 		return false
 	}
 


### PR DESCRIPTION
We already return an empty list for GetDirChildren, so refuse lookups to be consistent.

Also cleanup a small thing in `NodeCache` I noticed.

Issue: KBFS-2189