### PR TITLE
block_retrieval_queue: Monitor prefetches in a separate context

### DIFF
--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -243,6 +243,11 @@ func (b *BlockCacheStandard) makeRoomForSize(size uint64, lifetime BlockCacheLif
 func (b *BlockCacheStandard) PutWithPrefetch(
 	ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime,
 	prefetchStatus PrefetchStatus) (err error) {
+	// We first check if the block shouldn't be cached, since CommonBlocks can
+	// take this path.
+	if lifetime == NoCacheEntry {
+		return nil
+	}
 	// Just in case we tried to cache a block type that shouldn't be cached,
 	// return an error. This is an insurance check. That said, this got rid of
 	// a flake in TestSBSConflicts, so we should still look for the underlying
@@ -259,9 +264,6 @@ func (b *BlockCacheStandard) PutWithPrefetch(
 	var wasInCache bool
 
 	switch lifetime {
-	case NoCacheEntry:
-		return nil
-
 	case TransientEntry:
 		// If it's the right type of block, store the hash -> ID mapping.
 		if fBlock, isFileBlock := block.(*FileBlock); b.ids != nil &&

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -332,8 +332,7 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	kmd2 := makeFakeKeyMetadata(tlfID, keyGen+3)
 	decryptedBlock := &FileBlock{}
 	err = bops.Get(ctx, kmd2,
-		BlockPointer{ID: id, DataVer: FirstValidDataVer,
-			KeyGen: keyGen, Context: bCtx},
+		BlockPointer{ID: id, KeyGen: keyGen, Context: bCtx},
 		decryptedBlock, NoCacheEntry)
 	require.NoError(t, err)
 	require.Equal(t, block, decryptedBlock)
@@ -359,8 +358,7 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, DataVer: FirstValidDataVer,
-			KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.IsType(t, kbfsblock.BServerErrorBlockNonExistent{}, err)
 }
@@ -406,8 +404,7 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, DataVer: FirstValidDataVer,
-			KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.IsType(t, kbfshash.HashMismatchError{}, errors.Cause(err))
 }
@@ -436,8 +433,7 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, DataVer: FirstValidDataVer,
-			KeyGen: latestKeyGen + 1, Context: bCtx},
+		BlockPointer{ID: id, KeyGen: latestKeyGen + 1, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.EqualError(t, err, fmt.Sprintf(
 		"no key for block decryption (keygen=%d)", latestKeyGen+1))
@@ -507,8 +503,7 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, DataVer: FirstValidDataVer,
-			KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.Equal(t, decodeErr, err)
 }
@@ -547,8 +542,7 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, DataVer: FirstValidDataVer,
-			KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.EqualError(t, err, "could not decrypt block")
 }

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -332,7 +332,8 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	kmd2 := makeFakeKeyMetadata(tlfID, keyGen+3)
 	decryptedBlock := &FileBlock{}
 	err = bops.Get(ctx, kmd2,
-		BlockPointer{ID: id, KeyGen: keyGen, Context: bCtx},
+		BlockPointer{ID: id, DataVer: FirstValidDataVer,
+			KeyGen: keyGen, Context: bCtx},
 		decryptedBlock, NoCacheEntry)
 	require.NoError(t, err)
 	require.Equal(t, block, decryptedBlock)
@@ -358,7 +359,8 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, DataVer: FirstValidDataVer,
+			KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.IsType(t, kbfsblock.BServerErrorBlockNonExistent{}, err)
 }
@@ -404,7 +406,8 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, DataVer: FirstValidDataVer,
+			KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.IsType(t, kbfshash.HashMismatchError{}, errors.Cause(err))
 }
@@ -433,7 +436,8 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, KeyGen: latestKeyGen + 1, Context: bCtx},
+		BlockPointer{ID: id, DataVer: FirstValidDataVer,
+			KeyGen: latestKeyGen + 1, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.EqualError(t, err, fmt.Sprintf(
 		"no key for block decryption (keygen=%d)", latestKeyGen+1))
@@ -503,7 +507,8 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, DataVer: FirstValidDataVer,
+			KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.Equal(t, decodeErr, err)
 }
@@ -542,7 +547,8 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 
 	var decryptedBlock FileBlock
 	err = bops.Get(ctx, kmd,
-		BlockPointer{ID: id, KeyGen: latestKeyGen, Context: bCtx},
+		BlockPointer{ID: id, DataVer: FirstValidDataVer,
+			KeyGen: latestKeyGen, Context: bCtx},
 		&decryptedBlock, NoCacheEntry)
 	require.EqualError(t, err, "could not decrypt block")
 }

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -448,13 +448,6 @@ func (brq *blockRetrievalQueue) RequestWithPrefetch(ctx context.Context,
 		ch <- nil
 		return ch
 	}
-	if err := checkDataVersion(brq.config, path{}, ptr); err != nil {
-		if deepPrefetchCancelCh != nil {
-			deepPrefetchCancelCh <- struct{}{}
-		}
-		ch <- err
-		return ch
-	}
 
 	bpLookup := blockPtrLookup{ptr, reflect.TypeOf(block)}
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -443,6 +443,14 @@ func (brq *blockRetrievalQueue) RequestWithPrefetch(ctx context.Context,
 		ch <- nil
 		return ch
 	}
+	err = checkDataVersion(brq.config, path{}, ptr)
+	if err != nil {
+		if deepPrefetchCancelCh != nil {
+			deepPrefetchCancelCh <- struct{}{}
+		}
+		ch <- err
+		return ch
+	}
 
 	bpLookup := blockPtrLookup{ptr, reflect.TypeOf(block)}
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -443,14 +443,6 @@ func (brq *blockRetrievalQueue) RequestWithPrefetch(ctx context.Context,
 		ch <- nil
 		return ch
 	}
-	err = checkDataVersion(brq.config, path{}, ptr)
-	if err != nil {
-		if deepPrefetchCancelCh != nil {
-			deepPrefetchCancelCh <- struct{}{}
-		}
-		ch <- err
-		return ch
-	}
 
 	bpLookup := blockPtrLookup{ptr, reflect.TypeOf(block)}
 

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -490,9 +490,6 @@ func (cache *DiskBlockCacheStandard) Get(ctx context.Context, tlfID tlf.ID,
 	}
 
 	defer func() {
-		cache.log.CDebugf(ctx, "Cache Get id=%s tlf=%s bSize=%d, "+
-			"prefetchStatus=%s err=%+v", blockID, tlfID, len(buf),
-			prefetchStatus.String(), err)
 		if err == nil {
 			cache.hitMeter.Mark(1)
 		} else {

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -570,11 +570,13 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 	}
 	encodedLen := int64(len(entry))
 	defer func() {
-		cache.log.CDebugf(ctx, "Cache Put id=%s tlf=%s bSize=%d entrySize=%d "+
-			"err=%+v", blockID, tlfID, blockLen, encodedLen, err)
 		if err == nil {
 			cache.putMeter.Mark(1)
+		} else {
+			err = errors.WithStack(err)
 		}
+		cache.log.CDebugf(ctx, "Cache Put id=%s tlf=%s bSize=%d entrySize=%d "+
+			"err=%+v", blockID, tlfID, blockLen, encodedLen, err)
 	}()
 	blockKey := blockID.Bytes()
 	hasKey, err := cache.blockDb.Has(blockKey, nil)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -308,6 +308,11 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 		return 0, InvalidBlockRefError{ptr.Ref()}
 	}
 
+	// Try to get the encoded size from the cache before escalating to the
+	// block retriever (even though it's supposed to do a similar thing with
+	// checking caches before checking the data version).
+	// TODO: Figure out how to remove this without breaking journal tests in
+	// kbfs/test.
 	if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
 		return block.GetEncodedSize(), nil
 	}
@@ -369,21 +374,6 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 	if block, err := fbo.config.DirtyBlockCache().Get(
 		fbo.id(), ptr, branch); err == nil {
 		return block, nil
-	}
-
-	if block, prefetchStatus, lifetime, err :=
-		fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
-		// If the block was cached in the past, we need to handle it as if it's
-		// an on-demand request so that its downstream prefetches are triggered
-		// correctly according to the new on-demand fetch priority.
-		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(ctx,
-			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
-			prefetchStatus, nil, nil)
-		return block, nil
-	}
-
-	if err := checkDataVersion(fbo.config, notifyPath, ptr); err != nil {
-		return nil, err
 	}
 
 	if notifyPath.isValidForNotification() {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1299,7 +1299,7 @@ func (fbo *folderBlockOps) updateWithDirtyEntriesLocked(ctx context.Context,
 }
 
 // getDirtyDirLocked composes getDirLocked and
-// updatedWithDirtyEntriesLocked. Note that a dirty dir means that it
+// updateWithDirtyEntriesLocked. Note that a dirty dir means that it
 // has entries possibly pointing to dirty files, and/or that its
 // children list is dirty.
 func (fbo *folderBlockOps) getDirtyDirLocked(ctx context.Context,
@@ -1481,11 +1481,6 @@ func (fbo *folderBlockOps) Lookup(
 
 	if de.Type == Sym {
 		return nil, de, nil
-	}
-
-	err = checkDataVersion(fbo.config, childPath, de.BlockPointer)
-	if err != nil {
-		return nil, DirEntry{}, err
 	}
 
 	node, err := fbo.nodeCache.GetOrCreate(de.BlockPointer, name, dir)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -308,14 +308,6 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 		return 0, InvalidBlockRefError{ptr.Ref()}
 	}
 
-	if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
-		return block.GetEncodedSize(), nil
-	}
-
-	if err := checkDataVersion(fbo.config, path{}, ptr); err != nil {
-		return 0, err
-	}
-
 	// Unlock the blockLock while we wait for the network, only if
 	// it's locked for reading by a single goroutine.  If it's locked
 	// for writing, that indicates we are performing an atomic write
@@ -369,21 +361,6 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 	if block, err := fbo.config.DirtyBlockCache().Get(
 		fbo.id(), ptr, branch); err == nil {
 		return block, nil
-	}
-
-	if block, prefetchStatus, lifetime, err :=
-		fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
-		// If the block was cached in the past, we need to handle it as if it's
-		// an on-demand request so that its downstream prefetches are triggered
-		// correctly according to the new on-demand fetch priority.
-		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(ctx,
-			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
-			prefetchStatus, nil, nil)
-		return block, nil
-	}
-
-	if err := checkDataVersion(fbo.config, notifyPath, ptr); err != nil {
-		return nil, err
 	}
 
 	if notifyPath.isValidForNotification() {

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -27,6 +27,7 @@ type FolderBranchStatus struct {
 	FolderID            string
 	Revision            kbfsmd.Revision
 	MDVersion           MetadataVer
+	RootBlockID         string
 	SyncEnabled         bool
 	PrefetchStatus      string
 
@@ -205,6 +206,7 @@ func (fbsk *folderBranchStatusKeeper) getStatus(ctx context.Context,
 		prefetchStatus := fbsk.config.PrefetchStatus(ctx, fbsk.md.TlfID(),
 			fbsk.md.Data().Dir.BlockPointer)
 		fbs.PrefetchStatus = prefetchStatus.String()
+		fbs.RootBlockID = fbsk.md.Data().Dir.BlockPointer.ID.String()
 
 		// TODO: Ideally, the journal would push status
 		// updates to this object instead, so we can notify

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -716,8 +716,6 @@ func TestKBFSOpsGetBaseDirChildrenHidesFiles(t *testing.T) {
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, p)
 
-	expectBlock(config, rmd, blockPtr, dirBlock, nil)
-
 	children, err := config.KBFSOps().GetDirChildren(ctx, n)
 	if err != nil {
 		t.Errorf("Got error on getdir: %+v", err)
@@ -750,8 +748,6 @@ func TestKBFSOpsGetBaseDirChildrenCacheSuccess(t *testing.T) {
 	testPutBlockInCache(t, config, node.BlockPointer, id, dirBlock)
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, p)
-
-	expectBlock(config, rmd, blockPtr, dirBlock, nil)
 
 	children, err := config.KBFSOps().GetDirChildren(ctx, n)
 	if err != nil {
@@ -884,8 +880,6 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, bNode.BlockPointer, id, dirBlock)
 
-	expectBlock(config, rmd, bNode.BlockPointer, dirBlock, nil)
-
 	children, err := config.KBFSOps().GetDirChildren(ctx, n)
 	if err != nil {
 		t.Errorf("Got error on getdir: %+v", err)
@@ -931,8 +925,6 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
-	expectBlock(config, rmd, aNode.BlockPointer, dirBlock, nil)
-
 	bn, ei, err := config.KBFSOps().Lookup(ctx, n, "b")
 	if err != nil {
 		t.Errorf("Error on Lookup: %+v", err)
@@ -977,8 +969,6 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
-	expectBlock(config, rmd, aNode.BlockPointer, dirBlock, nil)
-
 	bn, ei, err := config.KBFSOps().Lookup(ctx, n, "b")
 	if err != nil {
 		t.Errorf("Error on Lookup: %+v", err)
@@ -1020,9 +1010,6 @@ func TestKBFSOpsLookupNoSuchNameFail(t *testing.T) {
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
 
 	expectedErr := NoSuchNameError{"c"}
-
-	expectBlock(config, rmd, aNode.BlockPointer, dirBlock, expectedErr)
-
 	_, _, err := config.KBFSOps().Lookup(ctx, n, "c")
 	if err == nil {
 		t.Error("No error as expected on Lookup")
@@ -1066,8 +1053,6 @@ func TestKBFSOpsLookupNewDataVersionFail(t *testing.T) {
 		bInfo.DataVer,
 	}
 
-	expectBlock(config, rmd, aNode.BlockPointer, dirBlock, expectedErr)
-
 	_, _, err := config.KBFSOps().Lookup(ctx, n, "b")
 	if err == nil {
 		t.Error("No expected error found on lookup")
@@ -1104,8 +1089,6 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 	n := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, aNode.BlockPointer, id, dirBlock)
-
-	expectBlock(config, rmd, aNode.BlockPointer, dirBlock, nil)
 
 	ei, err := config.KBFSOps().Stat(ctx, n)
 	if err != nil {
@@ -1174,7 +1157,6 @@ func testCreateEntryFailDupName(t *testing.T, isDir bool) {
 	// creating "a", which already exists in the root block
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	expectedErr := NameExistsError{"a"}
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, expectedErr)
 
 	var err error
 	// dir and link have different checks for dup name
@@ -1257,7 +1239,6 @@ func testCreateEntryFailDirTooBig(t *testing.T, isDir bool) {
 	name := "aaa"
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
 
 	var err error
 	// dir and link have different checks for dup name
@@ -1452,8 +1433,6 @@ func TestRemoveDirFailNonEmpty(t *testing.T) {
 		testPutBlockInCache(
 			t, config, p.path[i].BlockPointer, id, block)
 	}
-	expectBlock(config, rmd, p.path[3].BlockPointer, blocks[3], nil)
-	expectBlock(config, rmd, p.path[4].BlockPointer, blocks[4], nil)
 
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, *p.parentPath().parentPath())
@@ -1540,7 +1519,6 @@ func TestRemoveDirFailNoSuchName(t *testing.T) {
 		testPutBlockInCache(
 			t, config, p.path[i].BlockPointer, id, block)
 	}
-	expectBlock(config, rmd, p.path[5].BlockPointer, blocks[5], nil)
 
 	ops := getOps(config, id)
 	n := nodeFromPath(t, ops, p)
@@ -1640,8 +1618,6 @@ func TestKBFSOpsCacheReadFullSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
 
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-
 	n := len(fileBlock.Contents)
 	dest := make([]byte, n, n)
 	if n2, err := config.KBFSOps().Read(ctx, pNode, dest, 0); err != nil {
@@ -1670,8 +1646,6 @@ func TestKBFSOpsCacheReadPartialSuccess(t *testing.T) {
 	pNode := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 
 	dest := make([]byte, 4, 4)
 	if n, err := config.KBFSOps().Read(ctx, pNode, dest, 2); err != nil {
@@ -1722,12 +1696,6 @@ func TestKBFSOpsCacheReadFullMultiBlockSuccess(t *testing.T) {
 	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[2].BlockPointer, id, block3)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[3].BlockPointer, id, block4)
-
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[0].BlockPointer, block1, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[2].BlockPointer, block3, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[3].BlockPointer, block4, nil)
 
 	n := 20
 	dest := make([]byte, n, n)
@@ -1782,11 +1750,6 @@ func TestKBFSOpsCacheReadPartialMultiBlockSuccess(t *testing.T) {
 	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[2].BlockPointer, id, block3)
 
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[0].BlockPointer, block1, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[2].BlockPointer, block3, nil)
-
 	n := 10
 	dest := make([]byte, n, n)
 	contents := append(block1.Contents[3:], block2.Contents...)
@@ -1817,8 +1780,6 @@ func TestKBFSOpsCacheReadFailPastEnd(t *testing.T) {
 	pNode := nodeFromPath(t, ops, p)
 
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 
 	dest := make([]byte, 4, 4)
 	if n, err := config.KBFSOps().Read(ctx, pNode, dest, 10); err != nil {
@@ -1958,10 +1919,6 @@ func TestKBFSOpsWriteNewBlockSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-
 	config.mockBsplit.EXPECT().CopyUntilSplit(
 		gomock.Any(), gomock.Any(), data, int64(0)).
 		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
@@ -2035,9 +1992,6 @@ func TestKBFSOpsWriteExtendSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 	config.mockBsplit.EXPECT().CopyUntilSplit(
 		gomock.Any(), gomock.Any(), data, int64(5)).
 		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
@@ -2099,9 +2053,6 @@ func TestKBFSOpsWritePastEndSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 	config.mockBsplit.EXPECT().CopyUntilSplit(
 		gomock.Any(), gomock.Any(), data, int64(7)).
 		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
@@ -2163,9 +2114,6 @@ func TestKBFSOpsWriteCauseSplit(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 
 	// only copy the first half first
 	config.mockBsplit.EXPECT().CopyUntilSplit(
@@ -2307,10 +2255,6 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[0].BlockPointer, id, block1)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[0].BlockPointer, block1, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2, nil)
 
 	// only copy the first half first
 	config.mockBsplit.EXPECT().CopyUntilSplit(
@@ -2394,10 +2338,6 @@ func TestKBFSOpsTruncateToZeroSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 
 	data := []byte{}
 	if err := config.KBFSOps().Truncate(ctx, n, 0); err != nil {
@@ -2463,16 +2403,6 @@ func TestKBFSOpsTruncateSameSize(t *testing.T) {
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
 
-	// FIXME: I couldn't figure out the correct incantation of EXPECTs here.
-	// Fix some other time.
-	config.mockBops.EXPECT().Get(gomock.Any(), kmdMatcher{rmd},
-		gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(ctx context.Context, kmd KeyMetadata,
-			blockPtr BlockPointer, getBlock Block, lifetime BlockCacheLifetime) {
-			getBlock.Set(fileBlock)
-			config.BlockCache().Put(blockPtr, kmd.TlfID(), getBlock, lifetime)
-		}).Return(nil).AnyTimes()
-
 	data := fileBlock.Contents
 	if err := config.KBFSOps().Truncate(ctx, n, 10); err != nil {
 		t.Errorf("Got error on truncate: %+v", err)
@@ -2513,10 +2443,6 @@ func TestKBFSOpsTruncateSmallerSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 
 	data := []byte{1, 2, 3, 4, 5}
 	if err := config.KBFSOps().Truncate(ctx, n, 5); err != nil {
@@ -2585,10 +2511,6 @@ func TestKBFSOpsTruncateShortensLastBlock(t *testing.T) {
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[0].BlockPointer, id, block1)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[1].BlockPointer, block2, nil)
 
 	data2 := []byte{10, 9}
 	if err := config.KBFSOps().Truncate(ctx, n, 7); err != nil {
@@ -2675,10 +2597,6 @@ func TestKBFSOpsTruncateRemovesABlock(t *testing.T) {
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[0].BlockPointer, id, block1)
 	testPutBlockInCache(t, config, fileBlock.IPtrs[1].BlockPointer, id, block2)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[0].BlockPointer, block1, nil)
-	expectBlock(config, rmd, fileBlock.IPtrs[0].BlockPointer, block1, nil)
 
 	data := []byte{5, 4, 3, 2}
 	if err := config.KBFSOps().Truncate(ctx, n, 4); err != nil {
@@ -2748,11 +2666,6 @@ func TestKBFSOpsTruncateBiggerSuccess(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	testPutBlockInCache(t, config, fileNode.BlockPointer, id, fileBlock)
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
-	expectBlock(config, rmd, fileNode.BlockPointer, fileBlock, nil)
 	config.mockBsplit.EXPECT().CopyUntilSplit(
 		gomock.Any(), gomock.Any(), []byte{0, 0, 0, 0, 0}, int64(5)).
 		Do(func(block *FileBlock, lb bool, data []byte, off int64) {
@@ -2805,7 +2718,6 @@ func TestSetExFailNoSuchName(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	expectedErr := NoSuchNameError{p.tailName()}
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, expectedErr)
 
 	// chmod a+x a
 	if err := config.KBFSOps().SetEx(ctx, n, true); err == nil {
@@ -2870,7 +2782,6 @@ func TestMtimeFailNoSuchName(t *testing.T) {
 
 	testPutBlockInCache(t, config, node.BlockPointer, id, rootBlock)
 	expectedErr := NoSuchNameError{p.tailName()}
-	expectBlock(config, rmd, node.BlockPointer, rootBlock, expectedErr)
 
 	newMtime := time.Now()
 	if err := config.KBFSOps().SetMtime(ctx, n, &newMtime); err == nil {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -122,12 +122,6 @@ func (p *blockPrefetcher) run() {
 func (p *blockPrefetcher) request(priority int, kmd KeyMetadata,
 	ptr BlockPointer, block Block, entryName string,
 	doneCh, errCh chan<- struct{}) error {
-	if _, err := p.config.BlockCache().Get(ptr); err == nil {
-		return nil
-	}
-	if err := checkDataVersion(p.config, path{}, ptr); err != nil {
-		return err
-	}
 	select {
 	case p.progressCh <- prefetchRequest{
 		priority, kmd, ptr, block, doneCh, errCh}:


### PR DESCRIPTION
Do this so the monitoring doesn't get canceled.