### PR TITLE
improve testing for single-team TLFs

### DIFF
--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -443,6 +443,10 @@ func splitAndNormalizeTLFName(name string, t tlf.Type) (
 	if err != nil {
 		return nil, nil, "", err
 	}
+	if t == tlf.SingleTeam && len(writerNames) != 1 {
+		// No team folder can have more than one writer.
+		return nil, nil, "", NoSuchNameError{Name: name}
+	}
 
 	hasReaders := len(readerNames) != 0
 	if t != tlf.Private && hasReaders {

--- a/test/engine.go
+++ b/test/engine.go
@@ -21,6 +21,13 @@ type Node interface{}
 
 type username string
 
+type teamMembers struct {
+	writers []libkb.NormalizedUsername
+	readers []libkb.NormalizedUsername
+}
+
+type teamMap map[libkb.NormalizedUsername]teamMembers
+
 // Engine is the interface to the filesystem to be used by the test harness.
 // It may wrap libkbfs directly or it may wrap other users of libkbfs (e.g., libfuse).
 type Engine interface {
@@ -40,7 +47,8 @@ type Engine interface {
 	InitTest(ver libkbfs.MetadataVer, blockSize int64,
 		blockChangeSize int64, batchSize int, bwKBps int,
 		opTimeout time.Duration, users []libkb.NormalizedUsername,
-		clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User
+		teams teamMap, clock libkbfs.Clock,
+		journal bool) map[libkb.NormalizedUsername]User
 	// GetUID is called by the test harness to retrieve a user instance's UID.
 	GetUID(u User) keybase1.UID
 	// GetFavorites returns the set of all public or private

--- a/test/engine_common.go
+++ b/test/engine_common.go
@@ -7,6 +7,7 @@ package test
 import (
 	"testing"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/kbfs/libkbfs"
 )
 
@@ -39,5 +40,20 @@ func maybeSetBw(t testing.TB, config libkbfs.Config, bwKBps int) {
 		// Looks like we're testing big transfers, so let's do
 		// background flushes.
 		config.SetDoBackgroundFlushes(true)
+	}
+}
+
+func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
+	users map[libkb.NormalizedUsername]User) {
+	for name, members := range teams {
+		infos := libkbfs.AddEmptyTeamsForTestOrBust(t, config, name)
+		for _, w := range members.writers {
+			libkbfs.AddTeamWriterForTestOrBust(t, config, infos[0].TID,
+				e.GetUID(users[w]))
+		}
+		for _, r := range members.readers {
+			libkbfs.AddTeamReaderForTestOrBust(t, config, infos[0].TID,
+				e.GetUID(users[r]))
+		}
 	}
 }

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -82,6 +82,8 @@ func buildRootPath(u *fsUser, t tlf.Type) string {
 		path = filepath.Join(u.mntDir, "public")
 	case tlf.Private:
 		path = filepath.Join(u.mntDir, "private")
+	case tlf.SingleTeam:
+		path = filepath.Join(u.mntDir, "team")
 	default:
 		panic(fmt.Sprintf("Unknown TLF type: %s", t))
 	}
@@ -544,7 +546,7 @@ func fiTypeString(fi os.FileInfo) string {
 
 func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []libkb.NormalizedUsername,
+	opTimeout time.Duration, users []libkb.NormalizedUsername, teams teamMap,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {
 	res := map[libkb.NormalizedUsername]User{}
 	initSuccess := false
@@ -614,6 +616,10 @@ func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 				panic(fmt.Sprintf("Couldn't disable journaling: %+v", err))
 			}
 		}
+	}
+
+	for _, c := range cfgs {
+		makeTeams(e.tb, c, e, teams, res)
 	}
 
 	initSuccess = true

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -45,7 +45,7 @@ func (k *LibKBFS) Name() string {
 // InitTest implements the Engine interface.
 func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []libkb.NormalizedUsername,
+	opTimeout time.Duration, users []libkb.NormalizedUsername, teams teamMap,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {
 	userMap := make(map[libkb.NormalizedUsername]User)
 	// create the first user specially
@@ -102,6 +102,11 @@ func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 				panic(fmt.Sprintf("Couldn't disable journaling: %+v", err))
 			}
 		}
+	}
+
+	for _, u := range userMap {
+		c := u.(libkbfs.Config)
+		makeTeams(k.tb, c, k, teams, userMap)
 	}
 
 	return userMap

--- a/test/teams_test.go
+++ b/test/teams_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"testing"
+)
+
+func TestTeamsTwoWriters(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		team("ab", "alice,bob", ""),
+		inSingleTeamTlf("ab"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}
+
+func TestTeamsTwoWritersNonCanonical(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		team("ab", "alice,bob", ""),
+		inSingleTeamNonCanonical("AB", "ab"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}
+
+func TestTeamsWriterReader(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		team("a_b", "alice", "bob"),
+		inSingleTeamTlf("a_b"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			expectError(mkfile("b", "world"),
+				"bob does not have write access to directory /keybase/team/a_b"),
+		),
+	)
+}

--- a/tlf/handle.go
+++ b/tlf/handle.go
@@ -86,19 +86,22 @@ func MakeHandle(
 		}
 	}
 
-	for _, w := range writers {
+	for i, w := range writers {
 		if w == keybase1.PUBLIC_UID {
+			return Handle{}, errInvalidWriter
+		} else if i > 0 && w.IsTeamOrSubteam() {
 			return Handle{}, errInvalidWriter
 		}
 	}
 
-	if (len(readers) + len(unresolvedReaders)) > 1 {
-		// If we have more than one reader, none of them
-		// should be the public UID.
-		for _, r := range readers {
-			if r == keybase1.PUBLIC_UID {
-				return Handle{}, errInvalidReader
-			}
+	// If we have more than one reader, none of them should be the
+	// public UID.  And no readers should be a team.
+	checkPublic := (len(readers) + len(unresolvedReaders)) > 1
+	for _, r := range readers {
+		if checkPublic && r == keybase1.PUBLIC_UID {
+			return Handle{}, errInvalidReader
+		} else if r.IsTeamOrSubteam() {
+			return Handle{}, errInvalidReader
 		}
 	}
 


### PR DESCRIPTION
This adds handle and DSL tests for single team TLFs, including some new error checking code for handle creation.

Issue: KBFS-2238