### PR TITLE
kbfsgit: support verbosity and progress options, and print timing

### DIFF
--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -42,7 +42,7 @@ func TestRunnerCapabilities(t *testing.T) {
 	require.NoError(t, err)
 	err = r.processCommands(ctx)
 	require.NoError(t, err)
-	require.Equal(t, "fetch\npush\n\n", output.String())
+	require.Equal(t, "fetch\npush\noption\n\n", output.String())
 }
 
 func initConfigForRunner(t *testing.T) (

--- a/kbfsgit/start.go
+++ b/kbfsgit/start.go
@@ -48,6 +48,9 @@ func Start(ctx context.Context, options StartOptions,
 		return libfs.InitError(err.Error())
 	}
 
+	// Ideally we wouldn't print this if the verbosity is 0, but we
+	// don't know that until we start parsing options.  TODO: get rid
+	// of this once we integrate with the kbfs daemon.
 	errput.Write([]byte("Initializing Keybase... "))
 
 	// Assign a unique ID to each remote-helper instance, since


### PR DESCRIPTION
With these changes, if '-q' is given to a git command, git-remote-keybase will print (almost) nothing to stderr.  If '-v -v' is given, it will print timing measurements after each phase, to help with debugging.

Sample clone output with '-v -v':

```
KEYBASE_RUN_MODE=staging git clone -v -v  keybase://private/strib/test12
Cloning into 'test12'...
Initializing Keybase... done.
Syncing with Keybase... done. [1.803462194s]
Counting: 36 objects... done. [944.830662ms]
Reading: 36/36 objects... done. [58.81333ms]
Sorting... done. [111.516µs]
Calculating deltas: 36/36 objects... done. [165.307µs]
Fetching: 36/36 objects... done. [10.526864ms]
Checking connectivity... done.
```