### PR TITLE
[KBFS-2417] De-duplicate prefetches

### DIFF
--- a/kbfsblock/id.go
+++ b/kbfsblock/id.go
@@ -19,15 +19,19 @@ type ID struct {
 	h kbfshash.Hash
 }
 
+var ZeroID = ID{}
+
 var _ encoding.BinaryMarshaler = ID{}
 var _ encoding.BinaryUnmarshaler = (*ID)(nil)
 
 var _ encoding.TextMarshaler = ID{}
 var _ encoding.TextUnmarshaler = (*ID)(nil)
 
-// MaxIDStringLength is the maximum length of the string
-// representation of a ID.
-const MaxIDStringLength = kbfshash.MaxHashStringLength
+const (
+	// MaxIDStringLength is the maximum length of the string
+	// representation of a ID.
+	MaxIDStringLength = kbfshash.MaxHashStringLength
+)
 
 // IDFromString creates a ID from the given string. If the
 // returned error is nil, the returned ID is valid.

--- a/kbfsblock/id.go
+++ b/kbfsblock/id.go
@@ -19,6 +19,7 @@ type ID struct {
 	h kbfshash.Hash
 }
 
+// ZeroID is a zero-valued ID.
 var ZeroID = ID{}
 
 var _ encoding.BinaryMarshaler = ID{}

--- a/libdokan/prefetch_file.go
+++ b/libdokan/prefetch_file.go
@@ -28,7 +28,7 @@ func (f *PrefetchFile) WriteFile(ctx context.Context, fi *dokan.FileInfo, bs []b
 		return 0, nil
 	}
 
-	f.fs.config.BlockOps().TogglePrefetcher(ctx, f.enable)
+	f.fs.config.BlockOps().TogglePrefetcher(f.enable)
 
 	return len(bs), err
 }

--- a/libfuse/prefetch_file.go
+++ b/libfuse/prefetch_file.go
@@ -41,7 +41,7 @@ func (f *PrefetchFile) Write(ctx context.Context, req *fuse.WriteRequest,
 		return nil
 	}
 
-	f.fs.config.BlockOps().TogglePrefetcher(ctx, f.enable)
+	f.fs.config.BlockOps().TogglePrefetcher(f.enable)
 
 	resp.Size = len(req.Data)
 	return nil

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -194,9 +194,8 @@ func (b *BlockOpsStandard) Archive(ctx context.Context, tlfID tlf.ID,
 }
 
 // TogglePrefetcher implements the BlockOps interface for BlockOpsStandard.
-func (b *BlockOpsStandard) TogglePrefetcher(ctx context.Context,
-	enable bool) <-chan struct{} {
-	return b.queue.TogglePrefetcher(ctx, enable, nil)
+func (b *BlockOpsStandard) TogglePrefetcher(enable bool) <-chan struct{} {
+	return b.queue.TogglePrefetcher(enable, nil)
 }
 
 // Prefetcher implements the BlockOps interface for BlockOpsStandard.

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -195,7 +195,7 @@ func (b *BlockOpsStandard) Archive(ctx context.Context, tlfID tlf.ID,
 
 // TogglePrefetcher implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) TogglePrefetcher(ctx context.Context,
-	enable bool) error {
+	enable bool) <-chan struct{} {
 	return b.queue.TogglePrefetcher(ctx, enable, nil)
 }
 

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -196,7 +196,7 @@ func (b *BlockOpsStandard) Archive(ctx context.Context, tlfID tlf.ID,
 // TogglePrefetcher implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) TogglePrefetcher(ctx context.Context,
 	enable bool) error {
-	return b.queue.TogglePrefetcher(ctx, enable)
+	return b.queue.TogglePrefetcher(ctx, enable, nil)
 }
 
 // Prefetcher implements the BlockOps interface for BlockOpsStandard.

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -304,6 +304,7 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	// Check caches before locking the mutex.
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block)
 	if err == nil {
+		brq.log.CDebugf(ctx, "Triggering prefetch for block %s with priority %x", ptr.ID, priority)
 		brq.Prefetcher().TriggerPrefetch(ctx, ptr, block, kmd,
 			priority, lifetime, prefetchStatus)
 		ch <- nil

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -304,7 +304,7 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	// Check caches before locking the mutex.
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block)
 	if err == nil {
-		brq.Prefetcher().TriggerPrefetch(ctx, ptr, block, kmd,
+		brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
 			priority, lifetime, prefetchStatus)
 		ch <- nil
 		return ch
@@ -412,7 +412,7 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 		// only way to get here is if the request wasn't already cached.
 		// Need to call with context.Background() because the retrieval's
 		// context will be canceled as soon as this method returns.
-		brq.Prefetcher().TriggerPrefetch(context.Background(),
+		brq.Prefetcher().ProcessBlockForPrefetch(context.Background(),
 			retrieval.blockPtr, block, retrieval.kmd, retrieval.priority,
 			retrieval.cacheLifetime, NoPrefetch)
 	} else {

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -393,15 +393,15 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 	brq.mtx.Unlock()
 	defer retrieval.cancelFunc()
 
-	// This is a lock that exists for the race detector, since there shouldn't
-	// be any other goroutines accessing the retrieval at this point. In
-	// `Request`, the requests slice can be modified while locked
-	// by `brq.mtx`. But once we delete `bpLookup` from `brq.ptrs` here (while
-	// locked by `brq.mtx`), there is no longer a way for anyone else to write
-	// `retrieval.requests`. However, the race detector still notices that
-	// we're reading `retrieval.requests` without a lock, where it was written
-	// by a different goroutine in `Request`. So, we lock it with
-	// its own mutex in both places.
+	// This is a lock that exists for the race detector, since there
+	// shouldn't be any other goroutines accessing the retrieval at this
+	// point. In `Request`, the requests slice can be modified while locked
+	// by `brq.mtx`. But once we delete `bpLookup` from `brq.ptrs` here
+	// (while locked by `brq.mtx`), there is no longer a way for anyone else
+	// to write `retrieval.requests`. However, the race detector still
+	// notices that we're reading `retrieval.requests` without a lock, where
+	// it was written by a different goroutine in `Request`. So, we lock it
+	// with its own mutex in both places.
 	retrieval.reqMtx.RLock()
 	defer retrieval.reqMtx.RUnlock()
 
@@ -411,9 +411,9 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 		// only way to get here is if the request wasn't already cached.
 		// Need to call with context.Background() because the retrieval's
 		// context will be canceled as soon as this method returns.
-		brq.Prefetcher().TriggerPrefetch(context.Background(), retrieval.blockPtr,
-			block, retrieval.kmd, retrieval.priority, retrieval.cacheLifetime,
-			NoPrefetch)
+		brq.Prefetcher().TriggerPrefetch(context.Background(),
+			retrieval.blockPtr, block, retrieval.kmd, retrieval.priority,
+			retrieval.cacheLifetime, NoPrefetch)
 	} else {
 		brq.Prefetcher().CancelPrefetch(retrieval.blockPtr.ID)
 	}
@@ -438,8 +438,8 @@ func (brq *blockRetrievalQueue) Shutdown() {
 	select {
 	case <-brq.doneCh:
 	default:
-		// We close `doneCh` first so that new requests coming in get finalized
-		// immediately rather than racing with dying workers.
+		// We close `doneCh` first so that new requests coming in get
+		// finalized immediately rather than racing with dying workers.
 		close(brq.doneCh)
 		for _, w := range brq.workers {
 			w.Shutdown()

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -431,6 +431,8 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 	}
 	// Clearing references to the requested blocks seems to plug a
 	// leak, but not sure why yet.
+	// TODO: strib fixed this earlier. Should be safe to remove here, but
+	// follow up in PR.
 	retrieval.requests = nil
 }
 

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -304,7 +304,6 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	// Check caches before locking the mutex.
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block)
 	if err == nil {
-		brq.log.CDebugf(ctx, "Triggering prefetch for block %s with priority %x", ptr.ID, priority)
 		brq.Prefetcher().TriggerPrefetch(ctx, ptr, block, kmd,
 			priority, lifetime, prefetchStatus)
 		ch <- nil

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -457,18 +457,18 @@ func (brq *blockRetrievalQueue) Shutdown() {
 // off. If an error is returned due to a context cancelation, the prefetcher is
 // never re-enabled.
 func (brq *blockRetrievalQueue) TogglePrefetcher(ctx context.Context,
-	enable bool, testSyncCh <-chan struct{}) (err error) {
+	enable bool, testSyncCh <-chan struct{}) <-chan struct{} {
 	// We must hold this lock for the whole function so that multiple calls to
 	// this function doesn't leak prefetchers.
 	brq.prefetchMtx.Lock()
 	defer brq.prefetchMtx.Unlock()
 	// Don't wait for the existing prefetcher to shutdown so we don't deadlock
 	// any callers.
-	_ = brq.prefetcher.Shutdown()
+	ch := brq.prefetcher.Shutdown()
 	if enable {
 		brq.prefetcher = newBlockPrefetcher(brq, brq.config, testSyncCh)
 	}
-	return nil
+	return ch
 }
 
 // Prefetcher allows us to retrieve the prefetcher.

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -304,8 +304,9 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	// Check caches before locking the mutex.
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block)
 	if err == nil {
-		ch <- brq.Prefetcher().TriggerPrefetch(ctx, ptr, block, kmd,
+		brq.Prefetcher().TriggerPrefetch(ctx, ptr, block, kmd,
 			priority, lifetime, prefetchStatus)
+		ch <- nil
 		return ch
 	}
 	err = checkDataVersion(brq.config, path{}, ptr)

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -282,7 +282,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	return prefetchStatus, err
 }
 
-// Requestimplements the BlockRetriever interface for blockRetrievalQueue.
+// Request implements the BlockRetriever interface for blockRetrievalQueue.
 func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime) <-chan error {

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -456,14 +456,13 @@ func (brq *blockRetrievalQueue) Shutdown() {
 // TogglePrefetcher allows upstream components to turn the prefetcher on or
 // off. If an error is returned due to a context cancelation, the prefetcher is
 // never re-enabled.
-func (brq *blockRetrievalQueue) TogglePrefetcher(ctx context.Context,
-	enable bool, testSyncCh <-chan struct{}) <-chan struct{} {
+func (brq *blockRetrievalQueue) TogglePrefetcher(enable bool,
+	testSyncCh <-chan struct{}) <-chan struct{} {
 	// We must hold this lock for the whole function so that multiple calls to
 	// this function doesn't leak prefetchers.
 	brq.prefetchMtx.Lock()
 	defer brq.prefetchMtx.Unlock()
-	// Don't wait for the existing prefetcher to shutdown so we don't deadlock
-	// any callers.
+	// Allow the caller to block on the current shutdown.
 	ch := brq.prefetcher.Shutdown()
 	if enable {
 		brq.prefetcher = newBlockPrefetcher(brq, brq.config, testSyncCh)

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -405,7 +405,10 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 				id, tlfID, context, size)
 			dbc := b.config.DiskBlockCache()
 			if dbc != nil {
-				go dbc.Put(ctx, tlfID, id, buf, serverHalf)
+				// This used to be called in a goroutine to prevent blocking
+				// the `Get`. But we need this cached synchronously for
+				// later behavior.
+				dbc.Put(ctx, tlfID, id, buf, serverHalf)
 			}
 		}
 	}()
@@ -434,7 +437,7 @@ func (b *BlockServerRemote) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
 	dbc := b.config.DiskBlockCache()
 	if dbc != nil {
-		go dbc.Put(ctx, tlfID, id, buf, serverHalf)
+		dbc.Put(ctx, tlfID, id, buf, serverHalf)
 	}
 	size := len(buf)
 	b.log.LazyTrace(ctx, "BServer: Put %s", id)
@@ -469,7 +472,7 @@ func (b *BlockServerRemote) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsb
 	bContext kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
 	dbc := b.config.DiskBlockCache()
 	if dbc != nil {
-		go dbc.Put(ctx, tlfID, id, buf, serverHalf)
+		dbc.Put(ctx, tlfID, id, buf, serverHalf)
 	}
 	size := len(buf)
 	b.log.LazyTrace(ctx, "BServer: Put %s", id)

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -406,8 +406,8 @@ func (b *BlockServerRemote) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.
 			dbc := b.config.DiskBlockCache()
 			if dbc != nil {
 				// This used to be called in a goroutine to prevent blocking
-				// the `Get`. But we need this cached synchronously for
-				// later behavior.
+				// the `Get`. But we need this cached synchronously so prefetch
+				// operations can work correctly.
 				dbc.Put(ctx, tlfID, id, buf, serverHalf)
 			}
 		}

--- a/libkbfs/channels.go
+++ b/libkbfs/channels.go
@@ -1,0 +1,50 @@
+package libkbfs
+
+import (
+	"sync"
+
+	"github.com/eapache/channels"
+)
+
+// infiniteChannelWrapper is a wrapper to allow us to select on sending to an
+// infinite channel without fearing a panic when we Close() it.
+type infiniteChannelWrapper struct {
+	*channels.InfiniteChannel
+	input        chan interface{}
+	shutdownOnce sync.Once
+	shutdownCh   chan struct{}
+}
+
+var _ channels.Channel = (*infiniteChannelWrapper)(nil)
+
+func newInfiniteChannelWrapper() *infiniteChannelWrapper {
+	ch := &infiniteChannelWrapper{
+		InfiniteChannel: channels.NewInfiniteChannel(),
+		input:           make(chan interface{}),
+		shutdownCh:      make(chan struct{}),
+	}
+	go ch.run()
+	return ch
+}
+
+func (ch *infiniteChannelWrapper) run() {
+	for {
+		select {
+		case next := <-ch.input:
+			ch.InfiniteChannel.In() <- next
+		case <-ch.shutdownCh:
+			ch.InfiniteChannel.Close()
+			return
+		}
+	}
+}
+
+func (ch *infiniteChannelWrapper) In() chan<- interface{} {
+	return ch.input
+}
+
+func (ch *infiniteChannelWrapper) Close() {
+	ch.shutdownOnce.Do(func() {
+		close(ch.shutdownCh)
+	})
+}

--- a/libkbfs/channels.go
+++ b/libkbfs/channels.go
@@ -1,3 +1,7 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
 package libkbfs
 
 import (

--- a/libkbfs/channels.go
+++ b/libkbfs/channels.go
@@ -6,6 +6,10 @@ import (
 	"github.com/eapache/channels"
 )
 
+const (
+	defaultInfiniteBufferSize int = 100
+)
+
 // infiniteChannelWrapper is a wrapper to allow us to select on sending to an
 // infinite channel without fearing a panic when we Close() it.
 type infiniteChannelWrapper struct {
@@ -20,7 +24,7 @@ var _ channels.Channel = (*infiniteChannelWrapper)(nil)
 func newInfiniteChannelWrapper() *infiniteChannelWrapper {
 	ch := &infiniteChannelWrapper{
 		InfiniteChannel: channels.NewInfiniteChannel(),
-		input:           make(chan interface{}),
+		input:           make(chan interface{}, defaultInfiniteBufferSize),
 		shutdownCh:      make(chan struct{}),
 	}
 	go ch.run()

--- a/libkbfs/channels.go
+++ b/libkbfs/channels.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultInfiniteBufferSize int = 100
+	defaultInfiniteBufferSize int = 0
 )
 
 // infiniteChannelWrapper is a wrapper to allow us to select on sending to an

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1346,6 +1346,7 @@ func (c *ConfigLocal) SetTlfSyncState(tlfID tlf.ID, isSynced bool) error {
 		}
 	}
 	c.syncedTlfs[tlfID] = isSynced
+	<-c.BlockOps().TogglePrefetcher(context.Background(), true)
 	return nil
 }
 
@@ -1369,4 +1370,12 @@ func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 // GetRekeyFSMLimiter implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) GetRekeyFSMLimiter() *OngoingWorkLimiter {
 	return c.rekeyFSMLimiter
+}
+
+// BlockRetriever implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) BlockRetriever() BlockRetriever {
+	if c.BlockOps() != nil {
+		return c.BlockOps().BlockRetriever()
+	}
+	return nil
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1371,11 +1371,3 @@ func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 func (c *ConfigLocal) GetRekeyFSMLimiter() *OngoingWorkLimiter {
 	return c.rekeyFSMLimiter
 }
-
-// BlockRetriever implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) BlockRetriever() BlockRetriever {
-	if c.BlockOps() != nil {
-		return c.BlockOps().BlockRetriever()
-	}
-	return nil
-}

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1346,7 +1346,7 @@ func (c *ConfigLocal) SetTlfSyncState(tlfID tlf.ID, isSynced bool) error {
 		}
 	}
 	c.syncedTlfs[tlfID] = isSynced
-	<-c.BlockOps().TogglePrefetcher(context.Background(), true)
+	<-c.BlockOps().TogglePrefetcher(true)
 	return nil
 }
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -865,7 +865,6 @@ func (s PrefetchStatus) String() string {
 		return "TriggeredPrefetch"
 	case FinishedPrefetch:
 		return "FinishedPrefetch"
-	default:
-		return "Unknown"
 	}
+	return "Unknown"
 }

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -650,6 +650,7 @@ func (cache *DiskBlockCacheStandard) Put(ctx context.Context, tlfID tlf.ID,
 		// rely on the later-called UpdateMetadata to fix it.
 		md.TlfID = tlfID
 		md.BlockSize = uint32(encodedLen)
+		err = nil
 	}
 	return cache.updateMetadataLocked(ctx, blockKey, md)
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -381,11 +381,8 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		// TODO: remove this and call the prefetcher directly once we plumb
-		// through priority.
-		fbo.config.BlockOps().BlockRetriever().CacheAndPrefetch(ctx,
-			ptr, block, kmd, defaultOnDemandRequestPriority, lifetime,
-			prefetchStatus, nil, nil)
+		fbo.config.BlockOps().Prefetcher().TriggerPrefetch(ptr, block, kmd,
+			defaultOnDemandRequestPriority, lifetime, prefetchStatus)
 		return block, nil
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -381,9 +381,9 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		// No need to cache because it's already cached.
-		fbo.config.BlockOps().Prefetcher().TriggerPrefetch(ctx, ptr, block,
-			kmd, defaultOnDemandRequestPriority, lifetime, prefetchStatus)
+		fbo.config.BlockOps().Prefetcher().ProcessBlockForPrefetch(ctx, ptr,
+			block, kmd, defaultOnDemandRequestPriority, lifetime,
+			prefetchStatus)
 		return block, nil
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3344,17 +3344,20 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 			// Prefetch the new ref, but only if the old ref already exists in
 			// the block cache. Ideally we'd always prefetch it, but we need
 			// the type of the block so that we can call `NewEmpty`.
-			block, _, lifetime, err := fbo.config.BlockCache().GetWithPrefetch(oldPtr)
+			block, prefetchStatus, lifetime, err :=
+				fbo.config.BlockCache().GetWithPrefetch(oldPtr)
 			if err != nil {
 				return
 			}
 
 			// TODO: reintroduce updatePointerPrefetchPriority
-			fbo.config.BlockOps().Prefetcher().TriggerAndMonitorPrefetch(
+			fbo.config.BlockOps().Prefetcher().TriggerPrefetch(
 				newPtr,
 				block.NewEmpty(),
 				kmd,
+				updatePointerPrefetchPriority,
 				lifetime,
+				prefetchStatus,
 			)
 		}
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -381,8 +381,9 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		fbo.config.BlockOps().Prefetcher().TriggerPrefetch(ptr, block, kmd,
-			defaultOnDemandRequestPriority, lifetime, prefetchStatus)
+		// No need to cache because it's already cached.
+		fbo.config.BlockOps().Prefetcher().TriggerPrefetch(ctx, ptr, block,
+			kmd, defaultOnDemandRequestPriority, lifetime, prefetchStatus)
 		return block, nil
 	}
 
@@ -3339,7 +3340,8 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 	// Only prefetch if the updated pointer is a new block ID.
 	if oldPtr.ID != newPtr.ID {
 		// TODO: Remove this comment when we're done debugging because it'll be everywhere.
-		fbo.log.CDebugf(context.TODO(), "Updated reference for pointer %s to %s.", oldPtr.ID, newPtr.ID)
+		ctx := context.TODO()
+		fbo.log.CDebugf(ctx, "Updated reference for pointer %s to %s.", oldPtr.ID, newPtr.ID)
 		if shouldPrefetch {
 			// Prefetch the new ref, but only if the old ref already exists in
 			// the block cache. Ideally we'd always prefetch it, but we need
@@ -3350,15 +3352,10 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 				return
 			}
 
-			// TODO: reintroduce updatePointerPrefetchPriority
+			// No need to cache because it's already cached.
 			fbo.config.BlockOps().Prefetcher().TriggerPrefetch(
-				newPtr,
-				block.NewEmpty(),
-				kmd,
-				updatePointerPrefetchPriority,
-				lifetime,
-				prefetchStatus,
-			)
+				ctx, newPtr, block.NewEmpty(), kmd,
+				updatePointerPrefetchPriority, lifetime, prefetchStatus)
 		}
 	}
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3346,16 +3346,16 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 			// Prefetch the new ref, but only if the old ref already exists in
 			// the block cache. Ideally we'd always prefetch it, but we need
 			// the type of the block so that we can call `NewEmpty`.
-			block, prefetchStatus, lifetime, err :=
+			block, _, lifetime, err :=
 				fbo.config.BlockCache().GetWithPrefetch(oldPtr)
 			if err != nil {
 				return
 			}
 
 			// No need to cache because it's already cached.
-			fbo.config.BlockOps().Prefetcher().TriggerPrefetch(
-				ctx, newPtr, block.NewEmpty(), kmd,
-				updatePointerPrefetchPriority, lifetime, prefetchStatus)
+			go fbo.config.BlockOps().BlockRetriever().Request(ctx,
+				updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
+				lifetime)
 		}
 	}
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3353,7 +3353,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 			}
 
 			// No need to cache because it's already cached.
-			go fbo.config.BlockOps().BlockRetriever().Request(ctx,
+			_ = fbo.config.BlockOps().BlockRetriever().Request(ctx,
 				updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
 				lifetime)
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1582,11 +1582,9 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	}()
 
 	if md.IsReadable() && fbo.config.Mode() != InitMinimal {
-		// We will prefetch this as on-demand so that it triggers downstream
-		// prefetches.
-		// TODO: reintroduce priority: defaultOnDemandRequestPriority
-		fbo.config.BlockOps().Prefetcher().TriggerAndMonitorPrefetch(
-			md.data.Dir.BlockPointer, &DirBlock{}, md, TransientEntry)
+		// We `Get` the root block to ensure downstream prefetches occur.
+		go fbo.config.BlockOps().Get(ctx, md, md.data.Dir.BlockPointer,
+			&DirBlock{}, TransientEntry)
 	} else {
 		fbo.log.CDebugf(ctx,
 			"Setting an unreadable head with revision=%d", md.Revision())

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1583,7 +1583,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 
 	if md.IsReadable() && fbo.config.Mode() != InitMinimal {
 		// We `Get` the root block to ensure downstream prefetches occur.
-		go fbo.config.BlockOps().BlockRetriever().Request(ctx,
+		_ = fbo.config.BlockOps().BlockRetriever().Request(ctx,
 			defaultOnDemandRequestPriority, md, md.data.Dir.BlockPointer,
 			&DirBlock{}, TransientEntry)
 	} else {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1583,7 +1583,8 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 
 	if md.IsReadable() && fbo.config.Mode() != InitMinimal {
 		// We `Get` the root block to ensure downstream prefetches occur.
-		go fbo.config.BlockOps().Get(ctx, md, md.data.Dir.BlockPointer,
+		go fbo.config.BlockOps().BlockRetriever().Request(ctx,
+			defaultOnDemandRequestPriority, md, md.data.Dir.BlockPointer,
 			&DirBlock{}, TransientEntry)
 	} else {
 		fbo.log.CDebugf(ctx,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1584,9 +1584,9 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	if md.IsReadable() && fbo.config.Mode() != InitMinimal {
 		// We will prefetch this as on-demand so that it triggers downstream
 		// prefetches.
-		fbo.config.BlockOps().Prefetcher().PrefetchBlock(
-			&DirBlock{}, md.data.Dir.BlockPointer, md,
-			defaultOnDemandRequestPriority)
+		// TODO: reintroduce priority: defaultOnDemandRequestPriority
+		fbo.config.BlockOps().Prefetcher().TriggerAndMonitorPrefetch(
+			md.data.Dir.BlockPointer, &DirBlock{}, md, TransientEntry)
 	} else {
 		fbo.log.CDebugf(ctx,
 			"Setting an unreadable head with revision=%d", md.Revision())

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1744,7 +1744,6 @@ type Config interface {
 	syncedTlfGetterSetter
 	initModeGetter
 	Tracer
-	blockRetrieverGetter
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1773,6 +1773,8 @@ type Config interface {
 	SetConflictRenamer(ConflictRenamer)
 	MetadataVersion() MetadataVer
 	SetMetadataVersion(MetadataVer)
+	DefaultBlockType() keybase1.BlockType
+	SetDefaultBlockType(blockType keybase1.BlockType)
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)
 	// ReqsBufSize indicates the number of read or write operations

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1234,9 +1234,6 @@ type KeyOps interface {
 
 // Prefetcher is an interface to a block prefetcher.
 type Prefetcher interface {
-	// PrefetchBlock directs the prefetcher to prefetch a block.
-	PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata,
-		priority int) (err error)
 	// TriggerAndMonitorPrefetch triggers and monitors a prefetch.
 	TriggerAndMonitorPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
 		lifetime BlockCacheLifetime)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1249,7 +1249,7 @@ type Prefetcher interface {
 	// TriggerPrefetch triggers and monitors a prefetch.
 	TriggerPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		prefetchStatus PrefetchStatus) error
+		prefetchStatus PrefetchStatus)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -786,6 +786,18 @@ type KeyCache interface {
 // BlockCacheLifetime denotes the lifetime of an entry in BlockCache.
 type BlockCacheLifetime int
 
+func (l BlockCacheLifetime) String() string {
+	switch l {
+	case NoCacheEntry:
+		return "NoCacheEntry"
+	case TransientEntry:
+		return "TransientEntry"
+	case PermanentEntry:
+		return "PermanentEntry"
+	}
+	return "Unknown"
+}
+
 const (
 	// NoCacheEntry means that the entry will not be cached.
 	NoCacheEntry BlockCacheLifetime = iota
@@ -1241,9 +1253,6 @@ type Prefetcher interface {
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)
-	// NotifyPrefetchDone notifies the prefetcher that a prefetch has
-	// completed.
-	NotifyPrefetchDone(kbfsblock.ID)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1250,8 +1250,8 @@ type KeyOps interface {
 
 // Prefetcher is an interface to a block prefetcher.
 type Prefetcher interface {
-	// TriggerPrefetch triggers and monitors a prefetch.
-	TriggerPrefetch(ctx context.Context, ptr BlockPointer, block Block,
+	// ProcessBlockForPrefetch potentially triggers and monitors a prefetch.
+	ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
 		prefetchStatus PrefetchStatus)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
@@ -1263,9 +1263,6 @@ type Prefetcher interface {
 	// complete. This feature is mainly used for testing, but also to toggle
 	// the prefetcher on and off.
 	Shutdown() <-chan struct{}
-	// ShutdownCh returns a channel that is closed if and when the prefetcher
-	// is shut down.
-	ShutdownCh() <-chan struct{}
 }
 
 // BlockOps gets and puts data blocks to a BlockServer. It performs

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1234,9 +1234,10 @@ type KeyOps interface {
 
 // Prefetcher is an interface to a block prefetcher.
 type Prefetcher interface {
-	// TriggerAndMonitorPrefetch triggers and monitors a prefetch.
-	TriggerAndMonitorPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
-		lifetime BlockCacheLifetime)
+	// TriggerPrefetch triggers and monitors a prefetch.
+	TriggerPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
+		priority int, lifetime BlockCacheLifetime,
+		prefetchStatus PrefetchStatus) PrefetchStatus
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1239,8 +1239,7 @@ type Prefetcher interface {
 		priority int) (err error)
 	// TriggerAndMonitorPrefetch triggers and monitors a prefetch.
 	TriggerAndMonitorPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
-		lifetime BlockCacheLifetime, parentBlockIDs []kbfsblock.ID,
-		didUpdateCh <-chan struct{})
+		lifetime BlockCacheLifetime)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)
@@ -1776,8 +1775,6 @@ type Config interface {
 	SetConflictRenamer(ConflictRenamer)
 	MetadataVersion() MetadataVer
 	SetMetadataVersion(MetadataVer)
-	DefaultBlockType() keybase1.BlockType
-	SetDefaultBlockType(blockType keybase1.BlockType)
 	RekeyQueue() RekeyQueue
 	SetRekeyQueue(RekeyQueue)
 	// ReqsBufSize indicates the number of read or write operations
@@ -2316,9 +2313,4 @@ type BlockRetriever interface {
 	// Request retrieves blocks asynchronously.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
-	// RequestWithPrefetch retrieves blocks asynchronously and accepts channels
-	// to notify when child blocks are done prefetching.
-	RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
-		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
-		parentBlockID kbfsblock.ID) <-chan error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1235,9 +1235,9 @@ type KeyOps interface {
 // Prefetcher is an interface to a block prefetcher.
 type Prefetcher interface {
 	// TriggerPrefetch triggers and monitors a prefetch.
-	TriggerPrefetch(ptr BlockPointer, block Block, kmd KeyMetadata,
-		priority int, lifetime BlockCacheLifetime,
-		prefetchStatus PrefetchStatus) PrefetchStatus
+	TriggerPrefetch(ctx context.Context, ptr BlockPointer, block Block,
+		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
+		prefetchStatus PrefetchStatus) error
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)
@@ -2313,4 +2313,9 @@ type BlockRetriever interface {
 	// Request retrieves blocks asynchronously.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+	// PutInCaches puts the block into the in-memory cache, and ensures that
+	// the disk cache metadata is updated.
+	PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID,
+		block Block, lifetime BlockCacheLifetime,
+		prefetchStatus PrefetchStatus) error
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1309,7 +1309,7 @@ type BlockOps interface {
 	Archive(ctx context.Context, tlfID tlf.ID, ptrs []BlockPointer) error
 
 	// TogglePrefetcher activates or deactivates the prefetcher.
-	TogglePrefetcher(ctx context.Context, enable bool) <-chan struct{}
+	TogglePrefetcher(enable bool) <-chan struct{}
 
 	// Prefetcher retrieves this BlockOps' Prefetcher.
 	Prefetcher() Prefetcher
@@ -2332,6 +2332,5 @@ type BlockRetriever interface {
 		block Block, lifetime BlockCacheLifetime,
 		prefetchStatus PrefetchStatus) error
 	// TogglePrefetcher creates a new prefetcher.
-	TogglePrefetcher(ctx context.Context, enable bool,
-		syncCh <-chan struct{}) <-chan struct{}
+	TogglePrefetcher(enable bool, syncCh <-chan struct{}) <-chan struct{}
 }

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -104,15 +104,15 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	// Ignore Archive calls for now
 	config.mockBops.EXPECT().Archive(gomock.Any(), gomock.Any(),
 		gomock.Any()).AnyTimes().Return(nil)
-	// Ignore Prefetcher calls
+	// Ignore BlockRetriever calls
 	brc := &testBlockRetrievalConfig{nil, newTestLogMaker(t),
 		config.BlockCache(), nil, newTestDiskBlockCacheGetter(t, nil),
 		newTestSyncedTlfGetterSetter(), testInitModeGetter{InitDefault}}
-	pre := newBlockPrefetcher(nil, brc)
-	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(pre)
-	// Ignore BlockRetriever calls
 	brq := newBlockRetrievalQueue(0, 0, brc)
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
+	// Ignore Prefetcher calls
+	pre := newBlockPrefetcher(brq, brc)
+	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(pre)
 
 	// Ignore key bundle ID creation calls for now
 	config.mockCrypto.EXPECT().MakeTLFWriterKeyBundleID(gomock.Any()).

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -111,7 +111,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	brq := newBlockRetrievalQueue(0, 0, brc)
 	config.mockBops.EXPECT().BlockRetriever().AnyTimes().Return(brq)
 	// Ignore Prefetcher calls
-	pre := newBlockPrefetcher(brq, brc)
+	pre := newBlockPrefetcher(brq, brc, nil)
 	config.mockBops.EXPECT().Prefetcher().AnyTimes().Return(pre)
 
 	// Ignore key bundle ID creation calls for now

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4248,15 +4248,15 @@ func (mr *MockBlockOpsMockRecorder) Archive(ctx, tlfID, ptrs interface{}) *gomoc
 }
 
 // TogglePrefetcher mocks base method
-func (m *MockBlockOps) TogglePrefetcher(ctx context.Context, enable bool) <-chan struct{} {
-	ret := m.ctrl.Call(m, "TogglePrefetcher", ctx, enable)
+func (m *MockBlockOps) TogglePrefetcher(enable bool) <-chan struct{} {
+	ret := m.ctrl.Call(m, "TogglePrefetcher", enable)
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
 // TogglePrefetcher indicates an expected call of TogglePrefetcher
-func (mr *MockBlockOpsMockRecorder) TogglePrefetcher(ctx, enable interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockOps)(nil).TogglePrefetcher), ctx, enable)
+func (mr *MockBlockOpsMockRecorder) TogglePrefetcher(enable interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockOps)(nil).TogglePrefetcher), enable)
 }
 
 // Prefetcher mocks base method
@@ -8592,13 +8592,13 @@ func (mr *MockBlockRetrieverMockRecorder) PutInCaches(ctx, ptr, tlfID, block, li
 }
 
 // TogglePrefetcher mocks base method
-func (m *MockBlockRetriever) TogglePrefetcher(ctx context.Context, enable bool, syncCh <-chan struct{}) <-chan struct{} {
-	ret := m.ctrl.Call(m, "TogglePrefetcher", ctx, enable, syncCh)
+func (m *MockBlockRetriever) TogglePrefetcher(enable bool, syncCh <-chan struct{}) <-chan struct{} {
+	ret := m.ctrl.Call(m, "TogglePrefetcher", enable, syncCh)
 	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
 // TogglePrefetcher indicates an expected call of TogglePrefetcher
-func (mr *MockBlockRetrieverMockRecorder) TogglePrefetcher(ctx, enable, syncCh interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockRetriever)(nil).TogglePrefetcher), ctx, enable, syncCh)
+func (mr *MockBlockRetrieverMockRecorder) TogglePrefetcher(enable, syncCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockRetriever)(nil).TogglePrefetcher), enable, syncCh)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4103,14 +4103,14 @@ func (m *MockPrefetcher) EXPECT() *MockPrefetcherMockRecorder {
 	return m.recorder
 }
 
-// TriggerPrefetch mocks base method
-func (m *MockPrefetcher) TriggerPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) {
-	m.ctrl.Call(m, "TriggerPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
+// ProcessBlockForPrefetch mocks base method
+func (m *MockPrefetcher) ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) {
+	m.ctrl.Call(m, "ProcessBlockForPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
 }
 
-// TriggerPrefetch indicates an expected call of TriggerPrefetch
-func (mr *MockPrefetcherMockRecorder) TriggerPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).TriggerPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
+// ProcessBlockForPrefetch indicates an expected call of ProcessBlockForPrefetch
+func (mr *MockPrefetcherMockRecorder) ProcessBlockForPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockForPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).ProcessBlockForPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
 }
 
 // CancelPrefetch mocks base method
@@ -4133,18 +4133,6 @@ func (m *MockPrefetcher) Shutdown() <-chan struct{} {
 // Shutdown indicates an expected call of Shutdown
 func (mr *MockPrefetcherMockRecorder) Shutdown() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockPrefetcher)(nil).Shutdown))
-}
-
-// ShutdownCh mocks base method
-func (m *MockPrefetcher) ShutdownCh() <-chan struct{} {
-	ret := m.ctrl.Call(m, "ShutdownCh")
-	ret0, _ := ret[0].(<-chan struct{})
-	return ret0
-}
-
-// ShutdownCh indicates an expected call of ShutdownCh
-func (mr *MockPrefetcherMockRecorder) ShutdownCh() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutdownCh", reflect.TypeOf((*MockPrefetcher)(nil).ShutdownCh))
 }
 
 // MockBlockOps is a mock of BlockOps interface

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -557,6 +557,41 @@ func (mr *MocksyncedTlfGetterSetterMockRecorder) SetTlfSyncState(tlfID, isSynced
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).SetTlfSyncState), tlfID, isSynced)
 }
 
+// MockblockRetrieverGetter is a mock of blockRetrieverGetter interface
+type MockblockRetrieverGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockblockRetrieverGetterMockRecorder
+}
+
+// MockblockRetrieverGetterMockRecorder is the mock recorder for MockblockRetrieverGetter
+type MockblockRetrieverGetterMockRecorder struct {
+	mock *MockblockRetrieverGetter
+}
+
+// NewMockblockRetrieverGetter creates a new mock instance
+func NewMockblockRetrieverGetter(ctrl *gomock.Controller) *MockblockRetrieverGetter {
+	mock := &MockblockRetrieverGetter{ctrl: ctrl}
+	mock.recorder = &MockblockRetrieverGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockblockRetrieverGetter) EXPECT() *MockblockRetrieverGetterMockRecorder {
+	return m.recorder
+}
+
+// BlockRetriever mocks base method
+func (m *MockblockRetrieverGetter) BlockRetriever() BlockRetriever {
+	ret := m.ctrl.Call(m, "BlockRetriever")
+	ret0, _ := ret[0].(BlockRetriever)
+	return ret0
+}
+
+// BlockRetriever indicates an expected call of BlockRetriever
+func (mr *MockblockRetrieverGetterMockRecorder) BlockRetriever() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockRetriever", reflect.TypeOf((*MockblockRetrieverGetter)(nil).BlockRetriever))
+}
+
 // MockBlock is a mock of Block interface
 type MockBlock struct {
 	ctrl     *gomock.Controller
@@ -4135,6 +4170,18 @@ func (m *MockBlockOps) EXPECT() *MockBlockOpsMockRecorder {
 	return m.recorder
 }
 
+// BlockRetriever mocks base method
+func (m *MockBlockOps) BlockRetriever() BlockRetriever {
+	ret := m.ctrl.Call(m, "BlockRetriever")
+	ret0, _ := ret[0].(BlockRetriever)
+	return ret0
+}
+
+// BlockRetriever indicates an expected call of BlockRetriever
+func (mr *MockBlockOpsMockRecorder) BlockRetriever() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockRetriever", reflect.TypeOf((*MockBlockOps)(nil).BlockRetriever))
+}
+
 // Get mocks base method
 func (m *MockBlockOps) Get(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer, block Block, cacheLifetime BlockCacheLifetime) error {
 	ret := m.ctrl.Call(m, "Get", ctx, kmd, blockPtr, block, cacheLifetime)
@@ -4201,27 +4248,15 @@ func (mr *MockBlockOpsMockRecorder) Archive(ctx, tlfID, ptrs interface{}) *gomoc
 }
 
 // TogglePrefetcher mocks base method
-func (m *MockBlockOps) TogglePrefetcher(ctx context.Context, enable bool) error {
+func (m *MockBlockOps) TogglePrefetcher(ctx context.Context, enable bool) <-chan struct{} {
 	ret := m.ctrl.Call(m, "TogglePrefetcher", ctx, enable)
-	ret0, _ := ret[0].(error)
+	ret0, _ := ret[0].(<-chan struct{})
 	return ret0
 }
 
 // TogglePrefetcher indicates an expected call of TogglePrefetcher
 func (mr *MockBlockOpsMockRecorder) TogglePrefetcher(ctx, enable interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockOps)(nil).TogglePrefetcher), ctx, enable)
-}
-
-// BlockRetriever mocks base method
-func (m *MockBlockOps) BlockRetriever() BlockRetriever {
-	ret := m.ctrl.Call(m, "BlockRetriever")
-	ret0, _ := ret[0].(BlockRetriever)
-	return ret0
-}
-
-// BlockRetriever indicates an expected call of BlockRetriever
-func (mr *MockBlockOpsMockRecorder) BlockRetriever() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockRetriever", reflect.TypeOf((*MockBlockOps)(nil).BlockRetriever))
 }
 
 // Prefetcher mocks base method
@@ -5866,6 +5901,18 @@ func (m *MockConfig) MaybeFinishTrace(ctx context.Context, err error) {
 // MaybeFinishTrace indicates an expected call of MaybeFinishTrace
 func (mr *MockConfigMockRecorder) MaybeFinishTrace(ctx, err interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeFinishTrace", reflect.TypeOf((*MockConfig)(nil).MaybeFinishTrace), ctx, err)
+}
+
+// BlockRetriever mocks base method
+func (m *MockConfig) BlockRetriever() BlockRetriever {
+	ret := m.ctrl.Call(m, "BlockRetriever")
+	ret0, _ := ret[0].(BlockRetriever)
+	return ret0
+}
+
+// BlockRetriever indicates an expected call of BlockRetriever
+func (mr *MockConfigMockRecorder) BlockRetriever() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockRetriever", reflect.TypeOf((*MockConfig)(nil).BlockRetriever))
 }
 
 // KBFSOps mocks base method
@@ -8542,4 +8589,16 @@ func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, 
 // PutInCaches indicates an expected call of PutInCaches
 func (mr *MockBlockRetrieverMockRecorder) PutInCaches(ctx, ptr, tlfID, block, lifetime, prefetchStatus interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInCaches", reflect.TypeOf((*MockBlockRetriever)(nil).PutInCaches), ctx, ptr, tlfID, block, lifetime, prefetchStatus)
+}
+
+// TogglePrefetcher mocks base method
+func (m *MockBlockRetriever) TogglePrefetcher(ctx context.Context, enable bool, syncCh <-chan struct{}) <-chan struct{} {
+	ret := m.ctrl.Call(m, "TogglePrefetcher", ctx, enable, syncCh)
+	ret0, _ := ret[0].(<-chan struct{})
+	return ret0
+}
+
+// TogglePrefetcher indicates an expected call of TogglePrefetcher
+func (mr *MockBlockRetrieverMockRecorder) TogglePrefetcher(ctx, enable, syncCh interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TogglePrefetcher", reflect.TypeOf((*MockBlockRetriever)(nil).TogglePrefetcher), ctx, enable, syncCh)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4068,32 +4068,24 @@ func (m *MockPrefetcher) EXPECT() *MockPrefetcherMockRecorder {
 	return m.recorder
 }
 
-// PrefetchBlock mocks base method
-func (m *MockPrefetcher) PrefetchBlock(block Block, blockPtr BlockPointer, kmd KeyMetadata, priority int) (<-chan struct{}, <-chan struct{}, error) {
-	ret := m.ctrl.Call(m, "PrefetchBlock", block, blockPtr, kmd, priority)
-	ret0, _ := ret[0].(<-chan struct{})
-	ret1, _ := ret[1].(<-chan struct{})
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+// TriggerPrefetch mocks base method
+func (m *MockPrefetcher) TriggerPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) {
+	m.ctrl.Call(m, "TriggerPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
 }
 
-// PrefetchBlock indicates an expected call of PrefetchBlock
-func (mr *MockPrefetcherMockRecorder) PrefetchBlock(block, blockPtr, kmd, priority interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchBlock", reflect.TypeOf((*MockPrefetcher)(nil).PrefetchBlock), block, blockPtr, kmd, priority)
+// TriggerPrefetch indicates an expected call of TriggerPrefetch
+func (mr *MockPrefetcherMockRecorder) TriggerPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TriggerPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).TriggerPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
 }
 
-// PrefetchAfterBlockRetrieved mocks base method
-func (m *MockPrefetcher) PrefetchAfterBlockRetrieved(b Block, blockPtr BlockPointer, kmd KeyMetadata) (<-chan struct{}, <-chan struct{}, int) {
-	ret := m.ctrl.Call(m, "PrefetchAfterBlockRetrieved", b, blockPtr, kmd)
-	ret0, _ := ret[0].(<-chan struct{})
-	ret1, _ := ret[1].(<-chan struct{})
-	ret2, _ := ret[2].(int)
-	return ret0, ret1, ret2
+// CancelPrefetch mocks base method
+func (m *MockPrefetcher) CancelPrefetch(arg0 kbfsblock.ID) {
+	m.ctrl.Call(m, "CancelPrefetch", arg0)
 }
 
-// PrefetchAfterBlockRetrieved indicates an expected call of PrefetchAfterBlockRetrieved
-func (mr *MockPrefetcherMockRecorder) PrefetchAfterBlockRetrieved(b, blockPtr, kmd interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchAfterBlockRetrieved", reflect.TypeOf((*MockPrefetcher)(nil).PrefetchAfterBlockRetrieved), b, blockPtr, kmd)
+// CancelPrefetch indicates an expected call of CancelPrefetch
+func (mr *MockPrefetcherMockRecorder) CancelPrefetch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).CancelPrefetch), arg0)
 }
 
 // Shutdown mocks base method
@@ -8540,26 +8532,14 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime)
 }
 
-// RequestWithPrefetch mocks base method
-func (m *MockBlockRetriever) RequestWithPrefetch(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime, deepPrefetchDoneCh, deepPrefetchCancelCh chan<- struct{}) <-chan error {
-	ret := m.ctrl.Call(m, "RequestWithPrefetch", ctx, priority, kmd, ptr, block, lifetime, deepPrefetchDoneCh, deepPrefetchCancelCh)
-	ret0, _ := ret[0].(<-chan error)
-	return ret0
-}
-
-// RequestWithPrefetch indicates an expected call of RequestWithPrefetch
-func (mr *MockBlockRetrieverMockRecorder) RequestWithPrefetch(ctx, priority, kmd, ptr, block, lifetime, deepPrefetchDoneCh, deepPrefetchCancelCh interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestWithPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestWithPrefetch), ctx, priority, kmd, ptr, block, lifetime, deepPrefetchDoneCh, deepPrefetchCancelCh)
-}
-
-// CacheAndPrefetch mocks base method
-func (m *MockBlockRetriever) CacheAndPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh chan<- struct{}) error {
-	ret := m.ctrl.Call(m, "CacheAndPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh)
+// PutInCaches mocks base method
+func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
+	ret := m.ctrl.Call(m, "PutInCaches", ctx, ptr, tlfID, block, lifetime, prefetchStatus)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CacheAndPrefetch indicates an expected call of CacheAndPrefetch
-func (mr *MockBlockRetrieverMockRecorder) CacheAndPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CacheAndPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).CacheAndPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, deepPrefetchDoneCh, deepPrefetchCancelCh)
+// PutInCaches indicates an expected call of PutInCaches
+func (mr *MockBlockRetrieverMockRecorder) PutInCaches(ctx, ptr, tlfID, block, lifetime, prefetchStatus interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutInCaches", reflect.TypeOf((*MockBlockRetriever)(nil).PutInCaches), ctx, ptr, tlfID, block, lifetime, prefetchStatus)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5903,18 +5903,6 @@ func (mr *MockConfigMockRecorder) MaybeFinishTrace(ctx, err interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeFinishTrace", reflect.TypeOf((*MockConfig)(nil).MaybeFinishTrace), ctx, err)
 }
 
-// BlockRetriever mocks base method
-func (m *MockConfig) BlockRetriever() BlockRetriever {
-	ret := m.ctrl.Call(m, "BlockRetriever")
-	ret0, _ := ret[0].(BlockRetriever)
-	return ret0
-}
-
-// BlockRetriever indicates an expected call of BlockRetriever
-func (mr *MockConfigMockRecorder) BlockRetriever() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockRetriever", reflect.TypeOf((*MockConfig)(nil).BlockRetriever))
-}
-
 // KBFSOps mocks base method
 func (m *MockConfig) KBFSOps() KBFSOps {
 	ret := m.ctrl.Call(m, "KBFSOps")

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -213,6 +213,9 @@ top:
 func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 	defer func() {
 		close(p.doneCh)
+		p.prefetchRequestCh.Close()
+		p.prefetchCancelCh.Close()
+		p.inFlightFetches.Close()
 	}()
 	isShuttingDown := false
 	for {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -181,18 +181,23 @@ top:
 
 // run prefetches blocks.
 // E.g. a synced prefetch:
-// a -> {b -> c, d -> e}:
-// 1) a is fetched, triggers b and d.
-//    * a:2 -> {b:1, d:1}
-// 2) b is fetched, decrements b and a by 1, and triggers c to increment them
-//    both.
-//    * a:2 -> {b:1 -> c:1, d:1}
+// a -> {b -> {c, d}, e -> {f, g}}:
+// * state of prefetch tree in `p.prefetches`.
+// 1) a is fetched, triggers b and e.
+//    * a:2 -> {b:1, e:1}
+// 2) b is fetched, decrements b and a by 1, and triggers c and d to increment
+//    b and a by 2.
+//    * a:3 -> {b:2 -> {c:1, d:1}, e:1}
 // 3) c is fetched, and isTail==true so it completes up the tree.
-//    * a:1 -> {d:1}
-// 4) d is fetched, decrements d and a by 1, and triggers e to increment them
-//    both.
-//    * a:1 -> {d:1 -> e:1}
-// 5) e is fetched, completing d and a.
+//    * a:2 -> {b:1 -> {d:1}, e:1}
+// 4) d is fetched, and isTail==true so it completes up the tree.
+//    * a:1 -> {e:1}
+// 5) e is fetched, decrements e and a by 1, and triggers f and g to increment
+//    them both.
+//    * a:2 -> {e:2 -> {f:1, g:1}}
+// 6) f is fetched, and isTail==true so it completes up the tree.
+//    * a:1 -> {e:1 -> {g:1}}
+// 5) g is fetched, completing g, e, and a.
 //    * <empty>
 func (p *blockPrefetcher) run() {
 	defer func() {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -507,44 +507,13 @@ func (p *blockPrefetcher) TriggerPrefetch(ctx context.Context,
 		p.triggerPrefetch(req)
 		return nil
 	}
-	// JZ: I'm removing this code to allow the prefetcher to decide how to
-	// handle prefetches. prefetchStatus should only be used in the actual
-	// prefetcher.
-	//if brq.config.IsSyncedTlf(kmd.TlfID()) {
-	//	// For synced blocks, callers need to be able to register themselves
-	//	// with the prefetcher as parents of a given block, so that their
-	//	// prefetch state is updated when the prefetch completes.
-	//} else if prefetchStatus == TriggeredPrefetch {
-	//	// If a prefetch has already been triggered for a block in a non-synced
-	//	// TLF, then there is no waiting to be done.
-	//	// TODO: maybe cancel here?
-	//	// The issue is that if we don't cancel at some point down the tree,
-	//	// the prefetcher will never remove the prefetches unless we do a true
-	//	// deep prefetch.
-	//	// On the other hand, if we _do_ cancel, we could be canceling a
-	//	// prefetch that needs to finish. Since prefetches are de-duped, this
-	//	// is a real risk..
-	//	//
-	//	// Plan A: store whether a block is a tail block in the `prefetch`. If
-	//	// a tail block completes, and it makes its parent counter 0, it should
-	//	// percolate. But if a non-tail block completes, it should percolate
-	//	// its counter and remove blocks from the prefetch tree, but it
-	//	// shouldn't mark the block done in the cache.
-	//	// * Problem: if all the tail blocks complete before the non-tail is
-	//	//   done fetching, there's no way to know that the mid-tree block should
-	//	//   percolate doneness.
-	//	//   * Answer: This is fine. If a mid-tree block triggers a prefetch,
-	//	//   then it has already been retrieved. And if it doesn't trigger, we
-	//	//   rely on the completion counter.
-	//	return TriggeredPrefetch
-	//}
 	isDeepSync := false
 	if p.config.IsSyncedTlf(kmd.TlfID()) {
 		isDeepSync = true
 	}
 	if priority < lowestTriggerPrefetchPriority {
 		// Only high priority requests can trigger prefetches. Leave the
-		// prefetchStatus unchanged.
+		// prefetchStatus unchanged, but cache anyway.
 		p.retriever.PutInCaches(ctx, ptr, kmd.TlfID(), block, lifetime,
 			prefetchStatus)
 		return nil

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -388,7 +388,9 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 			<-testSyncCh
 		}
 		select {
-		case <-shuttingDownCh:
+		case chInterface := <-shuttingDownCh:
+			ch := chInterface.(<-chan error)
+			<-ch
 		case bid := <-p.prefetchCancelCh.Out():
 			blockID := bid.(kbfsblock.ID)
 			pre, ok := p.prefetches[blockID]

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -393,6 +393,7 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	case p.inFlightFetches <- ch:
 	default:
 		// Ensure this can't block.
+		p.log.Debug("launching goroutine for request")
 		go func() {
 			p.inFlightFetches <- ch
 		}()
@@ -546,6 +547,7 @@ func (p *blockPrefetcher) triggerPrefetch(req *prefetchRequest) {
 		p.log.Warning("Skipping prefetch for block %v since "+
 			"the prefetcher is shutdown", req.ptr.ID)
 	default:
+		p.log.Debug("launching goroutine for triggerPrefetch")
 		go func() {
 			select {
 			case p.prefetchRequestCh <- req:
@@ -606,6 +608,7 @@ func (p *blockPrefetcher) CancelPrefetch(blockID kbfsblock.ID) {
 	case p.prefetchCancelCh <- blockID:
 	default:
 		// Ensure this can't block.
+		p.log.Debug("launching goroutine for CancelPrefetch")
 		go func() {
 			select {
 			case <-p.almostDoneCh:

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -236,12 +236,10 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 		case reqInt := <-p.prefetchRequestCh.Out():
 			req := reqInt.(*prefetchRequest)
 			pre, isPrefetchWaiting := p.prefetches[req.ptr.ID]
-			if isPrefetchWaiting {
-				if pre.req == nil {
-					// If this prefetch already appeared in the tree, ensure it
-					// has a req associated with it.
-					pre.req = req
-				}
+			if isPrefetchWaiting && pre.req == nil {
+				// If this prefetch already appeared in the tree, ensure it
+				// has a req associated with it.
+				pre.req = req
 			}
 			if req.prefetchStatus == FinishedPrefetch {
 				p.log.Debug("prefetch already finished for block %s",

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -124,8 +124,12 @@ func (p *blockPrefetcher) completePrefetch(numBlocks int) func(kbfsblock.ID, *pr
 			panic("completePrefetch overstepped its bounds")
 		}
 		if pp.subtreeBlockCount == 0 {
-			// TODO: mark complete.
 			delete(p.prefetches, blockID)
+			// TODO: log error
+			// TODO: export brq.checkCaches, retrieve from a cache, then put.
+			ctx := context.Background()
+			_ = p.retriever.PutInCaches(ctx, ptr, tlfID, block, lifetime,
+				prefetchStatus)
 		}
 	}
 }
@@ -516,7 +520,7 @@ func (p *blockPrefetcher) TriggerPrefetch(ctx context.Context,
 	if err == nil {
 		p.triggerPrefetch(ptr, block, kmd, priority, lifetime, prefetchStatus)
 	}
-	return nil
+	return err
 }
 
 func (p *blockPrefetcher) CancelPrefetch(blockID kbfsblock.ID) {

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -606,10 +606,10 @@ func (p *blockPrefetcher) ProcessBlockForPrefetch(ctx context.Context,
 
 func (p *blockPrefetcher) CancelPrefetch(blockID kbfsblock.ID) {
 	select {
-	// After `p.shutdownCh` is closed, we still need to receive prefetch
-	// cancelation until all prefetching is done.
-	case <-p.almostDoneCh:
 	case p.prefetchCancelCh.In() <- blockID:
+	case <-p.shutdownCh:
+		p.log.Warning("Skipping prefetch cancel for block %v since "+
+			"the prefetcher is shutdown", blockID)
 	}
 }
 

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -287,7 +287,13 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 						p.applyToParentsRecursive(p.cancelPrefetch, req.ptr.ID,
 							pre)
 					}
-					continue
+					if !pre.req.isDeepSync && req.isDeepSync {
+						// The prefetcher doesn't know about a deep sync but
+						// now one has been created.
+						pre.req.isDeepSync = true
+					} else {
+						continue
+					}
 				} else {
 					// This block was in the tree and thus was counted, but now
 					// it has been successfully fetched. We need to percolate

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -180,7 +180,7 @@ func (p *blockPrefetcher) run() {
 					continue
 				}
 			}
-			ctx, cancel := context.WithTimeout(context.Background(),
+			ctx, _ := context.WithTimeout(context.Background(),
 				prefetchTimeout)
 			// TODO: there is a potential optimization here that we can consider:
 			// Currently every time a prefetch is triggered, we iterate through

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -379,7 +379,7 @@ func (p *blockPrefetcher) recordPrefetchParent(childBlockID kbfsblock.ID,
 	if !pre.parents[parentBlockID] {
 		// The new parent needs its subtree block count increased.
 		pre.parents[parentBlockID] = true
-		return 1, needNewFetch
+		return pre.subtreeBlockCount, needNewFetch
 	}
 	return 0, needNewFetch
 }
@@ -556,7 +556,7 @@ func (p *blockPrefetcher) TriggerPrefetch(ctx context.Context,
 		TriggeredPrefetch)
 	if err == nil {
 		req := &prefetchRequest{ptr, block, kmd, priority, lifetime,
-			prefetchStatus, isDeepSync}
+			TriggeredPrefetch, isDeepSync}
 		p.triggerPrefetch(req)
 	}
 	return err

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -719,7 +719,6 @@ func TestPrefetcherBackwardPrefetch(t *testing.T) {
 	kmd := makeKMD()
 	prefetchSyncCh := make(chan struct{})
 	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
-	p := q.Prefetcher().(*blockPrefetcher)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Initialize a folder tree with structure: " +

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -506,6 +506,8 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 	}()
 	t.Log("Wait for prefetching to complete.")
 	// First we wait for all prefetches to be triggered.
+	// FIXME: UGH this is still racy, between when the block getter returns
+	// and when the blocks are retrieved.
 	wg.Wait()
 	// Then we wait for the pending prefetches to complete.
 	<-q.Prefetcher().Shutdown()

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -904,6 +904,8 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 
 	t.Log("Now set the folder to sync.")
 	config.SetTlfSyncState(kmd.TlfID(), true)
+	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Fetch dir root again.")
 	block = &DirBlock{}

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -907,6 +907,13 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
+	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
+		TriggeredPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		root.Children["a"].BlockPointer, a, NoPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		root.Children["b"].BlockPointer, b, NoPrefetch, TransientEntry)
+
 	t.Log("Fetch dir root again.")
 	block = &DirBlock{}
 	ch = q.Request(context.Background(), defaultOnDemandRequestPriority, kmd,

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -573,7 +573,6 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 }
 
 func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
-	t.Skip("Isn't quite working yet.")
 	t.Log("Test multi-level indirect file block prefetching.")
 	q, bg, config := initPrefetcherTest(t)
 	defer shutdownPrefetcherTest(q)
@@ -593,10 +592,12 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 		makeFakeIndirectFilePtr(t, 10),
 		makeFakeIndirectFilePtr(t, 20),
 	}}
+	indBlock1.IsInd = true
 	indBlock2 := &FileBlock{IPtrs: []IndirectFilePtr{
 		makeFakeIndirectFilePtr(t, 30),
 		makeFakeIndirectFilePtr(t, 40),
 	}}
+	indBlock2.IsInd = true
 	indBlock11 := makeFakeFileBlock(t, true)
 	indBlock12 := makeFakeFileBlock(t, true)
 	indBlock21 := makeFakeFileBlock(t, true)

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -505,7 +505,7 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 		notifyContinueCh(continueChDirBfileDblock2, wg)
 	}()
 	t.Log("Wait for prefetching to complete.")
-	// First we wait for all prefetches to been triggered.
+	// First we wait for all prefetches to be triggered.
 	wg.Wait()
 	// Then we wait for the pending prefetches to complete.
 	<-q.Prefetcher().Shutdown()

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -420,11 +420,11 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 	require.Equal(t, rootDir, block)
 
 	t.Log("Wait for prefetching to complete.")
+	<-q.Prefetcher().Shutdown()
 
 	t.Log("Ensure that the directory block is in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
 		FinishedPrefetch, TransientEntry)
-	<-q.Prefetcher().Shutdown()
 }
 
 func notifyContinueCh(ch chan<- error) {

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -506,8 +506,9 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 	}()
 	t.Log("Wait for prefetching to complete.")
 	// First we wait for all prefetches to be triggered.
-	// FIXME: UGH this is still racy, between when the block getter returns
-	// and when the blocks are retrieved.
+	// FIXME: still a potential race here, between when the block getter
+	// returns and when the blocks are retrieved. But it seems to be
+	// extraordinarily rare.
 	wg.Wait()
 	// Then we wait for the pending prefetches to complete.
 	<-q.Prefetcher().Shutdown()

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -119,7 +119,7 @@ func TestPrefetcherIndirectFileBlock(t *testing.T) {
 	var block Block = &FileBlock{}
 	deepPrefetchDoneCh := make(chan struct{}, 1)
 	deepPrefetchCancelCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
 		TransientEntry, deepPrefetchDoneCh, deepPrefetchCancelCh)
 	continueChRootBlock <- nil
@@ -169,7 +169,7 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 	block := NewDirBlock()
 	deepPrefetchDoneCh := make(chan struct{}, 1)
 	deepPrefetchCancelCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
 		TransientEntry, deepPrefetchDoneCh, deepPrefetchCancelCh)
 	continueChRootBlock <- nil
@@ -225,7 +225,7 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	var block Block = &DirBlock{}
 	deepPrefetchDoneCh := make(chan struct{}, 1)
 	deepPrefetchCancelCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
 		TransientEntry, deepPrefetchDoneCh, deepPrefetchCancelCh)
 	continueChRootDir <- nil
@@ -288,7 +288,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	var block Block = &DirBlock{}
 	deepPrefetchDoneCh := make(chan struct{}, 1)
 	deepPrefetchCancelCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry,
 		deepPrefetchDoneCh, deepPrefetchCancelCh)
 	continueChRootDir <- nil
@@ -317,7 +317,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	block = &DirBlock{}
 	deepPrefetchDoneCh = make(chan struct{}, 1)
 	deepPrefetchCancelCh = make(chan struct{}, 1)
-	ch = q.RequestWithPrefetch(context.Background(),
+	ch = q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd,
 		rootDir.Children["a"].BlockPointer, block, TransientEntry,
 		deepPrefetchDoneCh, deepPrefetchCancelCh)
@@ -351,7 +351,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	block = &DirBlock{}
 	deepPrefetchDoneCh = make(chan struct{}, 1)
 	deepPrefetchCancelCh = make(chan struct{}, 1)
-	ch = q.RequestWithPrefetch(context.Background(),
+	ch = q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd,
 		rootDir.Children["a"].BlockPointer, block, TransientEntry,
 		deepPrefetchDoneCh, deepPrefetchCancelCh)
@@ -386,7 +386,7 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 	kmd := makeKMD()
 	deepPrefetchDoneCh := make(chan struct{}, 1)
 	deepPrefetchCancelCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry,
 		deepPrefetchDoneCh, deepPrefetchCancelCh)
 	continueChRootDir <- nil
@@ -415,7 +415,7 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 	block = &DirBlock{}
 	deepPrefetchDoneCh = make(chan struct{}, 1)
 	deepPrefetchCancelCh = make(chan struct{}, 1)
-	ch = q.RequestWithPrefetch(context.Background(),
+	ch = q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry,
 		deepPrefetchDoneCh, deepPrefetchCancelCh)
 	err = <-ch
@@ -443,7 +443,7 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 
 	var block Block = &DirBlock{}
 	deepPrefetchDoneCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
 		TransientEntry, deepPrefetchDoneCh, nil)
 	continueChRootDir <- nil
@@ -514,7 +514,7 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 
 	var block Block = &DirBlock{}
 	deepPrefetchDoneCh := make(chan struct{}, 1)
-	ch := q.RequestWithPrefetch(context.Background(),
+	ch := q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry,
 		deepPrefetchDoneCh, nil)
 	continueChRootDir <- nil
@@ -563,7 +563,7 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 	block = &DirBlock{}
 	deepPrefetchDoneCh = make(chan struct{}, 1)
 	deepPrefetchCancelCh := make(chan struct{})
-	ch = q.RequestWithPrefetch(context.Background(),
+	ch = q.Request(context.Background(),
 		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry,
 		deepPrefetchDoneCh, deepPrefetchCancelCh)
 	// We don't need to release the block this time because it should be cached

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -288,7 +288,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	continueChDirA <- nil
 	t.Log("Wait for the prefetch to finish.")
 	<-q.Prefetcher().Shutdown()
-	q.TogglePrefetcher(context.Background(), true, nil)
+	q.TogglePrefetcher(true, nil)
 
 	t.Log("Ensure that the prefetched block is in the cache.")
 	block, err = cache.Get(rootDir.Children["a"].BlockPointer)
@@ -313,7 +313,7 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 	continueChFileB <- nil
 	t.Log("Wait for the prefetch to finish.")
 	<-q.Prefetcher().Shutdown()
-	q.TogglePrefetcher(context.Background(), true, nil)
+	q.TogglePrefetcher(true, nil)
 
 	testPrefetcherCheckGet(t, cache, dirA.Children["b"].BlockPointer, fileB,
 		NoPrefetch, TransientEntry)
@@ -374,7 +374,7 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 	t.Log("Wait for the prefetch to finish, then verify that the prefetched " +
 		"block is in the cache.")
 	<-q.Prefetcher().Shutdown()
-	q.TogglePrefetcher(context.Background(), true, nil)
+	q.TogglePrefetcher(true, nil)
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrA, fileA, NoPrefetch,
 		TransientEntry)
 
@@ -447,7 +447,7 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 	q, bg, config := initPrefetcherTest(t)
 	defer shutdownPrefetcherTest(q)
 	prefetchSyncCh := make(chan struct{})
-	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
 	kmd := makeKMD()
@@ -529,7 +529,7 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 	// Then we wait for the pending prefetches to complete.
 	<-q.Prefetcher().Shutdown()
-	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Ensure that the prefetched blocks are all in the cache.")
@@ -580,7 +580,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	q, bg, config := initPrefetcherTest(t)
 	defer shutdownPrefetcherTest(q)
 	prefetchSyncCh := make(chan struct{})
-	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 	ctx := context.Background()
 
@@ -640,7 +640,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 
 	t.Log("Wait for the prefetch to finish.")
 	<-q.Prefetcher().Shutdown()
-	q.TogglePrefetcher(ctx, true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
@@ -718,7 +718,7 @@ func TestPrefetcherBackwardPrefetch(t *testing.T) {
 	defer shutdownPrefetcherTest(q)
 	kmd := makeKMD()
 	prefetchSyncCh := make(chan struct{})
-	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Initialize a folder tree with structure: " +
@@ -856,7 +856,7 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	defer shutdownPrefetcherTest(q)
 	kmd := makeKMD()
 	prefetchSyncCh := make(chan struct{})
-	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Initialize a folder tree with structure: " +
@@ -904,7 +904,7 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 
 	t.Log("Now set the folder to sync.")
 	config.SetTlfSyncState(kmd.TlfID(), true)
-	q.TogglePrefetcher(context.Background(), true, prefetchSyncCh)
+	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Fetch dir root again.")

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -81,8 +81,8 @@ func testPrefetcherCheckGet(t *testing.T, bcache BlockCache, ptr BlockPointer,
 	block, prefetchStatus, lifetime, err := bcache.GetWithPrefetch(ptr)
 	require.NoError(t, err)
 	require.Equal(t, expectedBlock, block)
-	require.Equal(t, expectedPrefetchStatus, prefetchStatus)
-	require.Equal(t, expectedLifetime, lifetime)
+	require.Equal(t, expectedPrefetchStatus.String(), prefetchStatus.String())
+	require.Equal(t, expectedLifetime.String(), lifetime.String())
 }
 
 func waitForPrefetchOrBust(t *testing.T, ch <-chan struct{}) {

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -665,6 +665,8 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	prefetchSyncCh <- struct{}{}
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
+	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
+		indBlock1, TriggeredPrefetch, TransientEntry)
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		indBlock1.IPtrs[0].BlockPointer, indBlock11, NoPrefetch, TransientEntry)
 	testPrefetcherCheckGet(t, config.BlockCache(),
@@ -687,6 +689,8 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	<-q.Prefetcher().Shutdown()
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
+	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[1].BlockPointer,
+		indBlock2, TriggeredPrefetch, TransientEntry)
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		indBlock2.IPtrs[0].BlockPointer, indBlock21, NoPrefetch, TransientEntry)
 	testPrefetcherCheckGet(t, config.BlockCache(),

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -758,10 +758,8 @@ func (k *LibKBFS) DirtyPaths(u User, tlfName string, t tlf.Type) (
 func (k *LibKBFS) TogglePrefetch(u User, enable bool) error {
 	config := u.(*libkbfs.ConfigLocal)
 
-	ctx, cancel := k.newContext(u)
-	defer cancel()
-
-	return config.BlockOps().TogglePrefetcher(ctx, enable)
+	_ = config.BlockOps().TogglePrefetcher(enable)
+	return nil
 }
 
 // Shutdown implements the Engine interface.


### PR DESCRIPTION
This rewrites prefetching. Design is detailed in KBFS-2417, and comments in code extensively detail the cases being handled.

Short story: all prefetches are now triggered and tracked in the primary `blockPrefetcher.run()` goroutine. There are no more goroutines spawned by the block retrieval queue.

Suggested review order:
* prefetcher.go (you may need to view both the raw file and the diff)
* block_retrieval_queue.go
* prefetcher_test.go
* everything else