### PR TITLE
folder_branch_ops: fix the timestamps in update history

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6195,7 +6195,7 @@ func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 		}
 		updateSummary := UpdateSummary{
 			Revision:  rmd.Revision(),
-			Date:      time.Unix(0, rmd.data.Dir.Mtime),
+			Date:      rmd.localTimestamp,
 			Writer:    writer,
 			LiveBytes: rmd.DiskUsage(),
 			Ops:       make([]OpSummary, 0, len(rmd.data.Changes.Ops)),


### PR DESCRIPTION
The previous one was just supposed to be a placeholder; it only tracks
the actual update time if the root directory was updated (and the
user's clock is synced).

Issue: KBFS-2321