### PR TITLE
keybase_service_base: use refreshers to bust service and local team caches

### DIFF
--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -354,7 +354,8 @@ func (f *Folder) isWriter(ctx context.Context) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		isWriter, err := f.fs.config.KBPKI().IsTeamWriter(ctx, tid, session.UID)
+		isWriter, err := f.fs.config.KBPKI().IsTeamWriter(
+			ctx, tid, session.UID, session.VerifyingKey)
 		if err != nil {
 			return false, err
 		}

--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -309,7 +309,8 @@ func (md *BareRootMetadataV2) IsFinal() bool {
 // IsWriter implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) IsWriter(
 	_ context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey,
-	_ TeamMembershipChecker, _ ExtraMetadata) (bool, error) {
+	_ kbfscrypto.VerifyingKey, _ TeamMembershipChecker, _ ExtraMetadata) (
+	bool, error) {
 	if md.ID.Type() != tlf.Private {
 		for _, w := range md.Writers {
 			if w == user.AsUserOrTeam() {
@@ -765,7 +766,8 @@ func (md *BareRootMetadataV2) GetTLFCryptKeyParams(
 // IsValidAndSigned implements the BareRootMetadata interface for BareRootMetadataV2.
 func (md *BareRootMetadataV2) IsValidAndSigned(
 	_ context.Context, codec kbfscodec.Codec, crypto cryptoPure,
-	_ TeamMembershipChecker, extra ExtraMetadata) error {
+	_ TeamMembershipChecker, extra ExtraMetadata,
+	_ kbfscrypto.VerifyingKey) error {
 	// Optimization -- if the WriterMetadata signature is nil, it
 	// will fail verification.
 	if md.WriterMetadataSigInfo.IsNil() {

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -397,7 +397,7 @@ func (md *BareRootMetadataV3) isNonTeamWriter(
 		}
 		return wkb.IsWriter(user, cryptKey), nil
 	default:
-		panic(fmt.Sprintf("Unknown TLF type: %s", md.TlfID().Type()))
+		return false, errors.Errorf("Unknown TLF type: %s", md.TlfID().Type())
 	}
 }
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -41,6 +41,7 @@ type UserInfo struct {
 	VerifyingKeys   []kbfscrypto.VerifyingKey
 	CryptPublicKeys []kbfscrypto.CryptPublicKey
 	KIDNames        map[keybase1.KID]string
+	EldestSeqno     keybase1.Seqno
 
 	// Revoked keys, and the time at which they were revoked.
 	RevokedVerifyingKeys   map[kbfscrypto.VerifyingKey]keybase1.KeybaseTime

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -155,6 +155,10 @@ const (
 	// PublicKeyGen is the value used for public TLFs. Note that
 	// it is not considered a valid key generation.
 	PublicKeyGen KeyGen = -1
+	// UnspecifiedKeyGen indicates that the application doesn't have a
+	// particular keygen in mind when requesting keys; any keygen will
+	// do.
+	UnspecifiedKeyGen KeyGen = 0
 	// FirstValidKeyGen is the first value that is considered a
 	// valid key generation. Note that the nil value is not
 	// considered valid.

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -1048,7 +1048,8 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 	if err != nil {
 		return err
 	}
-	isWriter, err := head.IsWriter(ctx, fbm.config.KBPKI(), session.UID)
+	isWriter, err := head.IsWriter(
+		ctx, fbm.config.KBPKI(), session.UID, session.VerifyingKey)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1881,7 +1881,8 @@ func (fbo *folderBlockOps) writeGetFileLocked(
 	if err != nil {
 		return nil, err
 	}
-	isWriter, err := kmd.IsWriter(ctx, fbo.config.KBPKI(), session.UID)
+	isWriter, err := kmd.IsWriter(
+		ctx, fbo.config.KBPKI(), session.UID, session.VerifyingKey)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1443,7 +1443,8 @@ func (fbo *folderBranchOps) initMDLocked(
 		if err != nil {
 			return err
 		}
-		keys, keyGen, err := fbo.config.KBPKI().GetTeamTLFCryptKeys(ctx, tid)
+		keys, keyGen, err := fbo.config.KBPKI().GetTeamTLFCryptKeys(
+			ctx, tid, UnspecifiedKeyGen)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1233,7 +1233,8 @@ func (fbo *folderBranchOps) getMDForWriteLockedForFilename(
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
-	isWriter, err := md.IsWriter(ctx, fbo.config.KBPKI(), session.UID)
+	isWriter, err := md.IsWriter(
+		ctx, fbo.config.KBPKI(), session.UID, session.VerifyingKey)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -1410,7 +1411,8 @@ func (fbo *folderBranchOps) initMDLocked(
 	handle := md.GetTlfHandle()
 
 	// make sure we're a writer before rekeying or putting any blocks.
-	isWriter, err := md.IsWriter(ctx, fbo.config.KBPKI(), session.UID)
+	isWriter, err := md.IsWriter(
+		ctx, fbo.config.KBPKI(), session.UID, session.VerifyingKey)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -419,7 +419,8 @@ type KeybaseService interface {
 	// yet according to local caches; it may be set to "" if no server
 	// check is required.
 	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
-		desiredKeyGen KeyGen, desiredUID keybase1.UID) (TeamInfo, error)
+		desiredKeyGen KeyGen, desiredUID keybase1.UID,
+		desiredRole keybase1.TeamRole) (TeamInfo, error)
 
 	// CurrentSession returns a SessionInfo struct with all the
 	// information for the current session, or an error otherwise.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1910,7 +1910,7 @@ type BareRootMetadata interface {
 		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
 	// IsReader returns whether or not the user+device is an authorized reader.
 	IsReader(ctx context.Context, user keybase1.UID,
-		deviceKey kbfscrypto.CryptPublicKey,
+		cryptKey kbfscrypto.CryptPublicKey,
 		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
 	// DeepCopy returns a deep copy of the underlying data structure.
 	DeepCopy(codec kbfscodec.Codec) (MutableBareRootMetadata, error)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -419,7 +419,7 @@ type KeybaseService interface {
 	// yet according to local caches; it may be set to "" if no server
 	// check is required.
 	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
-		desiredKeyGen KeyGen, desiredUID keybase1.UID,
+		desiredKeyGen KeyGen, desiredUser keybase1.UserVersion,
 		desiredRole keybase1.TeamRole) (TeamInfo, error)
 
 	// CurrentSession returns a SessionInfo struct with all the

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -517,10 +517,10 @@ type CurrentSessionGetter interface {
 // TeamMembershipChecker is an interface for objects that can check
 // the writer/reader membership of teams.
 type TeamMembershipChecker interface {
-	// IsTeamWriter checks whether the given user is a writer of the
-	// given team right now.
-	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
-		bool, error)
+	// IsTeamWriter checks whether the given user (with the given
+	// verifying key) is a writer of the given team right now.
+	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,
+		verifyingKey kbfscrypto.VerifyingKey) (bool, error)
 	// IsTeamReader checks whether the given user is a reader of the
 	// given team right now.
 	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
@@ -615,7 +615,8 @@ type KeyMetadata interface {
 	// IsWriter checks that the given user is a valid writer of the TLF
 	// right now.
 	IsWriter(
-		ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
+		ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID,
+		verifyingKey kbfscrypto.VerifyingKey) (
 		bool, error)
 
 	// HasKeyForUser returns whether or not the given user has
@@ -1904,7 +1905,8 @@ type BareRootMetadata interface {
 	IsFinal() bool
 	// IsWriter returns whether or not the user+device is an authorized writer.
 	IsWriter(ctx context.Context, user keybase1.UID,
-		deviceKey kbfscrypto.CryptPublicKey,
+		cryptKey kbfscrypto.CryptPublicKey,
+		verifyingKey kbfscrypto.VerifyingKey,
 		teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error)
 	// IsReader returns whether or not the user+device is an authorized reader.
 	IsReader(ctx context.Context, user keybase1.UID,
@@ -1957,7 +1959,7 @@ type BareRootMetadata interface {
 	// checking with KBPKI.
 	IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec,
 		crypto cryptoPure, teamMemChecker TeamMembershipChecker,
-		extra ExtraMetadata) error
+		extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey) error
 	// IsLastModifiedBy verifies that the BareRootMetadata is
 	// written by the given user and device (identified by the
 	// device verifying key), and returns an error if not.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -411,8 +411,12 @@ type KeybaseService interface {
 		[]keybase1.PublicKey, error)
 
 	// LoadTeamPlusKeys returns a TeamInfo struct for a team with the
-	// specified TeamID.
-	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID) (TeamInfo, error)
+	// specified TeamID.  The caller can specify `desiredKeyGen` to
+	// force a server check if that particular key gen isn't yet
+	// known; it may be set to UnspecifiedKeyGen if no server check is
+	// required.
+	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
+		desiredKeyGen KeyGen) (TeamInfo, error)
 
 	// CurrentSession returns a SessionInfo struct with all the
 	// information for the current session, or an error otherwise.
@@ -527,8 +531,11 @@ type TeamMembershipChecker interface {
 type teamKeysGetter interface {
 	// GetTeamTLFCryptKeys gets all of a team's secret crypt keys, by
 	// generation, as well as the latest key generation number for the
-	// team.
-	GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (
+	// team.  The caller can specify `desiredKeyGen` to force a server
+	// check if that particular key gen isn't yet known; it may be set
+	// to UnspecifiedKeyGen if no server check is required.
+	GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID,
+		desiredKeyGen KeyGen) (
 		map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error)
 }
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -414,9 +414,12 @@ type KeybaseService interface {
 	// specified TeamID.  The caller can specify `desiredKeyGen` to
 	// force a server check if that particular key gen isn't yet
 	// known; it may be set to UnspecifiedKeyGen if no server check is
-	// required.
+	// required.  The caller can specify `desiredUID` to force a
+	// server check if that particular UID isn't a member of the team
+	// yet according to local caches; it may be set to "" if no server
+	// check is required.
 	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
-		desiredKeyGen KeyGen) (TeamInfo, error)
+		desiredKeyGen KeyGen, desiredUID keybase1.UID) (TeamInfo, error)
 
 	// CurrentSession returns a SessionInfo struct with all the
 	// information for the current session, or an error otherwise.

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -202,7 +202,7 @@ func (k *KBPKIClient) GetTeamTLFCryptKeys(
 	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
 	map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, desiredKeyGen, keybase1.UID(""), keybase1.TeamRole_NONE)
+		ctx, tid, desiredKeyGen, keybase1.UserVersion{}, keybase1.TeamRole_NONE)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -218,8 +218,9 @@ func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
 // IsTeamWriter implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) IsTeamWriter(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	desiredUser := keybase1.UserVersion{Uid: uid}
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, uid, keybase1.TeamRole_WRITER)
+		ctx, tid, UnspecifiedKeyGen, desiredUser, keybase1.TeamRole_WRITER)
 	if err != nil {
 		return false, err
 	}
@@ -229,8 +230,9 @@ func (k *KBPKIClient) IsTeamWriter(
 // IsTeamReader implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) IsTeamReader(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
+	desiredUser := keybase1.UserVersion{Uid: uid}
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, uid, keybase1.TeamRole_READER)
+		ctx, tid, UnspecifiedKeyGen, desiredUser, keybase1.TeamRole_READER)
 	if err != nil {
 		return false, err
 	}

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -202,7 +202,7 @@ func (k *KBPKIClient) GetTeamTLFCryptKeys(
 	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
 	map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, desiredKeyGen, keybase1.UID(""))
+		ctx, tid, desiredKeyGen, keybase1.UID(""), keybase1.TeamRole_NONE)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -219,7 +219,7 @@ func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
 func (k *KBPKIClient) IsTeamWriter(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, uid)
+		ctx, tid, UnspecifiedKeyGen, uid, keybase1.TeamRole_WRITER)
 	if err != nil {
 		return false, err
 	}
@@ -230,7 +230,7 @@ func (k *KBPKIClient) IsTeamWriter(
 func (k *KBPKIClient) IsTeamReader(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, uid)
+		ctx, tid, UnspecifiedKeyGen, uid, keybase1.TeamRole_READER)
 	if err != nil {
 		return false, err
 	}

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -202,7 +202,7 @@ func (k *KBPKIClient) GetTeamTLFCryptKeys(
 	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
 	map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, desiredKeyGen)
+		ctx, tid, desiredKeyGen, keybase1.UID(""))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -219,7 +219,7 @@ func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
 func (k *KBPKIClient) IsTeamWriter(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen)
+		ctx, tid, UnspecifiedKeyGen, uid)
 	if err != nil {
 		return false, err
 	}
@@ -230,7 +230,7 @@ func (k *KBPKIClient) IsTeamWriter(
 func (k *KBPKIClient) IsTeamReader(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen)
+		ctx, tid, UnspecifiedKeyGen, uid)
 	if err != nil {
 		return false, err
 	}

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -233,6 +233,19 @@ func (k *KBPKIClient) IsTeamWriter(
 		}
 	}
 	if !found {
+		// For the purposes of finding the eldest seqno, we need to
+		// check the verified key against the list of revoked keys as
+		// well.  (The caller should use `HasVerifyingKey` later to
+		// check whether the revoked key was valid at the time of the
+		// update or not.)
+		for key := range userInfo.RevokedVerifyingKeys {
+			if verifyingKey.KID().Equal(key.KID()) {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
 		// The user doesn't currently have this KID, therefore they
 		// shouldn't be treated as a writer.  The caller should check
 		// historical device records and team membership.

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -199,9 +199,10 @@ func (k *KBPKIClient) GetCryptPublicKeys(ctx context.Context,
 
 // GetTeamTLFCryptKeys implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) GetTeamTLFCryptKeys(
-	ctx context.Context, tid keybase1.TeamID) (
+	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
 	map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
-	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(ctx, tid)
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
+		ctx, tid, desiredKeyGen)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -217,7 +218,8 @@ func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
 // IsTeamWriter implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) IsTeamWriter(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
-	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(ctx, tid)
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
+		ctx, tid, UnspecifiedKeyGen)
 	if err != nil {
 		return false, err
 	}
@@ -227,7 +229,8 @@ func (k *KBPKIClient) IsTeamWriter(
 // IsTeamReader implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) IsTeamReader(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
-	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(ctx, tid)
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
+		ctx, tid, UnspecifiedKeyGen)
 	if err != nil {
 		return false, err
 	}

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -206,7 +206,7 @@ func TestKBPKIClientGetTeamTLFCryptKeys(t *testing.T) {
 
 	for _, team := range localTeams {
 		keys, keyGen, err := c.GetTeamTLFCryptKeys(
-			context.Background(), team.TID)
+			context.Background(), team.TID, UnspecifiedKeyGen)
 		if err != nil {
 			t.Error(err)
 		}

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -125,7 +125,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		if err != nil {
 			return kbfscrypto.TLFCryptKey{}, err
 		}
-		keys, _, err := km.config.KBPKI().GetTeamTLFCryptKeys(ctx, tid)
+		keys, _, err := km.config.KBPKI().GetTeamTLFCryptKeys(ctx, tid, keyGen)
 		if err != nil {
 			return kbfscrypto.TLFCryptKey{}, err
 		}

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -173,8 +173,8 @@ func (kmd emptyKeyMetadata) GetTlfHandle() *TlfHandle {
 }
 
 func (kmd emptyKeyMetadata) IsWriter(
-	ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
-	bool, error) {
+	_ context.Context, _ TeamMembershipChecker, _ keybase1.UID,
+	_ kbfscrypto.VerifyingKey) (bool, error) {
 	return false, nil
 }
 

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -258,7 +258,7 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, _ KeyGen, _ keybase1.UID,
+	ctx context.Context, tid keybase1.TeamID, _ KeyGen, _ keybase1.UserVersion,
 	_ keybase1.TeamRole) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -258,8 +258,8 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, _ KeyGen, _ keybase1.UID) (
-	TeamInfo, error) {
+	ctx context.Context, tid keybase1.TeamID, _ KeyGen, _ keybase1.UID,
+	_ keybase1.TeamRole) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err
 	}

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -258,7 +258,8 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, _ KeyGen) (TeamInfo, error) {
+	ctx context.Context, tid keybase1.TeamID, _ KeyGen, _ keybase1.UID) (
+	TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err
 	}

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -258,7 +258,7 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID) (TeamInfo, error) {
+	ctx context.Context, tid keybase1.TeamID, _ KeyGen) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err
 	}

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -440,7 +440,8 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,
 // LoadTeamPlusKeys implements the KeybaseService interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID) (TeamInfo, error) {
+	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
+	TeamInfo, error) {
 	cachedTeamInfo := k.getCachedTeamInfo(tid)
 	if cachedTeamInfo.Name != libkb.NormalizedUsername("") {
 		return cachedTeamInfo, nil
@@ -450,6 +451,12 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 		Id:          tid,
 		Application: keybase1.TeamApplication_KBFS,
 	}
+
+	if desiredKeyGen >= FirstValidKeyGen {
+		arg.Refreshers.NeedKeyGeneration =
+			keybase1.PerTeamKeyGeneration(desiredKeyGen)
+	}
+
 	res, err := k.teamsClient.LoadTeamPlusApplicationKeys(ctx, arg)
 	if err != nil {
 		return TeamInfo{}, err

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -440,8 +440,8 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,
 // LoadTeamPlusKeys implements the KeybaseService interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
-	TeamInfo, error) {
+	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen,
+	desiredUID keybase1.UID) (TeamInfo, error) {
 	cachedTeamInfo := k.getCachedTeamInfo(tid)
 	if cachedTeamInfo.Name != libkb.NormalizedUsername("") {
 		return cachedTeamInfo, nil
@@ -455,6 +455,11 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	if desiredKeyGen >= FirstValidKeyGen {
 		arg.Refreshers.NeedKeyGeneration =
 			keybase1.PerTeamKeyGeneration(desiredKeyGen)
+	}
+
+	if desiredUID.Exists() {
+		arg.Refreshers.WantMembers = append(arg.Refreshers.WantMembers,
+			keybase1.UserVersion{Uid: desiredUID})
 	}
 
 	res, err := k.teamsClient.LoadTeamPlusApplicationKeys(ctx, arg)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -441,7 +441,7 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen,
-	desiredUID keybase1.UID) (TeamInfo, error) {
+	desiredUID keybase1.UID, desiredRole keybase1.TeamRole) (TeamInfo, error) {
 	cachedTeamInfo := k.getCachedTeamInfo(tid)
 	if cachedTeamInfo.Name != libkb.NormalizedUsername("") {
 		return cachedTeamInfo, nil
@@ -460,6 +460,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	if desiredUID.Exists() {
 		arg.Refreshers.WantMembers = append(arg.Refreshers.WantMembers,
 			keybase1.UserVersion{Uid: desiredUID})
+		arg.Refreshers.WantMembersRole = desiredRole
 	}
 
 	res, err := k.teamsClient.LoadTeamPlusApplicationKeys(ctx, arg)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -441,7 +441,8 @@ func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen,
-	desiredUID keybase1.UID, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+	desiredUser keybase1.UserVersion, desiredRole keybase1.TeamRole) (
+	TeamInfo, error) {
 	cachedTeamInfo := k.getCachedTeamInfo(tid)
 	if cachedTeamInfo.Name != libkb.NormalizedUsername("") {
 		return cachedTeamInfo, nil
@@ -457,9 +458,9 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 			keybase1.PerTeamKeyGeneration(desiredKeyGen)
 	}
 
-	if desiredUID.Exists() {
-		arg.Refreshers.WantMembers = append(arg.Refreshers.WantMembers,
-			keybase1.UserVersion{Uid: desiredUID})
+	if desiredUser.Uid.Exists() {
+		arg.Refreshers.WantMembers = append(
+			arg.Refreshers.WantMembers, desiredUser)
 		arg.Refreshers.WantMembersRole = desiredRole
 	}
 
@@ -544,6 +545,7 @@ func (k *KeybaseServiceBase) processUserPlusKeys(upk keybase1.UserPlusKeys) (
 		VerifyingKeys:          verifyingKeys,
 		CryptPublicKeys:        cryptPublicKeys,
 		KIDNames:               kidNames,
+		EldestSeqno:            upk.EldestSeqno,
 		RevokedVerifyingKeys:   revokedVerifyingKeys,
 		RevokedCryptPublicKeys: revokedCryptPublicKeys,
 	}

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -89,9 +89,9 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
-	tid keybase1.TeamID) (teamInfo TeamInfo, err error) {
+	tid keybase1.TeamID, desiredKeyGen KeyGen) (teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
-		teamInfo, err = k.delegate.LoadTeamPlusKeys(ctx, tid)
+		teamInfo, err = k.delegate.LoadTeamPlusKeys(ctx, tid, desiredKeyGen)
 	})
 	return teamInfo, err
 }

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -89,11 +89,11 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
-	tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID) (
-	teamInfo TeamInfo, err error) {
+	tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID,
+	desiredRole keybase1.TeamRole) (teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(
-			ctx, tid, desiredKeyGen, desiredUID)
+			ctx, tid, desiredKeyGen, desiredUID, desiredRole)
 	})
 	return teamInfo, err
 }

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -89,9 +89,11 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
-	tid keybase1.TeamID, desiredKeyGen KeyGen) (teamInfo TeamInfo, err error) {
+	tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID) (
+	teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
-		teamInfo, err = k.delegate.LoadTeamPlusKeys(ctx, tid, desiredKeyGen)
+		teamInfo, err = k.delegate.LoadTeamPlusKeys(
+			ctx, tid, desiredKeyGen, desiredUID)
 	})
 	return teamInfo, err
 }

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -89,11 +89,11 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
-	tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID,
+	tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUser keybase1.UserVersion,
 	desiredRole keybase1.TeamRole) (teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(
-			ctx, tid, desiredKeyGen, desiredUID, desiredRole)
+			ctx, tid, desiredKeyGen, desiredUser, desiredRole)
 	})
 	return teamInfo, err
 }

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -474,7 +474,8 @@ func (j mdJournal) getMDAndExtra(ctx context.Context, entry mdIDJournalEntry,
 		return nil, nil, time.Time{}, err
 	}
 
-	err = rmd.IsValidAndSigned(ctx, j.codec, j.crypto, j.teamMemChecker, extra)
+	err = rmd.IsValidAndSigned(
+		ctx, j.codec, j.crypto, j.teamMemChecker, extra, j.key)
 	if err != nil {
 		return nil, nil, time.Time{}, err
 	}
@@ -1293,7 +1294,7 @@ func (j *mdJournal) put(
 	// Check permissions and consistency with head, if it exists.
 	if head != (ImmutableBareRootMetadata{}) {
 		ok, err := isWriterOrValidRekey(
-			ctx, j.teamMemChecker, j.codec, j.uid, head.BareRootMetadata,
+			ctx, j.teamMemChecker, j.codec, j.uid, j.key, head.BareRootMetadata,
 			rmd.bareMd, head.extra, rmd.extra)
 		if err != nil {
 			return kbfsmd.ID{}, err
@@ -1340,7 +1341,7 @@ func (j *mdJournal) put(
 	}
 
 	err = rmd.bareMd.IsValidAndSigned(
-		ctx, j.codec, j.crypto, j.teamMemChecker, rmd.extra)
+		ctx, j.codec, j.crypto, j.teamMemChecker, rmd.extra, j.key)
 	if err != nil {
 		return kbfsmd.ID{}, err
 	}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -162,7 +162,7 @@ func checkBRMD(t *testing.T, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	require.Equal(t, expectedPrevRoot, brmd.GetPrevRoot())
 	require.Equal(t, expectedMergeStatus, brmd.MergedStatus())
 	err := brmd.IsValidAndSigned(
-		context.Background(), codec, crypto, nil, extra)
+		context.Background(), codec, crypto, nil, extra, key)
 	require.NoError(t, err)
 	err = brmd.IsLastModifiedBy(uid, key)
 	require.NoError(t, err)

--- a/libkbfs/mdserver_local_shared.go
+++ b/libkbfs/mdserver_local_shared.go
@@ -46,8 +46,8 @@ func isReader(ctx context.Context, teamMemChecker TeamMembershipChecker,
 // true is returned.
 func isWriterOrValidRekey(ctx context.Context,
 	teamMemChecker TeamMembershipChecker, codec kbfscodec.Codec,
-	currentUID keybase1.UID, mergedMasterHead, newMd BareRootMetadata,
-	prevExtra, extra ExtraMetadata) (
+	currentUID keybase1.UID, verifyingKey kbfscrypto.VerifyingKey,
+	mergedMasterHead, newMd BareRootMetadata, prevExtra, extra ExtraMetadata) (
 	bool, error) {
 	h, err := mergedMasterHead.MakeBareTlfHandle(prevExtra)
 	if err != nil {
@@ -56,7 +56,7 @@ func isWriterOrValidRekey(ctx context.Context,
 
 	if h.Type() == tlf.SingleTeam {
 		isWriter, err := teamMemChecker.IsTeamWriter(
-			ctx, h.Writers[0].AsTeamOrBust(), currentUID)
+			ctx, h.Writers[0].AsTeamOrBust(), currentUID, verifyingKey)
 		if err != nil {
 			return false, kbfsmd.ServerError{Err: err}
 		}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -441,7 +441,8 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 		}
 		ok, err := isWriterOrValidRekey(
 			ctx, md.config.teamMembershipChecker(), md.config.Codec(),
-			session.UID, mergedMasterHead.MD, rmds.MD, prevExtra, extra)
+			session.UID, session.VerifyingKey, mergedMasterHead.MD,
+			rmds.MD, prevExtra, extra)
 		if err != nil {
 			return kbfsmd.ServerError{Err: err}
 		}

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -435,7 +435,7 @@ func (s *mdServerTlfStorage) put(ctx context.Context,
 			return false, kbfsmd.ServerError{Err: err}
 		}
 		ok, err := isWriterOrValidRekey(
-			ctx, s.teamMemChecker, s.codec, currentUID,
+			ctx, s.teamMemChecker, s.codec, currentUID, currentVerifyingKey,
 			mergedMasterHead.MD, rmds.MD,
 			prevExtra, extra)
 		if err != nil {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1121,15 +1121,15 @@ func (_mr *_MockKeybaseServiceRecorder) LoadUnverifiedKeys(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadUnverifiedKeys", arg0, arg1)
 }
 
-func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID) (TeamInfo, error) {
-	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid)
+func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (TeamInfo, error) {
+	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1)
+func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1, arg2)
 }
 
 func (_m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error) {
@@ -1466,16 +1466,16 @@ func (_m *MockteamKeysGetter) EXPECT() *_MockteamKeysGetterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
-	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid)
+func (_m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
 	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(KeyGen)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockteamKeysGetterRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
+func (_mr *_MockteamKeysGetterRecorder) GetTeamTLFCryptKeys(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1, arg2)
 }
 
 // Mock of KBPKI interface
@@ -1578,16 +1578,16 @@ func (_mr *_MockKBPKIRecorder) IsTeamReader(arg0, arg1, arg2 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamReader", arg0, arg1, arg2)
 }
 
-func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
-	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid)
+func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+	ret := _m.ctrl.Call(_m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
 	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(KeyGen)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-func (_mr *_MockKBPKIRecorder) GetTeamTLFCryptKeys(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1)
+func (_mr *_MockKBPKIRecorder) GetTeamTLFCryptKeys(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTeamTLFCryptKeys", arg0, arg1, arg2)
 }
 
 func (_m *MockKBPKI) HasVerifyingKey(ctx context.Context, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey, atServerTime time.Time) error {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1121,8 +1121,8 @@ func (_mr *_MockKeybaseServiceRecorder) LoadUnverifiedKeys(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadUnverifiedKeys", arg0, arg1)
 }
 
-func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID, desiredRole keybase1.TeamRole) (TeamInfo, error) {
-	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUID, desiredRole)
+func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUser keybase1.UserVersion, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUser, desiredRole)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1423,15 +1423,15 @@ func (_m *MockTeamMembershipChecker) EXPECT() *_MockTeamMembershipCheckerRecorde
 	return _m.recorder
 }
 
-func (_m *MockTeamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid)
+func (_m *MockTeamMembershipChecker) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockTeamMembershipCheckerRecorder) IsTeamWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2)
+func (_mr *_MockTeamMembershipCheckerRecorder) IsTeamWriter(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockTeamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
@@ -1556,15 +1556,15 @@ func (_mr *_MockKBPKIRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
 }
 
-func (_m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid)
+func (_m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsTeamWriter", ctx, tid, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKBPKIRecorder) IsTeamWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2)
+func (_mr *_MockKBPKIRecorder) IsTeamWriter(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsTeamWriter", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
@@ -1713,15 +1713,15 @@ func (_mr *_MockKeyMetadataRecorder) GetTlfHandle() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTlfHandle")
 }
 
-func (_m *MockKeyMetadata) IsWriter(ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsWriter", ctx, checker, uid)
+func (_m *MockKeyMetadata) IsWriter(ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsWriter", ctx, checker, uid, verifyingKey)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKeyMetadataRecorder) IsWriter(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2)
+func (_mr *_MockKeyMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockKeyMetadata) HasKeyForUser(user keybase1.UID) (bool, error) {
@@ -5689,15 +5689,15 @@ func (_mr *_MockBareRootMetadataRecorder) IsFinal() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFinal")
 }
 
-func (_m *MockBareRootMetadata) IsWriter(ctx context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsWriter", ctx, user, deviceKey, teamMemChecker, extra)
+func (_m *MockBareRootMetadata) IsWriter(ctx context.Context, user keybase1.UID, cryptKey kbfscrypto.CryptPublicKey, verifyingKey kbfscrypto.VerifyingKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsWriter", ctx, user, cryptKey, verifyingKey, teamMemChecker, extra)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockBareRootMetadata) IsReader(ctx context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
@@ -5801,14 +5801,14 @@ func (_mr *_MockBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1, arg2,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockBareRootMetadata) IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "IsValidAndSigned", ctx, codec, crypto, teamMemChecker, extra)
+func (_m *MockBareRootMetadata) IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, teamMemChecker TeamMembershipChecker, extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", ctx, codec, crypto, teamMemChecker, extra, writerVerifyingKey)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockBareRootMetadata) IsLastModifiedBy(uid keybase1.UID, key kbfscrypto.VerifyingKey) error {
@@ -6137,15 +6137,15 @@ func (_mr *_MockMutableBareRootMetadataRecorder) IsFinal() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsFinal")
 }
 
-func (_m *MockMutableBareRootMetadata) IsWriter(ctx context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsWriter", ctx, user, deviceKey, teamMemChecker, extra)
+func (_m *MockMutableBareRootMetadata) IsWriter(ctx context.Context, user keybase1.UID, cryptKey kbfscrypto.CryptPublicKey, verifyingKey kbfscrypto.VerifyingKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsWriter", ctx, user, cryptKey, verifyingKey, teamMemChecker, extra)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockMutableBareRootMetadata) IsReader(ctx context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
@@ -6249,14 +6249,14 @@ func (_mr *_MockMutableBareRootMetadataRecorder) GetTLFCryptKeyParams(arg0, arg1
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTLFCryptKeyParams", arg0, arg1, arg2, arg3)
 }
 
-func (_m *MockMutableBareRootMetadata) IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) error {
-	ret := _m.ctrl.Call(_m, "IsValidAndSigned", ctx, codec, crypto, teamMemChecker, extra)
+func (_m *MockMutableBareRootMetadata) IsValidAndSigned(ctx context.Context, codec kbfscodec.Codec, crypto cryptoPure, teamMemChecker TeamMembershipChecker, extra ExtraMetadata, writerVerifyingKey kbfscrypto.VerifyingKey) error {
+	ret := _m.ctrl.Call(_m, "IsValidAndSigned", ctx, codec, crypto, teamMemChecker, extra, writerVerifyingKey)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockMutableBareRootMetadataRecorder) IsValidAndSigned(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsValidAndSigned", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 func (_m *MockMutableBareRootMetadata) IsLastModifiedBy(uid keybase1.UID, key kbfscrypto.VerifyingKey) error {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1121,15 +1121,15 @@ func (_mr *_MockKeybaseServiceRecorder) LoadUnverifiedKeys(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadUnverifiedKeys", arg0, arg1)
 }
 
-func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID) (TeamInfo, error) {
-	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUID)
+func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUID, desiredRole)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1, arg2, arg3)
+func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1, arg2, arg3, arg4)
 }
 
 func (_m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1121,15 +1121,15 @@ func (_mr *_MockKeybaseServiceRecorder) LoadUnverifiedKeys(arg0, arg1 interface{
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadUnverifiedKeys", arg0, arg1)
 }
 
-func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (TeamInfo, error) {
-	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen)
+func (_m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUID keybase1.UID) (TeamInfo, error) {
+	ret := _m.ctrl.Call(_m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUID)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1, arg2)
+func (_mr *_MockKeybaseServiceRecorder) LoadTeamPlusKeys(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "LoadTeamPlusKeys", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockKeybaseService) CurrentSession(ctx context.Context, sessionID int) (SessionInfo, error) {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -871,8 +871,8 @@ func (md *RootMetadata) GetHistoricTLFCryptKey(
 // IsWriter checks that the given user is a valid writer of the TLF
 // right now.  Implements the KeyMetadata interface for RootMetadata.
 func (md *RootMetadata) IsWriter(
-	ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID) (
-	bool, error) {
+	ctx context.Context, checker TeamMembershipChecker, uid keybase1.UID,
+	verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
 	h := md.GetTlfHandle()
 	if h.Type() != tlf.SingleTeam {
 		return h.IsWriter(uid), nil
@@ -885,7 +885,7 @@ func (md *RootMetadata) IsWriter(
 	if err != nil {
 		return false, err
 	}
-	return checker.IsTeamWriter(ctx, tid, uid)
+	return checker.IsTeamWriter(ctx, tid, uid, verifyingKey)
 }
 
 // IsReader checks that the given user is a valid reader of the TLF
@@ -1174,7 +1174,9 @@ func (rmds *RootMetadataSigned) IsValidAndSigned(
 		return errors.New("Missing WriterMetadata signature")
 	}
 
-	err := rmds.MD.IsValidAndSigned(ctx, codec, crypto, teamMemChecker, extra)
+	err := rmds.MD.IsValidAndSigned(
+		ctx, codec, crypto, teamMemChecker, extra,
+		rmds.WriterSigInfo.VerifyingKey)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -279,7 +279,8 @@ func (md *RootMetadata) MakeSuccessor(
 			if err != nil {
 				return nil, err
 			}
-			_, keyGen, err := teamKeyer.GetTeamTLFCryptKeys(ctx, tid)
+			_, keyGen, err := teamKeyer.GetTeamTLFCryptKeys(
+				ctx, tid, UnspecifiedKeyGen)
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -471,7 +471,8 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 		return errors.New("Bad keybase daemon")
 	}
 
-	ti, err := kbd.LoadTeamPlusKeys(context.Background(), tid)
+	ti, err := kbd.LoadTeamPlusKeys(
+		context.Background(), tid, UnspecifiedKeyGen)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -472,7 +472,7 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	}
 
 	ti, err := kbd.LoadTeamPlusKeys(
-		context.Background(), tid, UnspecifiedKeyGen)
+		context.Background(), tid, UnspecifiedKeyGen, keybase1.UID(""))
 	if err != nil {
 		return err
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -472,7 +472,8 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	}
 
 	ti, err := kbd.LoadTeamPlusKeys(
-		context.Background(), tid, UnspecifiedKeyGen, keybase1.UID(""))
+		context.Background(), tid, UnspecifiedKeyGen, keybase1.UID(""),
+		keybase1.TeamRole_NONE)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -472,7 +472,7 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	}
 
 	ti, err := kbd.LoadTeamPlusKeys(
-		context.Background(), tid, UnspecifiedKeyGen, keybase1.UID(""),
+		context.Background(), tid, UnspecifiedKeyGen, keybase1.UserVersion{},
 		keybase1.TeamRole_NONE)
 	if err != nil {
 		return err

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -1597,11 +1597,15 @@ func (s SigChainLocation) LessThanOrEqualTo(s2 SigChainLocation) bool {
 }
 
 func (r TeamRole) IsAdminOrAbove() bool {
-	return r == TeamRole_ADMIN || r == TeamRole_OWNER
+	return r.IsOrAbove(TeamRole_ADMIN)
 }
 
 func (r TeamRole) IsReaderOrAbove() bool {
-	return r == TeamRole_ADMIN || r == TeamRole_OWNER || r == TeamRole_READER || r == TeamRole_WRITER
+	return r.IsOrAbove(TeamRole_READER)
+}
+
+func (r TeamRole) IsOrAbove(min TeamRole) bool {
+	return int(r) >= int(min)
 }
 
 type idDesc struct {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -397,6 +397,7 @@ func (o TeamPlusApplicationKeys) DeepCopy() TeamPlusApplicationKeys {
 }
 
 type TeamData struct {
+	Secretless      bool                                                 `codec:"secretless" json:"secretless"`
 	Chain           TeamSigChainState                                    `codec:"chain" json:"chain"`
 	PerTeamKeySeeds map[PerTeamKeyGeneration]PerTeamKeySeedItem          `codec:"perTeamKeySeeds" json:"perTeamKeySeeds"`
 	ReaderKeyMasks  map[TeamApplication]map[PerTeamKeyGeneration]MaskB64 `codec:"readerKeyMasks" json:"readerKeyMasks"`
@@ -405,7 +406,8 @@ type TeamData struct {
 
 func (o TeamData) DeepCopy() TeamData {
 	return TeamData{
-		Chain: o.Chain.DeepCopy(),
+		Secretless: o.Secretless,
+		Chain:      o.Chain.DeepCopy(),
 		PerTeamKeySeeds: (func(x map[PerTeamKeyGeneration]PerTeamKeySeedItem) map[PerTeamKeyGeneration]PerTeamKeySeedItem {
 			ret := make(map[PerTeamKeyGeneration]PerTeamKeySeedItem)
 			for k, v := range x {
@@ -860,6 +862,28 @@ func (o TeamList) DeepCopy() TeamList {
 	}
 }
 
+type TeamAddMemberResult struct {
+	Invited   bool  `codec:"invited" json:"invited"`
+	User      *User `codec:"user,omitempty" json:"user,omitempty"`
+	EmailSent bool  `codec:"emailSent" json:"emailSent"`
+	ChatSent  bool  `codec:"chatSent" json:"chatSent"`
+}
+
+func (o TeamAddMemberResult) DeepCopy() TeamAddMemberResult {
+	return TeamAddMemberResult{
+		Invited: o.Invited,
+		User: (func(x *User) *User {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.User),
+		EmailSent: o.EmailSent,
+		ChatSent:  o.ChatSent,
+	}
+}
+
 type TeamCreateArg struct {
 	SessionID int    `codec:"sessionID" json:"sessionID"`
 	Name      string `codec:"name" json:"name"`
@@ -915,6 +939,7 @@ func (o TeamChangeMembershipArg) DeepCopy() TeamChangeMembershipArg {
 type TeamAddMemberArg struct {
 	SessionID            int      `codec:"sessionID" json:"sessionID"`
 	Name                 string   `codec:"name" json:"name"`
+	Email                string   `codec:"email" json:"email"`
 	Username             string   `codec:"username" json:"username"`
 	Role                 TeamRole `codec:"role" json:"role"`
 	SendChatNotification bool     `codec:"sendChatNotification" json:"sendChatNotification"`
@@ -924,6 +949,7 @@ func (o TeamAddMemberArg) DeepCopy() TeamAddMemberArg {
 	return TeamAddMemberArg{
 		SessionID:            o.SessionID,
 		Name:                 o.Name,
+		Email:                o.Email,
 		Username:             o.Username,
 		Role:                 o.Role.DeepCopy(),
 		SendChatNotification: o.SendChatNotification,
@@ -995,7 +1021,7 @@ type TeamsInterface interface {
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamList(context.Context, TeamListArg) (TeamList, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
-	TeamAddMember(context.Context, TeamAddMemberArg) error
+	TeamAddMember(context.Context, TeamAddMemberArg) (TeamAddMemberResult, error)
 	TeamRemoveMember(context.Context, TeamRemoveMemberArg) error
 	TeamLeave(context.Context, TeamLeaveArg) error
 	TeamEditMember(context.Context, TeamEditMemberArg) error
@@ -1084,7 +1110,7 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]TeamAddMemberArg)(nil), args)
 						return
 					}
-					err = i.TeamAddMember(ctx, (*typedArgs)[0])
+					ret, err = i.TeamAddMember(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1181,8 +1207,8 @@ func (c TeamsClient) TeamChangeMembership(ctx context.Context, __arg TeamChangeM
 	return
 }
 
-func (c TeamsClient) TeamAddMember(ctx context.Context, __arg TeamAddMemberArg) (err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMember", []interface{}{__arg}, nil)
+func (c TeamsClient) TeamAddMember(ctx context.Context, __arg TeamAddMemberArg) (res TeamAddMemberResult, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.teams.teamAddMember", []interface{}{__arg}, &res)
 	return
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -767,6 +767,7 @@ func (o TeamChangeRow) DeepCopy() TeamChangeRow {
 type TeamRefreshers struct {
 	NeedKeyGeneration PerTeamKeyGeneration `codec:"needKeyGeneration" json:"needKeyGeneration"`
 	WantMembers       []UserVersion        `codec:"wantMembers" json:"wantMembers"`
+	WantMembersRole   TeamRole             `codec:"wantMembersRole" json:"wantMembersRole"`
 }
 
 func (o TeamRefreshers) DeepCopy() TeamRefreshers {
@@ -780,6 +781,7 @@ func (o TeamRefreshers) DeepCopy() TeamRefreshers {
 			}
 			return ret
 		})(o.WantMembers),
+		WantMembersRole: o.WantMembersRole.DeepCopy(),
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -189,10 +189,10 @@
 			"revisionTime": "2017-05-26T23:09:42Z"
 		},
 		{
-			"checksumSHA1": "AStdIdgL3/AkVXVNbdAi1J7kLu8=",
+			"checksumSHA1": "VLCyqVzUI2sShdymTueA2SH7iQE=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "c4503730272ea78381285c84e0c59353ccd6bb7e",
-			"revisionTime": "2017-07-11T21:36:17Z"
+			"revision": "d2a2ea1f6deb589f07f8e5748686fcbdf18a69cd",
+			"revisionTime": "2017-07-12T19:09:33Z"
 		},
 		{
 			"checksumSHA1": "5jCtx/ogKTP/L08r9Vt2Z0e36i4=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -189,10 +189,10 @@
 			"revisionTime": "2017-05-26T23:09:42Z"
 		},
 		{
-			"checksumSHA1": "CRTQZesb/lB0rUOTxqV0tvSvA1g=",
+			"checksumSHA1": "AStdIdgL3/AkVXVNbdAi1J7kLu8=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "04772004bb6dbdcf4e84b22f70aca2e67f3e4bd4",
-			"revisionTime": "2017-07-07T19:29:57Z"
+			"revision": "c4503730272ea78381285c84e0c59353ccd6bb7e",
+			"revisionTime": "2017-07-11T21:36:17Z"
 		},
 		{
 			"checksumSHA1": "5jCtx/ogKTP/L08r9Vt2Z0e36i4=",


### PR DESCRIPTION
Both KBFS and the service have team caches.  Cached info is generally invalidated by lazy messages sent via the server, but these may not arrive in time or at all in some scenarios.  In those cases, the client can specify exactly what information it is trying to validate, and if that info doesn't match what's in the cache, it can force the service to check with the server to get the most up-to-date information.

In particular:
* When trying to decrypt a team TLF MD encryted with a particular keygen, we need to check whether that's a known keygen yet.
* When trying to verify that a user + verifying key is a valid writer for a team TLF, we need to verify both that the verifying key is currently valid for the user, _and_ that the version of the user that contains that verifying key is a member of the team (using the "eldest seqno" currently associated with the user).  This means we have to plumb the verifying key into the `IsTeamWriter` call, which is kind of annoying, but it'll make future Merkle checks a bit easier I think.
* When trying to verify that the current signed-in user is a valid reader for a team TLF, we need to verify that the current version of the user is currently a reader for the team.  In this case, we don't need to know the eldest seqno, we can just set it to 0 and let the service use the current cached eldest seqno for that user.
* We also need to cache-bust based on the expected role of the user, in case the user role gets changed.

Issue: KBFS-2308