### PR TITLE
journal_server: error, instead of panic, if no handle given

### DIFF
--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -507,10 +507,9 @@ func (j *JournalServer) Enable(ctx context.Context, tlfID tlf.ID,
 		if h == nil {
 			// Any path that creates a single-team TLF journal should
 			// also provide a handle.  If not, we'd have to fetch it
-			// from the server, which isn't a trusted path.  So panic
-			// instead; if we hit this, we might need to rethink this.
-			panic(fmt.Sprintf(
-				"No handle provided for single-team TLF %s", tlfID))
+			// from the server, which isn't a trusted path.
+			return errors.Errorf(
+				"No handle provided for single-team TLF %s", tlfID)
 		}
 
 		chargedTo = h.FirstResolvedWriter()


### PR DESCRIPTION
We require a handle to be passed in when enabling a journal for a team TLF, since otherwise we'd have to talk to the (untrusted) server to look up the `chargedTo` ID for the folder.  Previously we panicked when the caller didn't provide a handle.

However there are legitimate callers, like `folderBranchOps.getJournalPredecessorRevision()`, which might try to inadvertently enable a journal without passing in a handle, if they happen to be called before some other `folderBranchOps` function. These callers generally expect an error if the journal is not 
enablable.  So let's turn the panic into an error instead.

Issue: KBFS-2563