### PR TITLE
kbfsgit: fix windows compile for git-remote-keybase

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,9 @@ build_script:
   - go test -c
   - cd ..\kbfsdokan
   - go install
-  - cd ..\test
+  - cd ..\kbfsgit\git-remote-keybase
+  - go install
+  - cd ..\..\test
   - go test -i
   - cd ..
 # Eventually there will be more tests, but let's just start with these for now

--- a/kbfsgit/git-remote-keybase/dup_stderr_windows.go
+++ b/kbfsgit/git-remote-keybase/dup_stderr_windows.go
@@ -18,7 +18,7 @@ func dupStderr() (*os.File, error) {
 	var dupStderrFd windows.Handle
 	err = windows.DuplicateHandle(
 		proc, windows.Handle(os.Stderr.Fd()), proc, &dupStderrFd, 0,
-		true, syscall.DUPLICATE_SAME_ACCESS)
+		true, windows.DUPLICATE_SAME_ACCESS)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
And make sure we compile it in appveyor.