### PR TITLE
interfaces: change KBPKI interface to deal with UserOrTeamID

### DIFF
--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -23,6 +23,7 @@ import (
 	"bazil.org/fuse/fs/fstestutil"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -456,8 +457,9 @@ type kbserviceBrokenIdentify struct {
 }
 
 func (k kbserviceBrokenIdentify) Identify(ctx context.Context, assertion,
-	reason string) (libkbfs.UserInfo, error) {
-	return libkbfs.UserInfo{}, errors.New("Fake identify error")
+	reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		errors.New("Fake identify error")
 }
 
 // Regression test for KBFS-772 on OSX.  (There's a bug where ls only

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1872,16 +1872,12 @@ func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 		return res, err
 	}
 	res.BlockInfo = de.BlockInfo
-	uid := de.Writer
-	if uid == keybase1.UserOrTeamID("") {
-		uid = de.Creator
-	}
-	asUser, err := uid.AsUser()
-	if err != nil {
-		return NodeMetadata{}, err
+	id := de.Writer
+	if id == keybase1.UserOrTeamID("") {
+		id = de.Creator
 	}
 	res.LastWriterUnverified, err =
-		fbo.config.KBPKI().GetNormalizedUsername(ctx, asUser)
+		fbo.config.KBPKI().GetNormalizedUsername(ctx, id)
 	if err != nil {
 		return res, err
 	}
@@ -5998,8 +5994,8 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 	for _, rmd := range rmds {
 		writer, ok := writerNames[rmd.LastModifyingWriter()]
 		if !ok {
-			name, err := fbo.config.KBPKI().
-				GetNormalizedUsername(ctx, rmd.LastModifyingWriter())
+			name, err := fbo.config.KBPKI().GetNormalizedUsername(
+				ctx, rmd.LastModifyingWriter().AsUserOrTeam())
 			if err != nil {
 				return TLFUpdateHistory{}, err
 			}

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -187,7 +187,8 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context,
 	if fbsk.md != (ImmutableRootMetadata{}) {
 		fbs.Staged = fbsk.md.IsUnmergedSet()
 		fbs.BranchID = fbsk.md.BID().String()
-		name, err := fbsk.config.KBPKI().GetNormalizedUsername(ctx, fbsk.md.LastModifyingWriter())
+		name, err := fbsk.config.KBPKI().GetNormalizedUsername(
+			ctx, fbsk.md.LastModifyingWriter().AsUserOrTeam())
 		if err != nil {
 			return FolderBranchStatus{}, nil, err
 		}

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -168,7 +168,8 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	} else {
 		reason = fmt.Sprintf("You accessed a private folder with %s.", username.String())
 	}
-	resName, resID, err := identifier.Identify(ctx, username.String(), reason)
+	resultName, resultID, err :=
+		identifier.Identify(ctx, username.String(), reason)
 	if err != nil {
 		// Convert libkb.NoSigChainError into one we can report.  (See
 		// KBFS-1252).
@@ -177,13 +178,13 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 		}
 		return err
 	}
-	if resName != username {
+	if resultName != username {
 		return fmt.Errorf("Identify returned name=%s, expected %s",
-			resName, username)
+			resultName, username)
 	}
-	if resID != uid.AsUserOrTeam() {
+	if resultID != uid.AsUserOrTeam() {
 		return fmt.Errorf("Identify returned uid=%s, expected %s",
-			resID, uid)
+			resultID, uid)
 	}
 	return nil
 }

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -145,7 +145,7 @@ func getExtendedIdentify(ctx context.Context) (ei *extendedIdentify) {
 // used only if the username is not known - as e.g. when rekeying.
 func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier, uid keybase1.UID, isPublic bool) error {
-	username, err := nug.GetNormalizedUsername(ctx, uid)
+	username, err := nug.GetNormalizedUsername(ctx, uid.AsUserOrTeam())
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	} else {
 		reason = fmt.Sprintf("You accessed a private folder with %s.", username.String())
 	}
-	userInfo, err := identifier.Identify(ctx, username.String(), reason)
+	resName, resID, err := identifier.Identify(ctx, username.String(), reason)
 	if err != nil {
 		// Convert libkb.NoSigChainError into one we can report.  (See
 		// KBFS-1252).
@@ -177,11 +177,13 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 		}
 		return err
 	}
-	if userInfo.Name != username {
-		return fmt.Errorf("Identify returned name=%s, expected %s", userInfo.Name, username)
+	if resName != username {
+		return fmt.Errorf("Identify returned name=%s, expected %s",
+			resName, username)
 	}
-	if userInfo.UID != uid {
-		return fmt.Errorf("Identify returned uid=%s, expected %s", userInfo.UID, uid)
+	if resID != uid.AsUserOrTeam() {
+		return fmt.Errorf("Identify returned uid=%s, expected %s",
+			resID, uid)
 	}
 	return nil
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -370,13 +370,14 @@ type KeybaseService interface {
 	// assertion before the assertion -> (username, UID) mapping
 	// can be trusted.
 	Resolve(ctx context.Context, assertion string) (
-		libkb.NormalizedUsername, keybase1.UID, error)
+		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
 
 	// Identify, given an assertion, returns a UserInfo struct
 	// with the user that matches that assertion, or an error
 	// otherwise. The reason string is displayed on any tracker
 	// popups spawned.
-	Identify(ctx context.Context, assertion, reason string) (UserInfo, error)
+	Identify(ctx context.Context, assertion, reason string) (
+		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
 
 	// LoadUserPlusKeys returns a UserInfo struct for a
 	// user with the specified UID.
@@ -456,10 +457,14 @@ type resolver interface {
 	// also be trusted. If the returned pair is equal to that of
 	// the current session, then it can also be
 	// trusted. Otherwise, Identify() needs to be called on the
-	// assertion before the assertion -> (username, UID) mapping
+	// assertion before the assertion -> (username, UserOrTeamID) mapping
 	// can be trusted.
+	//
+	// TODO: some of the above assumptions on cacheability aren't
+	// right for subteams, which can change their name, so this may
+	// need updating.
 	Resolve(ctx context.Context, assertion string) (
-		libkb.NormalizedUsername, keybase1.UID, error)
+		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
 }
 
 type identifier interface {
@@ -467,13 +472,15 @@ type identifier interface {
 	// username) to a UserInfo struct, spawning tracker popups if
 	// necessary.  The reason string is displayed on any tracker
 	// popups spawned.
-	Identify(ctx context.Context, assertion, reason string) (UserInfo, error)
+	Identify(ctx context.Context, assertion, reason string) (
+		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
 }
 
 type normalizedUsernameGetter interface {
 	// GetNormalizedUsername returns the normalized username
 	// corresponding to the given UID.
-	GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error)
+	GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (
+		libkb.NormalizedUsername, error)
 }
 
 // CurrentSessionGetter is an interface for objects that can return

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -447,8 +447,11 @@ type failIdentifyKBPKI struct {
 	identifyErr error
 }
 
-func (kbpki failIdentifyKBPKI) Identify(ctx context.Context, assertion, reason string) (UserInfo, error) {
-	return UserInfo{}, kbpki.identifyErr
+func (kbpki failIdentifyKBPKI) Identify(
+	ctx context.Context, assertion, reason string) (
+	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		kbpki.identifyErr
 }
 
 func TestKBFSOpsGetRootNodeCacheIdentifyFail(t *testing.T) {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -45,21 +45,22 @@ func (k *KBPKIClient) GetCurrentSession(ctx context.Context) (
 
 // Resolve implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UID, error) {
+	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return k.serviceOwner.KeybaseService().Resolve(ctx, assertion)
 }
 
 // Identify implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) Identify(ctx context.Context, assertion, reason string) (
-	UserInfo, error) {
+	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return k.serviceOwner.KeybaseService().Identify(ctx, assertion, reason)
 }
 
 // GetNormalizedUsername implements the KBPKI interface for
 // KBPKIClient.
-func (k *KBPKIClient) GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (
+func (k *KBPKIClient) GetNormalizedUsername(
+	ctx context.Context, id keybase1.UserOrTeamID) (
 	libkb.NormalizedUsername, error) {
-	username, _, err := k.Resolve(ctx, fmt.Sprintf("uid:%s", uid))
+	username, _, err := k.Resolve(ctx, fmt.Sprintf("uid:%s", id))
 	if err != nil {
 		return libkb.NormalizedUsername(""), err
 	}

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -60,11 +60,11 @@ func makeTestKBPKIClientWithRevokedKey(t *testing.T, revokeTime time.Time) (
 func TestKBPKIClientIdentify(t *testing.T) {
 	c, _, _ := makeTestKBPKIClient(t)
 
-	u, err := c.Identify(context.Background(), "test_name1", "")
+	_, id, err := c.Identify(context.Background(), "test_name1", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if u.UID == keybase1.UID("") {
+	if id == keybase1.UserOrTeamID("") {
 		t.Fatal("empty user")
 	}
 }
@@ -72,7 +72,8 @@ func TestKBPKIClientIdentify(t *testing.T) {
 func TestKBPKIClientGetNormalizedUsername(t *testing.T) {
 	c, _, _ := makeTestKBPKIClient(t)
 
-	name, err := c.GetNormalizedUsername(context.Background(), keybase1.MakeTestUID(1))
+	name, err := c.GetNormalizedUsername(
+		context.Background(), keybase1.MakeTestUID(1).AsUserOrTeam())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/kbpki_util_test.go
+++ b/libkbfs/kbpki_util_test.go
@@ -27,16 +27,23 @@ func (d *daemonKBPKI) GetCurrentSession(ctx context.Context) (
 }
 
 func (d *daemonKBPKI) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UID, error) {
+	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Resolve(ctx, assertion)
 }
 
-func (d *daemonKBPKI) Identify(ctx context.Context, assertion, reason string) (UserInfo, error) {
+func (d *daemonKBPKI) Identify(ctx context.Context, assertion, reason string) (
+	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Identify(ctx, assertion, reason)
 }
 
-func (d *daemonKBPKI) GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error) {
-	userInfo, err := d.daemon.LoadUserPlusKeys(ctx, uid, "")
+func (d *daemonKBPKI) GetNormalizedUsername(
+	ctx context.Context, id keybase1.UserOrTeamID) (
+	libkb.NormalizedUsername, error) {
+	asUser, err := id.AsUser()
+	if err != nil {
+		return libkb.NormalizedUsername(""), err
+	}
+	userInfo, err := d.daemon.LoadUserPlusKeys(ctx, asUser, "")
 	if err != nil {
 		return libkb.NormalizedUsername(""), err
 	}
@@ -84,7 +91,9 @@ func (ik *identifyCountingKBPKI) getIdentifyCalls() int {
 	return ik.identifyCalls
 }
 
-func (ik *identifyCountingKBPKI) Identify(ctx context.Context, assertion, reason string) (UserInfo, error) {
+func (ik *identifyCountingKBPKI) Identify(
+	ctx context.Context, assertion, reason string) (
+	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ik.addIdentifyCall()
 	return ik.KBPKI.Identify(ctx, assertion, reason)
 }

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -776,7 +776,10 @@ func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver Metad
 	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
 	daemon.addNewAssertionForTestOrBust("dave", "dave@twitter")
 
-	_, bobUID, err := daemon.Resolve(ctx, "bob")
+	_, bobID, err := daemon.Resolve(ctx, "bob")
+	require.NoError(t, err)
+	bobUID, err := bobID.AsUser()
+	require.NoError(t, err)
 	daemon.setCurrentUID(bobUID)
 
 	// Now resolve using only a device addition, which won't bump the
@@ -1136,10 +1139,13 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver MetadataVer) 
 	config1.SetMetadataVersion(ver)
 
 	// Revoke user 3's device for now, to test the "other" rekey error.
-	_, uid3, err := config1.KBPKI().Resolve(ctx, u3.String())
+	_, id3, err := config1.KBPKI().Resolve(ctx, u3.String())
 	if err != nil {
 		t.Fatalf("Couldn't resolve u3: %+v", err)
 	}
+	uid3, err := id3.AsUser()
+	require.NoError(t, err)
+
 	RevokeDeviceForLocalUserOrBust(t, config1, uid3, 0)
 
 	config2 := ConfigAsUser(config1, u2)

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -56,7 +56,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 
 // Resolve implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
-	name libkb.NormalizedUsername, uid keybase1.UID, err error) {
+	name libkb.NormalizedUsername, uid keybase1.UserOrTeamID, err error) {
 	k.resolveTimer.Time(func() {
 		name, uid, err = k.delegate.Resolve(ctx, assertion)
 	})
@@ -65,11 +65,11 @@ func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
 
 // Identify implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Identify(ctx context.Context, assertion, reason string) (
-	userInfo UserInfo, err error) {
+	name libkb.NormalizedUsername, id keybase1.UserOrTeamID, err error) {
 	k.identifyTimer.Time(func() {
-		userInfo, err = k.delegate.Identify(ctx, assertion, reason)
+		name, id, err = k.delegate.Identify(ctx, assertion, reason)
 	})
-	return userInfo, err
+	return name, id, err
 }
 
 // LoadUserPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -44,7 +44,7 @@ func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 
 	tlf := handle.GetCanonicalPath()
 	writer, nameErr := md.config.KBPKI().GetNormalizedUsername(ctx,
-		rmds.MD.LastModifyingWriter())
+		rmds.MD.LastModifyingWriter().AsUserOrTeam())
 	if nameErr != nil {
 		writer = libkb.NormalizedUsername("uid: " +
 			rmds.MD.LastModifyingWriter().String())

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1024,10 +1024,10 @@ func (_m *MockKeybaseService) EXPECT() *_MockKeybaseServiceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UID, error) {
+func (_m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := _m.ctrl.Call(_m, "Resolve", ctx, assertion)
 	ret0, _ := ret[0].(libkb.NormalizedUsername)
-	ret1, _ := ret[1].(keybase1.UID)
+	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -1036,11 +1036,12 @@ func (_mr *_MockKeybaseServiceRecorder) Resolve(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Resolve", arg0, arg1)
 }
 
-func (_m *MockKeybaseService) Identify(ctx context.Context, assertion string, reason string) (UserInfo, error) {
+func (_m *MockKeybaseService) Identify(ctx context.Context, assertion string, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := _m.ctrl.Call(_m, "Identify", ctx, assertion, reason)
-	ret0, _ := ret[0].(UserInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret1, _ := ret[1].(keybase1.UserOrTeamID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockKeybaseServiceRecorder) Identify(arg0, arg1, arg2 interface{}) *gomock.Call {
@@ -1230,10 +1231,10 @@ func (_m *Mockresolver) EXPECT() *_MockresolverRecorder {
 	return _m.recorder
 }
 
-func (_m *Mockresolver) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UID, error) {
+func (_m *Mockresolver) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := _m.ctrl.Call(_m, "Resolve", ctx, assertion)
 	ret0, _ := ret[0].(libkb.NormalizedUsername)
-	ret1, _ := ret[1].(keybase1.UID)
+	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -1263,11 +1264,12 @@ func (_m *Mockidentifier) EXPECT() *_MockidentifierRecorder {
 	return _m.recorder
 }
 
-func (_m *Mockidentifier) Identify(ctx context.Context, assertion string, reason string) (UserInfo, error) {
+func (_m *Mockidentifier) Identify(ctx context.Context, assertion string, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := _m.ctrl.Call(_m, "Identify", ctx, assertion, reason)
-	ret0, _ := ret[0].(UserInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret1, _ := ret[1].(keybase1.UserOrTeamID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockidentifierRecorder) Identify(arg0, arg1, arg2 interface{}) *gomock.Call {
@@ -1295,8 +1297,8 @@ func (_m *MocknormalizedUsernameGetter) EXPECT() *_MocknormalizedUsernameGetterR
 	return _m.recorder
 }
 
-func (_m *MocknormalizedUsernameGetter) GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error) {
-	ret := _m.ctrl.Call(_m, "GetNormalizedUsername", ctx, uid)
+func (_m *MocknormalizedUsernameGetter) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (libkb.NormalizedUsername, error) {
+	ret := _m.ctrl.Call(_m, "GetNormalizedUsername", ctx, id)
 	ret0, _ := ret[0].(libkb.NormalizedUsername)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -1370,10 +1372,10 @@ func (_mr *_MockKBPKIRecorder) GetCurrentSession(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentSession", arg0)
 }
 
-func (_m *MockKBPKI) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UID, error) {
+func (_m *MockKBPKI) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := _m.ctrl.Call(_m, "Resolve", ctx, assertion)
 	ret0, _ := ret[0].(libkb.NormalizedUsername)
-	ret1, _ := ret[1].(keybase1.UID)
+	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -1382,19 +1384,20 @@ func (_mr *_MockKBPKIRecorder) Resolve(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Resolve", arg0, arg1)
 }
 
-func (_m *MockKBPKI) Identify(ctx context.Context, assertion string, reason string) (UserInfo, error) {
+func (_m *MockKBPKI) Identify(ctx context.Context, assertion string, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := _m.ctrl.Call(_m, "Identify", ctx, assertion, reason)
-	ret0, _ := ret[0].(UserInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret1, _ := ret[1].(keybase1.UserOrTeamID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 func (_mr *_MockKBPKIRecorder) Identify(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Identify", arg0, arg1, arg2)
 }
 
-func (_m *MockKBPKI) GetNormalizedUsername(ctx context.Context, uid keybase1.UID) (libkb.NormalizedUsername, error) {
-	ret := _m.ctrl.Call(_m, "GetNormalizedUsername", ctx, uid)
+func (_m *MockKBPKI) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (libkb.NormalizedUsername, error) {
+	ret := _m.ctrl.Call(_m, "GetNormalizedUsername", ctx, id)
 	ret0, _ := ret[0].(libkb.NormalizedUsername)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1


### PR DESCRIPTION
And also Identify() now calls keybase1.IdentifyLite, since none of the
callers were directly depending on any of the keys being available in
the response.  This will be needed later since teams can't be
identified through Identify2, as their keys are incompatible with that
result data structure.

Note that this depends on keybase/client#7046 and #990.

Issue: KBFS-2185