### PR TITLE
libkbfs: introduce eventually-consistent merkle root cache

### DIFF
--- a/libkbfs/fetch_decider.go
+++ b/libkbfs/fetch_decider.go
@@ -1,0 +1,135 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
+)
+
+// fetchDecider is a struct that helps avoid having too frequent calls
+// into a remote server.
+type fetchDecider struct {
+	log     logger.Logger
+	fetcher func(ctx context.Context) error
+	tagKey  interface{}
+	tagName string
+	clock   clockGetter
+
+	blockingForTest chan<- struct{}
+
+	lock    sync.Mutex
+	readyCh chan struct{}
+	errPtr  *error
+}
+
+func newFetchDecider(
+	log logger.Logger, fetcher func(ctx context.Context) error,
+	tagKey interface{}, tagName string,
+	clock clockGetter) *fetchDecider {
+	return &fetchDecider{
+		log:     log,
+		fetcher: fetcher,
+		tagKey:  tagKey,
+		tagName: tagName,
+		clock:   clock,
+	}
+}
+
+func (fd *fetchDecider) launchBackgroundFetch(ctx context.Context) (
+	readyCh <-chan struct{}, errPtr *error) {
+	fd.lock.Lock()
+	defer fd.lock.Unlock()
+
+	if fd.readyCh != nil {
+		fd.log.CDebugf(ctx, "Waiting on existing fetch")
+		// There's already a fetch in progress.
+		return fd.readyCh, fd.errPtr
+	}
+
+	fd.readyCh = make(chan struct{})
+	fd.errPtr = new(error)
+
+	id, err := MakeRandomRequestID()
+	if err != nil {
+		fd.log.Warning("Couldn't generate a random request ID: %v", err)
+	}
+	fd.log.CDebugf(
+		ctx, "Spawning fetch in background with tag:%s=%v", fd.tagName, id)
+	go func() {
+		// Make a new context so that it doesn't get canceled
+		// when returned.
+		logTags := make(logger.CtxLogTags)
+		logTags[fd.tagKey] = fd.tagName
+		bgCtx := logger.NewContextWithLogTags(
+			context.Background(), logTags)
+		bgCtx = context.WithValue(bgCtx, fd.tagKey, id)
+		// Make sure a timeout is on the context, in case the
+		// RPC blocks forever somehow, where we'd end up with
+		// never resetting backgroundInProcess flag again.
+		bgCtx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+		defer cancel()
+		err := fd.fetcher(bgCtx)
+
+		// Notify everyone we're done fetching.
+		fd.lock.Lock()
+		defer fd.lock.Unlock()
+		fd.log.CDebugf(bgCtx, "Finished fetch")
+		*fd.errPtr = err
+		readyCh := fd.readyCh
+		fd.readyCh = nil
+		fd.errPtr = nil
+		close(readyCh)
+	}()
+	return fd.readyCh, fd.errPtr
+}
+
+// Do decides whether to block on a fetch, launch a background fetch
+// and use existing cached value, or simply use the existing cached
+// value with no more fetching. The caller can provide a positive
+// tolerance, to accept stale LimitBytes and UsageBytes data. If
+// tolerance is 0 or negative, this always makes a blocking RPC to
+// bserver and return latest quota usage.
+//
+// 1) If the age of cached data is more than blockTolerance, it blocks
+// until a new value is fetched and ready in the caller's cache.
+// 2) Otherwise, if the age of cached data is more than bgTolerance,
+// a background RPC is spawned to refresh cached data using `fd.fetcher`,
+// but returns immediately to let the caller use stale data.
+// 3) Otherwise, it returns immediately
+func (fd *fetchDecider) Do(
+	ctx context.Context, bgTolerance, blockTolerance time.Duration,
+	cachedTimestamp time.Time) (err error) {
+	past := fd.clock.Clock().Now().Sub(cachedTimestamp)
+	switch {
+	case past > blockTolerance || cachedTimestamp.IsZero():
+		fd.log.CDebugf(
+			ctx, "Blocking on fetch; cached data is %s old", past)
+		readyCh, errPtr := fd.launchBackgroundFetch(ctx)
+
+		if fd.blockingForTest != nil {
+			fd.blockingForTest <- struct{}{}
+		}
+
+		select {
+		case <-readyCh:
+			return *errPtr
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case past > bgTolerance:
+		fd.log.CDebugf(ctx, "Cached data is %s old", past)
+		_, _ = fd.launchBackgroundFetch(ctx)
+		// Return immediately, with no error, since the caller can
+		// just use the existing cache value.
+		return nil
+	default:
+		fd.log.CDebugf(ctx, "Using cached data from %s ago", past)
+		return nil
+	}
+}

--- a/libkbfs/fetch_decider.go
+++ b/libkbfs/fetch_decider.go
@@ -79,7 +79,7 @@ func (fd *fetchDecider) launchBackgroundFetch(ctx context.Context) (
 		// Notify everyone we're done fetching.
 		fd.lock.Lock()
 		defer fd.lock.Unlock()
-		fd.log.CDebugf(bgCtx, "Finished fetch")
+		fd.log.CDebugf(bgCtx, "Finished fetch: %+v", err)
 		*fd.errPtr = err
 		readyCh := fd.readyCh
 		fd.readyCh = nil
@@ -93,8 +93,8 @@ func (fd *fetchDecider) launchBackgroundFetch(ctx context.Context) (
 // and use existing cached value, or simply use the existing cached
 // value with no more fetching. The caller can provide a positive
 // tolerance, to accept stale LimitBytes and UsageBytes data. If
-// tolerance is 0 or negative, this always makes a blocking RPC to
-// bserver and return latest quota usage.
+// tolerance is 0 or negative, this always makes a blocking call using
+// `fd.fetcher`.
 //
 // 1) If the age of cached data is more than blockTolerance, it blocks
 // until a new value is fetched and ready in the caller's cache.

--- a/libkbfs/fetch_decider_test.go
+++ b/libkbfs/fetch_decider_test.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestFetchDecider(t *testing.T) {
+	errCh := make(chan error, 1)
+	fetcher := func(ctx context.Context) error {
+		return <-errCh
+	}
+
+	log := logger.NewTestLogger(t)
+	clock := newTestClockNow()
+	fd := newFetchDecider(log, fetcher, "", "", &testClockGetter{clock})
+	ctx, cancel := context.WithTimeout(
+		context.Background(), individualTestTimeout)
+	defer cancel()
+
+	t.Log("Blocking fetch")
+	errCh <- nil
+	err := fd.Do(ctx, 2*time.Second, 4*time.Second, time.Time{})
+	require.NoError(t, err)
+
+	t.Log("Use cached value (`fetcher` isn't called)")
+	err = fd.Do(
+		ctx, 2*time.Second, 4*time.Second, clock.Now().Add(-1*time.Second))
+	require.NoError(t, err)
+
+	t.Log("Use cached value, but launch bg fetcher (will return before " +
+		"`fetcher` completes)")
+	err = fd.Do(
+		ctx, 2*time.Second, 4*time.Second, clock.Now().Add(-3*time.Second))
+	require.NoError(t, err)
+
+	errCh <- nil // Let the background fetcher complete.
+
+	// Once we can put a new value in the sized-1 `errCh`, we know the
+	// bg fetch has finished.
+	errCh <- nil
+	<-errCh
+
+	t.Log("Use cached value, and subsequent blocking call will wait for " +
+		"the background fetcher")
+	err = fd.Do(
+		ctx, 2*time.Second, 4*time.Second, clock.Now().Add(-3*time.Second))
+	require.NoError(t, err)
+
+	checkBlocking := make(chan struct{})
+	fd.blockingForTest = checkBlocking
+	blockingCh := make(chan error, 1)
+	go func() {
+		blockingCh <- fd.Do(ctx, 2*time.Second, 4*time.Second, time.Time{})
+	}()
+
+	// Wait for the previous call to start blocking.
+	select {
+	case <-checkBlocking:
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err())
+	}
+
+	errCh <- nil
+	select {
+	case err = <-blockingCh:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		require.NoError(t, ctx.Err())
+	}
+}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -90,6 +90,10 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	// Ignore Notify calls for now
 	config.mockRep.EXPECT().Notify(gomock.Any(), gomock.Any()).AnyTimes()
 
+	// Ignore MerkleRoot calls for now.
+	config.mockKbpki.EXPECT().GetCurrentMerkleRoot(gomock.Any()).
+		Return(keybase1.MerkleRootV2{}, nil).AnyTimes()
+
 	// Max out MaxPtrsPerBlock
 	config.mockBsplit.EXPECT().MaxPtrsPerBlock().
 		Return(int((^uint(0)) >> 1)).AnyTimes()

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -76,8 +76,10 @@ func NewKeybaseServiceBase(config Config, kbCtx Context, log logger.Logger) *Key
 		userCacheUnverifiedKeys: make(map[keybase1.UID][]keybase1.PublicKey),
 		teamCache:               make(map[keybase1.TeamID]TeamInfo),
 	}
-	k.merkleRoot = NewEventuallyConsistentMerkleRoot(
-		config, &keybaseServiceMerkleGetter{&k})
+	if config != nil {
+		k.merkleRoot = NewEventuallyConsistentMerkleRoot(
+			config, &keybaseServiceMerkleGetter{&k})
+	}
 	return &k
 }
 

--- a/libkbfs/merkle_root.go
+++ b/libkbfs/merkle_root.go
@@ -34,6 +34,7 @@ type cachedMerkleRoot struct {
 type EventuallyConsistentMerkleRoot struct {
 	config Config
 	log    logger.Logger
+	getter merkleRootGetter
 
 	backgroundInProcess int32
 
@@ -44,10 +45,11 @@ type EventuallyConsistentMerkleRoot struct {
 // NewEventuallyConsistentMerkleRoot creates a new
 // EventuallyConsistentMerkleRoot object.
 func NewEventuallyConsistentMerkleRoot(
-	config Config, loggerSuffix string) *EventuallyConsistentMerkleRoot {
+	config Config, getter merkleRootGetter) *EventuallyConsistentMerkleRoot {
 	return &EventuallyConsistentMerkleRoot{
 		config: config,
-		log:    config.MakeLogger(ECMRID + "-" + loggerSuffix),
+		log:    config.MakeLogger(ECMRID),
+		getter: getter,
 	}
 }
 
@@ -56,7 +58,8 @@ func (q *EventuallyConsistentMerkleRoot) getAndCache(
 	defer func() {
 		q.log.CDebugf(ctx, "getAndCache: error=%v", err)
 	}()
-	bareRoot, err := q.config.KBPKI().GetCurrentMerkleRoot(ctx)
+	// Go through the
+	bareRoot, err := q.getter.GetCurrentMerkleRoot(ctx)
 	if err != nil {
 		return cachedMerkleRoot{}, err
 	}

--- a/libkbfs/merkle_root.go
+++ b/libkbfs/merkle_root.go
@@ -60,7 +60,6 @@ func (ecmr *EventuallyConsistentMerkleRoot) getAndCache(
 	defer func() {
 		ecmr.log.CDebugf(ctx, "getAndCache: error=%v", err)
 	}()
-	// Go through the
 	bareRoot, err := ecmr.getter.GetCurrentMerkleRoot(ctx)
 	if err != nil {
 		return err

--- a/libkbfs/merkle_root.go
+++ b/libkbfs/merkle_root.go
@@ -1,0 +1,114 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"golang.org/x/net/context"
+)
+
+// ECMRCtxTagKey is the type for unique ECMR background operation IDs.
+type ECMRCtxTagKey struct{}
+
+// ECMRID is used in EventuallyConsistentMerkleRoot for only
+// background RPCs.  More specifically, when we need to spawn a
+// background goroutine for GetCurrentMerkleRoot, a new context with
+// this tag is created and used. This is also used as a prefix for the
+// logger module name in EventuallyConsistentMerkleRoot.
+const ECMRID = "ECMR"
+
+type cachedMerkleRoot struct {
+	timestamp time.Time
+	root      keybase1.MerkleRootV2
+}
+
+// EventuallyConsistentMerkleRoot keeps tracks of the current global
+// Merkle root, in a way user of which can choose to accept stale data
+// to reduce calls to the API server.
+type EventuallyConsistentMerkleRoot struct {
+	config Config
+	log    logger.Logger
+
+	backgroundInProcess int32
+
+	mu     sync.RWMutex
+	cached cachedMerkleRoot
+}
+
+// NewEventuallyConsistentMerkleRoot creates a new
+// EventuallyConsistentMerkleRoot object.
+func NewEventuallyConsistentMerkleRoot(
+	config Config, loggerSuffix string) *EventuallyConsistentMerkleRoot {
+	return &EventuallyConsistentMerkleRoot{
+		config: config,
+		log:    config.MakeLogger(ECMRID + "-" + loggerSuffix),
+	}
+}
+
+func (q *EventuallyConsistentMerkleRoot) getAndCache(
+	ctx context.Context) (root cachedMerkleRoot, err error) {
+	defer func() {
+		q.log.CDebugf(ctx, "getAndCache: error=%v", err)
+	}()
+	bareRoot, err := q.config.KBPKI().GetCurrentMerkleRoot(ctx)
+	if err != nil {
+		return cachedMerkleRoot{}, err
+	}
+
+	root.root = bareRoot
+	root.timestamp = q.config.Clock().Now()
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.cached = root
+
+	return root, nil
+}
+
+// Get returns the current merkle root. To help avoid having too
+// frequent calls into the API server, caller can provide a positive
+// tolerance, to accept stale LimitBytes and UsageBytes data. If
+// tolerance is 0 or negative, this always makes a blocking RPC to
+// bserver and return latest quota usage.
+//
+// 1) If the age of cached data is more than blockTolerance, a blocking RPC is
+// issued and the function only returns after RPC finishes, with the newest
+// data from RPC. The RPC causes cached data to be refreshed as well.
+// 2) Otherwise, if the age of cached data is more than bgTolerance,
+// a background RPC is spawned to refresh cached data, and the stale
+// data is returned immediately.
+// 3) Otherwise, the cached stale data is returned immediately.
+func (q *EventuallyConsistentMerkleRoot) Get(
+	ctx context.Context, bgTolerance, blockTolerance time.Duration) (
+	timestamp time.Time, root keybase1.MerkleRootV2, err error) {
+	c := func() cachedMerkleRoot {
+		q.mu.RLock()
+		defer q.mu.RUnlock()
+		return q.cached
+	}()
+	getAndCache := func(ctx context.Context) {
+		// The error is igonred here without logging since getAndCache already
+		// logs it.
+		_, _ = q.getAndCache(ctx)
+	}
+	decision, err := fetchAndCacheDecider(
+		ctx, bgTolerance, blockTolerance, c.timestamp, getAndCache,
+		&q.backgroundInProcess, q.log, ECMRCtxTagKey{}, ECMRID,
+		q.config.Clock())
+	if err != nil {
+		return time.Time{}, keybase1.MerkleRootV2{}, err
+	}
+
+	if decision == fetchAndCache {
+		c, err = q.getAndCache(ctx)
+		if err != nil {
+			return time.Time{}, keybase1.MerkleRootV2{}, err
+		}
+	}
+	return c.timestamp, c.root, nil
+}

--- a/libkbfs/quota_usage.go
+++ b/libkbfs/quota_usage.go
@@ -6,7 +6,6 @@ package libkbfs
 
 import (
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/keybase/client/go/logger"
@@ -15,7 +14,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// ECQUCtxTagKey is the type for unique ECQU background opertaion IDs.
+// ECQUCtxTagKey is the type for unique ECQU background operation IDs.
 type ECQUCtxTagKey struct{}
 
 // ECQUID is used in EventuallyConsistentQuotaUsage for only background RPCs.
@@ -116,46 +115,24 @@ func (q *EventuallyConsistentQuotaUsage) Get(
 		defer q.mu.RUnlock()
 		return q.cached
 	}()
-	past := q.config.Clock().Now().Sub(c.timestamp)
-	switch {
-	case past > blockTolerance || c.timestamp.IsZero():
-		q.log.CDebugf(ctx, "Blocking on getAndCache. Cached data is %s old.", past)
-		// TODO: optimize this to make sure there's only one outstanding RPC. In
-		// other words, wait for it to finish if one is already in progress.
+	getAndCache := func(ctx context.Context) {
+		// The error is igonred here without logging since getAndCache already
+		// logs it.
+		_, _ = q.getAndCache(ctx)
+	}
+	decision, err := fetchAndCacheDecider(
+		ctx, bgTolerance, blockTolerance, c.timestamp, getAndCache,
+		&q.backgroundInProcess, q.log, ECQUCtxTagKey{}, ECQUID,
+		q.config.Clock())
+	if err != nil {
+		return time.Time{}, -1, -1, err
+	}
+
+	if decision == fetchAndCache {
 		c, err = q.getAndCache(ctx)
 		if err != nil {
 			return time.Time{}, -1, -1, err
 		}
-	case past > bgTolerance:
-		if atomic.CompareAndSwapInt32(&q.backgroundInProcess, 0, 1) {
-			id, err := MakeRandomRequestID()
-			if err != nil {
-				q.log.Warning("Couldn't generate a random request ID: %v", err)
-			}
-			q.log.CDebugf(ctx, "Cached data is %s old. Spawning getAndCache in "+
-				"background with tag:%s=%v.", past, ECQUID, id)
-			go func() {
-				// Make a new context so that it doesn't get canceled when returned.
-				logTags := make(logger.CtxLogTags)
-				logTags[ECQUCtxTagKey{}] = ECQUID
-				bgCtx := logger.NewContextWithLogTags(context.Background(), logTags)
-				bgCtx = context.WithValue(bgCtx, ECQUCtxTagKey{}, id)
-				// Make sure a timeout is on the context, in case the RPC blocks
-				// forever somehow, where we'd end up with never resetting
-				// backgroundInProcess flag again.
-				bgCtx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
-				defer cancel()
-				// The error is igonred here without logging since getAndCache already
-				// logs it.
-				_, _ = q.getAndCache(bgCtx)
-				atomic.StoreInt32(&q.backgroundInProcess, 0)
-			}()
-		} else {
-			q.log.CDebugf(ctx,
-				"Cached data is %s old, but background getAndCache is already running.", past)
-		}
-	default:
-		q.log.CDebugf(ctx, "Returning cached data from %s ago.", past)
 	}
 	return c.timestamp, c.usageBytes, c.limitBytes, nil
 }

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -141,4 +143,71 @@ func chargedToForTLF(ctx context.Context, sessionGetter CurrentSessionGetter,
 		return keybase1.UserOrTeamID(""), err
 	}
 	return session.UID.AsUserOrTeam(), nil
+}
+
+type useFromCacheOrFetch int
+
+const (
+	useFromCache useFromCacheOrFetch = iota
+	fetchAndCache
+)
+
+// fetchAndCacheDecider is a helper function that helps avoid having
+// too frequent calls into a remote server. The caller can provide a
+// positive tolerance, to accept stale LimitBytes and UsageBytes
+// data. If tolerance is 0 or negative, this always makes a blocking
+// RPC to bserver and return latest quota usage.
+//
+// 1) If the age of cached data is more than blockTolerance, it returns a
+// `fetchAndCache` decision, telling the caller to fetch the newest data.
+// 2) Otherwise, if the age of cached data is more than bgTolerance,
+// a background RPC is spawned to refresh cached data using `backgroundFetch`,
+// and the caller is instructed to use the stale data immediately with a
+// `useFromCache` decision.
+// 3) Otherwise, a `useFromCache` decision is returned.
+func fetchAndCacheDecider(
+	ctx context.Context, bgTolerance, blockTolerance time.Duration,
+	cachedTimestamp time.Time, backgroundFetch func(ctx context.Context),
+	backgroundInProcess *int32, log logger.Logger, tagKey interface{},
+	tagName string, clock Clock) (decision useFromCacheOrFetch, err error) {
+	past := clock.Now().Sub(cachedTimestamp)
+	switch {
+	case past > blockTolerance || cachedTimestamp.IsZero():
+		log.CDebugf(
+			ctx, "Blocking on getAndCache. Cached data is %s old.", past)
+		// TODO: optimize this to make sure there's only one outstanding RPC. In
+		// other words, wait for it to finish if one is already in progress.
+		return fetchAndCache, nil
+	case past > bgTolerance:
+		if atomic.CompareAndSwapInt32(backgroundInProcess, 0, 1) {
+			id, err := MakeRandomRequestID()
+			if err != nil {
+				log.Warning("Couldn't generate a random request ID: %v", err)
+			}
+			log.CDebugf(ctx, "Cached data is %s old. Spawning getAndCache in "+
+				"background with tag:%s=%v.", past, tagName, id)
+			go func() {
+				// Make a new context so that it doesn't get canceled
+				// when returned.
+				logTags := make(logger.CtxLogTags)
+				logTags[tagKey] = tagName
+				bgCtx := logger.NewContextWithLogTags(
+					context.Background(), logTags)
+				bgCtx = context.WithValue(bgCtx, tagKey, id)
+				// Make sure a timeout is on the context, in case the
+				// RPC blocks forever somehow, where we'd end up with
+				// never resetting backgroundInProcess flag again.
+				bgCtx, cancel := context.WithTimeout(bgCtx, 10*time.Second)
+				defer cancel()
+				backgroundFetch(bgCtx)
+				atomic.StoreInt32(backgroundInProcess, 0)
+			}()
+		} else {
+			log.CDebugf(ctx, "Cached data is %s old, but backgroundFetch "+
+				"is already running.", past)
+		}
+	default:
+		log.CDebugf(ctx, "Using cached data from %s ago.", past)
+	}
+	return useFromCache, nil
 }


### PR DESCRIPTION
This PR factors out the existing logic in `EventuallyConsistentQuotaUsage` into a common helper struct, and uses it to construct a cache for the service Merkle root.  The goal is to keep the server RTT for fetching the merkle root from blocking foreground writes.  Currently, `SyncAll` absorbs this RTT when the service needs to fetch from the server, and `SyncAll` blocks foreground writes.

This also improves the fetching logic by making sure there's only ever one outstanding fetch; subsequent blocking fetches wait for the outstanding fetch to complete.

`folderBranchOps` signals that it needs the merkle root as soon as a write comes in.  Hopefully, 1 second later when `SyncAll` is called, the merkle root will be in the cache and ready to be used.

Issue: KBFS-2271