### PR TITLE
reporter_kbpki: avoid notification for "folder" user

### DIFF
--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -66,6 +66,7 @@ var noErrorNames = map[string]bool{
 	"m4root":         true, // OS X, iMovie?
 	"BDMV":           true, // OS X, iMovie?
 	"node_modules":   true, // Some npm shell configuration
+	"folder":         true, // Dolphin?  keybase/client#7304
 }
 
 // ReporterKBPKI implements the Notify function of the Reporter


### PR DESCRIPTION
I think maybe the Dolphin windows manager or Nautilus does automatic
lookups on /keybase/private/folder when you click open a folder
through the GUI.

Issue: keybase/client#7304