### PR TITLE
use default mount type by default and reinstall mountdir if needed

### DIFF
--- a/kbfsfuse/defaults_production.go
+++ b/kbfsfuse/defaults_production.go
@@ -6,4 +6,4 @@
 
 package main
 
-const defaultMountType = "force"
+const defaultMountType = "default"

--- a/kbfsfuse/main.go
+++ b/kbfsfuse/main.go
@@ -30,13 +30,13 @@ const usageFormatStr = `Usage:
 
 To run against remote KBFS servers:
   kbfsfuse
-    [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
+    [-runtime-dir=path/to/dir] [-label=label] [-mount-type=` + defaultMountType + `]
 %s
     %s/path/to/mountpoint
 
 To run in a local testing environment:
   kbfsfuse
-    [-runtime-dir=path/to/dir] [-label=label] [-mount-type=force]
+    [-runtime-dir=path/to/dir] [-label=label] [-mount-type=` + defaultMountType + `]
 %s
     %s/path/to/mountpoint
 

--- a/libfuse/mounter.go
+++ b/libfuse/mounter.go
@@ -20,13 +20,28 @@ type mounter struct {
 	c       *fuse.Conn
 }
 
+const darwinInstallerPath = "/Applications/Keybase.app/Contents/Resources/" +
+	"KeybaseInstaller.app/Contents/MacOS/Keybase"
+
+func (m *mounter) reinstallMountDirForDarwin() {
+	args := []string{
+		"--app-path=/Applications/Keybase.app",
+		"--run-mode=prod",
+		"--timeout=60",
+	}
+	exec.Command(darwinInstallerPath,
+		append(args, "--uninstall-mountdir")...).Run()
+	exec.Command(darwinInstallerPath,
+		append(args, "--install-mountdir")...).Run()
+}
+
 // fuseMount tries to mount the mountpoint.
 // On a force mount then unmount, re-mount if unsuccessful
 func (m *mounter) Mount() (err error) {
 	m.c, err = fuseMountDir(m.options.MountPoint, m.options.PlatformParams)
 	// Exit if we were succesful. Otherwise, try unmounting and mounting again.
 	if err == nil {
-		return err
+		return nil
 	}
 
 	// Mount failed, let's try to unmount and then try mounting again, even
@@ -34,6 +49,22 @@ func (m *mounter) Mount() (err error) {
 	m.Unmount()
 
 	m.c, err = fuseMountDir(m.options.MountPoint, m.options.PlatformParams)
+
+	if err == nil {
+		return nil
+	}
+
+	if runtime.GOOS == "darwin" {
+		// Mount failed again, and we are on darwin. So ask the installer to
+		// reinstall the mount dir and try again as the last resort. This
+		// specifically fixes a situation where /keybase gets created and owned
+		// by root after Keybase app is started, and `kbfs` later fails to
+		// mount because of a permission error.
+		m.Unmount()
+		m.reinstallMountDirForDarwin()
+		m.c, err = fuseMountDir(m.options.MountPoint, m.options.PlatformParams)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
In https://github.com/keybase/kbfs/commit/39534e4a6ffe95f84a5480d60b3606112fa93206 , we made default mounter do unmount-then-mount in case of failure too. So the only difference between the default mounter and the force mounter now is the force mounter returns an error causing `kbfsfuse` to exit in case of a mount failure. 

This PR changes the default mount type for production build from `force` to `default` so that we don't get stuck in a crash loop in case of mount failures.

In addition, if mount fails with the unmount-then-mount-again approach too, on darwin we call the installer to reinstall the mountdir and try again. This should cover the case where `/keybase` permission is messed up preventing us from mounting.