### PR TITLE
libkbfs: identify/resolve team names with a "team:" prefix

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -164,15 +164,19 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 	}
 
 	var reason string
+	nameAssertion := name.String()
 	switch t {
 	case tlf.Public:
 		reason = "You accessed a public folder."
 	case tlf.Private:
-		reason = fmt.Sprintf("You accessed a private folder with %s.", name.String())
+		reason = fmt.Sprintf(
+			"You accessed a private folder with %s.", nameAssertion)
 	case tlf.SingleTeam:
-		reason = fmt.Sprintf("You accessed a folder for private team %s.", name.String())
+		reason = fmt.Sprintf(
+			"You accessed a folder for private team %s.", nameAssertion)
+		nameAssertion = "team:" + nameAssertion
 	}
-	resultName, resultID, err := identifier.Identify(ctx, name.String(), reason)
+	resultName, resultID, err := identifier.Identify(ctx, nameAssertion, reason)
 	if err != nil {
 		// Convert libkb.NoSigChainError into one we can report.  (See
 		// KBFS-1252).

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -178,7 +178,7 @@ func (k *KeybaseDaemonLocal) assertionToIDLocked(ctx context.Context,
 		} else {
 			key, val := url.ToKeyValuePair()
 			a := fmt.Sprintf("%s@%s", val, key)
-			if url.IsKeybase() {
+			if url.IsKeybase() && key != "team" {
 				a = val
 			}
 			var ok bool
@@ -535,7 +535,7 @@ func (k *KeybaseDaemonLocal) addTeamKeyForTest(
 func (k *KeybaseDaemonLocal) addTeamsForTestLocked(teams []TeamInfo) {
 	for _, t := range teams {
 		k.localTeams[t.TID] = t
-		k.asserts[string(t.Name)] = t.TID.AsUserOrTeam()
+		k.asserts[string(t.Name)+"@team"] = t.TID.AsUserOrTeam()
 		f := keybase1.Folder{
 			Name:       string(t.Name),
 			FolderType: keybase1.FolderType_TEAM,

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -440,7 +440,7 @@ func (ra resolvableAssertionWithChangeReport) resolve(ctx context.Context) (
 		}
 	}
 	if nuid.name.String() != "" {
-		if nuid.name.String() != ra.assertion {
+		if nuid.name.String() != strings.TrimPrefix(ra.assertion, "team:") {
 			sendIfPossible()
 		}
 	} else if sa != (keybase1.SocialAssertion{}) {
@@ -533,6 +533,9 @@ func parseTlfHandleLoose(
 	changesCh := make(chan struct{}, 1)
 	writers := make([]resolvableUser, len(writerNames))
 	for i, w := range writerNames {
+		if t == tlf.SingleTeam {
+			w = "team:" + w
+		}
 		writers[i] = resolvableAssertionWithChangeReport{
 			resolvableAssertion{kbpki, kbpki, w, keybase1.UID("")}, changesCh}
 	}

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -105,13 +105,20 @@ func TestParseTlfHandleSingleTeamFailures(t *testing.T) {
 		},
 	}
 
+	_, err := ParseTlfHandle(ctx, kbpki, "u1", tlf.SingleTeam)
+	assert.Equal(t, 0, kbpki.getIdentifyCalls())
+	assert.Equal(t, NoSuchUserError{Input: "u1@team"}, err)
+
 	checkNoSuchName := func(name string, ty tlf.Type) {
 		_, err := ParseTlfHandle(ctx, kbpki, name, ty)
 		assert.Equal(t, 0, kbpki.getIdentifyCalls())
-		assert.Equal(t, NoSuchNameError{Name: name}, err)
+		if ty == tlf.SingleTeam {
+			assert.Equal(t, NoSuchNameError{Name: name}, err)
+		} else {
+			assert.Equal(t, NoSuchUserError{Input: "t1"}, err)
+		}
 	}
 
-	checkNoSuchName("u1", tlf.SingleTeam)
 	checkNoSuchName("t1,u1", tlf.SingleTeam)
 	checkNoSuchName("u1,t1", tlf.SingleTeam)
 	checkNoSuchName("t1,t2", tlf.SingleTeam)

--- a/vendor/github.com/keybase/client/go/libkb/assertion.go
+++ b/vendor/github.com/keybase/client/go/libkb/assertion.go
@@ -447,6 +447,9 @@ func ParseAssertionURLKeyValue(ctx AssertionContext, key string, val string, str
 	switch key {
 	case "keybase":
 		ret = AssertionKeybase{base}
+	case "team":
+		// TODO(CORE-5376): REMOVE THIS HACK.
+		ret = AssertionKeybase{base}
 	case "uid":
 		ret = AssertionUID{AssertionURLBase: base}
 	case "tid":


### PR DESCRIPTION
@maxtaco says it's better if we always resolve/identify team names with a "team:" prefix, to make things easier for the service, and to allow us to split the namespaces someday in the future if we want.

Also adds a hack in vendor that we need until CORE-5376 is complete (at which point I'll revert the hack's commit and revendor libkb).

Issue: KBFS-2275