### PR TITLE
fix panic during conflict resolution

### DIFF
--- a/libkbfs/path.go
+++ b/libkbfs/path.go
@@ -103,6 +103,13 @@ func (p path) isValidForNotification() bool {
 		return false
 	}
 
+	if p.Tlf == (tlf.ID{}) {
+		return false
+	}
+	if _, err := p.Tlf.SafeType(); err != nil {
+		return false
+	}
+
 	return len(p.path[0].Name) > 0 && !strings.HasPrefix(p.path[0].Name, "<")
 }
 

--- a/libkbfs/path.go
+++ b/libkbfs/path.go
@@ -103,10 +103,7 @@ func (p path) isValidForNotification() bool {
 		return false
 	}
 
-	if p.Tlf == (tlf.ID{}) {
-		return false
-	}
-	if _, err := p.Tlf.SafeType(); err != nil {
+	if p.Tlf == (tlf.NullID) {
 		return false
 	}
 

--- a/tlf/id.go
+++ b/tlf/id.go
@@ -147,9 +147,6 @@ func (id *ID) UnmarshalText(buf []byte) error {
 // SafeType returns the type of TLF represented by this ID.  If the ID
 // isn't valid, it returns tlf.Unknown along with an error.
 func (id ID) SafeType() (Type, error) {
-	if len(id.id) != idByteLen {
-		return Unknown, fmt.Errorf("Invalid ID length: %d", len(id.id))
-	}
 	switch id.id[idByteLen-1] {
 	case idSuffix:
 		return Private, nil


### PR DESCRIPTION
Steve's KBFS was in a crash loop. He said he revoked a device hours ago. I think this is the correct fix for the crash as shown in the log, but I'm not sure if it'd crash somewhere afterwards.

Log send: https://keybase.io/_/admin/logdump_viewer?39510239#acad1c98d3388ec687e99b1c