### PR TITLE
folder_block_ops: don't list .kbfs_git entry, and don't allow renames to prefixes

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1327,6 +1327,10 @@ func (fbo *folderBlockOps) GetDirtyDir(
 	return fbo.getDirtyDirLocked(ctx, lState, kmd, dir, rtype)
 }
 
+var hiddenEntries = map[string]bool{
+	".kbfs_git": true,
+}
+
 // GetDirtyDirChildren returns a map of EntryInfos for the (possibly
 // dirty) children entries of the given directory.
 func (fbo *folderBlockOps) GetDirtyDirChildren(
@@ -1343,6 +1347,10 @@ func (fbo *folderBlockOps) GetDirtyDirChildren(
 
 	children := make(map[string]EntryInfo)
 	for k, de := range dblock.Children {
+		if hiddenEntries[k] {
+			fbo.log.CDebugf(ctx, "Hiding entry %s", k)
+			continue
+		}
 		children[k] = de.EntryInfo
 	}
 	return children, nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3314,6 +3314,10 @@ func (fbo *folderBranchOps) renameLocked(
 		return err
 	}
 
+	if err := checkDisallowedPrefixes(newName); err != nil {
+		return err
+	}
+
 	oldParentPath, err := fbo.pathFromNodeForMDWriteLocked(lState, oldParent)
 	if err != nil {
 		return err


### PR DESCRIPTION
The rename fix is a long-existing bug I just noticed.

Issue: KBFS-2340