### PR TITLE
mounter changes

### DIFF
--- a/libfs/mount_interrupter.go
+++ b/libfs/mount_interrupter.go
@@ -58,17 +58,19 @@ func (mi *MountInterrupter) MountAndSetUnmount(mounter Mounter) error {
 }
 
 // Done signals Wait and runs the unmounter if set by MountAndSetUnmount.
-// It can be called multiple times with no harm.
+// It can be called multiple times with no harm. Each call triggers a call to
+// the unmounter.
 func (mi *MountInterrupter) Done() {
-	mi.once.Do(func() {
-		mi.Lock()
-		defer mi.Unlock()
-		if mi.fun != nil {
-			err := mi.fun()
-			if err != nil {
-				mi.log.Error("Mount interrupter callback failed: ", err)
-			}
+	mi.Lock()
+	defer mi.Unlock()
+	if mi.fun != nil {
+		err := mi.fun()
+		if err != nil {
+			mi.log.Error("Mount interrupter callback failed: ", err)
+			return
 		}
+	}
+	mi.once.Do(func() {
 		close(mi.done)
 	})
 }

--- a/libfuse/mounter.go
+++ b/libfuse/mounter.go
@@ -24,8 +24,8 @@ type mounter struct {
 // On a force mount then unmount, re-mount if unsuccessful
 func (m *mounter) Mount() (err error) {
 	m.c, err = fuseMountDir(m.options.MountPoint, m.options.PlatformParams)
-	// Exit if we were succesful or we are not a force mounting on error.
-	if err == nil || !m.options.ForceMount {
+	// Exit if we were succesful. Otherwise, try unmounting and mounting again.
+	if err == nil {
 		return err
 	}
 


### PR DESCRIPTION
Specifically,

1) Unmount on SIGINT multiple times in case of open file handle. We already try to do this in [`libkbfs.Init`](https://github.com/keybase/kbfs/blob/d1ef47bfbd9135be64da20ea21f80e9098e99bba/libkbfs/init.go#L467-L479). This fixes the MountInterrupter to honor that.

2) Try unmounting and mounting again if initial mounting fails. Previously we only do it when the mount type is force. However, if process is SIGKILL-ed, or we have some bug that crashes the process, we can leave a broken mount point and if we try to mount again we may get an error. So try unmounting it if we get an error regardless. If we fail again, we return the error. The `force` mount type is still useful since it makes us error out and exit as long as mounting fails, while the default one runs without the mount point happily.