### PR TITLE
libfuse: don't send error notifications for ._ files

### DIFF
--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -151,11 +151,6 @@ func (fl *FolderList) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (_ fs.N
 	fl.fs.log.CDebugf(ctx, "FL Mkdir")
 	tlfName := libkbfs.CanonicalTlfName(req.Name)
 	defer func() { fl.reportErr(ctx, libkbfs.WriteMode, tlfName, err) }()
-	if strings.HasPrefix(req.Name, "._") {
-		// Quietly ignore writes to special macOS files, without
-		// triggering a notification.
-		return nil, libkbfs.WriteUnsupportedError{}.Errno()
-	}
 	return nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(fl.PathType(), string(tlfName)))
 }
 

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -138,6 +138,11 @@ func (fl *FolderList) Create(ctx context.Context, req *fuse.CreateRequest, resp 
 	fl.fs.log.CDebugf(ctx, "FL Create")
 	tlfName := libkbfs.CanonicalTlfName(req.Name)
 	defer func() { fl.reportErr(ctx, libkbfs.WriteMode, tlfName, err) }()
+	if strings.HasPrefix(req.Name, "._") {
+		// Quietly ignore writes to special macOS files, without
+		// triggering a notification.
+		return nil, nil, libkbfs.WriteUnsupportedError{}.Errno()
+	}
 	return nil, nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(fl.PathType(), string(tlfName)))
 }
 
@@ -146,6 +151,11 @@ func (fl *FolderList) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (_ fs.N
 	fl.fs.log.CDebugf(ctx, "FL Mkdir")
 	tlfName := libkbfs.CanonicalTlfName(req.Name)
 	defer func() { fl.reportErr(ctx, libkbfs.WriteMode, tlfName, err) }()
+	if strings.HasPrefix(req.Name, "._") {
+		// Quietly ignore writes to special macOS files, without
+		// triggering a notification.
+		return nil, libkbfs.WriteUnsupportedError{}.Errno()
+	}
 	return nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(fl.PathType(), string(tlfName)))
 }
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -482,6 +482,11 @@ var _ fs.NodeCreater = (*Root)(nil)
 func (r *Root) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (_ fs.Node, _ fs.Handle, err error) {
 	r.log().CDebugf(ctx, "FS Create")
 	defer func() { r.private.fs.reportErr(ctx, libkbfs.WriteMode, err) }()
+	if strings.HasPrefix(req.Name, "._") {
+		// Quietly ignore writes to special macOS files, without
+		// triggering a notification.
+		return nil, nil, libkbfs.WriteUnsupportedError{}.Errno()
+	}
 	return nil, nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(r.PathType(), req.Name))
 }
 
@@ -489,6 +494,11 @@ func (r *Root) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.C
 func (r *Root) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (_ fs.Node, err error) {
 	r.log().CDebugf(ctx, "FS Mkdir")
 	defer func() { r.private.fs.reportErr(ctx, libkbfs.WriteMode, err) }()
+	if strings.HasPrefix(req.Name, "._") {
+		// Quietly ignore writes to special macOS files, without
+		// triggering a notification.
+		return nil, libkbfs.WriteUnsupportedError{}.Errno()
+	}
 	return nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(r.PathType(), req.Name))
 }
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -494,11 +494,6 @@ func (r *Root) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.C
 func (r *Root) Mkdir(ctx context.Context, req *fuse.MkdirRequest) (_ fs.Node, err error) {
 	r.log().CDebugf(ctx, "FS Mkdir")
 	defer func() { r.private.fs.reportErr(ctx, libkbfs.WriteMode, err) }()
-	if strings.HasPrefix(req.Name, "._") {
-		// Quietly ignore writes to special macOS files, without
-		// triggering a notification.
-		return nil, libkbfs.WriteUnsupportedError{}.Errno()
-	}
 	return nil, libkbfs.NewWriteUnsupportedError(libkbfs.BuildCanonicalPath(r.PathType(), req.Name))
 }
 


### PR DESCRIPTION
If something on the client tries to make a metadata file under
/keybase or /keybase/{private,public}, it will fail.  But there's no
reason to bother the user with a notification about that, so just
return the bare error code instead of the typed error that will cause
a notification.

Issue: keybase/client#7306