### PR TITLE
libfuse: handle singleTeam type in  `PathType`

### DIFF
--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -127,6 +127,8 @@ func (fl *FolderList) PathType() libkbfs.PathType {
 		return libkbfs.PrivatePathType
 	case tlf.Public:
 		return libkbfs.PublicPathType
+	case tlf.SingleTeam:
+		return libkbfs.SingleTeamPathType
 	default:
 		// TODO: support the team path.
 		panic(fmt.Sprintf("Unsupported tlf type: %s", fl.tlfType))

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -130,7 +130,6 @@ func (fl *FolderList) PathType() libkbfs.PathType {
 	case tlf.SingleTeam:
 		return libkbfs.SingleTeamPathType
 	default:
-		// TODO: support the team path.
 		panic(fmt.Sprintf("Unsupported tlf type: %s", fl.tlfType))
 	}
 }


### PR DESCRIPTION
Otherwise, certain errors can cause a panic.

Found by @modalduality.