### PR TITLE
kbfsgit: push multiple refspecs in a batch, fixing hang

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -930,7 +930,7 @@ func (r *runner) handlePushBatch(ctx context.Context, args [][]string) (
 		if err == gogit.NoErrAlreadyUpToDate {
 			err = nil
 		}
-		// All refspecs in the batch get the same error.
+		// All non-delete refspecs in the batch get the same error.
 		for _, refspec := range refspecs {
 			refStr := refspec.String()
 			start := strings.Index(refStr, ":") + 1


### PR DESCRIPTION
If you tried to push more than one branch/tag at once, kbfsgit would hang because after the first refspec, the statusChan would get a Done event and stop processing more events, eventually causing go-git to block.

Instead let's just push the whole batch at once, like we're supposed to.  I was previously worried that this would mean we wouldn't have a unique error for each branch, but now I don't think that's a big deal. We'll just use the same error for all destinations in a batch.