### PR TITLE
mdserver_tlf_storage: create branch journal when reading head

### DIFF
--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -217,9 +217,9 @@ func (s *mdServerTlfStorage) getOrCreateBranchJournalLocked(
 
 func (s *mdServerTlfStorage) getHeadForTLFReadLocked(bid BranchID) (
 	rmds *RootMetadataSigned, err error) {
-	j, ok := s.branchJournals[bid]
-	if !ok {
-		return nil, nil
+	j, err := s.getOrCreateBranchJournalLocked(bid)
+	if err != nil {
+		return nil, err
 	}
 	entry, exists, err := j.getLatestEntry()
 	if err != nil {


### PR DESCRIPTION
Otherwise, even if there's already a branch journal on the disk, we won't check it for the head, and it will look like updates don't persist across reboots.

This fixes a bug where using `kbfsfuse` with local disk storage for the MD didn't work after a reboot.