### PR TITLE
kbfs: fix a few nits in git and FBO suggested on other PRs

### DIFF
--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -103,6 +103,9 @@ func NewFS(ctx context.Context, config libkbfs.Config,
 	if err != nil {
 		return nil, err
 	}
+	if subdir != "" {
+		subdir = path.Clean(subdir)
+	}
 
 	// Look up the subdir's root.
 	n := rootNode

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2013,7 +2013,7 @@ func (bps *blockPutState) removeOtherBps(other *blockPutState) {
 	// Assume that `other` is a subset of `bps` when initializing the
 	// slice length.
 	newLen := len(bps.blockStates) - len(other.blockStates)
-	if newLen <= 0 {
+	if newLen < 0 {
 		newLen = 0
 	}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2014,7 +2014,7 @@ func (bps *blockPutState) removeOtherBps(other *blockPutState) {
 	// slice length.
 	newLen := len(bps.blockStates) - len(other.blockStates)
 	if newLen <= 0 {
-		newLen = 1
+		newLen = 0
 	}
 
 	// Remove any blocks that appear in `other`.


### PR DESCRIPTION
* #1263: add `gitExec` test function
* #1260: clean subdir in `NewFS` if needed
* #954: when removing block states, allow cap of 0
