### PR TITLE
kbfs_ops: Status() should always return the status channel

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -678,7 +678,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		err := fillInJournalStatusUnflushedPaths(
 			ctx, fs.config, jServerStatus, tlfIDs)
 		if err != nil {
-			return KBFSStatus{}, nil, err
+			return KBFSStatus{}, ch, err
 		}
 		if usageBytes >= 0 {
 			usageBytes += status.UnflushedBytes

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -678,6 +678,9 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		err := fillInJournalStatusUnflushedPaths(
 			ctx, fs.config, jServerStatus, tlfIDs)
 		if err != nil {
+			// The caller might depend on the channel (e.g., in
+			// libfs/remote_status.go), even in the case where err !=
+			// nil.
 			return KBFSStatus{}, ch, err
 		}
 		if usageBytes >= 0 {


### PR DESCRIPTION
Even on a status error (which is ignored otherwise).  Otherwise the
listeners won't get notifications when the status changes, and they
won't force-fast-forward cleared folders when a login happens.

Issue: keybase/client#7475