### PR TITLE
populate KEYBASE_TEST_ROOT_CERT_PEM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,8 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                KBFS_DOCKER_CERT=$(echo \"$KBFS_DOCKER_CERT_B64\" | base64 -d);
-                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
+                                KBFS_DOCKER_CERT=$(echo \"$$KBFS_DOCKER_CERT_B64\" | base64 -d);
+                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }
                         sh "docker save keybaseprivate/kbfsfuse | gzip > kbfsfuse.tar.gz"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                KBFS_DOCKER_CERT=$(echo \'$KBFS_DOCKER_CERT_B64\' | base64 -d);
+                                KBFS_DOCKER_CERT=$(echo '$KBFS_DOCKER_CERT_B64' | base64 -d);
                                 docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                KEYBASE_DOCKER_CERT="$(echo $KEYBASE_DOCKER_CERT_B64 | base64 -d)";
+                                KBFS_DOCKER_CERT="$(echo $KBFS_DOCKER_CERT_B64 | base64 -d)";
                                 docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,11 +158,7 @@ helpers.rootLinuxNode(env, {
                         sh "cp ${env.GOPATH}/bin/git-remote-keybase ./kbfsgit/git-remote-keybase/git-remote-keybase"
                         withCredentials([[$class: 'StringBinding', credentialsId: 'kbfs-docker-cert-b64-new', variable: 'KBFS_DOCKER_CERT_B64']]) {
                             println "Building Docker"
-                            sh '''
-                                set +x
-                                KBFS_DOCKER_CERT=$(echo '$KBFS_DOCKER_CERT_B64' | base64 -d);
-                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
-                            '''
+                            sh "bash docker.build.jenkins"
                         }
                         sh "docker save keybaseprivate/kbfsfuse | gzip > kbfsfuse.tar.gz"
                         archive("kbfsfuse.tar.gz")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,13 @@ helpers.rootLinuxNode(env, {
                         sh "cp ${env.GOPATH}/bin/git-remote-keybase ./kbfsgit/git-remote-keybase/git-remote-keybase"
                         withCredentials([[$class: 'StringBinding', credentialsId: 'kbfs-docker-cert-b64-new', variable: 'KBFS_DOCKER_CERT_B64']]) {
                             println "Building Docker"
-                            sh "bash docker.build.jenkins"
+                            sh '''
+                                set +x
+                                KBFS_DOCKER_CERT="$(echo $KBFS_DOCKER_CERT_B64 | sed 's/ //g' | base64 -d)"
+                                docker build -t keybaseprivate/kbfsfuse \
+                                    --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \
+                                    --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64="$KBFS_DOCKER_CERT_B64" .
+                            '''
                         }
                         sh "docker save keybaseprivate/kbfsfuse | gzip > kbfsfuse.tar.gz"
                         archive("kbfsfuse.tar.gz")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,8 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$(echo $KBFS_DOCKER_CERT_B64 | base64 -d)\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
+                                KEYBASE_DOCKER_CERT="$(echo $KEYBASE_DOCKER_CERT_B64 | base64 -d)";
+                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }
                         sh "docker save keybaseprivate/kbfsfuse | gzip > kbfsfuse.tar.gz"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
+                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$(echo $KBFS_DOCKER_CERT_B64 | base64 -d)\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }
                         sh "docker save keybaseprivate/kbfsfuse | gzip > kbfsfuse.tar.gz"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,7 +160,7 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d);
+                                KBFS_DOCKER_CERT=$(echo \"$KBFS_DOCKER_CERT_B64\" | base64 -d);
                                 docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,8 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                KBFS_DOCKER_CERT=$(echo \"$$KBFS_DOCKER_CERT_B64\" | base64 -d);
-                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$$KBFS_DOCKER_CERT_B64\" .
+                                KBFS_DOCKER_CERT=$(echo \'$KBFS_DOCKER_CERT_B64\' | base64 -d);
+                                docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }
                         sh "docker save keybaseprivate/kbfsfuse | gzip > kbfsfuse.tar.gz"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,7 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
-                                echo $KBFS_DOCKER_CERT_B64 | cut -c1-10
-                                KBFS_DOCKER_CERT="$(echo $KBFS_DOCKER_CERT_B64 | base64 -d)";
+                                KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d);
                                 docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,6 +160,7 @@ helpers.rootLinuxNode(env, {
                             println "Building Docker"
                             sh '''
                                 set +x
+                                echo $KBFS_DOCKER_CERT_B64 | cut -c1-10
                                 KBFS_DOCKER_CERT="$(echo $KBFS_DOCKER_CERT_B64 | base64 -d)";
                                 docker build -t keybaseprivate/kbfsfuse --build-arg KEYBASE_TEST_ROOT_CERT_PEM=\"$KBFS_DOCKER_CERT\" --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64=\"$KBFS_DOCKER_CERT_B64\" .
                             '''

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,0 +1,5 @@
+set +x
+KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d)
+docker build -t keybaseprivate/kbfsfuse \
+    --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \
+    --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64="$KBFS_DOCKER_CERT_B64" .

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,5 +1,0 @@
-set +x
-KBFS_DOCKER_CERT="$(echo $KBFS_DOCKER_CERT_B64 | sed 's/ //g' | base64 -d)"
-docker build -t keybaseprivate/kbfsfuse \
-    --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \
-    --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64="$KBFS_DOCKER_CERT_B64" .

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,5 +1,5 @@
 set +x
-KBFS_DOCKER_CERT="$(echo \"$KBFS_DOCKER_CERT_B64\" | sed 's/ //g' | base64 -d)"
+KBFS_DOCKER_CERT="$(echo $KBFS_DOCKER_CERT_B64 | sed 's/ //g' | base64 -d)"
 docker build -t keybaseprivate/kbfsfuse \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64="$KBFS_DOCKER_CERT_B64" .

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,5 +1,5 @@
 set +x
-echo "$KBFS_DOCKER_CERT_B64" | cut -c1-20
+echo "$KBFS_DOCKER_CERT_B64" 
 KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d)
 docker build -t keybaseprivate/kbfsfuse \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,4 +1,5 @@
 set +x
+echo "$KBFS_DOCKER_CERT_B64" | cut -c1-20
 KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d)
 docker build -t keybaseprivate/kbfsfuse \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,5 +1,5 @@
 set +x
-echo "$KBFS_DOCKER_CERT_B64" 
+echo "$KBFS_DOCKER_CERT_B64" | base64
 KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d)
 docker build -t keybaseprivate/kbfsfuse \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,5 +1,5 @@
 set +x
-KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | sed 's/ //g' | base64 -d)
+KBFS_DOCKER_CERT="$(echo \"$KBFS_DOCKER_CERT_B64\" | sed 's/ //g' | base64 -d)"
 docker build -t keybaseprivate/kbfsfuse \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64="$KBFS_DOCKER_CERT_B64" .

--- a/docker.build.jenkins
+++ b/docker.build.jenkins
@@ -1,6 +1,5 @@
 set +x
-echo "$KBFS_DOCKER_CERT_B64" | base64
-KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | base64 -d)
+KBFS_DOCKER_CERT=$(echo "$KBFS_DOCKER_CERT_B64" | sed 's/ //g' | base64 -d)
 docker build -t keybaseprivate/kbfsfuse \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM="$KBFS_DOCKER_CERT" \
     --build-arg KEYBASE_TEST_ROOT_CERT_PEM_B64="$KBFS_DOCKER_CERT_B64" .


### PR DESCRIPTION
because `git-remote-keybase` can't rely on `kbfsfuse.sh` to populate it.

Related: https://github.com/keybase/kbfs-server/pull/404