### PR TITLE
libgit: generate repo IDs and check repo names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -320,6 +320,13 @@ def runNixTest(prefix) {
             sh './libfs.test -test.timeout 10m'
         }
     }
+    tests[prefix+'libgit'] = {
+        dir('libgit') {
+            sh 'go test -i'
+            sh 'go test -race -c'
+            sh './libgit.test -test.timeout 10m'
+        }
+    }
     tests[prefix+'libkbfs'] = {
         dir('libkbfs') {
             sh 'go test -i'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,6 +65,7 @@ build_script:
   - echo github.com/keybase/kbfs/kbfssync >> testlist.txt
   - echo github.com/keybase/kbfs/tlf >> testlist.txt
   - echo github.com/keybase/kbfs/libfs >> testlist.txt
+  - echo github.com/keybase/kbfs/libgit >> testlist.txt
   - echo github.com/keybase/kbfs/libkbfs >> testlist.txt
   - echo github.com/keybase/kbfs/libdokan >> testlist.txt
   - echo github.com/keybase/kbfs/kbfsgit >> testlist.txt

--- a/libgit/config.go
+++ b/libgit/config.go
@@ -8,7 +8,8 @@ import "encoding/json"
 
 // Config is a KBFS git repo config file.
 type Config struct {
-	ID ID
+	ID   ID
+	Name string // the original user-supplied format of the name
 }
 
 func configFromBytes(buf []byte) (*Config, error) {

--- a/libgit/config.go
+++ b/libgit/config.go
@@ -1,0 +1,25 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import "encoding/json"
+
+// Config is a KBFS git repo config file.
+type Config struct {
+	ID ID
+}
+
+func configFromBytes(buf []byte) (*Config, error) {
+	var c Config
+	err := json.Unmarshal(buf, &c)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (c *Config) toBytes() ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/libgit/id.go
+++ b/libgit/id.go
@@ -1,0 +1,113 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"encoding"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/pkg/errors"
+)
+
+const (
+	// idByteLen is the number of bytes in a git repo ID.
+	idByteLen = 16
+	// idStringLen is the number of characters in the string
+	// representation of a git repo ID.
+	idStringLen = 2 * idByteLen
+
+	idSuffix = 0x2c
+)
+
+// InvalidIDError indicates that a repo ID string is not parseable or
+// invalid.
+type InvalidIDError struct {
+	id string
+}
+
+func (e InvalidIDError) Error() string {
+	return fmt.Sprintf("Invalid repo ID %q", e.id)
+}
+
+// ID encapsulates a repo ID.
+type ID struct {
+	id [idByteLen]byte
+}
+
+var _ encoding.BinaryMarshaler = ID{}
+var _ encoding.BinaryUnmarshaler = (*ID)(nil)
+
+var _ encoding.TextMarshaler = ID{}
+var _ encoding.TextUnmarshaler = (*ID)(nil)
+
+// NullID is an empty ID
+var NullID = ID{}
+
+// Bytes returns the bytes of the ID.
+func (id ID) Bytes() []byte {
+	return id.id[:]
+}
+
+// String implements the Stringer interface for ID.
+func (id ID) String() string {
+	return hex.EncodeToString(id.id[:])
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface for ID.
+func (id ID) MarshalBinary() (data []byte, err error) {
+	suffix := id.id[idByteLen-1]
+	if suffix != idSuffix {
+		return nil, errors.WithStack(InvalidIDError{id.String()})
+	}
+	return id.id[:], nil
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+// for ID.
+func (id *ID) UnmarshalBinary(data []byte) error {
+	if len(data) != idByteLen {
+		return errors.WithStack(InvalidIDError{hex.EncodeToString(data)})
+	}
+	suffix := data[idByteLen-1]
+	if suffix != idSuffix {
+		return errors.WithStack(InvalidIDError{hex.EncodeToString(data)})
+	}
+	copy(id.id[:], data)
+	return nil
+}
+
+// MarshalText implements the encoding.TextMarshaler interface for ID.
+func (id ID) MarshalText() ([]byte, error) {
+	bytes, err := id.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return []byte(hex.EncodeToString(bytes)), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface for
+// ID.
+func (id *ID) UnmarshalText(buf []byte) error {
+	s := string(buf)
+	bytes, err := hex.DecodeString(s)
+	if err != nil {
+		return errors.WithStack(InvalidIDError{s})
+	}
+	return id.UnmarshalBinary(bytes)
+}
+
+func makeRandomID() (id ID, err error) {
+	// Loop just in case we randomly pick the null ID.
+	for id == NullID {
+		err := kbfscrypto.RandRead(id.id[:idByteLen-1])
+		if err != nil {
+			return ID{}, err
+		}
+	}
+	id.id[idByteLen-1] = idSuffix
+	return id, nil
+}

--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -63,7 +64,7 @@ func createNewRepoAndID(
 	config.MakeLogger("").CDebugf(ctx,
 		"Creating a new repo %s in %s: repoID=%s",
 		repoName, tlfHandle.GetCanonicalPath(), repoID)
-	c := &Config{repoID}
+	c := &Config{repoID, repoName}
 	buf, err := c.toBytes()
 	if err != nil {
 		return NullID, err
@@ -93,6 +94,7 @@ func GetOrCreateRepoAndID(
 	if err != nil {
 		return nil, NullID, err
 	}
+	normalizedRepoName := strings.ToLower(repoName)
 
 	lookupOrCreateDir := func(n libkbfs.Node, name string) (
 		libkbfs.Node, error) {
@@ -114,13 +116,14 @@ func GetOrCreateRepoAndID(
 	if err != nil {
 		return nil, NullID, err
 	}
-	_, err = lookupOrCreateDir(repoDir, repoName)
+	_, err = lookupOrCreateDir(repoDir, normalizedRepoName)
 	if err != nil {
 		return nil, NullID, err
 	}
 
 	fs, err := libfs.NewFS(
-		ctx, config, tlfHandle, path.Join(kbfsRepoDir, repoName), uniqID)
+		ctx, config, tlfHandle, path.Join(kbfsRepoDir, normalizedRepoName),
+		uniqID)
 	if err != nil {
 		return nil, NullID, err
 	}

--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -1,0 +1,150 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/pkg/errors"
+)
+
+const (
+	kbfsRepoDir    = ".kbfs_git"
+	kbfsConfigName = "kbfs_config"
+)
+
+// This character set is what Github supports in repo names.  It's
+// probably to avoid any problems when cloning onto filesystems that
+// have different Unicode decompression schemes
+// (https://en.wikipedia.org/wiki/Unicode_equivalence).  There's no
+// internal reason to be so restrictive, but it probably makes sense
+// to start off more restrictive and then relax things later as we
+// test.
+var repoNameRE = regexp.MustCompile(`^([a-zA-Z0-9][a-zA-Z0-9_.-]+)$`)
+
+func checkValidRepoName(repoName string, config libkbfs.Config) bool {
+	return len(repoName) >= 1 &&
+		uint32(len(repoName)) <= config.MaxNameBytes() &&
+		(os.Getenv("KBFS_GIT_REPONAME_SKIP_CHECK") != "" ||
+			repoNameRE.MatchString(repoName))
+}
+
+// InvalidRepoNameError indicates that a repo name is invalid.
+type InvalidRepoNameError struct {
+	name string
+}
+
+func (e InvalidRepoNameError) Error() string {
+	return fmt.Sprintf("Invalid repo name %q", e.name)
+}
+
+func createNewRepoAndID(
+	ctx context.Context, config libkbfs.Config, tlfHandle *libkbfs.TlfHandle,
+	repoName string, fs *libfs.FS) (ID, error) {
+	if !checkValidRepoName(repoName, config) {
+		return NullID, errors.WithStack(InvalidRepoNameError{repoName})
+	}
+
+	// TODO: take a global repo lock here to make sure only one
+	// client generates the repo ID.
+	repoID, err := makeRandomID()
+	if err != nil {
+		return NullID, err
+	}
+	config.MakeLogger("").CDebugf(ctx,
+		"Creating a new repo %s in %s: repoID=%s",
+		repoName, tlfHandle.GetCanonicalPath(), repoID)
+	c := &Config{repoID}
+	buf, err := c.toBytes()
+	if err != nil {
+		return NullID, err
+	}
+	f, err := fs.Create(kbfsConfigName)
+	if err != nil {
+		return NullID, err
+	}
+	defer f.Close()
+	_, err = f.Write(buf)
+	if err != nil {
+		return NullID, err
+	}
+	return repoID, nil
+}
+
+// GetOrCreateRepoAndID returns a filesystem object rooted at the
+// specified repo, along with the stable repo ID.  If the repo hasn't
+// been created yet, it generates a new ID and creates the repo.  The
+// caller is responsible for syncing the FS and flushing the journal,
+// if desired.
+func GetOrCreateRepoAndID(
+	ctx context.Context, config libkbfs.Config, tlfHandle *libkbfs.TlfHandle,
+	repoName string, uniqID string) (*libfs.FS, ID, error) {
+	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
+		ctx, tlfHandle, libkbfs.MasterBranch)
+	if err != nil {
+		return nil, NullID, err
+	}
+
+	lookupOrCreateDir := func(n libkbfs.Node, name string) (
+		libkbfs.Node, error) {
+		newNode, _, err := config.KBFSOps().Lookup(ctx, n, name)
+		switch errors.Cause(err).(type) {
+		case libkbfs.NoSuchNameError:
+			newNode, _, err = config.KBFSOps().CreateDir(ctx, n, name)
+			if err != nil {
+				return nil, err
+			}
+		case nil:
+		default:
+			return nil, err
+		}
+		return newNode, nil
+	}
+
+	repoDir, err := lookupOrCreateDir(rootNode, kbfsRepoDir)
+	if err != nil {
+		return nil, NullID, err
+	}
+	_, err = lookupOrCreateDir(repoDir, repoName)
+	if err != nil {
+		return nil, NullID, err
+	}
+
+	fs, err := libfs.NewFS(
+		ctx, config, tlfHandle, path.Join(kbfsRepoDir, repoName), uniqID)
+	if err != nil {
+		return nil, NullID, err
+	}
+
+	f, err := fs.Open(kbfsConfigName)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, NullID, err
+	} else if os.IsNotExist(err) {
+		// Create a new repo ID.
+		repoID, err := createNewRepoAndID(ctx, config, tlfHandle, repoName, fs)
+		if err != nil {
+			return nil, NullID, err
+		}
+		return fs, repoID, nil
+	}
+	defer f.Close()
+
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, NullID, err
+	}
+	c, err := configFromBytes(buf)
+	if err != nil {
+		return nil, NullID, err
+	}
+	return fs, c.ID, nil
+}

--- a/libgit/repo_test.go
+++ b/libgit/repo_test.go
@@ -1,0 +1,81 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+)
+
+func initConfig(t *testing.T) (
+	ctx context.Context, config *libkbfs.ConfigLocal, tempDir string) {
+	ctx = libkbfs.BackgroundContextWithCancellationDelayer()
+	config = libkbfs.MakeTestConfigOrBustLoggedInWithMode(
+		t, 0, libkbfs.InitSingleOp, "user1")
+	success := false
+
+	var err error
+	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
+	require.NoError(t, err)
+	defer func() {
+		if !success {
+			os.RemoveAll(tempdir)
+		}
+	}()
+
+	err = config.EnableDiskLimiter(tempdir)
+	require.NoError(t, err)
+	err = config.EnableJournaling(
+		ctx, tempdir, libkbfs.TLFJournalBackgroundWorkEnabled)
+	require.NoError(t, err)
+
+	return ctx, config, tempDir
+}
+
+func TestRepo(t *testing.T) {
+	ctx, config, tempdir := initConfig(t)
+	defer os.RemoveAll(tempdir)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+
+	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	require.NoError(t, err)
+
+	fs, id1, err := GetOrCreateRepoAndID(ctx, config, h, "Repo1", "")
+	require.NoError(t, err)
+
+	// Another get should have the same ID.
+	_, id2, err := GetOrCreateRepoAndID(ctx, config, h, "Repo1", "")
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+
+	// Now make sure case doesn't matter.
+	_, id3, err := GetOrCreateRepoAndID(ctx, config, h, "repo1", "")
+	require.NoError(t, err)
+	require.Equal(t, id1, id3)
+
+	// Invalid names.
+	_, _, err = GetOrCreateRepoAndID(ctx, config, h, ".repo2", "")
+	require.NotNil(t, err)
+	_, _, err = GetOrCreateRepoAndID(ctx, config, h, "repo3.ツ", "")
+	require.NotNil(t, err)
+	_, _, err = GetOrCreateRepoAndID(ctx, config, h, "repo(4)", "")
+	require.NotNil(t, err)
+
+	fs.SyncAll()
+
+	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
+		ctx, h, libkbfs.MasterBranch)
+	require.NoError(t, err)
+	jServer, err := libkbfs.GetJournalServer(config)
+	require.NoError(t, err)
+	err = jServer.FinishSingleOp(ctx, rootNode.GetFolderBranch().Tlf)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR refactors the kbfsgit code a bit to move repo directory creation into its own library, because that part will likely be used by the kbfsfuse/kbfsdokan binaries upon a request from the GUI to create a repo.

The service also requires a stable random ID per repo, and KBFS will be the source of truth for that ID.  So we write that ID to a new config file in the repo, so we can always retrieve it.

This also adds some restrictions on repo names, and normalizes names by lower-casing them.  It preserves the original casing of the name in the kbfs repo config file, in case we want to display it that way in the GUI.

Issue: KBFS-2389