### PR TITLE
libkbfs: store the full Merkle root in the MD update

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -962,11 +962,11 @@ func (md *BareRootMetadataV2) RevisionNumber() kbfsmd.Revision {
 	return md.Revision
 }
 
-// MerkleSeqNo implements the BareRootMetadata interface for
+// MerkleRoot implements the BareRootMetadata interface for
 // BareRootMetadataV2.
-func (md *BareRootMetadataV2) MerkleSeqNo() MerkleSeqNo {
+func (md *BareRootMetadataV2) MerkleRoot() keybase1.MerkleRootV2 {
 	// No v2 MDs will have had this field set.
-	return UnknownMerkleSeqNo
+	return keybase1.MerkleRootV2{}
 }
 
 // BID implements the BareRootMetadata interface for BareRootMetadataV2.
@@ -1072,9 +1072,9 @@ func (md *BareRootMetadataV2) SetRevision(revision kbfsmd.Revision) {
 	md.Revision = revision
 }
 
-// SetMerkleSeqNo implements the MutableBareRootMetadata interface for
+// SetMerkleRoot implements the MutableBareRootMetadata interface for
 // BareRootMetadataV2.
-func (md *BareRootMetadataV2) SetMerkleSeqNo(seqNo MerkleSeqNo) {
+func (md *BareRootMetadataV2) SetMerkleRoot(root keybase1.MerkleRootV2) {
 	// V2 doesn't support merkle seqnos, just ignore.
 }
 

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -88,15 +88,18 @@ type BareRootMetadataV3 struct {
 	// of writing to the given folder.
 	FinalizedInfo *tlf.HandleExtension `codec:"fi,omitempty"`
 
-	// The sequence number of the global Keybase Merkle tree at the
-	// time this update was created (from the writer's perspective).
-	// This field was added to V3 after it was live for a while, and
-	// older clients that don't know about this field yet might copy
-	// it into new updates via the unknown fields copier. Which means
-	// new MD updates might end up referring to older Merkle roots.
-	// That's ok since this is just a hint anyway, and shouldn't be
-	// fully trusted when checking MD updates against the Merkle tree.
+	// DEPRECATED -- see KBMerkleRoot.Seqno instead.
 	KBMerkleSeqNo MerkleSeqNo `codec:"msn,omitempty"`
+
+	// The root of the global Keybase Merkle tree at the time this
+	// update was created (from the writer's perspective).  This field
+	// was added to V3 after it was live for a while, and older
+	// clients that don't know about this field yet might copy it into
+	// new updates via the unknown fields copier. Which means new MD
+	// updates might end up referring to older Merkle roots.  That's
+	// ok since this is just a hint anyway, and shouldn't be fully
+	// trusted when checking MD updates against the Merkle tree.
+	KBMerkleRoot keybase1.MerkleRootV2 `codec:"mr,omitempty"`
 
 	codec.UnknownFieldSetHandler
 }
@@ -1058,10 +1061,10 @@ func (md *BareRootMetadataV3) RevisionNumber() kbfsmd.Revision {
 	return md.Revision
 }
 
-// MerkleSeqNo implements the BareRootMetadata interface for
+// MerkleRoot implements the BareRootMetadata interface for
 // BareRootMetadataV3.
-func (md *BareRootMetadataV3) MerkleSeqNo() MerkleSeqNo {
-	return md.KBMerkleSeqNo
+func (md *BareRootMetadataV3) MerkleRoot() keybase1.MerkleRootV2 {
+	return md.KBMerkleRoot
 }
 
 // BID implements the BareRootMetadata interface for BareRootMetadataV3.
@@ -1161,10 +1164,10 @@ func (md *BareRootMetadataV3) SetRevision(revision kbfsmd.Revision) {
 	md.Revision = revision
 }
 
-// SetMerkleSeqNo implements the MutableBareRootMetadata interface for
+// SetMerkleRoot implements the MutableBareRootMetadata interface for
 // BareRootMetadataV3.
-func (md *BareRootMetadataV3) SetMerkleSeqNo(seqNo MerkleSeqNo) {
-	md.KBMerkleSeqNo = seqNo
+func (md *BareRootMetadataV3) SetMerkleRoot(root keybase1.MerkleRootV2) {
+	md.KBMerkleRoot = root
 }
 
 func (md *BareRootMetadataV3) updateKeyBundles(crypto cryptoPure,

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -88,9 +88,6 @@ type BareRootMetadataV3 struct {
 	// of writing to the given folder.
 	FinalizedInfo *tlf.HandleExtension `codec:"fi,omitempty"`
 
-	// DEPRECATED -- see KBMerkleRoot.Seqno instead.
-	KBMerkleSeqNo MerkleSeqNo `codec:"msn,omitempty"`
-
 	// The root of the global Keybase Merkle tree at the time this
 	// update was created (from the writer's perspective).  This field
 	// was added to V3 after it was live for a while, and older
@@ -99,7 +96,9 @@ type BareRootMetadataV3 struct {
 	// updates might end up referring to older Merkle roots.  That's
 	// ok since this is just a hint anyway, and shouldn't be fully
 	// trusted when checking MD updates against the Merkle tree.
-	KBMerkleRoot keybase1.MerkleRootV2 `codec:"mr,omitempty"`
+	// NOTE: this is a pointer in order to get the correct "omitempty"
+	// behavior, so that old MDs are still verifiable.
+	KBMerkleRoot *keybase1.MerkleRootV2 `codec:"mr,omitempty"`
 
 	codec.UnknownFieldSetHandler
 }
@@ -1064,7 +1063,7 @@ func (md *BareRootMetadataV3) RevisionNumber() kbfsmd.Revision {
 // MerkleRoot implements the BareRootMetadata interface for
 // BareRootMetadataV3.
 func (md *BareRootMetadataV3) MerkleRoot() keybase1.MerkleRootV2 {
-	return md.KBMerkleRoot
+	return *md.KBMerkleRoot
 }
 
 // BID implements the BareRootMetadata interface for BareRootMetadataV3.
@@ -1167,7 +1166,7 @@ func (md *BareRootMetadataV3) SetRevision(revision kbfsmd.Revision) {
 // SetMerkleRoot implements the MutableBareRootMetadata interface for
 // BareRootMetadataV3.
 func (md *BareRootMetadataV3) SetMerkleRoot(root keybase1.MerkleRootV2) {
-	md.KBMerkleRoot = root
+	md.KBMerkleRoot = &root
 }
 
 func (md *BareRootMetadataV3) updateKeyBundles(crypto cryptoPure,

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -818,6 +818,3 @@ func (im InitMode) String() string {
 		return "unknown"
 	}
 }
-
-// MerkleSeqNo is a sequence number in the Keybase Merkle tree -- DEPRECATED.
-type MerkleSeqNo uint64

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -819,14 +819,5 @@ func (im InitMode) String() string {
 	}
 }
 
-// MerkleSeqNo is a sequence number in the Keybase Merkle tree.
+// MerkleSeqNo is a sequence number in the Keybase Merkle tree -- DEPRECATED.
 type MerkleSeqNo uint64
-
-const (
-	// UnknownMerkleSeqNo represents an invalid sequence number
-	// indicating the correct seqno is not known (e.g., because the
-	// update pre-dates storing the seqno).
-	UnknownMerkleSeqNo MerkleSeqNo = 0
-	// FirstValidMerkleSeqNo is the smallest valid Merkle seqno.
-	FirstValidMerkleSeqNo MerkleSeqNo = 1
-)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -361,16 +361,16 @@ type KBFSOps interface {
 	TeamNameChanged(ctx context.Context, tid keybase1.TeamID)
 }
 
-type merkleSeqNoGetter interface {
-	// GetCurrentMerkleSeqNo returns the current sequence number of the
-	// global Keybase Merkle tree.
-	GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error)
+type merkleRootGetter interface {
+	// GetCurrentMerkleRoot returns the current root of the global
+	// Keybase Merkle tree.
+	GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error)
 }
 
 // KeybaseService is an interface for communicating with the keybase
 // service.
 type KeybaseService interface {
-	merkleSeqNoGetter
+	merkleRootGetter
 
 	// Resolve, given an assertion, resolves it to a username/UID
 	// pair. The username <-> UID mapping is trusted and
@@ -526,10 +526,10 @@ type TeamMembershipChecker interface {
 	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
 		bool, error)
 	// TODO: add Was* method for figuring out whether the user was a
-	// writer/reader at a particular Merkle sequence number.  Not sure
-	// whether these calls should also verify that sequence number
-	// corresponds to a given TLF revision, or leave that work to
-	// another component.
+	// writer/reader at a particular Merkle root.  Not sure whether
+	// these calls should also verify that sequence number corresponds
+	// to a given TLF revision, or leave that work to another
+	// component.
 }
 
 type teamKeysGetter interface {
@@ -549,7 +549,7 @@ type KBPKI interface {
 	resolver
 	identifier
 	normalizedUsernameGetter
-	merkleSeqNoGetter
+	merkleRootGetter
 	TeamMembershipChecker
 	teamKeysGetter
 
@@ -1987,9 +1987,9 @@ type BareRootMetadata interface {
 	MDDiskUsage() uint64
 	// RevisionNumber returns the revision number associated with this metadata structure.
 	RevisionNumber() kbfsmd.Revision
-	// MerkleSeqNo returns the sequence number of the global
-	// Keybase Merkle tree at the time the MD was written.
-	MerkleSeqNo() MerkleSeqNo
+	// MerkleRoot returns the root of the global Keybase Merkle tree
+	// at the time the MD was written.
+	MerkleRoot() keybase1.MerkleRootV2
 	// BID returns the per-device branch ID associated with this metadata revision.
 	BID() BranchID
 	// GetPrevRoot returns the hash of the previous metadata revision.
@@ -2079,9 +2079,9 @@ type MutableBareRootMetadata interface {
 	SetWriterMetadataCopiedBit()
 	// SetRevision sets the revision number of the underlying metadata.
 	SetRevision(revision kbfsmd.Revision)
-	// SetMerkleSeqNo sets the sequence number of the global
-	// Keybase Merkle tree at the time the MD was written.
-	SetMerkleSeqNo(seqNo MerkleSeqNo)
+	// SetMerkleRoot sets the root of the global Keybase Merkle tree
+	// at the time the MD was written.
+	SetMerkleRoot(root keybase1.MerkleRootV2)
 	// SetUnresolvedReaders sets the list of unresolved readers associated with this folder.
 	SetUnresolvedReaders(readers []keybase1.SocialAssertion)
 	// SetUnresolvedWriters sets the list of unresolved writers associated with this folder.

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -207,10 +207,10 @@ func (k *KBPKIClient) GetTeamTLFCryptKeys(
 	return teamInfo.CryptKeys, teamInfo.LatestKeyGen, nil
 }
 
-// GetCurrentMerkleSeqNo implements the KBPKI interface for KBPKIClient.
-func (k *KBPKIClient) GetCurrentMerkleSeqNo(ctx context.Context) (
-	MerkleSeqNo, error) {
-	return k.serviceOwner.KeybaseService().GetCurrentMerkleSeqNo(ctx)
+// GetCurrentMerkleRoot implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) GetCurrentMerkleRoot(ctx context.Context) (
+	keybase1.MerkleRootV2, error) {
+	return k.serviceOwner.KeybaseService().GetCurrentMerkleRoot(ctx)
 }
 
 // IsTeamWriter implements the KBPKI interface for KBPKIClient.

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -146,7 +146,7 @@ type KeybaseDaemonLocal struct {
 	currentUID    keybase1.UID
 	asserts       map[string]keybase1.UserOrTeamID
 	favoriteStore favoriteStore
-	merkleSeqNo   MerkleSeqNo
+	merkleRoot    keybase1.MerkleRootV2
 }
 
 var _ KeybaseService = &KeybaseDaemonLocal{}
@@ -295,17 +295,17 @@ func (k *KeybaseDaemonLocal) LoadUnverifiedKeys(ctx context.Context, uid keybase
 	return u.UnverifiedKeys, nil
 }
 
-// GetCurrentMerkleSeqNo implements the KeybaseService interface for
+// GetCurrentMerkleRoot implements the KeybaseService interface for
 // KeybaseDaemonLocal.
-func (k *KeybaseDaemonLocal) GetCurrentMerkleSeqNo(ctx context.Context) (
-	MerkleSeqNo, error) {
+func (k *KeybaseDaemonLocal) GetCurrentMerkleRoot(ctx context.Context) (
+	keybase1.MerkleRootV2, error) {
 	if err := checkContext(ctx); err != nil {
-		return 0, err
+		return keybase1.MerkleRootV2{}, err
 	}
 
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	return k.merkleSeqNo, nil
+	return k.merkleRoot, nil
 }
 
 // CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.
@@ -723,7 +723,7 @@ func newKeybaseDaemonLocal(codec kbfscodec.Codec,
 		asserts:       asserts,
 		currentUID:    currentUID,
 		favoriteStore: favoriteStore,
-		merkleSeqNo:   FirstValidMerkleSeqNo,
+		// TODO: let test fill in valid merkle root.
 	}
 	k.addTeamsForTest(teams)
 	return k

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -552,24 +552,17 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	return info, nil
 }
 
-// GetCurrentMerkleSeqNo implements the KeybaseService interface for
+// GetCurrentMerkleRoot implements the KeybaseService interface for
 // KeybaseServiceBase.
-func (k *KeybaseServiceBase) GetCurrentMerkleSeqNo(ctx context.Context) (
-	MerkleSeqNo, error) {
+func (k *KeybaseServiceBase) GetCurrentMerkleRoot(ctx context.Context) (
+	keybase1.MerkleRootV2, error) {
 	const merkleFreshnessMs = int(time.Second * 60 / time.Millisecond)
 	res, err := k.merkleClient.GetCurrentMerkleRoot(ctx, merkleFreshnessMs)
 	if err != nil {
-		return 0, err
+		return keybase1.MerkleRootV2{}, err
 	}
 
-	if res.Root.Seqno < 0 {
-		return 0, fmt.Errorf(
-			"Illegal negative merkle seqno: %d", res.Root.Seqno)
-	}
-
-	// NOTE: `res.Seqno` is an int64, while `MerkleSeqNo` is a uint64,
-	// so casting in this direction should be safe.
-	return MerkleSeqNo(res.Root.Seqno), nil
+	return res.Root, nil
 }
 
 func (k *KeybaseServiceBase) processUserPlusKeys(upk keybase1.UserPlusKeys) (

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -14,18 +14,18 @@ import (
 // KeybaseServiceMeasured delegates to another KeybaseService instance
 // but also keeps track of stats.
 type KeybaseServiceMeasured struct {
-	delegate                   KeybaseService
-	resolveTimer               metrics.Timer
-	identifyTimer              metrics.Timer
-	loadUserPlusKeysTimer      metrics.Timer
-	loadTeamPlusKeysTimer      metrics.Timer
-	loadUnverifiedKeysTimer    metrics.Timer
-	getCurrentMerkleSeqNoTimer metrics.Timer
-	currentSessionTimer        metrics.Timer
-	favoriteAddTimer           metrics.Timer
-	favoriteDeleteTimer        metrics.Timer
-	favoriteListTimer          metrics.Timer
-	notifyTimer                metrics.Timer
+	delegate                  KeybaseService
+	resolveTimer              metrics.Timer
+	identifyTimer             metrics.Timer
+	loadUserPlusKeysTimer     metrics.Timer
+	loadTeamPlusKeysTimer     metrics.Timer
+	loadUnverifiedKeysTimer   metrics.Timer
+	getCurrentMerkleRootTimer metrics.Timer
+	currentSessionTimer       metrics.Timer
+	favoriteAddTimer          metrics.Timer
+	favoriteDeleteTimer       metrics.Timer
+	favoriteListTimer         metrics.Timer
+	notifyTimer               metrics.Timer
 }
 
 var _ KeybaseService = KeybaseServiceMeasured{}
@@ -38,25 +38,25 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 	loadUserPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUserPlusKeys", r)
 	loadTeamPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadTeamPlusKeys", r)
 	loadUnverifiedKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUnverifiedKeys", r)
-	getCurrentMerkleSeqNoTimer := metrics.GetOrRegisterTimer("KeybaseService.GetCurrentMerkleSeqNo", r)
+	getCurrentMerkleRootTimer := metrics.GetOrRegisterTimer("KeybaseService.GetCurrentMerkleRoot", r)
 	currentSessionTimer := metrics.GetOrRegisterTimer("KeybaseService.CurrentSession", r)
 	favoriteAddTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteAdd", r)
 	favoriteDeleteTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteDelete", r)
 	favoriteListTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteList", r)
 	notifyTimer := metrics.GetOrRegisterTimer("KeybaseService.Notify", r)
 	return KeybaseServiceMeasured{
-		delegate:                   delegate,
-		resolveTimer:               resolveTimer,
-		identifyTimer:              identifyTimer,
-		loadUserPlusKeysTimer:      loadUserPlusKeysTimer,
-		loadTeamPlusKeysTimer:      loadTeamPlusKeysTimer,
-		loadUnverifiedKeysTimer:    loadUnverifiedKeysTimer,
-		getCurrentMerkleSeqNoTimer: getCurrentMerkleSeqNoTimer,
-		currentSessionTimer:        currentSessionTimer,
-		favoriteAddTimer:           favoriteAddTimer,
-		favoriteDeleteTimer:        favoriteDeleteTimer,
-		favoriteListTimer:          favoriteListTimer,
-		notifyTimer:                notifyTimer,
+		delegate:                  delegate,
+		resolveTimer:              resolveTimer,
+		identifyTimer:             identifyTimer,
+		loadUserPlusKeysTimer:     loadUserPlusKeysTimer,
+		loadTeamPlusKeysTimer:     loadTeamPlusKeysTimer,
+		loadUnverifiedKeysTimer:   loadUnverifiedKeysTimer,
+		getCurrentMerkleRootTimer: getCurrentMerkleRootTimer,
+		currentSessionTimer:       currentSessionTimer,
+		favoriteAddTimer:          favoriteAddTimer,
+		favoriteDeleteTimer:       favoriteDeleteTimer,
+		favoriteListTimer:         favoriteListTimer,
+		notifyTimer:               notifyTimer,
 	}
 }
 
@@ -98,14 +98,14 @@ func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 	return teamInfo, err
 }
 
-// GetCurrentMerkleSeqNo implements the KeybaseService interface for
+// GetCurrentMerkleRoot implements the KeybaseService interface for
 // KeybaseServiceMeasured.
-func (k KeybaseServiceMeasured) GetCurrentMerkleSeqNo(ctx context.Context) (
-	seqno MerkleSeqNo, err error) {
-	k.getCurrentMerkleSeqNoTimer.Time(func() {
-		seqno, err = k.delegate.GetCurrentMerkleSeqNo(ctx)
+func (k KeybaseServiceMeasured) GetCurrentMerkleRoot(ctx context.Context) (
+	root keybase1.MerkleRootV2, err error) {
+	k.getCurrentMerkleRootTimer.Time(func() {
+		root, err = k.delegate.GetCurrentMerkleRoot(ctx)
 	})
-	return seqno, err
+	return root, err
 }
 
 // LoadUnverifiedKeys implements the KeybaseService interface for KeybaseServiceMeasured.

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -107,11 +107,11 @@ func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 
 type constMerkleRootGetter struct{}
 
-var _ merkleSeqNoGetter = constMerkleRootGetter{}
+var _ merkleRootGetter = constMerkleRootGetter{}
 
-func (cmrg constMerkleRootGetter) GetCurrentMerkleSeqNo(
-	ctx context.Context) (MerkleSeqNo, error) {
-	return FirstValidMerkleSeqNo, nil
+func (cmrg constMerkleRootGetter) GetCurrentMerkleRoot(
+	ctx context.Context) (keybase1.MerkleRootV2, error) {
+	return keybase1.MerkleRootV2{}, nil
 }
 
 func putMDRangeHelper(t testing.TB, ver MetadataVer, tlfID tlf.ID,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1011,36 +1011,36 @@ func (_mr *_MockKBFSOpsRecorder) TeamNameChanged(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "TeamNameChanged", arg0, arg1)
 }
 
-// Mock of merkleSeqNoGetter interface
-type MockmerkleSeqNoGetter struct {
+// Mock of merkleRootGetter interface
+type MockmerkleRootGetter struct {
 	ctrl     *gomock.Controller
-	recorder *_MockmerkleSeqNoGetterRecorder
+	recorder *_MockmerkleRootGetterRecorder
 }
 
-// Recorder for MockmerkleSeqNoGetter (not exported)
-type _MockmerkleSeqNoGetterRecorder struct {
-	mock *MockmerkleSeqNoGetter
+// Recorder for MockmerkleRootGetter (not exported)
+type _MockmerkleRootGetterRecorder struct {
+	mock *MockmerkleRootGetter
 }
 
-func NewMockmerkleSeqNoGetter(ctrl *gomock.Controller) *MockmerkleSeqNoGetter {
-	mock := &MockmerkleSeqNoGetter{ctrl: ctrl}
-	mock.recorder = &_MockmerkleSeqNoGetterRecorder{mock}
+func NewMockmerkleRootGetter(ctrl *gomock.Controller) *MockmerkleRootGetter {
+	mock := &MockmerkleRootGetter{ctrl: ctrl}
+	mock.recorder = &_MockmerkleRootGetterRecorder{mock}
 	return mock
 }
 
-func (_m *MockmerkleSeqNoGetter) EXPECT() *_MockmerkleSeqNoGetterRecorder {
+func (_m *MockmerkleRootGetter) EXPECT() *_MockmerkleRootGetterRecorder {
 	return _m.recorder
 }
 
-func (_m *MockmerkleSeqNoGetter) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
-	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
-	ret0, _ := ret[0].(MerkleSeqNo)
+func (_m *MockmerkleRootGetter) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleRoot", ctx)
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockmerkleSeqNoGetterRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+func (_mr *_MockmerkleRootGetterRecorder) GetCurrentMerkleRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleRoot", arg0)
 }
 
 // Mock of KeybaseService interface
@@ -1064,15 +1064,15 @@ func (_m *MockKeybaseService) EXPECT() *_MockKeybaseServiceRecorder {
 	return _m.recorder
 }
 
-func (_m *MockKeybaseService) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
-	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
-	ret0, _ := ret[0].(MerkleSeqNo)
+func (_m *MockKeybaseService) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleRoot", ctx)
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKeybaseServiceRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+func (_mr *_MockKeybaseServiceRecorder) GetCurrentMerkleRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleRoot", arg0)
 }
 
 func (_m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
@@ -1545,15 +1545,15 @@ func (_mr *_MockKBPKIRecorder) GetNormalizedUsername(arg0, arg1 interface{}) *go
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetNormalizedUsername", arg0, arg1)
 }
 
-func (_m *MockKBPKI) GetCurrentMerkleSeqNo(ctx context.Context) (MerkleSeqNo, error) {
-	ret := _m.ctrl.Call(_m, "GetCurrentMerkleSeqNo", ctx)
-	ret0, _ := ret[0].(MerkleSeqNo)
+func (_m *MockKBPKI) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error) {
+	ret := _m.ctrl.Call(_m, "GetCurrentMerkleRoot", ctx)
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockKBPKIRecorder) GetCurrentMerkleSeqNo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleSeqNo", arg0)
+func (_mr *_MockKBPKIRecorder) GetCurrentMerkleRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetCurrentMerkleRoot", arg0)
 }
 
 func (_m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
@@ -5700,8 +5700,8 @@ func (_mr *_MockBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3, arg4,
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockBareRootMetadata) IsReader(ctx context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsReader", ctx, user, deviceKey, teamMemChecker, extra)
+func (_m *MockBareRootMetadata) IsReader(ctx context.Context, user keybase1.UID, cryptKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsReader", ctx, user, cryptKey, teamMemChecker, extra)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -5901,14 +5901,14 @@ func (_mr *_MockBareRootMetadataRecorder) RevisionNumber() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevisionNumber")
 }
 
-func (_m *MockBareRootMetadata) MerkleSeqNo() MerkleSeqNo {
-	ret := _m.ctrl.Call(_m, "MerkleSeqNo")
-	ret0, _ := ret[0].(MerkleSeqNo)
+func (_m *MockBareRootMetadata) MerkleRootV2() keybase1.MerkleRootV2 {
+	ret := _m.ctrl.Call(_m, "MerkleRootV2")
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	return ret0
 }
 
-func (_mr *_MockBareRootMetadataRecorder) MerkleSeqNo() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MerkleSeqNo")
+func (_mr *_MockBareRootMetadataRecorder) MerkleRootV2() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MerkleRootV2")
 }
 
 func (_m *MockBareRootMetadata) BID() BranchID {
@@ -6148,8 +6148,8 @@ func (_mr *_MockMutableBareRootMetadataRecorder) IsWriter(arg0, arg1, arg2, arg3
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "IsWriter", arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-func (_m *MockMutableBareRootMetadata) IsReader(ctx context.Context, user keybase1.UID, deviceKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
-	ret := _m.ctrl.Call(_m, "IsReader", ctx, user, deviceKey, teamMemChecker, extra)
+func (_m *MockMutableBareRootMetadata) IsReader(ctx context.Context, user keybase1.UID, cryptKey kbfscrypto.CryptPublicKey, teamMemChecker TeamMembershipChecker, extra ExtraMetadata) (bool, error) {
+	ret := _m.ctrl.Call(_m, "IsReader", ctx, user, cryptKey, teamMemChecker, extra)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -6349,14 +6349,14 @@ func (_mr *_MockMutableBareRootMetadataRecorder) RevisionNumber() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "RevisionNumber")
 }
 
-func (_m *MockMutableBareRootMetadata) MerkleSeqNo() MerkleSeqNo {
-	ret := _m.ctrl.Call(_m, "MerkleSeqNo")
-	ret0, _ := ret[0].(MerkleSeqNo)
+func (_m *MockMutableBareRootMetadata) MerkleRootV2() keybase1.MerkleRootV2 {
+	ret := _m.ctrl.Call(_m, "MerkleRootV2")
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
 	return ret0
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) MerkleSeqNo() *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "MerkleSeqNo")
+func (_mr *_MockMutableBareRootMetadataRecorder) MerkleRootV2() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "MerkleRootV2")
 }
 
 func (_m *MockMutableBareRootMetadata) BID() BranchID {
@@ -6676,12 +6676,12 @@ func (_mr *_MockMutableBareRootMetadataRecorder) SetRevision(arg0 interface{}) *
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetRevision", arg0)
 }
 
-func (_m *MockMutableBareRootMetadata) SetMerkleSeqNo(seqNo MerkleSeqNo) {
-	_m.ctrl.Call(_m, "SetMerkleSeqNo", seqNo)
+func (_m *MockMutableBareRootMetadata) SetMerkleRoot(root keybase1.MerkleRootV2) {
+	_m.ctrl.Call(_m, "SetMerkleRoot", root)
 }
 
-func (_mr *_MockMutableBareRootMetadataRecorder) SetMerkleSeqNo(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMerkleSeqNo", arg0)
+func (_mr *_MockMutableBareRootMetadataRecorder) SetMerkleRoot(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetMerkleRoot", arg0)
 }
 
 func (_m *MockMutableBareRootMetadata) SetUnresolvedReaders(readers []keybase1.SocialAssertion) {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -241,7 +241,7 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 // with the revision incremented and a correct backpointer.
 func (md *RootMetadata) MakeSuccessor(
 	ctx context.Context, latestMDVer MetadataVer, codec kbfscodec.Codec,
-	crypto cryptoPure, keyManager KeyManager, merkleGetter merkleSeqNoGetter,
+	crypto cryptoPure, keyManager KeyManager, merkleGetter merkleRootGetter,
 	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
 	*RootMetadata, error) {
 	if mdID == (kbfsmd.ID{}) {
@@ -300,11 +300,11 @@ func (md *RootMetadata) MakeSuccessor(
 	}
 	newMd.SetRevision(md.Revision() + 1)
 
-	merkleSeqNo, err := merkleGetter.GetCurrentMerkleSeqNo(ctx)
+	merkleRoot, err := merkleGetter.GetCurrentMerkleRoot(ctx)
 	if err != nil {
 		return nil, err
 	}
-	newMd.SetMerkleSeqNo(merkleSeqNo)
+	newMd.SetMerkleRoot(merkleRoot)
 
 	return newMd, nil
 }
@@ -630,10 +630,10 @@ func (md *RootMetadata) Revision() kbfsmd.Revision {
 	return md.bareMd.RevisionNumber()
 }
 
-// MerkleSeqNo wraps the respective method of the underlying
+// MerkleRoot wraps the respective method of the underlying
 // BareRootMetadata for convenience.
-func (md *RootMetadata) MerkleSeqNo() MerkleSeqNo {
-	return md.bareMd.MerkleSeqNo()
+func (md *RootMetadata) MerkleRoot() keybase1.MerkleRootV2 {
+	return md.bareMd.MerkleRoot()
 }
 
 // MergedStatus wraps the respective method of the underlying BareRootMetadata for convenience.
@@ -720,10 +720,10 @@ func (md *RootMetadata) SetRevision(revision kbfsmd.Revision) {
 	md.bareMd.SetRevision(revision)
 }
 
-// SetMerkleSeqNo wraps the respective method of the underlying
+// SetMerkleRoot wraps the respective method of the underlying
 // BareRootMetadata for convenience.
-func (md *RootMetadata) SetMerkleSeqNo(seqNo MerkleSeqNo) {
-	md.bareMd.SetMerkleSeqNo(seqNo)
+func (md *RootMetadata) SetMerkleRoot(root keybase1.MerkleRootV2) {
+	md.bareMd.SetMerkleRoot(root)
 }
 
 // SetWriters wraps the respective method of the underlying BareRootMetadata for convenience.


### PR DESCRIPTION
Instead of just the seqno, which can be predicted/guessed.

This PR assumes we want to include the merkle root in the MD ID forever.  If this goes in, a future PR (for KBFS-2271) will add an "eventually consistent" caching layer for the merkle root to avoid a server RTT when setting this fields during foreground writes, in most cases.

Issue: KBFS-2296