### PR TITLE
folder_branch_ops: don't collect resolved paths for unlinked nodes

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3826,7 +3826,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	fbo.log.CDebugf(ctx, "Syncing %d dir(s)", len(dirtyDirs))
 	for _, ref := range dirtyDirs {
 		node := fbo.nodeCache.Get(ref)
-		if node == nil {
+		if node == nil || fbo.nodeCache.IsUnlinked(node) {
 			continue
 		}
 
@@ -3915,7 +3915,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 					return err
 				}
 				lbc[newPointer] = dblock
-				resolvedPaths[newPointer] = newPath
+				if !fbo.nodeCache.IsUnlinked(newNode) {
+					resolvedPaths[newPointer] = newPath
+				}
 			}
 
 			if len(dblock.Children) > 0 {
@@ -3973,7 +3975,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	fileSyncBlocks := newBlockPutState(1)
 	for _, ref := range dirtyFiles {
 		node := fbo.nodeCache.Get(ref)
-		if node == nil {
+		if node == nil || fbo.nodeCache.IsUnlinked(node) {
 			continue
 		}
 		file := fbo.nodeCache.PathFromNode(node)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3826,7 +3826,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	fbo.log.CDebugf(ctx, "Syncing %d dir(s)", len(dirtyDirs))
 	for _, ref := range dirtyDirs {
 		node := fbo.nodeCache.Get(ref)
-		if node == nil || fbo.nodeCache.IsUnlinked(node) {
+		if node == nil {
 			continue
 		}
 
@@ -3837,7 +3837,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 		}
 
 		lbc[dir.tailPointer()] = dblock
-		resolvedPaths[dir.tailPointer()] = dir
+		if !fbo.nodeCache.IsUnlinked(node) {
+			resolvedPaths[dir.tailPointer()] = dir
+		}
 
 		// On a successful sync, clean up the cached entries and the
 		// dirty blocks.
@@ -3975,7 +3977,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	fileSyncBlocks := newBlockPutState(1)
 	for _, ref := range dirtyFiles {
 		node := fbo.nodeCache.Get(ref)
-		if node == nil || fbo.nodeCache.IsUnlinked(node) {
+		if node == nil {
 			continue
 		}
 		file := fbo.nodeCache.PathFromNode(node)

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -222,7 +222,9 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlfID tlf.ID) erro
 				}
 			}
 			for _, update := range op.allUpdates() {
-				delete(expectedLiveBlocks, update.Unref)
+				if update.Ref != update.Unref {
+					delete(expectedLiveBlocks, update.Unref)
+				}
 				if update.Unref != zeroPtr && update.Ref != update.Unref {
 					if rmd.Revision() <= gcRevision {
 						delete(archivedBlocks, update.Unref)
@@ -230,7 +232,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlfID tlf.ID) erro
 						archivedBlocks[update.Unref] = true
 					}
 				}
-				if update.Ref != zeroPtr {
+				if update.Ref != zeroPtr && update.Ref != update.Unref {
 					expectedLiveBlocks[update.Ref] = true
 				}
 			}


### PR DESCRIPTION
During SyncAll(), we don't want to bother adding resolved paths for
nodes that have already been unlinked, as this will result in the
folderUpdatePrepper attempting (and failing) to find their current
directory entries.

Fixing this exposed an issue with the StateChecker: if a node is
added, modified and removed within a batch, there may be some ops that
have "updates" for BlockPointers that only existed during the batch,
and thus will never make it to the BlockPointer.  It would be better
to somehow edit the list of ops to not reference these blocks, but
that's fairly tricky given that nodes within removed directories could
have moved out before the parent was deleted, and we still need a
record of the original create somewhere.  The self-updates are pretty
harmless, so for now just ignore them in the StateChecker so that
tests will pass.

Issue: KBFS-2243