### PR TITLE
kbfsgit: avoid opening a Repository for local git dirs

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1166,15 +1166,7 @@ func (r *runner) canPushAll(
 	if err != nil {
 		return false, false, err
 	}
-	// The worktree is not used for listing refs, but is required to
-	// be non-nil to open a non-bare repo.
-	fakeWorktree := osfs.New("/dev/null")
-	localRepo, err := gogit.Open(localStorer, fakeWorktree)
-	if err != nil {
-		return false, false, err
-	}
-
-	localRefs, err := localRepo.References()
+	localRefs, err := localStorer.IterReferences()
 	if err != nil {
 		return false, false, err
 	}


### PR DESCRIPTION
Opening a Repo means trying to unmarshal the local config file, and the scanner used by go-git doesn't seem to be able to scan all valid config files.  Luckily we don't need a Repo, we just needed the Storer, so everything works out for the best.

Issue: KBFS-2497
Issue: keybase/client#8812