### PR TITLE
libgit: ignore ".git" suffix

### DIFF
--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	kbfsRepoDir    = ".kbfs_git"
-	kbfsConfigName = "kbfs_config"
+	kbfsRepoDir       = ".kbfs_git"
+	kbfsConfigName    = "kbfs_config"
+	gitSuffixToIgnore = ".git"
 )
 
 // This character set is what Github supports in repo names.  It's
@@ -114,7 +115,8 @@ func getOrCreateRepoAndID(
 	if err != nil {
 		return nil, NullID, err
 	}
-	normalizedRepoName := strings.ToLower(repoName)
+	normalizedRepoName := strings.TrimSuffix(
+		strings.ToLower(repoName), gitSuffixToIgnore)
 
 	lookupOrCreateDir := func(n libkbfs.Node, name string) (
 		libkbfs.Node, error) {

--- a/libgit/repo_test.go
+++ b/libgit/repo_test.go
@@ -61,10 +61,15 @@ func TestGetOrCreateRepoAndID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, id1, id3)
 
-	// A one letter repo name is ok.
-	_, id4, err := GetOrCreateRepoAndID(ctx, config, h, "r", "")
+	// A trailing ".git" should be ignored.
+	_, id4, err := GetOrCreateRepoAndID(ctx, config, h, "repo1.git", "")
 	require.NoError(t, err)
-	require.NotEqual(t, id1, id4)
+	require.Equal(t, id1, id4)
+
+	// A one letter repo name is ok.
+	_, id5, err := GetOrCreateRepoAndID(ctx, config, h, "r", "")
+	require.NoError(t, err)
+	require.NotEqual(t, id1, id5)
 
 	// Invalid names.
 	_, _, err = GetOrCreateRepoAndID(ctx, config, h, ".repo2", "")


### PR DESCRIPTION
Looks like the UI will recommend people put this in their clone URLs, like GitHub does.  Just ignore it.