### PR TITLE
folder_branch_ops: remove unlinked files from dirty list

### DIFF
--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -896,6 +896,23 @@ func checkUnflushedPaths(expectedPaths []string) fileOp {
 	}, IsInit, fmt.Sprintf("checkUnflushedPaths(%s)", expectedPaths)}
 }
 
+func checkDirtyPaths(expectedPaths []string) fileOp {
+	return fileOp{func(c *ctx) error {
+		paths, err := c.engine.DirtyPaths(c.user, c.tlfName, c.tlfType)
+		if err != nil {
+			return err
+		}
+
+		sort.Strings(expectedPaths)
+		sort.Strings(paths)
+		if !reflect.DeepEqual(expectedPaths, paths) {
+			return fmt.Errorf("Expected dirty paths %v, got %v",
+				expectedPaths, paths)
+		}
+		return nil
+	}, IsInit, fmt.Sprintf("checkDirtyPaths(%s)", expectedPaths)}
+}
+
 func disablePrefetch() fileOp {
 	return fileOp{func(c *ctx) error {
 		return c.engine.TogglePrefetch(c.user, false)

--- a/test/engine.go
+++ b/test/engine.go
@@ -144,6 +144,9 @@ type Engine interface {
 	// paths haven't yet been flushed from the journal.
 	UnflushedPaths(u User, tlfName string, t tlf.Type) (
 		paths []string, err error)
+	// DirtyPaths called by the test harness to find out which
+	// paths haven't yet been flushed out of memory.
+	DirtyPaths(u User, tlfName string, t tlf.Type) (paths []string, err error)
 	// TogglePrefetch is called by the test harness as the given user to toggle
 	// whether prefetching should be enabled
 	TogglePrefetch(u User, enable bool) error

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -398,6 +398,25 @@ func (*fsEngine) UnflushedPaths(user User, tlfName string, t tlf.Type) (
 	return bufStatus.Journal.UnflushedPaths, nil
 }
 
+// DirtyPaths implements the Engine interface.
+func (*fsEngine) DirtyPaths(user User, tlfName string, t tlf.Type) (
+	[]string, error) {
+	u := user.(*fsUser)
+	path := buildTlfPath(u, tlfName, t)
+	buf, err := ioutil.ReadFile(filepath.Join(path, libfs.StatusFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	var bufStatus libkbfs.FolderBranchStatus
+	err = json.Unmarshal(buf, &bufStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	return bufStatus.DirtyPaths, nil
+}
+
 // TogglePrefetch implements the Engine interface.
 func (*fsEngine) TogglePrefetch(user User, enable bool) error {
 	u := user.(*fsUser)

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -727,6 +727,26 @@ func (k *LibKBFS) UnflushedPaths(u User, tlfName string, t tlf.Type) (
 	return status.Journal.UnflushedPaths, nil
 }
 
+// DirtyPaths implements the Engine interface.
+func (k *LibKBFS) DirtyPaths(u User, tlfName string, t tlf.Type) (
+	[]string, error) {
+	config := u.(*libkbfs.ConfigLocal)
+
+	ctx, cancel := k.newContext(u)
+	defer cancel()
+	dir, err := getRootNode(ctx, config, tlfName, t)
+	if err != nil {
+		return nil, err
+	}
+
+	status, _, err := config.KBFSOps().FolderStatus(ctx, dir.GetFolderBranch())
+	if err != nil {
+		return nil, err
+	}
+
+	return status.DirtyPaths, nil
+}
+
 // TogglePrefetch implements the Engine interface.
 func (k *LibKBFS) TogglePrefetch(u User, enable bool) error {
 	config := u.(*libkbfs.ConfigLocal)

--- a/test/simple_test.go
+++ b/test/simple_test.go
@@ -488,7 +488,7 @@ func TestCreateAndRemoveDirTreeWithinBatch(t *testing.T) {
 		as(alice,
 			mkdir("a"),
 			mkdir("a/b"),
-			mkfile("a/b/c", "hello"),
+			pwriteBSSync("a/b/c", []byte("hello"), 0, false),
 			rm("a/b/c"),
 			mkdir("b"),
 			rmdir("a/b"),
@@ -496,8 +496,13 @@ func TestCreateAndRemoveDirTreeWithinBatch(t *testing.T) {
 			// Initial check before SyncAll is called.
 			lsdir("", m{"b$": "DIR"}),
 			lsdir("b", m{}),
+			checkDirtyPaths([]string{
+				"alice,bob",
+				"alice,bob/a/b/c",
+			}),
 		),
 		as(alice,
+			checkDirtyPaths(nil),
 			lsdir("", m{"b$": "DIR"}),
 			lsdir("b", m{}),
 		),


### PR DESCRIPTION
Once we clear the cache info for the file, they shouldn't be considered dirty anymore.

Also add test infrastructure to be able to check dirty paths from the DSL tests.

Issue: KBFS-2272