### PR TITLE
libkbfs: use field in `ImmutableRootMetadata` to track whether an MD has been put

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -97,7 +97,7 @@ func crMakeFakeRMD(rev kbfsmd.Revision, bid BranchID) ImmutableRootMetadata {
 			PrevRoot: kbfsmd.FakeID(byte(rev - 1)),
 		},
 		tlfHandle: &TlfHandle{name: "fake"},
-	}, key, kbfsmd.FakeID(byte(rev)), time.Now())
+	}, key, kbfsmd.FakeID(byte(rev)), time.Now(), true)
 }
 
 func TestCRInput(t *testing.T) {

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -982,6 +982,10 @@ func (fbm *folderBlockManager) isQRNecessary(
 		fbm.log.CWarningf(ctx, "Couldn't get the current session: %+v", err)
 		return false
 	}
+	// It's ok to treat both MDs written by this process on this
+	// device, and MDs written by other processes (e.g., kbgit) in the
+	// same way.  Other processes are likely to be short-lived, and
+	// probably won't do their own QR, so a conflict is unlikely here.
 	selfWroteHead := session.VerifyingKey == head.LastModifyingWriterVerifyingKey()
 
 	// Don't do reclamation if the head isn't old enough and it wasn't

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2209,7 +2209,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 				return err
 			}
 			irmd = MakeImmutableRootMetadata(
-				md, session.VerifyingKey, mdID, fbo.config.Clock().Now())
+				md, session.VerifyingKey, mdID, fbo.config.Clock().Now(), true)
 			err = fbo.config.MDCache().Put(irmd)
 			if err != nil {
 				return err
@@ -6165,7 +6165,7 @@ func (fbo *folderBranchOps) TeamNameChanged(
 		oldHandle.GetCanonicalName(), newHandle.GetCanonicalName())
 	fbo.head = MakeImmutableRootMetadata(
 		newHead, fbo.head.lastWriterVerifyingKey, fbo.head.mdID,
-		fbo.head.localTimestamp)
+		fbo.head.localTimestamp, fbo.head.putToServer)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Error setting head: %+v", err)
 		return

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -130,7 +130,7 @@ func TestFBStatusAllFields(t *testing.T) {
 
 	fbsk.setRootMetadata(
 		MakeImmutableRootMetadata(rmd, signingKey.GetVerifyingKey(),
-			kbfsmd.FakeID(1), time.Now()))
+			kbfsmd.FakeID(1), time.Now(), true))
 	fbsk.addDirtyNode(n1)
 	fbsk.addDirtyNode(n2)
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -748,6 +748,9 @@ type MDCache interface {
 	// that's already in the cache.  This should be used when putting
 	// new MDs created locally.
 	Replace(newRmd ImmutableRootMetadata, oldBID BranchID) error
+	// MarkPutToServer sets `PutToServer` to true for the specified
+	// MD, if it already exists in the cache.
+	MarkPutToServer(tlf tlf.ID, rev kbfsmd.Revision, bid BranchID)
 }
 
 // KeyCache handles caching for both TLFCryptKeys and BlockCryptKeys.

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -42,7 +42,8 @@ type journalMDOps struct {
 var _ MDOps = journalMDOps{}
 
 // convertImmutableBareRMDToIRMD decrypts the bare MD into a
-// full-fledged RMD.
+// full-fledged RMD.  The MD is assumed to have been read from the
+// journal.
 func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	ibrmd ImmutableBareRootMetadata, handle *TlfHandle,
 	uid keybase1.UID, key kbfscrypto.VerifyingKey) (
@@ -66,7 +67,7 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 
 	rmd.data = pmd
 	irmd := MakeImmutableRootMetadata(
-		rmd, key, ibrmd.mdID, ibrmd.localTimestamp)
+		rmd, key, ibrmd.mdID, ibrmd.localTimestamp, false)
 	return irmd, nil
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -330,7 +330,8 @@ func makeImmutableRMDForTest(t *testing.T, config Config, rmd *RootMetadata,
 			VerifyingKey: session.VerifyingKey,
 		}
 	}
-	return MakeImmutableRootMetadata(rmd, session.VerifyingKey, mdID, time.Now())
+	return MakeImmutableRootMetadata(
+		rmd, session.VerifyingKey, mdID, time.Now(), true)
 }
 
 // injectNewRMD creates a new RMD and makes sure the existing ops for

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -766,7 +766,7 @@ func (j *mdJournal) convertToBranch(
 			err = mdcache.Replace(
 				MakeImmutableRootMetadata(newRmd,
 					oldIrmd.LastModifyingWriterVerifyingKey(),
-					newID, ts),
+					newID, ts, false),
 				NullBranchID)
 			if err != nil {
 				return err

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -631,7 +631,7 @@ func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
 	cachedMdID, _, _, _, err := j.getEarliestWithExtra(ctx, false)
 	require.NoError(t, err)
 	err = mdcache.Put(MakeImmutableRootMetadata(cachedMd,
-		j.key, cachedMdID, time.Now()))
+		j.key, cachedMdID, time.Now(), false))
 	require.NoError(t, err)
 
 	bid := PendingLocalSquashBranchID

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -293,7 +293,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 
 	key := rmds.GetWriterMetadataSigInfo().VerifyingKey
 	*rmds = RootMetadataSigned{}
-	irmd := MakeImmutableRootMetadata(rmd, key, mdID, localTimestamp)
+	irmd := MakeImmutableRootMetadata(rmd, key, mdID, localTimestamp, true)
 
 	// Revisions created locally should always override anything else
 	// in the cache.
@@ -620,7 +620,7 @@ func (md *MDOpsStandard) put(
 	}
 
 	irmd := MakeImmutableRootMetadata(
-		rmd, verifyingKey, mdID, md.config.Clock().Now())
+		rmd, verifyingKey, mdID, md.config.Clock().Now(), true)
 	// Revisions created locally should always override anything else
 	// in the cache.
 	err = md.config.MDCache().Replace(irmd, irmd.BID())

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -258,7 +258,7 @@ func getMergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 			// rewrite.
 			irmdCopy := MakeImmutableRootMetadata(rmdCopy,
 				rmd.LastModifyingWriterVerifyingKey(), rmd.MdID(),
-				rmd.LocalTimestamp())
+				rmd.LocalTimestamp(), rmd.putToServer)
 			if err := config.MDCache().Put(irmdCopy); err != nil {
 				return nil, err
 			}

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -92,3 +92,22 @@ func (md *MDCacheStandard) Replace(newRmd ImmutableRootMetadata,
 	md.lru.Add(newKey, newRmd)
 	return nil
 }
+
+// MarkPutToServer implements the MDCache interface for
+// MDCacheStandard.
+func (md *MDCacheStandard) MarkPutToServer(
+	tlf tlf.ID, rev kbfsmd.Revision, bid BranchID) {
+	md.lock.Lock()
+	defer md.lock.Unlock()
+	key := mdCacheKey{tlf, rev, bid}
+	tmp, ok := md.lru.Get(key)
+	if !ok {
+		return
+	}
+	rmd, ok := tmp.(ImmutableRootMetadata)
+	if !ok {
+		return
+	}
+	rmd.putToServer = true
+	md.lru.Add(key, rmd)
+}

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -52,7 +52,7 @@ func testMdcachePut(t *testing.T, tlfID tlf.ID, rev kbfsmd.Revision,
 
 	// put the md
 	irmd := MakeImmutableRootMetadata(
-		rmd, signingKey.GetVerifyingKey(), kbfsmd.FakeID(1), time.Now())
+		rmd, signingKey.GetVerifyingKey(), kbfsmd.FakeID(1), time.Now(), true)
 	if err := mdcache.Put(irmd); err != nil {
 		t.Errorf("Got error on put on md %v: %v", tlfID, err)
 	}
@@ -109,7 +109,8 @@ func TestMdcacheReplace(t *testing.T) {
 
 	newRmd.SetBranchID(bid)
 	err = mdcache.Replace(MakeImmutableRootMetadata(newRmd,
-		irmd.LastModifyingWriterVerifyingKey(), kbfsmd.FakeID(2), time.Now()), NullBranchID)
+		irmd.LastModifyingWriterVerifyingKey(), kbfsmd.FakeID(2), time.Now(),
+		true), NullBranchID)
 	require.NoError(t, err)
 
 	_, err = mdcache.Get(id, 1, NullBranchID)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2442,6 +2442,16 @@ func (_mr *MockMDCacheMockRecorder) Replace(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "Replace", reflect.TypeOf((*MockMDCache)(nil).Replace), arg0, arg1)
 }
 
+// MarkPutToServer mocks base method
+func (_m *MockMDCache) MarkPutToServer(tlf tlf.ID, rev kbfsmd.Revision, bid BranchID) {
+	_m.ctrl.Call(_m, "MarkPutToServer", tlf, rev, bid)
+}
+
+// MarkPutToServer indicates an expected call of MarkPutToServer
+func (_mr *MockMDCacheMockRecorder) MarkPutToServer(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCallWithMethodType(_mr.mock, "MarkPutToServer", reflect.TypeOf((*MockMDCache)(nil).MarkPutToServer), arg0, arg1, arg2)
+}
+
 // MockKeyCache is a mock of KeyCache interface
 type MockKeyCache struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -955,13 +955,18 @@ type ImmutableRootMetadata struct {
 	// persists in the journal or in the cache, localTimestamp comes
 	// directly from the local clock.
 	localTimestamp time.Time
+	// putToServer indicates whether this MD has been put successfully
+	// to the remote server (e.g., it isn't just local to the
+	// process's journal).
+	putToServer bool
 }
 
 // MakeImmutableRootMetadata makes a new ImmutableRootMetadata from
 // the given RMD and its corresponding MdID.
 func MakeImmutableRootMetadata(
 	rmd *RootMetadata, writerVerifyingKey kbfscrypto.VerifyingKey,
-	mdID kbfsmd.ID, localTimestamp time.Time) ImmutableRootMetadata {
+	mdID kbfsmd.ID, localTimestamp time.Time,
+	putToServer bool) ImmutableRootMetadata {
 	if writerVerifyingKey == (kbfscrypto.VerifyingKey{}) {
 		panic("zero writerVerifyingKey passed to MakeImmutableRootMetadata")
 	}
@@ -982,7 +987,7 @@ func MakeImmutableRootMetadata(
 		}
 	}
 	return ImmutableRootMetadata{
-		rmd.ReadOnly(), mdID, writerVerifyingKey, localTimestamp}
+		rmd.ReadOnly(), mdID, writerVerifyingKey, localTimestamp, putToServer}
 }
 
 // MdID returns the pre-computed MdID of the contained RootMetadata

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -2043,7 +2043,7 @@ func (j *tlfJournal) doPutMD(ctx context.Context, rmd *RootMetadata,
 	// converted into a branch before any of the upper layer have a
 	// chance to cache it.
 	irmd = MakeImmutableRootMetadata(
-		rmd, verifyingKey, mdID, j.config.Clock().Now())
+		rmd, verifyingKey, mdID, j.config.Clock().Now(), false)
 	// Revisions created locally should always override anything else
 	// in the cache, so use `Replace` rather than `Put`.
 	err = j.config.MDCache().Replace(irmd, irmd.BID())
@@ -2199,7 +2199,7 @@ func (j *tlfJournal) doResolveBranch(ctx context.Context,
 	// override anything else in the cache, so use `Replace` rather
 	// than `Put`.
 	irmd = MakeImmutableRootMetadata(
-		rmd, verifyingKey, mdID, j.config.Clock().Now())
+		rmd, verifyingKey, mdID, j.config.Clock().Now(), false)
 	err = j.config.MDCache().Replace(irmd, irmd.BID())
 	if err != nil {
 		return ImmutableRootMetadata{}, false, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1379,6 +1379,9 @@ func (j *tlfJournal) flushOneMDOp(
 		return false, pushErr
 	}
 
+	j.config.MDCache().MarkPutToServer(
+		rmds.MD.TlfID(), rmds.MD.RevisionNumber(), rmds.MD.BID())
+
 	err = j.doOnMDFlushAndRemoveFlushedMDEntry(ctx, mdID, rmds)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Previously, we were relying on the last writer's device key, and whether or not journaling was enabled, to decide whether an MD had been fully merged to the server.  But once we have multiple processes writing to the same TLF, using the verifying key will no longer be an effective way to decide whether the MD has been merged to the server or not.

Instead, keep track of this status in a local field in each `ImmutableRootMetadata`, which can be set to `false` for MDs written to or read from the journal, and switched to `true` once the MD is successfully put to the server.

Issue: KBFS-2341



