### PR TITLE
vendor: update go-git, so we don't over-transfer on a push

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -756,284 +756,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "WvL3FqrWDmA4F65zGPDHCFHbw2k=",
+			"checksumSHA1": "ffhMZlMSyi2hSRHkHGhLcdavVV0=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "7dpHa2hTeGy/UCjKdBl6CxlaTFY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "s2fDbBv2kbfbaGz7GMlLgCfarPQ=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "pVBa3dcSCdSmiRg1aXv7mmYSDW0=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "swgKesrSv7rTjmZv2y/t9tNfCps=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "b5GHaJ79kh/bNz4QXtJT6WoXNyw=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "e43eca4c7291c67096fa909d429e38266bb37e56",
-			"revisionTime": "2017-09-29T22:29:44Z"
+			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
+			"revisionTime": "2017-10-03T02:19:18Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
If the user is doing a push to a branch in the KBFS repo, and the KBFS repo has extra commits not known to the local repo (i.e.., the local user has forked), then go-git was causing way too much data to be transferred because it doesn't fully negotiate the common commits between the two repos.  It simply sends the commits representing all references known by the KBFS repo; the local side wouldn't recognize the new commit from the KBFS branch, and would therefore conclude the user needs to push all commits in its history.  (Note: if the KBFS repo has multiple branches, and at least one of which has a reference with a common commit, then the entire history isn't sent, only the commits up to that common commit, which is still wasteful.)

The right way to improve this is to implement the multi-round git ack protocol (https://github.com/git/git/blob/master/Documentation/technical/pack-protocol.txt), which keeps iterating until the two sides agree on a set of common commits.  Unfortunately, go-git doesn't implement this, and it looks like it would be a ton of work to implement it right.

Instead, do something quick-and-dirty in go-git.  Instead of sending just the HEAD commit for each KBFS references, send the most recent 100 commits.  Hopefully, the local side will know at least one of these, and can prune the set of pushed objects appropriately.  As an optimization, we don't need to send the full 100 if we already know for sure that the local side has the reference.  In practice, this shouldn't add much latency or extra communication overhead, especially in the common case when most references match between the two repos.

In the case where the local branch is ahead of the KBFS branch (i.e., normally the case for a push), this also shouldn't cause much extra data to be sent, because almost certainly the local repo would have a "remotes/origin" reference for the branch it was based on, so the commit walker would be able to stop early once it runs into that common commit.

I filed KBFS-2487 to track the more correct approach of the multi-ack protocol.  Hopefully we can get to that eventually.

Issue: KBFS-2486