### PR TITLE
unset paperkey prompt if another deivce has serverd the rekey request

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4705,6 +4705,13 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 			}
 		}
 		if rmd.IsRekeySet() {
+			// One might have concern that a MD update written by the device
+			// itself can slip in here, for example during the rekey after
+			// setting paper prompt, and the event may cause the paper prompt
+			// to be unset. This is not a problem because 1) the revision check
+			// above shouldn't allow MD update written by this device to reach
+			// here; 2) the rekey FSM doesn't touch anything if it has the
+			// paper prompt set and is in scheduled state.
 			fbo.rekeyFSM.Event(NewRekeyRequestEvent())
 		} else {
 			fbo.rekeyFSM.Event(NewRekeyNotNeededEvent())

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4704,6 +4704,11 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 				return err
 			}
 		}
+		if rmd.IsRekeySet() {
+			fbo.rekeyFSM.Event(NewRekeyRequestEvent())
+		} else {
+			fbo.rekeyFSM.Event(NewRekeyNotNeededEvent())
+		}
 		appliedRevs = append(appliedRevs, rmd)
 	}
 	if len(appliedRevs) > 0 {

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1670,14 +1670,6 @@ func testKeyManagerRekeyBit(t *testing.T, ver MetadataVer) {
 		t.Fatalf("Device 2 couldn't read a: %+v", err)
 	}
 
-	// Cancel the original promptPaper timer for user2 now that the
-	// TLF is readable; otherwise the rekey later on will hang because
-	// it looks like prompt for paper was already set.  TODO: should
-	// KBFS cancel a promptPaper request when it sees a rekey was
-	// already done by another node?
-	ops := getOps(config2Dev2, rootNode1.GetFolderBranch().Tlf)
-	ops.rekeyFSM.Event(newRekeyCancelEventForTest())
-
 	config3Dev2 := ConfigAsUser(config1, u3)
 	// we don't check the config because this device can't read all of the md blocks.
 	defer config3Dev2.Shutdown(ctx)

--- a/libkbfs/rekey_fsm.go
+++ b/libkbfs/rekey_fsm.go
@@ -29,7 +29,7 @@ digraph rekeyFSM {
 
   start -> Idle
   Idle -> Scheduled [label=Request]
-  Scheduled -> Scheduled [label=Request]
+  Scheduled -> Scheduled [label="Request,RekeyNotNeeded"]
   Scheduled -> Started [label=Timeup]
   Started -> Scheduled [label="Finished(TTL valid && (rekey done || needs paper))"]
   Started -> Idle [label="Finished (*)"]
@@ -307,7 +307,7 @@ func (r *rekeyStateScheduled) reactToEvent(event RekeyEvent) rekeyState {
 		return newRekeyStateScheduled(r.fsm, event.request.delay, task)
 	case rekeyNotNeededEvent:
 		// KBFS-2254: if another device finished rekey, we should unset the
-		// paperkey prompt so that if this other deivce goes offline before a
+		// paperkey prompt so that if this other device goes offline before a
 		// third device triggers a rekey request, the timer can be preempted.
 		// What if the FoldersNeedRekey call comes in before this and we still
 		// miss the rekey request? Well now we also send a rekey request into

--- a/libkbfs/rekey_fsm.go
+++ b/libkbfs/rekey_fsm.go
@@ -58,6 +58,7 @@ const (
 	rekeyRequestEvent
 	rekeyFinishedEvent
 	rekeyTimeupEvent
+	rekeyNotNeededEvent
 
 	rekeyShutdownEvent
 
@@ -73,6 +74,8 @@ func (e rekeyEventType) String() string {
 		return "rekeyFinishedEvent"
 	case rekeyTimeupEvent:
 		return "rekeyTimeupEvent"
+	case rekeyNotNeededEvent:
+		return "rekeyNotNeededEvent"
 	case rekeyShutdownEvent:
 		return "rekeyShutdownEvent"
 	case rekeyKickoffEventForTest:
@@ -162,6 +165,18 @@ func NewRekeyRequestWithPaperPromptEvent() RekeyEvent {
 func NewRekeyRequestEvent() RekeyEvent {
 	return newRekeyRequestEventWithContext(ctxWithRandomIDReplayable(
 		context.Background(), CtxRekeyIDKey, CtxRekeyOpID, nil))
+}
+
+// NewRekeyNotNeededEvent creates a rekeyNotNeededEvent typed event. If the FSM
+// is in rekeyStateScheduled, this causes FSM to unset paperkey prompt. In
+// other states nothing happens. This event is sent to the FSM when we see a MD
+// update with rekey flag unset. It can be an indication that an old
+// outstanding rekey request has been served by another device, or just a
+// regular rekey updates.
+func NewRekeyNotNeededEvent() RekeyEvent {
+	return RekeyEvent{
+		eventType: rekeyNotNeededEvent,
+	}
 }
 
 func newRekeyFinishedEvent(res RekeyResult, err error) RekeyEvent {
@@ -290,6 +305,17 @@ func (r *rekeyStateScheduled) reactToEvent(event RekeyEvent) rekeyState {
 		}
 		r.timer.Stop()
 		return newRekeyStateScheduled(r.fsm, event.request.delay, task)
+	case rekeyNotNeededEvent:
+		// KBFS-2254: if another device finished rekey, we should unset the
+		// paperkey prompt so that if this other deivce goes offline before a
+		// third device triggers a rekey request, the timer can be preempted.
+		// What if the FoldersNeedRekey call comes in before this and we still
+		// miss the rekey request? Well now we also send a rekey request into
+		// the FSM on MD updates with rekey flag set. Since the MD updates are
+		// applied in order, and that FSM's state transition is
+		// single-goroutined, we are safe here.
+		r.task.promptPaper = false
+		return r
 	case rekeyKickoffEventForTest:
 		r.timer.Reset(time.Millisecond)
 		return r


### PR DESCRIPTION
Approach as discussed on [slack](https://keybase.slack.com/archives/C055SBA3H/p1497911382463613).

Also, remove the explicit rekey cancellation in key manager tests.