### PR TITLE
libfuse: don't try to get quota when disconnected

### DIFF
--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -354,6 +354,13 @@ func (f *FS) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.Sta
 		Namelen: ^uint32(0),
 		Frsize:  fuseBlockSize,
 	}
+
+	if f.remoteStatus.ExtraFileName() != "" {
+		f.log.CDebugf(
+			ctx, "Skipping quota usage check while errors are present")
+		return nil
+	}
+
 	if session, err := libkbfs.GetCurrentSessionIfPossible(
 		ctx, f.config.KBPKI(), true); err != nil {
 		return err


### PR DESCRIPTION
Make Linux/macOS work the same way as Windows.  I saw someone complain
about this on Twitter:

https://twitter.com/bytebot/status/865182626977640449