### PR TITLE
libkbfs: fix two quota issues on startup and first block put

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -904,7 +904,8 @@ func (cache *DiskBlockCacheStandard) evictLocked(ctx context.Context,
 }
 
 // Status implements the DiskBlockCache interface for DiskBlockCacheStandard.
-func (cache *DiskBlockCacheStandard) Status() *DiskBlockCacheStatus {
+func (cache *DiskBlockCacheStandard) Status(
+	ctx context.Context) *DiskBlockCacheStatus {
 	select {
 	case <-cache.startedCh:
 	default:
@@ -916,7 +917,7 @@ func (cache *DiskBlockCacheStandard) Status() *DiskBlockCacheStatus {
 	// we don't have easy access to the UID here, so pass in a dummy.
 	limiterStatus :=
 		cache.config.DiskLimiter().getStatus(
-			keybase1.UserOrTeamID("")).(backpressureDiskLimiterStatus)
+			ctx, keybase1.UserOrTeamID("")).(backpressureDiskLimiterStatus)
 	return &DiskBlockCacheStatus{
 		NumBlocks:       uint64(cache.numBlocks),
 		BlockBytes:      cache.currBytes,

--- a/libkbfs/disk_limiter.go
+++ b/libkbfs/disk_limiter.go
@@ -120,5 +120,5 @@ type DiskLimiter interface {
 
 	// getStatus returns an object that's marshallable into JSON
 	// for use in displaying status.
-	getStatus(chargedTo keybase1.UserOrTeamID) interface{}
+	getStatus(ctx context.Context, chargedTo keybase1.UserOrTeamID) interface{}
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -924,7 +924,7 @@ type DiskBlockCache interface {
 	// Size returns the size in bytes of the disk cache.
 	Size() int64
 	// Status returns the current status of the disk cache.
-	Status() *DiskBlockCacheStatus
+	Status(ctx context.Context) *DiskBlockCacheStatus
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -757,7 +757,7 @@ func (j *JournalServer) Status(
 		StoredFiles:         totalStoredFiles,
 		UnflushedBytes:      totalUnflushedBytes,
 		DiskLimiterStatus: j.config.DiskLimiter().getStatus(
-			j.currentUID.AsUserOrTeam()),
+			ctx, j.currentUID.AsUserOrTeam()),
 	}, tlfIDs
 }
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -697,7 +697,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	dbc := fs.config.DiskBlockCache()
 	var dbcStatus *DiskBlockCacheStatus
 	if dbc != nil {
-		dbcStatus = dbc.Status()
+		dbcStatus = dbc.Status(ctx)
 	}
 
 	return KBFSStatus{

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2528,14 +2528,14 @@ func (_mr *_MockDiskBlockCacheRecorder) Size() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Size")
 }
 
-func (_m *MockDiskBlockCache) Status() *DiskBlockCacheStatus {
-	ret := _m.ctrl.Call(_m, "Status")
+func (_m *MockDiskBlockCache) Status(ctx context.Context) *DiskBlockCacheStatus {
+	ret := _m.ctrl.Call(_m, "Status", ctx)
 	ret0, _ := ret[0].(*DiskBlockCacheStatus)
 	return ret0
 }
 
-func (_mr *_MockDiskBlockCacheRecorder) Status() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status")
+func (_mr *_MockDiskBlockCacheRecorder) Status(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Status", arg0)
 }
 
 func (_m *MockDiskBlockCache) Shutdown(ctx context.Context) {

--- a/libkbfs/quota_usage.go
+++ b/libkbfs/quota_usage.go
@@ -118,7 +118,7 @@ func (q *EventuallyConsistentQuotaUsage) Get(
 	}()
 	past := q.config.Clock().Now().Sub(c.timestamp)
 	switch {
-	case past > blockTolerance:
+	case past > blockTolerance || c.timestamp.IsZero():
 		q.log.CDebugf(ctx, "Blocking on getAndCache. Cached data is %s old.", past)
 		// TODO: optimize this to make sure there's only one outstanding RPC. In
 		// other words, wait for it to finish if one is already in progress.

--- a/libkbfs/semaphore_disk_limiter.go
+++ b/libkbfs/semaphore_disk_limiter.go
@@ -229,7 +229,8 @@ type semaphoreDiskLimiterStatus struct {
 	QuotaUsed  int64
 }
 
-func (sdl semaphoreDiskLimiter) getStatus(_ keybase1.UserOrTeamID) interface{} {
+func (sdl semaphoreDiskLimiter) getStatus(
+	_ context.Context, _ keybase1.UserOrTeamID) interface{} {
 	byteFree := sdl.byteSemaphore.Count()
 	fileFree := sdl.fileSemaphore.Count()
 	usedQuotaBytes, quotaBytes := sdl.quotaTracker.getQuotaInfo()


### PR DESCRIPTION
This fixes two quota issues noticed by @jzila:
1. The very first call to `EventuallyConsistentQuotaUsage.Get()` wasn't blocking when `blockTolerance` is very high.
2. If `.kbfs_status` was checked before any writes, the quota status wouldn't be filled in.

Issue: KBFS-2314