### PR TITLE
config: turn off the metrics registry in minimal mode

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -310,8 +310,9 @@ func NewConfigLocal(mode InitMode, loggerFn func(module string) logger.Logger,
 	config.qrUnrefAge = qrUnrefAgeDefault
 	config.qrMinHeadAge = qrMinHeadAgeDefault
 
-	// Don't bother creating the registry if UseNilMetrics is set.
-	if !metrics.UseNilMetrics {
+	// Don't bother creating the registry if UseNilMetrics is set, or
+	// if we're in minimal mode.
+	if !metrics.UseNilMetrics && mode != InitMinimal {
 		registry := metrics.NewRegistry()
 		config.SetMetricsRegistry(registry)
 	}


### PR DESCRIPTION
So it doesn't waste CPU on mobile.

Suggested by patrickxb.

Issue: KBFS-2288