### PR TITLE
disk_limits_unix: on FreeBSD, apparently Bavail is an int64

### DIFF
--- a/libkbfs/disk_limits_unix.go
+++ b/libkbfs/disk_limits_unix.go
@@ -24,12 +24,12 @@ func getDiskLimits(path string) (
 	}
 
 	// Bavail is the free block count for an unprivileged user.
-	availableBytes = stat.Bavail * uint64(stat.Bsize)
+	availableBytes = uint64(stat.Bavail) * uint64(stat.Bsize)
 	// Some filesystems, like btrfs, don't keep track of inodes.
 	// (See https://github.com/keybase/client/issues/6206 .) Use
 	// the total inode count to detect that case.
 	if stat.Files > 0 {
-		availableFiles = stat.Ffree
+		availableFiles = uint64(stat.Ffree)
 	} else {
 		availableFiles = math.MaxInt64
 	}


### PR DESCRIPTION
Issue: #998