### PR TITLE
folder_branch_ops: don't back up ptr on unlink for cached dirOp

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4352,7 +4352,7 @@ func (fbo *folderBranchOps) getUnlinkPathBeforeUpdatingPointers(
 	// inspect it to look for the *real* original pointer for this
 	// node.  Though only do that if the op we're processing is
 	// actually a part of this MD object; if it's the latest cached
-	// dirOp, then the resOp we're looking at belong to a previous
+	// dirOp, then the resOp we're looking at belongs to a previous
 	// revision.
 	if resOp, ok := md.data.Changes.Ops[0].(*resolutionOp); ok &&
 		(len(fbo.dirOps) == 0 || op != fbo.dirOps[len(fbo.dirOps)-1].dirOp) {

--- a/test/complex_test.go
+++ b/test/complex_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+// These tests all do multiple operations while a user is unstaged.
+
+package test
+
+import (
+	"testing"
+)
+
+// Regression test for KBFS-2501
+func TestRenameAfterRenameThatWouldHaveBeenAnOverwrite(t *testing.T) {
+	test(t,
+		users("alice"),
+		as(alice,
+			mkfile("a/foo", "foo"),
+			mkfile("a/b/foo2", "foo2"),
+			mkfile("bar", "bar"),
+		),
+		as(alice,
+			rename("a", "b"),
+		),
+		as(alice,
+			rename("b/b", "a"),
+		),
+		as(alice,
+			write("b/foo", "foo after rename"),
+			write("bar", "bar after rename"),
+		),
+	)
+}


### PR DESCRIPTION
When checking whether or not a node needs to be unlinked on an rmOp or renameOp, `getUnlinkPathBeforeUpdatingPointers()` needs to look at the original dir block, before the update happened, and see whether there's a matching entry or not.  To do this, we need to find the correct block pointer corresponding to the original block.  If this is part of a set of operations that include a `resolutionOp`, we may need to "back up" the block pointer listed in the op itself to find the original block pointer, since the resolutionOp may have changed it.

However, this is only relevant if the op being processed is actually part of the MD; if it's actually a cached dir op instead, and not listed in the MD itself, then the resolutionOp is irrelevant and should be ignored since the pointers in the op itself still represent the original block.

Without this fix, the following is possible (and was experienced by a user):
* The user renames a directory: /a -> /b
* This operation gets synced and an MD revision R is created.  This revision includes a resolutionOp as the first operation, because that's how `SyncAll` works.
* The user renames another directory: b/a -> /a.
* When calling `notifyOneOp`, revision R is passed in (which doesn't include this new renameOp)
* `getUnlinkPathBeforeUpdatingPointers` finds the block pointer for the root directory as of revision R-1, looks up the name "/a", and sees that it corresponds to the directory that is now called "/b" (but as of revision R-1, it was still "/a").
* This means that it thinks "/b" is being overwritten, and thus needs to be unlinked.
* It marks the `Node` for "/b" as unlinked, which freezes its `path` in place in the node cache.
* Revision R+1 is created and synced.
* Next, the user writes to the file "/b/foo".
* In the same batch, the user writes to the file "/bar".
* Then `SyncAll` is called.
* Because "/b" is marked unlinked, it uses the cached path to generate a "resolved path" for "/b/foo", which includes the *wrong* root block pointer from revision R-1. The "resolved path" for "/bar" contains the correct root block pointer.
* The root dir block used to construct the next revision of the TLF might be the one represented by the old root block.  This can resurrect old block pointers in directory entries that have changed since revision R-1.
* When later clients look up these old block pointers, and they have been GC'd, they receive "block does not exist" errors from the bserver.

Issue: KBFS-2501
Issue: keybase/client#8914