### PR TITLE
libdokan: Provide fake root directory for other SIDs

### DIFF
--- a/libdokan/common.go
+++ b/libdokan/common.go
@@ -25,6 +25,9 @@ const (
 
 	// CtxOpID is the display name for the unique operation Dokan ID tag.
 	CtxOpID = "DID"
+
+	// WrongUserErrorDirName is the name of error directory for other users.
+	WrongUserErrorDirName = `kbfs.access.denied.for.other.windows.users`
 )
 
 // CtxTagKey is the type used for unique context tags

--- a/libdokan/common.go
+++ b/libdokan/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
 )
 
 const (
@@ -26,8 +27,11 @@ const (
 	// CtxOpID is the display name for the unique operation Dokan ID tag.
 	CtxOpID = "DID"
 
-	// WrongUserErrorDirName is the name of error directory for other users.
-	WrongUserErrorDirName = `kbfs.access.denied.for.other.windows.users`
+	// WrongUserErrorFileName is the name of error directory for other users.
+	WrongUserErrorFileName = `kbfs.access.denied.for.other.windows.users.txt`
+
+	// WrongUserErrorContents is the contents of the file.
+	WrongUserErrorContents = `Access to KBFS is limited to the windows user (sid) running KBFS.`
 )
 
 // CtxTagKey is the type used for unique context tags
@@ -123,4 +127,40 @@ func lowerTranslateCandidate(oc *openContext, s string) string {
 		return ""
 	}
 	return c
+}
+
+func stringReadFile(contents string) dokan.File {
+	return &stringFile{data: contents}
+}
+
+type stringFile struct {
+	emptyFile
+	data string
+}
+
+// GetFileInformation does stats for dokan.
+func (s *stringFile) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (*dokan.Stat, error) {
+	a, err := defaultFileInformation()
+	if err != nil {
+		return nil, err
+	}
+	a.FileAttributes |= dokan.FileAttributeReadonly
+	a.FileSize = int64(len(s.data))
+	t := time.Now()
+	a.LastWrite = t
+	a.LastAccess = t
+	a.Creation = t
+	return a, nil
+}
+
+// ReadFile does reads for dokan.
+func (s *stringFile) ReadFile(ctx context.Context, fi *dokan.FileInfo, bs []byte, offset int64) (int, error) {
+	data := s.data
+	if offset >= int64(len(data)) {
+		return 0, nil
+	}
+
+	data = data[int(offset):]
+
+	return copy(bs, data), nil
 }

--- a/libdokan/fakeroot.go
+++ b/libdokan/fakeroot.go
@@ -11,19 +11,23 @@ import (
 
 type fakeRoot struct {
 	EmptyFolder
+	isRoot bool
 }
 
 func openFakeRoot(ctx context.Context, fs *FS, fi *dokan.FileInfo) (dokan.File, bool, error) {
 	path := fi.Path()
 	fs.log.CDebugf(ctx, "openFakeRoot %q", path)
 	if path == `\`+WrongUserErrorDirName {
-		return &EmptyFolder{}, true, nil
+		return &fakeRoot{isRoot: false}, true, nil
 	}
-	return &fakeRoot{}, true, nil
+	return &fakeRoot{isRoot: true}, true, nil
 }
 
 // FindFiles for dokan.
-func (*fakeRoot) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
+func (fr *fakeRoot) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
+	if !fr.isRoot {
+		return nil
+	}
 	var ns dokan.NamedStat
 	ns.FileAttributes = dokan.FileAttributeDirectory
 	ns.Name = WrongUserErrorDirName

--- a/libdokan/fakeroot.go
+++ b/libdokan/fakeroot.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libdokan
+
+import (
+	"github.com/keybase/kbfs/dokan"
+	"golang.org/x/net/context"
+)
+
+type fakeRoot struct {
+	EmptyFolder
+}
+
+func openFakeRoot(ctx context.Context, fs *FS, fi *dokan.FileInfo) (dokan.File, bool, error) {
+	path := fi.Path()
+	fs.log.CDebugf(ctx, "openFakeRoot %q", path)
+	if path == `\`+WrongUserErrorDirName {
+		return &EmptyFolder{}, true, nil
+	}
+	return &fakeRoot{}, true, nil
+}
+
+// FindFiles for dokan.
+func (*fakeRoot) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored string, callback func(*dokan.NamedStat) error) (err error) {
+	var ns dokan.NamedStat
+	ns.FileAttributes = dokan.FileAttributeDirectory
+	ns.Name = WrongUserErrorDirName
+	return callback(&ns)
+}

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -419,7 +419,7 @@ func (f *FS) MoveFile(ctx context.Context, source *dokan.FileInfo, targetPath st
 	// However we only allow fake files with names that are not potential rename
 	// paths. Filter those out here.
 	if !isPotentialRenamePath(source.Path()) {
-		f.log.Errorf("Refusing MoveFile access: SID match error")
+		f.log.Errorf("Refusing MoveFile access: not potential rename path")
 		return dokan.ErrAccessDenied
 	}
 


### PR DESCRIPTION
Provides a fake root directory for different SIDs. Should help with:
https://github.com/keybase/client/issues/5490 and more recent issues.

The basic issue is with corporate AV products doing:
1) try to access K:
2) access denied because AV running with different user/permissions
3) goto 1 in a hot loop

To test this patch using  `-mount-flags 0` when mounting kbfsdokan + switch user is the simplest way.

@zanderz is the error folder name ok for you?