### PR TITLE
kbfsgit: check if GC is needed on every fetch/clone/push

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1035,6 +1035,7 @@ func (r *runner) checkGC(ctx context.Context) (err error) {
 					"mem.gc.prof", "cpu.gc.prof")
 			})
 		case <-ctx.Done():
+			timer.Stop()
 		}
 	}()
 	defer func() {

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -36,7 +36,8 @@ func (te testErrput) Write(buf []byte) (int, error) {
 
 func TestRunnerCapabilities(t *testing.T) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
-	config := libkbfs.MakeTestConfigOrBust(t, "user1")
+	config := libkbfs.MakeTestConfigOrBustLoggedInWithMode(
+		t, 0, libkbfs.InitSingleOp, "user1")
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	inputReader, inputWriter := io.Pipe()


### PR DESCRIPTION
For now, we just check if:
* GC hasn't been run on the repo in the last week.
* There are more than 50 loose refs.

If the check is taking more than a second, it prints "Checking repo for inefficiencies... " to stderr as a progress indicator.

If GC is needed, it prints something like:

```
Tip: this repo could be sped up with some garbage collection. Run this command:
    keybase git gc repo

```

Issue: KBFS-2539