### PR TITLE
libkbfs: Handle GetForTLF returning an empty result in folder branch ops

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1634,12 +1634,15 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 				return err
 			}
 
-			func() {
-				fbo.headLock.Lock(lState)
-				defer fbo.headLock.Unlock(lState)
-				fbo.setLatestMergedRevisionLocked(ctx, lState,
-					mergedMD.Revision(), false)
-			}()
+			// GetForTLF may have returned an empty non-error result for us.
+			if mergedMD != (ImmutableRootMetadata{}) {
+				func() {
+					fbo.headLock.Lock(lState)
+					defer fbo.headLock.Unlock(lState)
+					fbo.setLatestMergedRevisionLocked(ctx, lState,
+						mergedMD.Revision(), false)
+				}()
+			}
 		}
 
 		fbo.headLock.Lock(lState)


### PR DESCRIPTION
Spotted in wild.