### PR TITLE
libgit: check for valid repo name earlier

### DIFF
--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -118,10 +118,6 @@ func UpdateRepoMD(ctx context.Context, config libkbfs.Config,
 func createNewRepoAndID(
 	ctx context.Context, config libkbfs.Config, tlfHandle *libkbfs.TlfHandle,
 	repoName string, fs *libfs.FS) (ID, error) {
-	if !checkValidRepoName(repoName, config) {
-		return NullID, errors.WithStack(InvalidRepoNameError{repoName})
-	}
-
 	// TODO: take a global repo lock here to make sure only one
 	// client generates the repo ID.
 	repoID, err := makeRandomID()
@@ -188,6 +184,10 @@ func lookupOrCreateDir(ctx context.Context, config libkbfs.Config,
 func getOrCreateRepoAndID(
 	ctx context.Context, config libkbfs.Config, tlfHandle *libkbfs.TlfHandle,
 	repoName string, uniqID string, createOnly bool) (*libfs.FS, ID, error) {
+	if !checkValidRepoName(repoName, config) {
+		return nil, NullID, errors.WithStack(InvalidRepoNameError{repoName})
+	}
+
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, tlfHandle, libkbfs.MasterBranch)
 	if err != nil {

--- a/libgit/repo_test.go
+++ b/libgit/repo_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,12 +73,14 @@ func TestGetOrCreateRepoAndID(t *testing.T) {
 	require.NotEqual(t, id1, id5)
 
 	// Invalid names.
+	_, _, err = GetOrCreateRepoAndID(ctx, config, h, "", "")
+	require.IsType(t, InvalidRepoNameError{}, errors.Cause(err))
 	_, _, err = GetOrCreateRepoAndID(ctx, config, h, ".repo2", "")
-	require.NotNil(t, err)
+	require.IsType(t, InvalidRepoNameError{}, errors.Cause(err))
 	_, _, err = GetOrCreateRepoAndID(ctx, config, h, "repo3.ツ", "")
-	require.NotNil(t, err)
+	require.IsType(t, InvalidRepoNameError{}, errors.Cause(err))
 	_, _, err = GetOrCreateRepoAndID(ctx, config, h, "repo(4)", "")
-	require.NotNil(t, err)
+	require.IsType(t, InvalidRepoNameError{}, errors.Cause(err))
 
 	fs.SyncAll()
 


### PR DESCRIPTION
This will catch an empty name before we try to create any blocks for it.

Issue: KBFS-2466