### PR TITLE
journal_md_ops: be careful with caching in `GetForHandle`

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -733,7 +733,11 @@ type MDCache interface {
 	// Get gets the metadata object associated with the given TLF ID,
 	// revision number, and branch ID (NullBranchID for merged MD).
 	Get(tlf tlf.ID, rev kbfsmd.Revision, bid BranchID) (ImmutableRootMetadata, error)
-	// Put stores the metadata object.
+	// Put stores the metadata object, only if an MD matching that TLF
+	// ID, revision number, and branch ID isn't already cached.  If
+	// there is already a matching item in the cache, we require that
+	// caller manages the cache explicitly by deleting or replacing it
+	// explicitly.
 	Put(md ImmutableRootMetadata) error
 	// Delete removes the given metadata object from the cache if it exists.
 	Delete(tlf tlf.ID, rev kbfsmd.Revision, bid BranchID)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -737,13 +737,16 @@ type MDCache interface {
 	// ID, revision number, and branch ID isn't already cached.  If
 	// there is already a matching item in the cache, we require that
 	// caller manages the cache explicitly by deleting or replacing it
-	// explicitly.
+	// explicitly.  This should be used when putting existing MDs
+	// being fetched from the server.
 	Put(md ImmutableRootMetadata) error
 	// Delete removes the given metadata object from the cache if it exists.
 	Delete(tlf tlf.ID, rev kbfsmd.Revision, bid BranchID)
 	// Replace replaces the entry matching the md under the old branch
 	// ID with the new one.  If the old entry doesn't exist, this is
-	// equivalent to a Put.
+	// equivalent to a Put, except that it overrides anything else
+	// that's already in the cache.  This should be used when putting
+	// new MDs created locally.
 	Replace(newRmd ImmutableRootMetadata, oldBID BranchID) error
 }
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -272,7 +272,9 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	*rmds = RootMetadataSigned{}
 	irmd := MakeImmutableRootMetadata(rmd, key, mdID, localTimestamp)
 
-	err = md.config.MDCache().Put(irmd)
+	// Revisions created locally should always override anything else
+	// in the cache.
+	err = md.config.MDCache().Replace(irmd, irmd.BID())
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -596,7 +598,9 @@ func (md *MDOpsStandard) put(
 
 	irmd := MakeImmutableRootMetadata(
 		rmd, verifyingKey, mdID, md.config.Clock().Now())
-	err = md.config.MDCache().Put(irmd)
+	// Revisions created locally should always override anything else
+	// in the cache.
+	err = md.config.MDCache().Replace(irmd, irmd.BID())
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -282,17 +282,19 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 // GetForHandle implements the MDOps interface for MDOpsStandard.
 func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 	mStatus MergeStatus) (id tlf.ID, rmd ImmutableRootMetadata, err error) {
-	md.log.CDebugf(ctx, "GetForHandle: %s", handle.GetCanonicalPath())
+	md.log.CDebugf(
+		ctx, "GetForHandle: %s %s", handle.GetCanonicalPath(), mStatus)
 	defer func() {
 		// Temporary debugging for KBFS-1921.  TODO: remove.
 		if err != nil {
 			md.log.CDebugf(ctx, "GetForHandle done with err=%+v", err)
 		} else if rmd != (ImmutableRootMetadata{}) {
-			md.log.CDebugf(ctx, "GetForHandle done, id=%s, revision=%d",
-				id, rmd.Revision())
+			md.log.CDebugf(ctx, "GetForHandle done, id=%s, revision=%d, "+
+				"mStatus=%s", id, rmd.Revision(), rmd.MergedStatus())
 		} else {
 			md.log.CDebugf(
-				ctx, "GetForHandle done, id=%s, no MD revisions yet", id)
+				ctx, "GetForHandle done, id=%s, no %s MD revisions yet", id,
+				mStatus)
 		}
 	}()
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -129,7 +129,7 @@ func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).AnyTimes().Return(hasVerifyingKeyErr)
 	if hasVerifyingKeyErr == nil {
-		config.mockMdcache.EXPECT().Put(gomock.Any())
+		config.mockMdcache.EXPECT().Replace(gomock.Any(), gomock.Any())
 	}
 }
 
@@ -195,7 +195,7 @@ func verifyMDForPrivateHelper(
 		config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	}
-	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes()
+	config.mockMdcache.EXPECT().Replace(gomock.Any(), gomock.Any()).AnyTimes()
 }
 
 func verifyMDForPrivate(
@@ -211,7 +211,7 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
 		Return(true)
 	config.mockMdserv.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	config.mockMdcache.EXPECT().Put(gomock.Any())
+	config.mockMdcache.EXPECT().Replace(gomock.Any(), gomock.Any())
 }
 
 func testMDOpsGetForHandlePublicSuccess(t *testing.T, ver MetadataVer) {

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -15,8 +15,8 @@ import (
 // MDCacheStandard implements a simple LRU cache for per-folder
 // metadata objects.
 type MDCacheStandard struct {
-	// lock protects `lru` from atomic operations that need to
-	// atomicity across multiple `lru` calls.
+	// lock protects `lru` from atomic operations that need atomicity
+	// across multiple `lru` calls.
 	lock sync.RWMutex
 	lru  *lru.Cache
 }

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -49,9 +49,14 @@ func (md *MDCacheStandard) Get(tlf tlf.ID, rev kbfsmd.Revision, bid BranchID) (
 
 // Put implements the MDCache interface for MDCacheStandard.
 func (md *MDCacheStandard) Put(rmd ImmutableRootMetadata) error {
-	// TODO: is it worth the extra lookup here to make sure if there's
-	// one already in the cache that it has the same MdID?
 	key := mdCacheKey{rmd.TlfID(), rmd.Revision(), rmd.BID()}
+	if _, ok := md.lru.Get(key); ok {
+		// Don't overwrite the cache.  In the case that `rmd` is
+		// different from what's in the cache, we require that upper
+		// layers manage the cache explicitly by deleting or replacing
+		// it explicitly.
+		return nil
+	}
 	md.lru.Add(key, rmd)
 	return nil
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -2044,7 +2044,9 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	// chance to cache it.
 	irmd = MakeImmutableRootMetadata(
 		rmd, verifyingKey, mdID, j.config.Clock().Now())
-	err = j.config.MDCache().Put(irmd)
+	// Revisions created locally should always override anything else
+	// in the cache, so use `Replace` rather than `Put`.
+	err = j.config.MDCache().Replace(irmd, irmd.BID())
 	if err != nil {
 		return ImmutableRootMetadata{}, false, err
 	}
@@ -2193,10 +2195,12 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	// Put the MD into the cache under the same lock as it is put in
 	// the journal, to guarantee it will be replaced if the journal is
 	// converted into a branch before any of the upper layer have a
-	// chance to cache it.
+	// chance to cache it. Revisions created locally should always
+	// override anything else in the cache, so use `Replace` rather
+	// than `Put`.
 	irmd = MakeImmutableRootMetadata(
 		rmd, verifyingKey, mdID, j.config.Clock().Now())
-	err = j.config.MDCache().Put(irmd)
+	err = j.config.MDCache().Replace(irmd, irmd.BID())
 	if err != nil {
 		return ImmutableRootMetadata{}, false, err
 	}


### PR DESCRIPTION
We hit a test flake where the journal contained an unmerged MD update that conflicted with the server's MD update (but the conflict wasn't yet known).  Then the test infrastructure called `kbfsOps.getMaybeCreateRootNode`, which called `JournalMDOps.GetForHandle()`, which fetched the server's version for that revision and overwrote the value we had already cached.  Then CR ran and based the new branch on the server's MD by reading it out of the cache, even though it should have been based on the local version, and there was a failure.

This PR deals the problem in two different ways.

1. `JournalMDOps.GetForHandle` shouldn't cause the server's MD to be cached when it's just trying to look up the TLF ID.
2. We shouldn't overwrite existing items in the cache that were created locally; upper layers should explicitly delete/replace things when managing MDs.  Instead, local MDs should be put into the cache using `Replace`, while fetched MDs should use `Put`, which does no overwriting.

Issue: KBFS-2310