### PR TITLE
[KBFS-2499] Don't sync when there's a full cache

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -1072,6 +1072,7 @@ type backpressureDiskLimiterStatus struct {
 
 	JournalTrackerStatus journalTrackerStatus
 	DiskCacheByteStatus  backpressureTrackerStatus
+	SyncCacheByteStatus  backpressureTrackerStatus
 }
 
 func (bdl *backpressureDiskLimiter) getStatus(
@@ -1097,5 +1098,6 @@ func (bdl *backpressureDiskLimiter) getStatus(
 
 		JournalTrackerStatus: jStatus,
 		DiskCacheByteStatus:  bdl.diskCacheByteTracker.getStatus(),
+		SyncCacheByteStatus:  bdl.syncCacheByteTracker.getStatus(),
 	}
 }

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -235,8 +235,8 @@ func (brq *blockRetrievalQueue) PutInCaches(ctx context.Context,
 	case NoSuchBlockError:
 		// TODO: Add the block to the DBC. This is complicated because we
 		// need the serverHalf.
-		brq.log.CWarningf(ctx, "Block missing for disk block "+
-			"cache metadata update")
+		brq.log.CWarningf(ctx, "Block %s missing for disk block "+
+			"cache metadata update", ptr.ID)
 	default:
 		brq.log.CWarningf(ctx, "Error updating metadata: %+v", err)
 	}

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -20,7 +20,7 @@ type testBlockRetrievalConfig struct {
 	logMaker
 	testCache BlockCache
 	bg        blockGetter
-	diskBlockCacheGetter
+	*testDiskBlockCacheGetter
 	*testSyncedTlfGetterSetter
 	initModeGetter
 }

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -123,14 +123,21 @@ func shutdownDiskBlockCacheTest(cache DiskBlockCache) {
 	cache.Shutdown(context.Background())
 }
 
-func setupBlockForDiskCache(t *testing.T, config diskBlockCacheConfig) (
-	BlockPointer, Block, []byte, kbfscrypto.BlockCryptKeyServerHalf) {
-	ptr := makeRandomBlockPointer(t)
-	block := makeFakeFileBlock(t, true)
+func setupRealBlockForDiskCache(t *testing.T, ptr BlockPointer, block Block,
+	config diskBlockCacheConfig) ([]byte, kbfscrypto.BlockCryptKeyServerHalf) {
 	blockEncoded, err := config.Codec().Encode(block)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
+	return blockEncoded, serverHalf
+}
+
+func setupBlockForDiskCache(t *testing.T, config diskBlockCacheConfig) (
+	BlockPointer, Block, []byte, kbfscrypto.BlockCryptKeyServerHalf) {
+	ptr := makeRandomBlockPointer(t)
+	block := makeFakeFileBlock(t, true)
+	blockEncoded, serverHalf :=
+		setupRealBlockForDiskCache(t, ptr, block, config)
 	return ptr, block, blockEncoded, serverHalf
 }
 

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -983,7 +983,7 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 }
 
 func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
-	t.Log("Test synced TLF prefetching in a more complex fetch order.")
+	t.Log("Test synced TLF prefetching with the disk cache.")
 	cache, dbcConfig := initDiskBlockCacheTest(t)
 	q, bg, config := initPrefetcherTestWithDiskCache(t, cache)
 	defer shutdownPrefetcherTest(q)

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -967,3 +967,121 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		aa.Children["aab"].BlockPointer, aab, FinishedPrefetch, TransientEntry)
 }
+
+func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
+	t.Log("Test synced TLF prefetching in a more complex fetch order.")
+	q, bg, config := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q)
+	kmd := makeKMD()
+	prefetchSyncCh := make(chan struct{})
+	q.TogglePrefetcher(true, prefetchSyncCh)
+	notifySyncCh(t, prefetchSyncCh)
+
+	t.Log("Initialize a folder tree with structure: " +
+		"root -> {b, a -> {ab, aa -> {aab, aaa}}}")
+	rootPtr := makeRandomBlockPointer(t)
+	root := &DirBlock{Children: map[string]DirEntry{
+		"a": makeRandomDirEntry(t, Dir, 10, "a"),
+		"b": makeRandomDirEntry(t, File, 20, "b"),
+	}}
+	a := &DirBlock{Children: map[string]DirEntry{
+		"aa": makeRandomDirEntry(t, Dir, 30, "aa"),
+		"ab": makeRandomDirEntry(t, File, 40, "ab"),
+	}}
+	b := makeFakeFileBlock(t, true)
+	aa := &DirBlock{Children: map[string]DirEntry{
+		"aaa": makeRandomDirEntry(t, File, 50, "aaa"),
+		"aab": makeRandomDirEntry(t, File, 60, "aab"),
+	}}
+	ab := makeFakeFileBlock(t, true)
+	aaa := makeFakeFileBlock(t, true)
+	aab := makeFakeFileBlock(t, true)
+
+	_, contChRoot := bg.setBlockToReturn(rootPtr, root)
+	_, contChA := bg.setBlockToReturn(root.Children["a"].BlockPointer, a)
+	_, contChB := bg.setBlockToReturn(root.Children["b"].BlockPointer, b)
+	_, contChAA := bg.setBlockToReturn(a.Children["aa"].BlockPointer, aa)
+	_, contChAB := bg.setBlockToReturn(a.Children["ab"].BlockPointer, ab)
+	_, contChAAA := bg.setBlockToReturn(aa.Children["aaa"].BlockPointer, aaa)
+	_, contChAAB := bg.setBlockToReturn(aa.Children["aab"].BlockPointer, aab)
+
+	t.Log("Fetch dir root.")
+	block := &DirBlock{}
+	ch := q.Request(context.Background(), defaultOnDemandRequestPriority, kmd,
+		rootPtr, block, TransientEntry)
+	contChRoot <- nil
+	notifySyncCh(t, prefetchSyncCh)
+	err := <-ch
+	require.NoError(t, err)
+
+	t.Log("Release prefetched children of root.")
+	contChA <- nil
+	notifySyncCh(t, prefetchSyncCh)
+	contChB <- nil
+	notifySyncCh(t, prefetchSyncCh)
+
+	t.Log("Now set the folder to sync.")
+	config.SetTlfSyncState(kmd.TlfID(), true)
+	q.TogglePrefetcher(true, prefetchSyncCh)
+	notifySyncCh(t, prefetchSyncCh)
+
+	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
+		TriggeredPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		root.Children["a"].BlockPointer, a, NoPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		root.Children["b"].BlockPointer, b, NoPrefetch, TransientEntry)
+
+	t.Log("Fetch dir root again.")
+	block = &DirBlock{}
+	ch = q.Request(context.Background(), defaultOnDemandRequestPriority, kmd,
+		rootPtr, block, TransientEntry)
+	err = <-ch
+
+	t.Log("Release all the blocks.")
+	go func() {
+		// After this, the prefetch worker order is less clear due to
+		// priorities.
+		// TODO: The prefetcher should have a "global" prefetch priority
+		// reservation system that goes down with each next set of prefetches.
+		notifyContinueCh(contChAA)
+		notifyContinueCh(contChAB)
+		notifyContinueCh(contChAAA)
+		notifyContinueCh(contChAAB)
+	}()
+
+	t.Log("Wait for prefetching to complete.")
+	// Release after prefetching root
+	notifySyncCh(t, prefetchSyncCh)
+	// Release after prefetching a
+	notifySyncCh(t, prefetchSyncCh)
+	// Release after prefetching b
+	notifySyncCh(t, prefetchSyncCh)
+	// Release after prefetching aa
+	notifySyncCh(t, prefetchSyncCh)
+	// Release after prefetching ab
+	notifySyncCh(t, prefetchSyncCh)
+	// Release after prefetching aaa
+	notifySyncCh(t, prefetchSyncCh)
+	// Release after prefetching aab
+	notifySyncCh(t, prefetchSyncCh)
+	// Then we wait for the pending prefetches to complete.
+	<-q.Prefetcher().Shutdown()
+
+	t.Log("Ensure that the prefetched blocks are in the cache, " +
+		"and the prefetch statuses are correct.")
+	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
+		FinishedPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		root.Children["a"].BlockPointer, a, FinishedPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		root.Children["b"].BlockPointer, b, FinishedPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		a.Children["aa"].BlockPointer, aa, FinishedPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		a.Children["ab"].BlockPointer, ab, FinishedPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		aa.Children["aaa"].BlockPointer, aaa, FinishedPrefetch, TransientEntry)
+	testPrefetcherCheckGet(t, config.BlockCache(),
+		aa.Children["aab"].BlockPointer, aab, FinishedPrefetch, TransientEntry)
+}


### PR DESCRIPTION
Add a test that regresses KBFS-2499, and fix the failure.

As a bonus, we now have a test that tests the prefetcher and disk cache combined.