### PR TITLE
kbfsgit: allow debugging to be turned off with an env var

### DIFF
--- a/libgit/init.go
+++ b/libgit/init.go
@@ -7,6 +7,7 @@ package libgit
 import (
 	"context"
 	"io/ioutil"
+	"os"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libkbfs"
@@ -37,7 +38,12 @@ func Params(kbCtx libkbfs.Context, storageRoot string) (
 
 	params = libkbfs.DefaultInitParams(kbCtx)
 	params.LogToFile = true
-	params.Debug = true
+	// Set the debug default to true only if the env variable isn't
+	// explicitly set to a false option.
+	envDebug := os.Getenv("KBFSGIT_DEBUG")
+	if envDebug != "0" && envDebug != "false" && envDebug != "no" {
+		params.Debug = true
+	}
 	params.EnableDiskCache = false
 	params.StorageRoot = tempDir
 	params.Mode = libkbfs.InitSingleOpString

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -402,7 +402,6 @@ func InitLogWithPrefix(
 	params InitParams, ctx Context, prefix string,
 	defaultLogPath string) (logger.Logger, error) {
 	var err error
-	log := logger.NewWithCallDepth(prefix, 1)
 
 	// Set log file to default if log-to-file was specified
 	if params.LogToFile {
@@ -416,6 +415,7 @@ func InitLogWithPrefix(
 	if params.LogFileConfig.Path != "" {
 		err = logger.SetLogFileConfig(&params.LogFileConfig)
 	}
+	log := logger.NewWithCallDepth(prefix, 1)
 
 	log.Configure("", params.Debug, "")
 	log.Info("KBFS version %s", VersionString())


### PR DESCRIPTION
With this commit, you can turn off KBFS debugging by setting
KBFSGIT_DEBUG=0 in your environment.

Note I had to move the `NewWithCallDepth` line below the
`SetLogFileConfig` line, because the latter call erases all the
default INFO levels set by the keybase logger whenever a new log is
made.

Turning off debugging completely reduced the time of the "Preparing"
phase by 52% (31% compared to #1176), but I don't think we want to do
this by default until we're more comfortable with git.

Issue: KBFS-2390