### PR TITLE
kbfs: properly type TLFs, instead of using just a boolean

### DIFF
--- a/fsrpc/fs.go
+++ b/fsrpc/fs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -30,7 +31,7 @@ func (f fs) favorites(ctx context.Context, path Path) (keybase1.ListResult, erro
 	}
 	files := []keybase1.File{}
 	for _, fav := range favs {
-		if fav.Public == path.Public {
+		if fav.Public == (path.TLFType == tlf.Public) {
 			favPath, err := path.Join(fav.Name)
 			if err != nil {
 				return keybase1.ListResult{}, err

--- a/kbfstool/ls.go
+++ b/kbfstool/ls.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/kbfs/fsrpc"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -119,7 +120,7 @@ func lsHelper(ctx context.Context, config libkbfs.Config, p fsrpc.Path, hasMulti
 			printHeader(p)
 		}
 		for _, fav := range favs {
-			if p.Public == fav.Public {
+			if (p.TLFType == tlf.Public) == fav.Public {
 				handleEntry(fav.Name, libkbfs.Dir)
 			}
 		}

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -29,7 +29,7 @@ func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI, tlfStr string) (
 		return nil, fmt.Errorf(
 			"%q is not the root path of a TLF", tlfStr)
 	}
-	return fsrpc.ParseTlfHandle(ctx, kbpki, p.TLFName, p.Public)
+	return fsrpc.ParseTlfHandle(ctx, kbpki, p.TLFName, p.TLFType)
 }
 
 func getTlfID(

--- a/kbfstool/mkdir.go
+++ b/kbfstool/mkdir.go
@@ -42,7 +42,7 @@ func mkdirOne(ctx context.Context, config libkbfs.Config, dirPathStr string, cre
 
 		tlfRoot := fsrpc.Path{
 			PathType: fsrpc.TLFPathType,
-			Public:   p.Public,
+			TLFType:  p.TLFType,
 			TLFName:  p.TLFName,
 		}
 		tlfNode, err := tlfRoot.GetDirNode(ctx, config)

--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -125,7 +126,7 @@ func (f *Folder) reportErr(ctx context.Context,
 		return
 	}
 
-	f.fs.config.Reporter().ReportErr(ctx, f.name(), f.list.public, mode, err)
+	f.fs.config.Reporter().ReportErr(ctx, f.name(), f.list.tlfType, mode, err)
 	// We just log the error as debug, rather than error, because it
 	// might just indicate an expected error such as an ENOENT.
 	//
@@ -162,7 +163,7 @@ func (f *Folder) TlfHandleChange(ctx context.Context,
 	// Handle in the background because we shouldn't lock during
 	// the notification
 	f.fs.queueNotification(func() {
-		session, err := libkbfs.GetCurrentSessionIfPossible(ctx, f.fs.config.KBPKI(), f.list.public)
+		session, err := libkbfs.GetCurrentSessionIfPossible(ctx, f.fs.config.KBPKI(), f.list.tlfType == tlf.Public)
 		// Here we get an error, but there is little that can be done.
 		// session will be empty in the error case in which case we will default to the
 		// canonical format.

--- a/libdokan/tlf.go
+++ b/libdokan/tlf.go
@@ -37,10 +37,6 @@ func newTLF(fl *FolderList, h *libkbfs.TlfHandle,
 	return tlf
 }
 
-func (tlf *TLF) isPublic() bool {
-	return tlf.folder.list.public
-}
-
 func (tlf *TLF) getStoredDir() *Dir {
 	tlf.dirLock.RLock()
 	defer tlf.dirLock.RUnlock()
@@ -66,8 +62,8 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, info string,
 	name := tlf.folder.name()
 
 	tlf.folder.fs.log.CDebugf(ctx, "Loading root directory for folder %s "+
-		"(public: %t, filter error: %t) for %s",
-		name, tlf.isPublic(), filterErr, info)
+		"(type: %s, filter error: %t) for %s",
+		name, tlf.folder.list.tlfType, filterErr, info)
 	defer func() {
 		if filterErr {
 			exitEarly, err = libfs.FilterTLFEarlyExitError(ctx, err, tlf.folder.fs.log, name)

--- a/libfs/status_file.go
+++ b/libfs/status_file.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -32,7 +33,7 @@ func GetEncodedStatus(ctx context.Context, config libkbfs.Config) (
 	data []byte, t time.Time, err error) {
 	status, _, err := config.KBFSOps().Status(ctx)
 	if err != nil {
-		config.Reporter().ReportErr(ctx, "", false, libkbfs.ReadMode, err)
+		config.Reporter().ReportErr(ctx, "", tlf.Private, libkbfs.ReadMode, err)
 	}
 	data, err = PrettyJSON(status)
 	return

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/sysutils"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -79,7 +80,7 @@ func (f *Folder) reportErr(ctx context.Context,
 		return
 	}
 
-	f.fs.config.Reporter().ReportErr(ctx, f.name(), f.list.public, mode, err)
+	f.fs.config.Reporter().ReportErr(ctx, f.name(), f.list.tlfType, mode, err)
 	// We just log the error as debug, rather than error, because it
 	// might just indicate an expected error such as an ENOENT.
 	//
@@ -312,7 +313,8 @@ func canonicalNameIfNotNil(h *libkbfs.TlfHandle) string {
 
 func (f *Folder) tlfHandleChangeInvalidate(ctx context.Context,
 	newHandle *libkbfs.TlfHandle) {
-	session, err := libkbfs.GetCurrentSessionIfPossible(ctx, f.fs.config.KBPKI(), f.list.public)
+	session, err := libkbfs.GetCurrentSessionIfPossible(
+		ctx, f.fs.config.KBPKI(), f.list.tlfType == tlf.Public)
 	// Here we get an error, but there is little that can be done.
 	// session will be empty in the error case in which case we will default to the
 	// canonical format.
@@ -338,7 +340,7 @@ func (f *Folder) tlfHandleChangeInvalidate(ctx context.Context,
 
 func (f *Folder) isWriter(ctx context.Context) (bool, error) {
 	session, err := libkbfs.GetCurrentSessionIfPossible(
-		ctx, f.fs.config.KBPKI(), f.list.public)
+		ctx, f.fs.config.KBPKI(), f.list.tlfType == tlf.Public)
 	// We are using GetCurrentUserInfoIfPossible here so err is only non-nil if
 	// a real problem happened. If the user is logged out, we will get an empty
 	// username and uid, with a nil error.

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -21,6 +21,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
@@ -118,11 +119,12 @@ func NewFS(config libkbfs.Config, conn *fuse.Conn, debug bool, platformParams Pl
 	}
 	fs.root.private = &FolderList{
 		fs:      fs,
+		tlfType: tlf.Private,
 		folders: make(map[string]*TLF),
 	}
 	fs.root.public = &FolderList{
 		fs:      fs,
-		public:  true,
+		tlfType: tlf.Public,
 		folders: make(map[string]*TLF),
 	}
 	fs.execAfterDelay = func(d time.Duration, f func()) {
@@ -328,7 +330,7 @@ func (f *FS) reportErr(ctx context.Context,
 		return
 	}
 
-	f.config.Reporter().ReportErr(ctx, "", false, mode, err)
+	f.config.Reporter().ReportErr(ctx, "", tlf.Private, mode, err)
 	// We just log the error as debug, rather than error, because it
 	// might just indicate an expected error such as an ENOENT.
 	//

--- a/libfuse/tlf.go
+++ b/libfuse/tlf.go
@@ -37,10 +37,6 @@ func newTLF(fl *FolderList, h *libkbfs.TlfHandle,
 
 var _ DirInterface = (*TLF)(nil)
 
-func (tlf *TLF) isPublic() bool {
-	return tlf.folder.list.public
-}
-
 func (tlf *TLF) getStoredDir() *Dir {
 	tlf.dirLock.RLock()
 	defer tlf.dirLock.RUnlock()
@@ -73,8 +69,8 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, mode libkbfs.ErrorModeType,
 	}
 
 	tlf.log().CDebugf(ctx, "Loading root directory for folder %s "+
-		"(public: %t, filter error: %t)", tlf.folder.name(),
-		tlf.isPublic(), filterErr)
+		"(type: %s, filter error: %t)", tlf.folder.name(),
+		tlf.folder.list.tlfType, filterErr)
 	defer func() {
 		if filterErr {
 			exitEarly, err = libfs.FilterTLFEarlyExitError(ctx, err, tlf.log(), tlf.folder.name())

--- a/libkbfs/bare_root_metadata_test.go
+++ b/libkbfs/bare_root_metadata_test.go
@@ -109,10 +109,11 @@ func TestRootMetadataFinalVerify(t *testing.T) {
 }
 
 func testRootMetadataFinalVerify(t *testing.T, ver MetadataVer) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadata(ver, tlfID, bh)

--- a/libkbfs/bare_root_metadata_test_util.go
+++ b/libkbfs/bare_root_metadata_test_util.go
@@ -26,7 +26,7 @@ func FakeInitialRekey(md MutableBareRootMetadata,
 	wKeys := make(UserDevicePublicKeys)
 	for _, w := range h.Writers {
 		k := kbfscrypto.MakeFakeCryptPublicKeyOrBust(string(w))
-		wKeys[w] = DevicePublicKeys{
+		wKeys[w.AsUserOrBust()] = DevicePublicKeys{
 			k: true,
 		}
 	}
@@ -34,7 +34,7 @@ func FakeInitialRekey(md MutableBareRootMetadata,
 	rKeys := make(UserDevicePublicKeys)
 	for _, r := range h.Readers {
 		k := kbfscrypto.MakeFakeCryptPublicKeyOrBust(string(r))
-		rKeys[r] = DevicePublicKeys{
+		rKeys[r.AsUserOrBust()] = DevicePublicKeys{
 			k: true,
 		}
 	}

--- a/libkbfs/bare_root_metadata_v2_test.go
+++ b/libkbfs/bare_root_metadata_v2_test.go
@@ -21,14 +21,14 @@ import (
 )
 
 func TestBareRootMetadataVersionV2(t *testing.T) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	// Metadata objects with unresolved assertions should have
 	// InitialExtraMetadataVer.
 
 	uid := keybase1.MakeTestUID(1)
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid}, nil, []keybase1.SocialAssertion{{}},
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, []keybase1.SocialAssertion{{}},
 		nil, nil)
 	require.NoError(t, err)
 
@@ -38,7 +38,7 @@ func TestBareRootMetadataVersionV2(t *testing.T) {
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 
 	// All other folders should use PreExtraMetadataVer.
-	bh2, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh2, err := tlf.MakeHandle([]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	rmd2, err := MakeInitialBareRootMetadata(
@@ -81,8 +81,8 @@ func testWriterMetadataV2UnchangedEncoding(t *testing.T, ver MetadataVer) {
 	expectedWm := WriterMetadataV2{
 		SerializedPrivateMetadata: []byte{0xa, 0xb},
 		LastModifyingWriter:       "uid1",
-		Writers:                   []keybase1.UID{"uid1", "uid2"},
-		ID:                        tlf.FakeID(1, false),
+		Writers:                   []keybase1.UserOrTeamID{"uid1", "uid2"},
+		ID:                        tlf.FakeID(1, tlf.Private),
 		BID:                       NullBranchID,
 		WFlags:                    0xa,
 		DiskUsage:                 100,
@@ -114,8 +114,8 @@ func TestWriterMetadataV2EncodedFields(t *testing.T) {
 	// Usually exactly one of Writers/WKeys is filled in, but we
 	// fill in both here for testing.
 	wm := WriterMetadataV2{
-		ID:      tlf.FakeID(0xa, false),
-		Writers: []keybase1.UID{"uid1", "uid2"},
+		ID:      tlf.FakeID(0xa, tlf.Private),
+		Writers: []keybase1.UserOrTeamID{"uid1", "uid2"},
 		WKeys:   TLFWriterKeyGenerationsV2{{}},
 		Extra: WriterMetadataExtraV2{
 			UnresolvedWriters: []keybase1.SocialAssertion{sa1, sa2},
@@ -199,9 +199,9 @@ func makeFakeWriterMetadataV2Future(t *testing.T) writerMetadataV2Future {
 		// have been added
 		[]byte{0xa, 0xb},
 		"uid1",
-		[]keybase1.UID{"uid1", "uid2"},
+		[]keybase1.UserOrTeamID{"uid1", "uid2"},
 		nil,
-		tlf.FakeID(1, false),
+		tlf.FakeID(1, tlf.Private),
 		NullBranchID,
 		0xa,
 		100,
@@ -316,10 +316,11 @@ func TestBareRootMetadataV2UnknownFields(t *testing.T) {
 }
 
 func TestIsValidRekeyRequestBasicV2(t *testing.T) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadataV2(tlfID, bh)
@@ -398,10 +399,11 @@ func TestRevokeRemovedDevicesV2(t *testing.T) {
 	id3b, err := crypto.GetTLFCryptKeyServerHalfID(uid3, key3, half3b)
 	require.NoError(t, err)
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3}, nil, nil, nil)
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam()}, nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadataV2(tlfID, bh)
@@ -555,10 +557,12 @@ func TestRevokeLastDeviceV2(t *testing.T) {
 	id2, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2)
 	require.NoError(t, err)
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3, uid4}, nil, nil, nil)
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam(), uid4.AsUserOrTeam()},
+		nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadataV2(tlfID, bh)
@@ -932,10 +936,11 @@ func TestBareRootMetadataV2UpdateKeyBundles(t *testing.T) {
 		uid3: {privKey3.GetPublicKey(): true},
 	}
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3},
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam()},
 		[]keybase1.SocialAssertion{{}},
 		nil, nil)
 	require.NoError(t, err)
@@ -1154,10 +1159,11 @@ func TestBareRootMetadataV2AddKeyGenerationKeylessUsers(t *testing.T) {
 		uid3: {},
 	}
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3},
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam()},
 		[]keybase1.SocialAssertion{{}},
 		nil, nil)
 	require.NoError(t, err)

--- a/libkbfs/bare_root_metadata_v3_test.go
+++ b/libkbfs/bare_root_metadata_v3_test.go
@@ -15,12 +15,13 @@ import (
 )
 
 func TestBareRootMetadataVersionV3(t *testing.T) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	// All V3 objects should have SegregatedKeyBundlesVer.
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	rmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
@@ -30,10 +31,11 @@ func TestBareRootMetadataVersionV3(t *testing.T) {
 }
 
 func TestRootMetadataV3ExtraNew(t *testing.T) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	rmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
@@ -63,10 +65,11 @@ func TestRootMetadataV3ExtraNew(t *testing.T) {
 }
 
 func TestIsValidRekeyRequestBasicV3(t *testing.T) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	codec := kbfscodec.NewMsgpack()
@@ -99,10 +102,13 @@ func TestIsValidRekeyRequestBasicV3(t *testing.T) {
 }
 
 func TestBareRootMetadataPublicVersionV3(t *testing.T) {
-	tlfID := tlf.FakeID(1, true)
+	tlfID := tlf.FakeID(1, tlf.Public)
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, []keybase1.UID{keybase1.PublicUID}, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{keybase1.UserOrTeamID(keybase1.PublicUID)},
+		nil, nil, nil)
 	require.NoError(t, err)
 
 	rmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
@@ -135,10 +141,11 @@ func TestRevokeRemovedDevicesV3(t *testing.T) {
 	id3a, err := crypto.GetTLFCryptKeyServerHalfID(uid3, key3, half3a)
 	require.NoError(t, err)
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3}, nil, nil, nil)
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam()}, nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
@@ -243,10 +250,12 @@ func TestRevokeLastDeviceV3(t *testing.T) {
 	id2, err := crypto.GetTLFCryptKeyServerHalfID(uid2, key2, half2)
 	require.NoError(t, err)
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3, uid4}, nil, nil, nil)
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam(), uid4.AsUserOrTeam()},
+		nil, nil, nil)
 	require.NoError(t, err)
 
 	brmd, err := MakeInitialBareRootMetadataV3(tlfID, bh)
@@ -467,10 +476,11 @@ func TestBareRootMetadataV3UpdateKeyBundles(t *testing.T) {
 		uid3: {privKey3.GetPublicKey(): true},
 	}
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3},
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam()},
 		[]keybase1.SocialAssertion{{}},
 		nil, nil)
 	require.NoError(t, err)
@@ -708,10 +718,11 @@ func TestBareRootMetadataV3AddKeyGenerationKeylessUsers(t *testing.T) {
 		uid3: {},
 	}
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bh, err := tlf.MakeHandle(
-		[]keybase1.UID{uid1, uid2}, []keybase1.UID{uid3},
+		[]keybase1.UserOrTeamID{uid1.AsUserOrTeam(), uid2.AsUserOrTeam()},
+		[]keybase1.UserOrTeamID{uid3.AsUserOrTeam()},
 		[]keybase1.SocialAssertion{{}},
 		nil, nil)
 	require.NoError(t, err)

--- a/libkbfs/bcache_test.go
+++ b/libkbfs/bcache_test.go
@@ -24,7 +24,7 @@ func blockCacheTestInit(t *testing.T, capacity int,
 
 func testBcachePutWithBlock(t *testing.T, id kbfsblock.ID, bcache BlockCache, lifetime BlockCacheLifetime, block Block) {
 	ptr := BlockPointer{ID: id}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 
 	// put the block
 	err := bcache.Put(ptr, tlf, block, lifetime)
@@ -88,7 +88,7 @@ func TestBlockCacheCheckPtrSuccess(t *testing.T) {
 	block.Contents = []byte{1, 2, 3, 4}
 	id := kbfsblock.FakeID(1)
 	ptr := BlockPointer{ID: id}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 
 	err := bcache.Put(ptr, tlf, block, TransientEntry)
 	require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestBlockCacheCheckPtrPermanent(t *testing.T) {
 	block.Contents = []byte{1, 2, 3, 4}
 	id := kbfsblock.FakeID(1)
 	ptr := BlockPointer{ID: id}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 
 	err := bcache.Put(ptr, tlf, block, PermanentEntry)
 	require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestBlockCacheCheckPtrNotFound(t *testing.T) {
 	block.Contents = []byte{1, 2, 3, 4}
 	id := kbfsblock.FakeID(1)
 	ptr := BlockPointer{ID: id}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 
 	err := bcache.Put(ptr, tlf, block, TransientEntry)
 	require.NoError(t, err)
@@ -150,7 +150,7 @@ func TestBlockCacheDeleteTransient(t *testing.T) {
 	block.Contents = []byte{1, 2, 3, 4}
 	id := kbfsblock.FakeID(1)
 	ptr := BlockPointer{ID: id}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 
 	err := bcache.Put(ptr, tlf, block, TransientEntry)
 	require.NoError(t, err)
@@ -197,7 +197,7 @@ func TestBlockCacheEmptyTransient(t *testing.T) {
 	block := NewFileBlock()
 	id := kbfsblock.FakeID(1)
 	ptr := BlockPointer{ID: id}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 
 	// Make sure all the operations work even if the cache has no
 	// transient capacity.
@@ -223,7 +223,7 @@ func TestBlockCacheEvictOnBytes(t *testing.T) {
 
 	bcache := config.BlockCache()
 
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 	for i := byte(0); i < 8; i++ {
 		block := &FileBlock{
 			Contents: make([]byte, 1),
@@ -256,7 +256,7 @@ func TestBlockCacheEvictIncludesPermanentSize(t *testing.T) {
 
 	bcache := config.BlockCache()
 
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 	idPerm := kbfsblock.FakeID(0)
 	ptr := BlockPointer{ID: idPerm}
 	block := &FileBlock{
@@ -334,7 +334,7 @@ func TestBlockCachePutNoHashCalculation(t *testing.T) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 	bcache := config.BlockCache()
 	ptr := BlockPointer{ID: kbfsblock.FakeID(1)}
-	tlf := tlf.FakeID(1, false)
+	tlf := tlf.FakeID(1, tlf.Private)
 	block := NewFileBlock().(*FileBlock)
 	block.Contents = []byte{1, 2, 3, 4}
 

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -895,7 +895,7 @@ func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 		totalFlushedBytes += flushedBytes
 
 		reporter.NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{
-			PublicTopLevelFolder: tlfID.IsPublic(),
+			PublicTopLevelFolder: tlfID.Type() == tlf.Public,
 			// Path: TODO,
 			// SyncingBytes: TODO,
 			// SyncingOps: TODO,

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -437,7 +437,7 @@ func TestBlockJournalFlush(t *testing.T) {
 
 	blockServer := NewBlockServerMemory(log)
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
@@ -576,7 +576,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 	blockServer := NewBlockServerMemory(log)
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
@@ -707,7 +707,7 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 	require.NoError(t, err)
 
 	blockServer := NewBlockServerMemory(log)
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
 
@@ -767,7 +767,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	require.Equal(t, int64(len(data2)+len(data3)), ignoredBytes)
 
 	blockServer := NewBlockServerMemory(log)
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
 
@@ -843,7 +843,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.Equal(t, int64(len(data2)+len(data3)), ignoredBytes)
 
 	blockServer := NewBlockServerMemory(log)
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
 
@@ -908,7 +908,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 	savedBlocks := []kbfsblock.ID{bID1, bID2, bID3, bID4}
 
 	blockServer := NewBlockServerMemory(log)
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
 
@@ -1063,7 +1063,7 @@ func TestBlockJournalByteCounters(t *testing.T) {
 	requireCounts(expectedSize, 2*filesPerBlockMax)
 
 	blockServer := NewBlockServerMemory(log)
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bcache := NewBlockCacheStandard(0, 0)
 	reporter := NewReporterSimple(nil, 0)
 	flushOne := func() (int64, int64, int64) {

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -125,7 +125,7 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var latestKeyGen KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
@@ -168,7 +168,7 @@ func TestBlockOpsReadyFailKeyGet(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	kmd := makeFakeKeyMetadata(tlfID, 0)
 
 	ctx := context.Background()
@@ -194,7 +194,7 @@ func TestBlockOpsReadyFailServerHalfGet(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
 
 	ctx := context.Background()
@@ -220,7 +220,7 @@ func TestBlockOpsReadyFailEncryption(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
 
 	ctx := context.Background()
@@ -259,7 +259,7 @@ func TestBlockOpsReadyFailEncode(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
 
 	ctx := context.Background()
@@ -284,7 +284,7 @@ func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
 
 	ctx := context.Background()
@@ -300,7 +300,7 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var keyGen KeyGen = 3
 	kmd1 := makeFakeKeyMetadata(tlfID, keyGen)
 
@@ -334,7 +334,7 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var latestKeyGen KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
@@ -375,7 +375,7 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var latestKeyGen KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
@@ -403,7 +403,7 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var latestKeyGen KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
@@ -469,7 +469,7 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var latestKeyGen KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
@@ -510,7 +510,7 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
 	defer bops.Shutdown()
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 	var latestKeyGen KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
@@ -558,7 +558,7 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bserver.EXPECT().RemoveBlockReferences(ctx, tlfID, contexts).
 		Return(expectedLiveCounts, nil)
 
@@ -589,7 +589,7 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 	// Fail the delete call.
 
 	ctx := context.Background()
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	expectedErr := errors.New("Fake fail")
 	bserver.EXPECT().RemoveBlockReferences(ctx, tlfID, contexts).
 		Return(nil, expectedErr)
@@ -623,7 +623,7 @@ func TestBlockOpsArchiveSuccess(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	bserver.EXPECT().ArchiveBlockReferences(ctx, tlfID, contexts).
 		Return(nil)
 
@@ -656,7 +656,7 @@ func TestBlockOpsArchiveFail(t *testing.T) {
 	// Fail the archive call.
 
 	ctx := context.Background()
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	expectedErr := errors.New("Fake fail")
 	bserver.EXPECT().ArchiveBlockReferences(ctx, tlfID, contexts).
 		Return(expectedErr)

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -64,7 +64,7 @@ func makeRandomBlockPointer(t *testing.T) BlockPointer {
 }
 
 func makeKMD() KeyMetadata {
-	return emptyKeyMetadata{tlf.FakeID(0, false), 1}
+	return emptyKeyMetadata{tlf.FakeID(0, tlf.Private), 1}
 }
 
 func TestBlockRetrievalQueueBasic(t *testing.T) {

--- a/libkbfs/block_util.go
+++ b/libkbfs/block_util.go
@@ -51,7 +51,7 @@ func PutBlockCheckLimitErrs(ctx context.Context, bserv BlockServer,
 		if !typedErr.Throttled {
 			// Report the error, but since it's not throttled the Put
 			// actually succeeded, so return nil back to the caller.
-			reporter.ReportErr(ctx, tlfName, tlfID.IsPublic(),
+			reporter.ReportErr(ctx, tlfName, tlfID.Type(),
 				WriteMode, OverQuotaWarning{typedErr.Usage, typedErr.Limit})
 			return nil
 		}
@@ -61,7 +61,8 @@ func PutBlockCheckLimitErrs(ctx context.Context, bserv BlockServer,
 		// otherwise be reported.  Mark the error as unreportable to
 		// avoid the upper FS layer reporting it twice, if this block
 		// put is the result of a foreground fsync.
-		reporter.ReportErr(ctx, tlfName, tlfID.IsPublic(), WriteMode, err)
+		reporter.ReportErr(
+			ctx, tlfName, tlfID.Type(), WriteMode, err)
 		typedErr.reportable = false
 		return err
 	}

--- a/libkbfs/block_util_test.go
+++ b/libkbfs/block_util_test.go
@@ -34,7 +34,7 @@ func TestBlockUtilPutNewBlockSuccess(t *testing.T) {
 	encData := []byte{1, 2, 3, 4}
 	blockPtr := BlockPointer{ID: id}
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	readyBlockData := ReadyBlockData{
 		buf: encData,
@@ -62,7 +62,7 @@ func TestBlockUtilPutIncRefSuccess(t *testing.T) {
 		},
 	}
 
-	tlfID := tlf.FakeID(0, false)
+	tlfID := tlf.FakeID(0, tlf.Private)
 
 	readyBlockData := ReadyBlockData{
 		buf: encData,
@@ -86,7 +86,7 @@ func TestBlockUtilPutFail(t *testing.T) {
 
 	expectedErr := errors.New("Fake fail")
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	readyBlockData := ReadyBlockData{
 		buf: encData,

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -97,7 +97,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 		newTestLogMaker(t), nil, nil, nil}
 	b := newBlockServerRemoteWithClient(config, &fc)
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	bCtx := kbfsblock.MakeFirstContext(
 		currentUID.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
@@ -143,7 +143,7 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 
 	f := func(ctx context.Context) error {
 		bID := kbfsblock.FakeID(1)
-		tlfID := tlf.FakeID(2, false)
+		tlfID := tlf.FakeID(2, tlf.Private)
 		bCtx := kbfsblock.MakeFirstContext(
 			currentUID.AsUserOrTeam(), keybase1.BlockType_DATA)
 		data := []byte{1, 2, 3, 4}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2999,9 +2999,8 @@ outer:
 		panic("maybeUnstageAfterFailure: head is nil (should be impossible)")
 	}
 	handle := head.GetTlfHandle()
-	cr.config.Reporter().ReportErr(ctx,
-		handle.GetCanonicalName(), handle.IsPublic(),
-		WriteMode, reportedError)
+	cr.config.Reporter().ReportErr(
+		ctx, handle.GetCanonicalName(), handle.Type(), WriteMode, reportedError)
 	return nil
 }
 
@@ -3031,8 +3030,8 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 				panic("doResolve: head is nil (should be impossible)")
 			}
 			handle := head.GetTlfHandle()
-			cr.config.Reporter().ReportErr(ctx,
-				handle.GetCanonicalName(), handle.IsPublic(),
+			cr.config.Reporter().ReportErr(
+				ctx, handle.GetCanonicalName(), handle.Type(),
 				WriteMode, CRWrapError{err})
 			if err == context.Canceled {
 				cr.inputLock.Lock()

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -28,7 +28,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	config = NewConfigMock(mockCtrl, ctr)
 	config.SetCodec(kbfscodec.NewMsgpack())
 	config.SetClock(wallClock{})
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	fbo := newFolderBranchOps(config, FolderBranch{id, MasterBranch}, standard)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(gomock.Any(), gomock.Any()).
@@ -86,7 +86,7 @@ func crMakeFakeRMD(rev kbfsmd.Revision, bid BranchID) ImmutableRootMetadata {
 	return MakeImmutableRootMetadata(&RootMetadata{
 		bareMd: &BareRootMetadataV2{
 			WriterMetadataV2: WriterMetadataV2{
-				ID:     tlf.FakeID(0x1, false),
+				ID:     tlf.FakeID(0x1, tlf.Private),
 				WFlags: writerFlags,
 				BID:    bid,
 			},
@@ -243,7 +243,7 @@ func testCRSharedFolderForUsers(
 
 	// create by the first user
 	kbfsOps := configs[createAs].KBFSOps()
-	rootNode := GetRootNodeOrBust(ctx, t, configs[createAs], name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, configs[createAs], name, tlf.Private)
 	dir := rootNode
 	for _, d := range dirs {
 		dirNext, _, err := kbfsOps.CreateDir(ctx, dir, d)
@@ -270,7 +270,7 @@ func testCRSharedFolderForUsers(
 
 		kbfsOps := config.KBFSOps()
 		kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch())
-		rootNode := GetRootNodeOrBust(ctx, t, config, name, false)
+		rootNode := GetRootNodeOrBust(ctx, t, config, name, tlf.Private)
 		dir := rootNode
 		for _, d := range dirs {
 			var err error

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -148,14 +148,15 @@ func testCRCheckOps(t *testing.T, cc *crChains, original BlockPointer,
 }
 
 func newChainMDForTest(t *testing.T) rootMetadataWithKeyAndTimestamp {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 
 	uid := keybase1.MakeTestUID(1)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	nug := testNormalizedUsernameGetter{
-		uid: "fake_user",
+		uid.AsUserOrTeam(): "fake_user",
 	}
 
 	ctx := context.Background()

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -35,8 +35,8 @@ func MakeCryptoCommon(codec kbfscodec.Codec) CryptoCommon {
 }
 
 // MakeRandomTlfID implements the Crypto interface for CryptoCommon.
-func (c CryptoCommon) MakeRandomTlfID(isPublic bool) (tlf.ID, error) {
-	return tlf.MakeRandomID(isPublic)
+func (c CryptoCommon) MakeRandomTlfID(t tlf.Type) (tlf.ID, error) {
+	return tlf.MakeRandomID(t)
 }
 
 // MakeRandomBranchID implements the Crypto interface for CryptoCommon.

--- a/libkbfs/dirty_bcache_test.go
+++ b/libkbfs/dirty_bcache_test.go
@@ -20,7 +20,7 @@ func testDirtyBcachePut(t *testing.T, id kbfsblock.ID, dirtyBcache DirtyBlockCac
 	branch := MasterBranch
 
 	// put the block
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	if err := dirtyBcache.Put(tlfID, ptr, branch, block); err != nil {
 		t.Errorf("Got error on Put for block %s: %v", id, err)
 	}
@@ -42,7 +42,7 @@ func testExpectedMissingDirty(t *testing.T, id kbfsblock.ID,
 	dirtyBcache DirtyBlockCache) {
 	expectedErr := NoSuchBlockError{id}
 	ptr := BlockPointer{ID: id}
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	if _, err := dirtyBcache.Get(tlfID, ptr, MasterBranch); err == nil {
 		t.Errorf("No expected error on 1st get: %v", err)
 	} else if err != expectedErr {
@@ -72,7 +72,7 @@ func TestDirtyBcachePutDuplicate(t *testing.T) {
 		ID:      id1,
 		Context: kbfsblock.Context{RefNonce: newNonce},
 	}
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	err := dirtyBcache.Put(id, bp2, MasterBranch, newNonceBlock)
 	if err != nil {
 		t.Errorf("Unexpected error on PutDirty: %v", err)
@@ -112,7 +112,7 @@ func TestDirtyBcacheDelete(t *testing.T) {
 	testDirtyBcachePut(t, id1, dirtyBcache)
 	newBranch := BranchName("dirtyBranch")
 	newBranchBlock := NewFileBlock()
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	err := dirtyBcache.Put(id, BlockPointer{ID: id1}, newBranch, newBranchBlock)
 	if err != nil {
 		t.Errorf("Unexpected error on PutDirty: %v", err)
@@ -135,7 +135,7 @@ func TestDirtyBcacheRequestPermission(t *testing.T) {
 	ctx := context.Background()
 
 	// The first write should get immediate permission.
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	c1, err := dirtyBcache.RequestPermissionToDirty(ctx, id, bufSize*2+1)
 	if err != nil {
 		t.Fatalf("Request permission error: %v", err)
@@ -212,7 +212,7 @@ func TestDirtyBcacheCalcBackpressure(t *testing.T) {
 	}
 
 	// still less
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	dirtyBcache.UpdateUnsyncedBytes(id, 9, false)
 	bp = dirtyBcache.calcBackpressure(now, now.Add(11*time.Second))
 	if bp != 0 {
@@ -252,7 +252,7 @@ func TestDirtyBcacheResetBufferCap(t *testing.T) {
 	ctx := context.Background()
 
 	// The first write should get immediate permission.
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	c1, err := dirtyBcache.RequestPermissionToDirty(ctx, id, bufSize*2+1)
 	if err != nil {
 		t.Fatalf("Request permission error: %v", err)

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -132,7 +132,7 @@ func TestDiskBlockCachePutAndGet(t *testing.T) {
 	cache, config := initDiskBlockCacheTest(t)
 	defer shutdownDiskBlockCacheTest(cache)
 
-	tlf1 := tlf.FakeID(0, false)
+	tlf1 := tlf.FakeID(0, tlf.Private)
 	block1Ptr, _, block1Encoded, block1ServerHalf := setupBlockForDiskCache(
 		t, config)
 
@@ -179,13 +179,13 @@ func TestDiskBlockCacheDelete(t *testing.T) {
 	t.Log("Seed the cache with some other TLFs")
 	fakeTlfs := []byte{0, 1, 2, 4, 5}
 	for _, f := range fakeTlfs {
-		tlf := tlf.FakeID(f, false)
+		tlf := tlf.FakeID(f, tlf.Private)
 		blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 			t, config)
 		err := cache.Put(ctx, tlf, blockPtr.ID, blockEncoded, serverHalf)
 		require.NoError(t, err)
 	}
-	tlf1 := tlf.FakeID(3, false)
+	tlf1 := tlf.FakeID(3, tlf.Private)
 	block1Ptr, _, block1Encoded, block1ServerHalf := setupBlockForDiskCache(t,
 		config)
 	block2Ptr, _, block2Encoded, block2ServerHalf := setupBlockForDiskCache(t,
@@ -226,14 +226,14 @@ func TestDiskBlockCacheEvictFromTLF(t *testing.T) {
 	cache, config := initDiskBlockCacheTest(t)
 	defer shutdownDiskBlockCacheTest(cache)
 
-	tlf1 := tlf.FakeID(3, false)
+	tlf1 := tlf.FakeID(3, tlf.Private)
 	ctx := context.Background()
 	clock := config.TestClock()
 	initialTime := clock.Now()
 	t.Log("Seed the cache with some other TLFs.")
 	fakeTlfs := []byte{0, 1, 2, 4, 5}
 	for _, f := range fakeTlfs {
-		tlf := tlf.FakeID(f, false)
+		tlf := tlf.FakeID(f, tlf.Private)
 		blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 			t, config)
 		err := cache.Put(ctx, tlf, blockPtr.ID, blockEncoded, serverHalf)
@@ -318,7 +318,7 @@ func TestDiskBlockCacheEvictOverall(t *testing.T) {
 
 	t.Log("Seed the cache with some other TLFs.")
 	for i := byte(0); int(i) < numTlfs; i++ {
-		currTlf := tlf.FakeID(i, false)
+		currTlf := tlf.FakeID(i, tlf.Private)
 		for j := 0; j < numBlocksPerTlf; j++ {
 			blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 				t, config)
@@ -393,7 +393,7 @@ func TestDiskBlockCacheStaticLimit(t *testing.T) {
 
 	t.Log("Seed the cache with some blocks.")
 	for i := byte(0); int(i) < numTlfs; i++ {
-		currTlf := tlf.FakeID(i, false)
+		currTlf := tlf.FakeID(i, tlf.Private)
 		for j := 0; j < numBlocksPerTlf; j++ {
 			blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 				t, config)
@@ -411,7 +411,8 @@ func TestDiskBlockCacheStaticLimit(t *testing.T) {
 	t.Log("Add a block to the cache. Verify that blocks were evicted.")
 	blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 		t, config)
-	err := cache.Put(ctx, tlf.FakeID(10, false), blockPtr.ID, blockEncoded, serverHalf)
+	err := cache.Put(
+		ctx, tlf.FakeID(10, tlf.Private), blockPtr.ID, blockEncoded, serverHalf)
 	require.NoError(t, err)
 
 	require.True(t, int64(cache.currBytes) < currBytes)
@@ -433,7 +434,7 @@ func TestDiskBlockCacheDynamicLimit(t *testing.T) {
 
 	t.Log("Seed the cache with some blocks.")
 	for i := byte(0); int(i) < numTlfs; i++ {
-		currTlf := tlf.FakeID(i, false)
+		currTlf := tlf.FakeID(i, tlf.Private)
 		for j := 0; j < numBlocksPerTlf; j++ {
 			blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 				t, config)
@@ -463,7 +464,9 @@ func TestDiskBlockCacheDynamicLimit(t *testing.T) {
 	for i := 1; i <= numBlocks; i++ {
 		blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 			t, config)
-		err := cache.Put(ctx, tlf.FakeID(10, false), blockPtr.ID, blockEncoded, serverHalf)
+		err := cache.Put(
+			ctx, tlf.FakeID(10, tlf.Private), blockPtr.ID, blockEncoded,
+			serverHalf)
 		require.NoError(t, err)
 		require.Equal(t, start+(i%int(defaultNumBlocksToEvict)), cache.numBlocks)
 	}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -164,17 +164,13 @@ type ReadAccessError struct {
 	User     libkb.NormalizedUsername
 	Filename string
 	Tlf      CanonicalTlfName
-	Public   bool
+	Type     tlf.Type
 }
 
 // Error implements the error interface for ReadAccessError
 func (e ReadAccessError) Error() string {
-	t := tlf.Private
-	if e.Public {
-		t = tlf.Public
-	}
 	return fmt.Sprintf("%s does not have read access to directory %s",
-		e.User, buildCanonicalPathForTlfName(t, e.Tlf))
+		e.User, buildCanonicalPathForTlfName(e.Type, e.Tlf))
 }
 
 // WriteAccessError indicates an error when trying to write a file
@@ -182,18 +178,14 @@ type WriteAccessError struct {
 	User     libkb.NormalizedUsername
 	Filename string
 	Tlf      CanonicalTlfName
-	Public   bool
+	Type     tlf.Type
 }
 
 // Error implements the error interface for WriteAccessError
 func (e WriteAccessError) Error() string {
 	if e.Tlf != "" {
-		t := tlf.Private
-		if e.Public {
-			t = tlf.Public
-		}
 		return fmt.Sprintf("%s does not have write access to directory %s",
-			e.User, buildCanonicalPathForTlfName(t, e.Tlf))
+			e.User, buildCanonicalPathForTlfName(e.Type, e.Tlf))
 	}
 	return fmt.Sprintf("%s does not have write access to %s", e.User, e.Filename)
 }
@@ -228,23 +220,23 @@ func NewReadAccessError(h *TlfHandle, username libkb.NormalizedUsername, filenam
 		User:     username,
 		Filename: filename,
 		Tlf:      tlfname,
-		Public:   h.Type() == tlf.Public,
+		Type:     h.Type(),
 	}
 }
 
 // NewWriteAccessError is an access error trying to write a file
 func NewWriteAccessError(h *TlfHandle, username libkb.NormalizedUsername, filename string) error {
 	tlfName := CanonicalTlfName("")
-	public := false
+	t := tlf.Private
 	if h != nil {
 		tlfName = h.GetCanonicalName()
-		public = h.Type() == tlf.Public
+		t = h.Type()
 	}
 	return WriteAccessError{
 		User:     username,
 		Filename: filename,
 		Tlf:      tlfName,
-		Public:   public,
+		Type:     t,
 	}
 }
 

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -27,7 +27,7 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 		ID:         kbfsblock.FakeID(42),
 		DirectType: DirectBlock,
 	}
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	file := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "file"}}}
 	uid := keybase1.MakeTestUID(1)
 	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -106,13 +106,13 @@ func TestFBStatusAllFields(t *testing.T) {
 	ctx := context.Background()
 
 	// make a new root metadata
-	id := tlf.FakeID(1, false)
-	h := parseTlfHandleOrBust(t, config, "alice", false)
+	id := tlf.FakeID(1, tlf.Private)
+	h := parseTlfHandleOrBust(t, config, "alice", tlf.Private)
 	u := h.FirstResolvedWriter()
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
 	rmd.SetUnmerged()
-	rmd.SetLastModifyingWriter(u)
+	rmd.SetLastModifyingWriter(u.AsUserOrBust())
 
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("fake seed")
 	signer := kbfscrypto.SigningKeySigner{Key: signingKey}

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
@@ -144,18 +145,18 @@ func getExtendedIdentify(ctx context.Context) (ei *extendedIdentify) {
 // identifyUID performs identify based only on UID. It should be
 // used only if the username is not known - as e.g. when rekeying.
 func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, uid keybase1.UID, isPublic bool) error {
-	username, err := nug.GetNormalizedUsername(ctx, uid.AsUserOrTeam())
+	identifier identifier, id keybase1.UserOrTeamID, t tlf.Type) error {
+	name, err := nug.GetNormalizedUsername(ctx, id)
 	if err != nil {
 		return err
 	}
-	return identifyUser(ctx, nug, identifier, username, uid, isPublic)
+	return identifyUser(ctx, nug, identifier, name, id, t)
 }
 
 // identifyUser is the preferred way to run identifies.
 func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, username libkb.NormalizedUsername,
-	uid keybase1.UID, isPublic bool) error {
+	identifier identifier, name libkb.NormalizedUsername,
+	id keybase1.UserOrTeamID, t tlf.Type) error {
 	// Check to see if identify should be skipped altogether.
 	ei := getExtendedIdentify(ctx)
 	if ei.behavior == keybase1.TLFIdentifyBehavior_CHAT_SKIP {
@@ -163,52 +164,54 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	}
 
 	var reason string
-	if isPublic {
+	switch t {
+	case tlf.Public:
 		reason = "You accessed a public folder."
-	} else {
-		reason = fmt.Sprintf("You accessed a private folder with %s.", username.String())
+	case tlf.Private:
+		reason = fmt.Sprintf("You accessed a private folder with %s.", name.String())
+	case tlf.SingleTeam:
+		reason = fmt.Sprintf("You accessed a folder for private team %s.", name.String())
 	}
-	resultName, resultID, err :=
-		identifier.Identify(ctx, username.String(), reason)
+	resultName, resultID, err := identifier.Identify(ctx, name.String(), reason)
 	if err != nil {
 		// Convert libkb.NoSigChainError into one we can report.  (See
 		// KBFS-1252).
 		if _, ok := err.(libkb.NoSigChainError); ok {
-			return NoSigChainError{username}
+			return NoSigChainError{name}
 		}
 		return err
 	}
-	if resultName != username {
+	if resultName != name {
 		return fmt.Errorf("Identify returned name=%s, expected %s",
-			resultName, username)
+			resultName, name)
 	}
-	if resultID != uid.AsUserOrTeam() {
-		return fmt.Errorf("Identify returned uid=%s, expected %s",
-			resultID, uid)
+	if resultID != id {
+		return fmt.Errorf("Identify returned uid=%s, expected %s", resultID, id)
 	}
 	return nil
 }
 
 // identifyUserToChan calls identifyUser and plugs the result into the error channnel.
 func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, name libkb.NormalizedUsername, uid keybase1.UID,
-	isPublic bool, errChan chan error) {
-	errChan <- identifyUser(ctx, nug, identifier, name, uid, isPublic)
+	identifier identifier, name libkb.NormalizedUsername,
+	id keybase1.UserOrTeamID, t tlf.Type, errChan chan error) {
+	errChan <- identifyUser(ctx, nug, identifier, name, id, t)
 }
 
 // identifyUsers identifies the users in the given maps.
 func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, users map[keybase1.UID]libkb.NormalizedUsername,
-	public bool) error {
+	identifier identifier,
+	names map[keybase1.UserOrTeamID]libkb.NormalizedUsername,
+	t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	// TODO: limit the number of concurrent identifies?
 	// TODO: implement a version of errgroup with limited concurrency.
-	for uid, name := range users {
+	for id, name := range names {
 		// Capture range variables.
-		uid, name := uid, name
+		id, name := id, name
 		eg.Go(func() error {
-			return identifyUser(ctx, nug, identifier, name, uid, public)
+			return identifyUser(ctx, nug, identifier, name, id, t)
 		})
 	}
 
@@ -217,16 +220,17 @@ func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
 
 // identifyUserList identifies the users in the given list.
 // Only use this when the usernames are not known - like when rekeying.
-func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, uids []keybase1.UID, public bool) error {
+func identifyUserList(ctx context.Context, nug normalizedUsernameGetter,
+	identifier identifier, ids []keybase1.UserOrTeamID, t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	// TODO: limit the number of concurrent identifies?
 	// TODO: implement concurrency limited version of errgroup.
-	for _, uid := range uids {
+	for _, id := range ids {
 		// Capture range variable.
-		uid := uid
+		id := id
 		eg.Go(func() error {
-			return identifyUID(ctx, nug, identifier, uid, public)
+			return identifyUID(ctx, nug, identifier, id, t)
 		})
 	}
 
@@ -235,17 +239,18 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter, identif
 
 // identifyUsersForTLF is a helper for identifyHandle for easier testing.
 func identifyUsersForTLF(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, users map[keybase1.UID]libkb.NormalizedUsername,
-	public bool) error {
+	identifier identifier,
+	names map[keybase1.UserOrTeamID]libkb.NormalizedUsername,
+	t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
 		ei := getExtendedIdentify(ctx)
-		return ei.makeTlfBreaksIfNeeded(ctx, len(users))
+		return ei.makeTlfBreaksIfNeeded(ctx, len(names))
 	})
 
 	eg.Go(func() error {
-		return identifyUsers(ctx, nug, identifier, users, public)
+		return identifyUsers(ctx, nug, identifier, names, t)
 	})
 
 	return eg.Wait()
@@ -254,5 +259,5 @@ func identifyUsersForTLF(ctx context.Context, nug normalizedUsernameGetter,
 // identifyHandle identifies the canonical names in the given handle.
 func identifyHandle(ctx context.Context, nug normalizedUsernameGetter, identifier identifier, h *TlfHandle) error {
 	return identifyUsersForTLF(ctx, nug, identifier,
-		h.ResolvedUsersMap(), h.IsPublic())
+		h.ResolvedUsersMap(), h.Type())
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -653,7 +653,7 @@ type KeyManager interface {
 // Reporter exports events (asynchronously) to any number of sinks
 type Reporter interface {
 	// ReportErr records that a given error happened.
-	ReportErr(ctx context.Context, tlfName CanonicalTlfName, public bool,
+	ReportErr(ctx context.Context, tlfName CanonicalTlfName, t tlf.Type,
 		mode ErrorModeType, err error)
 	// AllKnownErrors returns all errors known to this Reporter.
 	AllKnownErrors() []ReportedError
@@ -870,7 +870,7 @@ type DiskBlockCache interface {
 // implicit state, i.e. they're pure functions of the input.
 type cryptoPure interface {
 	// MakeRandomTlfID generates a dir ID using a CSPRNG.
-	MakeRandomTlfID(isPublic bool) (tlf.ID, error)
+	MakeRandomTlfID(t tlf.Type) (tlf.ID, error)
 
 	// MakeRandomBranchID generates a per-device branch ID using a
 	// CSPRNG.  It will not return LocalSquashBranchID or
@@ -2000,7 +2000,7 @@ type MutableBareRootMetadata interface {
 	// SetFinalizedInfo sets any finalized info associated with this metadata revision.
 	SetFinalizedInfo(fi *tlf.HandleExtension)
 	// SetWriters sets the list of writers associated with this folder.
-	SetWriters(writers []keybase1.UID)
+	SetWriters(writers []keybase1.UserOrTeamID)
 	// SetTlfID sets the ID of the underlying folder in the metadata structure.
 	SetTlfID(tlf tlf.ID)
 

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -89,7 +89,7 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	// journal tries to access it.
 	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -103,7 +103,8 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	// (1) get metadata -- allocates an ID
-	bh, err := tlf.MakeHandle([]keybase1.UID{session.UID}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
@@ -282,7 +283,8 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
-	bh, err := tlf.MakeHandle([]keybase1.UID{session.UID}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
@@ -313,7 +315,8 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
-	bh, err := tlf.MakeHandle([]keybase1.UID{session.UID}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
@@ -342,7 +345,8 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
-	bh, err := tlf.MakeHandle([]keybase1.UID{session.UID}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -122,21 +122,20 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 	_, _, _, err := quotaUsage.Get(ctx, 0, 0)
 	require.NoError(t, err)
 
-	tlfID1 := tlf.FakeID(1, false)
+	tlfID1 := tlf.FakeID(1, tlf.Private)
 	err = jServer.Enable(ctx, tlfID1, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	blockServer := config.BlockServer()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), "test_user1,test_user2", false)
+		ctx, config.KBPKI(), "test_user1,test_user2", tlf.Private)
 	require.NoError(t, err)
-	uid1 := h.ResolvedWriters()[0]
+	id1 := h.ResolvedWriters()[0]
 
 	// Put a block, which should return with a quota error.
 
-	bCtx := kbfsblock.MakeFirstContext(
-		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -191,7 +190,7 @@ func TestJournalServerOverDiskLimitError(t *testing.T) {
 	_, _, _, err := quotaUsage.Get(ctx, 0, 0)
 	require.NoError(t, err)
 
-	tlfID1 := tlf.FakeID(1, false)
+	tlfID1 := tlf.FakeID(1, tlf.Private)
 	err = jServer.Enable(ctx, tlfID1, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
@@ -209,14 +208,13 @@ func TestJournalServerOverDiskLimitError(t *testing.T) {
 	blockServer := config.BlockServer()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), "test_user1,test_user2", false)
+		ctx, config.KBPKI(), "test_user1,test_user2", tlf.Private)
 	require.NoError(t, err)
-	uid1 := h.ResolvedWriters()[0]
+	id1 := h.ResolvedWriters()[0]
 
 	// Put a block, which should return with a disk limit error.
 
-	bCtx := kbfsblock.MakeFirstContext(
-		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -268,21 +266,20 @@ func TestJournalServerRestart(t *testing.T) {
 	// journal tries to access it.
 	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", false)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", tlf.Private)
 	require.NoError(t, err)
-	uid := h.ResolvedWriters()[0]
+	id := h.ResolvedWriters()[0]
 
 	// Put a block.
 
-	bCtx := kbfsblock.MakeFirstContext(
-		uid.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -340,21 +337,20 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	// journal tries to access it.
 	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", false)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", tlf.Private)
 	require.NoError(t, err)
-	uid := h.ResolvedWriters()[0]
+	id := h.ResolvedWriters()[0]
 
 	// Put a block.
 
-	bCtx := kbfsblock.MakeFirstContext(
-		uid.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)
@@ -413,7 +409,7 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
@@ -446,7 +442,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	// journal tries to access it.
 	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
@@ -454,15 +450,14 @@ func TestJournalServerMultiUser(t *testing.T) {
 	mdOps := config.MDOps()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), "test_user1,test_user2", false)
+		ctx, config.KBPKI(), "test_user1,test_user2", tlf.Private)
 	require.NoError(t, err)
-	uid1 := h.ResolvedWriters()[0]
-	uid2 := h.ResolvedWriters()[1]
+	id1 := h.ResolvedWriters()[0]
+	id2 := h.ResolvedWriters()[1]
 
 	// Put a block under user 1.
 
-	bCtx1 := kbfsblock.MakeFirstContext(
-		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx1 := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data1 := []byte{1, 2, 3, 4}
 	bID1, err := kbfsblock.MakePermanentID(data1)
 	require.NoError(t, err)
@@ -475,7 +470,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	rmd1, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
-	rmd1.SetLastModifyingWriter(uid1)
+	rmd1.SetLastModifyingWriter(id1.AsUserOrBust())
 	rekeyDone, _, err := config.KeyManager().Rekey(ctx, rmd1, false)
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
@@ -491,7 +486,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	serviceLoggedOut(ctx, config)
 
 	service := config.KeybaseService().(*KeybaseDaemonLocal)
-	service.setCurrentUID(uid2)
+	service.setCurrentUID(id2.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
@@ -514,8 +509,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	// Put a block under user 2.
 
-	bCtx2 := kbfsblock.MakeFirstContext(
-		uid2.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx2 := kbfsblock.MakeFirstContext(id2, keybase1.BlockType_DATA)
 	data2 := []byte{1, 2, 3, 4, 5}
 	bID2, err := kbfsblock.MakePermanentID(data2)
 	require.NoError(t, err)
@@ -528,7 +522,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	rmd2, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
-	rmd2.SetLastModifyingWriter(uid2)
+	rmd2.SetLastModifyingWriter(id2.AsUserOrBust())
 	rekeyDone, _, err = config.KeyManager().Rekey(ctx, rmd2, false)
 	require.NoError(t, err)
 	require.True(t, rekeyDone)
@@ -554,7 +548,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	// Log in user 1.
 
-	service.setCurrentUID(uid1)
+	service.setCurrentUID(id1.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
@@ -572,13 +566,13 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	head, err = mdOps.GetForTLF(ctx, tlfID)
 	require.NoError(t, err)
-	require.Equal(t, uid1, head.LastModifyingWriter())
+	require.Equal(t, id1.AsUserOrBust(), head.LastModifyingWriter())
 
 	// Log in user 2.
 
 	serviceLoggedOut(ctx, config)
 
-	service.setCurrentUID(uid2)
+	service.setCurrentUID(id2.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
 	serviceLoggedIn(
@@ -596,14 +590,14 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	head, err = mdOps.GetForTLF(ctx, tlfID)
 	require.NoError(t, err)
-	require.Equal(t, uid2, head.LastModifyingWriter())
+	require.Equal(t, id2.AsUserOrBust(), head.LastModifyingWriter())
 }
 
 func TestJournalServerEnableAuto(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 
-	tlfID := tlf.FakeID(2, false)
+	tlfID := tlf.FakeID(2, tlf.Private)
 	err := jServer.EnableAuto(ctx)
 	require.NoError(t, err)
 
@@ -613,13 +607,12 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	blockServer := config.BlockServer()
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", false)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", tlf.Private)
 	require.NoError(t, err)
-	uid := h.ResolvedWriters()[0]
+	id := h.ResolvedWriters()[0]
 
 	// Access a TLF, which should create a journal automatically.
-	bCtx := kbfsblock.MakeFirstContext(
-		uid.AsUserOrTeam(), keybase1.BlockType_DATA)
+	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)
 	require.NoError(t, err)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -21,7 +21,7 @@ import (
 
 func readAndCompareData(t *testing.T, config Config, ctx context.Context,
 	name string, expectedData []byte, user libkb.NormalizedUsername) {
-	rootNode := GetRootNodeOrBust(ctx, t, config, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, name, tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.Lookup(ctx, rootNode, "a")
@@ -74,8 +74,8 @@ func TestBasicMDUpdate(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, statusChan, err := kbfsOps2.FolderStatus(ctx, rootNode2.GetFolderBranch())
@@ -126,7 +126,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	// user 1 creates a file
@@ -136,7 +136,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	require.NoError(t, err)
 
 	// user 2 looks up the directory (and sees the file)
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	// now user 1 renames the old file, and creates a new one
 	err = kbfsOps1.Rename(ctx, rootNode1, "a", rootNode1, "b")
@@ -195,7 +195,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	fileNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -212,7 +212,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -253,7 +253,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 
 	DisableCRForTesting(config1B, rootNode1.GetFolderBranch())
 
-	tlfHandle, err := ParseTlfHandle(ctx, config1B.KBPKI(), name, false)
+	tlfHandle, err := ParseTlfHandle(ctx, config1B.KBPKI(), name, tlf.Private)
 	require.NoError(t, err)
 
 	_, _, err = config1B.KBFSOps().GetTLFCryptKeys(ctx, tlfHandle)
@@ -275,7 +275,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	fileNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -288,7 +288,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 	DisableCRForTesting(config1, rootNode1.GetFolderBranch())
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -330,7 +330,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 
 	// Keep the config1B node in memory, so it doesn't get garbage
 	// collected (preventing notifications)
-	rootNode1B := GetRootNodeOrBust(ctx, t, config1B, name, false)
+	rootNode1B := GetRootNodeOrBust(ctx, t, config1B, name, tlf.Private)
 
 	kbfsOps1B := config1B.KBFSOps()
 	fileNode1B, _, err := kbfsOps1B.Lookup(ctx, rootNode1B, "a")
@@ -414,7 +414,7 @@ func TestMultiUserWrite(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -423,7 +423,7 @@ func TestMultiUserWrite(t *testing.T) {
 	require.NoError(t, err)
 
 	// then user2 write to the file
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	fileNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -477,7 +477,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err := kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
@@ -486,7 +486,7 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -601,7 +601,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -612,7 +612,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -686,7 +686,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -697,7 +697,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -776,7 +776,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -785,7 +785,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -863,7 +863,7 @@ func TestCRDouble(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	require.NoError(t, err)
@@ -871,7 +871,7 @@ func TestCRDouble(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1003,7 +1003,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1014,7 +1014,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1036,7 +1036,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 
 	// user2 device 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, tlf.Private)
 	require.IsType(t, NeedSelfRekeyError{}, err)
 
 	// User 2 syncs
@@ -1093,7 +1093,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
 	require.NoError(t, err)
 
@@ -1142,7 +1142,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1153,7 +1153,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	dirA2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1173,7 +1173,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 
 	// user2 device 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
-	_, err = GetRootNodeForTest(ctx, config2Dev2, name, false)
+	_, err = GetRootNodeForTest(ctx, config2Dev2, name, tlf.Private)
 	require.IsType(t, NeedSelfRekeyError{}, err)
 
 	// User 2 syncs
@@ -1223,7 +1223,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
+	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 	dirA2Dev2, _, err := kbfsOps2Dev2.Lookup(ctx, rootNode2Dev2, "a")
 	require.NoError(t, err)
 
@@ -1280,7 +1280,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	config1.SetBlockSplitter(bsplit)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	_, _, err = kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	require.NoError(t, err)
@@ -1288,7 +1288,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1404,7 +1404,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	require.NoError(t, err)
@@ -1415,7 +1415,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	aNode2, _, err := kbfsOps2.Lookup(ctx, rootNode2, "a")
@@ -1513,7 +1513,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// user1 creates a file in a shared dir
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
 	kbfsOps1 := config1.KBFSOps()
 	dirA1, _, err := kbfsOps1.CreateDir(ctx, rootNode1, "a")
@@ -1524,7 +1524,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	ops2 := getOps(config2, rootNode2.GetFolderBranch().Tlf)
@@ -1659,7 +1659,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	name := userName1.String() + "," + userName2.String()
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	aNode1, _, err := kbfsOps1.CreateFile(ctx, rootNode, "a", false, NoExcl)
 	require.NoError(t, err)
@@ -1670,7 +1670,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	require.NoError(t, err)
 
 	// look it up on user2
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	kbfsOps2 := config2.KBFSOps()
 	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -77,7 +77,7 @@ func TestKBFSOpsConcurDoubleMDGet(t *testing.T) {
 	// Initialize the MD using a different config
 	c2 := ConfigAsUser(config, "test_user")
 	defer CheckConfigAndShutdown(ctx, t, c2)
-	rootNode := GetRootNodeOrBust(ctx, t, c2, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, c2, "test_user", tlf.Private)
 
 	n := 10
 	c := make(chan error, n)
@@ -120,7 +120,7 @@ func TestKBFSOpsConcurReadDuringSync(t *testing.T) {
 		StallMDOp(ctx, config, StallableMDAfterPut, 1)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -192,7 +192,7 @@ func testKBFSOpsConcurWritesDuringSync(t *testing.T,
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	fileNodes := make([]Node, nFiles)
 	kbfsOps := config.KBFSOps()
@@ -357,7 +357,7 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -471,7 +471,7 @@ func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -600,7 +600,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -687,7 +687,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -778,7 +778,7 @@ func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create a file.
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -940,7 +940,7 @@ func TestKBFSOpsConcurBlockSyncReadIndirect(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// Create a file.
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -993,7 +993,7 @@ func TestKBFSOpsConcurWriteDuringFolderUpdate(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1043,7 +1043,7 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	config.SetBlockSplitter(bsplit)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1240,7 +1240,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	config.SetBlockSplitter(bsplit)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1393,7 +1393,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	config.SetBlockSplitter(bsplit)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -1482,7 +1482,7 @@ func testKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T, nFiles int) {
 		StallBlockOp(ctx, config, StallableBlockPut, 1)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNodes := make([]Node, nFiles)
@@ -1641,7 +1641,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 	ctxStallSync, cancel2 := context.WithCancel(ctxStallSync)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNodes := make([]Node, nFiles)
@@ -1833,7 +1833,7 @@ func TestKBFSOpsCanceledCreateNoError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error, 1)
@@ -1891,7 +1891,7 @@ func TestKBFSOpsCanceledCreateDelayTimeoutErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	errChan := make(chan error, 1)
@@ -1960,7 +1960,7 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -2058,7 +2058,7 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -2148,7 +2148,7 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	_, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -2251,7 +2251,7 @@ func TestKBFSOpsErrorOnBlockedWriteDuringSync(t *testing.T) {
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)
@@ -2390,7 +2390,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 	kbfsOps2 := config2.KBFSOps()
 	ops2 := getOps(config2, rootNode2.GetFolderBranch().Tlf)
 	doStallUpdate := make(chan struct{}, 1)
@@ -2412,7 +2412,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	}()
 
 	// u1 creates a file.
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	fileNodeA1, _, err := kbfsOps1.CreateFile(
 		ctx, rootNode1, "a", false, NoExcl)
@@ -2532,7 +2532,7 @@ func TestKBFSOpsConcurMultiblockOverwriteWithCanceledSync(t *testing.T) {
 	config.SetBlockSplitter(bsplitter)
 
 	// create and write to a file
-	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", false)
+	rootNode := GetRootNodeOrBust(ctx, t, config, "test_user", tlf.Private)
 
 	kbfsOps := config.KBFSOps()
 	fileNode, _, err := kbfsOps.CreateFile(ctx, rootNode, "a", false, NoExcl)

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -217,17 +217,19 @@ func (k *KBPKIClient) loadUnverifiedKeys(ctx context.Context, uid keybase1.UID) 
 	return k.serviceOwner.KeybaseService().LoadUnverifiedKeys(ctx, uid)
 }
 
-// GetCurrentSessionIfPossible returns the current username and UID from
-// kbpki.GetCurrentSession.
-// If isPublic is true NoCurrentSessionError is ignored and empty username
-// and uid will be returned. If it is false all errors are returned.
-func GetCurrentSessionIfPossible(ctx context.Context, kbpki KBPKI, isPublic bool) (SessionInfo, error) {
+// GetCurrentSessionIfPossible returns the current username and UID
+// from kbpki.GetCurrentSession.  If sessionNotRequired is true
+// NoCurrentSessionError is ignored and empty username and uid will be
+// returned. If it is false all errors are returned.
+func GetCurrentSessionIfPossible(
+	ctx context.Context, kbpki KBPKI, sessionNotRequired bool) (
+	SessionInfo, error) {
 	session, err := kbpki.GetCurrentSession(ctx)
 	if err == nil {
 		return session, nil
 	}
-	// Return all error for private folders.
-	if !isPublic {
+	// Return all errors if a session is required.
+	if !sessionNotRequired {
 		return SessionInfo{}, err
 	}
 

--- a/libkbfs/key_bundle_cache_test.go
+++ b/libkbfs/key_bundle_cache_test.go
@@ -14,8 +14,8 @@ import (
 
 func getKeyBundlesForTesting(t *testing.T, c Config, tlfByte byte, handleStr string) (
 	tlf.ID, TLFWriterKeyBundleID, *TLFWriterKeyBundleV3, TLFReaderKeyBundleID, *TLFReaderKeyBundleV3) {
-	tlfID := tlf.FakeID(tlfByte, false)
-	h := parseTlfHandleOrBust(t, c, handleStr, false)
+	tlfID := tlf.FakeID(tlfByte, tlf.Private)
+	h := parseTlfHandleOrBust(t, c, handleStr, tlf.Private)
 	rmd, err := makeInitialRootMetadata(SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
 	rmd.fakeInitialRekey()

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -387,8 +388,8 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -568,7 +569,13 @@ const CtxKeybaseServiceOpID = "KSID"
 func (k *KeybaseServiceBase) getHandleFromFolderName(ctx context.Context,
 	tlfName string, public bool) (*TlfHandle, error) {
 	for {
-		tlfHandle, err := ParseTlfHandle(ctx, k.config.KBPKI(), tlfName, public)
+		// TODO(KBFS-2185): update the protocol to support requests
+		// for single-team TLFs.
+		t := tlf.Private
+		if public {
+			t = tlf.Public
+		}
+		tlfHandle, err := ParseTlfHandle(ctx, k.config.KBPKI(), tlfName, t)
 		switch e := err.(type) {
 		case TlfNameNotCanonical:
 			tlfName = e.NameToTry

--- a/libkbfs/keycache_test.go
+++ b/libkbfs/keycache_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestKeyCacheBasic(t *testing.T) {
 	cache := NewKeyCacheStandard(10)
-	id := tlf.FakeID(100, true)
+	id := tlf.FakeID(100, tlf.Public)
 	key := kbfscrypto.MakeTLFCryptKey([32]byte{0xf})
 	keyGen := FirstValidKeyGen
 	_, err := cache.GetTLFCryptKey(id, keyGen)
@@ -38,7 +38,7 @@ func TestKeyCacheBasic(t *testing.T) {
 		t.Fatal("keys are unequal")
 	}
 	for i := 0; i < 11; i++ {
-		id = tlf.FakeID(byte(i), true)
+		id = tlf.FakeID(byte(i), tlf.Public)
 		key = kbfscrypto.MakeTLFCryptKey([32]byte{byte(i)})
 		err = cache.PutTLFCryptKey(id, keyGen, key)
 		if err != nil {
@@ -46,7 +46,7 @@ func TestKeyCacheBasic(t *testing.T) {
 		}
 	}
 	for i := 0; i < 11; i++ {
-		id = tlf.FakeID(byte(i), true)
+		id = tlf.FakeID(byte(i), tlf.Public)
 		key, err = cache.GetTLFCryptKey(id, keyGen)
 		if i > 0 && err != nil {
 			t.Fatal(err)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -47,7 +47,7 @@ func setupMDJournalTest(t testing.TB, ver MetadataVer) (
 	crypto = MakeCryptoCommon(codec)
 
 	uid := keybase1.MakeTestUID(1)
-	tlfID = tlf.FakeID(1, false)
+	tlfID = tlf.FakeID(1, tlf.Private)
 
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("fake seed")
 	signer = kbfscrypto.SigningKeySigner{Key: signingKey}
@@ -89,9 +89,10 @@ func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	revision kbfsmd.Revision, uid keybase1.UID,
 	signer kbfscrypto.Signer, prevRoot kbfsmd.ID) *RootMetadata {
 	nug := testNormalizedUsernameGetter{
-		uid: "fake_username",
+		uid.AsUserOrTeam(): "fake_username",
 	}
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	bh, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 	h, err := MakeTlfHandle(context.Background(), bh, nug)
 	require.NoError(t, err)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -203,7 +203,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 
 	// Get the UID unless this is a public tlf - then proceed with empty uid.
 	var uid keybase1.UID
-	if !handle.IsPublic() {
+	if handle.Type() != tlf.Public {
 		session, err := md.config.KBPKI().GetCurrentSession(ctx)
 		if err != nil {
 			return ImmutableRootMetadata{}, err

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -27,7 +27,7 @@ type mdRange struct {
 func makeRekeyReadErrorHelper(
 	err error, kmd KeyMetadata, resolvedHandle *TlfHandle,
 	uid keybase1.UID, username libkb.NormalizedUsername) error {
-	if resolvedHandle.IsPublic() {
+	if resolvedHandle.Type() == tlf.Public {
 		panic("makeRekeyReadError called on public folder")
 	}
 	// If the user is not a legitimate reader of the folder, this is a
@@ -342,11 +342,11 @@ func encryptMDPrivateData(
 	brmd := rmd.bareMd
 	privateData := rmd.data
 
-	if brmd.TlfID().IsPublic() || !brmd.IsWriterMetadataCopiedSet() {
+	if brmd.TlfID().Type() == tlf.Public || !brmd.IsWriterMetadataCopiedSet() {
 		// Record the last writer to modify this writer metadata
 		brmd.SetLastModifyingWriter(me)
 
-		if brmd.TlfID().IsPublic() {
+		if brmd.TlfID().Type() == tlf.Public {
 			// Encode the private metadata
 			encodedPrivateMetadata, err := codec.Encode(privateData)
 			if err != nil {
@@ -481,7 +481,7 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 	handle := rmdToDecrypt.GetTlfHandle()
 
 	var pmd PrivateMetadata
-	if handle.IsPublic() {
+	if handle.Type() == tlf.Public {
 		if err := codec.Decode(serializedPrivateMetadata,
 			&pmd); err != nil {
 			return PrivateMetadata{}, err

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
-	uid := keybase1.MakeTestUID(n)
-	bh, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	id := keybase1.MakeTestUID(n).AsUserOrTeam()
+	bh, err := tlf.MakeHandle([]keybase1.UserOrTeamID{id}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	nug := testNormalizedUsernameGetter{
-		uid: libkb.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
+		id: libkb.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
 	}
 
 	ctx := context.Background()
@@ -64,7 +64,7 @@ func testMdcachePut(t *testing.T, tlfID tlf.ID, rev kbfsmd.Revision,
 }
 
 func TestMdcachePut(t *testing.T) {
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	h := testMdcacheMakeHandle(t, 1)
 
 	mdcache := NewMDCacheStandard(100)
@@ -72,13 +72,13 @@ func TestMdcachePut(t *testing.T) {
 }
 
 func TestMdcachePutPastCapacity(t *testing.T) {
-	id0 := tlf.FakeID(1, false)
+	id0 := tlf.FakeID(1, tlf.Private)
 	h0 := testMdcacheMakeHandle(t, 0)
 
-	id1 := tlf.FakeID(2, false)
+	id1 := tlf.FakeID(2, tlf.Private)
 	h1 := testMdcacheMakeHandle(t, 1)
 
-	id2 := tlf.FakeID(3, false)
+	id2 := tlf.FakeID(3, tlf.Private)
 	h2 := testMdcacheMakeHandle(t, 2)
 
 	mdcache := NewMDCacheStandard(2)
@@ -93,7 +93,7 @@ func TestMdcachePutPastCapacity(t *testing.T) {
 }
 
 func TestMdcacheReplace(t *testing.T) {
-	id := tlf.FakeID(1, false)
+	id := tlf.FakeID(1, tlf.Private)
 	h := testMdcacheMakeHandle(t, 1)
 
 	mdcache := NewMDCacheStandard(100)

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -188,12 +188,12 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 	if err != nil {
 		return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 	}
-	if !handle.IsReader(session.UID) {
+	if !handle.IsReader(session.UID.AsUserOrTeam()) {
 		return tlf.NullID, false, kbfsmd.ServerErrorUnauthorized{}
 	}
 
 	// Allocate a new random ID.
-	id, err := md.config.cryptoPure().MakeRandomTlfID(handle.IsPublic())
+	id, err := md.config.cryptoPure().MakeRandomTlfID(handle.Type())
 	if err != nil {
 		return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 	}

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -26,7 +26,7 @@ func isReader(currentUID keybase1.UID, mergedMasterHead BareRootMetadata,
 	if err != nil {
 		return false, err
 	}
-	return h.IsReader(currentUID), nil
+	return h.IsReader(currentUID.AsUserOrTeam()), nil
 }
 
 // Helper to aid in enforcement that only specified public keys can
@@ -39,11 +39,11 @@ func isWriterOrValidRekey(codec kbfscodec.Codec, currentUID keybase1.UID,
 	if err != nil {
 		return false, err
 	}
-	if h.IsWriter(currentUID) {
+	if h.IsWriter(currentUID.AsUserOrTeam()) {
 		return true, nil
 	}
 
-	if h.IsReader(currentUID) {
+	if h.IsReader(currentUID.AsUserOrTeam()) {
 		// if this is a reader, are they acting within their
 		// restrictions?
 		return newMd.IsValidRekeyRequest(

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -148,12 +148,12 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 	if err != nil {
 		return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 	}
-	if !handle.IsReader(session.UID) {
+	if !handle.IsReader(session.UID.AsUserOrTeam()) {
 		return tlf.NullID, false, kbfsmd.ServerErrorUnauthorized{}
 	}
 
 	// Allocate a new random ID.
-	id, err = md.config.cryptoPure().MakeRandomTlfID(handle.IsPublic())
+	id, err = md.config.cryptoPure().MakeRandomTlfID(handle.Type())
 	if err != nil {
 		return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 	}

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -63,7 +63,8 @@ func TestMDServerBasics(t *testing.T) {
 	uid := session.UID
 
 	// (1) get metadata -- allocates an ID
-	h, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	h, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	id, rmds, err := mdServer.GetForHandle(ctx, h, Merged)
@@ -173,10 +174,10 @@ func TestMDServerRegisterForUpdate(t *testing.T) {
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
-	uid := session.UID
+	id := session.UID.AsUserOrTeam()
 
 	// Create first TLF.
-	h1, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	h1, err := tlf.MakeHandle([]keybase1.UserOrTeamID{id}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	id1, _, err := mdServer.GetForHandle(ctx, h1, Merged)
@@ -184,7 +185,9 @@ func TestMDServerRegisterForUpdate(t *testing.T) {
 
 	// Create second TLF, which should end up being different from
 	// the first one.
-	h2, err := tlf.MakeHandle([]keybase1.UID{uid}, []keybase1.UID{keybase1.PUBLIC_UID}, nil, nil, nil)
+	h2, err := tlf.MakeHandle([]keybase1.UserOrTeamID{id},
+		[]keybase1.UserOrTeamID{keybase1.UserOrTeamID(keybase1.PUBLIC_UID)},
+		nil, nil, nil)
 	require.NoError(t, err)
 
 	id2, _, err := mdServer.GetForHandle(ctx, h2, Merged)

--- a/libkbfs/mdserver_tlf_storage_test.go
+++ b/libkbfs/mdserver_tlf_storage_test.go
@@ -39,7 +39,7 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	tlfID := tlf.FakeID(1, false)
+	tlfID := tlf.FakeID(1, tlf.Private)
 	s := makeMDServerTlfStorage(tlfID, codec, crypto, wallClock{},
 		defaultClientMetadataVer, tempdir)
 	defer s.shutdown()
@@ -47,7 +47,8 @@ func TestMDServerTlfStorageBasic(t *testing.T) {
 	require.Equal(t, 0, getMDStorageLength(t, s, NullBranchID))
 
 	uid := keybase1.MakeTestUID(1)
-	h, err := tlf.MakeHandle([]keybase1.UID{uid}, nil, nil, nil, nil)
+	h, err := tlf.MakeHandle(
+		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
 	// (1) Validate merged branch is empty.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1813,8 +1813,8 @@ func (_m *MockReporter) EXPECT() *_MockReporterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockReporter) ReportErr(ctx context.Context, tlfName CanonicalTlfName, public bool, mode ErrorModeType, err error) {
-	_m.ctrl.Call(_m, "ReportErr", ctx, tlfName, public, mode, err)
+func (_m *MockReporter) ReportErr(ctx context.Context, tlfName CanonicalTlfName, t tlf.Type, mode ErrorModeType, err error) {
+	_m.ctrl.Call(_m, "ReportErr", ctx, tlfName, t, mode, err)
 }
 
 func (_mr *_MockReporterRecorder) ReportErr(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
@@ -2373,8 +2373,8 @@ func (_m *MockcryptoPure) EXPECT() *_MockcryptoPureRecorder {
 	return _m.recorder
 }
 
-func (_m *MockcryptoPure) MakeRandomTlfID(isPublic bool) (tlf.ID, error) {
-	ret := _m.ctrl.Call(_m, "MakeRandomTlfID", isPublic)
+func (_m *MockcryptoPure) MakeRandomTlfID(t tlf.Type) (tlf.ID, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomTlfID", t)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -2638,8 +2638,8 @@ func (_m *MockCrypto) EXPECT() *_MockCryptoRecorder {
 	return _m.recorder
 }
 
-func (_m *MockCrypto) MakeRandomTlfID(isPublic bool) (tlf.ID, error) {
-	ret := _m.ctrl.Call(_m, "MakeRandomTlfID", isPublic)
+func (_m *MockCrypto) MakeRandomTlfID(t tlf.Type) (tlf.ID, error) {
+	ret := _m.ctrl.Call(_m, "MakeRandomTlfID", t)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -6448,7 +6448,7 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetFinalizedInfo(arg0 interface
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetFinalizedInfo", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) SetWriters(writers []keybase1.UID) {
+func (_m *MockMutableBareRootMetadata) SetWriters(writers []keybase1.UserOrTeamID) {
 	_m.ctrl.Call(_m, "SetWriters", writers)
 }
 

--- a/libkbfs/node_cache_test.go
+++ b/libkbfs/node_cache_test.go
@@ -131,7 +131,7 @@ func simulateGC(ncs *nodeCacheStandard, liveList []Node) {
 // Tests for simple GetOrCreate successes (with and without a parent)
 func TestNodeCacheGetOrCreateSuccess(t *testing.T) {
 	ncs, parentNode, childNode1A, _, path1, path2 :=
-		setupNodeCache(t, tlf.FakeID(0, false), MasterBranch, true)
+		setupNodeCache(t, tlf.FakeID(0, tlf.Private), MasterBranch, true)
 	parentPtr := path1[0].BlockPointer
 	childPtr1 := path1[1].BlockPointer
 	childPtr2 := path2[1].BlockPointer
@@ -159,7 +159,7 @@ func TestNodeCacheGetOrCreateSuccess(t *testing.T) {
 
 // Tests that a child can't be created with an unknown parent.
 func TestNodeCacheGetOrCreateNoParent(t *testing.T) {
-	ncs := newNodeCacheStandard(FolderBranch{tlf.FakeID(0, false), ""})
+	ncs := newNodeCacheStandard(FolderBranch{tlf.FakeID(0, tlf.Private), ""})
 
 	parentPtr := BlockPointer{ID: kbfsblock.FakeID(0)}
 	parentNode, err := ncs.GetOrCreate(parentPtr, "parent", nil)
@@ -180,7 +180,7 @@ func TestNodeCacheGetOrCreateNoParent(t *testing.T) {
 
 // Tests that UpdatePointer works
 func TestNodeCacheUpdatePointer(t *testing.T) {
-	ncs := newNodeCacheStandard(FolderBranch{tlf.FakeID(0, false), ""})
+	ncs := newNodeCacheStandard(FolderBranch{tlf.FakeID(0, tlf.Private), ""})
 
 	parentPtr := BlockPointer{ID: kbfsblock.FakeID(0)}
 	parentNode, err := ncs.GetOrCreate(parentPtr, "parent", nil)
@@ -199,7 +199,7 @@ func TestNodeCacheUpdatePointer(t *testing.T) {
 // Tests that Move works as expected
 func TestNodeCacheMoveSuccess(t *testing.T) {
 	ncs, parentNode, childNode1, childNode2, path1, path2 :=
-		setupNodeCache(t, tlf.FakeID(0, false), MasterBranch, true)
+		setupNodeCache(t, tlf.FakeID(0, tlf.Private), MasterBranch, true)
 	parentPtr := path1[0].BlockPointer
 	childPtr1 := path1[1].BlockPointer
 	childPtr2 := path2[1].BlockPointer
@@ -244,7 +244,7 @@ func TestNodeCacheMoveSuccess(t *testing.T) {
 // Tests that a child can't be updated with an unknown parent
 func TestNodeCacheMoveNoParent(t *testing.T) {
 	ncs, _, childNode1, childNode2, path1, path2 :=
-		setupNodeCache(t, tlf.FakeID(0, false), MasterBranch, true)
+		setupNodeCache(t, tlf.FakeID(0, tlf.Private), MasterBranch, true)
 	childPtr1 := path1[1].BlockPointer
 	childPtr2 := path2[1].BlockPointer
 
@@ -281,7 +281,7 @@ func checkNodeCachePath(t *testing.T, id tlf.ID, branch BranchName,
 // Tests that a child can be unlinked completely from the parent, and
 // still have a path, but not a basename.
 func TestNodeCacheUnlink(t *testing.T) {
-	id := tlf.FakeID(42, false)
+	id := tlf.FakeID(42, tlf.Private)
 	branch := BranchName("testBranch")
 	ncs, _, _, childNode2, _, path2 :=
 		setupNodeCache(t, id, branch, false)
@@ -312,7 +312,7 @@ func TestNodeCacheUnlink(t *testing.T) {
 // Tests that a child's ancestor can be unlinked completely from its
 // parent, and the child still has a path and a basename.
 func TestNodeCacheUnlinkParent(t *testing.T) {
-	id := tlf.FakeID(42, false)
+	id := tlf.FakeID(42, tlf.Private)
 	branch := BranchName("testBranch")
 	ncs, _, childNode1, childNode2, _, path2 :=
 		setupNodeCache(t, id, branch, false)
@@ -337,7 +337,7 @@ func TestNodeCacheUnlinkParent(t *testing.T) {
 // then re-added with a new pointer and still work, but with a new
 // node core.
 func TestNodeCacheUnlinkThenRelink(t *testing.T) {
-	id := tlf.FakeID(42, false)
+	id := tlf.FakeID(42, tlf.Private)
 	branch := BranchName("testBranch")
 	ncs, _, childNode1, childNode2, _, path2 :=
 		setupNodeCache(t, id, branch, false)
@@ -381,7 +381,7 @@ func TestNodeCacheUnlinkThenRelink(t *testing.T) {
 
 // Tests that PathFromNode works correctly
 func TestNodeCachePathFromNode(t *testing.T) {
-	id := tlf.FakeID(42, false)
+	id := tlf.FakeID(42, tlf.Private)
 	branch := BranchName("testBranch")
 	ncs, _, _, childNode2, _, path2 :=
 		setupNodeCache(t, id, branch, false)
@@ -392,7 +392,7 @@ func TestNodeCachePathFromNode(t *testing.T) {
 // Make sure that (simulated) GC works as expected.
 func TestNodeCacheGCBasic(t *testing.T) {
 	ncs, parentNode, _, childNode2, _, _ :=
-		setupNodeCache(t, tlf.FakeID(0, false), MasterBranch, true)
+		setupNodeCache(t, tlf.FakeID(0, tlf.Private), MasterBranch, true)
 
 	if len(ncs.nodes) != 3 {
 		t.Errorf("Expected %d nodes, got %d", 3, len(ncs.nodes))
@@ -421,7 +421,7 @@ func TestNodeCacheGCBasic(t *testing.T) {
 // last reference to a parent.
 func TestNodeCacheGCParent(t *testing.T) {
 	ncs, _, _, childNode2, _, _ :=
-		setupNodeCache(t, tlf.FakeID(0, false), MasterBranch, true)
+		setupNodeCache(t, tlf.FakeID(0, tlf.Private), MasterBranch, true)
 
 	if len(ncs.nodes) != 3 {
 		t.Errorf("Expected %d nodes, got %d", 3, len(ncs.nodes))
@@ -452,7 +452,7 @@ func testNodeStandardFinalizer(n *nodeStandard) {
 // Make sure that that making a node unreachable runs the finalizer on GC.
 func TestNodeCacheGCReal(t *testing.T) {
 	ncs, _, childNode1, childNode2, _, _ :=
-		setupNodeCache(t, tlf.FakeID(0, false), MasterBranch, true)
+		setupNodeCache(t, tlf.FakeID(0, tlf.Private), MasterBranch, true)
 
 	if len(ncs.nodes) != 3 {
 		t.Errorf("Expected %d nodes, got %d", 3, len(ncs.nodes))

--- a/libkbfs/path.go
+++ b/libkbfs/path.go
@@ -35,10 +35,8 @@ func BuildCanonicalPath(pathType PathType, paths ...string) string {
 	switch pathType {
 	case KeybasePathType:
 		prefix = "/" + string(KeybasePathType)
-	case PublicPathType:
-		prefix = "/" + string(KeybasePathType) + "/" + string(PublicPathType)
-	case PrivatePathType:
-		prefix = "/" + string(KeybasePathType) + "/" + string(PrivatePathType)
+	default:
+		prefix = "/" + string(KeybasePathType) + "/" + string(pathType)
 	}
 	pathElements := []string{prefix}
 	for _, p := range paths {

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
@@ -54,7 +55,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 		name := strings.Join(writers, ",")
 		names = append(names, name)
 		// user 1 creates the directory
-		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 		// user 1 creates a file
 		_, _, err = kbfsOps1.CreateFile(ctx, rootNode1, "a", false, NoExcl)
 		if err != nil {
@@ -77,7 +78,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 	// user 2 should be unable to read the data now since its device
 	// wasn't registered when the folder was originally created.
 	for _, name := range names {
-		_, err := GetRootNodeForTest(ctx, config2Dev2, name, false)
+		_, err := GetRootNodeForTest(ctx, config2Dev2, name, tlf.Private)
 		if _, ok := err.(NeedSelfRekeyError); !ok {
 			t.Fatalf("Got unexpected error when reading with new key: %v", err)
 		}
@@ -87,7 +88,7 @@ func TestRekeyQueueBasic(t *testing.T) {
 
 	// now user 1 should rekey via its rekey worker
 	for _, name := range names {
-		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
+		rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 		getRekeyFSM(config1.KBFSOps(), rootNode1.GetFolderBranch().Tlf).
 			listenOnEvent(rekeyFinishedEvent, func(e RekeyEvent) {
 				fch <- e.finished.err
@@ -105,6 +106,6 @@ func TestRekeyQueueBasic(t *testing.T) {
 
 	// user 2's new device should be able to read now
 	for _, name := range names {
-		_ = GetRootNodeOrBust(ctx, t, config2Dev2, name, false)
+		_ = GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 	}
 }

--- a/libkbfs/reporter_simple.go
+++ b/libkbfs/reporter_simple.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/tlf"
 )
 
 // ReporterSimple remembers the last maxErrors errors, or all errors
@@ -42,7 +43,7 @@ func NewReporterSimple(clock Clock, maxErrors int) *ReporterSimple {
 
 // ReportErr implements the Reporter interface for ReporterSimple.
 func (r *ReporterSimple) ReportErr(ctx context.Context,
-	_ CanonicalTlfName, _ bool, _ ErrorModeType, err error) {
+	_ CanonicalTlfName, _ tlf.Type, _ ErrorModeType, err error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 

--- a/libkbfs/reporter_simple_test.go
+++ b/libkbfs/reporter_simple_test.go
@@ -7,6 +7,8 @@ package libkbfs
 import (
 	"errors"
 	"testing"
+
+	"github.com/keybase/kbfs/tlf"
 )
 
 func checkReportedErrors(t *testing.T, expected []error,
@@ -27,40 +29,40 @@ func checkReportedErrors(t *testing.T, expected []error,
 func TestReporterSimpleMaxLimited(t *testing.T) {
 	r := NewReporterSimple(wallClock{}, 3)
 	err1 := errors.New("1")
-	r.ReportErr(nil, "", false, ReadMode, err1)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err1)
 	checkReportedErrors(t, []error{err1}, r.AllKnownErrors())
 	err2 := errors.New("2")
-	r.ReportErr(nil, "", false, ReadMode, err2)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err2)
 	err3 := errors.New("3")
-	r.ReportErr(nil, "", false, ReadMode, err3)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err3)
 	checkReportedErrors(t, []error{err1, err2, err3}, r.AllKnownErrors())
 	err4 := errors.New("4")
-	r.ReportErr(nil, "", false, ReadMode, err4)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err4)
 	checkReportedErrors(t, []error{err2, err3, err4}, r.AllKnownErrors())
 	err5 := errors.New("5")
-	r.ReportErr(nil, "", false, ReadMode, err5)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err5)
 	err6 := errors.New("6")
-	r.ReportErr(nil, "", false, ReadMode, err6)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err6)
 	checkReportedErrors(t, []error{err4, err5, err6}, r.AllKnownErrors())
 }
 
 func TestReporterSimpleUnlimited(t *testing.T) {
 	r := NewReporterSimple(wallClock{}, 0)
 	err1 := errors.New("1")
-	r.ReportErr(nil, "", false, ReadMode, err1)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err1)
 	checkReportedErrors(t, []error{err1}, r.AllKnownErrors())
 	err2 := errors.New("2")
-	r.ReportErr(nil, "", false, ReadMode, err2)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err2)
 	err3 := errors.New("3")
-	r.ReportErr(nil, "", false, ReadMode, err3)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err3)
 	checkReportedErrors(t, []error{err1, err2, err3}, r.AllKnownErrors())
 	err4 := errors.New("4")
-	r.ReportErr(nil, "", false, ReadMode, err4)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err4)
 	checkReportedErrors(t, []error{err1, err2, err3, err4}, r.AllKnownErrors())
 	err5 := errors.New("5")
-	r.ReportErr(nil, "", false, ReadMode, err5)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err5)
 	err6 := errors.New("6")
-	r.ReportErr(nil, "", false, ReadMode, err6)
+	r.ReportErr(nil, "", tlf.Private, ReadMode, err6)
 	checkReportedErrors(t, []error{err1, err2, err3, err4, err5, err6},
 		r.AllKnownErrors())
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -196,7 +196,7 @@ func (md *RootMetadata) Extra() ExtraMetadata {
 
 // IsReadable returns true if the private metadata can be read.
 func (md *RootMetadata) IsReadable() bool {
-	return md.TlfID().IsPublic() || md.data.Dir.IsInitialized()
+	return md.TlfID().Type() == tlf.Public || md.data.Dir.IsInitialized()
 }
 
 func (md *RootMetadata) clearLastRevision() {
@@ -311,7 +311,7 @@ func (md *RootMetadata) MakeBareTlfHandle() (tlf.Handle, error) {
 // IsInitialized returns whether or not this RootMetadata has been initialized
 func (md *RootMetadata) IsInitialized() bool {
 	keyGen := md.LatestKeyGeneration()
-	if md.TlfID().IsPublic() {
+	if md.TlfID().Type() == tlf.Public {
 		return keyGen == PublicKeyGen
 	}
 	// The data is only initialized once we have at least one set of keys
@@ -374,16 +374,16 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
 	// TODO: Strengthen check, e.g. make sure every writer/reader
 	// in the old handle is also a writer/reader of the new
 	// handle.
-	if md.TlfID().IsPublic() != newHandle.IsPublic() {
+	if md.TlfID().Type() != newHandle.Type() {
 		return fmt.Errorf(
-			"Trying to update public=%t rmd with public=%t handle",
-			md.TlfID().IsPublic(), newHandle.IsPublic())
+			"Trying to update type=%s rmd with type=%s handle",
+			md.TlfID().Type(), newHandle.Type())
 	}
 
-	if newHandle.IsPublic() {
-		md.SetWriters(newHandle.ResolvedWriters())
-	} else {
+	if newHandle.Type() == tlf.Private {
 		md.SetUnresolvedReaders(newHandle.UnresolvedReaders())
+	} else {
+		md.SetWriters(newHandle.ResolvedWriters())
 	}
 
 	md.SetUnresolvedWriters(newHandle.UnresolvedWriters())
@@ -695,7 +695,7 @@ func (md *RootMetadata) SetRevision(revision kbfsmd.Revision) {
 }
 
 // SetWriters wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) SetWriters(writers []keybase1.UID) {
+func (md *RootMetadata) SetWriters(writers []keybase1.UserOrTeamID) {
 	md.bareMd.SetWriters(writers)
 }
 

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -17,6 +17,7 @@ import (
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/tlf"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -542,8 +543,8 @@ func CheckConfigAndShutdown(
 // must be canonical, creating it if necessary.
 func GetRootNodeForTest(
 	ctx context.Context, config Config, name string,
-	public bool) (Node, error) {
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), name, public)
+	t tlf.Type) (Node, error) {
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), name, t)
 	if err != nil {
 		return nil, err
 	}
@@ -561,11 +562,11 @@ func GetRootNodeForTest(
 // an error.
 func GetRootNodeOrBust(
 	ctx context.Context, t logger.TestLogBackend,
-	config Config, name string, public bool) Node {
-	n, err := GetRootNodeForTest(ctx, config, name, public)
+	config Config, name string, ty tlf.Type) Node {
+	n, err := GetRootNodeForTest(ctx, config, name, ty)
 	if err != nil {
-		t.Fatalf("Couldn't get root node for %s (public=%t): %+v",
-			name, public, err)
+		t.Fatalf("Couldn't get root node for %s (type=%s): %+v",
+			name, ty, err)
 	}
 	return n
 }

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -252,7 +252,9 @@ func (teh *TlfEditHistory) calculateEditCounts(ctx context.Context,
 
 	edits := make(TlfWriterEdits)
 	for _, writer := range rmds[len(rmds)-1].GetTlfHandle().ResolvedWriters() {
-		edits[writer] = nil
+		// TODO: if this is a single-team TLF, we'll need to look up
+		// the set of users from the team ID.
+		edits[writer.AsUserOrBust()] = nil
 	}
 
 outer:
@@ -377,7 +379,9 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 
 	estimates := make(writerEditEstimates)
 	for _, writer := range head.GetTlfHandle().ResolvedWriters() {
-		estimates[writer] = 0
+		// TODO: if this is a single-team TLF, we'll need to look up
+		// the set of users from the team ID.
+		estimates[writer.AsUserOrBust()] = 0
 	}
 	rmds := []ImmutableRootMetadata{head}
 	estimates.update(rmds)

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
@@ -46,8 +47,8 @@ func TestBasicTlfEditHistory(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 
 	// user 1 creates a file
 	kbfsOps1 := config1.KBFSOps()
@@ -179,8 +180,8 @@ func TestLongTlfEditHistory(t *testing.T) {
 
 	name := userName1.String() + "," + userName2.String()
 
-	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, false)
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, false)
+	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
+	rootNode2 := GetRootNodeOrBust(ctx, t, config2, name, tlf.Private)
 	kbfsOps1 := config1.KBFSOps()
 	kbfsOps2 := config2.KBFSOps()
 

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -87,7 +87,7 @@ func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 	name := "u2,u3"
 	_, err := ParseTlfHandle(ctx, kbpki, name, tlf.Private)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
-	assert.Equal(t, ReadAccessError{User: "u1", Tlf: CanonicalTlfName(name), Public: false, Filename: "/keybase/private/u2,u3"}, err)
+	assert.Equal(t, ReadAccessError{User: "u1", Tlf: CanonicalTlfName(name), Type: tlf.Private, Filename: "/keybase/private/u2,u3"}, err)
 }
 
 func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1823,7 +1823,7 @@ func (j *tlfJournal) putBlockData(
 	}
 
 	j.config.Reporter().NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{
-		PublicTopLevelFolder: j.tlfID.IsPublic(),
+		PublicTopLevelFolder: j.tlfID.Type() == tlf.Public,
 		// Path: TODO,
 		// TODO: should this be the complete total for the file/directory,
 		// rather than the diff?

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -223,9 +223,11 @@ func setupTLFJournalTest(
 	require.NoError(t, err)
 
 	config = &testTLFJournalConfig{
-		newTestCodecGetter(), newTestLogMaker(t), t, tlf.FakeID(1, false), bsplitter, crypto,
+		newTestCodecGetter(), newTestLogMaker(t), t,
+		tlf.FakeID(1, tlf.Private), bsplitter, crypto,
 		nil, nil, NewMDCacheStandard(10), ver,
-		NewReporterSimple(newTestClockNow(), 10), uid, verifyingKey, ekg, nil, mdserver, defaultDiskLimitMaxDelay + time.Second,
+		NewReporterSimple(newTestClockNow(), 10), uid, verifyingKey, ekg, nil,
+		mdserver, defaultDiskLimitMaxDelay + time.Second,
 	}
 
 	ctx, cancel = context.WithTimeout(

--- a/test/engine.go
+++ b/test/engine.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 )
 
 // User is an implementation-defined object which acts as a handle to a particular user.
@@ -44,10 +45,10 @@ type Engine interface {
 	GetUID(u User) keybase1.UID
 	// GetFavorites returns the set of all public or private
 	// favorites, based on the given bool.
-	GetFavorites(u User, public bool) (map[string]bool, error)
+	GetFavorites(u User, t tlf.Type) (map[string]bool, error)
 	// GetRootDir is called by the test harness to get a handle to a TLF from the given user's
 	// perspective
-	GetRootDir(u User, tlfName string, isPublic bool, expectedCanonicalTlfName string) (dir Node, err error)
+	GetRootDir(u User, tlfName string, t tlf.Type, expectedCanonicalTlfName string) (dir Node, err error)
 	// CreateDir is called by the test harness to create a directory relative to the passed
 	// parent directory for the given user.
 	CreateDir(u User, parentDir Node, name string) (dir Node, err error)
@@ -89,7 +90,7 @@ type Engine interface {
 	GetMtime(u User, file Node) (mtime time.Time, err error)
 	// SyncAll is called by the test harness as the given user to
 	// flush all writes buffered in memory to disk.
-	SyncAll(u User, tlfName string, isPublic bool) (err error)
+	SyncAll(u User, tlfName string, t tlf.Type) (err error)
 
 	// All functions below don't take nodes so that they can be
 	// run before any real FS operations.
@@ -97,20 +98,20 @@ type Engine interface {
 	// DisableUpdatesForTesting is called by the test harness as
 	// the given user to disable updates to trigger conflict
 	// conditions.
-	DisableUpdatesForTesting(u User, tlfName string, isPublic bool) (err error)
+	DisableUpdatesForTesting(u User, tlfName string, t tlf.Type) (err error)
 	//MakeNaïveStaller returns a NaïveStaller associated with user u for
 	//stalling BlockOps or MDOps.
 	MakeNaïveStaller(u User) *libkbfs.NaïveStaller
 	// ReenableUpdates is called by the test harness as the given
 	// user to resume updates if previously disabled for testing.
-	ReenableUpdates(u User, tlfName string, isPublic bool) (err error)
+	ReenableUpdates(u User, tlfName string, t tlf.Type) (err error)
 	// SyncFromServerForTesting is called by the test harness as
 	// the given user to actively retrieve new metadata for a
 	// folder.
-	SyncFromServerForTesting(u User, tlfName string, isPublic bool) (err error)
+	SyncFromServerForTesting(u User, tlfName string, t tlf.Type) (err error)
 	// ForceQuotaReclamation starts quota reclamation by the given
 	// user in the TLF corresponding to the given node.
-	ForceQuotaReclamation(u User, tlfName string, isPublic bool) (err error)
+	ForceQuotaReclamation(u User, tlfName string, t tlf.Type) (err error)
 	// AddNewAssertion makes newAssertion, which should be a
 	// single assertion that doesn't already resolve to anything,
 	// resolve to the same UID as oldAssertion, which should be an
@@ -118,22 +119,22 @@ type Engine interface {
 	// It only applies to the given user.
 	AddNewAssertion(u User, oldAssertion, newAssertion string) (err error)
 	// Rekey rekeys the given TLF under the given user.
-	Rekey(u User, tlfName string, isPublic bool) (err error)
+	Rekey(u User, tlfName string, t tlf.Type) (err error)
 	// EnableJournal is called by the test harness as the given
 	// user to enable journaling.
-	EnableJournal(u User, tlfName string, isPublic bool) (err error)
+	EnableJournal(u User, tlfName string, t tlf.Type) (err error)
 	// PauseJournal is called by the test harness as the given
 	// user to pause journaling.
-	PauseJournal(u User, tlfName string, isPublic bool) (err error)
+	PauseJournal(u User, tlfName string, t tlf.Type) (err error)
 	// ResumeJournal is called by the test harness as the given
 	// user to resume journaling.
-	ResumeJournal(u User, tlfName string, isPublic bool) (err error)
+	ResumeJournal(u User, tlfName string, t tlf.Type) (err error)
 	// FlushJournal is called by the test harness as the given
 	// user to wait for the journal to flush, if enabled.
-	FlushJournal(u User, tlfName string, isPublic bool) (err error)
+	FlushJournal(u User, tlfName string, t tlf.Type) (err error)
 	// UnflushedPaths called by the test harness to find out which
 	// paths haven't yet been flushed from the journal.
-	UnflushedPaths(u User, tlfName string, isPublic bool) (
+	UnflushedPaths(u User, tlfName string, t tlf.Type) (
 		paths []string, err error)
 	// TogglePrefetch is called by the test harness as the given user to toggle
 	// whether prefetching should be enabled

--- a/tlf/handle_test.go
+++ b/tlf/handle_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestMakeHandle(t *testing.T) {
-	w := []keybase1.UID{
-		keybase1.MakeTestUID(4),
-		keybase1.MakeTestUID(3),
+	w := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
 	}
 
-	r := []keybase1.UID{
-		keybase1.MakeTestUID(5),
-		keybase1.MakeTestUID(1),
+	r := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(5).AsUserOrTeam(),
+		keybase1.MakeTestUID(1).AsUserOrTeam(),
 	}
 
 	uw := []keybase1.SocialAssertion{
@@ -43,13 +43,13 @@ func TestMakeHandle(t *testing.T) {
 
 	h, err := MakeHandle(w, r, uw, ur, nil)
 	require.NoError(t, err)
-	require.Equal(t, []keybase1.UID{
-		keybase1.MakeTestUID(3),
-		keybase1.MakeTestUID(4),
+	require.Equal(t, []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
 	}, h.Writers)
-	require.Equal(t, []keybase1.UID{
-		keybase1.MakeTestUID(1),
-		keybase1.MakeTestUID(5),
+	require.Equal(t, []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(1).AsUserOrTeam(),
+		keybase1.MakeTestUID(5).AsUserOrTeam(),
 	}, h.Readers)
 	require.Equal(t, []keybase1.SocialAssertion{
 		{
@@ -77,14 +77,14 @@ func TestMakeHandleFailures(t *testing.T) {
 	_, err := MakeHandle(nil, nil, nil, nil, nil)
 	assert.Equal(t, errNoWriters, err)
 
-	w := []keybase1.UID{
-		keybase1.MakeTestUID(4),
-		keybase1.MakeTestUID(3),
+	w := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
 	}
 
-	r := []keybase1.UID{
-		keybase1.PUBLIC_UID,
-		keybase1.MakeTestUID(2),
+	r := []keybase1.UserOrTeamID{
+		keybase1.UserOrTeamID(keybase1.PUBLIC_UID),
+		keybase1.MakeTestUID(2).AsUserOrTeam(),
 	}
 
 	_, err = MakeHandle(r, nil, nil, nil, nil)
@@ -105,14 +105,14 @@ func TestMakeHandleFailures(t *testing.T) {
 }
 
 func TestHandleAccessorsPrivate(t *testing.T) {
-	w := []keybase1.UID{
-		keybase1.MakeTestUID(4),
-		keybase1.MakeTestUID(3),
+	w := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
 	}
 
-	r := []keybase1.UID{
-		keybase1.MakeTestUID(5),
-		keybase1.MakeTestUID(1),
+	r := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(5).AsUserOrTeam(),
+		keybase1.MakeTestUID(1).AsUserOrTeam(),
 	}
 
 	uw := []keybase1.SocialAssertion{
@@ -140,7 +140,7 @@ func TestHandleAccessorsPrivate(t *testing.T) {
 	h, err := MakeHandle(w, r, uw, ur, nil)
 	require.NoError(t, err)
 
-	require.False(t, h.IsPublic())
+	require.Equal(t, Private, h.Type())
 
 	for _, u := range w {
 		require.True(t, h.IsWriter(u))
@@ -153,17 +153,17 @@ func TestHandleAccessorsPrivate(t *testing.T) {
 	}
 
 	for i := 6; i < 10; i++ {
-		u := keybase1.MakeTestUID(uint32(i))
+		u := keybase1.MakeTestUID(uint32(i)).AsUserOrTeam()
 		require.False(t, h.IsWriter(u))
 		require.False(t, h.IsReader(u))
 	}
 
 	require.Equal(t, h.ResolvedUsers(),
-		[]keybase1.UID{
-			keybase1.MakeTestUID(3),
-			keybase1.MakeTestUID(4),
-			keybase1.MakeTestUID(1),
-			keybase1.MakeTestUID(5),
+		[]keybase1.UserOrTeamID{
+			keybase1.MakeTestUID(3).AsUserOrTeam(),
+			keybase1.MakeTestUID(4).AsUserOrTeam(),
+			keybase1.MakeTestUID(1).AsUserOrTeam(),
+			keybase1.MakeTestUID(5).AsUserOrTeam(),
 		})
 	require.True(t, h.HasUnresolvedUsers())
 	require.Equal(t, h.UnresolvedUsers(),
@@ -188,9 +188,9 @@ func TestHandleAccessorsPrivate(t *testing.T) {
 }
 
 func TestHandleAccessorsPublic(t *testing.T) {
-	w := []keybase1.UID{
-		keybase1.MakeTestUID(4),
-		keybase1.MakeTestUID(3),
+	w := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
 	}
 
 	uw := []keybase1.SocialAssertion{
@@ -205,10 +205,11 @@ func TestHandleAccessorsPublic(t *testing.T) {
 	}
 
 	h, err := MakeHandle(
-		w, []keybase1.UID{keybase1.PUBLIC_UID}, uw, nil, nil)
+		w, []keybase1.UserOrTeamID{keybase1.UserOrTeamID(keybase1.PUBLIC_UID)},
+		uw, nil, nil)
 	require.NoError(t, err)
 
-	require.True(t, h.IsPublic())
+	require.Equal(t, Public, h.Type())
 
 	for _, u := range w {
 		require.True(t, h.IsWriter(u))
@@ -216,15 +217,15 @@ func TestHandleAccessorsPublic(t *testing.T) {
 	}
 
 	for i := 6; i < 10; i++ {
-		u := keybase1.MakeTestUID(uint32(i))
+		u := keybase1.MakeTestUID(uint32(i)).AsUserOrTeam()
 		require.False(t, h.IsWriter(u))
 		require.True(t, h.IsReader(u))
 	}
 
 	require.Equal(t, h.ResolvedUsers(),
-		[]keybase1.UID{
-			keybase1.MakeTestUID(3),
-			keybase1.MakeTestUID(4),
+		[]keybase1.UserOrTeamID{
+			keybase1.MakeTestUID(3).AsUserOrTeam(),
+			keybase1.MakeTestUID(4).AsUserOrTeam(),
 		})
 	require.True(t, h.HasUnresolvedUsers())
 	require.Equal(t, h.UnresolvedUsers(),
@@ -241,9 +242,9 @@ func TestHandleAccessorsPublic(t *testing.T) {
 }
 
 func TestHandleHasUnresolvedUsers(t *testing.T) {
-	w := []keybase1.UID{
-		keybase1.MakeTestUID(4),
-		keybase1.MakeTestUID(3),
+	w := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
 	}
 
 	uw := []keybase1.SocialAssertion{
@@ -284,14 +285,14 @@ func TestHandleHasUnresolvedUsers(t *testing.T) {
 }
 
 func TestHandleResolveAssertions(t *testing.T) {
-	w := []keybase1.UID{
-		keybase1.MakeTestUID(4),
-		keybase1.MakeTestUID(3),
+	w := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
 	}
 
-	r := []keybase1.UID{
-		keybase1.MakeTestUID(5),
-		keybase1.MakeTestUID(1),
+	r := []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(5).AsUserOrTeam(),
+		keybase1.MakeTestUID(1).AsUserOrTeam(),
 	}
 
 	uw := []keybase1.SocialAssertion{
@@ -350,16 +351,16 @@ func TestHandleResolveAssertions(t *testing.T) {
 
 	h = h.ResolveAssertions(assertions)
 
-	require.Equal(t, []keybase1.UID{
-		keybase1.MakeTestUID(1),
-		keybase1.MakeTestUID(2),
-		keybase1.MakeTestUID(3),
-		keybase1.MakeTestUID(4),
+	require.Equal(t, []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(1).AsUserOrTeam(),
+		keybase1.MakeTestUID(2).AsUserOrTeam(),
+		keybase1.MakeTestUID(3).AsUserOrTeam(),
+		keybase1.MakeTestUID(4).AsUserOrTeam(),
 	}, h.Writers)
-	require.Equal(t, []keybase1.UID{
-		keybase1.MakeTestUID(5),
-		keybase1.MakeTestUID(6),
-		keybase1.MakeTestUID(9),
+	require.Equal(t, []keybase1.UserOrTeamID{
+		keybase1.MakeTestUID(5).AsUserOrTeam(),
+		keybase1.MakeTestUID(6).AsUserOrTeam(),
+		keybase1.MakeTestUID(9).AsUserOrTeam(),
 	}, h.Readers)
 	require.Equal(t, []keybase1.SocialAssertion{
 		{

--- a/tlf/id_test.go
+++ b/tlf/id_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestIDEncodeDecode(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
-	id := FakeID(1, true)
+	id := FakeID(1, Public)
 
 	encodedID, err := codec.Encode(id)
 	require.NoError(t, err)

--- a/tlf/test_common.go
+++ b/tlf/test_common.go
@@ -6,12 +6,15 @@ package tlf
 
 // FakeID creates a fake public or private TLF ID from the given
 // byte.
-func FakeID(b byte, public bool) ID {
+func FakeID(b byte, t Type) ID {
 	bytes := [idByteLen]byte{b}
-	if public {
+	switch t {
+	case Public:
 		bytes[idByteLen-1] = pubIDSuffix
-	} else {
+	case Private:
 		bytes[idByteLen-1] = idSuffix
+	case SingleTeam:
+		bytes[idByteLen-1] = singleTeamIDSuffix
 	}
 	return ID{bytes}
 }


### PR DESCRIPTION
This ended up being a far-reaching change, not only because of
switching the TLF handles over, but because determining the proper
type of a handle for a RootMetadata object required storing the
Writers/Readers as keybase1.UserOrTeamIDs, instead of keybase1.UIDs.

This is a largely mechanical change that doesn't add much new logic.

Issue: KBFS-2185