### PR TITLE
[KBFS-2364] Track whether prefetches are done for a block

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -70,7 +70,8 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 
 	b.log.LazyTrace(ctx, "BOps: Requesting %s", blockPtr.ID)
 
-	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd, blockPtr, block, lifetime)
+	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd,
+		blockPtr, block, lifetime)
 	err := <-errCh
 
 	b.log.LazyTrace(ctx, "BOps: Request fulfilled for %s (err=%v)", blockPtr.ID, err)

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -248,7 +248,7 @@ func (brq *blockRetrievalQueue) triggerAndMonitorPrefetch(ctx context.Context,
 	dbc := brq.config.DiskBlockCache()
 	if dbc != nil {
 		prefetchStatus := FinishedPrefetch
-		err := dbc.UpdateMetadata(ctx, ptr.ID, &prefetchStatus)
+		err := dbc.UpdateMetadata(ctx, ptr.ID, prefetchStatus)
 		if err != nil {
 			brq.log.CWarningf(ctx, "Error updating metadata after "+
 				"prefetch: %+v", err)
@@ -286,7 +286,7 @@ func (brq *blockRetrievalQueue) CacheAndPrefetch(ctx context.Context,
 		if dbc != nil {
 			go func() {
 				// Leave FinishedPrefetch unchanged at this point.
-				err := dbc.UpdateMetadata(ctx, ptr.ID, &prefetchStatus)
+				err := dbc.UpdateMetadata(ctx, ptr.ID, prefetchStatus)
 				close(didUpdateCh)
 				switch err.(type) {
 				case nil:
@@ -374,7 +374,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	if dbc == nil {
 		return NoSuchBlockError{ptr.ID}
 	}
-	blockBuf, serverHalf, triggeredPrefetch, err := dbc.Get(ctx, kmd.TlfID(),
+	blockBuf, serverHalf, prefetchStatus, err := dbc.Get(ctx, kmd.TlfID(),
 		ptr.ID)
 	if err != nil {
 		return err
@@ -391,7 +391,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	}
 
 	return brq.CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime,
-		triggeredPrefetch, prefetchDoneCh, prefetchErrCh)
+		prefetchStatus, prefetchDoneCh, prefetchErrCh)
 }
 
 // RequestWithPrefetch implements the BlockRetriever interface for

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -658,7 +658,7 @@ func (cache *DiskBlockCacheStandard) GetMetadata(ctx context.Context,
 // UpdateMetadata implements the DiskBlockCache interface for
 // DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID, prefetchStatus *PrefetchStatus) (err error) {
+	blockID kbfsblock.ID, prefetchStatus PrefetchStatus) (err error) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	err = cache.checkCacheLocked("UpdateMetadata")
@@ -675,16 +675,14 @@ func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
 	if err != nil {
 		return NoSuchBlockError{blockID}
 	}
-	if prefetchStatus != nil {
-		md.TriggeredPrefetch = false
-		md.FinishedPrefetch = false
-		switch *prefetchStatus {
-		case TriggeredPrefetch:
-			md.TriggeredPrefetch = true
-		case FinishedPrefetch:
-			md.TriggeredPrefetch = true
-			md.FinishedPrefetch = true
-		}
+	md.TriggeredPrefetch = false
+	md.FinishedPrefetch = false
+	switch prefetchStatus {
+	case TriggeredPrefetch:
+		md.TriggeredPrefetch = true
+	case FinishedPrefetch:
+		md.TriggeredPrefetch = true
+		md.FinishedPrefetch = true
 	}
 	return cache.updateMetadataLocked(ctx, blockID.Bytes(), md)
 }

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -393,15 +393,8 @@ func (*DiskBlockCacheStandard) tlfKey(tlfID tlf.ID, blockKey []byte) []byte {
 // updateMetadataLocked updates the LRU time of a block in the LRU cache to
 // the current time.
 func (cache *DiskBlockCacheStandard) updateMetadataLocked(ctx context.Context,
-	tlfID tlf.ID, blockKey []byte, encodeLen int, triggeredPrefetch,
-	finishedPrefetch bool) error {
-	metadata := DiskBlockCacheMetadata{
-		TlfID:             tlfID,
-		LRUTime:           cache.config.Clock().Now(),
-		BlockSize:         uint32(encodeLen),
-		TriggeredPrefetch: triggeredPrefetch,
-		FinishedPrefetch:  finishedPrefetch,
-	}
+	blockKey []byte, metadata DiskBlockCacheMetadata) error {
+	metadata.LRUTime = cache.config.Clock().Now()
 	encodedMetadata, err := cache.config.Codec().Encode(&metadata)
 	if err != nil {
 		return err
@@ -476,7 +469,7 @@ func (cache *DiskBlockCacheStandard) checkCacheLocked(method string) error {
 	default:
 	}
 	if cache.blockDb == nil {
-		return errors.WithStack(DiskCacheClosedError{"Get"})
+		return errors.WithStack(DiskCacheClosedError{method})
 	}
 	return nil
 }
@@ -512,8 +505,7 @@ func (cache *DiskBlockCacheStandard) Get(ctx context.Context, tlfID tlf.ID,
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, false, err
 	}
-	err = cache.updateMetadataLocked(ctx, tlfID, blockKey, len(entry),
-		md.TriggeredPrefetch, md.FinishedPrefetch)
+	err = cache.updateMetadataLocked(ctx, blockKey, md)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, false, err
 	}
@@ -641,9 +633,11 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 		}
 	}
 	// Initially set TriggeredPrefetch and FinishedPrefetch to false; rely on
-	// UpdateMetadata to fix it.
-	return cache.updateMetadataLocked(ctx, tlfID, blockKey, int(encodedLen),
-		false, false)
+	// the later-called UpdateMetadata to fix it.
+	return cache.updateMetadataLocked(ctx, blockKey, DiskBlockCacheMetadata{
+		TlfID:     tlfID,
+		BlockSize: uint32(encodedLen),
+	})
 }
 
 // GetMetadata implements the DiskBlockCache interface for
@@ -658,7 +652,7 @@ func (cache *DiskBlockCacheStandard) GetMetadata(ctx context.Context,
 // UpdateMetadata implements the DiskBlockCache interface for
 // DiskBlockCacheStandard.
 func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch bool) (err error) {
+	blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch *bool) (err error) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
 	err = cache.checkCacheLocked("UpdateMetadata")
@@ -675,8 +669,13 @@ func (cache *DiskBlockCacheStandard) UpdateMetadata(ctx context.Context,
 	if err != nil {
 		return NoSuchBlockError{blockID}
 	}
-	return cache.updateMetadataLocked(ctx, md.TlfID, blockID.Bytes(),
-		int(md.BlockSize), triggeredPrefetch, finishedPrefetch)
+	if triggeredPrefetch != nil {
+		md.TriggeredPrefetch = *triggeredPrefetch
+	}
+	if finishedPrefetch != nil {
+		md.FinishedPrefetch = *finishedPrefetch
+	}
+	return cache.updateMetadataLocked(ctx, blockID.Bytes(), md)
 }
 
 // Size implements the DiskBlockCache interface for DiskBlockCacheStandard.

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -158,7 +158,7 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 // UpdateMetadata implements the DiskBlockCache interface for
 // diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID, prefetchStatus *PrefetchStatus) error {
+	blockID kbfsblock.ID, prefetchStatus PrefetchStatus) error {
 	// This is a write operation but we are only reading the pointers to the
 	// caches. So we use a read lock.
 	cache.mtx.RLock()

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -157,7 +157,7 @@ func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
 // UpdateMetadata implements the DiskBlockCache interface for
 // diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) UpdateMetadata(ctx context.Context,
-	blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch bool) error {
+	blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch *bool) error {
 	// This is a write operation but we are only reading the pointers to the
 	// caches. So we use a read lock.
 	cache.mtx.RLock()

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -371,14 +371,14 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		return block, nil
 	}
 
-	if block, triggeredPrefetch, lifetime, err :=
+	if block, prefetchStatus, lifetime, err :=
 		fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
 		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(ctx,
 			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
-			triggeredPrefetch, nil, nil)
+			prefetchStatus, nil, nil)
 		return block, nil
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -378,7 +378,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// correctly according to the new on-demand fetch priority.
 		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(ctx,
 			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
-			triggeredPrefetch)
+			triggeredPrefetch, nil, nil)
 		return block, nil
 	}
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -955,10 +955,8 @@ type DiskBlockCache interface {
 	Delete(ctx context.Context, blockIDs []kbfsblock.ID) (numRemoved int,
 		sizeRemoved int64, err error)
 	// UpdateMetadata updates metadata for a given block in the disk cache.
-	// A `nil` `prefetchStatus` indicates that it should be left unchanged in
-	// the cache (defaulting to `false` if the metadata doesn't exist yet).
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
-		prefetchStatus *PrefetchStatus) error
+		prefetchStatus PrefetchStatus) error
 	// GetMetadata gets metadata for a given block in the disk cache without
 	// changing it.
 	GetMetadata(ctx context.Context, blockID kbfsblock.ID) (

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2247,5 +2247,5 @@ type BlockRetriever interface {
 	// triggers prefetches as appropriate.
 	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		triggeredPrefetch bool) error
+		triggeredPrefetch bool) <-chan error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2247,5 +2247,6 @@ type BlockRetriever interface {
 	// triggers prefetches as appropriate.
 	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		triggeredPrefetch bool) <-chan error
+		triggeredPrefetch bool,
+		prefetchDoneCh, prefetchErrCh chan<- struct{}) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2237,10 +2237,12 @@ type RekeyFSM interface {
 type BlockRetriever interface {
 	// Request retrieves blocks asynchronously.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
-		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
+		prefetchDoneCh, prefetchErrCh chan<- struct{}) <-chan error
 	// CacheAndPrefetch caches a block along with its prefetch status, and then
 	// triggers prefetches as appropriate.
 	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		triggeredPrefetch bool) error
+		triggeredPrefetch bool,
+		prefetchDoneCh, prefetchErrCh chan<- struct{}) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1205,20 +1205,23 @@ type KeyOps interface {
 type Prefetcher interface {
 	// PrefetchBlock directs the prefetcher to prefetch a block.
 	PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata,
-		priority int) error
+		priority int) (doneCh, errCh <-chan struct{}, err error)
 	// PrefetchAfterBlockRetrieved allows the prefetcher to trigger prefetches
 	// after a block has been retrieved. Whichever component is responsible for
 	// retrieving blocks will call this method once it's done retrieving a
 	// block. Returns a channel that is closed once the all the underlying
 	// prefetches are complete.
 	PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer,
-		kmd KeyMetadata) <-chan struct{}
+		kmd KeyMetadata) (doneCh, errCh <-chan struct{}, numBlocks int)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are
 	// complete. This feature is mainly used for testing, but also to toggle
 	// the prefetcher on and off.
 	Shutdown() <-chan struct{}
+	// ShutdownCh returns a channel that is closed if and when the prefetcher
+	// is shut down.
+	ShutdownCh() <-chan struct{}
 }
 
 // BlockOps gets and puts data blocks to a BlockServer. It performs

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -942,6 +942,9 @@ type DiskBlockCache interface {
 	Delete(ctx context.Context, blockIDs []kbfsblock.ID) (numRemoved int,
 		sizeRemoved int64, err error)
 	// UpdateMetadata updates metadata for a given block in the disk cache.
+	// A `nil` `triggeredPrefetch` or `finishedPrefetch` indicates that they
+	// should remain as they are right now (defaulting to `false` if the
+	// metadata doesn't exist yet).
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
 		triggeredPrefetch, finishedPrefetch *bool) error
 	// GetMetadata gets metadata for a given block in the disk cache without
@@ -2245,6 +2248,10 @@ type BlockRetriever interface {
 		prefetchDoneCh, prefetchErrCh chan<- struct{}) <-chan error
 	// CacheAndPrefetch caches a block along with its prefetch status, and then
 	// triggers prefetches as appropriate.
+	// `prefetchDoneCh` and `prefetchErrCh` can be nil so the caller doesn't always
+	// have to instantiate a channel if it doesn't care about waiting for the
+	// prefetch to complete. In that case, the `blockRetrievalQueue` instantiates
+	// each channel to monitor the prefetches.
 	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
 		triggeredPrefetch bool,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -943,7 +943,7 @@ type DiskBlockCache interface {
 		sizeRemoved int64, err error)
 	// UpdateMetadata updates metadata for a given block in the disk cache.
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
-		triggeredPrefetch, finishedPrefetch bool) error
+		triggeredPrefetch, finishedPrefetch *bool) error
 	// GetMetadata gets metadata for a given block in the disk cache without
 	// changing it.
 	GetMetadata(ctx context.Context, blockID kbfsblock.ID) (
@@ -2237,12 +2237,15 @@ type RekeyFSM interface {
 type BlockRetriever interface {
 	// Request retrieves blocks asynchronously.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
+		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+	// RequestWithPrefetch retrieves blocks asynchronously and accepts channels
+	// to notify when child blocks are done prefetching.
+	RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
 		prefetchDoneCh, prefetchErrCh chan<- struct{}) <-chan error
 	// CacheAndPrefetch caches a block along with its prefetch status, and then
 	// triggers prefetches as appropriate.
 	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		triggeredPrefetch bool,
-		prefetchDoneCh, prefetchErrCh chan<- struct{}) error
+		triggeredPrefetch bool) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2255,15 +2255,15 @@ type BlockRetriever interface {
 	// to notify when child blocks are done prefetching.
 	RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
-		prefetchDoneCh, prefetchErrCh chan<- struct{}) <-chan error
+		deepPrefetchDoneCh, deepPrefetchCancelCh chan<- struct{}) <-chan error
 	// CacheAndPrefetch caches a block along with its prefetch status, and then
 	// triggers prefetches as appropriate.
-	// `prefetchDoneCh` and `prefetchErrCh` can be nil so the caller doesn't always
+	// `deepPrefetchDoneCh` and `deepPrefetchCancelCh` can be nil so the caller doesn't always
 	// have to instantiate a channel if it doesn't care about waiting for the
 	// prefetch to complete. In that case, the `blockRetrievalQueue` instantiates
 	// each channel to monitor the prefetches.
 	CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
 		prefetchStatus PrefetchStatus,
-		prefetchDoneCh, prefetchErrCh chan<- struct{}) error
+		deepPrefetchDoneCh, deepPrefetchCancelCh chan<- struct{}) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1222,8 +1222,14 @@ type Prefetcher interface {
 	// PrefetchAfterBlockRetrieved allows the prefetcher to trigger prefetches
 	// after a block has been retrieved. Whichever component is responsible for
 	// retrieving blocks will call this method once it's done retrieving a
-	// block. Returns a channel that is closed once the all the underlying
-	// prefetches are complete.
+	// block.
+	// `doneCh` is a semaphore with a `numBlocks` count. Once we've read from
+	// it `numBlocks` times, the whole underlying block tree has been
+	// prefetched.
+	// `errCh` can be read up to `numBlocks` times, but any writes to it mean
+	// that the deep prefetch won't complete. So even a single read from
+	// `errCh` by a caller can be used to communicate failure of the deep
+	// prefetch to its parent.
 	PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer,
 		kmd KeyMetadata) (doneCh, errCh <-chan struct{}, numBlocks int)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2743,10 +2743,10 @@ func (mr *MockBlockCacheMockRecorder) DeleteKnownPtr(tlf, block interface{}) *go
 }
 
 // GetWithPrefetch mocks base method
-func (m *MockBlockCache) GetWithPrefetch(ptr BlockPointer) (Block, bool, BlockCacheLifetime, error) {
+func (m *MockBlockCache) GetWithPrefetch(ptr BlockPointer) (Block, PrefetchStatus, BlockCacheLifetime, error) {
 	ret := m.ctrl.Call(m, "GetWithPrefetch", ptr)
 	ret0, _ := ret[0].(Block)
-	ret1, _ := ret[1].(bool)
+	ret1, _ := ret[1].(PrefetchStatus)
 	ret2, _ := ret[2].(BlockCacheLifetime)
 	ret3, _ := ret[3].(error)
 	return ret0, ret1, ret2, ret3
@@ -2758,15 +2758,15 @@ func (mr *MockBlockCacheMockRecorder) GetWithPrefetch(ptr interface{}) *gomock.C
 }
 
 // PutWithPrefetch mocks base method
-func (m *MockBlockCache) PutWithPrefetch(ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime, triggeredPrefetch bool) error {
-	ret := m.ctrl.Call(m, "PutWithPrefetch", ptr, tlf, block, lifetime, triggeredPrefetch)
+func (m *MockBlockCache) PutWithPrefetch(ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
+	ret := m.ctrl.Call(m, "PutWithPrefetch", ptr, tlf, block, lifetime, prefetchStatus)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutWithPrefetch indicates an expected call of PutWithPrefetch
-func (mr *MockBlockCacheMockRecorder) PutWithPrefetch(ptr, tlf, block, lifetime, triggeredPrefetch interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutWithPrefetch", reflect.TypeOf((*MockBlockCache)(nil).PutWithPrefetch), ptr, tlf, block, lifetime, triggeredPrefetch)
+func (mr *MockBlockCacheMockRecorder) PutWithPrefetch(ptr, tlf, block, lifetime, prefetchStatus interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutWithPrefetch", reflect.TypeOf((*MockBlockCache)(nil).PutWithPrefetch), ptr, tlf, block, lifetime, prefetchStatus)
 }
 
 // SetCleanBytesCapacity mocks base method
@@ -2976,11 +2976,11 @@ func (m *MockDiskBlockCache) EXPECT() *MockDiskBlockCacheMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockDiskBlockCache) Get(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, bool, error) {
+func (m *MockDiskBlockCache) Get(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, PrefetchStatus, error) {
 	ret := m.ctrl.Call(m, "Get", ctx, tlfID, blockID)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(kbfscrypto.BlockCryptKeyServerHalf)
-	ret2, _ := ret[2].(bool)
+	ret2, _ := ret[2].(PrefetchStatus)
 	ret3, _ := ret[3].(error)
 	return ret0, ret1, ret2, ret3
 }
@@ -3017,15 +3017,15 @@ func (mr *MockDiskBlockCacheMockRecorder) Delete(ctx, blockIDs interface{}) *gom
 }
 
 // UpdateMetadata mocks base method
-func (m *MockDiskBlockCache) UpdateMetadata(ctx context.Context, blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch *bool) error {
-	ret := m.ctrl.Call(m, "UpdateMetadata", ctx, blockID, triggeredPrefetch, finishedPrefetch)
+func (m *MockDiskBlockCache) UpdateMetadata(ctx context.Context, blockID kbfsblock.ID, prefetchStatus PrefetchStatus) error {
+	ret := m.ctrl.Call(m, "UpdateMetadata", ctx, blockID, prefetchStatus)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateMetadata indicates an expected call of UpdateMetadata
-func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, blockID, triggeredPrefetch, finishedPrefetch interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockDiskBlockCache)(nil).UpdateMetadata), ctx, blockID, triggeredPrefetch, finishedPrefetch)
+func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, blockID, prefetchStatus interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockDiskBlockCache)(nil).UpdateMetadata), ctx, blockID, prefetchStatus)
 }
 
 // GetMetadata mocks base method
@@ -8353,13 +8353,13 @@ func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetch(ctx, priority, kmd
 }
 
 // CacheAndPrefetch mocks base method
-func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, triggeredPrefetch bool, prefetchDoneCh, prefetchErrCh chan<- struct{}) error {
-	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch, prefetchDoneCh, prefetchErrCh)
+func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, prefetchDoneCh, prefetchErrCh chan<- struct{}) error {
+	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, prefetchDoneCh, prefetchErrCh)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CacheAndPrefetch indicates an expected call of CacheAndPrefetch
-func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch, prefetchDoneCh, prefetchErrCh interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch, prefetchDoneCh, prefetchErrCh)
+func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, prefetchDoneCh, prefetchErrCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, prefetchDoneCh, prefetchErrCh)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3017,7 +3017,7 @@ func (mr *MockDiskBlockCacheMockRecorder) Delete(ctx, blockIDs interface{}) *gom
 }
 
 // UpdateMetadata mocks base method
-func (m *MockDiskBlockCache) UpdateMetadata(ctx context.Context, blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch bool) error {
+func (m *MockDiskBlockCache) UpdateMetadata(ctx context.Context, blockID kbfsblock.ID, triggeredPrefetch, finishedPrefetch *bool) error {
 	ret := m.ctrl.Call(m, "UpdateMetadata", ctx, blockID, triggeredPrefetch, finishedPrefetch)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -4010,10 +4010,12 @@ func (m *MockPrefetcher) EXPECT() *MockPrefetcherMockRecorder {
 }
 
 // PrefetchBlock mocks base method
-func (m *MockPrefetcher) PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata, priority int) error {
+func (m *MockPrefetcher) PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata, priority int) (<-chan struct{}, <-chan struct{}, error) {
 	ret := m.ctrl.Call(m, "PrefetchBlock", block, blockPtr, kmd, priority)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(<-chan struct{})
+	ret1, _ := ret[1].(<-chan struct{})
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // PrefetchBlock indicates an expected call of PrefetchBlock
@@ -4022,10 +4024,12 @@ func (mr *MockPrefetcherMockRecorder) PrefetchBlock(block, blockPtr, kmd, priori
 }
 
 // PrefetchAfterBlockRetrieved mocks base method
-func (m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata) <-chan struct{} {
+func (m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata) (<-chan struct{}, <-chan struct{}, int) {
 	ret := m.ctrl.Call(m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd)
 	ret0, _ := ret[0].(<-chan struct{})
-	return ret0
+	ret1, _ := ret[1].(<-chan struct{})
+	ret2, _ := ret[2].(int)
+	return ret0, ret1, ret2
 }
 
 // PrefetchAfterBlockRetrieved indicates an expected call of PrefetchAfterBlockRetrieved
@@ -4043,6 +4047,18 @@ func (m *MockPrefetcher) Shutdown() <-chan struct{} {
 // Shutdown indicates an expected call of Shutdown
 func (mr *MockPrefetcherMockRecorder) Shutdown() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockPrefetcher)(nil).Shutdown))
+}
+
+// ShutdownCh mocks base method
+func (m *MockPrefetcher) ShutdownCh() <-chan struct{} {
+	ret := m.ctrl.Call(m, "ShutdownCh")
+	ret0, _ := ret[0].(<-chan struct{})
+	return ret0
+}
+
+// ShutdownCh indicates an expected call of ShutdownCh
+func (mr *MockPrefetcherMockRecorder) ShutdownCh() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutdownCh", reflect.TypeOf((*MockPrefetcher)(nil).ShutdownCh))
 }
 
 // MockBlockOps is a mock of BlockOps interface
@@ -8324,14 +8340,26 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime)
 }
 
+// RequestWithPrefetch mocks base method
+func (m *MockBlockRetriever) RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime, prefetchDoneCh, prefetchErrCh chan<- struct{}) <-chan error {
+	ret := m.ctrl.Call(m, "RequestWithPrefetch", ctx, priority, kmd, ptr, block, lifetime, prefetchDoneCh, prefetchErrCh)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+// RequestWithPrefetch indicates an expected call of RequestWithPrefetch
+func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetch(ctx, priority, kmd, ptr, block, lifetime, prefetchDoneCh, prefetchErrCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestWithPrefetch), ctx, priority, kmd, ptr, block, lifetime, prefetchDoneCh, prefetchErrCh)
+}
+
 // CacheAndPrefetch mocks base method
-func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, triggeredPrefetch bool) error {
-	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch)
+func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, triggeredPrefetch bool, prefetchDoneCh, prefetchErrCh chan<- struct{}) error {
+	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch, prefetchDoneCh, prefetchErrCh)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CacheAndPrefetch indicates an expected call of CacheAndPrefetch
-func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch)
+func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch, prefetchDoneCh, prefetchErrCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, triggeredPrefetch, prefetchDoneCh, prefetchErrCh)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8341,25 +8341,25 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 }
 
 // RequestWithPrefetch mocks base method
-func (m *MockBlockRetriever) RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime, prefetchDoneCh, prefetchErrCh chan<- struct{}) <-chan error {
-	ret := m.ctrl.Call(m, "RequestWithPrefetch", ctx, priority, kmd, ptr, block, lifetime, prefetchDoneCh, prefetchErrCh)
+func (m *MockBlockRetriever) RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime, deepPrefetchDoneCh, deepPrefetchCancelCh chan<- struct{}) <-chan error {
+	ret := m.ctrl.Call(m, "RequestWithPrefetch", ctx, priority, kmd, ptr, block, lifetime, deepPrefetchDoneCh, deepPrefetchCancelCh)
 	ret0, _ := ret[0].(<-chan error)
 	return ret0
 }
 
 // RequestWithPrefetch indicates an expected call of RequestWithPrefetch
-func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetch(ctx, priority, kmd, ptr, block, lifetime, prefetchDoneCh, prefetchErrCh interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestWithPrefetch), ctx, priority, kmd, ptr, block, lifetime, prefetchDoneCh, prefetchErrCh)
+func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetch(ctx, priority, kmd, ptr, block, lifetime, deepPrefetchDoneCh, deepPrefetchCancelCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestWithPrefetch), ctx, priority, kmd, ptr, block, lifetime, deepPrefetchDoneCh, deepPrefetchCancelCh)
 }
 
 // CacheAndPrefetch mocks base method
-func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, prefetchDoneCh, prefetchErrCh chan<- struct{}) error {
-	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, prefetchDoneCh, prefetchErrCh)
+func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh chan<- struct{}) error {
+	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CacheAndPrefetch indicates an expected call of CacheAndPrefetch
-func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, prefetchDoneCh, prefetchErrCh interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, prefetchDoneCh, prefetchErrCh)
+func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh)
 }

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -112,10 +112,6 @@ func (p *blockPrefetcher) run() {
 					cancel()
 					<-errCh
 				}
-				// TODO: doneCh should only receive once the Request's
-				// prefetches are done. If no prefetches are triggered but the
-				// request has child blocks, `errCh` should instead be assigned
-				// to.
 			}()
 		case <-p.shutdownCh:
 			return

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -36,7 +36,8 @@ type prefetchRequest struct {
 	kmd      KeyMetadata
 	ptr      BlockPointer
 	block    Block
-	wg       *sync.WaitGroup
+	doneCh   chan<- struct{}
+	errCh    chan<- struct{}
 }
 
 type blockPrefetcher struct {
@@ -104,12 +105,18 @@ func (p *blockPrefetcher) run() {
 							"Error: %+v", req.ptr.ID, err)
 					}
 				case <-p.shutdownCh:
-					// Cancel but still wait so p.doneCh accurately represents
-					// whether we still have requests pending.
+					// Cancel but still wait for the request to finish, so that
+					// p.doneCh accurately represents whether we still have
+					// requests pending.
 					cancel()
+					req.errCh <- struct{}{}
 					<-errCh
 				}
-				req.wg.Done()
+				// TODO: doneCh should only receive once the Request's
+				// prefetches are done. If no prefetches are triggered but the
+				// request has child blocks, `errCh` should instead be assigned
+				// to.
+				req.doneCh <- struct{}{}
 			}()
 		case <-p.shutdownCh:
 			return
@@ -119,7 +126,7 @@ func (p *blockPrefetcher) run() {
 
 func (p *blockPrefetcher) request(priority int, kmd KeyMetadata,
 	ptr BlockPointer, block Block, entryName string,
-	wg *sync.WaitGroup) error {
+	doneCh, errCh chan<- struct{}) error {
 	if _, err := p.config.BlockCache().Get(ptr); err == nil {
 		return nil
 	}
@@ -127,7 +134,8 @@ func (p *blockPrefetcher) request(priority int, kmd KeyMetadata,
 		return err
 	}
 	select {
-	case p.progressCh <- prefetchRequest{priority, kmd, ptr, block, wg}:
+	case p.progressCh <- prefetchRequest{
+		priority, kmd, ptr, block, doneCh, errCh}:
 		return nil
 	case <-p.shutdownCh:
 		return errors.Wrapf(io.EOF, "Skipping prefetch for block %v since "+
@@ -146,48 +154,51 @@ func (p *blockPrefetcher) calculatePriority(basePriority int,
 }
 
 func (p *blockPrefetcher) prefetchIndirectFileBlock(b *FileBlock,
-	kmd KeyMetadata) *sync.WaitGroup {
+	kmd KeyMetadata) (<-chan struct{}, <-chan struct{}, int) {
 	// Prefetch indirect block pointers.
 	p.log.CDebugf(context.TODO(), "Prefetching pointers for indirect file "+
 		"block. Num pointers to prefetch: %d", len(b.IPtrs))
-	wg := &sync.WaitGroup{}
-	wg.Add(len(b.IPtrs))
 	startingPriority :=
 		p.calculatePriority(fileIndirectBlockPrefetchPriority, kmd.TlfID())
+	numBlocks := len(b.IPtrs)
+	doneCh := make(chan struct{}, numBlocks)
+	errCh := make(chan struct{}, numBlocks)
 	for i, ptr := range b.IPtrs {
-		p.request(startingPriority-i, kmd, ptr.BlockPointer,
-			b.NewEmpty(), "", wg)
+		_ = p.request(startingPriority-i, kmd, ptr.BlockPointer,
+			b.NewEmpty(), "", doneCh, errCh)
 	}
-	return wg
+	return doneCh, errCh, numBlocks
 }
 
 func (p *blockPrefetcher) prefetchIndirectDirBlock(b *DirBlock,
-	kmd KeyMetadata) *sync.WaitGroup {
+	kmd KeyMetadata) (<-chan struct{}, <-chan struct{}, int) {
 	// Prefetch indirect block pointers.
 	p.log.CDebugf(context.TODO(), "Prefetching pointers for indirect dir "+
 		"block. Num pointers to prefetch: %d", len(b.IPtrs))
-	wg := &sync.WaitGroup{}
-	wg.Add(len(b.IPtrs))
 	startingPriority :=
 		p.calculatePriority(fileIndirectBlockPrefetchPriority, kmd.TlfID())
+	numBlocks := len(b.IPtrs)
+	doneCh := make(chan struct{}, numBlocks)
+	errCh := make(chan struct{}, numBlocks)
 	for i, ptr := range b.IPtrs {
-		_ = p.request(startingPriority-i, kmd,
-			ptr.BlockPointer, b.NewEmpty(), "", wg)
+		_ = p.request(startingPriority-i, kmd, ptr.BlockPointer, b.NewEmpty(),
+			"", doneCh, errCh)
 	}
-	return wg
+	return doneCh, errCh, numBlocks
 }
 
 func (p *blockPrefetcher) prefetchDirectDirBlock(ptr BlockPointer, b *DirBlock,
-	kmd KeyMetadata) *sync.WaitGroup {
+	kmd KeyMetadata) (<-chan struct{}, <-chan struct{}, int) {
 	p.log.CDebugf(context.TODO(), "Prefetching entries for directory block "+
 		"ID %s. Num entries: %d", ptr.ID, len(b.Children))
 	// Prefetch all DirEntry root blocks.
 	dirEntries := dirEntriesBySizeAsc{dirEntryMapToDirEntries(b.Children)}
 	sort.Sort(dirEntries)
-	wg := &sync.WaitGroup{}
-	wg.Add(len(dirEntries.dirEntries))
 	startingPriority :=
 		p.calculatePriority(dirEntryPrefetchPriority, kmd.TlfID())
+	numBlocks := 0
+	doneCh := make(chan struct{}, len(dirEntries.dirEntries))
+	errCh := make(chan struct{}, len(dirEntries.dirEntries))
 	for i, entry := range dirEntries.dirEntries {
 		// Prioritize small files
 		priority := startingPriority - i
@@ -202,59 +213,48 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(ptr BlockPointer, b *DirBlock,
 		default:
 			p.log.CDebugf(context.TODO(), "Skipping prefetch for entry of "+
 				"unknown type %d", entry.Type)
-			wg.Done()
 			continue
 		}
-		p.request(priority, kmd, entry.BlockPointer, block, entry.entryName,
-			wg)
+		_ = p.request(priority, kmd, entry.BlockPointer, block, entry.entryName,
+			doneCh, errCh)
+		numBlocks++
 	}
-	return wg
+	return doneCh, errCh, numBlocks
 }
 
 // PrefetchBlock implements the Prefetcher interface for blockPrefetcher.
-func (p *blockPrefetcher) PrefetchBlock(
-	block Block, ptr BlockPointer, kmd KeyMetadata, priority int) error {
+func (p *blockPrefetcher) PrefetchBlock(block Block, ptr BlockPointer,
+	kmd KeyMetadata, priority int) (<-chan struct{}, <-chan struct{}, error) {
 	// TODO: Remove this log line.
 	p.log.CDebugf(context.TODO(), "Prefetching block by request from "+
 		"upstream component. Priority: %d", priority)
-	// TODO: Return a channel that is closed when this WaitGroup completes, in
-	// case the caller wants to be notified about prefetch completion.
-	var wg sync.WaitGroup
-	wg.Add(1)
-	return p.request(priority, kmd, ptr, block, "", &wg)
+	doneCh := make(chan struct{}, 1)
+	errCh := make(chan struct{}, 1)
+	return doneCh, errCh,
+		p.request(priority, kmd, ptr, block, "", doneCh, errCh)
 }
 
 // PrefetchAfterBlockRetrieved implements the Prefetcher interface for
 // blockPrefetcher. Returns a channel that is closed once all the prefetches
 // complete.
-func (p *blockPrefetcher) PrefetchAfterBlockRetrieved(
-	b Block, ptr BlockPointer, kmd KeyMetadata) <-chan struct{} {
-	doneCh := make(chan struct{})
-	var wg *sync.WaitGroup
+func (p *blockPrefetcher) PrefetchAfterBlockRetrieved(b Block,
+	ptr BlockPointer, kmd KeyMetadata) (doneCh, errCh <-chan struct{},
+	numBlocks int) {
 	switch b := b.(type) {
 	case *FileBlock:
 		if b.IsInd {
-			wg = p.prefetchIndirectFileBlock(b, kmd)
-		} else {
-			close(doneCh)
+			doneCh, errCh, numBlocks = p.prefetchIndirectFileBlock(b, kmd)
 		}
 	case *DirBlock:
 		if b.IsInd {
-			wg = p.prefetchIndirectDirBlock(b, kmd)
+			doneCh, errCh, numBlocks = p.prefetchIndirectDirBlock(b, kmd)
 		} else {
-			wg = p.prefetchDirectDirBlock(ptr, b, kmd)
+			doneCh, errCh, numBlocks = p.prefetchDirectDirBlock(ptr, b, kmd)
 		}
 	default:
 		// Skipping prefetch for block of unknown type (likely CommonBlock)
-		close(doneCh)
 	}
-	if wg != nil {
-		go func() {
-			wg.Wait()
-			close(doneCh)
-		}()
-	}
-	return doneCh
+	return doneCh, errCh, numBlocks
 }
 
 // Shutdown implements the Prefetcher interface for blockPrefetcher.
@@ -265,4 +265,9 @@ func (p *blockPrefetcher) Shutdown() <-chan struct{} {
 		close(p.shutdownCh)
 	}
 	return p.doneCh
+}
+
+// ShutdownCh implements the Prefetcher interface for blockPrefetcher.
+func (p *blockPrefetcher) ShutdownCh() <-chan struct{} {
+	return p.shutdownCh
 }

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -100,6 +100,7 @@ func (p *blockPrefetcher) run() {
 				defer cancel()
 				select {
 				case err := <-errCh:
+					req.errCh <- struct{}{}
 					if err != nil {
 						p.log.CDebugf(ctx, "Done prefetch for block %s. "+
 							"Error: %+v", req.ptr.ID, err)

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -481,8 +481,11 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 		bg.setBlockToReturn(dirBfileDptrs[1].BlockPointer, dirBfileDblock2)
 
 	var block Block = &DirBlock{}
-	ch := q.Request(context.Background(), defaultOnDemandRequestPriority, kmd,
-		rootPtr, block, TransientEntry)
+	prefetchDoneCh := make(chan struct{}, 3)
+	prefetchErrCh := make(chan struct{}, 3)
+	ch := q.RequestWithPrefetch(context.Background(),
+		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry,
+		prefetchDoneCh, prefetchErrCh)
 	continueChRootDir <- nil
 	err := <-ch
 	require.NoError(t, err)


### PR DESCRIPTION
This PR passes through whether prefetches for a block are done.

It's not pretty, but to make it nice it'll need a much larger refactor where we combine the block retriever and prefetcher. The components are too tightly coupled right now and there's too much back-and-forth.

Missing:
* Persisting the sync state for a TLF (incoming PR soon)
* Correctly updating the `finishedPrefetch` state of a block when it wouldn't trigger prefetches itself (as in unsynced TLFs). This is not as high priority because blocks in the unsynced disk cache can be deleted arbitrarily.