### PR TITLE
root_metadata: set latest key gen for team TLF successors

### DIFF
--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -19,7 +19,7 @@ func mdForceQROne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.Crypto(), config.KeyManager(),
-		config.KBPKI(), irmd.MdID(), true)
+		config.KBPKI(), config.KBPKI(), irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -44,7 +44,7 @@ func mdResetOne(
 
 	rmdNext, err := irmd.MakeSuccessor(ctx, config.MetadataVersion(),
 		config.Codec(), config.Crypto(), config.KeyManager(),
-		config.KBPKI(), irmd.MdID(), true)
+		config.KBPKI(), config.KBPKI(), irmd.MdID(), true)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2496,7 +2496,7 @@ func (cr *ConflictResolver) createResolvedMD(ctx context.Context,
 	newMD, err := mostRecentMergedMD.MakeSuccessor(
 		ctx, cr.config.MetadataVersion(), cr.config.Codec(),
 		cr.config.Crypto(), cr.config.KeyManager(), cr.config.KBPKI(),
-		mostRecentMergedMD.MdID(), true)
+		cr.config.KBPKI(), mostRecentMergedMD.MdID(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1260,7 +1260,8 @@ func (fbo *folderBranchOps) getSuccessorMDForWriteLockedForFilename(
 	// or the changes will be lost.
 	return md.MakeSuccessor(ctx, fbo.config.MetadataVersion(),
 		fbo.config.Codec(), fbo.config.Crypto(),
-		fbo.config.KeyManager(), fbo.config.KBPKI(), md.mdID, true)
+		fbo.config.KeyManager(), fbo.config.KBPKI(), fbo.config.KBPKI(),
+		md.mdID, true)
 }
 
 // getSuccessorMDForWriteLocked returns a new RootMetadata object with
@@ -1298,8 +1299,8 @@ func (fbo *folderBranchOps) getMDForRekeyWriteLocked(
 
 	newMd, err := md.MakeSuccessor(ctx, fbo.config.MetadataVersion(),
 		fbo.config.Codec(), fbo.config.Crypto(),
-		fbo.config.KeyManager(), fbo.config.KBPKI(), md.mdID,
-		handle.IsWriter(session.UID))
+		fbo.config.KeyManager(), fbo.config.KBPKI(), fbo.config.KBPKI(),
+		md.mdID, handle.IsWriter(session.UID))
 	if err != nil {
 		return nil, kbfscrypto.VerifyingKey{}, false, err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -520,6 +520,14 @@ type TeamMembershipChecker interface {
 	// another component.
 }
 
+type teamKeysGetter interface {
+	// GetTeamTLFCryptKeys gets all of a team's secret crypt keys, by
+	// generation, as well as the latest key generation number for the
+	// team.
+	GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (
+		map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error)
+}
+
 // KBPKI interacts with the Keybase daemon to fetch user info.
 type KBPKI interface {
 	CurrentSessionGetter
@@ -528,6 +536,7 @@ type KBPKI interface {
 	normalizedUsernameGetter
 	merkleSeqNoGetter
 	TeamMembershipChecker
+	teamKeysGetter
 
 	// HasVerifyingKey returns nil if the given user has the given
 	// VerifyingKey, and an error otherwise.
@@ -548,12 +557,6 @@ type KBPKI interface {
 	// paper keys).
 	GetCryptPublicKeys(ctx context.Context, uid keybase1.UID) (
 		[]kbfscrypto.CryptPublicKey, error)
-
-	// GetTeamTLFCryptKeys gets all of a team's secret crypt keys, by
-	// generation, as well as the latest key generation number for the
-	// team.
-	GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (
-		map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error)
 
 	// TODO: Split the methods below off into a separate
 	// FavoriteOps interface.

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -377,7 +377,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	for i := 0; i < mdCount; i++ {
 		rmd, err = rmd.MakeSuccessor(ctx, config.MetadataVersion(),
 			config.Codec(), config.Crypto(), config.KeyManager(),
-			config.KBPKI(), mdID, true)
+			config.KBPKI(), config.KBPKI(), mdID, true)
 		require.NoError(t, err)
 		mdID, err = j.put(ctx, config.Crypto(), config.KeyManager(),
 			config.BlockSplitter(), rmd, false)

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -501,6 +501,26 @@ func (k *KeybaseDaemonLocal) addTeamReaderForTest(
 	return nil
 }
 
+func (k *KeybaseDaemonLocal) addTeamKeyForTest(
+	tid keybase1.TeamID, newKeyGen KeyGen,
+	newKey kbfscrypto.TLFCryptKey) error {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	t, err := k.localTeams.getLocalTeam(tid)
+	if err != nil {
+		return err
+	}
+
+	t.CryptKeys[newKeyGen] = newKey
+	if newKeyGen > t.LatestKeyGen {
+		t.LatestKeyGen = newKeyGen
+		// Only need to save back to the map if we've modified a
+		// non-reference type like the latest key gen.
+		k.localTeams[tid] = t
+	}
+	return nil
+}
+
 func (k *KeybaseDaemonLocal) addTeamsForTest(teams []TeamInfo) {
 	k.lock.Lock()
 	defer k.lock.Unlock()

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -132,7 +132,7 @@ func putMDRangeHelper(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	prevRoot := mdID
 	for i := 1; i < mdCount; i++ {
 		md, err = md.MakeSuccessor(ctx, ver, codec, crypto,
-			nil, constMerkleRootGetter{}, prevRoot, true)
+			nil, constMerkleRootGetter{}, nil, prevRoot, true)
 		require.NoError(t, err)
 		mdID, err := putMD(ctx, md)
 		require.NoError(t, err)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1437,6 +1437,39 @@ func (_mr *_MockTeamMembershipCheckerRecorder) IsTeamReader(arg0, arg1, arg2 int
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamReader", arg0, arg1, arg2)
 }
 
+// Mock of teamKeysGetter interface
+type MockteamKeysGetter struct {
+	ctrl     *gomock.Controller
+	recorder *_MockteamKeysGetterRecorder
+}
+
+// Recorder for MockteamKeysGetter (not exported)
+type _MockteamKeysGetterRecorder struct {
+	mock *MockteamKeysGetter
+}
+
+func NewMockteamKeysGetter(ctrl *gomock.Controller) *MockteamKeysGetter {
+	mock := &MockteamKeysGetter{ctrl: ctrl}
+	mock.recorder = &_MockteamKeysGetterRecorder{mock}
+	return mock
+}
+
+func (_m *MockteamKeysGetter) EXPECT() *_MockteamKeysGetterRecorder {
+	return _m.recorder
+}
+
+func (_m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid)
+	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
+	ret1, _ := ret[1].(KeyGen)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockteamKeysGetterRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
+}
+
 // Mock of KBPKI interface
 type MockKBPKI struct {
 	ctrl     *gomock.Controller
@@ -1537,6 +1570,18 @@ func (_mr *_MockKBPKIRecorder) IsTeamReader(arg0, arg1, arg2 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamReader", arg0, arg1, arg2)
 }
 
+func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid)
+	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
+	ret1, _ := ret[1].(KeyGen)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockKBPKIRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
+}
+
 func (_m *MockKBPKI) HasVerifyingKey(ctx context.Context, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, atServerTime time.Time) error {
 	ret := _m.ctrl.Call(_m, "HasVerifyingKey", ctx, uid, verifyingKey, atServerTime)
 	ret0, _ := ret[0].(error)
@@ -1566,18 +1611,6 @@ func (_m *MockKBPKI) GetCryptPublicKeys(ctx context.Context, uid keybase1.UID) (
 
 func (_mr *_MockKBPKIRecorder) GetCryptPublicKeys(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCryptPublicKeys", arg0, arg1)
-}
-
-func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
-	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid)
-	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
-	ret1, _ := ret[1].(KeyGen)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-func (_mr *_MockKBPKIRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
 }
 
 func (_m *MockKBPKI) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -271,7 +271,7 @@ func testRootMetadataFinalIsFinal(t *testing.T, ver MetadataVer) {
 
 	rmd.SetFinalBit()
 	_, err = rmd.MakeSuccessor(context.Background(), -1, nil, nil, nil, nil,
-		kbfsmd.FakeID(1), true)
+		nil, kbfsmd.FakeID(1), true)
 	_, isFinalError := err.(MetadataIsFinalError)
 	require.Equal(t, isFinalError, true)
 }
@@ -393,7 +393,8 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(), config.Crypto(),
-		config.KeyManager(), config.KBPKI(), kbfsmd.FakeID(1), true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
+		true)
 	require.NoError(t, err)
 	require.Equal(t, KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -484,7 +485,8 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(), config.Crypto(),
-		config.KeyManager(), config.KBPKI(), kbfsmd.FakeID(1), true)
+		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
+		true)
 	require.NoError(t, err)
 	require.Equal(t, PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
@@ -611,7 +613,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		configReader.MetadataVersion(), configReader.Codec(),
 		configReader.Crypto(), configReader.KeyManager(), configReader.KBPKI(),
-		kbfsmd.FakeID(1), false)
+		configReader.KBPKI(), kbfsmd.FakeID(1), false)
 	require.NoError(t, err)
 	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())

--- a/tlf/id.go
+++ b/tlf/id.go
@@ -82,7 +82,8 @@ func (id ID) String() string {
 // MarshalBinary implements the encoding.BinaryMarshaler interface for ID.
 func (id ID) MarshalBinary() (data []byte, err error) {
 	suffix := id.id[idByteLen-1]
-	if suffix != idSuffix && suffix != pubIDSuffix {
+	if suffix != idSuffix && suffix != pubIDSuffix &&
+		suffix != singleTeamIDSuffix {
 		return nil, errors.WithStack(InvalidIDError{id.String()})
 	}
 	return id.id[:], nil
@@ -96,7 +97,8 @@ func (id *ID) UnmarshalBinary(data []byte) error {
 			InvalidIDError{hex.EncodeToString(data)})
 	}
 	suffix := data[idByteLen-1]
-	if suffix != idSuffix && suffix != pubIDSuffix {
+	if suffix != idSuffix && suffix != pubIDSuffix &&
+		suffix != singleTeamIDSuffix {
 		return errors.WithStack(
 			InvalidIDError{hex.EncodeToString(data)})
 	}


### PR DESCRIPTION
Also fix (de)serialization of team TLF IDs.

Issue: KBFS-2192