### PR TITLE
Don't default to force mount in production for kbfsdokan

### DIFF
--- a/kbfsdokan/defaults_production.go
+++ b/kbfsdokan/defaults_production.go
@@ -6,4 +6,5 @@
 
 package main
 
-const defaultMountType = "force"
+//
+const defaultMountType = "default"


### PR DESCRIPTION
This keeps the split installer, currently shipping, from working.
@taruti 
Tagging @maxtaco because @strib is away.