### PR TITLE
libkbfs: add a new "single op" init mode

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -806,6 +806,11 @@ const (
 	// InitMinimal is for when KBFS will only be used as a MD lookup
 	// layer (e.g., for chat on mobile).
 	InitMinimal
+	// InitSingleOp is a mode for when KBFS is only needed for a
+	// single logical operation; no rekeys or update subscriptions is
+	// needed, and some naming restrictions are lifted (e.g., `.kbfs_`
+	// filenames are allowed).
+	InitSingleOp
 )
 
 func (im InitMode) String() string {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -788,7 +788,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 
 	// Make sure that any unembedded block changes have been swapped
 	// back in.
-	if fbo.config.Mode() == InitDefault &&
+	if fbo.config.Mode() != InitMinimal &&
 		md.data.Changes.Info.BlockPointer != zeroPtr &&
 		len(md.data.Changes.Ops) == 0 {
 		return errors.New("Must swap in block changes before setting head")

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -803,7 +803,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 		// Start registering for updates right away, using this MD
 		// as a starting point. For now only the master branch can
 		// get updates
-		if fbo.branch() == MasterBranch {
+		if fbo.branch() == MasterBranch && fbo.config.Mode() != InitSingleOp {
 			fbo.updateDoneChan = make(chan struct{})
 			go fbo.registerAndWaitForUpdates()
 		}
@@ -2446,7 +2446,12 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 	return fbo.notifyBatchLocked(ctx, lState, irmd)
 }
 
-func checkDisallowedPrefixes(name string) error {
+func checkDisallowedPrefixes(name string, mode InitMode) error {
+	if mode == InitSingleOp {
+		// Allow specialized, single-op KBFS programs (like the kbgit
+		// remote helper) to bypass the disallowed prefix check.
+		return nil
+	}
 	for _, prefix := range disallowedPrefixes {
 		if strings.HasPrefix(name, prefix) {
 			return DisallowedPrefixError{name, prefix}
@@ -2551,7 +2556,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 	entryType EntryType, excl Excl) (childNode Node, de DirEntry, err error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	if err := checkDisallowedPrefixes(name); err != nil {
+	if err := checkDisallowedPrefixes(name, fbo.config.Mode()); err != nil {
 		return nil, DirEntry{}, err
 	}
 
@@ -2988,7 +2993,7 @@ func (fbo *folderBranchOps) createLinkLocked(
 	toPath string) (DirEntry, error) {
 	fbo.mdWriterLock.AssertLocked(lState)
 
-	if err := checkDisallowedPrefixes(fromName); err != nil {
+	if err := checkDisallowedPrefixes(fromName, fbo.config.Mode()); err != nil {
 		return DirEntry{}, err
 	}
 
@@ -3314,7 +3319,7 @@ func (fbo *folderBranchOps) renameLocked(
 		return err
 	}
 
-	if err := checkDisallowedPrefixes(newName); err != nil {
+	if err := checkDisallowedPrefixes(newName, fbo.config.Mode()); err != nil {
 		return err
 	}
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -27,6 +27,9 @@ const (
 	// InitMinimalString is for when KBFS will only be used as a MD
 	// lookup layer (e.g., for chat on mobile).
 	InitMinimalString = "minimal"
+	// InitSingleOpString is for when KBFS will only be used for a
+	// single logical operation (e.g., as a git remote helper).
+	InitSingleOpString = "singleOp"
 )
 
 // InitParams contains the initialization parameters for Init(). It is
@@ -244,8 +247,8 @@ func AddFlags(flags *flag.FlagSet, ctx Context) *InitParams {
 		"Metadata version to use when creating new metadata")
 	flags.StringVar(&params.Mode, "mode", InitDefaultString,
 		fmt.Sprintf("Overall initialization mode for KBFS, indicating how "+
-			"heavy-weight it can be (%s or %s)", InitDefaultString,
-			InitMinimalString))
+			"heavy-weight it can be (%s, %s or %s)", InitDefaultString,
+			InitMinimalString, InitSingleOpString))
 
 	return &params
 }
@@ -486,6 +489,9 @@ func doInit(ctx Context, params InitParams, keybaseServiceCn KeybaseServiceCn,
 	case InitMinimalString:
 		log.Debug("Initializing in minimal mode")
 		mode = InitMinimal
+	case InitSingleOpString:
+		log.Debug("Initializing in singleOp mode")
+		mode = InitSingleOp
 	default:
 		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -419,11 +419,11 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 		return nil
 	}
 
-	if mode != InitDefault {
+	if mode == InitMinimal {
 		// Leave the block changes unembedded -- they aren't needed in
-		// non-default mode since there's no node cache, and thus
-		// there are no Nodes that needs to be updated due to
-		// BlockChange pointers in those blocks.
+		// minimal mode since there's no node cache, and thus there
+		// are no Nodes that needs to be updated due to BlockChange
+		// pointers in those blocks.
 		log.CDebugf(ctx, "Skipping block change reembedding in mode: %s", mode)
 		return nil
 	}

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -176,11 +176,11 @@ func NewTlfEditHistory(config Config, fbo *folderBranchOps,
 		rmdsChan: make(chan []ImmutableRootMetadata, 100),
 		cancel:   cancel,
 	}
-	if config.Mode() == InitMinimal {
-		// No need to process updates in minimal mode. TODO: avoid
-		// rmdsChan memory overhead?
-	} else {
+	if config.Mode() == InitDefault {
 		go teh.process(processCtx)
+	} else {
+		// No need to process updates in non-default mode. TODO: avoid
+		// rmdsChan memory overhead?
 	}
 	return teh
 }
@@ -638,8 +638,8 @@ func (teh *TlfEditHistory) process(ctx context.Context) {
 // ImmutableRootMetadata in rmds is the current head.
 func (teh *TlfEditHistory) UpdateHistory(ctx context.Context,
 	rmds []ImmutableRootMetadata) error {
-	if teh.config.Mode() == InitMinimal {
-		// Minimal mode doesn't have a processor.
+	if teh.config.Mode() != InitDefault {
+		// Non-default mode doesn't have a processor.
 		return nil
 	}
 


### PR DESCRIPTION
This mode is to be used by standalone KBFS programs, like the upcoming git remote helper, that don't need to keep a TLF update to date or rekey anything.

"single op" mode differs from default mode by:
* Not subscribing to folder updates.
* Not checking for rekeys.
* Not suppressing prefixes that are normally disallowed, on the assumption that the names will be controlled by the program implementing the single operation.

Issue: KBFS-2342