### PR TITLE
tlf_journal: add single op mode and use it in kbfsgit

### DIFF
--- a/kbfsgit/git-remote-keybase/main.go
+++ b/kbfsgit/git-remote-keybase/main.go
@@ -81,6 +81,8 @@ func start() *libfs.Error {
 	defaultParams.EnableDiskCache = false
 	defaultParams.StorageRoot = storageRoot
 	defaultParams.Mode = libkbfs.InitSingleOpString
+	defaultParams.TLFJournalBackgroundWorkStatus =
+		libkbfs.TLFJournalSingleOpBackgroundWorkEnabled
 	defaultLogPath := filepath.Join(
 		kbCtx.GetLogDir(), libkb.GitLogFileName)
 

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -334,7 +334,11 @@ func (r *runner) waitForJournal(ctx context.Context) error {
 		close(printDoneCh)
 	}()
 
-	err = jServer.Wait(ctx, rootNode.GetFolderBranch().Tlf)
+	// This squashes everything written to the journal into a single
+	// revision, to make sure that no partial states of the bare repo
+	// are seen by other readers of the TLF.  It also waits for any
+	// necessary conflict resolution to complete.
+	err = jServer.FinishSingleOp(ctx, rootNode.GetFolderBranch().Tlf)
 	if err != nil {
 		return err
 	}

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -64,7 +64,7 @@ func initConfigForRunner(t *testing.T) (
 	err = config.EnableDiskLimiter(tempdir)
 	require.NoError(t, err)
 	err = config.EnableJournaling(
-		ctx, tempdir, libkbfs.TLFJournalBackgroundWorkEnabled)
+		ctx, tempdir, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
 	require.NoError(t, err)
 
 	return ctx, config, tempDir

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -551,7 +551,7 @@ func (j *tlfJournal) doBackgroundWorkLoop(
 		ctx := CtxWithRandomIDReplayable(ctx, CtxJournalIDKey, CtxJournalOpID,
 			j.log)
 		switch {
-		case bws != TLFJournalBackgroundWorkPaused && errCh == nil:
+		case bws == TLFJournalBackgroundWorkEnabled && errCh == nil:
 			// 1) Idle.
 			if j.bwDelegate != nil {
 				j.bwDelegate.OnNewState(ctx, bwIdle)
@@ -581,7 +581,7 @@ func (j *tlfJournal) doBackgroundWorkLoop(
 				return
 			}
 
-		case bws != TLFJournalBackgroundWorkPaused && errCh != nil:
+		case bws == TLFJournalBackgroundWorkEnabled && errCh != nil:
 			// 2) Busy.
 			if j.bwDelegate != nil {
 				j.bwDelegate.OnNewState(ctx, bwBusy)

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -433,7 +433,9 @@ func makeTLFJournal(
 		j.log.CDebugf(
 			ctx, "Starting journal for %s in single op mode", tlfID.String())
 		// Now that we've set `j.singleOpMode`, `bws` can be the
-		// normal background work mode again.
+		// normal background work mode again, just to keep the
+		// transition logic in `doBackgroundWorkLoop` simple (it
+		// doesn't depend on single-opness).
 		bws = TLFJournalBackgroundWorkEnabled
 	case TLFJournalBackgroundWorkPaused:
 		j.pauseType |= journalPauseCommand


### PR DESCRIPTION
Single op mode allows an application to tell the journal not to flush any blocks until after the application has signalled its work is finished.  It may flush blocks in the meantime.  Then, the MDs and remaining blocks are squashed into a single revision and put to the server, so all the changes in the single op show up atomically to other TLF readers.

Using this mode in `kbfsgit` ensures that no partially-written git states are seen by other readers, and also waits for any conflict resolutions to complete.

Issue: KBFS-2379