### PR TITLE
libkbfs: allow a default block type and use everywhere

### DIFF
--- a/kbfsgit/start.go
+++ b/kbfsgit/start.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 )
@@ -73,6 +74,10 @@ func Start(ctx context.Context, options StartOptions,
 		return libfs.InitError(err.Error())
 	}
 	defer config.Shutdown(ctx)
+
+	// Make any blocks written by via this config charged to the git
+	// quota.
+	config.SetDefaultBlockType(keybase1.BlockType_GIT)
 
 	errput.Write([]byte("done.\n"))
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1370,7 +1370,7 @@ func ResetRootBlock(ctx context.Context, config Config,
 	info, plainSize, readyBlockData, err :=
 		ReadyBlock(ctx, config.BlockCache(), config.BlockOps(),
 			config.Crypto(), rmd.ReadOnly(), newDblock, chargedTo,
-			keybase1.BlockType_DATA)
+			config.DefaultBlockType())
 	if err != nil {
 		return nil, BlockInfo{}, ReadyBlockData{}, err
 	}
@@ -2641,7 +2641,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 		DataVer:    fbo.config.DataVersion(),
 		DirectType: DirectBlock,
 		Context: kbfsblock.MakeFirstContext(
-			chargedTo, keybase1.BlockType_DATA),
+			chargedTo, fbo.config.DefaultBlockType()),
 	}
 	co.AddRefBlock(newPtr)
 	co.AddSelfUpdate(parentPtr)

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -52,6 +52,8 @@ type KBFSStatus struct {
 	IsConnected     bool
 	UsageBytes      int64
 	LimitBytes      int64
+	GitUsageBytes   int64
+	GitLimitBytes   int64
 	FailingServices map[string]error
 	JournalServer   *JournalServerStatus            `json:",omitempty"`
 	DiskCacheStatus map[string]DiskBlockCacheStatus `json:",omitempty"`

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -195,7 +195,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 	var uid keybase1.UID
 	for len(newPath.path) < len(dir.path)+1 {
 		info, plainSize, err := fup.readyBlockMultiple(
-			ctx, md.ReadOnly(), currBlock, chargedTo, bps, keybase1.BlockType_DATA)
+			ctx, md.ReadOnly(), currBlock, chargedTo, bps,
+			fup.config.DefaultBlockType())
 		if err != nil {
 			return path{}, DirEntry{}, nil, err
 		}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1770,6 +1770,8 @@ type Config interface {
 	SetConflictRenamer(ConflictRenamer)
 	MetadataVersion() MetadataVer
 	SetMetadataVersion(MetadataVer)
+	DefaultBlockType() keybase1.BlockType
+	SetDefaultBlockType(blockType keybase1.BlockType)
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)
 	// ReqsBufSize indicates the number of read or write operations

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -656,15 +656,16 @@ func (fs *KBFSOpsStandard) FolderStatus(
 func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	KBFSStatus, <-chan StatusUpdate, error) {
 	session, err := fs.config.KBPKI().GetCurrentSession(ctx)
-	var usageBytes int64 = -1
-	var limitBytes int64 = -1
+	var usageBytes, limitBytes int64 = -1, -1
+	var gitUsageBytes, gitLimitBytes int64 = -1, -1
 	// Don't request the quota info until we're sure we've
 	// authenticated with our password.  TODO: fix this in the
 	// service/GUI by handling multiple simultaneous passphrase
 	// requests at once.
 	if err == nil && fs.config.MDServer().IsConnected() {
 		var quErr error
-		_, usageBytes, limitBytes, quErr = fs.quotaUsage.Get(ctx, 0, 0)
+		_, usageBytes, limitBytes, gitUsageBytes, gitLimitBytes, quErr =
+			fs.quotaUsage.GetAllTypes(ctx, 0, 0)
 		if quErr != nil {
 			// The error is ignored here so that other fields can still be populated
 			// even if this fails.
@@ -701,6 +702,8 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		IsConnected:     fs.config.MDServer().IsConnected(),
 		UsageBytes:      usageBytes,
 		LimitBytes:      limitBytes,
+		GitUsageBytes:   gitUsageBytes,
+		GitLimitBytes:   gitLimitBytes,
 		FailingServices: failures,
 		JournalServer:   jServerStatus,
 		DiskCacheStatus: dbcStatus,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -6263,6 +6263,28 @@ func (mr *MockConfigMockRecorder) SetMetadataVersion(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMetadataVersion", reflect.TypeOf((*MockConfig)(nil).SetMetadataVersion), arg0)
 }
 
+// DefaultBlockType mocks base method
+func (m *MockConfig) DefaultBlockType() keybase1.BlockType {
+	ret := m.ctrl.Call(m, "DefaultBlockType")
+	ret0, _ := ret[0].(keybase1.BlockType)
+	return ret0
+}
+
+// DefaultBlockType indicates an expected call of DefaultBlockType
+func (mr *MockConfigMockRecorder) DefaultBlockType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultBlockType", reflect.TypeOf((*MockConfig)(nil).DefaultBlockType))
+}
+
+// SetDefaultBlockType mocks base method
+func (m *MockConfig) SetDefaultBlockType(blockType keybase1.BlockType) {
+	m.ctrl.Call(m, "SetDefaultBlockType", blockType)
+}
+
+// SetDefaultBlockType indicates an expected call of SetDefaultBlockType
+func (mr *MockConfigMockRecorder) SetDefaultBlockType(blockType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDefaultBlockType", reflect.TypeOf((*MockConfig)(nil).SetDefaultBlockType), blockType)
+}
+
 // RekeyQueue mocks base method
 func (m *MockConfig) RekeyQueue() RekeyQueue {
 	ret := m.ctrl.Call(m, "RekeyQueue")

--- a/libkbfs/quota_usage.go
+++ b/libkbfs/quota_usage.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -25,9 +26,11 @@ type ECQUCtxTagKey struct{}
 const ECQUID = "ECQU"
 
 type cachedQuotaUsage struct {
-	timestamp  time.Time
-	usageBytes int64
-	limitBytes int64
+	timestamp     time.Time
+	usageBytes    int64
+	limitBytes    int64
+	gitUsageBytes int64
+	gitLimitBytes int64
 }
 
 // EventuallyConsistentQuotaUsage keeps tracks of quota usage, in a way user of
@@ -83,8 +86,10 @@ func (q *EventuallyConsistentQuotaUsage) getAndCache(
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.cached.limitBytes = quotaInfo.Limit
+	q.cached.gitLimitBytes = quotaInfo.GitLimit
 	if quotaInfo.Total != nil {
 		q.cached.usageBytes = quotaInfo.Total.Bytes[kbfsblock.UsageWrite]
+		q.cached.gitUsageBytes = quotaInfo.Total.Bytes[kbfsblock.UsageGitWrite]
 	} else {
 		q.cached.usageBytes = 0
 	}
@@ -99,10 +104,12 @@ func (q *EventuallyConsistentQuotaUsage) getCached() cachedQuotaUsage {
 	return q.cached
 }
 
-// Get returns KBFS bytes used and limit for user. To help avoid having too
-// frequent calls into bserver, caller can provide a positive tolerance, to
-// accept stale LimitBytes and UsageBytes data. If tolerance is 0 or negative,
-// this always makes a blocking RPC to bserver and return latest quota usage.
+// Get returns KBFS bytes used and limit for user, for the current
+// default block type. To help avoid having too frequent calls into
+// bserver, caller can provide a positive tolerance, to accept stale
+// LimitBytes and UsageBytes data. If tolerance is 0 or negative, this
+// always makes a blocking RPC to bserver and return latest quota
+// usage.
 //
 // 1) If the age of cached data is more than blockTolerance, a blocking RPC is
 // issued and the function only returns after RPC finishes, with the newest
@@ -121,5 +128,30 @@ func (q *EventuallyConsistentQuotaUsage) Get(
 	}
 
 	c = q.getCached()
-	return c.timestamp, c.usageBytes, c.limitBytes, nil
+	switch q.config.DefaultBlockType() {
+	case keybase1.BlockType_DATA:
+		return c.timestamp, c.usageBytes, c.limitBytes, nil
+	case keybase1.BlockType_GIT:
+		return c.timestamp, c.gitUsageBytes, c.gitLimitBytes, nil
+	default:
+		return time.Time{}, -1, -1, errors.Errorf(
+			"Unknown default block type: %d", q.config.DefaultBlockType())
+	}
+}
+
+// GetAllTypes is the same as Get, except it returns usage and limits
+// for all block types.
+func (q *EventuallyConsistentQuotaUsage) GetAllTypes(
+	ctx context.Context, bgTolerance, blockTolerance time.Duration) (
+	timestamp time.Time,
+	usageBytes, limitBytes, gitUsageBytes, getLimitBytes int64, err error) {
+	c := q.getCached()
+	err = q.fetcher.Do(ctx, bgTolerance, blockTolerance, c.timestamp)
+	if err != nil {
+		return time.Time{}, -1, -1, -1, -1, err
+	}
+
+	c = q.getCached()
+	return c.timestamp,
+		c.usageBytes, c.limitBytes, c.gitUsageBytes, c.gitLimitBytes, nil
 }


### PR DESCRIPTION
The journal also needs to calculate its limits based on the default block type.

kbfsgit uses the GIT block type as its default.  Everything else uses DATA.

Note that this shouldn't get merged until keybase/kbfs-server#383 is merged and deployed.  But it can be reviewed now.

Issue: KBFS-2366