### PR TITLE
[KBFS-2402] Fix working set cache status

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -411,6 +411,14 @@ func (cache *DiskBlockCacheStandard) getMetadataLocked(blockID kbfsblock.ID) (
 		return metadata, err
 	}
 	err = cache.config.Codec().Decode(metadataBytes, &metadata)
+	if cache.cacheType == workingSetCacheLimitTrackerType {
+		// KBFS-2402: a bug in a previous master caused the wrong prefetch
+		// status to be saved in the working set cache.
+		if metadata.FinishedPrefetch == true {
+			metadata.TriggeredPrefetch = true
+		}
+		metadata.FinishedPrefetch = false
+	}
 	return metadata, err
 }
 


### PR DESCRIPTION
This is needed to make the sync cache work properly for people with content in their working set disk cache.