### PR TITLE
vendor: pull in more go-git optimizations

### DIFF
--- a/vendor/gopkg.in/src-d/go-git.v4/config/config.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/config/config.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 
 	format "gopkg.in/src-d/go-git.v4/plumbing/format/config"
 )
@@ -40,6 +41,14 @@ type Config struct {
 		// Worktree is the path to the root of the working tree.
 		Worktree string
 	}
+
+	Pack struct {
+		// Window controls the size of the sliding window for delta
+		// compression.  The default is 10.  A value of 0 turns off
+		// delta compression entirely.
+		Window uint
+	}
+
 	// Remotes list of repository remotes, the key of the map is the name
 	// of the remote, should equal to RemoteConfig.Name.
 	Remotes map[string]*RemoteConfig
@@ -81,10 +90,14 @@ const (
 	remoteSection    = "remote"
 	submoduleSection = "submodule"
 	coreSection      = "core"
+	packSection      = "pack"
 	fetchKey         = "fetch"
 	urlKey           = "url"
 	bareKey          = "bare"
 	worktreeKey      = "worktree"
+	windowKey        = "window"
+
+	defaultPackWindow = uint(10)
 )
 
 // Unmarshal parses a git-config file and stores it.
@@ -98,6 +111,9 @@ func (c *Config) Unmarshal(b []byte) error {
 	}
 
 	c.unmarshalCore()
+	if err := c.unmarshalPack(); err != nil {
+		return err
+	}
 	c.unmarshalSubmodules()
 	return c.unmarshalRemotes()
 }
@@ -109,6 +125,21 @@ func (c *Config) unmarshalCore() {
 	}
 
 	c.Core.Worktree = s.Options.Get(worktreeKey)
+}
+
+func (c *Config) unmarshalPack() error {
+	s := c.Raw.Section(packSection)
+	window := s.Options.Get(windowKey)
+	if window == "" {
+		c.Pack.Window = defaultPackWindow
+	} else {
+		winUint, err := strconv.ParseUint(window, 10, 32)
+		if err != nil {
+			return err
+		}
+		c.Pack.Window = uint(winUint)
+	}
+	return nil
 }
 
 func (c *Config) unmarshalRemotes() error {
@@ -138,6 +169,7 @@ func (c *Config) unmarshalSubmodules() {
 // Marshal returns Config encoded as a git-config file.
 func (c *Config) Marshal() ([]byte, error) {
 	c.marshalCore()
+	c.marshalPack()
 	c.marshalRemotes()
 	c.marshalSubmodules()
 
@@ -155,6 +187,13 @@ func (c *Config) marshalCore() {
 
 	if c.Core.Worktree != "" {
 		s.SetOption(worktreeKey, c.Core.Worktree)
+	}
+}
+
+func (c *Config) marshalPack() {
+	s := c.Raw.Section(packSection)
+	if c.Pack.Window != defaultPackWindow {
+		s.SetOption(windowKey, fmt.Sprintf("%d", c.Pack.Window))
 	}
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/options.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/options.go
@@ -175,8 +175,15 @@ type PushOptions struct {
 	Auth transport.AuthMethod
 	// Progress is where the human readable information sent by the server is
 	// stored, if nil nothing is stored.
-	Progress   sideband.Progress
-	StatusChan plumbing.StatusChan
+	Progress sideband.Progress
+	// SkipCompression can be true if the caller doesn't need
+	// delta-compressed objects pushed to the remote.  This can be useful to
+	// avoid CPU overhead when the objects don't need to be
+	// transferred across a network.  If the remote wants a compressed
+	// repo after the transfer, it can run `git gc --aggressive` or
+	// `git repack -a -d -f --depth=250 --window=250` as needed.
+	SkipCompression bool
+	StatusChan      plumbing.StatusChan
 }
 
 // Validate validates the fields and sets the default values.

--- a/vendor/gopkg.in/src-d/go-git.v4/options.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/options.go
@@ -175,15 +175,8 @@ type PushOptions struct {
 	Auth transport.AuthMethod
 	// Progress is where the human readable information sent by the server is
 	// stored, if nil nothing is stored.
-	Progress sideband.Progress
-	// SkipCompression can be true if the caller doesn't need
-	// delta-compressed objects pushed to the remote.  This can be useful to
-	// avoid CPU overhead when the objects don't need to be
-	// transferred across a network.  If the remote wants a compressed
-	// repo after the transfer, it can run `git gc --aggressive` or
-	// `git repack -a -d -f --depth=250 --window=250` as needed.
-	SkipCompression bool
-	StatusChan      plumbing.StatusChan
+	Progress   sideband.Progress
+	StatusChan plumbing.StatusChan
 }
 
 // Validate validates the fields and sets the default values.

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder.go
@@ -49,9 +49,11 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *E
 // and writes it to the writer in the Encoder.
 func (e *Encoder) Encode(
 	hashes []plumbing.Hash,
+	skipCompression bool,
 	statusChan plumbing.StatusChan,
 ) (plumbing.Hash, error) {
-	objects, err := e.selector.ObjectsToPack(hashes, statusChan)
+	objects, err := e.selector.ObjectsToPack(
+		hashes, skipCompression, statusChan)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder.go
@@ -49,11 +49,11 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *E
 // and writes it to the writer in the Encoder.
 func (e *Encoder) Encode(
 	hashes []plumbing.Hash,
-	skipCompression bool,
+	packWindow uint,
 	statusChan plumbing.StatusChan,
 ) (plumbing.Hash, error) {
 	objects, err := e.selector.ObjectsToPack(
-		hashes, skipCompression, statusChan)
+		hashes, packWindow, statusChan)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/commit_walker.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/object/commit_walker.go
@@ -8,9 +8,10 @@ import (
 )
 
 type commitPreIterator struct {
-	seen  map[plumbing.Hash]bool
-	stack []CommitIter
-	start *Commit
+	seenExternal map[plumbing.Hash]bool
+	seen         map[plumbing.Hash]bool
+	stack        []CommitIter
+	start        *Commit
 }
 
 // NewCommitPreorderIter returns a CommitIter that walks the commit history,
@@ -20,16 +21,21 @@ type commitPreIterator struct {
 // and will return the error. Other errors might be returned if the history
 // cannot be traversed (e.g. missing objects). Ignore allows to skip some
 // commits from being iterated.
-func NewCommitPreorderIter(c *Commit, ignore []plumbing.Hash) CommitIter {
+func NewCommitPreorderIter(
+	c *Commit,
+	seenExternal map[plumbing.Hash]bool,
+	ignore []plumbing.Hash,
+) CommitIter {
 	seen := make(map[plumbing.Hash]bool)
 	for _, h := range ignore {
 		seen[h] = true
 	}
 
 	return &commitPreIterator{
-		seen:  seen,
-		stack: make([]CommitIter, 0),
-		start: c,
+		seenExternal: seenExternal,
+		seen:         seen,
+		stack:        make([]CommitIter, 0),
+		start:        c,
 	}
 }
 
@@ -57,7 +63,7 @@ func (w *commitPreIterator) Next() (*Commit, error) {
 			}
 		}
 
-		if w.seen[c.Hash] {
+		if w.seen[c.Hash] || w.seenExternal[c.Hash] {
 			continue
 		}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/revlist/revlist.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/revlist/revlist.go
@@ -119,7 +119,7 @@ func reachableObjects(
 	ignore []plumbing.Hash,
 	cb func(h plumbing.Hash),
 ) error {
-	i := object.NewCommitPreorderIter(commit, ignore)
+	i := object.NewCommitPreorderIter(commit, seen, ignore)
 	for {
 		commit, err := i.Next()
 		if err == io.EOF {

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/server/server.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/server/server.go
@@ -165,7 +165,8 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 	pr, pw := io.Pipe()
 	e := packfile.NewEncoder(pw, s.storer, false)
 	go func() {
-		_, err := e.Encode(objs, false, nil)
+		// TODO: plumb through a pack window.
+		_, err := e.Encode(objs, 10, nil)
 		pw.CloseWithError(err)
 	}()
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/server/server.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/server/server.go
@@ -165,7 +165,7 @@ func (s *upSession) UploadPack(ctx context.Context, req *packp.UploadPackRequest
 	pr, pw := io.Pipe()
 	e := packfile.NewEncoder(pw, s.storer, false)
 	go func() {
-		_, err := e.Encode(objs, nil)
+		_, err := e.Encode(objs, false, nil)
 		pw.CloseWithError(err)
 	}()
 

--- a/vendor/gopkg.in/src-d/go-git.v4/remote.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/remote.go
@@ -149,7 +149,8 @@ func (r *Remote) PushContext(ctx context.Context, o *PushOptions) error {
 		}
 	}
 
-	rs, err := pushHashes(ctx, s, r.s, req, hashesToPush, o.StatusChan)
+	rs, err := pushHashes(
+		ctx, s, r.s, req, hashesToPush, o.SkipCompression, o.StatusChan)
 	if err != nil {
 		return err
 	}
@@ -816,6 +817,7 @@ func pushHashes(
 	sto storer.EncodedObjectStorer,
 	req *packp.ReferenceUpdateRequest,
 	hs []plumbing.Hash,
+	skipCompression bool,
 	statusChan plumbing.StatusChan,
 ) (*packp.ReportStatus, error) {
 
@@ -824,7 +826,7 @@ func pushHashes(
 	done := make(chan error)
 	go func() {
 		e := packfile.NewEncoder(wr, sto, false)
-		if _, err := e.Encode(hs, statusChan); err != nil {
+		if _, err := e.Encode(hs, skipCompression, statusChan); err != nil {
 			done <- wr.CloseWithError(err)
 			return
 		}

--- a/vendor/gopkg.in/src-d/go-git.v4/remote.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/remote.go
@@ -631,7 +631,7 @@ func isFastForward(s storer.EncodedObjectStorer, old, new plumbing.Hash) (bool, 
 	}
 
 	found := false
-	iter := object.NewCommitPreorderIter(c, nil)
+	iter := object.NewCommitPreorderIter(c, nil, nil)
 	return found, iter.ForEach(func(c *object.Commit) error {
 		if c.Hash != old {
 			return nil

--- a/vendor/gopkg.in/src-d/go-git.v4/repository.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/repository.go
@@ -720,7 +720,7 @@ func (r *Repository) Log(o *LogOptions) (object.CommitIter, error) {
 		return nil, err
 	}
 
-	return object.NewCommitPreorderIter(commit, nil), nil
+	return object.NewCommitPreorderIter(commit, nil, nil), nil
 }
 
 // Tags returns all the References from Tags. This method returns all the tag
@@ -949,7 +949,7 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 				commit = c
 			}
 		case revision.CaretReg:
-			history := object.NewCommitPreorderIter(commit, nil)
+			history := object.NewCommitPreorderIter(commit, nil, nil)
 
 			re := item.(revision.CaretReg).Regexp
 			negate := item.(revision.CaretReg).Negate
@@ -979,7 +979,7 @@ func (r *Repository) ResolveRevision(rev plumbing.Revision) (*plumbing.Hash, err
 
 			commit = c
 		case revision.AtDate:
-			history := object.NewCommitPreorderIter(commit, nil)
+			history := object.NewCommitPreorderIter(commit, nil, nil)
 
 			date := item.(revision.AtDate).Date
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -762,284 +762,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "AlB7+zLj0QKCvUPoBwN7OZyrf+U=",
+			"checksumSHA1": "5WsW/yNLhZp3yceziVahymqQUl0=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "1d4PgjU+LhyJ2ROnz/WwrEKVh28=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
-			"checksumSHA1": "qW46T/d8YYaUd41oDvEF5jq9kvo=",
+			"checksumSHA1": "nK9mbm0TPqRuipvRYcUDmd60mZ8=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "2FPt2X+Z/oOO5twnW4QrzTvQ2yw=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
-			"checksumSHA1": "4YEzFU96Z6iR/NIpb3NXawFpFG8=",
+			"checksumSHA1": "r6pkMXt3+neE/h5mCJ/pK2tRaS8=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "CSiF391UdjILaSUJqctaa9rvSQc=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "a7qGxujLCO4NbK2+JuvNcucVze8=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "OfzMDAIu253dJ9591gd3w/APq0I=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
-			"revisionTime": "2017-09-09T00:51:38Z"
+			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
+			"revisionTime": "2017-09-09T19:14:59Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -762,284 +762,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "5WsW/yNLhZp3yceziVahymqQUl0=",
+			"checksumSHA1": "U3tqtWuGNTOEWX1ExyQ9YkJ+cNc=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
-			"checksumSHA1": "1d4PgjU+LhyJ2ROnz/WwrEKVh28=",
+			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
-			"checksumSHA1": "nK9mbm0TPqRuipvRYcUDmd60mZ8=",
+			"checksumSHA1": "0ITfxWDrma8DvTxUZ7/uIqrtCfo=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "2FPt2X+Z/oOO5twnW4QrzTvQ2yw=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
-			"checksumSHA1": "r6pkMXt3+neE/h5mCJ/pK2tRaS8=",
+			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "CSiF391UdjILaSUJqctaa9rvSQc=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "a7qGxujLCO4NbK2+JuvNcucVze8=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "OfzMDAIu253dJ9591gd3w/APq0I=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "7eafff95ef3ba46ad70d504e49de842f6f07fcef",
-			"revisionTime": "2017-09-09T19:14:59Z"
+			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
+			"revisionTime": "2017-09-11T03:59:31Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -762,284 +762,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "mgSGhREAKuKIA5KGEoq6+bywQis=",
+			"checksumSHA1": "AlB7+zLj0QKCvUPoBwN7OZyrf+U=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "1d4PgjU+LhyJ2ROnz/WwrEKVh28=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "qW46T/d8YYaUd41oDvEF5jq9kvo=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
-			"checksumSHA1": "6LZ2gIv993WaeqA2QMMvf04BRzk=",
+			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
-			"checksumSHA1": "Duljerw4Evbn8KNRKtmtpLoWnv8=",
+			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "2FPt2X+Z/oOO5twnW4QrzTvQ2yw=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "4YEzFU96Z6iR/NIpb3NXawFpFG8=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "CSiF391UdjILaSUJqctaa9rvSQc=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "a7qGxujLCO4NbK2+JuvNcucVze8=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "OfzMDAIu253dJ9591gd3w/APq0I=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "bf61ae1e0296cff73d948cdb582666270a621ada",
-			"revisionTime": "2017-09-08T18:12:15Z"
+			"revision": "af2c2978065f4bd8013abd1f4ec8e5e97c61c044",
+			"revisionTime": "2017-09-09T00:51:38Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
* Speeding up "Counting" phase: src-d/go-git#586
* Allowing us to skip delta compression (not used yet): src-d/go-git#587