### PR TITLE
md_util: don't cache MDs in `getMDRange()`

### DIFF
--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -598,6 +598,7 @@ func (md *MDOpsStandard) put(
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
+	md.log.CDebugf(ctx, "Put MD rev=%d id=%s", rmd.Revision(), mdID)
 
 	return irmd, nil
 }


### PR DESCRIPTION
MDs fetched from remote servers are already cached in
`MDOpsStandard.processMetadata()`, and if the MDs are fetched from our
local journal, we risk a race condition by caching them here.  (See
details in KBFS-2224.)

Also add some debugging to `MDOpsStandard` to see the MD ID of a
newly-put revision.

Issue: KBFS-2224