### PR TITLE
dokan: Use stdlib context package

### DIFF
--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -12,6 +12,7 @@ package dokan
 import "C"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -23,7 +24,6 @@ import (
 	"unsafe"
 
 	"github.com/keybase/kbfs/dokan/winacl"
-	"golang.org/x/net/context"
 	"golang.org/x/sys/windows"
 )
 

--- a/dokan/error_file.go
+++ b/dokan/error_file.go
@@ -5,11 +5,11 @@
 package dokan
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/keybase/kbfs/dokan/winacl"
-	"golang.org/x/net/context"
 )
 
 type errorFile struct {

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -5,11 +5,11 @@
 package dokan
 
 import (
+	"context"
 	"strconv"
 	"time"
 
 	"github.com/keybase/kbfs/dokan/winacl"
-	"golang.org/x/net/context"
 )
 
 // Config is the configuration used for a mount.

--- a/dokan/testfs_test.go
+++ b/dokan/testfs_test.go
@@ -8,6 +8,7 @@ package dokan
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -19,7 +20,6 @@ import (
 
 	"github.com/keybase/kbfs/dokan/winacl"
 	"github.com/keybase/kbfs/ioutil"
-	"golang.org/x/net/context"
 	"golang.org/x/sys/windows"
 )
 


### PR DESCRIPTION
This is the last piece before the dokan bindings should go to a separate repo.