### PR TITLE
kbfsgit: simple status messages during operation

### DIFF
--- a/kbfsgit/git-remote-keybase/dup_stderr_dummy.go
+++ b/kbfsgit/git-remote-keybase/dup_stderr_dummy.go
@@ -1,0 +1,15 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build android
+
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+func dupStderr() (*os.File, error) {
+	return nil, errors.New("Duplicating stderr is not supported on this operating system")
+}

--- a/kbfsgit/git-remote-keybase/dup_stderr_nix.go
+++ b/kbfsgit/git-remote-keybase/dup_stderr_nix.go
@@ -1,0 +1,20 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+// +build linux,!android darwin freebsd openbsd
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func dupStderr() (*os.File, error) {
+	dupStderrFd, err := syscall.Dup(2)
+	if err != nil {
+		return nil, err
+	}
+	stderrFile := os.NewFile(uintptr(dupStderrFd), "stderr")
+	return stderrFile, nil
+}

--- a/kbfsgit/git-remote-keybase/dup_stderr_windows.go
+++ b/kbfsgit/git-remote-keybase/dup_stderr_windows.go
@@ -1,0 +1,27 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package main
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func dupStderr() (*os.File, error) {
+	proc, err := windows.GetCurrentProcess()
+	if err != nil {
+		return nil, err
+	}
+
+	var dupStderrFd windows.Handle
+	err = windows.DuplicateHandle(
+		proc, windows.Handle(os.Stderr.Fd()), proc, &dupStderrFd, 0, false, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	stderrFile := os.NewFile(uintptr(dupStderrFd), "stderr")
+	return stderrFile, nil
+}

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -22,6 +22,15 @@ import (
 	gogitcfg "gopkg.in/src-d/go-git.v4/config"
 )
 
+type testErrput struct {
+	t *testing.T
+}
+
+func (te testErrput) Write(buf []byte) (int, error) {
+	te.t.Log(string(buf))
+	return 0, nil
+}
+
 func TestRunnerCapabilities(t *testing.T) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	config := libkbfs.MakeTestConfigOrBust(t, "user1")
@@ -29,7 +38,7 @@ func TestRunnerCapabilities(t *testing.T) {
 	input := bytes.NewBufferString("capabilities\n\n")
 	var output bytes.Buffer
 	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
-		"", input, &output)
+		"", input, &output, testErrput{t})
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
@@ -68,7 +77,7 @@ func TestRunnerInitRepo(t *testing.T) {
 	input := bytes.NewBufferString("list\n\n")
 	var output bytes.Buffer
 	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
-		"", input, &output)
+		"", input, &output, testErrput{t})
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
@@ -120,7 +129,7 @@ func testPush(t *testing.T, ctx context.Context, config libkbfs.Config,
 		"push %s\n\n", refspec))
 	var output bytes.Buffer
 	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
-		filepath.Join(gitDir, ".git"), input, &output)
+		filepath.Join(gitDir, ".git"), input, &output, testErrput{t})
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
@@ -135,7 +144,7 @@ func testListAndGetHeads(t *testing.T, ctx context.Context,
 	input := bytes.NewBufferString("list\n\n")
 	var output bytes.Buffer
 	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
-		filepath.Join(gitDir, ".git"), input, &output)
+		filepath.Join(gitDir, ".git"), input, &output, testErrput{t})
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
@@ -202,7 +211,7 @@ func TestRunnerPushFetch(t *testing.T) {
 		fmt.Sprintf("fetch %s refs/heads/master\n\n", heads[0]))
 	var output3 bytes.Buffer
 	r, err := newRunner(ctx, config, "origin", "keybase://private/user1/test",
-		git2, input, &output3)
+		git2, input, &output3, testErrput{t})
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)

--- a/kbfsgit/start.go
+++ b/kbfsgit/start.go
@@ -48,7 +48,7 @@ func Start(ctx context.Context, options StartOptions,
 		return libfs.InitError(err.Error())
 	}
 
-	errput.Write([]byte("Initializing KBFS... "))
+	errput.Write([]byte("Initializing Keybase... "))
 
 	// Assign a unique ID to each remote-helper instance, since
 	// they'll all share the same log.


### PR DESCRIPTION
Git remote helpers can print status messages on stderr that will be
displayed to the user.  This should have been easy, but
`client/go/logger` duplicates and closes the stderr file descriptor
that the program starts with.  So, before that happens,
`git-remote-keybase` needs to duplicate the original stderr in a
platform-specific way, before it gets redirected into a log file.

A future PR will print more useful status messages (e.g., "M/N objects
uploaded", etc).  But these simple messages are still useful.  Example
output on Linux:

```
$ KEYBASE_RUN_MODE=staging git clone keybase://private/strib/test12
Cloning into 'test12'...
Initializing KBFS... done.
Syncing to Keybase... done.
Fetching data from Keybase... done.
Checking connectivity... done.
```

Issue: KBFS-2385