### PR TITLE
kbfsgit: add on-demand delta objects, and update go-git vendor for memory fixes

### DIFF
--- a/kbfsgit/on_demand_delta_object.go
+++ b/kbfsgit/on_demand_delta_object.go
@@ -1,0 +1,131 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsgit
+
+import (
+	"io"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+)
+
+type onDemandDeltaObject struct {
+	s           storer.DeltaObjectStorer
+	hash        plumbing.Hash
+	typeSet     bool
+	objType     plumbing.ObjectType
+	sizeSet     bool
+	size        int64
+	baseHash    plumbing.Hash
+	actualHash  plumbing.Hash
+	actualSize  int64
+	recentCache *lru.Cache
+}
+
+var _ plumbing.DeltaObject = (*onDemandDeltaObject)(nil)
+
+type notDeltaError struct {
+}
+
+func (nde notDeltaError) Error() string {
+	return "Not a delta object"
+}
+
+func (oddo *onDemandDeltaObject) cache() (o plumbing.DeltaObject, err error) {
+	if tmp, ok := oddo.recentCache.Get(oddo.hash); ok {
+		o, ok = tmp.(plumbing.DeltaObject)
+		if !ok {
+			return nil, notDeltaError{}
+		}
+	} else {
+		eo, err := oddo.s.DeltaObject(oddo.objType, oddo.hash)
+		if err != nil {
+			return nil, err
+		}
+		oddo.recentCache.Add(oddo.hash, eo)
+		o, ok = eo.(plumbing.DeltaObject)
+		if !ok {
+			return nil, notDeltaError{}
+		}
+	}
+
+	if !oddo.sizeSet {
+		oddo.size = o.Size()
+	}
+	if !oddo.typeSet {
+		oddo.objType = o.Type()
+	}
+	oddo.baseHash = o.BaseHash()
+	oddo.actualHash = o.ActualHash()
+	oddo.actualSize = o.ActualSize()
+	return o, nil
+}
+
+func (oddo *onDemandDeltaObject) cacheIfNeeded() error {
+	if oddo.size >= 0 {
+		return nil
+	}
+	// TODDO: We should be able to read the type and size from the
+	// object's header, without loading the entire object itself.
+	_, err := oddo.cache()
+	return err
+}
+
+func (oddo *onDemandDeltaObject) Hash() plumbing.Hash {
+	return oddo.hash
+}
+
+func (oddo *onDemandDeltaObject) Type() plumbing.ObjectType {
+	_ = oddo.cacheIfNeeded()
+	return oddo.objType
+}
+
+func (oddo *onDemandDeltaObject) SetType(ot plumbing.ObjectType) {
+	oddo.typeSet = true
+	oddo.objType = ot
+}
+
+func (oddo *onDemandDeltaObject) Size() int64 {
+	_ = oddo.cacheIfNeeded()
+	return oddo.size
+}
+
+func (oddo *onDemandDeltaObject) SetSize(s int64) {
+	oddo.sizeSet = true
+	oddo.size = s
+}
+
+func (oddo *onDemandDeltaObject) Reader() (io.ReadCloser, error) {
+	// Create a new object to stream data from the storer on-demand,
+	// without caching the bytes to long-lived memory.  Let the block
+	// cache do its job to keep recent data in memory and control
+	// total memory usage.
+	o, err := oddo.cache()
+	if err != nil {
+		return nil, err
+	}
+	return o.Reader()
+}
+
+func (oddo *onDemandDeltaObject) Writer() (io.WriteCloser, error) {
+	return nil, errors.New("onDemandDeltaObject shouldn't be used for writes")
+}
+
+func (oddo *onDemandDeltaObject) BaseHash() plumbing.Hash {
+	_ = oddo.cacheIfNeeded()
+	return oddo.baseHash
+}
+
+func (oddo *onDemandDeltaObject) ActualHash() plumbing.Hash {
+	_ = oddo.cacheIfNeeded()
+	return oddo.actualHash
+}
+
+func (oddo *onDemandDeltaObject) ActualSize() int64 {
+	_ = oddo.cacheIfNeeded()
+	return oddo.actualSize
+}

--- a/kbfsgit/on_demand_storer.go
+++ b/kbfsgit/on_demand_storer.go
@@ -6,7 +6,9 @@ package kbfsgit
 
 import (
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage"
 )
 
@@ -23,7 +25,7 @@ var _ storage.Storer = (*onDemandStorer)(nil)
 func newOnDemandStorer(s storage.Storer) (*onDemandStorer, error) {
 	// Track a small number of recent in-memory objects, to improve
 	// performance without impacting memory too much.
-	recentCache, err := lru.New(10)
+	recentCache, err := lru.New(25)
 	if err != nil {
 		return nil, err
 	}
@@ -50,5 +52,31 @@ func (ods *onDemandStorer) EncodedObject(
 		return nil, err
 	}
 
+	return o, nil
+}
+
+func (ods *onDemandStorer) DeltaObject(
+	ot plumbing.ObjectType, hash plumbing.Hash) (
+	plumbing.EncodedObject, error) {
+	edos, ok := ods.Storer.(storer.DeltaObjectStorer)
+	if !ok {
+		return nil, errors.New("Not a delta storer")
+	}
+	o := &onDemandDeltaObject{
+		s:           edos,
+		hash:        hash,
+		objType:     ot,
+		size:        -1,
+		recentCache: ods.recentCache,
+	}
+	// Need to see if this is a delta object, which means reading all
+	// the data.
+	_, err := o.cache()
+	_, notDelta := err.(notDeltaError)
+	if notDelta {
+		return ods.EncodedObject(ot, hash)
+	} else if err != nil {
+		return nil, err
+	}
 	return o, nil
 }

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_selector.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_selector.go
@@ -276,6 +276,12 @@ func (dw *deltaSelector) walk(
 	}
 
 	for i := 0; i < len(objectsToPack); i++ {
+		// Clean up the index map for anything outside our pack
+		// window, to save memory.
+		if i > int(packWindow) {
+			delete(indexMap, objectsToPack[i-int(packWindow)].Hash())
+		}
+
 		target := objectsToPack[i]
 
 		// If we already have a delta, we don't try to find a new one for this

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -845,7 +845,7 @@
 			"revisionTime": "2017-10-13T00:11:41Z"
 		},
 		{
-			"checksumSHA1": "wq8eG0NqxByMSgSIe7h0Di5CPro=",
+			"checksumSHA1": "4Sj6nbZNTQrA/h8LoFkgn6z8ujo=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
 			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -764,281 +764,281 @@
 			"checksumSHA1": "c03Vz4vHwj36zjIWGJTjHCvDzSY=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
-			"checksumSHA1": "4Sj6nbZNTQrA/h8LoFkgn6z8ujo=",
+			"checksumSHA1": "/tEoNxPLDJIlf3h7KcKFzgUcNOQ=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "eEZ5nFvBguv43DME9TmS4pFTFys=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "s2fDbBv2kbfbaGz7GMlLgCfarPQ=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "wTJka4MB9KvMN7tmPwH1Q3fkCxw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "pVBa3dcSCdSmiRg1aXv7mmYSDW0=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "7n/zz8AuNloUhca0HBs1bQfLFsY=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "b5GHaJ79kh/bNz4QXtJT6WoXNyw=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "08427cdf876e1afa248388fac864a9b74d855ee4",
-			"revisionTime": "2017-10-13T00:11:41Z"
+			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
+			"revisionTime": "2017-10-30T23:02:57Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
This adds a custom layer for accessing "delta" git objects, without keeping all the data in memory for the lifetime of the object.  It will be useful once we have git garbage collection, but currently won't be used by `git-remote-keybase` because we set `pack.window = 0` for all kbfs git repos, and so diffs aren't used for pulls at all.

This also vendors in some changes from our fork of `go-git`, which help keep memory stable during delta compression (also not used currently in `git-remote-keybase`).  With these changes I was able to keep memory usage at less than 1.7 GB for the keybase/client repo when calculating diffs, as opposed to 3-4 GB of usage without it.