### PR TITLE
kbfsgit: optimizations for large `push --mirror/--all` initializations

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1082,7 +1082,7 @@ func (r *runner) handleFetchBatch(ctx context.Context, args [][]string) (
 // --all/--mirror).
 func (r *runner) canPushAll(
 	ctx context.Context, repo *gogit.Repository, args [][]string) (
-	canPushAll, repoEmpty bool, err error) {
+	canPushAll, kbfsRepoEmpty bool, err error) {
 	refs, err := repo.References()
 	if err != nil {
 		return false, false, err
@@ -1213,7 +1213,7 @@ func (r *runner) pushAll(ctx context.Context, fs *libfs.FS) error {
 
 func (r *runner) pushSome(
 	ctx context.Context, repo *gogit.Repository, fs *libfs.FS, args [][]string,
-	repoEmpty bool) (map[string]error, error) {
+	kbfsRepoEmpty bool) (map[string]error, error) {
 	r.log.CDebugf(ctx, "Pushing %d refs into %s", len(args), r.gitDir)
 
 	remote, err := repo.CreateRemote(&gogitcfg.RemoteConfig{
@@ -1274,7 +1274,7 @@ func (r *runner) pushSome(
 			}()
 		}
 
-		packRefs := repoEmpty && len(refspecs) > r.packedRefsThresh
+		packRefs := kbfsRepoEmpty && len(refspecs) > r.packedRefsThresh
 		if packRefs {
 			r.log.CDebugf(
 				ctx, "Requesting a pack-refs file for %d refs (threshold=%d)",
@@ -1336,7 +1336,7 @@ func (r *runner) handlePushBatch(ctx context.Context, args [][]string) (
 		return err
 	}
 
-	canPushAll, repoEmpty, err := r.canPushAll(ctx, repo, args)
+	canPushAll, kbfsRepoEmpty, err := r.canPushAll(ctx, repo, args)
 	if err != nil {
 		return err
 	}
@@ -1354,7 +1354,7 @@ func (r *runner) handlePushBatch(ctx context.Context, args [][]string) (
 			results[dst] = err
 		}
 	} else {
-		results, err = r.pushSome(ctx, repo, fs, args, repoEmpty)
+		results, err = r.pushSome(ctx, repo, fs, args, kbfsRepoEmpty)
 	}
 	if err != nil {
 		return err

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -856,9 +856,7 @@ func (r *runner) copyFileWithCount(
 		r.errput.Write([]byte(fmt.Sprintf("%s: ", copyingText)))
 	}
 
-	// Copy the entire objects subdirectory straight into the git
-	// directory.  This saves time and memory from having to calculate
-	// packfiles.
+	// Copy the file directly into the other file system.
 	startTime := r.config.Clock().Now()
 	err := r.copyFile(ctx, from, to, name, sw)
 	if err != nil {
@@ -932,9 +930,9 @@ func (r *runner) recursiveCopyWithCounts(
 		r.errput.Write([]byte(fmt.Sprintf("%s: ", copyingText)))
 	}
 
-	// Copy the entire objects subdirectory straight into the git
-	// directory.  This saves time and memory from having to calculate
-	// packfiles.
+	// Copy the entire subdirectory straight into the other file
+	// system.  This saves time and memory relative to going through
+	// go-git.
 	startTime := r.config.Clock().Now()
 	err := r.recursiveCopy(ctx, from, to, sw)
 	if err != nil {

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1180,7 +1180,7 @@ func (r *runner) pushAll(ctx context.Context, fs *libfs.FS) error {
 	}
 	err = r.recursiveCopyWithCounts(
 		ctx, localFSObjects, fsObjects,
-		"Counting objects", "countobj", "Pushing objects", "pushobj")
+		"Counting objects", "countobj", "Preparing objects", "pushobj")
 	if err != nil {
 		return err
 	}
@@ -1196,7 +1196,7 @@ func (r *runner) pushAll(ctx context.Context, fs *libfs.FS) error {
 	}
 	err = r.recursiveCopyWithCounts(
 		ctx, localFSRefs, fsRefs,
-		"Counting refs", "countref", "Pushing refs", "pushref")
+		"Counting refs", "countref", "Preparing refs", "pushref")
 	if err != nil {
 		return err
 	}
@@ -1209,7 +1209,7 @@ func (r *runner) pushAll(ctx context.Context, fs *libfs.FS) error {
 		return err
 	}
 	return r.copyFileWithCount(ctx, localFS, fs, "packed-refs",
-		"Counting packed refs", "countprefs", "Pushing packed refs",
+		"Counting packed refs", "countprefs", "Preparing packed refs",
 		"pushprefs")
 }
 

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -311,7 +311,7 @@ func (fs *FS) mkdirAll(filename string, perm os.FileMode) (err error) {
 		err = translateErr(err)
 	}()
 
-	if filename == "/" || filename == "" {
+	if filename == "/" || filename == "" || filename == "." {
 		return nil
 	}
 
@@ -324,7 +324,13 @@ func (fs *FS) mkdirAll(filename string, perm os.FileMode) (err error) {
 	// Make all necessary dirs.
 	for _, p := range parts {
 		n, _, err = fs.config.KBFSOps().CreateDir(fs.ctx, n, p)
-		if err != nil {
+		switch errors.Cause(err).(type) {
+		case libkbfs.NameExistsError:
+			// The child directory already exists.
+			continue
+		case nil:
+			continue
+		default:
 			return err
 		}
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/options.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/options.go
@@ -149,6 +149,12 @@ type FetchOptions struct {
 	// Force allows the fetch to update a local branch even when the remote
 	// branch does not descend from it.
 	Force bool
+	// PackRefs, if true, causes the fetch to write out a packed-refs
+	// file, rather that setting individual references.  If this is
+	// used, the caller MUST be assured that none of the references
+	// exist yet.  If packed-refs already exists, the fetch will
+	// return an error.
+	PackRefs bool
 }
 
 // Validate validates the fields and sets the default values.

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
@@ -20,6 +20,7 @@ type ReferenceStorer interface {
 	Reference(plumbing.ReferenceName) (*plumbing.Reference, error)
 	IterReferences() (ReferenceIter, error)
 	RemoveReference(plumbing.ReferenceName) error
+	SetPackedRefs(refs []plumbing.Reference) error
 }
 
 // ReferenceIter is a generic closable interface for iterating over references.

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
@@ -261,6 +261,12 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 	if err != nil {
 		return err
 	}
+	if ref.Hash().IsZero() {
+		ref, err = d.packedRef(old.Name())
+		if err != nil {
+			return err
+		}
+	}
 	if ref.Hash() != old.Hash() {
 		return fmt.Errorf("reference has changed concurrently")
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
@@ -575,6 +575,22 @@ func (d *DotGit) readReferenceFile(path, name string) (ref *plumbing.Reference, 
 	return d.readReferenceFrom(f, name)
 }
 
+func (d *DotGit) SetPackedRefs(refs []plumbing.Reference) (err error) {
+	f, err := d.fs.Create(packedRefsPath)
+	if err != nil {
+		return err
+	}
+	defer ioutil.CheckClose(f, &err)
+
+	for _, ref := range refs {
+		_, err := f.Write([]byte(ref.String() + "\n"))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Module return a billy.Filesystem poiting to the module folder
 func (d *DotGit) Module(name string) (billy.Filesystem, error) {
 	return d.fs.Chroot(d.fs.Join(modulePath, name))

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/reference.go
@@ -34,3 +34,7 @@ func (r *ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 func (r *ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	return r.dir.RemoveRef(n)
 }
+
+func (r *ReferenceStorage) SetPackedRefs(refs []plumbing.Reference) error {
+	return r.dir.SetPackedRefs(refs)
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/memory/storage.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/memory/storage.go
@@ -243,6 +243,17 @@ func (r ReferenceStorage) IterReferences() (storer.ReferenceIter, error) {
 	return storer.NewReferenceSliceIter(refs), nil
 }
 
+func (r ReferenceStorage) SetPackedRefs(refs []plumbing.Reference) error {
+	// Memory storage doesn't have packed refs.
+	for _, ref := range refs {
+		err := r.SetReference(&ref)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	delete(r, n)
 	return nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -759,281 +759,281 @@
 			"checksumSHA1": "E12sWMDcZv0ehbAnPxBtfX/34Xg=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "7dpHa2hTeGy/UCjKdBl6CxlaTFY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "PRw/wR2I1+J47IKuLwjkaeHC8dc=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "IBt5L09OBjfvq0h6ThX8L9Vl3g8=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
-			"checksumSHA1": "p67Xh7WZTKbsKuSAulYWbc/I7c0=",
+			"checksumSHA1": "KuPkrBI10UYK0GzUJe2IguRZ+os=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "NwjgsVALAv6In8dzVsIFYVZdWXM=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "a9dbeadd09ad2eb9c09a4792ef58bfe22998bb95",
-			"revisionTime": "2017-09-23T04:14:17Z"
+			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
+			"revisionTime": "2017-09-28T22:05:00Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -756,284 +756,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "E12sWMDcZv0ehbAnPxBtfX/34Xg=",
+			"checksumSHA1": "WvL3FqrWDmA4F65zGPDHCFHbw2k=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "7dpHa2hTeGy/UCjKdBl6CxlaTFY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
-			"checksumSHA1": "PRw/wR2I1+J47IKuLwjkaeHC8dc=",
+			"checksumSHA1": "s2fDbBv2kbfbaGz7GMlLgCfarPQ=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
-			"checksumSHA1": "IBt5L09OBjfvq0h6ThX8L9Vl3g8=",
+			"checksumSHA1": "pVBa3dcSCdSmiRg1aXv7mmYSDW0=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
-			"checksumSHA1": "KuPkrBI10UYK0GzUJe2IguRZ+os=",
+			"checksumSHA1": "Hh8ZHtbCv1IyM3W5pi/VG6wYiJo=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
-			"checksumSHA1": "NwjgsVALAv6In8dzVsIFYVZdWXM=",
+			"checksumSHA1": "b5GHaJ79kh/bNz4QXtJT6WoXNyw=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "feb0fb387419b3f1bc74d5178a03a2a2b7eccb78",
-			"revisionTime": "2017-09-28T22:05:00Z"
+			"revision": "382ba717aafed835ece4701d2be595e95d782cdc",
+			"revisionTime": "2017-09-28T23:45:12Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
This PR adds optimizations for the case where the user has a local repo with a lot of references, and then runs a `git push --mirror` or `git push --all` to initialize a new KBFS repo from this local repo.

`--mirror` syncs every single local ref to the remote, and so we can optimize by just copying all the objects/refs/packed-refs files themselves, rather than going through expensive go-git computation.  If there is a packed-refs file, this allows us to avoid having a ton of individual refs files, which is slow and might break KBFS's dir size limitations.

`--all` syncs every branch and tags (i.e., `refs/heads` and `refs/tags`). If these are the only types of refs in the local repo, then this is equivalent to `--mirror`.  If not, we can't use the above optimization because there may be some objects that shouldn't be transferred.  However, we still want the benefits of a packed-refs file as above.  Instead, when initializing a repo with more than 10 refs, we ask go-git to create a packed-refs file, rather than using individual refs files.

Also fixes a bug where a "." directory was being created in every git repo.  Oops!

Issue: KBFS-2464