### PR TITLE
kbfsgit: enable non-force pushes, and onDemandStorer shouldn't hide missing obj error

### DIFF
--- a/kbfsgit/on_demand_storer.go
+++ b/kbfsgit/on_demand_storer.go
@@ -40,6 +40,15 @@ func (ods *onDemandStorer) EncodedObject(
 		size:        -1,
 		recentCache: ods.recentCache,
 	}
+	// If the object is missing, we need to return an error for that
+	// here.  But don't read all the object data from disk by calling
+	// `Storer.EncodedObject()` or `o.cache()`.  Instead use a
+	// KBFS-specific `HasEncodedObject()` method that just tells us
+	// whether or not the object exists.
+	err := ods.Storer.HasEncodedObject(hash)
+	if err != nil {
+		return nil, err
+	}
 
 	return o, nil
 }

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -972,12 +972,6 @@ func (r *runner) handlePushBatch(ctx context.Context, args [][]string) (
 			}
 			results[dst] = err
 		} else {
-			if !refspec.IsForceUpdate() {
-				r.log.CDebugf(ctx,
-					"Turning a non-force push into a force push for now: %s",
-					refspec)
-			}
-
 			refspecs = append(refspecs, refspec)
 		}
 		if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4650,7 +4650,11 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 	// Wait for CR to happen.
 	if fbo.isMasterBranchLocked(lState) {
 		mergedRev, err := fbo.getJournalPredecessorRevision(ctx)
-		if err != nil {
+		if err == errNoFlushedRevisions {
+			// If the journal is still on the initial revision, ignore
+			// the error and fall through to ignore CR.
+			mergedRev = kbfsmd.RevisionInitial
+		} else if err != nil {
 			return err
 		}
 		if mergedRev != kbfsmd.RevisionUninitialized {

--- a/vendor/gopkg.in/src-d/go-git.v4/options.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/options.go
@@ -95,6 +95,9 @@ type PullOptions struct {
 	// stored, if nil nothing is stored and the capability (if supported)
 	// no-progress, is sent to the server to avoid send this information.
 	Progress sideband.Progress
+	// Force allows the pull to update a local branch even when the remote
+	// branch does not descend from it.
+	Force bool
 }
 
 // Validate validates the fields and sets the default values.
@@ -143,6 +146,9 @@ type FetchOptions struct {
 	// by default is TagFollowing.
 	Tags       TagMode
 	StatusChan plumbing.StatusChan
+	// Force allows the fetch to update a local branch even when the remote
+	// branch does not descend from it.
+	Force bool
 }
 
 // Validate validates the fields and sets the default values.

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_selector.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_selector.go
@@ -28,8 +28,11 @@ func newDeltaSelector(s storer.EncodedObjectStorer) *deltaSelector {
 	return &deltaSelector{s}
 }
 
-// ObjectsToPack creates a list of ObjectToPack from the hashes provided,
-// creating deltas if it's suitable, using an specific internal logic
+// ObjectsToPack creates a list of ObjectToPack from the hashes
+// provided, creating deltas if it's suitable, using an specific
+// internal logic.  `packWindow` specifies the size of the sliding
+// window used to compare objects for delta compression; 0 turns off
+// delta compression entirely.
 func (dw *deltaSelector) ObjectsToPack(
 	hashes []plumbing.Hash,
 	packWindow uint,

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/encoder.go
@@ -45,8 +45,10 @@ func NewEncoder(w io.Writer, s storer.EncodedObjectStorer, useRefDeltas bool) *E
 	}
 }
 
-// Encode creates a packfile containing all the objects referenced in hashes
-// and writes it to the writer in the Encoder.
+// Encode creates a packfile containing all the objects referenced in
+// hashes and writes it to the writer in the Encoder.  `packWindow`
+// specifies the size of the sliding window used to compare objects
+// for delta compression; 0 turns off delta compression entirely.
 func (e *Encoder) Encode(
 	hashes []plumbing.Hash,
 	packWindow uint,

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go
@@ -36,6 +36,9 @@ type EncodedObjectStorer interface {
 	//
 	// Valid plumbing.ObjectType values are CommitObject, BlobObject, TagObject,
 	IterEncodedObjects(plumbing.ObjectType) (EncodedObjectIter, error)
+	// HasEncodedObject returns ErrObjNotFound if the object doesn't
+	// exist.  If the object does exist, it returns nil.
+	HasEncodedObject(plumbing.Hash) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
@@ -16,6 +16,7 @@ var ErrMaxResolveRecursion = errors.New("max. recursion level reached")
 // ReferenceStorer is a generic storage of references.
 type ReferenceStorer interface {
 	SetReference(*plumbing.Reference) error
+	CheckAndSetReference(new, old *plumbing.Reference) error
 	Reference(plumbing.ReferenceName) (*plumbing.Reference, error)
 	IterReferences() (ReferenceIter, error)
 	RemoveReference(plumbing.ReferenceName) error

--- a/vendor/gopkg.in/src-d/go-git.v4/remote.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/remote.go
@@ -25,6 +25,7 @@ import (
 var (
 	NoErrAlreadyUpToDate     = errors.New("already up-to-date")
 	ErrDeleteRefNotSupported = errors.New("server does not support delete-refs")
+	ErrForceNeeded           = errors.New("some refs were not updated")
 )
 
 // Remote represents a connection to a remote repository.
@@ -301,7 +302,7 @@ func (r *Remote) fetch(ctx context.Context, o *FetchOptions) (storer.ReferenceSt
 		}
 	}
 
-	updated, err := r.updateLocalReferenceStorage(o.RefSpecs, refs, remoteRefs, o.Tags)
+	updated, err := r.updateLocalReferenceStorage(o.RefSpecs, refs, remoteRefs, o.Tags, o.Force)
 	if err != nil {
 		return nil, err
 	}
@@ -698,8 +699,11 @@ func (r *Remote) updateLocalReferenceStorage(
 	specs []config.RefSpec,
 	fetchedRefs, remoteRefs memory.ReferenceStorage,
 	tagMode TagMode,
+	force bool,
 ) (updated bool, err error) {
 	isWildcard := true
+	forceNeeded := false
+
 	for _, spec := range specs {
 		if !spec.IsWildcard() {
 			isWildcard = false
@@ -714,9 +718,25 @@ func (r *Remote) updateLocalReferenceStorage(
 				continue
 			}
 
-			new := plumbing.NewHashReference(spec.Dst(ref.Name()), ref.Hash())
+			localName := spec.Dst(ref.Name())
+			old, _ := storer.ResolveReference(r.s, localName)
+			new := plumbing.NewHashReference(localName, ref.Hash())
 
-			refUpdated, err := updateReferenceStorerIfNeeded(r.s, new)
+			// If the ref exists locally as a branch and force is not specified,
+			// only update if the new ref is an ancestor of the old
+			if old != nil && old.Name().IsBranch() && !force && !spec.IsForceUpdate() {
+				ff, err := isFastForward(r.s, old.Hash(), new.Hash())
+				if err != nil {
+					return updated, err
+				}
+
+				if !ff {
+					forceNeeded = true
+					continue
+				}
+			}
+
+			refUpdated, err := checkAndUpdateReferenceStorerIfNeeded(r.s, new, old)
 			if err != nil {
 				return updated, err
 			}
@@ -742,6 +762,10 @@ func (r *Remote) updateLocalReferenceStorage(
 
 	if tagUpdated {
 		updated = true
+	}
+
+	if err == nil && forceNeeded {
+		err = ErrForceNeeded
 	}
 
 	return

--- a/vendor/gopkg.in/src-d/go-git.v4/repository.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/repository.go
@@ -625,9 +625,9 @@ func (r *Repository) calculateRemoteHeadReference(spec []config.RefSpec,
 	return refs
 }
 
-func updateReferenceStorerIfNeeded(
-	s storer.ReferenceStorer, r *plumbing.Reference) (updated bool, err error) {
-
+func checkAndUpdateReferenceStorerIfNeeded(
+	s storer.ReferenceStorer, r, old *plumbing.Reference) (
+	updated bool, err error) {
 	p, err := s.Reference(r.Name())
 	if err != nil && err != plumbing.ErrReferenceNotFound {
 		return false, err
@@ -635,7 +635,7 @@ func updateReferenceStorerIfNeeded(
 
 	// we use the string method to compare references, is the easiest way
 	if err == plumbing.ErrReferenceNotFound || r.String() != p.String() {
-		if err := s.SetReference(r); err != nil {
+		if err := s.CheckAndSetReference(r, old); err != nil {
 			return false, err
 		}
 
@@ -643,6 +643,11 @@ func updateReferenceStorerIfNeeded(
 	}
 
 	return false, nil
+}
+
+func updateReferenceStorerIfNeeded(
+	s storer.ReferenceStorer, r *plumbing.Reference) (updated bool, err error) {
+	return checkAndUpdateReferenceStorerIfNeeded(s, r, nil)
 }
 
 // Fetch fetches references along with the objects necessary to complete

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/reference.go
@@ -11,7 +11,11 @@ type ReferenceStorage struct {
 }
 
 func (r *ReferenceStorage) SetReference(ref *plumbing.Reference) error {
-	return r.dir.SetRef(ref)
+	return r.dir.SetRef(ref, nil)
+}
+
+func (r *ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
+	return r.dir.SetRef(ref, old)
 }
 
 func (r *ReferenceStorage) Reference(n plumbing.ReferenceName) (*plumbing.Reference, error) {

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree.go
@@ -69,6 +69,7 @@ func (w *Worktree) PullContext(ctx context.Context, o *PullOptions) error {
 		Depth:      o.Depth,
 		Auth:       o.Auth,
 		Progress:   o.Progress,
+		Force:      o.Force,
 	})
 
 	updated := true

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -756,284 +756,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "U3tqtWuGNTOEWX1ExyQ9YkJ+cNc=",
+			"checksumSHA1": "E12sWMDcZv0ehbAnPxBtfX/34Xg=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
-			"checksumSHA1": "0ITfxWDrma8DvTxUZ7/uIqrtCfo=",
+			"checksumSHA1": "7dpHa2hTeGy/UCjKdBl6CxlaTFY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
-			"checksumSHA1": "2FPt2X+Z/oOO5twnW4QrzTvQ2yw=",
+			"checksumSHA1": "PRw/wR2I1+J47IKuLwjkaeHC8dc=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
-			"checksumSHA1": "CSiF391UdjILaSUJqctaa9rvSQc=",
+			"checksumSHA1": "IBt5L09OBjfvq0h6ThX8L9Vl3g8=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
-			"checksumSHA1": "a7qGxujLCO4NbK2+JuvNcucVze8=",
+			"checksumSHA1": "p67Xh7WZTKbsKuSAulYWbc/I7c0=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
-			"checksumSHA1": "OfzMDAIu253dJ9591gd3w/APq0I=",
+			"checksumSHA1": "NwjgsVALAv6In8dzVsIFYVZdWXM=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "5d3dc69e94c5a2c21aec3ca9a8a8cf57cc5e8692",
-			"revisionTime": "2017-09-11T03:59:31Z"
+			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
+			"revisionTime": "2017-09-23T04:14:17Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
go-git depends on getting on error from `EncodedObject()` when an object is missing, especially when constructing the set of "ignored" objects.  This is the set of objects that the local git repo already has. and there's no need for them to exist in the kbfs git repo. go-git allows objects to be missing when constructing that ignored list, but we were hiding that error in onDemandObject.cache(). Instead, we should surface it during `EncodedObject`, but without fully reading all object data from disk, which would negate the point of previous optimizations.

This is based on #1188, which vendors in go-billy master.  This also vendors in go-git master, which pulls in the locking code, requiring a small `folderBranchOps` fix.

Issue: KBFS-2445