### PR TITLE
folder_block_manager: turn off QR in single op mode

### DIFF
--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -148,7 +148,7 @@ func newFolderBlockManager(config Config, fb FolderBranch,
 
 	go fbm.archiveBlocksInBackground()
 	go fbm.deleteBlocksInBackground()
-	if fb.Branch == MasterBranch {
+	if fb.Branch == MasterBranch && config.Mode() != InitSingleOp {
 		go fbm.reclaimQuotaInBackground()
 	}
 	return fbm


### PR DESCRIPTION
Otherwise an ill-timed QR MD update can break the journal, which
assumes there will only be no more MD updates once the single op is
marked as finished.