### PR TITLE
libgit: implement CreateRepo RPC

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -81,22 +81,6 @@ const (
 	ctxCommandIDKey ctxCommandTagKey = iota
 )
 
-func getHandleFromFolderName(ctx context.Context, config libkbfs.Config,
-	tlfName string, t tlf.Type) (*libkbfs.TlfHandle, error) {
-	for {
-		tlfHandle, err := libkbfs.ParseTlfHandle(
-			ctx, config.KBPKI(), tlfName, t)
-		switch e := errors.Cause(err).(type) {
-		case libkbfs.TlfNameNotCanonical:
-			tlfName = e.NameToTry
-		case nil:
-			return tlfHandle, nil
-		default:
-			return nil, err
-		}
-	}
-}
-
 type runner struct {
 	config libkbfs.Config
 	log    logger.Logger
@@ -145,7 +129,8 @@ func newRunner(ctx context.Context, config libkbfs.Config,
 		return nil, errors.Errorf("Unrecognized TLF type: %s", parts[0])
 	}
 
-	h, err := getHandleFromFolderName(ctx, config, parts[1], t)
+	h, err := libkbfs.GetHandleFromFolderNameAndType(
+		ctx, config.KBPKI(), parts[1], t)
 	if err != nil {
 		return nil, err
 	}

--- a/kbfsgit/start.go
+++ b/kbfsgit/start.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libgit"
 	"github.com/keybase/kbfs/libkbfs"
@@ -38,15 +37,11 @@ func Start(ctx context.Context, options StartOptions,
 	// of this once we integrate with the kbfs daemon.
 	errput.Write([]byte("Initializing Keybase... "))
 	ctx, config, err := libgit.Init(
-		ctx, options.KbfsParams, kbCtx, defaultLogPath)
+		ctx, options.KbfsParams, kbCtx, nil, defaultLogPath)
 	if err != nil {
 		return libfs.InitError(err.Error())
 	}
 	defer config.Shutdown(ctx)
-
-	// Make any blocks written by via this config charged to the git
-	// quota.
-	config.SetDefaultBlockType(keybase1.BlockType_GIT)
 
 	config.MakeLogger("").CDebugf(
 		ctx, "Running Git remote helper: remote=%s, repo=%s, storageRoot=%s",

--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libgit"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/simplefs"
 	"golang.org/x/net/context"
@@ -44,6 +45,8 @@ func startMounting(options StartOptions,
 func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// Hook simplefs implementation in.
 	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
+	// Hook git implementation in.
+	options.KbfsParams.CreateGitHandlerInstance = libgit.NewRPCHandler
 
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libgit"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/simplefs"
 	"golang.org/x/net/context"
@@ -78,6 +79,8 @@ func startMounting(
 func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// Hook simplefs implementation in.
 	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
+	// Hook git implementation in.
+	options.KbfsParams.CreateGitHandlerInstance = libgit.NewRPCHandler
 
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {

--- a/libgit/config.go
+++ b/libgit/config.go
@@ -24,5 +24,5 @@ func configFromBytes(buf []byte) (*Config, error) {
 }
 
 func (c *Config) toBytes() ([]byte, error) {
-	return json.Marshal(c)
+	return json.MarshalIndent(c, "", " ")
 }

--- a/libgit/config.go
+++ b/libgit/config.go
@@ -8,8 +8,10 @@ import "encoding/json"
 
 // Config is a KBFS git repo config file.
 type Config struct {
-	ID   ID
-	Name string // the original user-supplied format of the name
+	ID         ID
+	Name       string // the original user-supplied format of the name
+	CreatorUID string
+	Ctime      int64 // create time in unix nanoseconds, by creator's clock
 }
 
 func configFromBytes(buf []byte) (*Config, error) {

--- a/libgit/init.go
+++ b/libgit/init.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/keybase/kbfs/libkbfs"
+)
+
+const (
+	// Debug tag ID for a batched set of git operations under a single
+	// config.
+	ctxGitOpID = "GITID"
+)
+
+type ctxGitTagKey int
+
+const (
+	ctxGitIDKey ctxGitTagKey = iota
+)
+
+// Params returns a set of default parameters for git-related
+// operations, along with a temp directory that should be cleaned
+// after the git work is complete.
+func Params(kbCtx libkbfs.Context, storageRoot string) (
+	params libkbfs.InitParams, tempDir string, err error) {
+	// TODO: Also remove all kbfsgit directories older than 24h.
+	tempDir, err = ioutil.TempDir(storageRoot, "kbfsgit")
+	if err != nil {
+		return libkbfs.InitParams{}, "", err
+	}
+
+	params = libkbfs.DefaultInitParams(kbCtx)
+	params.LogToFile = true
+	params.Debug = true
+	params.EnableDiskCache = false
+	params.StorageRoot = tempDir
+	params.Mode = libkbfs.InitSingleOpString
+	params.TLFJournalBackgroundWorkStatus =
+		libkbfs.TLFJournalSingleOpBackgroundWorkEnabled
+	return params, tempDir, nil
+}
+
+// Init initializes a context and a libkbfs.Config for git operations.
+// The config should be shutdown when it is done being used.
+func Init(ctx context.Context, kbfsParams libkbfs.InitParams,
+	kbCtx libkbfs.Context, defaultLogPath string) (
+	context.Context, libkbfs.Config, error) {
+	log, err := libkbfs.InitLogWithPrefix(
+		kbfsParams, kbCtx, "git", defaultLogPath)
+	if err != nil {
+		return ctx, nil, err
+	}
+
+	// Assign a unique ID to each remote-helper instance, since
+	// they'll all share the same log.
+	ctx, err = libkbfs.NewContextWithCancellationDelayer(
+		libkbfs.CtxWithRandomIDReplayable(
+			ctx, ctxGitIDKey, ctxGitOpID, log))
+	if err != nil {
+		return ctx, nil, err
+	}
+	log.CDebugf(ctx, "Initialized new git config")
+
+	config, err := libkbfs.InitWithLogPrefix(
+		ctx, kbCtx, kbfsParams, nil, nil, log, "git")
+	if err != nil {
+		return ctx, nil, err
+	}
+	return ctx, config, nil
+}

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -1,0 +1,151 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"os"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/env"
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+type RPCHandler struct {
+	config libkbfs.Config
+	log    logger.Logger
+}
+
+// NewRPCHandler returns a new instance of a Git RPC handler.
+func NewRPCHandler(config libkbfs.Config) keybase1.KBFSGitInterface {
+	return &RPCHandler{
+		config: config,
+		log:    config.MakeLogger(""),
+	}
+}
+
+var _ keybase1.KBFSGitInterface = (*RPCHandler)(nil)
+
+func (rh *RPCHandler) waitForJournal(
+	ctx context.Context, config libkbfs.Config, h *libkbfs.TlfHandle) error {
+	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
+		ctx, h, libkbfs.MasterBranch)
+	if err != nil {
+		return err
+	}
+
+	err = config.KBFSOps().SyncAll(ctx, rootNode.GetFolderBranch())
+	if err != nil {
+		return err
+	}
+
+	jServer, err := libkbfs.GetJournalServer(config)
+	if err != nil {
+		rh.log.CDebugf(ctx, "No journal server: %+v", err)
+		return nil
+	}
+
+	// This squashes everything written to the journal into a single
+	// revision, to make sure that no partial states of the bare repo
+	// are seen by other readers of the TLF.  It also waits for any
+	// necessary conflict resolution to complete.
+	err = jServer.FinishSingleOp(ctx, rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		return err
+	}
+
+	// Make sure that everything is truly flushed.
+	status, err := jServer.JournalStatus(rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		return err
+	}
+
+	if status.RevisionStart != kbfsmd.RevisionUninitialized {
+		rh.log.CDebugf(ctx, "Journal status: %+v", status)
+		return errors.New("Journal is non-empty after a wait")
+	}
+	return nil
+}
+
+// KeybaseServiceCn defines methods needed to construct KeybaseService
+// and Crypto implementations.
+type keybaseServicePassthrough struct {
+	config libkbfs.Config
+}
+
+func (ksp keybaseServicePassthrough) NewKeybaseService(
+	_ libkbfs.Config, _ libkbfs.InitParams, _ libkbfs.Context,
+	_ logger.Logger) (libkbfs.KeybaseService, error) {
+	return ksp.config.KeybaseService(), nil
+}
+
+func (ksp keybaseServicePassthrough) NewCrypto(
+	_ libkbfs.Config, _ libkbfs.InitParams, _ libkbfs.Context,
+	_ logger.Logger) (libkbfs.Crypto, error) {
+	return ksp.config.Crypto(), nil
+}
+
+var _ libkbfs.KeybaseServiceCn = keybaseServicePassthrough{}
+
+// CreateRepo implements keybase1.KBFSGitInterface for KeybaseServiceBase.
+func (rh *RPCHandler) CreateRepo(
+	ctx context.Context, arg keybase1.CreateRepoArg) (
+	id keybase1.RepoID, err error) {
+	rh.log.CDebugf(ctx, "Creating repo %s in folder %s/%s",
+		arg.Name, arg.Folder.FolderType, arg.Folder.Name)
+	defer func() {
+		rh.log.CDebugf(ctx, "Done creating repo: %+v", err)
+	}()
+
+	// Make sure we have a legit folder name.
+	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
+		ctx, rh.config.KBPKI(), arg.Folder.Name,
+		tlf.TypeFromFolderType(arg.Folder.FolderType))
+	if err != nil {
+		return "", err
+	}
+
+	// Initialize libgit.
+	kbCtx := env.NewContext()
+	params, tempDir, err := Params(kbCtx, rh.config.StorageRoot())
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		rmErr := os.RemoveAll(tempDir)
+		if rmErr != nil {
+			rh.log.CDebugf(
+				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
+		}
+	}()
+
+	// Let the init code know it shouldn't try to change the
+	// global logger settings.
+	params.LogToFile = false
+	params.LogFileConfig.Path = ""
+
+	ctx, config, err := Init(
+		ctx, params, kbCtx, keybaseServicePassthrough{rh.config}, "")
+	if err != nil {
+		return "", err
+	}
+	defer config.Shutdown(ctx)
+
+	gitID, err := CreateRepoAndID(ctx, config, tlfHandle, string(arg.Name))
+	if err != nil {
+		return "", err
+	}
+
+	err = rh.waitForJournal(ctx, config, tlfHandle)
+	if err != nil {
+		return "", err
+	}
+
+	return keybase1.RepoID(gitID.String()), nil
+}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -85,6 +85,10 @@ type InitParams struct {
 	// If this is nil then simplefs will be omitted in the rpc api.
 	CreateSimpleFSInstance func(Config) keybase1.SimpleFSInterface
 
+	// CreateGitHandlerInstance creates a KBFSGitInterface from config.
+	// If this is nil then git will be omitted in the rpc api.
+	CreateGitHandlerInstance func(Config) keybase1.KBFSGitInterface
+
 	// EnableJournal enables journaling.
 	EnableJournal bool
 

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -25,7 +25,10 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 		if err != nil {
 			return nil, err
 		}
-		return NewKeybaseDaemonRPC(config, ctx, log, params.Debug, params.CreateSimpleFSInstance), nil
+		return NewKeybaseDaemonRPC(
+			config, ctx, log, params.Debug, params.CreateSimpleFSInstance,
+			params.CreateGitHandlerInstance,
+		), nil
 	}
 
 	users := []libkb.NormalizedUsername{

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -146,3 +146,35 @@ func chargedToForTLF(ctx context.Context, sessionGetter CurrentSessionGetter,
 	}
 	return session.UID.AsUserOrTeam(), nil
 }
+
+// GetHandleFromFolderNameAndType returns a TLFHandle given a folder
+// name (e.g., "u1,u2#u3") and a TLF type.
+func GetHandleFromFolderNameAndType(
+	ctx context.Context, kbpki KBPKI, tlfName string, t tlf.Type) (
+	*TlfHandle, error) {
+	for {
+		tlfHandle, err := ParseTlfHandle(ctx, kbpki, tlfName, t)
+		switch e := err.(type) {
+		case TlfNameNotCanonical:
+			tlfName = e.NameToTry
+		case nil:
+			return tlfHandle, nil
+		default:
+			return nil, err
+		}
+	}
+}
+
+// getHandleFromFolderName returns a TLFHandle given a folder
+// name (e.g., "u1,u2#u3") and a public/private bool.  DEPRECATED.
+func getHandleFromFolderName(
+	ctx context.Context, kbpki KBPKI, tlfName string, public bool) (
+	*TlfHandle, error) {
+	// TODO(KBFS-2185): update the protocol to support requests
+	// for single-team TLFs.
+	t := tlf.Private
+	if public {
+		t = tlf.Public
+	}
+	return GetHandleFromFolderNameAndType(ctx, kbpki, tlfName, t)
+}

--- a/tlf/id.go
+++ b/tlf/id.go
@@ -73,6 +73,21 @@ func (t Type) FolderType() keybase1.FolderType {
 	}
 }
 
+// TypeFromFolderType returns the Type corresponding to the given
+// keybase1.FolderType.
+func TypeFromFolderType(ft keybase1.FolderType) Type {
+	switch ft {
+	case keybase1.FolderType_PRIVATE:
+		return Private
+	case keybase1.FolderType_PUBLIC:
+		return Public
+	case keybase1.FolderType_TEAM:
+		return SingleTeam
+	default:
+		return Unknown
+	}
+}
+
 // ID is a top-level folder ID
 type ID struct {
 	id [idByteLen]byte

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -711,11 +711,16 @@ func (s *SigID) MarshalJSON() ([]byte, error) {
 }
 
 func (f Folder) ToString() string {
-	prefix := "public/"
-	if f.Private {
-		prefix = "private/"
+	prefix := "<unrecognized>"
+	switch f.FolderType {
+	case FolderType_PRIVATE:
+		prefix = "private"
+	case FolderType_PUBLIC:
+		prefix = "public"
+	case FolderType_TEAM:
+		prefix = "team"
 	}
-	return prefix + f.Name
+	return prefix + "/" + f.Name
 }
 
 func (t TrackToken) String() string {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/git.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/git.go
@@ -4,6 +4,7 @@
 package keybase1
 
 import (
+	"errors"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	context "golang.org/x/net/context"
 )
@@ -33,6 +34,85 @@ type RepoID string
 
 func (o RepoID) DeepCopy() RepoID {
 	return o
+}
+
+type GitLocalMetadataVersion int
+
+const (
+	GitLocalMetadataVersion_V1 GitLocalMetadataVersion = 1
+)
+
+func (o GitLocalMetadataVersion) DeepCopy() GitLocalMetadataVersion { return o }
+
+var GitLocalMetadataVersionMap = map[string]GitLocalMetadataVersion{
+	"V1": 1,
+}
+
+var GitLocalMetadataVersionRevMap = map[GitLocalMetadataVersion]string{
+	1: "V1",
+}
+
+func (e GitLocalMetadataVersion) String() string {
+	if v, ok := GitLocalMetadataVersionRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type GitLocalMetadataV1 struct {
+	RepoName GitRepoName `codec:"repoName" json:"repoName"`
+}
+
+func (o GitLocalMetadataV1) DeepCopy() GitLocalMetadataV1 {
+	return GitLocalMetadataV1{
+		RepoName: o.RepoName.DeepCopy(),
+	}
+}
+
+type GitLocalMetadataVersioned struct {
+	Version__ GitLocalMetadataVersion `codec:"version" json:"version"`
+	V1__      *GitLocalMetadataV1     `codec:"v1,omitempty" json:"v1,omitempty"`
+}
+
+func (o *GitLocalMetadataVersioned) Version() (ret GitLocalMetadataVersion, err error) {
+	switch o.Version__ {
+	case GitLocalMetadataVersion_V1:
+		if o.V1__ == nil {
+			err = errors.New("unexpected nil value for V1__")
+			return ret, err
+		}
+	}
+	return o.Version__, nil
+}
+
+func (o GitLocalMetadataVersioned) V1() (res GitLocalMetadataV1) {
+	if o.Version__ != GitLocalMetadataVersion_V1 {
+		panic("wrong case accessed")
+	}
+	if o.V1__ == nil {
+		return
+	}
+	return *o.V1__
+}
+
+func NewGitLocalMetadataVersionedWithV1(v GitLocalMetadataV1) GitLocalMetadataVersioned {
+	return GitLocalMetadataVersioned{
+		Version__: GitLocalMetadataVersion_V1,
+		V1__:      &v,
+	}
+}
+
+func (o GitLocalMetadataVersioned) DeepCopy() GitLocalMetadataVersioned {
+	return GitLocalMetadataVersioned{
+		Version__: o.Version__.DeepCopy(),
+		V1__: (func(x *GitLocalMetadataV1) *GitLocalMetadataV1 {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.V1__),
+	}
 }
 
 type GitLocalMetadata struct {
@@ -108,10 +188,34 @@ func (o GetAllGitMetadataArg) DeepCopy() GetAllGitMetadataArg {
 	return GetAllGitMetadataArg{}
 }
 
+type CreatePersonalRepoArg struct {
+	RepoName GitRepoName `codec:"repoName" json:"repoName"`
+}
+
+func (o CreatePersonalRepoArg) DeepCopy() CreatePersonalRepoArg {
+	return CreatePersonalRepoArg{
+		RepoName: o.RepoName.DeepCopy(),
+	}
+}
+
+type CreateTeamRepoArg struct {
+	RepoName GitRepoName `codec:"repoName" json:"repoName"`
+	TeamName TeamName    `codec:"teamName" json:"teamName"`
+}
+
+func (o CreateTeamRepoArg) DeepCopy() CreateTeamRepoArg {
+	return CreateTeamRepoArg{
+		RepoName: o.RepoName.DeepCopy(),
+		TeamName: o.TeamName.DeepCopy(),
+	}
+}
+
 type GitInterface interface {
 	PutGitMetadata(context.Context, PutGitMetadataArg) error
 	GetGitMetadata(context.Context, Folder) ([]GitRepoResult, error)
 	GetAllGitMetadata(context.Context) ([]GitRepoResult, error)
+	CreatePersonalRepo(context.Context, GitRepoName) (RepoID, error)
+	CreateTeamRepo(context.Context, CreateTeamRepoArg) (RepoID, error)
 }
 
 func GitProtocol(i GitInterface) rpc.Protocol {
@@ -161,6 +265,38 @@ func GitProtocol(i GitInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"createPersonalRepo": {
+				MakeArg: func() interface{} {
+					ret := make([]CreatePersonalRepoArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]CreatePersonalRepoArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]CreatePersonalRepoArg)(nil), args)
+						return
+					}
+					ret, err = i.CreatePersonalRepo(ctx, (*typedArgs)[0].RepoName)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"createTeamRepo": {
+				MakeArg: func() interface{} {
+					ret := make([]CreateTeamRepoArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]CreateTeamRepoArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]CreateTeamRepoArg)(nil), args)
+						return
+					}
+					ret, err = i.CreateTeamRepo(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -182,5 +318,16 @@ func (c GitClient) GetGitMetadata(ctx context.Context, folder Folder) (res []Git
 
 func (c GitClient) GetAllGitMetadata(ctx context.Context) (res []GitRepoResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.git.getAllGitMetadata", []interface{}{GetAllGitMetadataArg{}}, &res)
+	return
+}
+
+func (c GitClient) CreatePersonalRepo(ctx context.Context, repoName GitRepoName) (res RepoID, err error) {
+	__arg := CreatePersonalRepoArg{RepoName: repoName}
+	err = c.Cli.Call(ctx, "keybase.1.git.createPersonalRepo", []interface{}{__arg}, &res)
+	return
+}
+
+func (c GitClient) CreateTeamRepo(ctx context.Context, __arg CreateTeamRepoArg) (res RepoID, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.git.createTeamRepo", []interface{}{__arg}, &res)
 	return
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -1102,12 +1102,14 @@ func (o TeamTreeEntry) DeepCopy() TeamTreeEntry {
 }
 
 type TeamCreateResult struct {
-	ChatSent bool `codec:"chatSent" json:"chatSent"`
+	ChatSent     bool `codec:"chatSent" json:"chatSent"`
+	CreatorAdded bool `codec:"creatorAdded" json:"creatorAdded"`
 }
 
 func (o TeamCreateResult) DeepCopy() TeamCreateResult {
 	return TeamCreateResult{
-		ChatSent: o.ChatSent,
+		ChatSent:     o.ChatSent,
+		CreatorAdded: o.CreatorAdded,
 	}
 }
 
@@ -1173,29 +1175,15 @@ func (o ImplicitTeamConflictInfo) DeepCopy() ImplicitTeamConflictInfo {
 }
 
 type TeamCreateArg struct {
-	SessionID            int      `codec:"sessionID" json:"sessionID"`
-	Name                 TeamName `codec:"name" json:"name"`
-	SendChatNotification bool     `codec:"sendChatNotification" json:"sendChatNotification"`
+	SessionID            int    `codec:"sessionID" json:"sessionID"`
+	Name                 string `codec:"name" json:"name"`
+	SendChatNotification bool   `codec:"sendChatNotification" json:"sendChatNotification"`
 }
 
 func (o TeamCreateArg) DeepCopy() TeamCreateArg {
 	return TeamCreateArg{
 		SessionID:            o.SessionID,
-		Name:                 o.Name.DeepCopy(),
-		SendChatNotification: o.SendChatNotification,
-	}
-}
-
-type TeamCreateSubteamArg struct {
-	SessionID            int      `codec:"sessionID" json:"sessionID"`
-	Name                 TeamName `codec:"name" json:"name"`
-	SendChatNotification bool     `codec:"sendChatNotification" json:"sendChatNotification"`
-}
-
-func (o TeamCreateSubteamArg) DeepCopy() TeamCreateSubteamArg {
-	return TeamCreateSubteamArg{
-		SessionID:            o.SessionID,
-		Name:                 o.Name.DeepCopy(),
+		Name:                 o.Name,
 		SendChatNotification: o.SendChatNotification,
 	}
 }
@@ -1470,7 +1458,6 @@ func (o GetTeamRootIDArg) DeepCopy() GetTeamRootIDArg {
 
 type TeamsInterface interface {
 	TeamCreate(context.Context, TeamCreateArg) (TeamCreateResult, error)
-	TeamCreateSubteam(context.Context, TeamCreateSubteamArg) (TeamCreateResult, error)
 	TeamGet(context.Context, TeamGetArg) (TeamDetails, error)
 	TeamList(context.Context, TeamListArg) (AnnotatedTeamList, error)
 	TeamChangeMembership(context.Context, TeamChangeMembershipArg) error
@@ -1512,22 +1499,6 @@ func TeamsProtocol(i TeamsInterface) rpc.Protocol {
 						return
 					}
 					ret, err = i.TeamCreate(ctx, (*typedArgs)[0])
-					return
-				},
-				MethodType: rpc.MethodCall,
-			},
-			"teamCreateSubteam": {
-				MakeArg: func() interface{} {
-					ret := make([]TeamCreateSubteamArg, 1)
-					return &ret
-				},
-				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
-					typedArgs, ok := args.(*[]TeamCreateSubteamArg)
-					if !ok {
-						err = rpc.NewTypeError((*[]TeamCreateSubteamArg)(nil), args)
-						return
-					}
-					ret, err = i.TeamCreateSubteam(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -1862,11 +1833,6 @@ type TeamsClient struct {
 
 func (c TeamsClient) TeamCreate(ctx context.Context, __arg TeamCreateArg) (res TeamCreateResult, err error) {
 	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreate", []interface{}{__arg}, &res)
-	return
-}
-
-func (c TeamsClient) TeamCreateSubteam(ctx context.Context, __arg TeamCreateSubteamArg) (res TeamCreateResult, err error) {
-	err = c.Cli.Call(ctx, "keybase.1.teams.teamCreateSubteam", []interface{}{__arg}, &res)
 	return
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -201,10 +201,10 @@
 			"revisionTime": "2017-05-26T23:09:42Z"
 		},
 		{
-			"checksumSHA1": "D8aS7Ep070xLGXpItdpBEps07nE=",
+			"checksumSHA1": "HV3stqSxAYEmLtU2AHz7nM697Bo=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "6e2f08137f225a8c83f5d01e5fe69c73018a8756",
-			"revisionTime": "2017-09-08T23:31:11Z"
+			"revision": "5667da45a1b056ac1e755aa9e9c95f6f6a5fb263",
+			"revisionTime": "2017-09-12T17:06:51Z"
 		},
 		{
 			"checksumSHA1": "5jCtx/ogKTP/L08r9Vt2Z0e36i4=",


### PR DESCRIPTION
This implements the new `CreateRepo` RPC expected by the service, which creates a repo and errors if the repo already exists.  This is to be served by the existing kbfsfuse/kbfsdokan daemon.

To avoid blocking on any big transfer currently in the journal, this spins up a completely new `Config`, with a journal in a temporary directory, just like the `git-remote-keybase` command does.  This PR refactors some of that code to share between the two paths.

To avoid import cycles, I needed to use the same trick as `SimpleFS` to pass an RPC interface creation hook to the keybase daemon, rather than importing `libgit` directly.

I also added some extra data to the config file that seems like it would be useful to record in the long run, and we're now marshaling it with indentation so it's easier to read by humans.