### PR TITLE
libkbfs: save the current Keybase Merkle root in mdv3

### DIFF
--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -19,7 +19,7 @@ func mdForceQROne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.Crypto(), config.KeyManager(),
-		irmd.MdID(), true)
+		config.KBPKI(), irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -44,7 +44,7 @@ func mdResetOne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.Crypto(), config.KeyManager(),
-		irmd.MdID(), true)
+		config.KBPKI(), irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -959,6 +959,13 @@ func (md *BareRootMetadataV2) RevisionNumber() kbfsmd.Revision {
 	return md.Revision
 }
 
+// MerkleSeqNo implements the BareRootMetadata interface for
+// BareRootMetadataV2.
+func (md *BareRootMetadataV2) MerkleSeqNo() MerkleSeqNo {
+	// No v2 MDs will have had this field set.
+	return UnknownMerkleSeqNo
+}
+
 // BID implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) BID() BranchID {
 	return md.WriterMetadataV2.BID
@@ -1060,6 +1067,12 @@ func (md *BareRootMetadataV2) SetWriterMetadataCopiedBit() {
 // SetRevision implements the MutableBareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) SetRevision(revision kbfsmd.Revision) {
 	md.Revision = revision
+}
+
+// SetMerkleSeqNo implements the MutableBareRootMetadata interface for
+// BareRootMetadataV2.
+func (md *BareRootMetadataV2) SetMerkleSeqNo(seqNo MerkleSeqNo) {
+	// V2 doesn't support merkle seqnos, just ignore.
 }
 
 // SetUnresolvedReaders implements the MutableBareRootMetadata interface for BareRootMetadataV2.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -88,6 +88,16 @@ type BareRootMetadataV3 struct {
 	// of writing to the given folder.
 	FinalizedInfo *tlf.HandleExtension `codec:"fi,omitempty"`
 
+	// The sequence number of the global Keybase Merkle tree at the
+	// time this update was created (from the writer's perspective).
+	// This field was added to V3 after it was live for a while, and
+	// older clients that don't know about this field yet might copy
+	// it into new updates via the unknown fields copier. Which means
+	// new MD updates might end up referring to older Merkle roots.
+	// That's ok since this is just a hint anyway, and shouldn't be
+	// fully trusted when checking MD updates against the Merkle tree.
+	KBMerkleSeqNo MerkleSeqNo `codec:"msn,omitempty"`
+
 	codec.UnknownFieldSetHandler
 }
 
@@ -968,6 +978,12 @@ func (md *BareRootMetadataV3) RevisionNumber() kbfsmd.Revision {
 	return md.Revision
 }
 
+// MerkleSeqNo implements the BareRootMetadata interface for
+// BareRootMetadataV3.
+func (md *BareRootMetadataV3) MerkleSeqNo() MerkleSeqNo {
+	return md.KBMerkleSeqNo
+}
+
 // BID implements the BareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) BID() BranchID {
 	return md.WriterMetadata.BID
@@ -1063,6 +1079,12 @@ func (md *BareRootMetadataV3) SetWriterMetadataCopiedBit() {
 // SetRevision implements the MutableBareRootMetadata interface for BareRootMetadataV3.
 func (md *BareRootMetadataV3) SetRevision(revision kbfsmd.Revision) {
 	md.Revision = revision
+}
+
+// SetMerkleSeqNo implements the MutableBareRootMetadata interface for
+// BareRootMetadataV3.
+func (md *BareRootMetadataV3) SetMerkleSeqNo(seqNo MerkleSeqNo) {
+	md.KBMerkleSeqNo = seqNo
 }
 
 func (md *BareRootMetadataV3) updateKeyBundles(crypto cryptoPure,

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2495,7 +2495,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 
 	newMD, err := mostRecentMergedMD.MakeSuccessor(
 		ctx, cr.config.MetadataVersion(), cr.config.Codec(),
-		cr.config.Crypto(), cr.config.KeyManager(),
+		cr.config.Crypto(), cr.config.KeyManager(), cr.config.KBPKI(),
 		mostRecentMergedMD.MdID(), true)
 	if err != nil {
 		return nil, err

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -773,3 +773,6 @@ func (im InitMode) String() string {
 		return "unknown"
 	}
 }
+
+// MerkleSeqNo is a sequence number in the Keybase Merkle tree.
+type MerkleSeqNo uint64

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -776,3 +776,12 @@ func (im InitMode) String() string {
 
 // MerkleSeqNo is a sequence number in the Keybase Merkle tree.
 type MerkleSeqNo uint64
+
+const (
+	// UnknownMerkleSeqNo represents an invalid sequence number
+	// indicating the correct seqno is not known (e.g., because the
+	// update pre-dates storing the seqno).
+	UnknownMerkleSeqNo MerkleSeqNo = 0
+	// FirstValidMerkleSeqNo is the smallest valid Merkle seqno.
+	FirstValidMerkleSeqNo MerkleSeqNo = 1
+)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1251,7 +1251,7 @@ func (fbo *folderBranchOps) getSuccessorMDForWriteLockedForFilename(
 	// or the changes will be lost.
 	return md.MakeSuccessor(ctx, fbo.config.MetadataVersion(),
 		fbo.config.Codec(), fbo.config.Crypto(),
-		fbo.config.KeyManager(), md.mdID, true)
+		fbo.config.KeyManager(), fbo.config.KBPKI(), md.mdID, true)
 }
 
 // getSuccessorMDForWriteLocked returns a new RootMetadata object with
@@ -1289,7 +1289,8 @@ func (fbo *folderBranchOps) getMDForRekeyWriteLocked(
 
 	newMd, err := md.MakeSuccessor(ctx, fbo.config.MetadataVersion(),
 		fbo.config.Codec(), fbo.config.Crypto(),
-		fbo.config.KeyManager(), md.mdID, handle.IsWriter(session.UID))
+		fbo.config.KeyManager(), fbo.config.KBPKI(), md.mdID,
+		handle.IsWriter(session.UID))
 	if err != nil {
 		return nil, kbfscrypto.VerifyingKey{}, false, err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -402,6 +402,10 @@ type KeybaseService interface {
 	// specified TeamID.
 	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID) (TeamInfo, error)
 
+	// GetCurrentMerkleSeqNo returns the current sequence number of the
+	// global Keybase Merkle tree.
+	GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error)
+
 	// CurrentSession returns a SessionInfo struct with all the
 	// information for the current session, or an error otherwise.
 	CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error)
@@ -526,6 +530,10 @@ type KBPKI interface {
 	// team.
 	GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (
 		map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error)
+
+	// GetCurrentMerkleSeqNo returns the current sequence number of the
+	// global Keybase Merkle tree.
+	GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error)
 
 	// TODO: Split the methods below off into a separate
 	// FavoriteOps interface.

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -377,7 +377,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		rmd, err = rmd.MakeSuccessor(ctx, config.MetadataVersion(),
 			config.Codec(), config.Crypto(), config.KeyManager(),
-			mdID, true)
+			config.KBPKI(), mdID, true)
 		require.NoError(t, err)
 		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
 			config.BlockSplitter(), rmd, false)

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -202,6 +202,12 @@ func (k *KBPKIClient) GetTeamTLFCryptKeys(
 	return teamInfo.CryptKeys, teamInfo.LatestKeyGen, nil
 }
 
+// GetCurrentMerkleSeqNo implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
+	MerkleSeqNo, error) {
+	return k.serviceOwner.KeybaseService().GetCurrentMerkleSeqNo(ctx)
+}
+
 // FavoriteAdd implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {
 	return k.serviceOwner.KeybaseService().FavoriteAdd(ctx, folder)

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -590,6 +590,6 @@ func newKeybaseDaemonLocal(codec kbfscodec.Codec,
 		asserts:       asserts,
 		currentUID:    currentUID,
 		favoriteStore: favoriteStore,
-		merkleSeqNo:   1,
+		merkleSeqNo:   FirstValidMerkleSeqNo,
 	}
 }

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -146,6 +146,7 @@ type KeybaseDaemonLocal struct {
 	currentUID    keybase1.UID
 	asserts       map[string]keybase1.UID
 	favoriteStore favoriteStore
+	merkleSeqNo   MerkleSeqNo
 }
 
 var _ KeybaseService = &KeybaseDaemonLocal{}
@@ -291,6 +292,19 @@ func (k *KeybaseDaemonLocal) LoadUnverifiedKeys(ctx context.Context, uid keybase
 		return nil, err
 	}
 	return u.UnverifiedKeys, nil
+}
+
+// GetCurrentMerkleSeqNo implements the KeybaseService interface for
+// KeybaseDaemonLocal.
+func (k *KeybaseDaemonLocal) GetCurrentMerkleSeqNo(ctx context.Context) (
+	MerkleSeqNo, error) {
+	if err := checkContext(ctx); err != nil {
+		return 0, err
+	}
+
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	return k.merkleSeqNo, nil
 }
 
 // CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.
@@ -576,5 +590,6 @@ func newKeybaseDaemonLocal(codec kbfscodec.Codec,
 		asserts:       asserts,
 		currentUID:    currentUID,
 		favoriteStore: favoriteStore,
+		merkleSeqNo:   1,
 	}
 }

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -412,7 +412,9 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetCurrentMerkleSeqNo(ctx context.Context) (
 	MerkleSeqNo, error) {
-	panic("The Keybase service doesn't support GetCurrentMerkleSeqNo yet")
+	// TODO: call into the service once they implement a way to get
+	// the current seqno.
+	return UnknownMerkleSeqNo, nil
 }
 
 func (k *KeybaseServiceBase) processUserPlusKeys(upk keybase1.UserPlusKeys) (

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -408,6 +408,13 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	panic("The Keybase service doesn't support LoadTeamPlusKeys yet")
 }
 
+// GetCurrentMerkleSeqNo implements the KeybaseService interface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) GetCurrentMerkleSeqNo(ctx context.Context) (
+	MerkleSeqNo, error) {
+	panic("The Keybase service doesn't support GetCurrentMerkleSeqNo yet")
+}
+
 func (k *KeybaseServiceBase) processUserPlusKeys(upk keybase1.UserPlusKeys) (
 	UserInfo, error) {
 	verifyingKeys, cryptPublicKeys, kidNames, err := filterKeys(upk.DeviceKeys)

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -14,17 +14,18 @@ import (
 // KeybaseServiceMeasured delegates to another KeybaseService instance
 // but also keeps track of stats.
 type KeybaseServiceMeasured struct {
-	delegate                KeybaseService
-	resolveTimer            metrics.Timer
-	identifyTimer           metrics.Timer
-	loadUserPlusKeysTimer   metrics.Timer
-	loadTeamPlusKeysTimer   metrics.Timer
-	loadUnverifiedKeysTimer metrics.Timer
-	currentSessionTimer     metrics.Timer
-	favoriteAddTimer        metrics.Timer
-	favoriteDeleteTimer     metrics.Timer
-	favoriteListTimer       metrics.Timer
-	notifyTimer             metrics.Timer
+	delegate                   KeybaseService
+	resolveTimer               metrics.Timer
+	identifyTimer              metrics.Timer
+	loadUserPlusKeysTimer      metrics.Timer
+	loadTeamPlusKeysTimer      metrics.Timer
+	loadUnverifiedKeysTimer    metrics.Timer
+	getCurrentMerkleSeqNoTimer metrics.Timer
+	currentSessionTimer        metrics.Timer
+	favoriteAddTimer           metrics.Timer
+	favoriteDeleteTimer        metrics.Timer
+	favoriteListTimer          metrics.Timer
+	notifyTimer                metrics.Timer
 }
 
 var _ KeybaseService = KeybaseServiceMeasured{}
@@ -37,23 +38,25 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 	loadUserPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUserPlusKeys", r)
 	loadTeamPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadTeamPlusKeys", r)
 	loadUnverifiedKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUnverifiedKeys", r)
+	getCurrentMerkleSeqNoTimer := metrics.GetOrRegisterTimer("KeybaseService.GetCurrentMerkleSeqNo", r)
 	currentSessionTimer := metrics.GetOrRegisterTimer("KeybaseService.CurrentSession", r)
 	favoriteAddTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteAdd", r)
 	favoriteDeleteTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteDelete", r)
 	favoriteListTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteList", r)
 	notifyTimer := metrics.GetOrRegisterTimer("KeybaseService.Notify", r)
 	return KeybaseServiceMeasured{
-		delegate:                delegate,
-		resolveTimer:            resolveTimer,
-		identifyTimer:           identifyTimer,
-		loadUserPlusKeysTimer:   loadUserPlusKeysTimer,
-		loadTeamPlusKeysTimer:   loadTeamPlusKeysTimer,
-		loadUnverifiedKeysTimer: loadUnverifiedKeysTimer,
-		currentSessionTimer:     currentSessionTimer,
-		favoriteAddTimer:        favoriteAddTimer,
-		favoriteDeleteTimer:     favoriteDeleteTimer,
-		favoriteListTimer:       favoriteListTimer,
-		notifyTimer:             notifyTimer,
+		delegate:                   delegate,
+		resolveTimer:               resolveTimer,
+		identifyTimer:              identifyTimer,
+		loadUserPlusKeysTimer:      loadUserPlusKeysTimer,
+		loadTeamPlusKeysTimer:      loadTeamPlusKeysTimer,
+		loadUnverifiedKeysTimer:    loadUnverifiedKeysTimer,
+		getCurrentMerkleSeqNoTimer: getCurrentMerkleSeqNoTimer,
+		currentSessionTimer:        currentSessionTimer,
+		favoriteAddTimer:           favoriteAddTimer,
+		favoriteDeleteTimer:        favoriteDeleteTimer,
+		favoriteListTimer:          favoriteListTimer,
+		notifyTimer:                notifyTimer,
 	}
 }
 
@@ -91,6 +94,16 @@ func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(ctx, tid)
 	})
 	return teamInfo, err
+}
+
+// GetCurrentMerkleSeqNo implements the KeybaseService interface for
+// KeybaseServiceMeasured.
+func (k KeybaseServiceMeasured) GetCurrentMerkleSeqNo(ctx context.Context) (
+	seqno MerkleSeqNo, err error) {
+	k.getCurrentMerkleSeqNoTimer.Time(func() {
+		seqno, err = k.delegate.GetCurrentMerkleSeqNo(ctx)
+	})
+	return seqno, err
 }
 
 // LoadUnverifiedKeys implements the KeybaseService interface for KeybaseServiceMeasured.

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -105,6 +105,15 @@ func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	return md
 }
 
+type constMerkleRootGetter struct{}
+
+var _ merkleSeqNoGetter = constMerkleRootGetter{}
+
+func (cmrg constMerkleRootGetter) GetCurrentMerkleSeqNo(
+	ctx context.Context) (MerkleSeqNo, error) {
+	return FirstValidMerkleSeqNo, nil
+}
+
 func putMDRangeHelper(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	signer kbfscrypto.Signer, firstRevision kbfsmd.Revision,
 	firstPrevRoot kbfsmd.ID, mdCount int, uid keybase1.UID,
@@ -123,7 +132,7 @@ func putMDRangeHelper(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	prevRoot := mdID
 	for i := 1; i < mdCount; i++ {
 		md, err = md.MakeSuccessor(ctx, ver, codec, crypto,
-			nil, prevRoot, true)
+			nil, constMerkleRootGetter{}, prevRoot, true)
 		require.NoError(t, err)
 		mdID, err := putMD(ctx, md)
 		require.NoError(t, err)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1003,6 +1003,38 @@ func (_mr *_MockKBFSOpsRecorder) ForceFastForward(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ForceFastForward", arg0)
 }
 
+// Mock of merkleSeqNoGetter interface
+type MockmerkleSeqNoGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockmerkleSeqNoGetterRecorder
+}
+
+// Recorder for MockmerkleSeqNoGetter (not exported)
+type _MockmerkleSeqNoGetterRecorder struct {
+	mock *MockmerkleSeqNoGetter
+}
+
+func NewMockmerkleSeqNoGetter(ctrl *gomock.Controller) *MockmerkleSeqNoGetter {
+	mock := &MockmerkleSeqNoGetter{ctrl: ctrl}
+	mock.recorder = &_MockmerkleSeqNoGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockmerkleSeqNoGetter) EXPECT() *_MockmerkleSeqNoGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockmerkleSeqNoGetter) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
+	ret0, _ := ret[0].(MerkleSeqNo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockmerkleSeqNoGetterRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+}
+
 // Mock of KeybaseService interface
 type MockKeybaseService struct {
 	ctrl     *gomock.Controller
@@ -1022,6 +1054,17 @@ func NewMockKeybaseService(ctrl *gomock.Controller) *MockKeybaseService {
 
 func (_m *MockKeybaseService) EXPECT() *_MockKeybaseServiceRecorder {
 	return _m.recorder
+}
+
+func (_m *MockKeybaseService) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
+	ret0, _ := ret[0].(MerkleSeqNo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKeybaseServiceRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
 }
 
 func (_m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
@@ -1079,17 +1122,6 @@ func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1
 
 func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1)
-}
-
-func (_m *MockKeybaseService) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
-	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
-	ret0, _ := ret[0].(MerkleSeqNo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKeybaseServiceRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
 }
 
 func (_m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error) {
@@ -1429,6 +1461,17 @@ func (_mr *_MockKBPKIRecorder) GetNormalizedUsername(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetNormalizedUsername", arg0, arg1)
 }
 
+func (_m *MockKBPKI) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
+	ret0, _ := ret[0].(MerkleSeqNo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKBPKIRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+}
+
 func (_m *MockKBPKI) HasVerifyingKey(ctx context.Context, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, atServerTime time.Time) error {
 	ret := _m.ctrl.Call(_m, "HasVerifyingKey", ctx, uid, verifyingKey, atServerTime)
 	ret0, _ := ret[0].(error)
@@ -1470,17 +1513,6 @@ func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamI
 
 func (_mr *_MockKBPKIRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
-}
-
-func (_m *MockKBPKI) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
-	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
-	ret0, _ := ret[0].(MerkleSeqNo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockKBPKIRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
 }
 
 func (_m *MockKBPKI) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {
@@ -5708,6 +5740,16 @@ func (_mr *_MockBareRootMetadataRecorder) RevisionNumber() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevisionNumber")
 }
 
+func (_m *MockBareRootMetadata) MerkleSeqNo() MerkleSeqNo {
+	ret := _m.ctrl.Call(_m, "MerkleSeqNo")
+	ret0, _ := ret[0].(MerkleSeqNo)
+	return ret0
+}
+
+func (_mr *_MockBareRootMetadataRecorder) MerkleSeqNo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MerkleSeqNo")
+}
+
 func (_m *MockBareRootMetadata) BID() BranchID {
 	ret := _m.ctrl.Call(_m, "BID")
 	ret0, _ := ret[0].(BranchID)
@@ -6144,6 +6186,16 @@ func (_mr *_MockMutableBareRootMetadataRecorder) RevisionNumber() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevisionNumber")
 }
 
+func (_m *MockMutableBareRootMetadata) MerkleSeqNo() MerkleSeqNo {
+	ret := _m.ctrl.Call(_m, "MerkleSeqNo")
+	ret0, _ := ret[0].(MerkleSeqNo)
+	return ret0
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) MerkleSeqNo() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MerkleSeqNo")
+}
+
 func (_m *MockMutableBareRootMetadata) BID() BranchID {
 	ret := _m.ctrl.Call(_m, "BID")
 	ret0, _ := ret[0].(BranchID)
@@ -6459,6 +6511,14 @@ func (_m *MockMutableBareRootMetadata) SetRevision(revision kbfsmd.Revision) {
 
 func (_mr *_MockMutableBareRootMetadataRecorder) SetRevision(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRevision", arg0)
+}
+
+func (_m *MockMutableBareRootMetadata) SetMerkleSeqNo(seqNo MerkleSeqNo) {
+	_m.ctrl.Call(_m, "SetMerkleSeqNo", seqNo)
+}
+
+func (_mr *_MockMutableBareRootMetadataRecorder) SetMerkleSeqNo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMerkleSeqNo", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) SetUnresolvedReaders(readers []keybase1.SocialAssertion) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1081,6 +1081,17 @@ func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1 interface{})
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1)
 }
 
+func (_m *MockKeybaseService) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
+	ret0, _ := ret[0].(MerkleSeqNo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKeybaseServiceRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+}
+
 func (_m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error) {
 	ret := _m.ctrl.Call(_m, "CurrentSession", ctx, sessionID)
 	ret0, _ := ret[0].(SessionInfo)
@@ -1459,6 +1470,17 @@ func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamI
 
 func (_mr *_MockKBPKIRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
+}
+
+func (_m *MockKBPKI) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
+	ret0, _ := ret[0].(MerkleSeqNo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKBPKIRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
 }
 
 func (_m *MockKBPKI) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -241,9 +241,8 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 // with the revision incremented and a correct backpointer.
 func (md *RootMetadata) MakeSuccessor(
 	ctx context.Context, latestMDVer MetadataVer, codec kbfscodec.Codec,
-	crypto cryptoPure, keyManager KeyManager, mdID kbfsmd.ID, isWriter bool) (
-	*RootMetadata, error) {
-
+	crypto cryptoPure, keyManager KeyManager, merkleGetter merkleSeqNoGetter,
+	mdID kbfsmd.ID, isWriter bool) (*RootMetadata, error) {
 	if mdID == (kbfsmd.ID{}) {
 		return nil, errors.New("Empty MdID in MakeSuccessor")
 	}
@@ -286,6 +285,13 @@ func (md *RootMetadata) MakeSuccessor(
 		return nil, errors.New("MD with invalid revision")
 	}
 	newMd.SetRevision(md.Revision() + 1)
+
+	merkleSeqNo, err := merkleGetter.GetCurrentMerkleSeqNo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	newMd.SetMerkleSeqNo(merkleSeqNo)
+
 	return newMd, nil
 }
 
@@ -610,6 +616,12 @@ func (md *RootMetadata) Revision() kbfsmd.Revision {
 	return md.bareMd.RevisionNumber()
 }
 
+// MerkleSeqNo wraps the respective method of the underlying
+// BareRootMetadata for convenience.
+func (md *RootMetadata) MerkleSeqNo() MerkleSeqNo {
+	return md.bareMd.MerkleSeqNo()
+}
+
 // MergedStatus wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) MergedStatus() MergeStatus {
 	return md.bareMd.MergedStatus()
@@ -692,6 +704,12 @@ func (md *RootMetadata) SetWriterMetadataCopiedBit() {
 // SetRevision wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) SetRevision(revision kbfsmd.Revision) {
 	md.bareMd.SetRevision(revision)
+}
+
+// SetMerkleSeqNo wraps the respective method of the underlying
+// BareRootMetadata for convenience.
+func (md *RootMetadata) SetMerkleSeqNo(seqNo MerkleSeqNo) {
+	md.bareMd.SetMerkleSeqNo(seqNo)
 }
 
 // SetWriters wraps the respective method of the underlying BareRootMetadata for convenience.

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -270,7 +270,7 @@ func testRootMetadataFinalIsFinal(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 
 	rmd.SetFinalBit()
-	_, err = rmd.MakeSuccessor(context.Background(), -1, nil, nil, nil,
+	_, err = rmd.MakeSuccessor(context.Background(), -1, nil, nil, nil, nil,
 		kbfsmd.FakeID(1), true)
 	_, isFinalError := err.(MetadataIsFinalError)
 	require.Equal(t, isFinalError, true)
@@ -393,7 +393,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(), config.Crypto(),
-		config.KeyManager(), kbfsmd.FakeID(1), true)
+		config.KeyManager(), config.KBPKI(), kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -484,7 +484,7 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(), config.Crypto(),
-		config.KeyManager(), kbfsmd.FakeID(1), true)
+		config.KeyManager(), config.KBPKI(), kbfsmd.FakeID(1), true)
 	require.NoError(t, err)
 	require.Equal(t, PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -610,7 +610,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	configReader.metadataVersion = SegregatedKeyBundlesVer
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		configReader.MetadataVersion(), configReader.Codec(),
-		configReader.Crypto(), configReader.KeyManager(),
+		configReader.Crypto(), configReader.KeyManager(), configReader.KBPKI(),
 		kbfsmd.FakeID(1), false)
 	require.NoError(t, err)
 	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())


### PR DESCRIPTION
Though in a live setting, this will actually only stored an omitted 0 for now, since the service doesn't expose this yet.

Issue: KBFS-2185
