### PR TITLE
libkbfs: check team membership on folder operations

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -56,7 +56,12 @@ type TeamInfo struct {
 	TID          keybase1.TeamID
 	CryptKeys    map[KeyGen]kbfscrypto.TLFCryptKey
 	LatestKeyGen KeyGen
-	// TODO: full user log or current membership + roles?
+
+	Writers map[keybase1.UID]bool
+	Readers map[keybase1.UID]bool
+
+	// TODO: Should we add a historic membership log to easily check
+	// whether a user was a member given some Merkle seqno?
 }
 
 // SessionInfo contains all the info about the keybase session that

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -1048,7 +1048,11 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	if err != nil {
 		return err
 	}
-	if !head.GetTlfHandle().IsWriter(session.UID) {
+	isWriter, err := head.IsWriter(ctx, fbm.config.KBPKI(), session.UID)
+	if err != nil {
+		return err
+	}
+	if !isWriter {
 		return NewWriteAccessError(head.GetTlfHandle(), session.Name,
 			head.GetTlfHandle().GetCanonicalPath())
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1874,7 +1874,11 @@ func (fbo *folderBlockOps) writeGetFileLocked(
 	if err != nil {
 		return nil, "", err
 	}
-	if !kmd.GetTlfHandle().IsWriter(session.UID) {
+	isWriter, err := kmd.IsWriter(ctx, fbo.config.KBPKI(), session.UID)
+	if err != nil {
+		return nil, "", err
+	}
+	if !isWriter {
 		return nil, "", NewWriteAccessError(kmd.GetTlfHandle(),
 			session.Name, file.String())
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -592,6 +592,12 @@ type KeyMetadata interface {
 	// fully.
 	GetTlfHandle() *TlfHandle
 
+	// IsWriter checks that the given user is a valid writer of the TLF
+	// right now.
+	IsWriter(
+		ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (
+		bool, error)
+
 	// HasKeyForUser returns whether or not the given user has
 	// keys for at least one device. Returns an error if the TLF
 	// is public.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -502,6 +502,22 @@ type CurrentSessionGetter interface {
 	GetCurrentSession(ctx context.Context) (SessionInfo, error)
 }
 
+type teamMembershipChecker interface {
+	// IsTeamWriter checks whether the given user is a writer of the
+	// given team right now.
+	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
+		bool, error)
+	// IsTeamReader checks whether the given user is a reader of the
+	// given team right now.
+	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
+		bool, error)
+	// TODO: add Was* method for figuring out whether the user was a
+	// writer/reader at a particular Merkle sequence number.  Not sure
+	// whether these calls should also verify that sequence number
+	// corresponds to a given TLF revision, or leave that work to
+	// another component.
+}
+
 // KBPKI interacts with the Keybase daemon to fetch user info.
 type KBPKI interface {
 	CurrentSessionGetter
@@ -509,6 +525,7 @@ type KBPKI interface {
 	identifier
 	normalizedUsernameGetter
 	merkleSeqNoGetter
+	teamMembershipChecker
 
 	// HasVerifyingKey returns nil if the given user has the given
 	// VerifyingKey, and an error otherwise.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -502,7 +502,9 @@ type CurrentSessionGetter interface {
 	GetCurrentSession(ctx context.Context) (SessionInfo, error)
 }
 
-type teamMembershipChecker interface {
+// TeamMembershipChecker is an interface for objects that can check
+// the writer/reader membership of teams.
+type TeamMembershipChecker interface {
 	// IsTeamWriter checks whether the given user is a writer of the
 	// given team right now.
 	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
@@ -525,7 +527,7 @@ type KBPKI interface {
 	identifier
 	normalizedUsernameGetter
 	merkleSeqNoGetter
-	teamMembershipChecker
+	TeamMembershipChecker
 
 	// HasVerifyingKey returns nil if the given user has the given
 	// VerifyingKey, and an error otherwise.
@@ -595,7 +597,7 @@ type KeyMetadata interface {
 	// IsWriter checks that the given user is a valid writer of the TLF
 	// right now.
 	IsWriter(
-		ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (
+		ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
 		bool, error)
 
 	// HasKeyForUser returns whether or not the given user has

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -208,6 +208,26 @@ func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
 	return k.serviceOwner.KeybaseService().GetCurrentMerkleSeqNo(ctx)
 }
 
+// IsTeamWriter implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) IsTeamWriter(
+	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(ctx, tid)
+	if err != nil {
+		return false, err
+	}
+	return teamInfo.Writers[uid], nil
+}
+
+// IsTeamReader implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) IsTeamReader(
+	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(ctx, tid)
+	if err != nil {
+		return false, err
+	}
+	return teamInfo.Writers[uid] || teamInfo.Readers[uid], nil
+}
+
 // FavoriteAdd implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {
 	return k.serviceOwner.KeybaseService().FavoriteAdd(ctx, folder)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -170,6 +170,12 @@ func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
 	return nil
 }
 
+func (kmd emptyKeyMetadata) IsWriter(
+	ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (
+	bool, error) {
+	return false, nil
+}
+
 func (kmd emptyKeyMetadata) LatestKeyGeneration() KeyGen {
 	return kmd.keyGen
 }

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -171,7 +171,7 @@ func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
 }
 
 func (kmd emptyKeyMetadata) IsWriter(
-	ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (
+	ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
 	bool, error) {
 	return false, nil
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1394,46 +1394,46 @@ func (_mr *_MockCurrentSessionGetterRecorder) GetCurrentSession(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentSession", arg0)
 }
 
-// Mock of teamMembershipChecker interface
-type MockteamMembershipChecker struct {
+// Mock of TeamMembershipChecker interface
+type MockTeamMembershipChecker struct {
 	ctrl     *gomock.Controller
-	recorder *_MockteamMembershipCheckerRecorder
+	recorder *_MockTeamMembershipCheckerRecorder
 }
 
-// Recorder for MockteamMembershipChecker (not exported)
-type _MockteamMembershipCheckerRecorder struct {
-	mock *MockteamMembershipChecker
+// Recorder for MockTeamMembershipChecker (not exported)
+type _MockTeamMembershipCheckerRecorder struct {
+	mock *MockTeamMembershipChecker
 }
 
-func NewMockteamMembershipChecker(ctrl *gomock.Controller) *MockteamMembershipChecker {
-	mock := &MockteamMembershipChecker{ctrl: ctrl}
-	mock.recorder = &_MockteamMembershipCheckerRecorder{mock}
+func NewMockTeamMembershipChecker(ctrl *gomock.Controller) *MockTeamMembershipChecker {
+	mock := &MockTeamMembershipChecker{ctrl: ctrl}
+	mock.recorder = &_MockTeamMembershipCheckerRecorder{mock}
 	return mock
 }
 
-func (_m *MockteamMembershipChecker) EXPECT() *_MockteamMembershipCheckerRecorder {
+func (_m *MockTeamMembershipChecker) EXPECT() *_MockTeamMembershipCheckerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockteamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+func (_m *MockTeamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockteamMembershipCheckerRecorder) IsTeamWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (_mr *_MockTeamMembershipCheckerRecorder) IsTeamWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2)
 }
 
-func (_m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+func (_m *MockTeamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	ret := _m.ctrl.Call(_m, "IsTeamReader", ctx, tid, uid)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockteamMembershipCheckerRecorder) IsTeamReader(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (_mr *_MockTeamMembershipCheckerRecorder) IsTeamReader(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamReader", arg0, arg1, arg2)
 }
 
@@ -1672,7 +1672,7 @@ func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
 }
 
-func (_m *MockKeyMetadata) IsWriter(ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (bool, error) {
+func (_m *MockKeyMetadata) IsWriter(ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (bool, error) {
 	ret := _m.ctrl.Call(_m, "IsWriter", ctx, checker, uid)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1672,6 +1672,17 @@ func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
 }
 
+func (_m *MockKeyMetadata) IsWriter(ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsWriter", ctx, checker, uid)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKeyMetadataRecorder) IsWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2)
+}
+
 func (_m *MockKeyMetadata) HasKeyForUser(user keybase1.UID) (bool, error) {
 	ret := _m.ctrl.Call(_m, "HasKeyForUser", user)
 	ret0, _ := ret[0].(bool)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1394,6 +1394,49 @@ func (_mr *_MockCurrentSessionGetterRecorder) GetCurrentSession(arg0 interface{}
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentSession", arg0)
 }
 
+// Mock of teamMembershipChecker interface
+type MockteamMembershipChecker struct {
+	ctrl     *gomock.Controller
+	recorder *_MockteamMembershipCheckerRecorder
+}
+
+// Recorder for MockteamMembershipChecker (not exported)
+type _MockteamMembershipCheckerRecorder struct {
+	mock *MockteamMembershipChecker
+}
+
+func NewMockteamMembershipChecker(ctrl *gomock.Controller) *MockteamMembershipChecker {
+	mock := &MockteamMembershipChecker{ctrl: ctrl}
+	mock.recorder = &_MockteamMembershipCheckerRecorder{mock}
+	return mock
+}
+
+func (_m *MockteamMembershipChecker) EXPECT() *_MockteamMembershipCheckerRecorder {
+	return _m.recorder
+}
+
+func (_m *MockteamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockteamMembershipCheckerRecorder) IsTeamWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2)
+}
+
+func (_m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsTeamReader", ctx, tid, uid)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockteamMembershipCheckerRecorder) IsTeamReader(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamReader", arg0, arg1, arg2)
+}
+
 // Mock of KBPKI interface
 type MockKBPKI struct {
 	ctrl     *gomock.Controller
@@ -1470,6 +1513,28 @@ func (_m *MockKBPKI) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, er
 
 func (_mr *_MockKBPKIRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+}
+
+func (_m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKBPKIRecorder) IsTeamWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2)
+}
+
+func (_m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsTeamReader", ctx, tid, uid)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockKBPKIRecorder) IsTeamReader(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamReader", arg0, arg1, arg2)
 }
 
 func (_m *MockKBPKI) HasVerifyingKey(ctx context.Context, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, atServerTime time.Time) error {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -857,7 +857,7 @@ func (md *RootMetadata) GetHistoricTLFCryptKey(
 // IsWriter checks that the given user is a valid writer of the TLF
 // right now.  Implements the KeyMetadata interface for RootMetadata.
 func (md *RootMetadata) IsWriter(
-	ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (
+	ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
 	bool, error) {
 	h := md.GetTlfHandle()
 	if h.Type() != tlf.SingleTeam {
@@ -875,7 +875,7 @@ func (md *RootMetadata) IsWriter(
 // IsReader checks that the given user is a valid reader of the TLF
 // right now.
 func (md *RootMetadata) IsReader(
-	ctx context.Context, checker teamMembershipChecker, uid keybase1.UID) (
+	ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
 	bool, error) {
 	h := md.GetTlfHandle()
 	if h.Type() != tlf.SingleTeam {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -864,7 +864,9 @@ func (md *RootMetadata) IsWriter(
 		return h.IsWriter(uid), nil
 	}
 
-	// Team membership needs to be checked with the service.
+	// Team membership needs to be checked with the service.  For a
+	// SingleTeam TLF, there is always only a single writer in the
+	// handle.
 	tid, err := h.FirstResolvedWriter().AsTeam()
 	if err != nil {
 		return false, err
@@ -882,7 +884,9 @@ func (md *RootMetadata) IsReader(
 		return h.IsReader(uid), nil
 	}
 
-	// Team membership needs to be checked with the service.
+	// Team membership needs to be checked with the service.  For a
+	// SingleTeam TLF, there is always only a single writer in the
+	// handle.
 	tid, err := h.FirstResolvedWriter().AsTeam()
 	if err != nil {
 		return false, err

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -413,6 +413,74 @@ func AddNewAssertionForTestOrBust(t logger.TestLogBackend, config Config,
 	}
 }
 
+// AddTeamWriterForTest makes the given user a team writer.
+func AddTeamWriterForTest(
+	config Config, tid keybase1.TeamID, uid keybase1.UID) error {
+	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
+	if !ok {
+		return errors.New("Bad keybase daemon")
+	}
+
+	return kbd.addTeamWriterForTest(tid, uid)
+}
+
+// AddTeamWriterForTestOrBust is like AddTeamWriterForTest, but
+// dies if there's an error.
+func AddTeamWriterForTestOrBust(t logger.TestLogBackend, config Config,
+	tid keybase1.TeamID, uid keybase1.UID) {
+	err := AddTeamWriterForTest(config, tid, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AddTeamReaderForTest makes the given user a team reader.
+func AddTeamReaderForTest(
+	config Config, tid keybase1.TeamID, uid keybase1.UID) error {
+	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
+	if !ok {
+		return errors.New("Bad keybase daemon")
+	}
+
+	return kbd.addTeamReaderForTest(tid, uid)
+}
+
+// AddTeamReaderForTestOrBust is like AddTeamWriterForTest, but
+// dies if there's an error.
+func AddTeamReaderForTestOrBust(t logger.TestLogBackend, config Config,
+	tid keybase1.TeamID, uid keybase1.UID) {
+	err := AddTeamReaderForTest(config, tid, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// AddEmptyTeamsForTest creates teams for the given names with empty
+// membership lists.
+func AddEmptyTeamsForTest(
+	config Config, teams ...libkb.NormalizedUsername) ([]TeamInfo, error) {
+	teamInfos := MakeLocalTeams(teams)
+
+	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
+	if !ok {
+		return nil, errors.New("Bad keybase daemon")
+	}
+
+	kbd.addTeamsForTest(teamInfos)
+	return teamInfos, nil
+}
+
+// AddEmptyTeamsForTestOrBust is like AddEmptyTeamsForTest, but dies
+// if there's an error.
+func AddEmptyTeamsForTestOrBust(t logger.TestLogBackend,
+	config Config, teams ...libkb.NormalizedUsername) []TeamInfo {
+	teamInfos, err := AddEmptyTeamsForTest(config, teams...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return teamInfos
+}
+
 func testRPCWithCanceledContext(t logger.TestLogBackend,
 	serverConn net.Conn, fn func(context.Context) error) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -107,7 +107,8 @@ func (h TlfHandle) ResolvedWriters() []keybase1.UserOrTeamID {
 }
 
 // FirstResolvedWriter returns the handle's first resolved writer ID
-// (when sorted). This is used mostly for tests.
+// (when sorted).  For SingleTeam handles, this returns the team to
+// which the TLF belongs.
 func (h TlfHandle) FirstResolvedWriter() keybase1.UserOrTeamID {
 	return h.ResolvedWriters()[0]
 }

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -639,7 +639,7 @@ func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
 	ctx := context.Background()
 	h, err := ParseTlfHandle(ctx, config.KBPKI(), name, ty)
 	if err != nil {
-		t.Fatalf("Couldn't parse %s (public=%s) into a TLF handle: %v",
+		t.Fatalf("Couldn't parse %s (type=%s) into a TLF handle: %v",
 			name, ty, err)
 	}
 	return h


### PR DESCRIPTION
This PR adds `IsWriter/IsReader` methods to `RootMetadata` to check team membership when appropriate, and uses them (instead of the `TlfHandle` methods) when appropriate.

Note that none of the rekey methods need to use these, since KBFS won't be rekeying team TLFs.  I've intentionally let the rekey methods continue to use the handle methods, to cause a panic if they're ever used for team TLFs.

Issue: KBFS-2185