### PR TITLE
govendor update rpc and add resinit

### DIFF
--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit.go
@@ -1,0 +1,20 @@
+package resinit
+
+import "net"
+
+// If we get a DNS error, it could be because glibc has cached an old version
+// of /etc/resolv.conf. The res_init() libc function busts that cache and keeps
+// us from getting stuck in a state where DNS requests keep failing even though
+// the network is up. This is similar to what the Rust standard library does:
+// https://github.com/rust-lang/rust/blob/028569ab1b/src/libstd/sys_common/net.rs#L186-L190
+func ResInitIfDNSError(err error) {
+	// There are two error cases we need to handle, a raw *net.DNSError, and
+	// one wrapped in a *net.OpError. Detect that second case, and unwrap it.
+	if opErr, isOpErr := err.(*net.OpError); isOpErr {
+		err = opErr.Err
+	}
+	if _, isDNSError := err.(*net.DNSError); isDNSError {
+		// defined per platform in resinit_*.go
+		resInit()
+	}
+}

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit_android.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit_android.go
@@ -1,0 +1,15 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build android
+
+package resinit
+
+// /* Bionic has res_init() but it's not in any header. Patterned off of: */
+// /* https://mail.gnome.org/archives/commits-list/2013-May/msg01329.html */
+// int res_init (void);
+import "C"
+
+func resInit() {
+	C.res_init()
+}

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit_nix.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit_nix.go
@@ -1,0 +1,14 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build !windows,!android
+
+package resinit
+
+// #cgo LDFLAGS: -lresolv
+// #include<resolv.h>
+import "C"
+
+func resInit() {
+	C.res_init()
+}

--- a/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit_windows.go
+++ b/vendor/github.com/keybase/go-framed-msgpack-rpc/rpc/resinit/resinit_windows.go
@@ -1,0 +1,10 @@
+// Copyright 2015 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build windows
+
+package resinit
+
+func resInit() {
+	// no-op
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -305,10 +305,16 @@
 			"revisionTime": "2016-12-08T01:54:25Z"
 		},
 		{
-			"checksumSHA1": "EByEHRqLqn43oRFBg+pr542YooU=",
+			"checksumSHA1": "gjj20DcVyDDJz+DaYpCuu4usgA8=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "6c50f8c9981723baf4eea80f5de8f5b33493a126",
-			"revisionTime": "2017-06-08T21:54:08Z"
+			"revision": "9a3cbac42f5013d0a5d9ebb67ee5a2122b02e925",
+			"revisionTime": "2017-07-18T14:09:20Z"
+		},
+		{
+			"checksumSHA1": "pi51SBDmToLthgwMA+5+wjyQans=",
+			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc/resinit",
+			"revision": "9a3cbac42f5013d0a5d9ebb67ee5a2122b02e925",
+			"revisionTime": "2017-07-18T14:09:20Z"
 		},
 		{
 			"checksumSHA1": "vecRkvbIBGmLUxH37v899JcgjO4=",


### PR DESCRIPTION
This pulls in the changes that call `libc::res_init` on DNS failure, to avoid getting stuck in the `host not found` loop.

r? @strib 