### PR TITLE
kbfsgit: update go-git to fix ref deletion from packed-refs, and add test

### DIFF
--- a/vendor/gopkg.in/src-d/go-git.v4/options.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/options.go
@@ -362,3 +362,9 @@ func (o *CommitOptions) Validate(r *Repository) error {
 
 	return nil
 }
+
+// ListOptions describes how a remote list should be performed.
+type ListOptions struct {
+	// Auth credentials, if required, to use with the remote repository.
+	Auth transport.AuthMethod
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_selector.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_selector.go
@@ -138,6 +138,9 @@ func (dw *deltaSelector) objectsToPack(
 		return objectsToPack, nil
 	}
 
+	if packWindow == 0 {
+		return objectsToPack, nil
+	}
 	if err := dw.fixAndBreakChains(objectsToPack, statusChan); err != nil {
 		return nil, err
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/revlist/revlist.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/revlist/revlist.go
@@ -39,6 +39,7 @@ func objects(
 ) ([]plumbing.Hash, error) {
 	seen := hashListToSet(ignore)
 	result := make(map[plumbing.Hash]bool)
+	visited := make(map[plumbing.Hash]bool)
 
 	update := plumbing.StatusUpdate{Stage: plumbing.StatusCount}
 	statusChan.SendUpdate(update)
@@ -53,7 +54,7 @@ func objects(
 	}
 
 	for _, h := range objects {
-		if err := processObject(s, h, seen, ignore, walkerFunc, statusChan); err != nil {
+		if err := processObject(s, h, seen, visited, ignore, walkerFunc, statusChan); err != nil {
 			if allowMissingObjects && err == plumbing.ErrObjectNotFound {
 				continue
 			}
@@ -73,6 +74,7 @@ func processObject(
 	s storer.EncodedObjectStorer,
 	h plumbing.Hash,
 	seen map[plumbing.Hash]bool,
+	visited map[plumbing.Hash]bool,
 	ignore []plumbing.Hash,
 	walkerFunc func(h plumbing.Hash),
 	statusChan plumbing.StatusChan,
@@ -93,12 +95,12 @@ func processObject(
 
 	switch do := do.(type) {
 	case *object.Commit:
-		return reachableObjects(do, seen, ignore, walkerFunc)
+		return reachableObjects(do, seen, visited, ignore, walkerFunc)
 	case *object.Tree:
 		return iterateCommitTrees(seen, do, walkerFunc)
 	case *object.Tag:
 		walkerFunc(do.Hash)
-		return processObject(s, do.Target, seen, ignore, walkerFunc, statusChan)
+		return processObject(s, do.Target, seen, visited, ignore, walkerFunc, statusChan)
 	case *object.Blob:
 		walkerFunc(do.Hash)
 	default:
@@ -116,10 +118,14 @@ func processObject(
 func reachableObjects(
 	commit *object.Commit,
 	seen map[plumbing.Hash]bool,
+	visited map[plumbing.Hash]bool,
 	ignore []plumbing.Hash,
 	cb func(h plumbing.Hash),
 ) error {
 	i := object.NewCommitPreorderIter(commit, seen, ignore)
+	pending := make(map[plumbing.Hash]bool)
+	addPendingParents(pending, visited, commit)
+
 	for {
 		commit, err := i.Next()
 		if err == io.EOF {
@@ -128,6 +134,16 @@ func reachableObjects(
 
 		if err != nil {
 			return err
+		}
+
+		if pending[commit.Hash] {
+			delete(pending, commit.Hash)
+		}
+
+		addPendingParents(pending, visited, commit)
+
+		if visited[commit.Hash] && len(pending) == 0 {
+			break
 		}
 
 		if seen[commit.Hash] {
@@ -147,6 +163,14 @@ func reachableObjects(
 	}
 
 	return nil
+}
+
+func addPendingParents(pending, visited map[plumbing.Hash]bool, commit *object.Commit) {
+	for _, p := range commit.ParentHashes {
+		if !visited[p] {
+			pending[p] = true
+		}
+	}
 }
 
 // iterateCommitTrees iterate all reachable trees from the given commit

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/common.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/transport/common.go
@@ -187,6 +187,7 @@ func (e urlEndpoint) Path() string {
 type scpEndpoint struct {
 	user string
 	host string
+	port string
 	path string
 }
 
@@ -194,8 +195,14 @@ func (e *scpEndpoint) Protocol() string { return "ssh" }
 func (e *scpEndpoint) User() string     { return e.user }
 func (e *scpEndpoint) Password() string { return "" }
 func (e *scpEndpoint) Host() string     { return e.host }
-func (e *scpEndpoint) Port() int        { return 22 }
 func (e *scpEndpoint) Path() string     { return e.path }
+func (e *scpEndpoint) Port() int {
+	i, err := strconv.Atoi(e.port)
+	if err != nil {
+		return 22
+	}
+	return i
+}
 
 func (e *scpEndpoint) String() string {
 	var user string
@@ -220,7 +227,7 @@ func (e *fileEndpoint) String() string   { return e.path }
 
 var (
 	isSchemeRegExp   = regexp.MustCompile(`^[^:]+://`)
-	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?P<path>[^\\].*)$`)
+	scpLikeUrlRegExp = regexp.MustCompile(`^(?:(?P<user>[^@]+)@)?(?P<host>[^:\s]+):(?:(?P<port>[0-9]{1,5})/)?(?P<path>[^\\].*)$`)
 )
 
 func parseSCPLike(endpoint string) (Endpoint, bool) {
@@ -232,7 +239,8 @@ func parseSCPLike(endpoint string) (Endpoint, bool) {
 	return &scpEndpoint{
 		user: m[1],
 		host: m[2],
-		path: m[3],
+		port: m[3],
+		path: m[4],
 	}, true
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree.go
@@ -25,7 +25,7 @@ import (
 var (
 	ErrWorktreeNotClean  = errors.New("worktree is not clean")
 	ErrSubmoduleNotFound = errors.New("submodule not found")
-	ErrUnstaggedChanges  = errors.New("worktree contains unstagged changes")
+	ErrUnstagedChanges   = errors.New("worktree contains unstaged changes")
 )
 
 // Worktree represents a git worktree.
@@ -153,7 +153,7 @@ func (w *Worktree) Checkout(opts *CheckoutOptions) error {
 		}
 
 		if unstaged {
-			return ErrUnstaggedChanges
+			return ErrUnstagedChanges
 		}
 	}
 
@@ -270,7 +270,7 @@ func (w *Worktree) Reset(opts *ResetOptions) error {
 		}
 
 		if unstaged {
-			return ErrUnstaggedChanges
+			return ErrUnstagedChanges
 		}
 	}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree_status.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree_status.go
@@ -243,7 +243,7 @@ func diffTreeIsEquals(a, b noder.Hasher) bool {
 }
 
 // Add adds the file contents of a file in the worktree to the index. if the
-// file is already stagged in the index no error is returned.
+// file is already staged in the index no error is returned.
 func (w *Worktree) Add(path string) (plumbing.Hash, error) {
 	s, err := w.Status()
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -755,284 +755,284 @@
 			"revisionTime": "2017-07-10T15:31:57Z"
 		},
 		{
-			"checksumSHA1": "ffhMZlMSyi2hSRHkHGhLcdavVV0=",
+			"checksumSHA1": "c03Vz4vHwj36zjIWGJTjHCvDzSY=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
-			"checksumSHA1": "7dpHa2hTeGy/UCjKdBl6CxlaTFY=",
+			"checksumSHA1": "wq8eG0NqxByMSgSIe7h0Di5CPro=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
-			"checksumSHA1": "O+2z2RgXT/SWfSuFEF97O1rvuZg=",
+			"checksumSHA1": "eEZ5nFvBguv43DME9TmS4pFTFys=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "s2fDbBv2kbfbaGz7GMlLgCfarPQ=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
-			"checksumSHA1": "kKJbFD1KBIE37kZACAzrDdwwzlw=",
+			"checksumSHA1": "wTJka4MB9KvMN7tmPwH1Q3fkCxw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "pVBa3dcSCdSmiRg1aXv7mmYSDW0=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
-			"checksumSHA1": "swgKesrSv7rTjmZv2y/t9tNfCps=",
+			"checksumSHA1": "7n/zz8AuNloUhca0HBs1bQfLFsY=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "b5GHaJ79kh/bNz4QXtJT6WoXNyw=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "9dbe76bd6a72dfed002d5d3d7bd98d61db4437f7",
-			"revisionTime": "2017-10-03T02:19:18Z"
+			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
+			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
This change also includes several src-d master fixes.

The go-git PR fixing the packed-refs deletion logic is here (self-reviewed): keybase/go-git#11

Issue: KBFS-2509
