### PR TITLE
libkbfs: support subteam TLFs

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -248,7 +248,7 @@ func MakeLocalUsers(users []libkb.NormalizedUsername) []LocalUser {
 }
 
 // MakeLocalTeams is a helper function to generate a list of local
-// teams suitable to use with KBPKILocal.  Any subteams must came
+// teams suitable to use with KBPKILocal.  Any subteams must come
 // after their root team names in the `teams` slice.
 func MakeLocalTeams(teams []libkb.NormalizedUsername) []TeamInfo {
 	localTeams := make([]TeamInfo, len(teams))

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -58,6 +58,7 @@ type TeamInfo struct {
 	TID          keybase1.TeamID
 	CryptKeys    map[KeyGen]kbfscrypto.TLFCryptKey
 	LatestKeyGen KeyGen
+	RootID       keybase1.TeamID // for subteams only
 
 	Writers map[keybase1.UID]bool
 	Readers map[keybase1.UID]bool

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -736,7 +736,7 @@ func (fbo *folderBlockOps) DeepCopyFile(
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		return BlockPointer{}, nil, err
 	}
@@ -751,7 +751,7 @@ func (fbo *folderBlockOps) UndupChildrenInCopy(ctx context.Context,
 	fbo.blockLock.Lock(lState)
 	defer fbo.blockLock.Unlock(lState)
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		return nil, err
 	}
@@ -767,7 +767,7 @@ func (fbo *folderBlockOps) ReadyNonLeafBlocksInCopy(ctx context.Context,
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		return nil, err
 	}
@@ -1630,7 +1630,7 @@ func (fbo *folderBlockOps) fixChildBlocksAfterRecoverableErrorLocked(
 	}
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't find uid during recovery: %v", err)
 		return
@@ -1929,7 +1929,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 	}
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		return WriteRange{}, nil, 0, err
 	}
@@ -2085,7 +2085,7 @@ func (fbo *folderBlockOps) truncateExtendLocked(
 	}
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		return WriteRange{}, nil, err
 	}
@@ -2149,7 +2149,7 @@ func (fbo *folderBlockOps) truncateLocked(
 	}
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), kmd.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
 		return &WriteRange{}, nil, 0, err
 	}
@@ -2554,7 +2554,7 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 	}()
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), md.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), md.GetTlfHandle())
 	if err != nil {
 		return nil, nil, syncState, nil, err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1325,7 +1325,7 @@ func (fbo *folderBranchOps) maybeUnembedAndPutBlocks(ctx context.Context,
 	}
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), md.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), md.GetTlfHandle())
 	if err != nil {
 		return nil, err
 	}
@@ -1361,7 +1361,8 @@ func (fbo *folderBranchOps) maybeUnembedAndPutBlocks(ctx context.Context,
 func ResetRootBlock(ctx context.Context, config Config,
 	rmd *RootMetadata) (Block, BlockInfo, ReadyBlockData, error) {
 	newDblock := NewDirBlock()
-	chargedTo, err := chargedToForTLF(ctx, config.KBPKI(), rmd.GetTlfHandle())
+	chargedTo, err := chargedToForTLF(
+		ctx, config.KBPKI(), config.KBPKI(), rmd.GetTlfHandle())
 	if err != nil {
 		return nil, BlockInfo{}, ReadyBlockData{}, err
 	}
@@ -2624,7 +2625,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 	}
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fbo.config.KBPKI(), md.GetTlfHandle())
+		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), md.GetTlfHandle())
 	if err != nil {
 		return nil, DirEntry{}, err
 	}

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -977,7 +977,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 	updates = make(map[BlockPointer]BlockPointer)
 
 	chargedTo, err := chargedToForTLF(
-		ctx, fup.config.KBPKI(), md.GetTlfHandle())
+		ctx, fup.config.KBPKI(), fup.config.KBPKI(), md.GetTlfHandle())
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -548,6 +548,13 @@ type teamKeysGetter interface {
 		map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error)
 }
 
+type teamRootIDGetter interface {
+	// GetTeamRootID returns the root team ID for the given (sub)team
+	// ID.
+	GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
+		keybase1.TeamID, error)
+}
+
 // KBPKI interacts with the Keybase daemon to fetch user info.
 type KBPKI interface {
 	CurrentSessionGetter
@@ -557,6 +564,7 @@ type KBPKI interface {
 	merkleRootGetter
 	TeamMembershipChecker
 	teamKeysGetter
+	teamRootIDGetter
 
 	// HasVerifyingKey returns nil if the given user has the given
 	// VerifyingKey, and an error otherwise.

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -503,6 +503,14 @@ func (j *JournalServer) Enable(ctx context.Context, tlfID tlf.ID,
 		}
 
 		chargedTo = h.FirstResolvedWriter()
+		if tid := chargedTo.AsTeamOrBust(); tid.IsSubTeam() {
+			// We can't charge to subteams; find the root team.
+			rootID, err := j.config.KBPKI().GetTeamRootID(ctx, tid)
+			if err != nil {
+				return err
+			}
+			chargedTo = rootID.AsUserOrTeam()
+		}
 	}
 	tj, err := j.enableLocked(ctx, tlfID, chargedTo, bws, false)
 	if err != nil {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -271,6 +271,18 @@ func (k *KBPKIClient) IsTeamReader(
 	return teamInfo.Writers[uid] || teamInfo.Readers[uid], nil
 }
 
+// GetTeamRootID implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
+	keybase1.TeamID, error) {
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
+		ctx, tid, UnspecifiedKeyGen, keybase1.UserVersion{},
+		keybase1.TeamRole_NONE)
+	if err != nil {
+		return keybase1.TeamID(""), err
+	}
+	return teamInfo.RootID, nil
+}
+
 // FavoriteAdd implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {
 	return k.serviceOwner.KeybaseService().FavoriteAdd(ctx, folder)

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -274,6 +274,10 @@ func (k *KBPKIClient) IsTeamReader(
 // GetTeamRootID implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
 	keybase1.TeamID, error) {
+	if !tid.IsSubTeam() {
+		return tid, nil
+	}
+
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
 		ctx, tid, UnspecifiedKeyGen, keybase1.UserVersion{},
 		keybase1.TeamRole_NONE)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -567,6 +567,16 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	for _, user := range res.OnlyReaders {
 		info.Readers[user.Uid] = true
 	}
+
+	// For subteams, get the root team ID.
+	if tid.IsSubTeam() {
+		rootID, err := k.teamsClient.GetTeamRootID(ctx, tid)
+		if err != nil {
+			return TeamInfo{}, err
+		}
+		info.RootID = rootID
+	}
+
 	k.setCachedTeamInfo(tid, info)
 	return info, nil
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1756,6 +1756,42 @@ func (_mr *MockteamKeysGetterMockRecorder) GetTeamTLFCryptKeys(arg0, arg1, arg2 
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockteamKeysGetter)(nil).GetTeamTLFCryptKeys), arg0, arg1, arg2)
 }
 
+// MockteamRootIDGetter is a mock of teamRootIDGetter interface
+type MockteamRootIDGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockteamRootIDGetterMockRecorder
+}
+
+// MockteamRootIDGetterMockRecorder is the mock recorder for MockteamRootIDGetter
+type MockteamRootIDGetterMockRecorder struct {
+	mock *MockteamRootIDGetter
+}
+
+// NewMockteamRootIDGetter creates a new mock instance
+func NewMockteamRootIDGetter(ctrl *gomock.Controller) *MockteamRootIDGetter {
+	mock := &MockteamRootIDGetter{ctrl: ctrl}
+	mock.recorder = &MockteamRootIDGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (_m *MockteamRootIDGetter) EXPECT() *MockteamRootIDGetterMockRecorder {
+	return _m.recorder
+}
+
+// GetTeamRootID mocks base method
+func (_m *MockteamRootIDGetter) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (keybase1.TeamID, error) {
+	ret := _m.ctrl.Call(_m, "GetTeamRootID", ctx, tid)
+	ret0, _ := ret[0].(keybase1.TeamID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamRootID indicates an expected call of GetTeamRootID
+func (_mr *MockteamRootIDGetterMockRecorder) GetTeamRootID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "GetTeamRootID", reflect.TypeOf((*MockteamRootIDGetter)(nil).GetTeamRootID), arg0, arg1)
+}
+
 // MockKBPKI is a mock of KBPKI interface
 type MockKBPKI struct {
 	ctrl     *gomock.Controller
@@ -1884,6 +1920,19 @@ func (_m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamI
 // GetTeamTLFCryptKeys indicates an expected call of GetTeamTLFCryptKeys
 func (_mr *MockKBPKIMockRecorder) GetTeamTLFCryptKeys(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "GetTeamTLFCryptKeys", reflect.TypeOf((*MockKBPKI)(nil).GetTeamTLFCryptKeys), arg0, arg1, arg2)
+}
+
+// GetTeamRootID mocks base method
+func (_m *MockKBPKI) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (keybase1.TeamID, error) {
+	ret := _m.ctrl.Call(_m, "GetTeamRootID", ctx, tid)
+	ret0, _ := ret[0].(keybase1.TeamID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamRootID indicates an expected call of GetTeamRootID
+func (_mr *MockKBPKIMockRecorder) GetTeamRootID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "GetTeamRootID", reflect.TypeOf((*MockKBPKI)(nil).GetTeamRootID), arg0, arg1)
 }
 
 // HasVerifyingKey mocks base method

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -22,7 +22,8 @@ import (
 func TestNormalizeNamesInTLF(t *testing.T) {
 	writerNames := []string{"BB", "C@Twitter", "d@twitter", "aa"}
 	readerNames := []string{"EE", "ff", "AA@HackerNews", "aa", "BB", "bb", "ZZ@hackernews"}
-	s, changes, err := normalizeNamesInTLF(writerNames, readerNames, "")
+	s, changes, err := normalizeNamesInTLF(
+		writerNames, readerNames, tlf.Private, "")
 	require.NoError(t, err)
 	require.True(t, changes)
 	assert.Equal(t, "aa,bb,c@twitter,d@twitter#AA@hackernews,ZZ@hackernews,aa,bb,bb,ee,ff", s)
@@ -32,7 +33,8 @@ func TestNormalizeNamesInTLFWithConflict(t *testing.T) {
 	writerNames := []string{"BB", "C@Twitter", "d@twitter", "aa"}
 	readerNames := []string{"EE", "ff", "AA@HackerNews", "aa", "BB", "bb", "ZZ@hackernews"}
 	conflictSuffix := "(cOnflictED coPy 2015-05-11 #4)"
-	s, changes, err := normalizeNamesInTLF(writerNames, readerNames, conflictSuffix)
+	s, changes, err := normalizeNamesInTLF(
+		writerNames, readerNames, tlf.Private, conflictSuffix)
 	require.NoError(t, err)
 	require.True(t, changes)
 	assert.Equal(t, "aa,bb,c@twitter,d@twitter#AA@hackernews,ZZ@hackernews,aa,bb,bb,ee,ff (conflicted copy 2015-05-11 #4)", s)

--- a/test/teams_test.go
+++ b/test/teams_test.go
@@ -67,7 +67,7 @@ func TestTeamsTwoWritersJournal(t *testing.T) {
 		inSingleTeamTlf("ab"),
 		as(alice,
 			// The tests don't support enabling journaling on a
-			// non-existent TF, so force the TLF creation first.
+			// non-existent TLF, so force the TLF creation first.
 			mkfile("foo", "bar"),
 			rm("foo"),
 		),
@@ -117,6 +117,60 @@ func TestTeamsNameChange(t *testing.T) {
 		),
 		as(bob,
 			read("a", "hello"),
+			read("b", "world"),
+		),
+	)
+}
+
+func TestSubteamsTwoWriters(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		team("al", "alice", ""),
+		team("al.ab", "alice,bob", ""),
+		inSingleTeamTlf("al.ab"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}
+
+func TestSubteamsTwoWritersJournal(t *testing.T) {
+	test(t, journal(),
+		users("alice", "bob"),
+		team("al", "alice", ""),
+		team("al.ab", "alice,bob", ""),
+		inSingleTeamTlf("al.ab"),
+		as(alice,
+			// The tests don't support enabling journaling on a
+			// non-existent TLF, so force the TLF creation first.
+			mkfile("foo", "bar"),
+			rm("foo"),
+		),
+		as(alice,
+			enableJournal(),
+			mkfile("a", "hello"),
+		),
+		as(alice,
+			// Wait for the flush, after doing a SyncAll().
+			flushJournal(),
+		),
+		as(bob,
+			enableJournal(),
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(bob,
+			// Wait for the flush, after doing a SyncAll().
+			flushJournal(),
+		),
+		as(alice,
 			read("b", "world"),
 		),
 	)


### PR DESCRIPTION
* The `chargedTo` of a subteam TLF is the subteam's root team ID
* When using libkb to parse subteam names, they must be prefixed with "team:", otherwise the parser gets confused since usernames can't have dots in them.
