### PR TITLE
[KBFS-2309] Count Meter

### DIFF
--- a/libkbfs/count_meter.go
+++ b/libkbfs/count_meter.go
@@ -7,39 +7,6 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 )
 
-// MeterSnapshot is a read-only copy of another Meter.
-type MeterSnapshot struct {
-	count                          int64
-	rate1, rate5, rate15, rateMean float64
-}
-
-// Count returns the count of events at the time the snapshot was taken.
-func (m *MeterSnapshot) Count() int64 { return m.count }
-
-// Mark panics.
-func (*MeterSnapshot) Mark(n int64) {
-	panic("Mark called on a MeterSnapshot")
-}
-
-// Rate1 returns the one-minute moving average rate of events per second at the
-// time the snapshot was taken.
-func (m *MeterSnapshot) Rate1() float64 { return m.rate1 }
-
-// Rate5 returns the five-minute moving average rate of events per second at
-// the time the snapshot was taken.
-func (m *MeterSnapshot) Rate5() float64 { return m.rate5 }
-
-// Rate15 returns the fifteen-minute moving average rate of events per second
-// at the time the snapshot was taken.
-func (m *MeterSnapshot) Rate15() float64 { return m.rate15 }
-
-// RateMean returns the meter's mean rate of events per second at the time the
-// snapshot was taken.
-func (m *MeterSnapshot) RateMean() float64 { return m.rateMean }
-
-// Snapshot returns the snapshot.
-func (m *MeterSnapshot) Snapshot() metrics.Meter { return m }
-
 // CountMeter counts ticks with a sliding window into the past.
 type CountMeter struct {
 	mtx      sync.RWMutex
@@ -48,6 +15,8 @@ type CountMeter struct {
 
 	shutdownCh chan struct{}
 }
+
+var _ metrics.Meter = (*CountMeter)(nil)
 
 func (m *CountMeter) tick() {
 	m.mtx.Lock()
@@ -141,7 +110,7 @@ func (m *CountMeter) Rate15() float64 {
 	return m.rate15()
 }
 
-// RateMean returns the overall mean rate of ticks.
+// RateMean returns the overall count of ticks.
 func (m *CountMeter) RateMean() float64 {
 	m.mtx.RLock()
 	defer m.mtx.RUnlock()

--- a/libkbfs/count_meter.go
+++ b/libkbfs/count_meter.go
@@ -1,0 +1,172 @@
+package libkbfs
+
+import (
+	"sync"
+	"time"
+
+	metrics "github.com/rcrowley/go-metrics"
+)
+
+// MeterSnapshot is a read-only copy of another Meter.
+type MeterSnapshot struct {
+	count                          int64
+	rate1, rate5, rate15, rateMean float64
+}
+
+// Count returns the count of events at the time the snapshot was taken.
+func (m *MeterSnapshot) Count() int64 { return m.count }
+
+// Mark panics.
+func (*MeterSnapshot) Mark(n int64) {
+	panic("Mark called on a MeterSnapshot")
+}
+
+// Rate1 returns the one-minute moving average rate of events per second at the
+// time the snapshot was taken.
+func (m *MeterSnapshot) Rate1() float64 { return m.rate1 }
+
+// Rate5 returns the five-minute moving average rate of events per second at
+// the time the snapshot was taken.
+func (m *MeterSnapshot) Rate5() float64 { return m.rate5 }
+
+// Rate15 returns the fifteen-minute moving average rate of events per second
+// at the time the snapshot was taken.
+func (m *MeterSnapshot) Rate15() float64 { return m.rate15 }
+
+// RateMean returns the meter's mean rate of events per second at the time the
+// snapshot was taken.
+func (m *MeterSnapshot) RateMean() float64 { return m.rateMean }
+
+// Snapshot returns the snapshot.
+func (m *MeterSnapshot) Snapshot() metrics.Meter { return m }
+
+// CountMeter counts ticks with a sliding window into the past.
+type CountMeter struct {
+	mtx      sync.RWMutex
+	counters []int64
+	overall  int64
+
+	shutdownCh chan struct{}
+}
+
+func (m *CountMeter) tick() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	for i := len(m.counters) - 1; i > 0; i-- {
+		m.counters[i] = m.counters[i-1]
+	}
+	m.counters[0] = 0
+}
+
+func (m *CountMeter) run() {
+	ticker := time.NewTicker(time.Minute)
+	for {
+		select {
+		case <-m.shutdownCh:
+			return
+		case <-ticker.C:
+			m.tick()
+		}
+	}
+}
+
+// NewCountMeter returns a new CountMeter.
+func NewCountMeter() *CountMeter {
+	m := &CountMeter{
+		counters:   make([]int64, 16),
+		shutdownCh: make(chan struct{}),
+	}
+	go m.run()
+
+	return m
+}
+
+// Count returns the overall count.
+func (m *CountMeter) Count() int64 {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.overall
+}
+
+// Mark ticks the counters.
+func (m *CountMeter) Mark(i int64) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.counters[0] += i
+	m.overall += i
+}
+
+func (m *CountMeter) rateN(n int) float64 {
+	var count int64
+	for i := 0; i < n; i++ {
+		count += m.counters[i]
+	}
+	return float64(count)
+}
+
+func (m *CountMeter) rate1() float64 {
+	return float64(m.counters[0])
+}
+
+func (m *CountMeter) rate5() float64 {
+	return m.rateN(5)
+}
+
+func (m *CountMeter) rate15() float64 {
+	return m.rateN(15)
+}
+
+func (m *CountMeter) rateMean() float64 {
+	return float64(m.overall)
+}
+
+// Rate1 returns the number of ticks in the last 1 minute.
+func (m *CountMeter) Rate1() float64 {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.rate1()
+}
+
+// Rate5 returns the number of ticks in the last 5 minutes.
+func (m *CountMeter) Rate5() float64 {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.rate5()
+}
+
+// Rate15 returns the number of ticks in the last 15 minutes.
+func (m *CountMeter) Rate15() float64 {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.rate15()
+}
+
+// RateMean returns the overall mean rate of ticks.
+func (m *CountMeter) RateMean() float64 {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return m.rateMean()
+}
+
+// Snapshot returns the snapshot in time of this CountMeter.
+func (m *CountMeter) Snapshot() metrics.Meter {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	return &MeterSnapshot{
+		m.overall,
+		m.rate1(),
+		m.rate5(),
+		m.rate15(),
+		m.rateMean(),
+	}
+}
+
+// Shutdown shuts down this CountMeter.
+func (m *CountMeter) Shutdown() <-chan struct{} {
+	select {
+	case <-m.shutdownCh:
+	default:
+		close(m.shutdownCh)
+	}
+	return m.shutdownCh
+}

--- a/libkbfs/count_meter_test.go
+++ b/libkbfs/count_meter_test.go
@@ -1,0 +1,48 @@
+package libkbfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountMeter(t *testing.T) {
+	m := NewCountMeter()
+	// Shutdown the meter so we manually control its ticks.
+	m.Shutdown()
+
+	var count1 float64
+	var count5 float64
+	var count15 float64
+	var countMean float64
+
+	for i := 0; i < 100; i++ {
+		count1 = 0
+		if i > 4 {
+			count5 -= float64(((i - 5) * 4) + 10)
+		}
+		if i > 14 {
+			count15 -= float64(((i - 15) * 4) + 10)
+		}
+		f := float64((i * 4) + 10)
+		count1 += f
+		count5 += f
+		count15 += f
+		countMean += f
+		for j := 1; j < 5; j++ {
+			m.Mark(int64(i + j))
+		}
+		s := m.Snapshot()
+		require.Equal(t, count1, m.Rate1(), "Invalid Rate1 for i=%d", i)
+		require.Equal(t, count5, m.Rate5(), "Invalid Rate5 for i=%d", i)
+		require.Equal(t, count15, m.Rate15(), "Invalid Rate15 for i=%d", i)
+		require.Equal(t, countMean, m.RateMean(), "Invalid RateMean for i=%d", i)
+		require.Equal(t, int64(countMean), m.Count(), "Invalid Count for i=%d", i)
+		require.Equal(t, s.Rate1(), m.Rate1())
+		require.Equal(t, s.Rate5(), m.Rate5())
+		require.Equal(t, s.Rate15(), m.Rate15())
+		require.Equal(t, s.RateMean(), m.RateMean())
+		require.Equal(t, s.Count(), m.Count())
+		m.tick()
+	}
+}

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -65,15 +65,15 @@ type DiskBlockCacheStandard struct {
 	tlfSizes  map[tlf.ID]uint64
 	currBytes uint64
 	// Track the cache hit rate and eviction rate
-	hitMeter         metrics.Meter
-	missMeter        metrics.Meter
-	putMeter         metrics.Meter
-	updateMeter      metrics.Meter
-	evictCountMeter  metrics.Meter
-	evictSizeMeter   metrics.Meter
-	deleteCountMeter metrics.Meter
-	deleteSizeMeter  metrics.Meter
-	// This protects the disk caches from being shutdown while they're being
+	hitMeter         *CountMeter
+	missMeter        *CountMeter
+	putMeter         *CountMeter
+	updateMeter      *CountMeter
+	evictCountMeter  *CountMeter
+	evictSizeMeter   *CountMeter
+	deleteCountMeter *CountMeter
+	deleteSizeMeter  *CountMeter
+	// Protect the disk caches from being shutdown while they're being
 	// accessed.
 	lock    sync.RWMutex
 	blockDb *leveldb.DB
@@ -96,11 +96,12 @@ type MeterStatus struct {
 }
 
 func rateMeterToStatus(m metrics.Meter) MeterStatus {
+	s := m.Snapshot()
 	return MeterStatus{
-		m.Rate1(),
-		m.Rate5(),
-		m.Rate15(),
-		m.RateMean(),
+		s.Rate1(),
+		s.Rate5(),
+		s.Rate15(),
+		s.RateMean(),
 	}
 }
 
@@ -192,14 +193,14 @@ func newDiskBlockCacheStandardFromStorage(config diskBlockCacheConfig,
 		maxBlockID:       maxBlockID.Bytes(),
 		tlfCounts:        map[tlf.ID]int{},
 		tlfSizes:         map[tlf.ID]uint64{},
-		hitMeter:         metrics.NewMeter(),
-		missMeter:        metrics.NewMeter(),
-		putMeter:         metrics.NewMeter(),
-		updateMeter:      metrics.NewMeter(),
-		evictCountMeter:  metrics.NewMeter(),
-		evictSizeMeter:   metrics.NewMeter(),
-		deleteCountMeter: metrics.NewMeter(),
-		deleteSizeMeter:  metrics.NewMeter(),
+		hitMeter:         NewCountMeter(),
+		missMeter:        NewCountMeter(),
+		putMeter:         NewCountMeter(),
+		updateMeter:      NewCountMeter(),
+		evictCountMeter:  NewCountMeter(),
+		evictSizeMeter:   NewCountMeter(),
+		deleteCountMeter: NewCountMeter(),
+		deleteSizeMeter:  NewCountMeter(),
 		log:              log,
 		blockDb:          blockDb,
 		metaDb:           metaDb,
@@ -968,4 +969,12 @@ func (cache *DiskBlockCacheStandard) Shutdown(ctx context.Context) {
 	cache.tlfDb = nil
 	cache.config.DiskLimiter().onSimpleByteTrackerDisable(ctx,
 		workingSetCacheLimitTrackerType, int64(cache.currBytes))
+	cache.hitMeter.Shutdown()
+	cache.missMeter.Shutdown()
+	cache.putMeter.Shutdown()
+	cache.updateMeter.Shutdown()
+	cache.evictCountMeter.Shutdown()
+	cache.evictSizeMeter.Shutdown()
+	cache.deleteCountMeter.Shutdown()
+	cache.deleteSizeMeter.Shutdown()
 }

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -92,7 +92,7 @@ type MeterStatus struct {
 	Minutes1  float64
 	Minutes5  float64
 	Minutes15 float64
-	Mean      float64
+	Count     int64
 }
 
 func rateMeterToStatus(m metrics.Meter) MeterStatus {
@@ -101,7 +101,7 @@ func rateMeterToStatus(m metrics.Meter) MeterStatus {
 		s.Rate1(),
 		s.Rate5(),
 		s.Rate15(),
-		s.RateMean(),
+		s.Count(),
 	}
 }
 

--- a/libkbfs/meter_snapshot.go
+++ b/libkbfs/meter_snapshot.go
@@ -1,0 +1,71 @@
+// Copied from github.com/rcrowley/go-metrics so that we can populate
+// unexported fields.
+//
+// Copyright 2012 Richard Crowley. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1.  Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following
+// disclaimer in the documentation and/or other materials provided
+// with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY RICHARD CROWLEY ``AS IS'' AND ANY EXPRESS
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL RICHARD CROWLEY OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// The views and conclusions contained in the software and documentation
+// are those of the authors and should not be interpreted as representing
+// official policies, either expressed or implied, of Richard Crowley.
+
+package libkbfs
+
+import metrics "github.com/rcrowley/go-metrics"
+
+// MeterSnapshot is a read-only copy of another Meter.
+type MeterSnapshot struct {
+	count                          int64
+	rate1, rate5, rate15, rateMean float64
+}
+
+var _ metrics.Meter = (*MeterSnapshot)(nil)
+
+// Count returns the count of events at the time the snapshot was taken.
+func (m *MeterSnapshot) Count() int64 { return m.count }
+
+// Mark panics.
+func (*MeterSnapshot) Mark(n int64) {
+	panic("Mark called on a MeterSnapshot")
+}
+
+// Rate1 returns the one-minute moving average rate of events per second at the
+// time the snapshot was taken.
+func (m *MeterSnapshot) Rate1() float64 { return m.rate1 }
+
+// Rate5 returns the five-minute moving average rate of events per second at
+// the time the snapshot was taken.
+func (m *MeterSnapshot) Rate5() float64 { return m.rate5 }
+
+// Rate15 returns the fifteen-minute moving average rate of events per second
+// at the time the snapshot was taken.
+func (m *MeterSnapshot) Rate15() float64 { return m.rate15 }
+
+// RateMean returns the meter's mean rate of events per second at the time the
+// snapshot was taken.
+func (m *MeterSnapshot) RateMean() float64 { return m.rateMean }
+
+// Snapshot returns the snapshot.
+func (m *MeterSnapshot) Snapshot() metrics.Meter { return m }


### PR DESCRIPTION
This correctly tracks disk block cache stats over the past 1, 5, 15 minutes, and overall.