### PR TITLE
git-remote-keybase: check for a running service

### DIFF
--- a/env/context.go
+++ b/env/context.go
@@ -25,6 +25,7 @@ type Context interface {
 	GetLogDir() string
 	GetDataDir() string
 	ConfigureSocketInfo() (err error)
+	GetGlobalContext() *libkb.GlobalContext
 	GetSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
 	NewRPCLogFactory() *libkb.RPCLogFactory
 	GetKBFSSocket(clearError bool) (net.Conn, rpc.Transporter, bool, error)
@@ -91,6 +92,11 @@ func (c *KBFSContext) GetDataDir() string {
 // GetRunMode returns run mode
 func (c *KBFSContext) GetRunMode() libkb.RunMode {
 	return c.g.GetRunMode()
+}
+
+// GetGlobalContext returns the libkb global context.
+func (c *KBFSContext) GetGlobalContext() *libkb.GlobalContext {
+	return c.g
 }
 
 // GetSocket returns a socket


### PR DESCRIPTION
Dialing it seems to be the best platform-agnostic way to check for a running service.  Just checking for the socket file doesn't work on Windows.

If the service isn't running, the user will see:

```
git-remote-keybase error: (1) The Keybase service is not running for this user.
```
cc: @malgorithms 

Issue: KBFS-2514