### PR TITLE
data_types: add `EntryInfo.TeamWriter` field

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -628,6 +628,9 @@ type EntryInfo struct {
 	Mtime int64
 	// Ctime is in unix nanoseconds
 	Ctime int64
+	// If this is a team TLF, we want to track the last writer of an
+	// entry, since in the block, only the team ID will be tracked.
+	TeamWriter keybase1.UID `codec:"tw,omitempty"`
 }
 
 // ReportedError represents an error reported by KBFS.

--- a/libkbfs/dir_entry_test.go
+++ b/libkbfs/dir_entry_test.go
@@ -33,6 +33,7 @@ func makeFakeDirEntry(t *testing.T, typ EntryType, size uint64) DirEntry {
 			"fake sym path",
 			101,
 			102,
+			"",
 		},
 		codec.UnknownFieldSetHandler{},
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1948,8 +1948,12 @@ func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 		return res, err
 	}
 	res.BlockInfo = de.BlockInfo
-	id := de.Writer
-	if id == keybase1.UserOrTeamID("") {
+
+	id := de.TeamWriter.AsUserOrTeam()
+	if id.IsNil() {
+		id = de.Writer
+	}
+	if id.IsNil() {
 		id = de.Creator
 	}
 	res.LastWriterUnverified, err =

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -192,6 +192,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 	var newDe DirEntry
 	doSetTime := true
 	now := fup.nowUnixNano()
+	var uid keybase1.UID
 	for len(newPath.path) < len(dir.path)+1 {
 		info, plainSize, err := fup.readyBlockMultiple(
 			ctx, md.ReadOnly(), currBlock, chargedTo, bps, keybase1.BlockType_DATA)
@@ -300,6 +301,18 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 				de.Ctime = now
 			}
 		}
+
+		if fup.id().Type() == tlf.SingleTeam {
+			if uid.IsNil() {
+				session, err := fup.config.KBPKI().GetCurrentSession(ctx)
+				if err != nil {
+					return path{}, DirEntry{}, nil, err
+				}
+				uid = session.UID
+			}
+			de.TeamWriter = uid
+		}
+
 		if !newDe.IsInitialized() {
 			newDe = de
 		}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3516,4 +3516,9 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	require.True(t, bytes.Equal(data, gotData3))
 	_, _, err = kbfsOps3.CreateFile(ctx, rootNode3, "c", false, NoExcl)
 	require.IsType(t, WriteAccessError{}, errors.Cause(err))
+
+	// Verify that "a" has the correct writer.
+	ei, err := kbfsOps3.GetNodeMetadata(ctx, nodeA3)
+	require.NoError(t, err)
+	require.Equal(t, u1, ei.LastWriterUnverified)
 }

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -28,6 +28,7 @@ func makeRandomDirEntry(t *testing.T, typ EntryType, size uint64, path string) D
 			path,
 			101,
 			102,
+			"",
 		},
 		codec.UnknownFieldSetHandler{},
 	}


### PR DESCRIPTION
To help track which user wrote which file in a team TLF.

Noticed by @jzila.