### PR TITLE
folder_branch_ops: always send the initial MD straight to server

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2310,13 +2310,6 @@ func (fbo *folderBranchOps) waitForJournalLocked(ctx context.Context,
 	return nil
 }
 
-func (fbo *folderBranchOps) waitForJournal(ctx context.Context,
-	lState *lockState, jServer *JournalServer) error {
-	fbo.mdWriterLock.Lock(lState)
-	defer fbo.mdWriterLock.Unlock(lState)
-	return fbo.waitForJournalLocked(ctx, lState, jServer)
-}
-
 func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata,
 	lastWriterVerifyingKey kbfscrypto.VerifyingKey) (err error) {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2305,6 +2305,13 @@ func (fbo *folderBranchOps) waitForJournalLocked(ctx context.Context,
 	return nil
 }
 
+func (fbo *folderBranchOps) waitForJournal(ctx context.Context,
+	lState *lockState, jServer *JournalServer) error {
+	fbo.mdWriterLock.Lock(lState)
+	defer fbo.mdWriterLock.Unlock(lState)
+	return fbo.waitForJournalLocked(ctx, lState, jServer)
+}
+
 func (fbo *folderBranchOps) finalizeMDRekeyWriteLocked(ctx context.Context,
 	lState *lockState, md *RootMetadata,
 	lastWriterVerifyingKey kbfscrypto.VerifyingKey) (err error) {


### PR DESCRIPTION
We don't want to return keys to chat that haven't yet been accepted by the server.

Issue: KBFS-2553