### PR TITLE
kbfsgit: concurrent PackRefs test

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1649,3 +1649,18 @@ func (r *runner) processCommands(ctx context.Context) (err error) {
 		}
 	}
 }
+
+func (r *runner) packRefs(ctx context.Context) (err error) {
+	r.log.CDebugf(ctx, "Packing refs")
+	repo, _, err := r.initRepoIfNeeded(ctx, "pack-refs")
+	if err != nil {
+		return err
+	}
+
+	err = repo.Storer.PackRefs()
+	if err != nil {
+		return err
+	}
+
+	return r.waitForJournal(ctx)
+}

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -666,3 +666,210 @@ func TestPushcertOptions(t *testing.T) {
 	checkPushcert("true", "unsupported")
 	checkPushcert("false", "ok")
 }
+
+func TestPackRefsAndOverwritePackedRef(t *testing.T) {
+	ctx, config, tempdir := initConfigForRunner(t)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+	defer os.RemoveAll(tempdir)
+
+	git1, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git1)
+
+	// Make shared repo with 2 branches.
+	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
+	testPushWithTemplate(t, ctx, config, git1,
+		[]string{"refs/heads/master:refs/heads/master"},
+		"ok %s\n\n", "user1,user2")
+	testPushWithTemplate(t, ctx, config, git1,
+		[]string{"refs/heads/master:refs/heads/test"},
+		"ok %s\n\n", "user1,user2")
+
+	// Config for the second user.
+	config2 := libkbfs.ConfigAsUser(config, "user2")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
+	tempdir2, err := ioutil.TempDir(os.TempDir(), "journal_server")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir2)
+	err = config2.EnableDiskLimiter(tempdir2)
+	require.NoError(t, err)
+	err = config2.EnableJournaling(
+		ctx, tempdir2, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
+	require.NoError(t, err)
+
+	git2, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git2)
+	dotgit2 := filepath.Join(git2, ".git")
+
+	heads := testListAndGetHeadsWithName(t, ctx, config2, git2,
+		[]string{"refs/heads/master", "refs/heads/test", "HEAD"}, "user1,user2")
+	require.Equal(t, heads[0], heads[1])
+
+	// Have the second user refpack.
+	r, err := newRunner(ctx, config2, "origin",
+		fmt.Sprintf("keybase://private/user1,user2/test"),
+		dotgit2, nil, nil, testErrput{t})
+	require.NoError(t, err)
+
+	// Stall it after it takes the lock.
+	packOnStalled, packUnstall, packCtx := libkbfs.StallMDOp(
+		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
+	packErrCh := make(chan error)
+	go func() {
+		packErrCh <- r.packRefs(packCtx)
+	}()
+	select {
+	case <-packOnStalled:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	// While the second user is stalled, have the first user update
+	// one of the refs.
+	addOneFileToRepo(t, git1, "foo2", "hello2")
+	testPushWithTemplate(t, ctx, config, git1,
+		[]string{"refs/heads/master:refs/heads/test"},
+		"ok %s\n\n", "user1,user2")
+
+	close(packUnstall)
+	select {
+	case err := <-packErrCh:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config2.KBPKI(), "user1,user2", tlf.Private)
+	require.NoError(t, err)
+	rootNode, _, err := config2.KBFSOps().GetOrCreateRootNode(
+		ctx, h, libkbfs.MasterBranch)
+	require.NoError(t, err)
+	err = config2.KBFSOps().SyncFromServerForTesting(
+		ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+	heads = testListAndGetHeadsWithName(t, ctx, config2, git2,
+		[]string{"refs/heads/master", "refs/heads/test", "HEAD"}, "user1,user2")
+	require.NotEqual(t, heads[0], heads[1])
+}
+
+func TestPackRefsAndDeletePackedRef(t *testing.T) {
+	ctx, config, tempdir := initConfigForRunner(t)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+	defer os.RemoveAll(tempdir)
+
+	git1, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git1)
+	dotgit1 := filepath.Join(git1, ".git")
+
+	// Make shared repo with 2 branches.  Make sure there's an initial
+	// pack-refs file.
+	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
+	gitExec(t, dotgit1, git1, "pack-refs", "--all")
+	testPushWithTemplate(t, ctx, config, git1,
+		[]string{"refs/heads/master:refs/heads/master"},
+		"ok %s\n\n", "user1,user2")
+	testPushWithTemplate(t, ctx, config, git1,
+		[]string{"refs/heads/master:refs/heads/test"},
+		"ok %s\n\n", "user1,user2")
+
+	// Config for the second user.
+	config2 := libkbfs.ConfigAsUser(config, "user2")
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
+	tempdir2, err := ioutil.TempDir(os.TempDir(), "journal_server")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir2)
+	err = config2.EnableDiskLimiter(tempdir2)
+	require.NoError(t, err)
+	err = config2.EnableJournaling(
+		ctx, tempdir2, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
+	require.NoError(t, err)
+
+	git2, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git2)
+	dotgit2 := filepath.Join(git2, ".git")
+
+	heads := testListAndGetHeadsWithName(t, ctx, config2, git2,
+		[]string{"refs/heads/master", "refs/heads/test", "HEAD"}, "user1,user2")
+	require.Equal(t, heads[0], heads[1])
+
+	// Have the second user refpack.
+	r, err := newRunner(ctx, config2, "origin",
+		fmt.Sprintf("keybase://private/user1,user2/test"),
+		dotgit2, nil, nil, testErrput{t})
+	require.NoError(t, err)
+
+	// Stall it after it takes the lock.
+	packOnStalled, packUnstall, packCtx := libkbfs.StallMDOp(
+		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
+	packErrCh := make(chan error)
+	go func() {
+		packErrCh <- r.packRefs(packCtx)
+	}()
+	select {
+	case <-packOnStalled:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	// While the second user is stalled, have the first user delete
+	// one of the refs.  Wait until it tries to get the lock, and then
+	// release the pack-refs call.
+	deleteOnStalled, deleteUnstall, deleteCtx := libkbfs.StallMDOp(
+		ctx, config, libkbfs.StallableMDGetRange, 1)
+	inputReader, inputWriter := io.Pipe()
+	defer inputWriter.Close()
+	go func() {
+		inputWriter.Write([]byte("push :refs/heads/test\n"))
+		inputWriter.Write([]byte("\n\n"))
+	}()
+
+	var output bytes.Buffer
+	deleteRunner, err := newRunner(ctx, config, "origin",
+		"keybase://private/user1,user2/test",
+		dotgit1, inputReader, &output, testErrput{t})
+	require.NoError(t, err)
+	deleteErrCh := make(chan error)
+	go func() {
+		deleteErrCh <- deleteRunner.processCommands(deleteCtx)
+	}()
+	select {
+	case <-deleteOnStalled:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	// Release it, and it should block on getting the lock.
+	close(deleteUnstall)
+
+	// Now let the pack-refs finish.
+	close(packUnstall)
+	select {
+	case err := <-packErrCh:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	// And the delete should finish right after.
+	select {
+	case err := <-deleteErrCh:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config2.KBPKI(), "user1,user2", tlf.Private)
+	require.NoError(t, err)
+	rootNode, _, err := config2.KBFSOps().GetOrCreateRootNode(
+		ctx, h, libkbfs.MasterBranch)
+	require.NoError(t, err)
+	err = config2.KBFSOps().SyncFromServerForTesting(
+		ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+	testListAndGetHeadsWithName(t, ctx, config2, git2,
+		[]string{"refs/heads/master", "HEAD"}, "user1,user2")
+}

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -35,6 +35,7 @@ const (
 	StallableMDGetLatestHandleForTLF StallableMDOp = "GetLatestHandleForTLF"
 	StallableMDGetUnmergedForTLF     StallableMDOp = "GetUnmergedForTLF"
 	StallableMDGetRange              StallableMDOp = "GetRange"
+	StallableMDAfterGetRange         StallableMDOp = "AfterGetRange"
 	StallableMDGetUnmergedRange      StallableMDOp = "GetUnmergedRange"
 	StallableMDPut                   StallableMDOp = "Put"
 	StallableMDAfterPut              StallableMDOp = "AfterPut"
@@ -463,6 +464,7 @@ func (m *stallingMDOps) GetRange(ctx context.Context, id tlf.ID,
 		var errGetRange error
 		mds, errGetRange = m.delegate.GetRange(
 			ctx, id, start, stop, lockBeforeGet)
+		m.maybeStall(ctx, StallableMDAfterGetRange)
 		return errGetRange
 	})
 	return mds, err

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
@@ -21,6 +21,8 @@ type ReferenceStorer interface {
 	IterReferences() (ReferenceIter, error)
 	RemoveReference(plumbing.ReferenceName) error
 	SetPackedRefs(refs []plumbing.Reference) error
+	CountLooseRefs() (int, error)
+	PackRefs() error
 }
 
 // ReferenceIter is a generic closable interface for iterating over references.

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/reference.go
@@ -38,3 +38,11 @@ func (r *ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 func (r *ReferenceStorage) SetPackedRefs(refs []plumbing.Reference) error {
 	return r.dir.SetPackedRefs(refs)
 }
+
+func (r *ReferenceStorage) CountLooseRefs() (int, error) {
+	return r.dir.CountLooseRefs()
+}
+
+func (r *ReferenceStorage) PackRefs() error {
+	return r.dir.PackRefs()
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/memory/storage.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/memory/storage.go
@@ -254,6 +254,14 @@ func (r ReferenceStorage) SetPackedRefs(refs []plumbing.Reference) error {
 	return nil
 }
 
+func (r ReferenceStorage) CountLooseRefs() (int, error) {
+	return len(r), nil
+}
+
+func (r ReferenceStorage) PackRefs() error {
+	return nil
+}
+
 func (r ReferenceStorage) RemoveReference(n plumbing.ReferenceName) error {
 	delete(r, n)
 	return nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -782,281 +782,281 @@
 			"checksumSHA1": "c03Vz4vHwj36zjIWGJTjHCvDzSY=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "A3WduoxOIVoBnsDAEZtI798CZtU=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "mI7Ks4Bumh+OYkxuSBrIeBTAKoA=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "/tEoNxPLDJIlf3h7KcKFzgUcNOQ=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "smz4vtvDIJUcPM4IXD7T6x7iV/o=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "sBjAjpwQtYwh1xgCC/Np6k1QCxA=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "+iFHG0LBT3gYImczKZy9Gkjogpk=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "eEZ5nFvBguv43DME9TmS4pFTFys=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
-			"checksumSHA1": "s2fDbBv2kbfbaGz7GMlLgCfarPQ=",
+			"checksumSHA1": "nDGquiK5lj/xor8BySBt86ekRjo=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "wTJka4MB9KvMN7tmPwH1Q3fkCxw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "aReXFIha6HkU5jPfLWWAEMPhEp4=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "KLaUkXK0IPfAwIyC9WuzgpKl4Ts=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "4B79ZyIoeNpT4OWl/CvEQn9RP+g=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "0H7p/EuPC+LQdRWLoNO775/JIPw=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "1P0AgwgfasGL7aL5+FuuDan835c=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "gDaPr5XmEH3bHya8MARK/m2tuls=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "NY+2qZNBynx/7d7vm20G7nU4LGk=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
-			"checksumSHA1": "pVBa3dcSCdSmiRg1aXv7mmYSDW0=",
+			"checksumSHA1": "yd87kHpl+GAlF/hnr/qCU4Klz34=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
-			"checksumSHA1": "7n/zz8AuNloUhca0HBs1bQfLFsY=",
+			"checksumSHA1": "ppDeieGc/kC5F9kYEwFiVkPHuWQ=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
-			"checksumSHA1": "b5GHaJ79kh/bNz4QXtJT6WoXNyw=",
+			"checksumSHA1": "WGYNKncHQESK0m08E0LsYDfiw18=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "UM8j6MDPfIvBJOYrXWYFpN6nwk8=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "6gGibezR20asX5JgNsGR9AWiF1s=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "EkYWmjvMAaEG9JPYtwE6x7hwxjY=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"checksumSHA1": "0H0x2urvYdo68NY6fGFJG59lqoI=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "2a4be50bf9f989b2f95b313083868ea80ca95d15",
-			"revisionTime": "2017-10-30T23:02:57Z"
+			"revision": "902a574496cb3ae8494d9c2087017412ec68e2d5",
+			"revisionTime": "2017-11-03T17:47:46Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
* One where a second client updates a reference during ref-packing.
* Another one where a second client deletes a reference during ref-packing.

This adds a `runner.packRefs()` method for now, that is only invoked by testing.  A later PR will call this as part of a larger GC operation.

(Depends on #1302 and keybase/go-git#13.  Will update the commit hash once the latter is merged.)

Issue: KBFS-2517
