### PR TITLE
kbfsgit: humanize byte and object counts, add percentages, and tweak stderr wording

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -330,9 +330,8 @@ func humanizeBytes(n int64, d int64) string {
 			return fmt.Sprintf("%.2f KB", float64(n)/kbf)
 		} else if n < gb {
 			return fmt.Sprintf("%.2f MB", float64(n)/mbf)
-		} else {
-			return fmt.Sprintf("%.2f MB", float64(n)/gbf)
 		}
+		return fmt.Sprintf("%.2f GB", float64(n)/gbf)
 	}
 
 	if d < kb {
@@ -341,9 +340,8 @@ func humanizeBytes(n int64, d int64) string {
 		return fmt.Sprintf("%.2f/%.2f KB", float64(n)/kbf, float64(d)/kbf)
 	} else if d < gb {
 		return fmt.Sprintf("%.2f/%.2f MB", float64(n)/mbf, float64(d)/mbf)
-	} else {
-		return fmt.Sprintf("%.2f/%.2f MB", float64(n)/gbf, float64(d)/gbf)
 	}
+	return fmt.Sprintf("%.2f/%.2f GB", float64(n)/gbf, float64(d)/gbf)
 }
 
 func (r *runner) printJournalStatus(
@@ -370,8 +368,6 @@ func (r *runner) printJournalStatus(
 	r.log.CDebugf(ctx, "Waiting for %d journal bytes to flush",
 		firstStatus.UnflushedBytes)
 
-	// TODO: should we "humanize" the units of these bytes if they are
-	// more than a KB, MB, etc?
 	bytesFmt := "(%.2f%%) %s... "
 	str := fmt.Sprintf(
 		bytesFmt, float64(0), humanizeBytes(0, firstStatus.UnflushedBytes))
@@ -548,18 +544,16 @@ func humanizeObjects(n int, d int) string {
 			return fmt.Sprintf("%d", n)
 		} else if n < m {
 			return fmt.Sprintf("%.2fK", float64(n)/k)
-		} else {
-			return fmt.Sprintf("%.2fM", float64(n)/m)
 		}
+		return fmt.Sprintf("%.2fM", float64(n)/m)
 	}
 
 	if d < k {
 		return fmt.Sprintf("%d/%d", n, d)
 	} else if d < m {
 		return fmt.Sprintf("%.2f/%.2fK", float64(n)/k, float64(d)/k)
-	} else {
-		return fmt.Sprintf("%.2f/%.2fM", float64(n)/m, float64(d)/m)
 	}
+	return fmt.Sprintf("%.2f/%.2fM", float64(n)/m, float64(d)/m)
 }
 
 func (r *runner) processGogitStatus(


### PR DESCRIPTION
@malgorithms and @songgao suggested some tweaks to the output the user sees.  Here's what things look like now:

Clone:
```
Cloning into 'test20'...
Running in staging mode
Initializing Keybase... done.
Syncing with Keybase... done.
Counting: 64.03 MB... done.
Cryptographic cloning: (56.97%) 36.48/64.03 MB... 
```

Push:
```
Initializing Keybase... done.
Syncing with Keybase... done.
Syncing data to Keybase: (100.00%) 21.22/21.22 KB... done.
Counting and decrypting: 35.38K objects... done.
Preparing and encrypting: (100.00%) 35.38/35.38K objects... done.
Indexing hashes: (100.00%) 35.38/35.38K objects... done.
Indexing CRCs: (100.00%) 35.38/35.38K objects... done.
Indexing offsets: (100.00%) 35.38/35.38K objects... done.
Syncing data to Keybase: (100.00%) 1.04/1.04 MB... done.
To keybase://private/strib/kbfs43
 * [new branch]      master -> master
```

Pull:
```
Initializing Keybase... done.
Syncing with Keybase... done.
Counting and decrypting: 3.00K objects... done.
Reading and decrypting metadata: (100.00%) 3.00/3.00K objects... done.
Fetching and decrypting objects: (100.00%) 3.00/3.00K objects... done.
From keybase://private/strib/test12
 * [new branch]      x          -> origin/x
```