### PR TITLE
fix paper key prompt spamming and race condition during shutdown

### DIFF
--- a/libkbfs/rekey_fsm.go
+++ b/libkbfs/rekey_fsm.go
@@ -434,15 +434,16 @@ func NewRekeyFSM(fbo *folderBranchOps) RekeyFSM {
 }
 
 func (m *rekeyFSM) loop() {
+	reqs := m.reqs
 	for {
 		select {
-		case e := <-m.reqs:
+		case e := <-reqs:
 			if e.eventType == rekeyShutdownEvent {
-				// Set m.reqs to nil so on next iteration, we will skip any
-				// content in m.reqs. So if there are multiple
+				// Set reqs to nil so on next iteration, we will skip any
+				// content in reqs. So if there are multiple
 				// rekeyShutdownEvent, we won't close m.shutdownCh multiple
 				// times.
-				m.reqs = nil
+				reqs = nil
 				close(m.shutdownCh)
 			}
 


### PR DESCRIPTION
The paper key prompt spamming is because when FBO concludes it would need paper key for rekey to proceed, it not only requests for the paper key, but also writes a MD to mdserver with rekey set at the same time. This causes the mdserver to call `FoldersNeedRekey` into KBFS client, which sends another rekey request into the rekey FSM, which kicks off the FSM into `rekeyStateStarted`. This PR makes sure `prmoptPaper` is not set before possibly shortening the rekey wait timer.

Also I found a bug with `atomic` usage for closing the `reqs` channel. Should've used `CompareAndSwapInt32`. This PR changes it to use a `RWMutex` which is less likely to become a foot gun.