### PR TITLE
libkbfs: don't set the PublicTopLevelFolder arg anymore

### DIFF
--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -895,7 +895,6 @@ func (j *blockJournal) removeFlushedEntries(ctx context.Context,
 		totalFlushedBytes += flushedBytes
 
 		reporter.NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{
-			PublicTopLevelFolder: tlfID.Type() == tlf.Public,
 			// Path: TODO,
 			// SyncingBytes: TODO,
 			// SyncingOps: TODO,

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -420,20 +420,18 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	// We should see 1 create edit for each user.
 	expectedEdits := []keybase1.FSNotification{
 		{
-			PublicTopLevelFolder: false,
-			Filename:             name + "/a",
-			StatusCode:           keybase1.FSStatusCode_FINISH,
-			NotificationType:     keybase1.FSNotificationType_FILE_CREATED,
-			WriterUid:            uid1,
-			LocalTime:            keybase1.ToTime(now),
+			Filename:         name + "/a",
+			StatusCode:       keybase1.FSStatusCode_FINISH,
+			NotificationType: keybase1.FSNotificationType_FILE_CREATED,
+			WriterUid:        uid1,
+			LocalTime:        keybase1.ToTime(now),
 		},
 		{
-			PublicTopLevelFolder: false,
-			Filename:             name + "/b",
-			StatusCode:           keybase1.FSStatusCode_FINISH,
-			NotificationType:     keybase1.FSNotificationType_FILE_CREATED,
-			WriterUid:            uid2,
-			LocalTime:            keybase1.ToTime(now),
+			Filename:         name + "/b",
+			StatusCode:       keybase1.FSStatusCode_FINISH,
+			NotificationType: keybase1.FSNotificationType_FILE_CREATED,
+			WriterUid:        uid2,
+			LocalTime:        keybase1.ToTime(now),
 		},
 	}
 

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -645,12 +645,11 @@ func (k *KeybaseServiceBase) FSEditListRequest(ctx context.Context,
 				continue
 			}
 			n := keybase1.FSNotification{
-				PublicTopLevelFolder: !req.Folder.Private,
-				Filename:             edit.Filepath,
-				StatusCode:           keybase1.FSStatusCode_FINISH,
-				NotificationType:     nType,
-				WriterUid:            writer,
-				LocalTime:            keybase1.ToTime(edit.LocalTime),
+				Filename:         edit.Filepath,
+				StatusCode:       keybase1.FSStatusCode_FINISH,
+				NotificationType: nType,
+				WriterUid:        writer,
+				LocalTime:        keybase1.ToTime(edit.LocalTime),
 			}
 			resp.Edits = append(resp.Edits, n)
 		}

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -290,10 +290,9 @@ func rekeyNotification(ctx context.Context, config Config, handle *TlfHandle, fi
 	}
 
 	return &keybase1.FSNotification{
-		PublicTopLevelFolder: handle.Type() == tlf.Public,
-		Filename:             string(handle.GetCanonicalPath()),
-		StatusCode:           code,
-		NotificationType:     keybase1.FSNotificationType_REKEYING,
+		Filename:         string(handle.GetCanonicalPath()),
+		StatusCode:       code,
+		NotificationType: keybase1.FSNotificationType_REKEYING,
 	}
 }
 
@@ -361,9 +360,8 @@ func baseNotification(file path, finish bool) *keybase1.FSNotification {
 	}
 
 	return &keybase1.FSNotification{
-		PublicTopLevelFolder: file.Tlf.Type() == tlf.Public,
-		Filename:             file.CanonicalPathString(),
-		StatusCode:           code,
+		Filename:   file.CanonicalPathString(),
+		StatusCode: code,
 	}
 }
 
@@ -394,13 +392,12 @@ func errorNotification(err error, errType keybase1.FSErrorType,
 		panic(fmt.Sprintf("Unknown mode: %v", mode))
 	}
 	return &keybase1.FSNotification{
-		Filename:             filename,
-		StatusCode:           keybase1.FSStatusCode_ERROR,
-		Status:               err.Error(),
-		ErrorType:            errType,
-		Params:               params,
-		NotificationType:     nType,
-		PublicTopLevelFolder: t == tlf.Public, // Deprecated
+		Filename:         filename,
+		StatusCode:       keybase1.FSStatusCode_ERROR,
+		Status:           err.Error(),
+		ErrorType:        errType,
+		Params:           params,
+		NotificationType: nType,
 	}
 }
 
@@ -411,10 +408,9 @@ func mdReadSuccessNotification(handle *TlfHandle,
 		params[errorParamTlf] = string(handle.GetCanonicalName())
 	}
 	return &keybase1.FSNotification{
-		Filename:             string(handle.GetCanonicalPath()),
-		StatusCode:           keybase1.FSStatusCode_START,
-		NotificationType:     keybase1.FSNotificationType_MD_READ_SUCCESS,
-		PublicTopLevelFolder: public,
-		Params:               params,
+		Filename:         string(handle.GetCanonicalPath()),
+		StatusCode:       keybase1.FSStatusCode_START,
+		NotificationType: keybase1.FSNotificationType_MD_READ_SUCCESS,
+		Params:           params,
 	}
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1829,7 +1829,6 @@ func (j *tlfJournal) putBlockData(
 	}
 
 	j.config.Reporter().NotifySyncStatus(ctx, &keybase1.FSPathSyncStatus{
-		PublicTopLevelFolder: j.tlfID.Type() == tlf.Public,
 		// Path: TODO,
 		// TODO: should this be the complete total for the file/directory,
 		// rather than the diff?


### PR DESCRIPTION
As of keybase/client#7270, the client no longer uses this field, and
we need to remove it from the protocol now that team TLFs are a thing.
This removes KBFS usage, so that we can remove it from the protocol in
a future PR.

Issue: KBFS-2116