### PR TITLE
increase duration in EnableDelayedCancellationWithGracePeriod

### DIFF
--- a/libkbfs/delayed_cancellation_test.go
+++ b/libkbfs/delayed_cancellation_test.go
@@ -141,7 +141,7 @@ func TestDelayedCancellationEnabled(t *testing.T) {
 	select {
 	case <-ctx.Done():
 		t.Fatalf("Cancellation is not delayed")
-	case <-time.After(20 * time.Millisecond):
+	case <-time.After(10 * time.Millisecond):
 	}
 
 	<-ctx.Done()

--- a/libkbfs/delayed_cancellation_test.go
+++ b/libkbfs/delayed_cancellation_test.go
@@ -134,14 +134,14 @@ func TestDelayedCancellationEnabled(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := makeContextWithDelayedCancellation(t)
-	EnableDelayedCancellationWithGracePeriod(ctx, 15*time.Millisecond)
+	EnableDelayedCancellationWithGracePeriod(ctx, 50*time.Millisecond)
 
 	cancel()
 
 	select {
 	case <-ctx.Done():
 		t.Fatalf("Cancellation is not delayed")
-	case <-time.After(10 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 	}
 
 	<-ctx.Done()


### PR DESCRIPTION
The test passed `repeat 100 ./libkbfs.test -test.run=TestDelayedCancellationEnabled` on my machine, so I assume this is just due to CI slowness (or high parallelism). This PR increases the delayed duration so the flake is less likely to happen. It increases (the major wait time of) the test from 15ms to 50ms, which is not too bad for a single test.

But in the future if this is still flaky, and we don't want to bump it to e.g. 200ms, we should probably just skip this test.