### PR TITLE
avoid sending notification to service if we only set rekey bit

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5241,7 +5241,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 
 	// send rekey finish notification
 	handle := md.GetTlfHandle()
-	if currKeyGen >= FirstValidKeyGen {
+	if currKeyGen >= FirstValidKeyGen && rekeyDone {
 		fbo.config.Reporter().Notify(ctx,
 			rekeyNotification(ctx, fbo.config, handle, true))
 	}


### PR DESCRIPTION
@mmaxim found out this one; As mentioned in keybase chat:

> without some kind of change there, chats that need rekey will just be slower to update, since when we get this notification, we fail to load the chat, and we just have to rely on our timer to pick up the success later

(Using `rekeyDone` instead of `!stillNeedsRekey` because I think with read-only shares it's possible that rekey has been done on a device, but we still need some work from another device.)