### PR TITLE
git-remote-keybase: fix windows dup handle for git bash shell

### DIFF
--- a/kbfsgit/git-remote-keybase/dup_stderr_windows.go
+++ b/kbfsgit/git-remote-keybase/dup_stderr_windows.go
@@ -17,7 +17,8 @@ func dupStderr() (*os.File, error) {
 
 	var dupStderrFd windows.Handle
 	err = windows.DuplicateHandle(
-		proc, windows.Handle(os.Stderr.Fd()), proc, &dupStderrFd, 0, false, 0)
+		proc, windows.Handle(os.Stderr.Fd()), proc, &dupStderrFd, 0,
+		true, syscall.DUPLICATE_SAME_ACCESS)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Bash shells on Windows seem to behave slightly different from the
regular windows shell, in terms of duplicated file handles.  Giving
the new handle the same access as the old handle seems to work well in
both environments.

Issue: KBFS-2481