### PR TITLE
libfs: symlink support in the billy FS layer

### DIFF
--- a/libfs/file_info.go
+++ b/libfs/file_info.go
@@ -46,6 +46,8 @@ func (fi *FileInfo) Mode() os.FileMode {
 	switch fi.ei.Type {
 	case libkbfs.Dir:
 		mode |= os.ModeDir | 0100
+	case libkbfs.Sym:
+		mode |= os.ModeSymlink
 	case libkbfs.Exec:
 		mode |= 0100
 	}

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -84,7 +84,7 @@ func NewFS(ctx context.Context, config libkbfs.Config,
 
 // lookupOrCreateEntryNoFollow looks up the entry for a file in a
 // given parent node.  If the entry is a symlink, it will return a nil
-// Node and a nil error.  If the entry doesn't exist an O_CREATE is
+// Node and a nil error.  If the entry doesn't exist and O_CREATE is
 // set in `flag`, it will create the entry as a file.
 func (fs *FS) lookupOrCreateEntryNoFollow(
 	dir libkbfs.Node, filename string, flag int, perm os.FileMode) (


### PR DESCRIPTION
Symlinks complicate all the other path-based operations, so this
involved a bit of a refactor.

Issue: KBFS-2338