### PR TITLE
libkbfs: team TLF blocks should be charged to teams

### DIFF
--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/fsrpc"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
@@ -168,20 +167,20 @@ func mdParseAndGet(ctx context.Context, config libkbfs.Config, input string) (
 }
 
 func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
-	tlfPath string) (libkbfs.ImmutableRootMetadata, keybase1.UID, error) {
+	tlfPath string) (libkbfs.ImmutableRootMetadata, error) {
 	handle, err := parseTLFPath(ctx, config.KBPKI(), tlfPath)
 	if err != nil {
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""), err
+		return libkbfs.ImmutableRootMetadata{}, err
 	}
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""), err
+		return libkbfs.ImmutableRootMetadata{}, err
 	}
 
 	// Make sure we're a writer before doing anything else.
 	if !handle.IsWriter(session.UID) {
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""),
+		return libkbfs.ImmutableRootMetadata{},
 			libkbfs.NewWriteAccessError(
 				handle, session.Name, handle.GetCanonicalPath())
 	}
@@ -191,10 +190,10 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	_, unmergedIRMD, err := config.MDOps().GetForHandle(
 		ctx, handle, libkbfs.Unmerged)
 	if err != nil {
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""), err
+		return libkbfs.ImmutableRootMetadata{}, err
 	}
 	if unmergedIRMD != (libkbfs.ImmutableRootMetadata{}) {
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""), fmt.Errorf(
+		return libkbfs.ImmutableRootMetadata{}, fmt.Errorf(
 			"%s has unmerged data; try unstaging it first",
 			tlfPath)
 	}
@@ -204,13 +203,13 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	_, irmd, err := config.MDOps().GetForHandle(
 		ctx, handle, libkbfs.Merged)
 	if err != nil {
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""), err
+		return libkbfs.ImmutableRootMetadata{}, err
 	}
 
 	if irmd == (libkbfs.ImmutableRootMetadata{}) {
 		fmt.Printf("No TLF found for %q\n", tlfPath)
-		return libkbfs.ImmutableRootMetadata{}, keybase1.UID(""), nil
+		return libkbfs.ImmutableRootMetadata{}, nil
 	}
 
-	return irmd, session.UID, nil
+	return irmd, nil
 }

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -12,7 +12,7 @@ func mdForceQROne(
 	ctx context.Context, config libkbfs.Config, tlfPath string,
 	dryRun bool) error {
 	// Get the latest head, and add a QR record up to that point.
-	irmd, _, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
+	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -14,7 +14,7 @@ import (
 func mdResetOne(
 	ctx context.Context, config libkbfs.Config, tlfPath string,
 	checkValid, dryRun, force bool) error {
-	irmd, uid, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
+	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func mdResetOne(
 	// TODO: Add an option to scan for and use the last known good
 	// root block.
 	_, info, readyBlockData, err :=
-		libkbfs.ResetRootBlock(ctx, config, uid, rmdNext)
+		libkbfs.ResetRootBlock(ctx, config, rmdNext)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -29,7 +29,7 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 	}
 	id := tlf.FakeID(1, tlf.Private)
 	file := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "file"}}}
-	uid := keybase1.MakeTestUID(1)
+	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
 	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
 	bsplit := &BlockSplitterSimple{maxBlockSize, maxPtrsPerBlock, 10}
 	kmd := emptyKeyMetadata{id, 1}
@@ -60,7 +60,8 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 	}
 
 	fd := newFileData(
-		file, uid, crypto, bsplit, kmd, getter, cacher, logger.NewTestLogger(t))
+		file, chargedTo, crypto, bsplit, kmd, getter, cacher,
+		logger.NewTestLogger(t))
 	df := newDirtyFile(file, dirtyBcache)
 	return fd, cleanCache, dirtyBcache, df
 }

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -444,8 +444,8 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 	// Reading doesn't use crypto or the block splitter, so for now
 	// just pass in nil.  Also, reading doesn't depend on the UID, so
 	// it's ok to be empty.
-	var uid keybase1.UID
-	fd := newFileData(file, uid, nil, nil, rmdWithKeys, getter, cacher, log)
+	var id keybase1.UserOrTeamID
+	fd := newFileData(file, id, nil, nil, rmdWithKeys, getter, cacher, log)
 
 	buf, err := fd.getBytes(ctx, 0, -1)
 	if err != nil {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -467,7 +467,7 @@ func (md *RootMetadata) loadCachedBlockChanges(
 
 	// uid, crypto and bsplitter aren't used for simply getting the
 	// indirect pointers, so set them to nil.
-	var uid keybase1.UID
+	var id keybase1.UserOrTeamID
 	file := path{
 		FolderBranch{md.TlfID(), MasterBranch},
 		[]pathNode{{
@@ -475,7 +475,7 @@ func (md *RootMetadata) loadCachedBlockChanges(
 			fmt.Sprintf("<MD with revision %d>", md.Revision()),
 		}},
 	}
-	fd := newFileData(file, uid, nil, nil, md.ReadOnly(),
+	fd := newFileData(file, id, nil, nil, md.ReadOnly(),
 		func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
 			_ path, _ blockReqType) (*FileBlock, bool, error) {
 			fblock, ok := fileBlocks[ptr]


### PR DESCRIPTION
In KBFS-2217, we decided that only root teams would have quotas, and all subteams would share that quota.  Since subteams aren't going to be implemented on the core side for a while, this PR only supports team TLFs, charging all blocks in the team TLF to the team.

Currently the server will reject these requests, since it checks that the chargedTo ID matches the session ID.

Issue: KBFS-2217