### PR TITLE
tlf_journal: enable single-team journals with team ID

### DIFF
--- a/libdokan/journal_control_file.go
+++ b/libdokan/journal_control_file.go
@@ -36,7 +36,8 @@ func (f *JournalControlFile) WriteFile(ctx context.Context,
 		return 0, err
 	}
 
-	err = f.action.Execute(ctx, jServer, f.folder.getFolderBranch().Tlf)
+	err = f.action.Execute(
+		ctx, jServer, f.folder.getFolderBranch().Tlf, f.folder.h)
 	if err != nil {
 		return 0, err
 	}

--- a/libfs/journal_control_file.go
+++ b/libfs/journal_control_file.go
@@ -60,7 +60,7 @@ func (a JournalAction) String() string {
 // given TLF.
 func (a JournalAction) Execute(
 	ctx context.Context, jServer *libkbfs.JournalServer,
-	tlfID tlf.ID) error {
+	tlfID tlf.ID, h *libkbfs.TlfHandle) error {
 	// These actions don't require TLF IDs.
 	switch a {
 	case JournalEnableAuto:
@@ -77,7 +77,7 @@ func (a JournalAction) Execute(
 	switch a {
 	case JournalEnable:
 		err := jServer.Enable(
-			ctx, tlfID, libkbfs.TLFJournalBackgroundWorkEnabled)
+			ctx, tlfID, h, libkbfs.TLFJournalBackgroundWorkEnabled)
 		if err != nil {
 			return err
 		}

--- a/libfuse/journal_control_file.go
+++ b/libfuse/journal_control_file.go
@@ -47,7 +47,8 @@ func (f *JournalControlFile) Write(ctx context.Context, req *fuse.WriteRequest,
 		return err
 	}
 
-	err = f.action.Execute(ctx, jServer, f.folder.getFolderBranch().Tlf)
+	err = f.action.Execute(
+		ctx, jServer, f.folder.getFolderBranch().Tlf, f.folder.h)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/journal_block_cache.go
+++ b/libkbfs/journal_block_cache.go
@@ -16,7 +16,7 @@ var _ BlockCache = journalBlockCache{}
 // CheckForKnownPtr implements BlockCache.
 func (j journalBlockCache) CheckForKnownPtr(
 	tlfID tlf.ID, block *FileBlock) (BlockPointer, error) {
-	_, ok := j.jServer.getTLFJournal(tlfID)
+	_, ok := j.jServer.getTLFJournal(tlfID, nil)
 	if !ok {
 		return j.BlockCache.CheckForKnownPtr(tlfID, block)
 	}

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -24,7 +24,7 @@ func (j journalBlockServer) getBlockFromJournal(
 	tlfID tlf.ID, id kbfsblock.ID) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf,
 	found bool, err error) {
-	tlfJournal, ok := j.jServer.getTLFJournal(tlfID)
+	tlfJournal, ok := j.jServer.getTLFJournal(tlfID, nil)
 	if !ok {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, false, nil
 	}
@@ -48,7 +48,7 @@ func (j journalBlockServer) getBlockFromJournal(
 func (j journalBlockServer) getBlockSizeFromJournal(
 	tlfID tlf.ID, id kbfsblock.ID) (
 	size uint32, found bool, err error) {
-	tlfJournal, ok := j.jServer.getTLFJournal(tlfID)
+	tlfJournal, ok := j.jServer.getTLFJournal(tlfID, nil)
 	if !ok {
 		return 0, false, nil
 	}
@@ -95,7 +95,7 @@ func (j journalBlockServer) Put(
 	// called in parallel anyway. Rely on caller (usually
 	// doBlockPuts) to do the tracing.
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID, nil); ok {
 		defer func() {
 			err = translateToBlockServerError(err)
 		}()
@@ -125,7 +125,7 @@ func (j journalBlockServer) AddBlockReference(
 		j.jServer.deferLog.LazyTrace(ctx, "jBServer: AddRef %s done (err=%v)", id, err)
 	}()
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID, nil); ok {
 		if !j.enableAddBlockReference {
 			// TODO: Temporarily return an error until KBFS-1149 is
 			// fixed. This is needed despite
@@ -192,7 +192,7 @@ func (j journalBlockServer) IsUnflushed(ctx context.Context, tlfID tlf.ID,
 		j.jServer.deferLog.LazyTrace(ctx, "jBServer: IsUnflushed %s done (err=%v)", id, err)
 	}()
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(tlfID, nil); ok {
 		defer func() {
 			err = translateToBlockServerError(err)
 		}()

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -90,7 +90,7 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
 
 	tlfID := tlf.FakeID(2, tlf.Private)
-	err := jServer.Enable(ctx, tlfID, TLFJournalBackgroundWorkPaused)
+	err := jServer.Enable(ctx, tlfID, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	blockServer := config.BlockServer()

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -79,7 +79,7 @@ func (j journalMDOps) getHeadFromJournal(
 	ctx context.Context, id tlf.ID, bid BranchID, mStatus MergeStatus,
 	handle *TlfHandle) (
 	ImmutableRootMetadata, error) {
-	tlfJournal, ok := j.jServer.getTLFJournal(id)
+	tlfJournal, ok := j.jServer.getTLFJournal(id, handle)
 	if !ok {
 		return ImmutableRootMetadata{}, nil
 	}
@@ -159,7 +159,7 @@ func (j journalMDOps) getRangeFromJournal(
 	ctx context.Context, id tlf.ID, bid BranchID, mStatus MergeStatus,
 	start, stop kbfsmd.Revision) (
 	[]ImmutableRootMetadata, error) {
-	tlfJournal, ok := j.jServer.getTLFJournal(id)
+	tlfJournal, ok := j.jServer.getTLFJournal(id, nil)
 	if !ok {
 		return nil, nil
 	}
@@ -412,7 +412,8 @@ func (j journalMDOps) Put(ctx context.Context, rmd *RootMetadata,
 		j.jServer.deferLog.LazyTrace(ctx, "jMDOps: Put %s %d done (err=%v)", rmd.TlfID(), rmd.Revision(), err)
 	}()
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(
+		rmd.TlfID(), rmd.GetTlfHandle()); ok {
 		// Just route to the journal.
 		irmd, err := tlfJournal.putMD(ctx, rmd, verifyingKey)
 		switch errors.Cause(err).(type) {
@@ -436,7 +437,8 @@ func (j journalMDOps) PutUnmerged(ctx context.Context, rmd *RootMetadata,
 		j.jServer.deferLog.LazyTrace(ctx, "jMDOps: PutUnmerged %s %d done (err=%v)", rmd.TlfID(), rmd.Revision(), err)
 	}()
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(rmd.TlfID()); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(
+		rmd.TlfID(), rmd.GetTlfHandle()); ok {
 		rmd.SetUnmerged()
 		irmd, err := tlfJournal.putMD(ctx, rmd, verifyingKey)
 		switch errors.Cause(err).(type) {
@@ -459,7 +461,7 @@ func (j journalMDOps) PruneBranch(
 		j.jServer.deferLog.LazyTrace(ctx, "jMDOps: PruneBranch %s %s (err=%v)", id, bid, err)
 	}()
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(id); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(id, nil); ok {
 		// Prune the journal, too.
 		err := tlfJournal.clearMDs(ctx, bid)
 		switch errors.Cause(err).(type) {
@@ -485,7 +487,7 @@ func (j journalMDOps) ResolveBranch(
 		j.jServer.deferLog.LazyTrace(ctx, "jMDOps: ResolveBranch %s %s (err=%v)", id, bid, err)
 	}()
 
-	if tlfJournal, ok := j.jServer.getTLFJournal(id); ok {
+	if tlfJournal, ok := j.jServer.getTLFJournal(id, rmd.GetTlfHandle()); ok {
 		irmd, err := tlfJournal.resolveBranch(
 			ctx, bid, blocksToDelete, rmd, verifyingKey)
 		switch errors.Cause(err).(type) {

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -117,7 +117,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
 
-	err = jServer.Enable(ctx, id, TLFJournalBackgroundWorkPaused)
+	err = jServer.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, kbfsmd.Revision(1))
@@ -193,7 +193,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.Equal(t, kbfsmd.Revision(8), head.Revision())
 
 	// Find the branch ID.
-	tlfJournal, ok := jServer.getTLFJournal(id)
+	tlfJournal, ok := jServer.getTLFJournal(id, nil)
 	require.True(t, ok)
 	bid := tlfJournal.mdJournal.branchID
 
@@ -297,7 +297,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
 
-	err = jServer.Enable(ctx, id, TLFJournalBackgroundWorkPaused)
+	err = jServer.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, kbfsmd.Revision(2))
@@ -329,7 +329,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
 
-	err = jServer.Enable(ctx, id, TLFJournalBackgroundWorkPaused)
+	err = jServer.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
 	rmd := makeMDForJournalMDOpsTest(t, config, id, h, kbfsmd.Revision(1))
@@ -356,10 +356,10 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	id, irmd, err := mdOps.GetForHandle(ctx, h, Merged)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
-	err = jServer.Enable(ctx, id, TLFJournalBackgroundWorkPaused)
+	err = jServer.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 
-	tlfJournal, ok := jServer.getTLFJournal(id)
+	tlfJournal, ok := jServer.getTLFJournal(id, nil)
 	require.True(t, ok)
 
 	// Prepare the md journal to have a leading local squash revision.

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -493,20 +493,12 @@ func (j *JournalServer) Enable(ctx context.Context, tlfID tlf.ID,
 	var tid keybase1.TeamID
 	if tlfID.Type() == tlf.SingleTeam {
 		if h == nil {
-			// We must have a handle for SingleTeam TLFs, so try to
-			// get one from the server.  This is an untrusted mapping
-			// since it's just using whatever the server tells it.
-			// It's the job of folderBranchOps to do proper identifies
-			// based on a handle before any data from the TLF is
-			// consumed.
-			irmd, err := j.delegateMDOps.GetForTLF(ctx, tlfID)
-			if err != nil {
-				return err
-			}
-			if irmd == (ImmutableRootMetadata{}) {
-				return errors.Errorf("Can't find handle for team TLF %s", tlfID)
-			}
-			h = irmd.GetTlfHandle()
+			// Any path that creates a single-team TLF journal should
+			// also provide a handle.  If not, we'd have to fetch it
+			// from the server, which isn't a trusted path.  So panic
+			// instead; if we hit this, we might need to rethink this.
+			panic(fmt.Sprintf(
+				"No handle provided for single-team TLF %s", tlfID))
 		}
 
 		tid, err = h.FirstResolvedWriter().AsTeam()

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -271,7 +271,7 @@ func setupTLFJournalTest(
 	diskLimitSemaphore := newSemaphoreDiskLimiter(
 		math.MaxInt64, math.MaxInt64, math.MaxInt64)
 	tlfJournal, err = makeTLFJournal(ctx, uid, verifyingKey,
-		tempdir, config.tlfID, config, delegateBlockServer,
+		tempdir, config.tlfID, "", config, delegateBlockServer,
 		bwStatus, delegate, nil, nil, diskLimitSemaphore)
 	require.NoError(t, err)
 

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -639,7 +639,12 @@ func (k *LibKBFS) EnableJournal(u User, tlfName string, t tlf.Type) error {
 		return err
 	}
 
-	return jServer.Enable(ctx, dir.GetFolderBranch().Tlf,
+	h, err := parseTlfHandle(ctx, config.KBPKI(), tlfName, t)
+	if err != nil {
+		return err
+	}
+
+	return jServer.Enable(ctx, dir.GetFolderBranch().Tlf, h,
 		libkbfs.TLFJournalBackgroundWorkEnabled)
 }
 

--- a/test/teams_test.go
+++ b/test/teams_test.go
@@ -59,3 +59,29 @@ func TestTeamsWriterReader(t *testing.T) {
 		),
 	)
 }
+
+func TestTeamsTwoWritersJournal(t *testing.T) {
+	test(t, journal(),
+		users("alice", "bob"),
+		team("ab", "alice,bob", ""),
+		inSingleTeamTlf("ab"),
+		as(alice,
+			// The tests don't support enabling journaling on a
+			// non-existent TF, so force the TLF creation first.
+			mkfile("foo", "bar"),
+			rm("foo"),
+		),
+		as(alice,
+			enableJournal(),
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			enableJournal(),
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}


### PR DESCRIPTION
In a future PR, the `tlfJournal` will need to know the team ID
corresponding to a single-team TLF, so that it can check the team's
quota when limiting space, rather than the user's quota.
Unfortunately, getting the team ID here is not very convenient.

This PR plumbs it through when the journal is created in the first
place, if possible.  If not possible, it trusts the MD server to
provide the handle, given a TLF ID.  It saves the team ID to the
journal info file on disk, so it can be used without needing server
access after a restart.

Issue: KBFS-2217