### PR TITLE
Move server constants out of libkbfs

### DIFF
--- a/kbfsblock/bserver_constants.go
+++ b/kbfsblock/bserver_constants.go
@@ -1,0 +1,12 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsblock
+
+const (
+	// ServerTokenServer is the expected server type for bserver authentication.
+	ServerTokenServer = "kbfs_block"
+	// ServerTokenExpireIn is the TTL to use when constructing an authentication token.
+	ServerTokenExpireIn = 2 * 60 * 60 // 2 hours
+)

--- a/kbfsmd/server_constants.go
+++ b/kbfsmd/server_constants.go
@@ -1,0 +1,12 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsmd
+
+const (
+	// ServerTokenServer is the expected server type for mdserver authentication.
+	ServerTokenServer = "kbfs_md"
+	// ServerTokenExpireIn is the TTL to use when constructing an authentication token.
+	ServerTokenExpireIn = 2 * 60 * 60 // 2 hours
+)

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -21,10 +21,6 @@ import (
 )
 
 const (
-	// BServerTokenServer is the expected server type for bserver authentication.
-	BServerTokenServer = "kbfs_block"
-	// BServerTokenExpireIn is the TTL to use when constructing an authentication token.
-	BServerTokenExpireIn = 2 * 60 * 60 // 2 hours
 	// BServerDefaultPingIntervalSeconds is the default interval on which the
 	// client should contact the block server.
 	BServerDefaultPingIntervalSeconds = 10
@@ -72,7 +68,7 @@ func newBlockServerRemoteClientHandler(name string, log logger.Logger,
 	}
 
 	b.authToken = kbfscrypto.NewAuthToken(
-		signer, BServerTokenServer, BServerTokenExpireIn,
+		signer, kbfsblock.ServerTokenServer, kbfsblock.ServerTokenExpireIn,
 		"libkbfs_bserver_remote", VersionString(), b)
 
 	constBackoff := backoff.NewConstantBackOff(RPCReconnectInterval)

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -22,10 +22,6 @@ import (
 )
 
 const (
-	// MdServerTokenServer is the expected server type for mdserver authentication.
-	MdServerTokenServer = "kbfs_md"
-	// MdServerTokenExpireIn is the TTL to use when constructing an authentication token.
-	MdServerTokenExpireIn = 2 * 60 * 60 // 2 hours
 	// MdServerBackgroundRekeyPeriod is how long the rekey checker
 	// waits between runs on average. The timer gets reset after
 	// every incoming FolderNeedsRekey RPC.
@@ -109,7 +105,7 @@ func NewMDServerRemote(config Config, srvAddr string,
 	}
 
 	mdServer.authToken = kbfscrypto.NewAuthToken(config.Crypto(),
-		MdServerTokenServer, MdServerTokenExpireIn,
+		kbfsmd.ServerTokenServer, kbfsmd.ServerTokenExpireIn,
 		"libkbfs_mdserver_remote", VersionString(), mdServer)
 	constBackoff := backoff.NewConstantBackOff(RPCReconnectInterval)
 	mdServer.connOpts = rpc.ConnectionOpts{


### PR DESCRIPTION
This is so that servers can use them without depending on
libkbfs.