### PR TITLE
jenkinsfile: Disable linux tests for now.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,10 @@ helpers.rootLinuxNode(env, {
 
                         parallel (
                             test_linux: {
-                                if (startKbweb) {
+                                // JZ: Currently FUSE tests are failing on
+                                // linux.  Disable until we can investigate the
+                                // busted machine situation.
+                                if (false && startKbweb) {
                                     parallel (
                                         pull_mysql: {
                                             mysqlImage.pull()


### PR DESCRIPTION
CI messed up something, disable Linux tests until I can investigate. macOS tests are still running.