### PR TITLE
Move FavoriteNameToPreferredTLFNameFormatAs

### DIFF
--- a/kbfstool/common.go
+++ b/kbfstool/common.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 )
 
 const (
@@ -17,7 +18,7 @@ const (
 	privateName = "private"
 )
 
-const publicSuffix = libkbfs.ReaderSep + libkbfs.PublicUIDName
+const publicSuffix = tlf.ReaderSep + libkbfs.PublicUIDName
 
 func byteCountStr(n int) string {
 	if n == 1 {

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -201,7 +201,7 @@ func (fl *FolderList) FindFiles(ctx context.Context, fi *dokan.FileInfo, ignored
 		if fav.Type != fl.tlfType {
 			continue
 		}
-		pname, err := libkbfs.FavoriteNameToPreferredTLFNameFormatAs(session.Name,
+		pname, err := tlf.FavoriteNameToPreferredTLFNameFormatAs(session.Name,
 			libkbfs.CanonicalTlfName(fav.Name))
 		if err != nil {
 			fl.fs.log.CErrorf(ctx, "FavoriteNameToPreferredTLFNameFormatAs: %q %v", fav.Name, err)

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -254,7 +254,7 @@ func (fl *FolderList) ReadDirAll(ctx context.Context) (res []fuse.Dirent, err er
 		if fav.Type != fl.tlfType {
 			continue
 		}
-		pname, err := libkbfs.FavoriteNameToPreferredTLFNameFormatAs(
+		pname, err := tlf.FavoriteNameToPreferredTLFNameFormatAs(
 			session.Name, libkbfs.CanonicalTlfName(fav.Name))
 		if err != nil {
 			fl.fs.log.Errorf("FavoriteNameToPreferredTLFNameFormatAs: %q %v", fav.Name, err)

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -19,10 +19,6 @@ import (
 )
 
 const (
-	// ReaderSep is the string that separates readers from writers in a
-	// TLF name.
-	ReaderSep = "#"
-
 	// PublicUIDName is the name given to keybase1.PublicUID.  This string
 	// should correspond to an illegal or reserved Keybase user name.
 	PublicUIDName = "_public"
@@ -331,7 +327,7 @@ func NewFavoriteFromFolder(folder keybase1.Folder) *Favorite {
 		// Old versions of the client still use an outdated "#public"
 		// suffix for favorited public folders. TODO: remove this once
 		// those old versions of the client are retired.
-		const oldPublicSuffix = ReaderSep + "public"
+		const oldPublicSuffix = tlf.ReaderSep + "public"
 		name = strings.TrimSuffix(folder.Name, oldPublicSuffix)
 	}
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1138,7 +1138,7 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver MetadataVer) 
 	uid2 := session2.UID
 
 	// Create a shared folder
-	name := u1.String() + "," + u2.String() + ReaderSep + u3.String()
+	name := u1.String() + "," + u2.String() + tlf.ReaderSep + u3.String()
 
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
@@ -1326,7 +1326,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver MetadataVer) {
 	uid2 := session2.UID
 
 	t.Log("Create a shared folder")
-	name := u1.String() + ReaderSep + u2.String()
+	name := u1.String() + tlf.ReaderSep + u2.String()
 
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 
@@ -1423,7 +1423,7 @@ func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver MetadataVer) {
 	SwitchDeviceForLocalUserOrBust(t, config2Dev2, devIndex)
 
 	t.Log("Create a shared folder")
-	name := u1.String() + ReaderSep + u2.String()
+	name := u1.String() + tlf.ReaderSep + u2.String()
 
 	rootNode1 := GetRootNodeOrBust(ctx, t, config1, name, tlf.Private)
 

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -407,29 +407,6 @@ func getSortedUnresolved(unresolved map[keybase1.SocialAssertion]bool) []keybase
 	return assertions
 }
 
-// splitTLFName splits a TLF name into components.
-func splitTLFName(name string) (writerNames, readerNames []string,
-	extensionSuffix string, err error) {
-	names := strings.SplitN(name, tlf.HandleExtensionSep, 2)
-	if len(names) > 2 {
-		return nil, nil, "", BadTLFNameError{name}
-	}
-	if len(names) > 1 {
-		extensionSuffix = names[1]
-	}
-
-	splitNames := strings.SplitN(names[0], ReaderSep, 3)
-	if len(splitNames) > 2 {
-		return nil, nil, "", BadTLFNameError{name}
-	}
-	writerNames = strings.Split(splitNames[0], ",")
-	if len(splitNames) > 1 {
-		readerNames = strings.Split(splitNames[1], ",")
-	}
-
-	return writerNames, readerNames, extensionSuffix, nil
-}
-
 // splitAndNormalizeTLFName takes a tlf name as a string
 // and tries to normalize it offline. In addition to other
 // checks it returns TlfNameNotCanonical if it does not
@@ -439,7 +416,7 @@ func splitTLFName(name string) (writerNames, readerNames []string,
 func splitAndNormalizeTLFName(name string, t tlf.Type) (
 	writerNames, readerNames []string,
 	extensionSuffix string, err error) {
-	writerNames, readerNames, extensionSuffix, err = splitTLFName(name)
+	writerNames, readerNames, extensionSuffix, err = tlf.SplitName(name)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -546,7 +523,7 @@ func normalizeNamesInTLF(writerNames, readerNames []string,
 		}
 		changesMade = changesMade || rchanges
 		sort.Strings(readerNames)
-		normalizedName += ReaderSep + strings.Join(readerNames, ",")
+		normalizedName += tlf.ReaderSep + strings.Join(readerNames, ",")
 	}
 	if len(extensionSuffix) != 0 {
 		// This *should* be normalized already but make sure.  I can see not
@@ -606,7 +583,7 @@ func FavoriteNameToPreferredTLFNameFormatAs(username libkb.NormalizedUsername,
 	if len(username) == 0 {
 		return PreferredTlfName(tlfname), nil
 	}
-	ws, rs, ext, err := splitTLFName(tlfname)
+	ws, rs, ext, err := tlf.SplitName(tlfname)
 	if err != nil {
 		return "", err
 	}
@@ -621,7 +598,7 @@ func FavoriteNameToPreferredTLFNameFormatAs(username libkb.NormalizedUsername,
 				ws[0] = w
 				tlfname = strings.Join(ws, ",")
 				if len(rs) > 0 {
-					tlfname += ReaderSep + strings.Join(rs, ",")
+					tlfname += tlf.ReaderSep + strings.Join(rs, ",")
 				}
 				if len(ext) > 0 {
 					tlfname += tlf.HandleExtensionSep + ext

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -21,8 +21,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// CanonicalTlfName is a string containing the canonical name of a TLF.
-type CanonicalTlfName string
+// CanonicalTlfName is a temporary alias.
+type CanonicalTlfName = tlf.CanonicalName
 
 // TlfHandle contains all the info in a tlf.Handle as well as
 // additional info. This doesn't embed tlf.Handle to avoid having to
@@ -556,56 +556,20 @@ func (h TlfHandle) IsConflict() bool {
 	return h.conflictInfo != nil
 }
 
-// PreferredTlfName is a preferred Tlf name.
-type PreferredTlfName string
+// PreferredTlfName is a temporary alias.
+type PreferredTlfName = tlf.PreferredName
 
 // GetPreferredFormat returns a TLF name formatted with the username given
 // as the parameter first.
-// This calls FavoriteNameToPreferredTLFNameFormatAs with the canonical
+// This calls tlf.FavoriteNameToPreferredTLFNameFormatAs with the canonical
 // tlf name which will be reordered into the preferred format.
 // An empty username is allowed here and results in the canonical ordering.
 func (h TlfHandle) GetPreferredFormat(
 	username libkb.NormalizedUsername) PreferredTlfName {
-	s, err := FavoriteNameToPreferredTLFNameFormatAs(
+	s, err := tlf.FavoriteNameToPreferredTLFNameFormatAs(
 		username, h.GetCanonicalName())
 	if err != nil {
 		panic("TlfHandle.GetPreferredFormat: Parsing canonical username failed!")
 	}
 	return s
-}
-
-// FavoriteNameToPreferredTLFNameFormatAs formats a favorite names for display with the
-// username given.
-// An empty username is allowed here and results in tlfname being returned unmodified.
-func FavoriteNameToPreferredTLFNameFormatAs(username libkb.NormalizedUsername,
-	canon CanonicalTlfName) (PreferredTlfName, error) {
-	tlfname := string(canon)
-	if len(username) == 0 {
-		return PreferredTlfName(tlfname), nil
-	}
-	ws, rs, ext, err := tlf.SplitName(tlfname)
-	if err != nil {
-		return "", err
-	}
-	if len(ws) == 0 {
-		return "", fmt.Errorf("TLF name %q with no writers", tlfname)
-	}
-	uname := username.String()
-	for i, w := range ws {
-		if w == uname {
-			if i != 0 {
-				copy(ws[1:i+1], ws[0:i])
-				ws[0] = w
-				tlfname = strings.Join(ws, ",")
-				if len(rs) > 0 {
-					tlfname += tlf.ReaderSep + strings.Join(rs, ",")
-				}
-				if len(ext) > 0 {
-					tlfname += tlf.HandleExtensionSep + ext
-				}
-			}
-			break
-		}
-	}
-	return PreferredTlfName(tlfname), nil
 }

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -133,7 +133,7 @@ func makeTlfHandleHelper(
 	canonicalName := strings.Join(writerNames, ",")
 	if t == tlf.Private && len(usedRNames)+len(unresolvedReaders) > 0 {
 		readerNames := getSortedNames(usedRNames, unresolvedReaders)
-		canonicalName += ReaderSep + strings.Join(readerNames, ",")
+		canonicalName += tlf.ReaderSep + strings.Join(readerNames, ",")
 	}
 
 	extensionList := tlf.HandleExtensionList(extensions)

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -1007,22 +1007,3 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	_, err = ParseTlfHandle(ctx, kbpki, nonCanonicalName, tlf.Private)
 	assert.Equal(t, TlfNameNotCanonical{nonCanonicalName, name}, err)
 }
-
-func TestFavoriteNameToPreferredTLFNameFormatAs(t *testing.T) {
-	for _, q := range []struct {
-		As     libkb.NormalizedUsername
-		Try    CanonicalTlfName
-		Answer PreferredTlfName
-	}{
-		{"", "a,b,c", "a,b,c"},
-		{"a", "a,b,c", "a,b,c"},
-		{"b", "a,b,c", "b,a,c"},
-		{"c", "a,b,c", "c,a,b"},
-		{"b", "a,b,c#d,e", "b,a,c#d,e"},
-		{"d", "a,b,c#d,e", "a,b,c#d,e"},
-	} {
-		r, err := FavoriteNameToPreferredTLFNameFormatAs(q.As, q.Try)
-		assert.Equal(t, q.Answer, r)
-		assert.NoError(t, err)
-	}
-}

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -149,7 +149,7 @@ func (k *SimpleFS) favoriteList(ctx context.Context, path keybase1.Path, t tlf.T
 		if fav.Type != t {
 			continue
 		}
-		pname, err := libkbfs.FavoriteNameToPreferredTLFNameFormatAs(
+		pname, err := tlf.FavoriteNameToPreferredTLFNameFormatAs(
 			session.Name, libkbfs.CanonicalTlfName(fav.Name))
 		if err != nil {
 			k.log.Errorf("FavoriteNameToPreferredTLFNameFormatAs: %q %v", fav.Name, err)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -116,12 +116,12 @@ func (e *fsEngine) GetFavorites(user User, t tlf.Type) (map[string]bool, error) 
 // GetRootDir implements the Engine interface.
 func (e *fsEngine) GetRootDir(user User, tlfName string, t tlf.Type, expectedCanonicalTlfName string) (dir Node, err error) {
 	u := user.(*fsUser)
-	preferredName, err := libkbfs.FavoriteNameToPreferredTLFNameFormatAs(u.username,
+	preferredName, err := tlf.FavoriteNameToPreferredTLFNameFormatAs(u.username,
 		libkbfs.CanonicalTlfName(tlfName))
 	if err != nil {
 		return nil, err
 	}
-	expectedPreferredName, err := libkbfs.FavoriteNameToPreferredTLFNameFormatAs(u.username,
+	expectedPreferredName, err := tlf.FavoriteNameToPreferredTLFNameFormatAs(u.username,
 		libkbfs.CanonicalTlfName(expectedCanonicalTlfName))
 	if err != nil {
 		return nil, err

--- a/tlf/errors.go
+++ b/tlf/errors.go
@@ -29,3 +29,14 @@ func (e HandleExtensionMismatchError) Error() string {
 	return fmt.Sprintf("Folder handle extension mismatch, "+
 		"expected: %s, actual: %s", e.Expected, e.Actual)
 }
+
+// BadNameError indicates a top-level folder name that has an
+// incorrect format.
+type BadNameError struct {
+	Name string
+}
+
+// Error implements the error interface for BadNameError.
+func (e BadNameError) Error() string {
+	return fmt.Sprintf("TLF name %s is in an incorrect format", e.Name)
+}

--- a/tlf/handle.go
+++ b/tlf/handle.go
@@ -1,3 +1,7 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
 package tlf
 
 import (

--- a/tlf/name.go
+++ b/tlf/name.go
@@ -1,0 +1,38 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package tlf
+
+import (
+	"strings"
+)
+
+const (
+	// ReaderSep is the string that separates readers from writers in a
+	// TLF name.
+	ReaderSep = "#"
+)
+
+// SplitName splits a TLF name into components.
+func SplitName(name string) (writerNames, readerNames []string,
+	extensionSuffix string, err error) {
+	names := strings.SplitN(name, HandleExtensionSep, 2)
+	if len(names) > 2 {
+		return nil, nil, "", BadNameError{name}
+	}
+	if len(names) > 1 {
+		extensionSuffix = names[1]
+	}
+
+	splitNames := strings.SplitN(names[0], ReaderSep, 3)
+	if len(splitNames) > 2 {
+		return nil, nil, "", BadNameError{name}
+	}
+	writerNames = strings.Split(splitNames[0], ",")
+	if len(splitNames) > 1 {
+		readerNames = strings.Split(splitNames[1], ",")
+	}
+
+	return writerNames, readerNames, extensionSuffix, nil
+}

--- a/tlf/name_test.go
+++ b/tlf/name_test.go
@@ -1,0 +1,31 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package tlf
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/libkb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFavoriteNameToPreferredTLFNameFormatAs(t *testing.T) {
+	for _, q := range []struct {
+		As     libkb.NormalizedUsername
+		Try    CanonicalName
+		Answer PreferredName
+	}{
+		{"", "a,b,c", "a,b,c"},
+		{"a", "a,b,c", "a,b,c"},
+		{"b", "a,b,c", "b,a,c"},
+		{"c", "a,b,c", "c,a,b"},
+		{"b", "a,b,c#d,e", "b,a,c#d,e"},
+		{"d", "a,b,c#d,e", "a,b,c#d,e"},
+	} {
+		r, err := FavoriteNameToPreferredTLFNameFormatAs(q.As, q.Try)
+		assert.Equal(t, q.Answer, r)
+		assert.NoError(t, err)
+	}
+}


### PR DESCRIPTION
... to tlf.

Also move splitTLFName and ReaderSep.

This is so that server code can use this without depending on libkbfs.