### PR TITLE
keybase_daemon_rpc: no need to run keepalives in minimal mode

### DIFF
--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -62,9 +62,11 @@ func NewKeybaseDaemonRPC(config Config, kbCtx Context, log logger.Logger,
 	k.fillClients(conn.GetClient())
 	k.shutdownFn = conn.Shutdown
 
-	ctx, cancel := context.WithCancel(context.Background())
-	k.keepAliveCancel = cancel
-	go k.keepAliveLoop(ctx)
+	if config.Mode() != InitMinimal {
+		ctx, cancel := context.WithCancel(context.Background())
+		k.keepAliveCancel = cancel
+		go k.keepAliveLoop(ctx)
+	}
 
 	return k
 }


### PR DESCRIPTION
This just wastes battery on mobile, where the service is in the same
process as KBFS.

Issue: KBFS-2250