### PR TITLE
libdokan, dokan: Pass opened dokan.File to MoveFile

### DIFF
--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -372,7 +372,9 @@ func kbfsLibdokanMoveFile(
 	if cancel != nil {
 		defer cancel()
 	}
-	err := getfs(pfi).MoveFile(ctx, makeFI(oldFName, pfi), newPath, bool(replaceExisiting != 0))
+	// On error nil, not a dummy file like in getfi.
+	file := fiTableGetFile(uint32(pfi.Context))
+	err := getfs(pfi).MoveFile(ctx, file, makeFI(oldFName, pfi), newPath, bool(replaceExisiting != 0))
 	return errToNT(err)
 }
 

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -47,7 +47,7 @@ type FileSystem interface {
 	GetVolumeInformation(ctx context.Context) (VolumeInformation, error)
 
 	// MoveFile corresponds to rename.
-	MoveFile(ctx context.Context, source *FileInfo, targetPath string, replaceExisting bool) error
+	MoveFile(ctx context.Context, sourceHandle File, sourceFileInfo *FileInfo, targetPath string, replaceExisting bool) error
 
 	// ErrorPrint is called when dokan needs notify the program of an error message.
 	// A sensible approach is to print the error.

--- a/dokan/testfs_test.go
+++ b/dokan/testfs_test.go
@@ -277,7 +277,7 @@ func (t emptyFile) SetAllocationSize(ctx context.Context, fi *FileInfo, length i
 	debug("emptyFile.SetAllocationSize")
 	return nil
 }
-func (t emptyFS) MoveFile(ctx context.Context, source *FileInfo, targetPath string, replaceExisting bool) error {
+func (t emptyFS) MoveFile(ctx context.Context, src File, sourceFI *FileInfo, targetPath string, replaceExisting bool) error {
 	debug("emptyFS.MoveFile")
 	return nil
 }

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -428,6 +428,7 @@ func (f *FS) MoveFile(ctx context.Context, src dokan.File, sourceFI *dokan.FileI
 	switch src.(type) {
 	case *FolderList, *File, *Dir, *TLF, *EmptyFolder:
 	default:
+		f.log.Errorf("Refusing MoveFile access: wrong type source argument")
 		return dokan.ErrAccessDenied
 	}
 


### PR DESCRIPTION
With this the opened source file is passed from dokan to libdokan.

Makes trying to move invalid sources error out earlier and adds a little extra safety net.