### PR TITLE
libgit: introduce deleted-repo cleaner

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -491,6 +491,13 @@ func (r *runner) printJournalStatus(
 }
 
 func (r *runner) waitForJournal(ctx context.Context) error {
+	// See if there are any deleted repos to clean up before we flush
+	// the journal.
+	err := libgit.CleanOldDeletedReposTimeLimited(ctx, r.config, r.h)
+	if err != nil {
+		return err
+	}
+
 	rootNode, _, err := r.config.KBFSOps().GetOrCreateRootNode(
 		ctx, r.h, libkbfs.MasterBranch)
 	if err != nil {

--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -29,6 +29,7 @@ const (
 	gitSuffixToIgnore        = ".git"
 	kbfsDeletedReposDir      = ".kbfs_deleted_repos"
 	minDeletedAgeForCleaning = 1 * time.Hour
+	cleaningTimeLimit        = 2 * time.Second
 )
 
 // This character set is what Github supports in repo names.  It's
@@ -147,7 +148,7 @@ func CleanOldDeletedRepos(
 func CleanOldDeletedReposTimeLimited(
 	ctx context.Context, config libkbfs.Config,
 	tlfHandle *libkbfs.TlfHandle) error {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, cleaningTimeLimit)
 	defer cancel()
 	err := CleanOldDeletedRepos(ctx, config, tlfHandle)
 	if errors.Cause(err) == context.DeadlineExceeded {

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -6,6 +6,7 @@ package libgit
 
 import (
 	"os"
+	"time"
 
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -47,6 +48,11 @@ var _ keybase1.KBFSGitInterface = (*RPCHandler)(nil)
 func (rh *RPCHandler) waitForJournal(
 	ctx context.Context, gitConfig libkbfs.Config,
 	h *libkbfs.TlfHandle) error {
+	err := CleanOldDeletedReposTimeLimited(ctx, gitConfig, h)
+	if err != nil {
+		return err
+	}
+
 	rootNode, _, err := gitConfig.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	if err != nil {
@@ -185,6 +191,46 @@ func (rh *RPCHandler) CreateRepo(
 	return keybase1.RepoID(gitID.String()), nil
 }
 
+func (rh *RPCHandler) scheduleCleaning(folder keybase1.Folder) {
+	// TODO: cancel outstanding timers on shutdown, if we ever utilize
+	// the DeleteRepo RPC handler in a test.
+	time.AfterFunc(minDeletedAgeForCleaning+1*time.Second, func() {
+		log := rh.config.MakeLogger("")
+
+		ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
+			context.Background(), folder)
+		if err != nil {
+			log.CDebugf(nil, "Couldn't init for scheduled cleaning of %s: %+v",
+				folder.Name, err)
+			return
+		}
+		defer func() {
+			rmErr := os.RemoveAll(tempDir)
+			if rmErr != nil {
+				rh.log.CDebugf(
+					ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
+			}
+		}()
+		defer gitConfig.Shutdown(ctx)
+
+		log.CDebugf(ctx, "Starting a scheduled repo clean for folder %s",
+			tlfHandle.GetCanonicalPath())
+		err = CleanOldDeletedRepos(ctx, gitConfig, tlfHandle)
+		if err != nil {
+			log.CDebugf(ctx, "Couldn't clean folder %s: %+v",
+				tlfHandle.GetCanonicalPath(), err)
+			return
+		}
+
+		err = rh.waitForJournal(ctx, gitConfig, tlfHandle)
+		if err != nil {
+			log.CDebugf(ctx, "Error waiting for journal after cleaning "+
+				"folder %s: %+v", tlfHandle.GetCanonicalPath(), err)
+			return
+		}
+	})
+}
+
 // DeleteRepo implements keybase1.KBFSGitInterface for KeybaseServiceBase.
 func (rh *RPCHandler) DeleteRepo(
 	ctx context.Context, arg keybase1.DeleteRepoArg) (err error) {
@@ -218,5 +264,6 @@ func (rh *RPCHandler) DeleteRepo(
 		return err
 	}
 
+	rh.scheduleCleaning(arg.Folder)
 	return nil
 }


### PR DESCRIPTION
Run it after every git operation, rather than periodically, because it would be difficult and expensive to build something that crawls *every* TLF for a user to look for repos to delete.

When a repo is deleted, this schedules a background task to clean up the repo after a set amount of time.  If KBFS is shut down before that scheduled task, any other git operation in that folder will trigger a cleanup.  However, if the cleanup blocks a git operation, it is time-limited, and will only delete as many files as it can within a 2 second timeout, so as not to block foreground operation for too long. Subsequent operations will clean up more data, etc, until the full repo is gone.

Issue: KBFS-2442