### PR TITLE
kbfsgit: allow readers to clone/fetch from repos

### DIFF
--- a/kbfsgit/config_without_remotes_storer.go
+++ b/kbfsgit/config_without_remotes_storer.go
@@ -34,8 +34,13 @@ func newConfigWithoutRemotesStorer(fs *libfs.FS) (
 		return nil, err
 	}
 	// To figure out if this config has been written already, check if
-	// the "IsBare" bit is already flipped.
-	return &configWithoutRemotesStorer{fsStorer, cfg, cfg.Core.IsBare}, nil
+	// it differs from the zero Core value (probably because the
+	// IsBare bit is flipped).
+	return &configWithoutRemotesStorer{
+		fsStorer,
+		cfg,
+		cfg.Core != gogitcfg.Config{}.Core,
+	}, nil
 }
 
 func (cwrs *configWithoutRemotesStorer) Init() error {

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -258,8 +258,9 @@ func (r *runner) initRepoIfNeeded(ctx context.Context, forCmd string) (
 	}
 
 	// Only allow lazy creates for public and multi-user TLFs.
-	if r.h.Type() == tlf.Public ||
-		len(r.h.ResolvedWriters())+len(r.h.UnresolvedWriters()) > 1 {
+	numUsers := len(r.h.ResolvedWriters()) + len(r.h.UnresolvedWriters()) +
+		len(r.h.ResolvedReaders()) + len(r.h.UnresolvedReaders())
+	if r.h.Type() == tlf.Public || numUsers > 1 {
 		fs, _, err = libgit.GetOrCreateRepoAndID(
 			ctx, r.config, r.h, r.repo, r.uniqID)
 	} else {

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -281,7 +281,7 @@ func configAsUserWithMode(config *ConfigLocal,
 // `config`.
 func ConfigAsUser(config *ConfigLocal,
 	loggedInUser libkb.NormalizedUsername) *ConfigLocal {
-	return configAsUserWithMode(config, loggedInUser, InitDefault)
+	return configAsUserWithMode(config, loggedInUser, config.Mode())
 }
 
 // FakeBranchID creates a fake branch ID from the given


### PR DESCRIPTION
This required a few small changes:

* Ignore go-git's attempt to flush the Config file if it hasn't changed from what's already on disk.
* libfs.FS.MkdirAll ignores write-access errors if the dir being created already exists.

Issue: KBFS-2491