### PR TITLE
teams: allow `/keybase/team` lookup and don't check team membership for fetched MDs

### DIFF
--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -381,11 +381,6 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 		oc.isUppercasePath = true
 		fallthrough
 	case TeamName == ps[0]:
-		if env.NewContext().GetRunMode() == libkb.ProductionRunMode &&
-			!libkbfs.EnableAdminFeature(ctx, f.config) {
-			return nil, false, dokan.ErrObjectNameNotFound
-		}
-
 		// Refuse team directories while we are in a error state.
 		if f.remoteStatus.ExtraFileName() != "" {
 			f.log.CWarningf(ctx, "Refusing access to team directory while errors are present!")

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -454,9 +454,7 @@ func (r *Root) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.L
 		return r.public, nil
 	}
 
-	if req.Name == TeamName &&
-		(env.NewContext().GetRunMode() != libkb.ProductionRunMode ||
-			libkbfs.EnableAdminFeature(ctx, r.team.fs.config)) {
+	if req.Name == TeamName {
 		return r.team, nil
 	}
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -180,11 +180,6 @@ func (fs *KBFSOpsStandard) RefreshCachedFavorites(ctx context.Context) {
 // AddFavorite implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) AddFavorite(ctx context.Context,
 	fav Favorite) error {
-	if fav.Type == tlf.SingleTeam {
-		// Ignore team favorites for now, until CORE-5378 is ready.
-		return nil
-	}
-
 	kbpki := fs.config.KBPKI()
 	_, err := kbpki.GetCurrentSession(ctx)
 	isLoggedIn := err == nil

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -219,7 +219,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	// easy way of verifying that they used to be in the team.  We
 	// rely on the fact that the updates are decryptable with the
 	// secret key as a way to prove that only an authorized team
-	// member posted the proof, along with trusting that the server
+	// member wrote the update, along with trusting that the server
 	// would have rejected an update from a former team member that is
 	// still using an old key.  TODO(KBFS-2229): remove this.
 	err := rmds.IsValidAndSigned(


### PR DESCRIPTION
This "soft-launches" teams by making it possible to `cd` into `/keybase/team` if you know it's there, but `ls /keybase` still won't show it.  Additionally, this enables manual favoriting of team directories.  (The server already auto-favorites for team members, but maybe someone will delete a team favorite and want to re-add it.)

Also, this turns off team-membership-checking on MD updates that have been fetched from the server, until our merkle story is implemented.  This matches what chat does for team membership checking.

Issue: KBFS-2319