### PR TITLE
[KBFS-2513] Allow a bigger leveldb file size for the block db.

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"golang.org/x/net/context"
@@ -32,6 +33,7 @@ import (
 const (
 	// 10 GB maximum storage by default
 	defaultDiskBlockCacheMaxBytes uint64 = 10 * (1 << 30)
+	defaultBlockCacheTableSize    int    = 50 * opt.MiB
 	evictionConsiderationFactor   int    = 3
 	defaultNumBlocksToEvict       int    = 10
 	maxEvictionsPerPut            int    = 4
@@ -139,7 +141,9 @@ func newDiskBlockCacheStandardFromStorage(
 			closer()
 		}
 	}()
-	blockDb, err := openLevelDB(blockStorage)
+	blockDbOptions := *leveldbOptions
+	blockDbOptions.CompactionTableSize = defaultBlockCacheTableSize
+	blockDb, err := openLevelDBWithOptions(blockStorage, &blockDbOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/leveldb.go
+++ b/libkbfs/leveldb.go
@@ -35,20 +35,27 @@ func (ldb *levelDb) Close() (err error) {
 }
 
 // openLevelDB opens or recovers a leveldb.DB with a passed-in storage.Storage
-// as its underlying storage layer.
-func openLevelDB(stor storage.Storage) (*levelDb, error) {
-	db, err := leveldb.Open(stor, leveldbOptions)
+// as its underlying storage layer, and with the options specified.
+func openLevelDBWithOptions(stor storage.Storage, options *opt.Options) (
+	*levelDb, error) {
+	db, err := leveldb.Open(stor, options)
 	if ldberrors.IsCorrupted(err) {
 		// There's a possibility that if the leveldb wasn't closed properly
 		// last time while it was being written, then the manifest is corrupt.
 		// This means leveldb must rebuild its manifest, which takes longer
 		// than a simple `Open`.
 		// TODO: log here
-		db, err = leveldb.Recover(stor, leveldbOptions)
+		db, err = leveldb.Recover(stor, options)
 	}
 	if err != nil {
 		stor.Close()
 		return nil, err
 	}
 	return &levelDb{db, stor}, nil
+}
+
+// openLevelDB opens or recovers a leveldb.DB with a passed-in storage.Storage
+// as its underlying storage layer.
+func openLevelDB(stor storage.Storage) (*levelDb, error) {
+	return openLevelDBWithOptions(stor, leveldbOptions)
 }


### PR DESCRIPTION
After writing a 120MiB file:
```
bash-4.3$ cd ~/.local/share/keybase.devel/kbfs_block_cache/v1/diskCacheBlocks.leveldb/
bash-4.3$ ls -lh
total 130292
-rw-r--r--    1 keybase  keybase    50.2M Oct 10 23:43 000077.ldb
-rw-r--r--    1 keybase  keybase     3.5M Oct 10 23:43 000079.ldb
-rw-r--r--    1 keybase  keybase    50.4M Oct 10 23:43 000080.ldb
-rw-r--r--    1 keybase  keybase     3.8M Oct 10 23:43 000082.ldb
-rw-r--r--    1 keybase  keybase    13.2M Oct 10 23:43 000083.ldb
-rw-r--r--    1 keybase  keybase     2.5M Oct 10 23:44 000084.log
-rw-r--r--    1 keybase  keybase     3.6M Oct 10 23:43 000085.ldb
-rw-r--r--    1 keybase  keybase       16 Oct 10 23:37 CURRENT
-rw-r--r--    1 keybase  keybase        0 Oct 10 23:37 LOCK
-rw-r--r--    1 keybase  keybase    16.6K Oct 10 23:43 LOG
-rw-r--r--    1 keybase  keybase     5.6K Oct 10 23:43 MANIFEST-000000
```