### PR TITLE
kbfsgit: progress status messages for fetch and push

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -274,15 +274,18 @@ func (r *runner) printJournalStatus(
 		return
 	}
 	r.errput.Write([]byte("Syncing data to Keybase: "))
+	// TODO: should we "humanize" the units of these bytes if they are
+	// more than a KB, MB, etc?
 	bytesFmt := "%d/%d bytes... "
 	str := fmt.Sprintf(bytesFmt, 0, firstStatus.UnflushedBytes)
 	lastByteCount := len(str)
 	r.errput.Write([]byte(str))
 
-	ticker := time.Tick(1 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-ticker:
+		case <-ticker.C:
 		case <-doneCh:
 		}
 		status, err := jServer.JournalStatus(tlf)

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -412,7 +412,7 @@ func (r *runner) handleList(ctx context.Context, args []string) (err error) {
 }
 
 var gogitStagesToStatus = map[plumbing.StatusStage]string{
-	plumbing.StatusCount: "Counting ",
+	plumbing.StatusCount: "Counting: ",
 	plumbing.StatusRead:  "Reading: ",
 	plumbing.StatusSort:  "Sorting... ",
 	plumbing.StatusDelta: "Calculating deltas: ",

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -432,7 +432,9 @@ func (r *runner) processGogitStatus(
 	lastByteCount := 0
 	for update := range statusChan {
 		if update.Stage != currStage {
-			r.errput.Write([]byte("done.\n"))
+			if currStage != plumbing.StatusUnknown {
+				r.errput.Write([]byte("done.\n"))
+			}
 			r.errput.Write([]byte(gogitStagesToStatus[update.Stage]))
 			lastByteCount = 0
 			currStage = update.Stage

--- a/vendor/gopkg.in/src-d/go-git.v4/options.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/options.go
@@ -133,7 +133,8 @@ type FetchOptions struct {
 	Progress sideband.Progress
 	// Tags describe how the tags will be fetched from the remote repository,
 	// by default is TagFollowing.
-	Tags TagFetchMode
+	Tags       TagFetchMode
+	StatusChan plumbing.StatusChan
 }
 
 // Validate validates the fields and sets the default values.
@@ -159,7 +160,8 @@ type PushOptions struct {
 	// object. A refspec with empty src can be used to delete a reference.
 	RefSpecs []config.RefSpec
 	// Auth credentials, if required, to use with the remote repository.
-	Auth transport.AuthMethod
+	Auth       transport.AuthMethod
+	StatusChan plumbing.StatusChan
 }
 
 // Validate validates the fields and sets the default values.

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/revlist/revlist.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/revlist/revlist.go
@@ -20,34 +20,41 @@ func Objects(
 	s storer.EncodedObjectStorer,
 	objs,
 	ignore []plumbing.Hash,
+	statusChan plumbing.StatusChan,
 ) ([]plumbing.Hash, error) {
-	ignore, err := objects(s, ignore, nil, true)
+	ignore, err := objects(s, ignore, nil, nil, true)
 	if err != nil {
 		return nil, err
 	}
 
-	return objects(s, objs, ignore, false)
+	return objects(s, objs, ignore, statusChan, false)
 }
 
 func objects(
 	s storer.EncodedObjectStorer,
 	objects,
 	ignore []plumbing.Hash,
+	statusChan plumbing.StatusChan,
 	allowMissingObjects bool,
 ) ([]plumbing.Hash, error) {
 
 	seen := hashListToSet(ignore)
 	result := make(map[plumbing.Hash]bool)
 
+	update := plumbing.StatusUpdate{Stage: plumbing.StatusCount}
+	statusChan.SendUpdate(update)
+
 	walkerFunc := func(h plumbing.Hash) {
 		if !seen[h] {
 			result[h] = true
 			seen[h] = true
+			update.ObjectsTotal++
+			statusChan.SendUpdateIfPossible(update)
 		}
 	}
 
 	for _, h := range objects {
-		if err := processObject(s, h, seen, ignore, walkerFunc); err != nil {
+		if err := processObject(s, h, seen, ignore, walkerFunc, statusChan); err != nil {
 			if allowMissingObjects && err == plumbing.ErrObjectNotFound {
 				continue
 			}
@@ -56,7 +63,10 @@ func objects(
 		}
 	}
 
-	return hashSetToList(result), nil
+	hashes := hashSetToList(result)
+	update.ObjectsTotal = len(hashes)
+	statusChan.SendUpdate(update)
+	return hashes, nil
 }
 
 // processObject obtains the object using the hash an process it depending of its type
@@ -66,6 +76,7 @@ func processObject(
 	seen map[plumbing.Hash]bool,
 	ignore []plumbing.Hash,
 	walkerFunc func(h plumbing.Hash),
+	statusChan plumbing.StatusChan,
 ) error {
 	if seen[h] {
 		return nil
@@ -88,7 +99,7 @@ func processObject(
 		return iterateCommitTrees(seen, do, walkerFunc)
 	case *object.Tag:
 		walkerFunc(do.Hash)
-		return processObject(s, do.Target, seen, ignore, walkerFunc)
+		return processObject(s, do.Target, seen, ignore, walkerFunc, statusChan)
 	case *object.Blob:
 		walkerFunc(do.Hash)
 	default:

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/status.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/status.go
@@ -1,0 +1,54 @@
+package plumbing
+
+type StatusStage int
+
+const (
+	StatusCount StatusStage = iota
+	StatusRead
+	StatusSort
+	StatusDelta
+	StatusSend
+	StatusFetch
+	StatusIndexHash
+	StatusIndexCRC
+	StatusIndexOffset
+	StatusDone
+
+	StatusUnknown StatusStage = -1
+)
+
+type StatusUpdate struct {
+	Stage StatusStage
+
+	ObjectsTotal int
+	ObjectsDone  int
+
+	BytesTotal int
+	BytesDone  int
+}
+
+type StatusChan chan<- StatusUpdate
+
+func (sc StatusChan) SendUpdate(update StatusUpdate) {
+	if sc == nil {
+		return
+	}
+	sc <- update
+}
+
+func (sc StatusChan) SendUpdateIfPossible(update StatusUpdate) {
+	if sc == nil {
+		return
+	}
+	if update.ObjectsDone == update.ObjectsTotal {
+		// We should always send the final status update, before the
+		// next stage change.
+		sc <- update
+		return
+	}
+
+	select {
+	case sc <- update:
+	default:
+	}
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go
@@ -60,7 +60,7 @@ type PackfileWriter interface {
 	//
 	// If the Storer not implements PackfileWriter the objects should be written
 	// using the Set method.
-	PackfileWriter() (io.WriteCloser, error)
+	PackfileWriter(plumbing.StatusChan) (io.WriteCloser, error)
 }
 
 // EncodedObjectIter is a generic closable interface for iterating over objects.

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/server/server.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/server/server.go
@@ -165,7 +165,7 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 	pr, pw := io.Pipe()
 	e := packfile.NewEncoder(pw, s.storer, false)
 	go func() {
-		_, err := e.Encode(objs)
+		_, err := e.Encode(objs, nil)
 		pw.CloseWithError(err)
 	}()
 
@@ -175,12 +175,12 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 }
 
 func (s *upSession) objectsToUpload(req *packp.UploadPackRequest) ([]plumbing.Hash, error) {
-	haves, err := revlist.Objects(s.storer, req.Haves, nil)
+	haves, err := revlist.Objects(s.storer, req.Haves, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return revlist.Objects(s.storer, req.Wants, haves)
+	return revlist.Objects(s.storer, req.Wants, haves, nil)
 }
 
 func (*upSession) setSupportedCapabilities(c *capability.List) error {
@@ -313,7 +313,7 @@ func (s *rpSession) writePackfile(r io.ReadCloser) error {
 		return nil
 	}
 
-	if err := packfile.UpdateObjectStorage(s.storer, r); err != nil {
+	if err := packfile.UpdateObjectStorage(s.storer, r, nil); err != nil {
 		_ = r.Close()
 		return err
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/writers.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/writers.go
@@ -22,15 +22,16 @@ import (
 type PackWriter struct {
 	Notify func(plumbing.Hash, *packfile.Index)
 
-	fs       billy.Filesystem
-	fr, fw   billy.File
-	synced   *syncedReader
-	checksum plumbing.Hash
-	index    *packfile.Index
-	result   chan error
+	fs         billy.Filesystem
+	fr, fw     billy.File
+	synced     *syncedReader
+	checksum   plumbing.Hash
+	index      *packfile.Index
+	result     chan error
+	statusChan plumbing.StatusChan
 }
 
-func newPackWrite(fs billy.Filesystem) (*PackWriter, error) {
+func newPackWrite(fs billy.Filesystem, statusChan plumbing.StatusChan) (*PackWriter, error) {
 	fw, err := fs.TempFile(fs.Join(objectsPath, packPath), "tmp_pack_")
 	if err != nil {
 		return nil, err
@@ -42,11 +43,12 @@ func newPackWrite(fs billy.Filesystem) (*PackWriter, error) {
 	}
 
 	writer := &PackWriter{
-		fs:     fs,
-		fw:     fw,
-		fr:     fr,
-		synced: newSyncedReader(fw, fr),
-		result: make(chan error),
+		fs:         fs,
+		fw:         fw,
+		fr:         fr,
+		synced:     newSyncedReader(fw, fr),
+		result:     make(chan error),
+		statusChan: statusChan,
 	}
 
 	go writer.buildIndex()
@@ -61,7 +63,7 @@ func (w *PackWriter) buildIndex() {
 		return
 	}
 
-	checksum, err := d.Decode()
+	checksum, err := d.Decode(w.statusChan)
 	if err != nil {
 		w.result <- err
 		return
@@ -149,7 +151,7 @@ func (w *PackWriter) encodeIdx(writer io.Writer) error {
 	idx.PackfileChecksum = w.checksum
 	idx.Version = idxfile.VersionSupported
 	e := idxfile.NewEncoder(writer)
-	_, err := e.Encode(idx)
+	_, err := e.Encode(idx, w.statusChan)
 	return err
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go
@@ -77,12 +77,12 @@ func (s *ObjectStorage) NewEncodedObject() plumbing.EncodedObject {
 	return &plumbing.MemoryObject{}
 }
 
-func (s *ObjectStorage) PackfileWriter() (io.WriteCloser, error) {
+func (s *ObjectStorage) PackfileWriter(statusChan plumbing.StatusChan) (io.WriteCloser, error) {
 	if err := s.requireIndex(); err != nil {
 		return nil, err
 	}
 
-	w, err := s.dir.NewObjectPack()
+	w, err := s.dir.NewObjectPack(statusChan)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -752,244 +752,244 @@
 			"revisionTime": "2017-06-27T12:15:46+02:00"
 		},
 		{
-			"checksumSHA1": "t2dQa3agGp94rYWRTMrRqFth2Yw=",
+			"checksumSHA1": "7qum7IO29Zb1XgHG3I34PG3RlSU=",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "1d4PgjU+LhyJ2ROnz/WwrEKVh28=",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "Re676e7BhdKLVVNfvNhnbiec2JM=",
+			"checksumSHA1": "fXSLB6xcjNZs1y+ATk0jPwuOFUU=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "G0TX3efLdk7noo/n1Dt9Tzempig=",
+			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "hmlwBI9eumRpXyaSX6mnypdgQkk=",
+			"checksumSHA1": "Lazrpcsfp+JJYtFNyjJCKK7DNXY=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "6LZ2gIv993WaeqA2QMMvf04BRzk=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "iq4LbRH6gbIYFu3LNmx/ACelgGU=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "xnSL7xqAg9rUrqzrFy2OtOkfBHY=",
+			"checksumSHA1": "Jy1tv3WSXikRMdxapWPq9OHZYY0=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "QL14x3W+ObgTwz2wRXyMhxGM9jM=",
+			"checksumSHA1": "2FPt2X+Z/oOO5twnW4QrzTvQ2yw=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "l2yjEZzSeCK6e5362izxwtb/QaU=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "bigy+qzPAfu/SO9Gism4W6GtlUU=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "WqaZfy8UDC25vPX8DJEUZH9urhw=",
+			"checksumSHA1": "4YEzFU96Z6iR/NIpb3NXawFpFG8=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "FIbvDZtO3BdDAU+6Ogi1iCqj0cA=",
+			"checksumSHA1": "CSiF391UdjILaSUJqctaa9rvSQc=",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
-			"checksumSHA1": "pHOerggxi2jrWa2A48gh262Scxo=",
+			"checksumSHA1": "a7qGxujLCO4NbK2+JuvNcucVze8=",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "OfzMDAIu253dJ9591gd3w/APq0I=",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "7aa9d15d395282144f31a09c0fac230da3f65360",
-			"revisionTime": "2017-08-28T18:38:58Z"
+			"revision": "3ca370277427c5d508f0dedacbd559523a305121",
+			"revisionTime": "2017-08-29T11:25:53Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
This prints out progressive counters in the terminal during kbfsgit operations.  It's not perfect, but it help shows what kbfsgit is spending time on.

Note that the go-git changes aren't committed or code-reviewed by anyone there, and might need to change significantly in the future. But I think we can commit them here for now to help make kbfsgit more usable for dogfooding.  (No need to review those vendored changes here, unless you want to.  I'll get people on that project to take a look.)

A push now looks like this (the numerators increase during operation):

```
$ KEYBASE_RUN_MODE=staging git push
Initializing Keybase... done.
Syncing with Keybase... done.
done.
Counting 2 objects... done.
Preparing: 2/2 objects... done.
Indexing hashes: 2/2 objects... done.
Indexing CRCs: 2/2 objects... done.
Indexing offsets: 2/2 objects... done.
Syncing data to Keybase: 12659/12659 bytes... done.
To keybase://private/strib/test12
   2870d3b..47b1aa5  master -> master
```

And a fetch looks like:

```
$ KEYBASE_RUN_MODE=staging git clone keybase://private/strib/test12
Cloning into 'test12'...
Initializing Keybase... done.
Syncing with Keybase... done.
Counting 22 objects... done.
Reading: 22/22 objects... done.
Sorting... done.
Calculating deltas: 22/22 objects... done.
Fetching: 22/22 objects... done.
Syncing data to Keybase: 6116/6116 bytes... done.
Checking connectivity... done.
```

Issue: KBFS-2385