### PR TITLE
[KBFS-1895] Prefetching Workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ helpers.rootLinuxNode(env, {
                     test_osx: {
                         def mountDir='/Volumes/untitled/kbfs'
                         helpers.nodeWithCleanup('macstadium', {}, {
-                                sh "rm -rf ${mountDir}"
+                                sh "rm -rf ${mountDir} || echo 'Something went wrong with cleanup.'"
                             }) {
                             def BASEDIR=pwd()
                             def GOPATH="${BASEDIR}/go"

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -34,13 +34,13 @@ var _ BlockOps = (*BlockOpsStandard)(nil)
 
 // NewBlockOpsStandard creates a new BlockOpsStandard
 func NewBlockOpsStandard(config blockOpsConfig,
-	queueSize int) *BlockOpsStandard {
+	queueSize, prefetchQueueSize int) *BlockOpsStandard {
 	bg := &realBlockGetter{config: config}
 	qConfig := &realBlockRetrievalConfig{
 		blockRetrievalPartialConfig: config,
 		bg: bg,
 	}
-	q := newBlockRetrievalQueue(queueSize, qConfig)
+	q := newBlockRetrievalQueue(queueSize, prefetchQueueSize, qConfig)
 	bops := &BlockOpsStandard{
 		config: config,
 		log:    traceLogger{config.MakeLogger("")},

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -122,7 +122,8 @@ func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 // encrypts its given block properly.
 func TestBlockOpsReadySuccess(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -165,7 +166,8 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 // fails properly if we fail to retrieve the key.
 func TestBlockOpsReadyFailKeyGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -191,7 +193,8 @@ func (c badServerHalfMaker) MakeRandomBlockCryptKeyServerHalf() (
 func TestBlockOpsReadyFailServerHalfGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.cp = badServerHalfMaker{config.cryptoPure()}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -217,7 +220,8 @@ func (c badBlockEncryptor) EncryptBlock(
 func TestBlockOpsReadyFailEncryption(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.cp = badBlockEncryptor{config.cryptoPure()}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -256,7 +260,8 @@ func (c badEncoder) Encode(o interface{}) ([]byte, error) {
 func TestBlockOpsReadyFailEncode(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.testCodecGetter.codec = badEncoder{config.codec}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -281,7 +286,8 @@ func (c tooSmallEncoder) Encode(o interface{}) ([]byte, error) {
 func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.codec = tooSmallEncoder{config.codec}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -297,7 +303,8 @@ func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 // previous key generation.
 func TestBlockOpsGetSuccess(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -331,7 +338,8 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 // if it can't retrieve the block from the server.
 func TestBlockOpsGetFailServerGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -372,7 +380,8 @@ func (bserver badGetBlockServer) Get(
 func TestBlockOpsGetFailVerify(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = badGetBlockServer{config.bserver}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -400,7 +409,8 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 // fails if it can't get the decryption key.
 func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -466,7 +476,8 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 		errors: make(map[string]error),
 	}
 	config.codec = &badDecoder
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -507,7 +518,8 @@ func (c badBlockDecryptor) DecryptBlock(encryptedBlock EncryptedBlock,
 func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	config := makeTestBlockOpsConfig(t)
 	config.cp = badBlockDecryptor{config.cryptoPure()}
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
@@ -539,7 +551,8 @@ func TestBlockOpsDeleteSuccess(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	// Expect one call to delete several blocks.
@@ -575,7 +588,8 @@ func TestBlockOpsDeleteFail(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	b1 := BlockPointer{ID: kbfsblock.FakeID(1)}
@@ -609,7 +623,8 @@ func TestBlockOpsArchiveSuccess(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	// Expect one call to archive several blocks.
@@ -642,7 +657,8 @@ func TestBlockOpsArchiveFail(t *testing.T) {
 	bserver := NewMockBlockServer(mockCtrl)
 	config := makeTestBlockOpsConfig(t)
 	config.bserver = bserver
-	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize)
+	bops := NewBlockOpsStandard(config, testBlockRetrievalWorkerQueueSize,
+		testPrefetchWorkerQueueSize)
 	defer bops.Shutdown()
 
 	b1 := BlockPointer{ID: kbfsblock.FakeID(1)}

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -191,7 +191,7 @@ func (brq *blockRetrievalQueue) notifyWorker(priority int) {
 	// design, on-demand requests _should_ starve prefetch requests, so this is
 	// a problem only if prefetch requests can starve on-demand workers. But
 	// because there are far more on-demand workers than prefetch workers, this
-	// should never acdtually happen.
+	// should never actually happen.
 	workerCh := brq.workerCh
 	if priority < defaultOnDemandRequestPriority {
 		workerCh = brq.prefetchWorkerCh

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -69,7 +69,7 @@ func makeKMD() KeyMetadata {
 
 func TestBlockRetrievalQueueBasic(t *testing.T) {
 	t.Log("Add a block retrieval request to the queue and retrieve it.")
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -94,7 +94,7 @@ func TestBlockRetrievalQueueBasic(t *testing.T) {
 
 func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 	t.Log("Preempt a lower-priority block retrieval request with a higher priority request.")
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -126,7 +126,7 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 
 func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 	t.Log("Handle a first request and then preempt another one.")
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -170,7 +170,7 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 
 func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 	t.Log("Request the same block multiple times.")
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -198,7 +198,7 @@ func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 
 func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	t.Log("Elevate the priority on an existing request.")
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -244,7 +244,7 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 
 func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	t.Log("Begin processing a request and then add another one for the same block.")
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, nil, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -77,7 +77,8 @@ func TestBlockRetrievalQueueBasic(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1.")
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
 
 	t.Log("Begin working on the request.")
 	ch := make(chan *blockRetrieval, 1)
@@ -86,14 +87,15 @@ func TestBlockRetrievalQueueBasic(t *testing.T) {
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, -1, br.index)
-	require.Equal(t, 1, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 1)
 	require.Equal(t, block, br.requests[0].block)
 }
 
 func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
-	t.Log("Preempt a lower-priority block retrieval request with a higher priority request.")
+	t.Log("Preempt a lower-priority block retrieval request with a higher " +
+		"priority request.")
 	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, nil, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
@@ -102,9 +104,12 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	ptr2 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
-	t.Log("Request a block retrieval for ptr1 and a higher priority retrieval for ptr2.")
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
-	_ = q.Request(ctx, 2, makeKMD(), ptr2, block, NoCacheEntry)
+	t.Log("Request a block retrieval for ptr1 and a higher priority " +
+		"retrieval for ptr2.")
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr2,
+		block, NoCacheEntry)
 
 	t.Log("Begin working on the preempted ptr2 request.")
 	ch := make(chan *blockRetrieval, 1)
@@ -112,7 +117,7 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 	br := <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr2, br.blockPtr)
-	require.Equal(t, 2, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
 
 	t.Log("Begin working on the ptr1 request.")
@@ -120,7 +125,7 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 	br = <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
-	require.Equal(t, 1, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 }
 
@@ -135,8 +140,10 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 	ptr2 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1 and ptr2.")
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
-	_ = q.Request(ctx, 1, makeKMD(), ptr2, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr2, block,
+		NoCacheEntry)
 
 	t.Log("Begin working on the ptr1 request.")
 	ch := make(chan *blockRetrieval, 1)
@@ -144,19 +151,20 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 	br := <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
-	require.Equal(t, 1, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 
 	ptr3 := makeRandomBlockPointer(t)
 	t.Log("Preempt the ptr2 request with the ptr3 request.")
-	_ = q.Request(ctx, 2, makeKMD(), ptr3, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr3,
+		block, NoCacheEntry)
 
 	t.Log("Begin working on the ptr3 request.")
 	q.Work(ch)
 	br = <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr3, br.blockPtr)
-	require.Equal(t, 2, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)
 	require.Equal(t, uint64(2), br.insertionOrder)
 
 	t.Log("Begin working on the ptr2 request.")
@@ -164,7 +172,7 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 	br = <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr2, br.blockPtr)
-	require.Equal(t, 1, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
 }
 
@@ -178,8 +186,10 @@ func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1 twice.")
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has 2 requests and that the queue is now empty.")
 	ch := make(chan *blockRetrieval, 1)
@@ -188,7 +198,7 @@ func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, -1, br.index)
-	require.Equal(t, 1, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 2)
 	require.Len(t, *q.heap, 0)
@@ -208,9 +218,12 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	ptr3 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request 3 block retrievals, each preempting the previous one.")
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
-	_ = q.Request(ctx, 2, makeKMD(), ptr2, block, NoCacheEntry)
-	_ = q.Request(ctx, 3, makeKMD(), ptr3, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr2,
+		block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+2, makeKMD(), ptr3,
+		block, NoCacheEntry)
 
 	t.Log("Begin working on the ptr3 retrieval.")
 	ch := make(chan *blockRetrieval, 1)
@@ -218,18 +231,19 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	br := <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr3, br.blockPtr)
-	require.Equal(t, 3, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+2, br.priority)
 	require.Equal(t, uint64(2), br.insertionOrder)
 
 	t.Log("Preempt the remaining retrievals with another retrieval for ptr1.")
-	_ = q.Request(ctx, 3, makeKMD(), ptr1, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+2, makeKMD(), ptr1,
+		block, NoCacheEntry)
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has increased in priority and has 2 requests.")
 	q.Work(ch)
 	br = <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr1, br.blockPtr)
-	require.Equal(t, 3, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+2, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 2)
 
@@ -238,7 +252,7 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	br = <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, ptr2, br.blockPtr)
-	require.Equal(t, 2, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
 }
 
@@ -252,7 +266,8 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1.")
-	_ = q.Request(ctx, 1, makeKMD(), ptr1, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry)
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has 1 request.")
 	ch := make(chan *blockRetrieval, 1)
@@ -260,14 +275,15 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	br := <-ch
 	require.Equal(t, ptr1, br.blockPtr)
 	require.Equal(t, -1, br.index)
-	require.Equal(t, 1, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 1)
 	require.Equal(t, block, br.requests[0].block)
 
 	t.Log("Request another block retrieval for ptr1 before it has finished. Verify that the priority is unchanged but there are now 2 requests.")
-	_ = q.Request(ctx, 2, makeKMD(), ptr1, block, NoCacheEntry)
-	require.Equal(t, 1, br.priority)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
+		block, NoCacheEntry)
+	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 2)
 	require.Equal(t, block, br.requests[0].block)
@@ -276,11 +292,12 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	t.Log("Finalize the existing request for ptr1.")
 	q.FinalizeRequest(br, &FileBlock{}, nil)
 	t.Log("Make another request for the same block. Verify that this is a new request.")
-	_ = q.Request(ctx, 2, makeKMD(), ptr1, block, NoCacheEntry)
+	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
+		block, NoCacheEntry)
 	q.Work(ch)
 	br = <-ch
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
-	require.Equal(t, 2, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)
 	require.Equal(t, uint64(1), br.insertionOrder)
 	require.Len(t, br.requests, 1)
 	require.Equal(t, block, br.requests[0].block)

--- a/libkbfs/block_retrieval_worker.go
+++ b/libkbfs/block_retrieval_worker.go
@@ -50,7 +50,7 @@ func newBlockRetrievalWorker(bg blockGetter,
 // blockGetter.getBlock, and responds to the subscribed requestors with the
 // results.
 func (brw *blockRetrievalWorker) HandleRequest() (err error) {
-	if isPrefetch {
+	if brw.isPrefetch {
 		brw.queue.PrefetchWork(brw.workCh)
 	} else {
 		brw.queue.Work(brw.workCh)

--- a/libkbfs/block_retrieval_worker.go
+++ b/libkbfs/block_retrieval_worker.go
@@ -11,10 +11,9 @@ import (
 // blockRetrievalWorker processes blockRetrievalQueue requests
 type blockRetrievalWorker struct {
 	blockGetter
-	stopCh     chan struct{}
-	queue      *blockRetrievalQueue
-	workCh     chan *blockRetrieval
-	isPrefetch bool
+	stopCh chan struct{}
+	queue  *blockRetrievalQueue
+	workCh <-chan struct{}
 }
 
 // run runs the worker loop until Shutdown is called
@@ -32,14 +31,13 @@ func (brw *blockRetrievalWorker) run() {
 // newBlockRetrievalWorker returns a blockRetrievalWorker for a given
 // blockRetrievalQueue, using the passed in blockGetter to obtain blocks for
 // requests.
-func newBlockRetrievalWorker(bg blockGetter,
-	q *blockRetrievalQueue, isPrefetch bool) *blockRetrievalWorker {
+func newBlockRetrievalWorker(bg blockGetter, q *blockRetrievalQueue,
+	workCh <-chan struct{}) *blockRetrievalWorker {
 	brw := &blockRetrievalWorker{
 		blockGetter: bg,
 		stopCh:      make(chan struct{}),
 		queue:       q,
-		workCh:      make(chan *blockRetrieval, 1),
-		isPrefetch:  isPrefetch,
+		workCh:      workCh,
 	}
 	go brw.run()
 	return brw
@@ -50,16 +48,12 @@ func newBlockRetrievalWorker(bg blockGetter,
 // blockGetter.getBlock, and responds to the subscribed requestors with the
 // results.
 func (brw *blockRetrievalWorker) HandleRequest() (err error) {
-	if brw.isPrefetch {
-		brw.queue.PrefetchWork(brw.workCh)
-	} else {
-		brw.queue.Work(brw.workCh)
-	}
 	var retrieval *blockRetrieval
 	select {
-	case retrieval = <-brw.workCh:
+	case <-brw.workCh:
+		retrieval = brw.queue.popIfNotEmpty()
 		if retrieval == nil {
-			panic("Received a nil block retrieval. This should never happen.")
+			return nil
 		}
 	case <-brw.stopCh:
 		return io.EOF

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -251,11 +251,11 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	t.Log("Test that worker shutdown works.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q, q.workerCh)
+	w := q.workers[0]
 	require.NotNil(t, w)
 
 	ptr1 := makeRandomBlockPointer(t)

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -113,11 +113,11 @@ func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {
 func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q)
+	w := newBlockRetrievalWorker(bg, q, onDemandWorker)
 	require.NotNil(t, w)
 	defer w.Shutdown()
 
@@ -136,7 +136,7 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	t.Log("Test the ability of multiple workers to retrieve concurrently.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(2, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(2, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -173,7 +173,7 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	t.Log("Test the ability of a worker and queue to work correctly together.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -220,11 +220,11 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	t.Log("Test the ability of a worker to handle a request cancelation.")
 	bg := newFakeBlockGetter(true)
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q)
+	w := newBlockRetrievalWorker(bg, q, onDemandWorker)
 	require.NotNil(t, w)
 	defer w.Shutdown()
 
@@ -243,11 +243,11 @@ func TestBlockRetrievalWorkerCancel(t *testing.T) {
 func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	t.Log("Test that worker shutdown works.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q)
+	w := newBlockRetrievalWorker(bg, q, onDemandWorker)
 	require.NotNil(t, w)
 
 	ptr1 := makeRandomBlockPointer(t)
@@ -289,7 +289,7 @@ func TestBlockRetrievalWorkerMultipleBlockTypes(t *testing.T) {
 	t.Log("Test that we can retrieve the same block into different block types.")
 	codec := kbfscodec.NewMsgpack()
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -255,7 +255,7 @@ func TestBlockRetrievalWorkerShutdown(t *testing.T) {
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
-	w := newBlockRetrievalWorker(bg, q, onDemandWorker)
+	w := newBlockRetrievalWorker(bg, q, q.workerCh)
 	require.NotNil(t, w)
 
 	ptr1 := makeRandomBlockPointer(t)

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -113,13 +113,9 @@ func makeFakeFileBlock(t *testing.T, doHash bool) *FileBlock {
 func TestBlockRetrievalWorkerBasic(t *testing.T) {
 	t.Log("Test the basic ability of a worker to return a block.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
-
-	w := newBlockRetrievalWorker(bg, q, onDemandWorker)
-	require.NotNil(t, w)
-	defer w.Shutdown()
 
 	ptr1 := makeRandomBlockPointer(t)
 	block1 := makeFakeFileBlock(t, false)
@@ -136,7 +132,7 @@ func TestBlockRetrievalWorkerBasic(t *testing.T) {
 func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 	t.Log("Test the ability of multiple workers to retrieve concurrently.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(2, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(0, 2, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -173,7 +169,7 @@ func TestBlockRetrievalWorkerMultipleWorkers(t *testing.T) {
 func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 	t.Log("Test the ability of a worker and queue to work correctly together.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 
@@ -220,13 +216,9 @@ func TestBlockRetrievalWorkerWithQueue(t *testing.T) {
 func TestBlockRetrievalWorkerCancel(t *testing.T) {
 	t.Log("Test the ability of a worker to handle a request cancelation.")
 	bg := newFakeBlockGetter(true)
-	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
-
-	w := newBlockRetrievalWorker(bg, q, onDemandWorker)
-	require.NotNil(t, w)
-	defer w.Shutdown()
 
 	ptr1 := makeRandomBlockPointer(t)
 	block1 := makeFakeFileBlock(t, false)
@@ -289,7 +281,7 @@ func TestBlockRetrievalWorkerMultipleBlockTypes(t *testing.T) {
 	t.Log("Test that we can retrieve the same block into different block types.")
 	codec := kbfscodec.NewMsgpack()
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(1, 0, newTestBlockRetrievalConfig(t, bg, nil))
+	q := newBlockRetrievalQueue(0, 1, newTestBlockRetrievalConfig(t, bg, nil))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -486,7 +486,7 @@ func TestDiskBlockCacheWithRetrievalQueue(t *testing.T) {
 
 	t.Log("Create a queue with 0 workers to rule it out from serving blocks.")
 	bg := newFakeBlockGetter(false)
-	q := newBlockRetrievalQueue(0, newTestBlockRetrievalConfig(t, bg, dbc))
+	q := newBlockRetrievalQueue(0, 0, newTestBlockRetrievalConfig(t, bg, dbc))
 	require.NotNil(t, q)
 	defer q.Shutdown()
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -513,14 +513,16 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 	}
 
 	workers := defaultBlockRetrievalWorkerQueueSize
+	prefetchWorkers := defaultPrefetchWorkerQueueSize
 	if config.Mode() == InitMinimal {
 		// In minimal mode, a few workers are still needed to fetch
 		// unembedded block changes in the MD updates, but not many.
 		// TODO: turn off the block retriever entirely as part of
 		// KBFS-2026, when block re-embedding is no longer required.
 		workers = minimalBlockRetrievalWorkerQueueSize
+		prefetchWorkers = minimalPrefetchWorkerQueueSize
 	}
-	config.SetBlockOps(NewBlockOpsStandard(config, workers))
+	config.SetBlockOps(NewBlockOpsStandard(config, workers, prefetchWorkers))
 
 	bsplitter, err := NewBlockSplitterSimple(MaxBlockSizeBytesDefault, 8*1024,
 		config.Codec())

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -106,7 +106,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	pre := newBlockPrefetcher(nil, brc)
 	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(pre)
 	// Ignore BlockRetriever calls
-	brq := newBlockRetrievalQueue(0, brc)
+	brq := newBlockRetrievalQueue(0, 0, brc)
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
 
 	// Ignore key bundle ID creation calls for now

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -62,7 +62,7 @@ func initPrefetcherTest(t *testing.T) (*blockRetrievalQueue,
 	// _actually_ completed.
 	bg := newFakeBlockGetter(false)
 	config := newTestBlockRetrievalConfig(t, bg, nil)
-	q := newBlockRetrievalQueue(1, config)
+	q := newBlockRetrievalQueue(1, 1, config)
 	require.NotNil(t, q)
 
 	return q, bg, config

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -46,7 +46,7 @@ func newConfigForTest(mode InitMode,
 	config := NewConfigLocal(mode, loggerFn, "")
 
 	bops := NewBlockOpsStandard(config,
-		testBlockRetrievalWorkerQueueSize)
+		testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize)
 	config.SetBlockOps(bops)
 
 	config.SetBlockSplitter(&BlockSplitterSimple{


### PR DESCRIPTION
I believe this is ready for review. I refactored the code a bit to spawn fewer goroutines in general, and I made the channel semantics more sane. The worker actually does the work now.

I'm also running the tests a bunch of times to minimize the likelihood of flakes.