### PR TITLE
libkbfs: avoid deadlock between `CreateFile` and `backgroundFlusher`

### DIFF
--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -490,6 +490,13 @@ func (d *DirtyBlockCacheStandard) RequestPermissionToDirty(
 		panic("Must request permission for a non-negative number of bytes.")
 	}
 	c := make(chan struct{})
+
+	// No need to wait to write 0 bytes.
+	if estimatedDirtyBytes == 0 {
+		close(c)
+		return c, nil
+	}
+
 	now := d.clock.Now()
 	deadline, ok := ctx.Deadline()
 	defaultDeadline := now.Add(backgroundTaskTimeout / 2)

--- a/libkbfs/dirty_bcache_test.go
+++ b/libkbfs/dirty_bcache_test.go
@@ -164,6 +164,17 @@ func TestDirtyBcacheRequestPermission(t *testing.T) {
 	default:
 	}
 
+	// A 0-byte request should never fail.
+	c3, err := dirtyBcache.RequestPermissionToDirty(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Request permission error: %v", err)
+	}
+	select {
+	case <-c3:
+	default:
+		t.Fatalf("A 0-byte request was blocked")
+	}
+
 	// Let's say the actual number of unsynced bytes for c1 was double
 	dirtyBcache.UpdateUnsyncedBytes(id, 4*bufSize+2, false)
 	// Now release the previous bytes

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1831,6 +1831,8 @@ func (fbo *folderBlockOps) maybeWaitOnDeferredWrites(
 			fbo.log.CDebugf(ctx,
 				"Blocking a write because of a full dirty buffer")
 			doLogUnblocked = true
+		case <-ctx.Done():
+			return ctx.Err()
 		case err = <-errListener:
 			// Fall through to check the cause of the error below.
 		}


### PR DESCRIPTION
KBFS-2295 details a race that happens when `CreateFile` calls `folderBlockOps.Write()` while holding `mdWriterLock` and blocks due to a full dirty bcache, and the background flusher can't sync anything because it needs to grab `mdWriterLock`.  This PR fixes it two ways:

* Blocked writes now time out based on contexts timing out (not sure how we missed this before).
* 0-byte writes, like the ones made from `CreateFile`, don't need to block at all.

I toyed with the idea of moving the `Write` call outside of the `CreateFile`, but a bunch of stuff depended on transactional semantics there and it seemed too complicated.

Issue: KBFS-2295