### PR TITLE
use rpc.Connection.ForceReconnect

### DIFF
--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -101,7 +101,7 @@ func (b *blockServerRemoteClientHandler) initNewConnection() {
 	b.client = keybase1.BlockClient{Cli: b.conn.GetClient()}
 }
 
-func (md *MDServerRemote) reconnect() error {
+func (md *blockServerRemoteClientHandler) reconnect() error {
 	md.connMu.Lock()
 	defer md.connMu.Unlock()
 

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -101,18 +101,18 @@ func (b *blockServerRemoteClientHandler) initNewConnection() {
 	b.client = keybase1.BlockClient{Cli: b.conn.GetClient()}
 }
 
-func (md *blockServerRemoteClientHandler) reconnect() error {
-	md.connMu.Lock()
-	defer md.connMu.Unlock()
+func (b *blockServerRemoteClientHandler) reconnect() error {
+	b.connMu.Lock()
+	defer b.connMu.Unlock()
 
-	if md.conn != nil {
+	if b.conn != nil {
 		ctx, cancel := context.WithTimeout(
 			context.Background(), reconnectTimeout)
 		defer cancel()
-		return md.conn.ForceReconnect(ctx)
+		return b.conn.ForceReconnect(ctx)
 	}
 
-	md.initNewConnection()
+	b.initNewConnection()
 	return nil
 
 }
@@ -284,8 +284,8 @@ func (b *blockServerRemoteClientHandler) pingOnce(ctx context.Context) {
 	if err == context.DeadlineExceeded {
 		b.log.CDebugf(
 			ctx, "%s: Ping timeout -- reinitializing connection", b.name)
-		if err = md.reconnect(); err != nil {
-			md.log.CDebugf(ctx, "reconnect error: %v", err)
+		if err = b.reconnect(); err != nil {
+			b.log.CDebugf(ctx, "reconnect error: %v", err)
 		}
 	} else if err != nil {
 		b.log.CDebugf(ctx, "%s: ping error %s", b.name, err)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -317,10 +317,10 @@
 			"revisionTime": "2016-12-08T01:54:25Z"
 		},
 		{
-			"checksumSHA1": "pIiu2/Rg8Rz6lp3PaqBqwL3nviE=",
+			"checksumSHA1": "FHQPLT2yDBpf4da7WbDtAXovZtI=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "3b7dbb848bdcf9c6c463b034d4195aab3c80e8d5",
-			"revisionTime": "2017-09-07T21:14:35Z"
+			"revision": "194315a754724e040e5e8b16ba61ac3486de1580",
+			"revisionTime": "2017-10-09T18:17:40Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -317,10 +317,10 @@
 			"revisionTime": "2016-12-08T01:54:25Z"
 		},
 		{
-			"checksumSHA1": "FHQPLT2yDBpf4da7WbDtAXovZtI=",
+			"checksumSHA1": "no9uKY1SikUPABHWdHmgVrooOEw=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "194315a754724e040e5e8b16ba61ac3486de1580",
-			"revisionTime": "2017-10-09T18:17:40Z"
+			"revision": "69af3d59399422d6ebe1dea19ba6dc3df5d906cb",
+			"revisionTime": "2017-10-09T23:01:07Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",


### PR DESCRIPTION
so that we don't have multiple `rpc.Connection`s for the same service.

Depends on https://github.com/keybase/go-framed-msgpack-rpc/pull/125