### PR TITLE
[KBFS-2291] Disk Limiter Refactor

### DIFF
--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -79,12 +79,11 @@ func (s *Semaphore) Acquire(ctx context.Context, n int64) (int64, error) {
 	}
 }
 
-// ForceAcquire atomically subtracts n (which must be positive) from
-// the resource count without waking up any waiting acquirers. It is
-// meant for correcting the initial resource count of the
-// semaphore. It's okay if adding n causes the resource count goes
-// negative, but it must not cause the resource count to overflow (in
-// the negative direction). The updated resource count is returned.
+// ForceAcquire atomically subtracts n (which must be positive) from the
+// resource count without waking up any waiting acquirers. It is meant for
+// correcting the initial resource count of the semaphore. It's okay if adding
+// n causes the resource count goes negative, but it must not cause the
+// resource count to underflow. The updated resource count is returned.
 func (s *Semaphore) ForceAcquire(n int64) int64 {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))
@@ -93,8 +92,32 @@ func (s *Semaphore) ForceAcquire(n int64) int64 {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if s.count < (math.MinInt64 + n) {
-		panic(fmt.Sprintf("s.count=%d - n=%d would overflow",
+		panic(fmt.Sprintf("s.count=%d - n=%d would underflow",
 			s.count, n))
+	}
+	s.count -= n
+	return s.count
+}
+
+// TryAcquire atomically subtracts n (which must be positive) from the resource
+// count without waking up any waiting acquirers, as long as it wouldn't go
+// negative. If the count would go negative, it doesn't update the count but
+// still returns the difference between the count and n. If the count would
+// underflow, it panics. In the successful case, TryAcquire returns the updated
+// resource count.
+func (s *Semaphore) TryAcquire(n int64) int64 {
+	if n <= 0 {
+		panic(fmt.Sprintf("n=%d must be positive", n))
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if s.count < n {
+		if s.count < (math.MinInt64 + n) {
+			panic(fmt.Sprintf("s.count=%d - n=%d would overflow",
+				s.count, n))
+		}
+		return s.count - n
 	}
 	s.count -= n
 	return s.count

--- a/kbfssync/semaphore.go
+++ b/kbfssync/semaphore.go
@@ -102,9 +102,10 @@ func (s *Semaphore) ForceAcquire(n int64) int64 {
 // TryAcquire atomically subtracts n (which must be positive) from the resource
 // count without waking up any waiting acquirers, as long as it wouldn't go
 // negative. If the count would go negative, it doesn't update the count but
-// still returns the difference between the count and n. If the count would
-// underflow, it panics. In the successful case, TryAcquire returns the updated
-// resource count.
+// still returns the difference between the count and n. TryAcquire is
+// successful if the return value is non-negative, and unsuccessful if the
+// return value is negative. If the count would underflow, it panics.
+// Otherwise, TryAcquire returns the updated resource count.
 func (s *Semaphore) TryAcquire(n int64) int64 {
 	if n <= 0 {
 		panic(fmt.Sprintf("n=%d must be positive", n))

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -954,19 +954,16 @@ func (bdl *backpressureDiskLimiter) onBlocksFlush(
 	bdl.journalTracker.onBlocksFlush(blockBytes, chargedTo)
 }
 
-func (bdl *backpressureDiskLimiter) onBlocksDelete(
-	ctx context.Context, blockBytes, blockFiles int64) {
+func (bdl *backpressureDiskLimiter) onBlocksDelete(ctx context.Context,
+	typ diskLimitTrackerType, blockBytes, blockFiles int64) {
 	bdl.lock.Lock()
 	defer bdl.lock.Unlock()
-	bdl.journalTracker.releaseAndCommit(blockBytes, blockFiles)
-	bdl.overallByteTracker.releaseAndCommit(blockBytes)
-}
-
-func (bdl *backpressureDiskLimiter) onDiskBlockCacheDelete(
-	ctx context.Context, blockBytes int64) {
-	bdl.lock.Lock()
-	defer bdl.lock.Unlock()
-	bdl.diskCacheByteTracker.releaseAndCommit(blockBytes)
+	switch typ {
+	case journalLimitTracker:
+		bdl.journalTracker.releaseAndCommit(blockBytes, blockFiles)
+	case diskCacheLimitTracker:
+		bdl.diskCacheByteTracker.releaseAndCommit(blockBytes)
+	}
 	bdl.overallByteTracker.releaseAndCommit(blockBytes)
 }
 

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -120,7 +120,7 @@ func (bt backpressureTracker) usedFrac() float64 {
 	return float64(bt.used) / bt.currLimit()
 }
 
-func (bt backpressureTracker) usedBytes() int64 {
+func (bt backpressureTracker) usedResources() int64 {
 	return bt.used
 }
 
@@ -898,9 +898,9 @@ func (bdl *backpressureDiskLimiter) getDelayLocked(
 func (bdl *backpressureDiskLimiter) reserveError(err error) (
 	availableBytes, availableFiles int64, _ error) {
 	bdl.lock.RLock()
+	defer bdl.lock.RUnlock()
 	availableBytes, availableFiles =
 		bdl.journalTracker.getSemaphoreCounts()
-	bdl.lock.RUnlock()
 	return availableBytes, availableFiles, err
 }
 
@@ -1041,7 +1041,7 @@ func (bdl *backpressureDiskLimiter) reserveBytes(
 	// We calculate the total free bytes by adding the reported free bytes and
 	// the non-`tracker` used bytes.
 	tracker.updateFree(freeBytes + bdl.overallByteTracker.used -
-		tracker.usedBytes())
+		tracker.usedResources())
 
 	count = tracker.tryReserve(blockBytes)
 	if count < 0 {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -577,6 +577,7 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 			if bytesAvailable >= 0 {
 				break
 			}
+			cache.log.CDebugf(ctx, "Need more bytes. Available: %d", bytesAvailable)
 			numRemoved, _, err := cache.evictLocked(ctx,
 				defaultNumBlocksToEvict)
 			if err != nil {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -225,7 +225,7 @@ func newDiskBlockCacheStandardFromStorage(config diskBlockCacheConfig,
 			// Notify the disk limiter of the disk cache's size once we've
 			// determined it.
 			ctx := context.Background()
-			cache.config.DiskLimiter().onDiskBlockCacheEnable(ctx,
+			cache.config.DiskLimiter().onByteTrackerEnable(ctx,
 				int64(cache.currBytes))
 		}
 		close(startedCh)
@@ -963,6 +963,6 @@ func (cache *DiskBlockCacheStandard) Shutdown(ctx context.Context) {
 		cache.log.CWarningf(ctx, "Error closing tlfDb: %+v", err)
 	}
 	cache.tlfDb = nil
-	cache.config.DiskLimiter().onDiskBlockCacheDisable(ctx,
+	cache.config.DiskLimiter().onByteTrackerDisable(ctx,
 		int64(cache.currBytes))
 }

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -731,7 +731,8 @@ func (cache *DiskBlockCacheStandard) deleteLocked(ctx context.Context,
 		cache.tlfSizes[k] -= removalSizes[k]
 		cache.currBytes -= removalSizes[k]
 	}
-	cache.config.DiskLimiter().onDiskBlockCacheDelete(ctx, sizeRemoved)
+	cache.config.DiskLimiter().onBlocksDelete(ctx, diskCacheLimitTracker,
+		sizeRemoved, 0)
 
 	return numRemoved, sizeRemoved, nil
 }

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -462,7 +462,7 @@ func TestDiskBlockCacheDynamicLimit(t *testing.T) {
 
 	t.Log("Add a round of blocks to the cache. Verify that blocks were" +
 		" evicted each time we went past the limit.")
-	start := numBlocks - int(defaultNumBlocksToEvict)
+	start := numBlocks - defaultNumBlocksToEvict
 	for i := 1; i <= numBlocks; i++ {
 		blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
 			t, config)
@@ -470,7 +470,7 @@ func TestDiskBlockCacheDynamicLimit(t *testing.T) {
 			ctx, tlf.FakeID(10, tlf.Private), blockPtr.ID, blockEncoded,
 			serverHalf)
 		require.NoError(t, err)
-		require.Equal(t, start+(i%int(defaultNumBlocksToEvict)), cache.numBlocks)
+		require.Equal(t, start+(i%defaultNumBlocksToEvict), cache.numBlocks)
 	}
 
 	require.True(t, int64(cache.currBytes) < currBytes)

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -1,11 +1,21 @@
 package libkbfs
 
 import (
+	"fmt"
+
 	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
 type diskLimitTrackerType int
+
+type unknownTrackerTypeError struct {
+	typ diskLimitTrackerType
+}
+
+func (e unknownTrackerTypeError) Error() string {
+	return fmt.Sprintf("Unknown tracker type: %d", e.typ)
+}
 
 const (
 	unknownLimitTracker diskLimitTrackerType = iota
@@ -18,6 +28,7 @@ type diskLimitByteTracker interface {
 	onEnable(usedResources int64) int64
 	onDisable(usedResources int64)
 	updateFree(freeResources int64)
+	usedBytes() int64
 	reserve(ctx context.Context, resources int64) (available int64, err error)
 	tryReserve(resources int64) (available int64)
 	commit(resources int64)
@@ -26,29 +37,17 @@ type diskLimitByteTracker interface {
 	releaseAndCommit(resources int64)
 }
 
-type diskBlockCacheLimiter interface {
-	// beforeDiskBlockCachePut is called by the disk block cache before putting
-	// a block into the cache. It returns the total number of available bytes.
-	beforeDiskBlockCachePut(ctx context.Context, blockBytes int64) (
-		availableBytes int64, err error)
-
-	// afterDiskBlockCachePut is called by the disk block cache after putting
-	// a block into the cache. It returns how many bytes it acquired.
-	afterDiskBlockCachePut(ctx context.Context, blockBytes int64,
-		putData bool)
-}
-
 // DiskLimiter is an interface for limiting disk usage.
 type DiskLimiter interface {
-	diskBlockCacheLimiter
-
 	// onByteTrackerEnable is called when a byte tracker is enabled to begin
 	// accounting.
-	onByteTrackerEnable(ctx context.Context, cacheBytes int64)
+	onByteTrackerEnable(ctx context.Context, typ diskLimitTrackerType,
+		cacheBytes int64)
 
-	// onByteTrackerDisable is called when a byte tracker is disable to stop
+	// onByteTrackerDisable is called when a byte tracker is disabled to stop
 	// accounting.
-	onByteTrackerDisable(ctx context.Context, cacheBytes int64)
+	onByteTrackerDisable(ctx context.Context, typ diskLimitTrackerType,
+		cacheBytes int64)
 
 	// onJournalEnable is called when initializing a TLF journal
 	// with that journal's current disk usage. Both journalBytes
@@ -66,24 +65,32 @@ type DiskLimiter interface {
 		journalStoredBytes, journalUnflushedBytes, journalFiles int64,
 		chargedTo keybase1.UserOrTeamID)
 
-	// beforeBlockPut is called before putting a block of the
-	// given byte and file count, both of which must be > 0. It
-	// may block, but must return immediately with a
-	// (possibly-wrapped) ctx.Err() if ctx is cancelled. The
-	// updated available byte and file count must be returned,
+	// reserveWithBackpressure is called before using disk storage of the given
+	// byte and file count, both of which must be > 0. It may block, but must
+	// return immediately with a (possibly-wrapped) ctx.Err() if ctx is
+	// cancelled. The updated available byte and file count must be returned,
 	// even if err is non-nil.
-	beforeBlockPut(ctx context.Context,
+	reserveWithBackpressure(ctx context.Context, typ diskLimitTrackerType,
 		blockBytes, blockFiles int64, chargedTo keybase1.UserOrTeamID) (
 		availableBytes, availableFiles int64, err error)
 
-	// afterBlockPut is called after putting a block of the given
-	// byte and file count, which must match the corresponding call to
-	// beforeBlockPut. putData reflects whether or not the data
-	// was actually put; if it's false, it's either because of an
-	// error or because the block already existed.
-	afterBlockPut(ctx context.Context,
-		blockBytes, blockFiles int64, putData bool,
-		chargedTo keybase1.UserOrTeamID)
+	// reserve is called by the disk block cache before using disk storage with
+	// the given byte count. It returns the total number of available bytes.
+	reserve(ctx context.Context, typ diskLimitTrackerType, blockBytes int64) (
+		availableBytes int64, err error)
+
+	// commitOrRollback is called after using disk storage of the given byte
+	// and file count, which must match the corresponding call to
+	// beforeBlockPut. putData reflects whether or not the data was actually
+	// put; if it's false, it's either because of an error or because the block
+	// already existed.
+	commitOrRollback(ctx context.Context, typ diskLimitTrackerType, blockBytes,
+		blockFiles int64, shouldCommit bool, chargedTo keybase1.UserOrTeamID)
+
+	// releaseAndCommit is called after deleting blocks for a given tracker of
+	// the given byte and file count, both of which must be >= 0.
+	releaseAndCommit(ctx context.Context, typ diskLimitTrackerType, blockBytes,
+		blockFiles int64)
 
 	// onBlocksFlush is called after flushing blocks of the given
 	// byte count, which must be >= 0. (Flushing a block with a
@@ -91,11 +98,6 @@ type DiskLimiter interface {
 	// through.)
 	onBlocksFlush(ctx context.Context, blockBytes int64,
 		chargedTo keybase1.UserOrTeamID)
-
-	// onBlocksDelete is called after deleting blocks for a given tracker of
-	// the given byte and file count, both of which must be >= 0.
-	onBlocksDelete(ctx context.Context, typ diskLimitTrackerType, blockBytes,
-		blockFiles int64)
 
 	// getQuotaInfo returns the quota info as known by the disk
 	// limiter.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -14,6 +14,18 @@ const (
 	syncCacheLimitTracker
 )
 
+type diskLimitByteTracker interface {
+	onEnable(usedResources int64) int64
+	onDisable(usedResources int64)
+	updateFree(freeResources int64)
+	reserve(ctx context.Context, resources int64) (available int64, err error)
+	tryReserve(resources int64) (available int64)
+	commit(resources int64)
+	rollback(resources int64)
+	commitOrRollback(resources int64, shouldCommit bool)
+	releaseAndCommit(resources int64)
+}
+
 type diskBlockCacheLimiter interface {
 	// beforeDiskBlockCachePut is called by the disk block cache before putting
 	// a block into the cache. It returns the total number of available bytes.

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -8,16 +8,13 @@ import (
 type diskLimitTrackerType int
 
 const (
-	journalLimitTracker diskLimitTrackerType = iota
+	unknownLimitTracker diskLimitTrackerType = iota
+	journalLimitTracker
 	diskCacheLimitTracker
 	syncCacheLimitTracker
 )
 
 type diskBlockCacheLimiter interface {
-	// onDiskBlockCacheDelete is called by the disk block cache after deleting
-	// blocks from the cache.
-	onDiskBlockCacheDelete(ctx context.Context, blockBytes int64)
-
 	// beforeDiskBlockCachePut is called by the disk block cache before putting
 	// a block into the cache. It returns the total number of available bytes.
 	beforeDiskBlockCachePut(ctx context.Context, blockBytes int64) (

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -30,7 +30,7 @@ type simpleResourceTracker interface {
 	onEnable(usedResources int64) int64
 	onDisable(usedResources int64)
 	updateFree(freeResources int64)
-	usedBytes() int64
+	usedResources() int64
 	reserve(ctx context.Context, resources int64) (available int64, err error)
 	tryReserve(resources int64) (available int64)
 	commit(resources int64)

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -174,19 +174,14 @@ func (sdl semaphoreDiskLimiter) onBlocksFlush(
 	sdl.quotaTracker.onBlocksFlush(blockBytes)
 }
 
-func (sdl semaphoreDiskLimiter) onBlocksDelete(
-	ctx context.Context, blockBytes, blockFiles int64) {
+func (sdl semaphoreDiskLimiter) onBlocksDelete(ctx context.Context,
+	typ diskLimitTrackerType, blockBytes, blockFiles int64) {
 	if blockBytes != 0 {
 		sdl.byteSemaphore.Release(blockBytes)
 	}
 	if blockFiles != 0 {
 		sdl.fileSemaphore.Release(blockFiles)
 	}
-}
-
-func (sdl semaphoreDiskLimiter) onDiskBlockCacheDelete(ctx context.Context,
-	blockBytes int64) {
-	sdl.onBlocksDelete(ctx, blockBytes, 0)
 }
 
 func (sdl semaphoreDiskLimiter) beforeDiskBlockCachePut(ctx context.Context,

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -117,14 +117,14 @@ func (sdl semaphoreDiskLimiter) onJournalDisable(
 	sdl.quotaTracker.onJournalDisable(journalUnflushedBytes)
 }
 
-func (sdl semaphoreDiskLimiter) onDiskBlockCacheEnable(
+func (sdl semaphoreDiskLimiter) onByteTrackerEnable(
 	ctx context.Context, diskCacheBytes int64) {
 	if diskCacheBytes != 0 {
 		sdl.byteSemaphore.ForceAcquire(diskCacheBytes)
 	}
 }
 
-func (sdl semaphoreDiskLimiter) onDiskBlockCacheDisable(
+func (sdl semaphoreDiskLimiter) onByteTrackerDisable(
 	ctx context.Context, diskCacheBytes int64) {
 	if diskCacheBytes != 0 {
 		sdl.byteSemaphore.Release(diskCacheBytes)

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -117,14 +117,14 @@ func (sdl semaphoreDiskLimiter) onJournalDisable(
 	sdl.quotaTracker.onJournalDisable(journalUnflushedBytes)
 }
 
-func (sdl semaphoreDiskLimiter) onByteTrackerEnable(
+func (sdl semaphoreDiskLimiter) onSimpleByteTrackerEnable(
 	ctx context.Context, typ diskLimitTrackerType, diskCacheBytes int64) {
 	if diskCacheBytes != 0 {
 		sdl.byteSemaphore.ForceAcquire(diskCacheBytes)
 	}
 }
 
-func (sdl semaphoreDiskLimiter) onByteTrackerDisable(
+func (sdl semaphoreDiskLimiter) onSimpleByteTrackerDisable(
 	ctx context.Context, typ diskLimitTrackerType, diskCacheBytes int64) {
 	if diskCacheBytes != 0 {
 		sdl.byteSemaphore.Release(diskCacheBytes)
@@ -174,7 +174,7 @@ func (sdl semaphoreDiskLimiter) onBlocksFlush(
 	sdl.quotaTracker.onBlocksFlush(blockBytes)
 }
 
-func (sdl semaphoreDiskLimiter) releaseAndCommit(ctx context.Context,
+func (sdl semaphoreDiskLimiter) release(ctx context.Context,
 	typ diskLimitTrackerType, blockBytes, blockFiles int64) {
 	if blockBytes != 0 {
 		sdl.byteSemaphore.Release(blockBytes)
@@ -184,7 +184,7 @@ func (sdl semaphoreDiskLimiter) releaseAndCommit(ctx context.Context,
 	}
 }
 
-func (sdl semaphoreDiskLimiter) reserve(ctx context.Context,
+func (sdl semaphoreDiskLimiter) reserveBytes(ctx context.Context,
 	typ diskLimitTrackerType, blockBytes int64) (availableBytes int64,
 	err error) {
 	if blockBytes == 0 {

--- a/libkbfs/semaphore_disk_limiter_test.go
+++ b/libkbfs/semaphore_disk_limiter_test.go
@@ -50,7 +50,7 @@ func TestSemaphoreDiskLimiterBlockBasic(t *testing.T) {
 	require.Equal(t, int64(0), usedQuotaBytes)
 	require.Equal(t, int64(12), quotaBytes)
 
-	sdl.onBlocksDelete(ctx, 9, 1)
+	sdl.onBlocksDelete(ctx, unknownLimitTracker, 9, 1)
 
 	require.Equal(t, int64(10), sdl.byteSemaphore.Count())
 	require.Equal(t, int64(2), sdl.fileSemaphore.Count())

--- a/libkbfs/semaphore_disk_limiter_test.go
+++ b/libkbfs/semaphore_disk_limiter_test.go
@@ -21,7 +21,7 @@ func TestSemaphoreDiskLimiterBlockBasic(t *testing.T) {
 
 	u := keybase1.UserOrTeamID("")
 	availBytes, availFiles, err := sdl.reserveWithBackpressure(ctx,
-		journalLimitTracker, 9, 1, u)
+		journalLimitTrackerType, 9, 1, u)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), availBytes)
 	require.Equal(t, int64(1), availFiles)
@@ -33,7 +33,7 @@ func TestSemaphoreDiskLimiterBlockBasic(t *testing.T) {
 	require.Equal(t, int64(0), usedQuotaBytes)
 	require.Equal(t, int64(12), quotaBytes)
 
-	sdl.commitOrRollback(ctx, journalLimitTracker, 9, 1, true, u)
+	sdl.commitOrRollback(ctx, journalLimitTrackerType, 9, 1, true, u)
 
 	require.Equal(t, int64(1), sdl.byteSemaphore.Count())
 	require.Equal(t, int64(1), sdl.fileSemaphore.Count())
@@ -51,7 +51,7 @@ func TestSemaphoreDiskLimiterBlockBasic(t *testing.T) {
 	require.Equal(t, int64(0), usedQuotaBytes)
 	require.Equal(t, int64(12), quotaBytes)
 
-	sdl.releaseAndCommit(ctx, unknownLimitTracker, 9, 1)
+	sdl.release(ctx, unknownLimitTrackerType, 9, 1)
 
 	require.Equal(t, int64(10), sdl.byteSemaphore.Count())
 	require.Equal(t, int64(2), sdl.fileSemaphore.Count())
@@ -72,7 +72,7 @@ func TestSemaphoreDiskLimiterBeforeBlockPutError(t *testing.T) {
 		context.Background(), 3*time.Millisecond)
 	defer cancel()
 
-	availBytes, availFiles, err := sdl.reserveWithBackpressure(ctx, journalLimitTracker, 10, 2,
+	availBytes, availFiles, err := sdl.reserveWithBackpressure(ctx, journalLimitTrackerType, 10, 2,
 		keybase1.UserOrTeamID(""))
 	require.Equal(t, context.DeadlineExceeded, errors.Cause(err))
 	require.Equal(t, int64(10), availBytes)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1242,7 +1242,8 @@ func (j *tlfJournal) doOnMDFlushAndRemoveFlushedMDEntry(ctx context.Context,
 			return err
 		}
 
-		j.diskLimiter.onBlocksDelete(ctx, removedBytes, removedFiles)
+		j.diskLimiter.onBlocksDelete(ctx, journalLimitTracker, removedBytes,
+			removedFiles)
 	}
 
 	j.journalLock.Lock()

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1242,7 +1242,7 @@ func (j *tlfJournal) doOnMDFlushAndRemoveFlushedMDEntry(ctx context.Context,
 			return err
 		}
 
-		j.diskLimiter.releaseAndCommit(ctx, journalLimitTracker, removedBytes,
+		j.diskLimiter.release(ctx, journalLimitTrackerType, removedBytes,
 			removedFiles)
 	}
 
@@ -1804,7 +1804,7 @@ func (j *tlfJournal) putBlockData(
 
 	bufLen := int64(len(buf))
 	availableBytes, availableFiles, err := j.diskLimiter.reserveWithBackpressure(
-		acquireCtx, journalLimitTracker, bufLen, filesPerBlockMax, j.chargedTo)
+		acquireCtx, journalLimitTrackerType, bufLen, filesPerBlockMax, j.chargedTo)
 	switch errors.Cause(err) {
 	case nil:
 		// Continue.
@@ -1827,7 +1827,7 @@ func (j *tlfJournal) putBlockData(
 
 	var putData bool
 	defer func() {
-		j.diskLimiter.commitOrRollback(ctx, journalLimitTracker, bufLen,
+		j.diskLimiter.commitOrRollback(ctx, journalLimitTrackerType, bufLen,
 			filesPerBlockMax, putData, j.chargedTo)
 	}()
 


### PR DESCRIPTION
This cleans up the disk limiter to be less tightly coupled to its usage.
* Methods now take as a parameter the tracker type they affect, and have been renamed to describe what they do to the tracker rather than where they are called.
* Some methods have been consolidated so that we don't have duplicated functionality across tracker types.
* There is now an overall tracker that tracks overall Keybase usage. This means trackers no longer depend on each other, instead treating the `overallTracker` as a single source of truth for the aggregate Keybase data usage.

Sorry this took so long; I had lots of corner case accounting bugs that I needed to fix because I put too many changes in at once before testing (consolidating and introducing the overall tracker accounting).