### PR TITLE
libgit: allow caller to pass in a context, instead of using env

### DIFF
--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libgit"
@@ -46,7 +47,10 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// Hook simplefs implementation in.
 	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
 	// Hook git implementation in.
-	options.KbfsParams.CreateGitHandlerInstance = libgit.NewRPCHandler
+	options.KbfsParams.CreateGitHandlerInstance =
+		func(config libkbfs.Config) keybase1.KBFSGitInterface {
+			return libgit.NewRPCHandlerWithCtx(kbCtx, config)
+		}
 
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libgit"
 	"github.com/keybase/kbfs/libkbfs"
@@ -80,7 +81,10 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// Hook simplefs implementation in.
 	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
 	// Hook git implementation in.
-	options.KbfsParams.CreateGitHandlerInstance = libgit.NewRPCHandler
+	options.KbfsParams.CreateGitHandlerInstance =
+		func(config libkbfs.Config) keybase1.KBFSGitInterface {
+			return libgit.NewRPCHandlerWithCtx(kbCtx, config)
+		}
 
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {


### PR DESCRIPTION
Mobile doesn't set the run mode environment variable, but passes it directly in via a context.  So libgit shouldn't rely on env.NewContext() for the right context, it should be passed in.

We will need to update `client/go/bind/keybase.go` to call the new constructor once this is merged.

Issue: KBFS-2458