### PR TITLE
folder_branch_ops: avoid data race in `Lookup()`

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1838,6 +1838,9 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 		return nil, EntryInfo{}, err
 	}
 
+	// It's racy for the goroutine to write directly to return param
+	// `node`, so use a new param for that.
+	var n Node
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
 		if fbo.nodeCache.IsUnlinked(dir) {
@@ -1852,7 +1855,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 			return err
 		}
 
-		node, de, err = fbo.blocks.Lookup(ctx, lState, md.ReadOnly(), dir, name)
+		n, de, err = fbo.blocks.Lookup(ctx, lState, md.ReadOnly(), dir, name)
 		if err != nil {
 			return err
 		}
@@ -1861,7 +1864,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	if err != nil {
 		return nil, EntryInfo{}, err
 	}
-	return node, de.EntryInfo, nil
+	return n, de.EntryInfo, nil
 }
 
 // statEntry is like Stat, but it returns a DirEntry. This is used by


### PR DESCRIPTION
If `Lookup` returns early, it could write to the return param `node`. But the internal goroutine might still be running, which also tried to write to the `node` param.  This leads to a possible (but really rare) data race.

Instead, have the goroutine write to a temp variable, which is only returned when the `Lookup` is successful.

Issue: KBFS-2579