### PR TITLE
kbfsgit: support list and simple fetches

### DIFF
--- a/kbfsgit/fs_test.go
+++ b/kbfsgit/fs_test.go
@@ -49,7 +49,7 @@ func TestBareRepoInKBFS(t *testing.T) {
 	ctx, _, fs := makeFS(t, "")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, fs.Config())
 
-	storer, err := newConfigInMemoryStorer(fs)
+	storer, err := newConfigWithoutRemotesStorer(fs)
 	require.NoError(t, err)
 
 	repo, err := gogit.Init(storer, nil)

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -97,7 +97,10 @@ type runner struct {
 }
 
 // newRunner creates a new runner for git commands.  It expects `repo`
-// to be in the form "keybase://private/user/reponame".
+// to be in the form "keybase://private/user/reponame".  `remote`
+// is the local name assigned to that URL, while `gitDir` is the
+// filepath leading to the .git directory of the caller's local
+// on-disk repo
 func newRunner(ctx context.Context, config libkbfs.Config,
 	remote, repo, gitDir string, input io.Reader, output io.Writer) (
 	*runner, error) {

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -22,8 +22,8 @@ func TestCapabilities(t *testing.T) {
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	input := bytes.NewBufferString("capabilities\n\n")
 	var output bytes.Buffer
-	r, err := newRunner(ctx, config, "keybase://private/user1/test",
-		input, &output)
+	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
+		"", input, &output)
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
@@ -53,8 +53,8 @@ func TestInitRepo(t *testing.T) {
 
 	input := bytes.NewBufferString("list\n\n")
 	var output bytes.Buffer
-	r, err := newRunner(ctx, config, "keybase://private/user1/test",
-		input, &output)
+	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
+		"", input, &output)
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -58,7 +58,8 @@ func TestInitRepo(t *testing.T) {
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
-	require.Equal(t, output.String(), "\n")
+	// Just one symref, from HEAD to master (and master has no commits yet).
+	require.Equal(t, output.String(), "@refs/heads/master HEAD\n\n")
 
 	// Now there should be a valid git repo stored in KBFS.  Check the
 	// existence of the HEAD file to be sure.

--- a/kbfsgit/start.go
+++ b/kbfsgit/start.go
@@ -17,6 +17,7 @@ type StartOptions struct {
 	KbfsParams libkbfs.InitParams
 	Remote     string
 	Repo       string
+	GitDir     string
 }
 
 const (
@@ -60,7 +61,9 @@ func Start(ctx context.Context, options StartOptions,
 	}
 	defer config.Shutdown(ctx)
 
-	r, err := newRunner(ctx, config, options.Repo, input, output)
+	r, err := newRunner(
+		ctx, config, options.Remote, options.Repo, options.GitDir,
+		input, output)
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}

--- a/kbfsgit/start.go
+++ b/kbfsgit/start.go
@@ -15,9 +15,15 @@ import (
 // StartOptions are options for starting up.
 type StartOptions struct {
 	KbfsParams libkbfs.InitParams
-	Remote     string
-	Repo       string
-	GitDir     string
+	// Remote is the name that the caller's repo (on local disk) has
+	// assigned to the KBFS-based repo.
+	Remote string
+	// Repo is the URL the caller's repo (on local disk) is trying to
+	// access, in the form "keybase://private/user/reponame".
+	Repo string
+	// GitDir is the filepath leading to the .git directory of the
+	// caller's local on-disk repo.
+	GitDir string
 }
 
 const (

--- a/kbfsgit/storer.go
+++ b/kbfsgit/storer.go
@@ -18,6 +18,7 @@ import (
 // backslashes in git file URLs.
 type configWithoutRemotesStorer struct {
 	*filesystem.Storage
+	cfg *gogitcfg.Config
 }
 
 func newConfigWithoutRemotesStorer(fs *libfs.FS) (
@@ -26,14 +27,23 @@ func newConfigWithoutRemotesStorer(fs *libfs.FS) (
 	if err != nil {
 		return nil, err
 	}
-	return &configWithoutRemotesStorer{fsStorer}, nil
+	cfg, err := fsStorer.Config()
+	if err != nil {
+		return nil, err
+	}
+	return &configWithoutRemotesStorer{fsStorer, cfg}, nil
 }
 
 func (cwrs *configWithoutRemotesStorer) Init() error {
 	return cwrs.Storage.Init()
 }
 
+func (cwrs *configWithoutRemotesStorer) Config() (*gogitcfg.Config, error) {
+	return cwrs.cfg, nil
+}
+
 func (cwrs *configWithoutRemotesStorer) SetConfig(c *gogitcfg.Config) error {
+	cwrs.cfg = c
 	if len(c.Remotes) != 0 {
 		// If there are remotes, we need to strip them out before writing
 		// them out to disk.  Do that by making a copy.


### PR DESCRIPTION
This may not cover all corner cases, but it works for simple cases. It sets the local repo as a "remote" in the bare repo, and pushes from the bare repo into this "remote".  go-git requires pushing to a ref name, but `git` gets upset if you push into the refname it's expecting, so we have to use a temporary name and then delete it afterwards.

Issue: KBFS-2353
