### PR TITLE
root_metadata: fix v2->v3 upconversion for conflict TLFs

### DIFF
--- a/libkbfs/bare_root_metadata_v2.go
+++ b/libkbfs/bare_root_metadata_v2.go
@@ -183,6 +183,10 @@ func MakeInitialBareRootMetadataV2(tlfID tlf.ID, h tlf.Handle) (
 		Revision:          kbfsmd.RevisionInitial,
 		RKeys:             rKeys,
 		UnresolvedReaders: unresolvedReaders,
+		// Normally an MD wouldn't start out with extensions, but this
+		// is useful for tests.
+		ConflictInfo:  h.ConflictInfo,
+		FinalizedInfo: h.FinalizedInfo,
 	}, nil
 }
 
@@ -443,7 +447,7 @@ func (md *BareRootMetadataV2) makeSuccessorCopyV3(
 
 	if md.ConflictInfo != nil {
 		ci := *md.ConflictInfo
-		md.ConflictInfo = &ci
+		mdV3.ConflictInfo = &ci
 	}
 
 	// Metadata with finalized info is never succeeded.

--- a/libkbfs/bare_root_metadata_v3.go
+++ b/libkbfs/bare_root_metadata_v3.go
@@ -228,6 +228,10 @@ func MakeInitialBareRootMetadataV3(tlfID tlf.ID, h tlf.Handle) (
 		},
 		Revision:          kbfsmd.RevisionInitial,
 		UnresolvedReaders: unresolvedReaders,
+		// Normally an MD wouldn't start out with extensions, but this
+		// is useful for tests.
+		ConflictInfo:  h.ConflictInfo,
+		FinalizedInfo: h.FinalizedInfo,
 	}, nil
 }
 


### PR DESCRIPTION
Oops.

The test fails without this fix on the final line.

Issue: KBFS-2381
Issue: keybase/client#8188