### PR TITLE
test: wait for journal to flush in TestTeamsTwoWritersJournal

### DIFF
--- a/test/teams_test.go
+++ b/test/teams_test.go
@@ -75,10 +75,18 @@ func TestTeamsTwoWritersJournal(t *testing.T) {
 			enableJournal(),
 			mkfile("a", "hello"),
 		),
+		as(alice,
+			// Wait for the flush, after doing a SyncAll().
+			flushJournal(),
+		),
 		as(bob,
 			enableJournal(),
 			read("a", "hello"),
 			mkfile("b", "world"),
+		),
+		as(bob,
+			// Wait for the flush, after doing a SyncAll().
+			flushJournal(),
 		),
 		as(alice,
 			read("b", "world"),


### PR DESCRIPTION
At the end of the `as` clause, bob does a SyncAll.  But we also need
to do a flush before alice can see the new data, since bob is using a
journal.

Issue: KBFS-2260