### PR TITLE
backpressure_disk_limiter: track quotas by UserOrTeamID

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -404,8 +404,8 @@ func newJournalTracker(
 		return journalTracker{}, err
 	}
 
-	// Test quota parameters -- actually quota trackers will be
-	// created per-chargedTo ID.
+	// Test quota parameters -- actual quota trackers will be created
+	// on a per-chargedTo-ID basis.
 	_, err = newQuotaBackpressureTracker(quotaMinThreshold, quotaMaxThreshold)
 	if err != nil {
 		return journalTracker{}, err

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -907,8 +908,11 @@ func (cache *DiskBlockCacheStandard) Status() *DiskBlockCacheStatus {
 	}
 	cache.lock.RLock()
 	defer cache.lock.RUnlock()
+	// The disk cache status doesn't depend on the chargedTo ID, and
+	// we don't have easy access to the UID here, so pass in a dummy.
 	limiterStatus :=
-		cache.config.DiskLimiter().getStatus().(backpressureDiskLimiterStatus)
+		cache.config.DiskLimiter().getStatus(
+			keybase1.UserOrTeamID("")).(backpressureDiskLimiterStatus)
 	return &DiskBlockCacheStatus{
 		NumBlocks:       uint64(cache.numBlocks),
 		BlockBytes:      cache.currBytes,

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
@@ -72,7 +73,8 @@ func newDiskBlockCacheStandardForTest(config *testDiskBlockCacheConfig,
 				freeBytes := maxBytes - int64(cache.currBytes)
 				return freeBytes, maxFiles, nil
 			},
-			quotaFn: func(context.Context) (int64, int64) {
+			quotaFn: func(
+				context.Context, keybase1.UserOrTeamID) (int64, int64) {
 				return 0, math.MaxInt64
 			},
 		}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -611,7 +611,7 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 
 	config.SetBlockServer(bserv)
 
-	_, err = config.EnableDiskLimiter(params.StorageRoot)
+	err = config.EnableDiskLimiter(params.StorageRoot)
 	if err != nil {
 		log.Warning("Could not enable disk limiter: %+v", err)
 		return nil, err

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -52,7 +52,7 @@ func setupJournalBlockServerTest(t *testing.T) (
 		}
 	}()
 
-	_, err = config.EnableDiskLimiter(tempdir)
+	err = config.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -52,7 +52,7 @@ func setupJournalMDOpsTest(t *testing.T) (
 	}()
 
 	oldMDOps = config.MDOps()
-	_, err = config.EnableDiskLimiter(tempdir)
+	err = config.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -179,7 +179,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 		err := ioutil.RemoveAll(tempdir)
 		assert.NoError(t, err)
 	}()
-	_, err = config1.EnableDiskLimiter(tempdir)
+	err = config1.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config1.EnableJournaling(
 		ctx, tempdir, TLFJournalBackgroundWorkEnabled)
@@ -240,7 +240,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 
 	// now re-login u1
 	config1B := ConfigAsUser(config1, userName1)
-	_, err = config1B.EnableDiskLimiter(tempdir)
+	err = config1B.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	defer CheckConfigAndShutdown(ctx, t, config1B)
 	err = config1B.EnableJournaling(

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -110,11 +110,13 @@ type TLFJournalStatus struct {
 	// The byte counters below are signed because
 	// os.FileInfo.Size() is signed. The file counter is signed
 	// for consistency.
-	StoredBytes    int64
-	StoredFiles    int64
-	UnflushedBytes int64
-	UnflushedPaths []string
-	LastFlushErr   string `json:",omitempty"`
+	StoredBytes     int64
+	StoredFiles     int64
+	UnflushedBytes  int64
+	UnflushedPaths  []string
+	QuotaUsedBytes  int64
+	QuotaLimitBytes int64
+	LastFlushErr    string `json:",omitempty"`
 }
 
 // TLFJournalBackgroundWorkStatus indicates whether a journal should
@@ -1429,16 +1431,19 @@ func (j *tlfJournal) getJournalStatusLocked() (TLFJournalStatus, error) {
 	storedBytes := j.blockJournal.getStoredBytes()
 	storedFiles := j.blockJournal.getStoredFiles()
 	unflushedBytes := j.blockJournal.getUnflushedBytes()
+	quotaUsed, quotaLimit := j.diskLimiter.getQuotaInfo(j.chargedTo)
 	return TLFJournalStatus{
-		Dir:            j.dir,
-		BranchID:       j.mdJournal.getBranchID().String(),
-		RevisionStart:  earliestRevision,
-		RevisionEnd:    latestRevision,
-		BlockOpCount:   blockEntryCount,
-		StoredBytes:    storedBytes,
-		StoredFiles:    storedFiles,
-		UnflushedBytes: unflushedBytes,
-		LastFlushErr:   lastFlushErr,
+		Dir:             j.dir,
+		BranchID:        j.mdJournal.getBranchID().String(),
+		RevisionStart:   earliestRevision,
+		RevisionEnd:     latestRevision,
+		BlockOpCount:    blockEntryCount,
+		StoredBytes:     storedBytes,
+		StoredFiles:     storedFiles,
+		QuotaUsedBytes:  quotaUsed,
+		QuotaLimitBytes: quotaLimit,
+		UnflushedBytes:  unflushedBytes,
+		LastFlushErr:    lastFlushErr,
 	}, nil
 }
 

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -601,7 +601,7 @@ func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
 		e.tb.Logf("Journal directory: %s", e.journalDir)
 		for i, c := range cfgs {
 			journalRoot := filepath.Join(jdir, users[i].String())
-			_, err = c.EnableDiskLimiter(journalRoot)
+			err = c.EnableDiskLimiter(journalRoot)
 			if err != nil {
 				panic(fmt.Sprintf("No disk limiter for %d: %+v", i, err))
 			}

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -87,7 +87,7 @@ func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
 		for name, c := range userMap {
 			config := c.(*libkbfs.ConfigLocal)
 			journalRoot := filepath.Join(jdir, name.String())
-			_, err = config.EnableDiskLimiter(journalRoot)
+			err = config.EnableDiskLimiter(journalRoot)
 			if err != nil {
 				panic(fmt.Sprintf("No disk limiter for %s: %+v", name, err))
 			}


### PR DESCRIPTION
So that we can compute pressure differently for private TLFs vs team TLFs.

The `tlfJournal` now stores a `ChargedTo` field, rather than a `TID`, so we can treat private TLFs and team TLFs symmetrically.

Also adds team quota support to the quota usage helper class.

Issue: KBFS-2217