### PR TITLE
block_retrieval_queue: clear references to requested blocks

### DIFF
--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -587,6 +587,9 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 		doneChans = append(doneChans, r.deepPrefetchDoneCh)
 		cancelChans = append(cancelChans, r.deepPrefetchCancelCh)
 	}
+	// Clearing references to the requested blocks seems to plug a
+	// leak, but not sure why yet.
+	retrieval.requests = nil
 
 	go func() {
 		// Fan-out the prefetch result to the channel of each individual


### PR DESCRIPTION
@jzila: any ideas about this?  I'm not happy that I couldn't figure out the exact reason for the leak, but I can reproduce it consistently without this fix, and can't repro it with the fix.

---------
I noticed a pretty massive leak in KBFS when retrieving blocks from the server.  The heap looked like this:

```
(pprof) top5
2525.69MB of 2578.60MB total (97.95%)
Dropped 959 nodes (cum <= 12.89MB)
Showing top 5 nodes out of 47 (cum >= 20.54MB)
      flat  flat%   sum%        cum   cum%
      1682.43MB 65.25% 65.25%  1682.43MB 65.25%  github.com/keybase/kbfs/libkbfs.(*FileBlock).DeepCopy
      815.25MB 31.62% 96.86%   815.25MB 31.62%  github.com/keybase/kbfs/vendor/github.com/keybase/go-codec/codec.decByteSlice
      28.01MB  1.09% 97.95%    28.01MB  1.09%  github.com/keybase/kbfs/vendor/github.com/syndtr/goleveldb/leveldb/memdb.New
```

The DeepCopy was happening at the `block.Set()` call in `FinalizeRequest`.  I looked and looked, but I couldn't figure out where the `blockRetrieval` object is being leaked.  However, setting the requests to `nil` seems to fix the leak.  I suspect it has something to do with the `go func()` just below it, although there were no leaked goroutines in the running process as far as I could tell.  Sigh.

Issue: KBFS-2482