### PR TITLE
disk_limiter: return currLimit(), rather than limit

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -205,8 +205,8 @@ func (bt *backpressureTracker) beforeDiskBlockCachePut(blockResources int64) (
 	return availableResources
 }
 
-func (bt *backpressureTracker) getLimitInfo() (used int64, limit int64) {
-	return bt.used, bt.limit
+func (bt *backpressureTracker) getLimitInfo() (used int64, limit float64) {
+	return bt.used, bt.currLimit()
 }
 
 type backpressureTrackerStatus struct {
@@ -535,7 +535,7 @@ func (jt journalTracker) getQuotaInfo() (usedQuotaBytes, quotaBytes int64) {
 }
 
 func (jt journalTracker) getDiskLimitInfo() (
-	usedBytes, limitBytes, usedFiles, limitFiles int64) {
+	usedBytes int64, limitBytes float64, usedFiles int64, limitFiles float64) {
 	usedBytes, limitBytes = jt.byte.getLimitInfo()
 	usedFiles, limitFiles = jt.file.getLimitInfo()
 	return usedBytes, limitBytes, usedFiles, limitFiles
@@ -938,7 +938,7 @@ func (bdl *backpressureDiskLimiter) getQuotaInfo() (
 }
 
 func (bdl *backpressureDiskLimiter) getDiskLimitInfo() (
-	usedBytes, limitBytes, usedFiles, limitFiles int64) {
+	usedBytes int64, limitBytes float64, usedFiles int64, limitFiles float64) {
 	bdl.lock.RLock()
 	defer bdl.lock.RUnlock()
 	return bdl.journalTracker.getDiskLimitInfo()

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -80,7 +80,8 @@ type DiskLimiter interface {
 
 	// getDiskLimitInfo returns the usage and limit info for the disk,
 	// as known by the disk limiter.
-	getDiskLimitInfo() (usedBytes, limitBytes, usedFiles, limitFiles int64)
+	getDiskLimitInfo() (usedBytes int64, limitBytes float64,
+		usedFiles int64, limitFiles float64)
 
 	// getStatus returns an object that's marshallable into JSON
 	// for use in displaying status.

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -162,9 +162,11 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 		}
 		code = keybase1.FSErrorType_DISK_LIMIT_REACHED
 		params[errorParamUsageBytes] = strconv.FormatInt(e.usageBytes, 10)
-		params[errorParamLimitBytes] = strconv.FormatInt(e.limitBytes, 10)
+		params[errorParamLimitBytes] =
+			strconv.FormatFloat(e.limitBytes, 'f', 0, 64)
 		params[errorParamUsageFiles] = strconv.FormatInt(e.usageFiles, 10)
-		params[errorParamLimitFiles] = strconv.FormatInt(e.limitFiles, 10)
+		params[errorParamLimitFiles] =
+			strconv.FormatFloat(e.limitFiles, 'f', 0, 64)
 	case NoSigChainError:
 		code = keybase1.FSErrorType_NO_SIG_CHAIN
 		params[errorParamUsername] = e.User.String()

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -207,9 +207,9 @@ func (sdl semaphoreDiskLimiter) getQuotaInfo() (
 }
 
 func (sdl semaphoreDiskLimiter) getDiskLimitInfo() (
-	usedBytes, limitBytes, usedFiles, limitFiles int64) {
-	return sdl.byteSemaphore.Count(), sdl.byteLimit,
-		sdl.fileSemaphore.Count(), sdl.fileLimit
+	usedBytes int64, limitBytes float64, usedFiles int64, limitFiles float64) {
+	return sdl.byteSemaphore.Count(), float64(sdl.byteLimit),
+		sdl.fileSemaphore.Count(), float64(sdl.fileLimit)
 }
 
 type semaphoreDiskLimiterStatus struct {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1737,8 +1737,8 @@ type ErrDiskLimitTimeout struct {
 	availableFiles int64
 	usageBytes     int64
 	usageFiles     int64
-	limitBytes     int64
-	limitFiles     int64
+	limitBytes     float64
+	limitFiles     float64
 	err            error
 	reportable     bool
 }


### PR DESCRIPTION
`getDiskLimitInfo` was returning the max limit for the journal, rather
than the limit calculated based on available space.  Oops!

Turns out this is a float64, so all those types needed to change
sadly.  When reporting to the user, it formats the float with no
decimals.