### PR TITLE
keybase_service_base: call `serviceLoggedIn` on new session

### DIFF
--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -455,7 +455,7 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.Equal(t, ImmutableRootMetadata{}, head)
 
 	serviceLoggedIn(
-		ctx, config, "test_user1", TLFJournalBackgroundWorkPaused)
+		ctx, config, session, TLFJournalBackgroundWorkPaused)
 
 	// Get the block.
 
@@ -555,13 +555,12 @@ func TestJournalServerMultiUser(t *testing.T) {
 	service.setCurrentUID(id2.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
+	session, err = config.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
 	serviceLoggedIn(
-		ctx, config, "test_user2", TLFJournalBackgroundWorkPaused)
+		ctx, config, session, TLFJournalBackgroundWorkPaused)
 
 	err = jServer.Enable(ctx, tlfID, nil, TLFJournalBackgroundWorkPaused)
-	require.NoError(t, err)
-
-	session, err = config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
 
 	// None of user 1's changes should be visible.
@@ -617,8 +616,10 @@ func TestJournalServerMultiUser(t *testing.T) {
 	service.setCurrentUID(id1.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
+	session, err = config.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
 	serviceLoggedIn(
-		ctx, config, "test_user1", TLFJournalBackgroundWorkPaused)
+		ctx, config, session, TLFJournalBackgroundWorkPaused)
 
 	// Only user 1's block and MD should be visible.
 
@@ -641,8 +642,10 @@ func TestJournalServerMultiUser(t *testing.T) {
 	service.setCurrentUID(id2.AsUserOrBust())
 	SwitchDeviceForLocalUserOrBust(t, config, 0)
 
+	session, err = config.KBPKI().GetCurrentSession(ctx)
+	require.NoError(t, err)
 	serviceLoggedIn(
-		ctx, config, "test_user2", TLFJournalBackgroundWorkPaused)
+		ctx, config, session, TLFJournalBackgroundWorkPaused)
 
 	// Only user 2's block and MD should be visible.
 

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -623,7 +623,8 @@ func (k *KeybaseServiceBase) LoadUnverifiedKeys(ctx context.Context, uid keybase
 	return keys, nil
 }
 
-func (k *KeybaseServiceBase) getCurrentSession(ctx context.Context, sessionID int) (SessionInfo, bool, error) {
+func (k *KeybaseServiceBase) getCurrentSession(
+	ctx context.Context, sessionID int) (SessionInfo, bool, error) {
 	// Hold the lock the entire function, to prevent multiple
 	// goroutines from trying to fetch the session at once.
 	k.sessionCacheLock.Lock()

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -54,18 +54,9 @@ func EnableAdminFeature(ctx context.Context, config Config) bool {
 
 // serviceLoggedIn should be called when a new user logs in. It
 // shouldn't be called again until after serviceLoggedOut is called.
-func serviceLoggedIn(ctx context.Context, config Config, name string,
+func serviceLoggedIn(ctx context.Context, config Config, session SessionInfo,
 	bws TLFJournalBackgroundWorkStatus) {
 	log := config.MakeLogger("")
-	const sessionID = 0
-	session, err := config.KeybaseService().CurrentSession(ctx, sessionID)
-	if err != nil {
-		log.CDebugf(ctx, "Getting current session failed when %s is logged in, so pretending user has logged out: %v",
-			name, err)
-		serviceLoggedOut(ctx, config)
-		return
-	}
-
 	if jServer, err := GetJournalServer(config); err == nil {
 		err := jServer.EnableExistingJournals(
 			ctx, session.UID, session.VerifyingKey, bws)


### PR DESCRIPTION
In at least two user reports, the client has gotten into a state where
journaling is not enabled, because the journal thinks it doesn't have
a current UID even though the user is logged in. This happens when
the KBFS init code can't connect to the service to check the current
session (e.g., because the service is still restarting or down/slow
for some reason). Later when KBFS does connect to the service, there
is no "logged in" notification (because the user was already logged
in), and so journal-enabling is never reenabled.

This PR executes the logged-in code whenever a new session is noticed,
not just when a new "logged in" notification comes in.

Issue: KBFS-2315