### PR TITLE
md_ops: when a TLF is finalized, always allow unverified keys

### DIFF
--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -49,7 +49,8 @@ func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 		writer = libkb.NormalizedUsername("uid: " +
 			rmds.MD.LastModifyingWriter().String())
 	}
-	md.log.CDebugf(ctx, "Unverifiable update for TLF %s", rmds.MD.TlfID())
+	md.log.CDebugf(ctx, "Unverifiable update for TLF %s: %+v",
+		rmds.MD.TlfID(), err)
 	return UnverifiableTlfUpdateError{tlf, writer, err}
 }
 


### PR DESCRIPTION
When trying to verify the MD update that the final update was copied
from, we need to instruct processMetadata to allow unverified keys,
since the last writer user may have been reset.  Do this by altering
the context, because plumbing a boolean through would be too messy.

The included test fails without the rest of the fixes in this PR.

Issue: KBFS-2226