### PR TITLE
Remove aliases in libkbfs/data_types.go

### DIFF
--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -45,7 +45,7 @@ func getTlfID(
 	}
 
 	_, irmd, err := config.MDOps().GetForHandle(
-		ctx, handle, libkbfs.Merged, nil)
+		ctx, handle, kbfsmd.Merged, nil)
 	if err != nil {
 		return tlf.ID{}, err
 	}
@@ -189,7 +189,7 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	fmt.Printf("Looking for unmerged branch...\n")
 
 	_, unmergedIRMD, err := config.MDOps().GetForHandle(
-		ctx, handle, libkbfs.Unmerged, nil)
+		ctx, handle, kbfsmd.Unmerged, nil)
 	if err != nil {
 		return libkbfs.ImmutableRootMetadata{}, err
 	}
@@ -202,7 +202,7 @@ func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	fmt.Printf("Getting latest metadata...\n")
 
 	_, irmd, err := config.MDOps().GetForHandle(
-		ctx, handle, libkbfs.Merged, nil)
+		ctx, handle, kbfsmd.Merged, nil)
 	if err != nil {
 		return libkbfs.ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfshash"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -38,10 +39,10 @@ var _ KeyMetadata = fakeKeyMetadata{}
 // KeyGen up to latestKeyGen. The key for KeyGen i is a deterministic
 // function of i, so multiple calls to this function will have the
 // same keys.
-func makeFakeKeyMetadata(tlfID tlf.ID, latestKeyGen KeyGen) fakeKeyMetadata {
+func makeFakeKeyMetadata(tlfID tlf.ID, latestKeyGen kbfsmd.KeyGen) fakeKeyMetadata {
 	keys := make([]kbfscrypto.TLFCryptKey, 0,
-		latestKeyGen-FirstValidKeyGen+1)
-	for keyGen := FirstValidKeyGen; keyGen <= latestKeyGen; keyGen++ {
+		latestKeyGen-kbfsmd.FirstValidKeyGen+1)
+	for keyGen := kbfsmd.FirstValidKeyGen; keyGen <= latestKeyGen; keyGen++ {
 		keys = append(keys,
 			kbfscrypto.MakeTLFCryptKey([32]byte{byte(keyGen)}))
 	}
@@ -68,7 +69,7 @@ func (kg fakeBlockKeyGetter) GetTLFCryptKeyForBlockDecryption(
 	ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer) (
 	kbfscrypto.TLFCryptKey, error) {
 	fkmd := kmd.(fakeKeyMetadata)
-	i := int(blockPtr.KeyGen - FirstValidKeyGen)
+	i := int(blockPtr.KeyGen - kbfsmd.FirstValidKeyGen)
 	if i >= len(fkmd.keys) {
 		return kbfscrypto.TLFCryptKey{}, errors.Errorf(
 			"no key for block decryption (keygen=%d)",
@@ -131,7 +132,7 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var latestKeyGen KeyGen = 5
+	var latestKeyGen kbfsmd.KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
 	block := &FileBlock{
@@ -156,7 +157,7 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 
 	blockCryptKey := kbfscrypto.UnmaskBlockCryptKey(
 		readyBlockData.serverHalf,
-		kmd.keys[latestKeyGen-FirstValidKeyGen])
+		kmd.keys[latestKeyGen-kbfsmd.FirstValidKeyGen])
 
 	decryptedBlock := &FileBlock{}
 	err = config.cryptoPure().DecryptBlock(
@@ -202,7 +203,7 @@ func TestBlockOpsReadyFailServerHalfGet(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
+	kmd := makeFakeKeyMetadata(tlfID, kbfsmd.FirstValidKeyGen)
 
 	ctx := context.Background()
 	_, _, _, err := bops.Ready(ctx, kmd, &FileBlock{})
@@ -229,7 +230,7 @@ func TestBlockOpsReadyFailEncryption(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
+	kmd := makeFakeKeyMetadata(tlfID, kbfsmd.FirstValidKeyGen)
 
 	ctx := context.Background()
 	_, _, _, err := bops.Ready(ctx, kmd, &FileBlock{})
@@ -269,7 +270,7 @@ func TestBlockOpsReadyFailEncode(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
+	kmd := makeFakeKeyMetadata(tlfID, kbfsmd.FirstValidKeyGen)
 
 	ctx := context.Background()
 	_, _, _, err := bops.Ready(ctx, kmd, &FileBlock{})
@@ -295,7 +296,7 @@ func TestBlockOpsReadyTooSmallEncode(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	kmd := makeFakeKeyMetadata(tlfID, FirstValidKeyGen)
+	kmd := makeFakeKeyMetadata(tlfID, kbfsmd.FirstValidKeyGen)
 
 	ctx := context.Background()
 	_, _, _, err := bops.Ready(ctx, kmd, &FileBlock{})
@@ -312,7 +313,7 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var keyGen KeyGen = 3
+	var keyGen kbfsmd.KeyGen = 3
 	kmd1 := makeFakeKeyMetadata(tlfID, keyGen)
 
 	block := &FileBlock{
@@ -348,7 +349,7 @@ func TestBlockOpsGetFailServerGet(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var latestKeyGen KeyGen = 5
+	var latestKeyGen kbfsmd.KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
 	ctx := context.Background()
@@ -391,7 +392,7 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var latestKeyGen KeyGen = 5
+	var latestKeyGen kbfsmd.KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
 	ctx := context.Background()
@@ -421,7 +422,7 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var latestKeyGen KeyGen = 5
+	var latestKeyGen kbfsmd.KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
 	ctx := context.Background()
@@ -489,7 +490,7 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var latestKeyGen KeyGen = 5
+	var latestKeyGen kbfsmd.KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
 	ctx := context.Background()
@@ -532,7 +533,7 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 	defer bops.Shutdown()
 
 	tlfID := tlf.FakeID(0, tlf.Private)
-	var latestKeyGen KeyGen = 5
+	var latestKeyGen kbfsmd.KeyGen = 5
 	kmd := makeFakeKeyMetadata(tlfID, latestKeyGen)
 
 	ctx := context.Background()

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -150,7 +150,7 @@ func TestBlockOpsReadySuccess(t *testing.T) {
 	err = kbfsblock.VerifyID(readyBlockData.buf, id)
 	require.NoError(t, err)
 
-	var encryptedBlock EncryptedBlock
+	var encryptedBlock kbfscrypto.EncryptedBlock
 	err = config.Codec().Decode(readyBlockData.buf, &encryptedBlock)
 	require.NoError(t, err)
 
@@ -215,8 +215,8 @@ type badBlockEncryptor struct {
 
 func (c badBlockEncryptor) EncryptBlock(
 	block Block, key kbfscrypto.BlockCryptKey) (
-	plainSize int, encryptedBlock EncryptedBlock, err error) {
-	return 0, EncryptedBlock{}, errors.New("could not encrypt block")
+	plainSize int, encryptedBlock kbfscrypto.EncryptedBlock, err error) {
+	return 0, kbfscrypto.EncryptedBlock{}, errors.New("could not encrypt block")
 }
 
 // TestBlockOpsReadyFailEncryption checks that BlockOpsStandard.Ready()
@@ -242,10 +242,10 @@ type tooSmallBlockEncryptor struct {
 
 func (c tooSmallBlockEncryptor) EncryptBlock(
 	block Block, key kbfscrypto.BlockCryptKey) (
-	plainSize int, encryptedBlock EncryptedBlock, err error) {
+	plainSize int, encryptedBlock kbfscrypto.EncryptedBlock, err error) {
 	plainSize, encryptedBlock, err = c.CryptoCommon.EncryptBlock(block, key)
 	if err != nil {
-		return 0, EncryptedBlock{}, err
+		return 0, kbfscrypto.EncryptedBlock{}, err
 	}
 	encryptedBlock.EncryptedData = nil
 	return plainSize, encryptedBlock, nil
@@ -517,7 +517,7 @@ type badBlockDecryptor struct {
 	cryptoPure
 }
 
-func (c badBlockDecryptor) DecryptBlock(encryptedBlock EncryptedBlock,
+func (c badBlockDecryptor) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock,
 	key kbfscrypto.BlockCryptKey, block Block) error {
 	return errors.New("could not decrypt block")
 }

--- a/libkbfs/block_util.go
+++ b/libkbfs/block_util.go
@@ -182,7 +182,7 @@ func assembleBlock(ctx context.Context, keyGetter blockKeyGetter,
 	blockCryptKey := kbfscrypto.UnmaskBlockCryptKey(
 		blockServerHalf, tlfCryptKey)
 
-	var encryptedBlock EncryptedBlock
+	var encryptedBlock kbfscrypto.EncryptedBlock
 	err = codec.Decode(buf, &encryptedBlock)
 	if err != nil {
 		return err

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -136,7 +136,7 @@ type ConfigLocal struct {
 	bgFlushPeriod time.Duration
 
 	// metadataVersion is the version to use when creating new metadata.
-	metadataVersion MetadataVer
+	metadataVersion kbfsmd.MetadataVer
 
 	mode InitMode
 
@@ -772,14 +772,14 @@ func (c *ConfigLocal) SetConflictRenamer(cr ConflictRenamer) {
 }
 
 // MetadataVersion implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) MetadataVersion() MetadataVer {
+func (c *ConfigLocal) MetadataVersion() kbfsmd.MetadataVer {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	return c.metadataVersion
 }
 
 // SetMetadataVersion implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) SetMetadataVersion(mdVer MetadataVer) {
+func (c *ConfigLocal) SetMetadataVersion(mdVer kbfsmd.MetadataVer) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	c.metadataVersion = mdVer

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -276,7 +276,7 @@ func MakeLocalUserCryptPublicKeyOrBust(
 // MakeLocalTLFCryptKeyOrBust returns a unique private symmetric key
 // for a TLF.
 func MakeLocalTLFCryptKeyOrBust(
-	name string, keyGen KeyGen) kbfscrypto.TLFCryptKey {
+	name string, keyGen kbfsmd.KeyGen) kbfscrypto.TLFCryptKey {
 	return kbfscrypto.MakeFakeTLFCryptKeyOrBust(
 		string(name) + " crypt key " + string(keyGen))
 }
@@ -313,14 +313,14 @@ func MakeLocalTeams(teams []libkb.NormalizedUsername) []TeamInfo {
 	for i := 0; i < len(teams); i++ {
 		cryptKey := MakeLocalTLFCryptKeyOrBust(
 			buildCanonicalPathForTlfType(tlf.SingleTeam, string(teams[i])),
-			FirstValidKeyGen)
+			kbfsmd.FirstValidKeyGen)
 		localTeams[i] = TeamInfo{
 			Name: teams[i],
 			TID:  keybase1.MakeTestTeamID(uint32(i+1), false),
-			CryptKeys: map[KeyGen]kbfscrypto.TLFCryptKey{
-				FirstValidKeyGen: cryptKey,
+			CryptKeys: map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey{
+				kbfsmd.FirstValidKeyGen: cryptKey,
 			},
-			LatestKeyGen: FirstValidKeyGen,
+			LatestKeyGen: kbfsmd.FirstValidKeyGen,
 		}
 		// If this is a subteam, set the root ID.
 		if strings.Contains(string(teams[i]), ".") {

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3153,7 +3153,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 		} else {
 			branchPoint := unmergedMDs[0].Revision() - 1
 			mostRecentMergedMD, err = getSingleMD(ctx, cr.config, cr.fbo.id(),
-				kbfsmd.NullBranchID, branchPoint, Merged, nil)
+				kbfsmd.NullBranchID, branchPoint, kbfsmd.Merged, nil)
 			if err != nil {
 				return
 			}

--- a/libkbfs/crypto_client.go
+++ b/libkbfs/crypto_client.go
@@ -127,7 +127,7 @@ func (c *CryptoClient) prepareTLFCryptKeyClientHalf(
 	encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (
 	encryptedData keybase1.EncryptedBytes32, nonce keybase1.BoxNonce,
 	err error) {
-	if encryptedClientHalf.Version != EncryptionSecretbox {
+	if encryptedClientHalf.Version != kbfscrypto.EncryptionSecretbox {
 		return keybase1.EncryptedBytes32{}, keybase1.BoxNonce{},
 			errors.WithStack(kbfscrypto.UnknownEncryptionVer{
 				Ver: encryptedClientHalf.Version})

--- a/libkbfs/crypto_client.go
+++ b/libkbfs/crypto_client.go
@@ -124,7 +124,7 @@ func (c *CryptoClient) SignToString(ctx context.Context, msg []byte) (
 }
 
 func (c *CryptoClient) prepareTLFCryptKeyClientHalf(
-	encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (
+	encryptedClientHalf kbfscrypto.EncryptedTLFCryptKeyClientHalf) (
 	encryptedData keybase1.EncryptedBytes32, nonce keybase1.BoxNonce,
 	err error) {
 	if encryptedClientHalf.Version != kbfscrypto.EncryptionSecretbox {
@@ -154,7 +154,7 @@ func (c *CryptoClient) prepareTLFCryptKeyClientHalf(
 // CryptoClient.
 func (c *CryptoClient) DecryptTLFCryptKeyClientHalf(ctx context.Context,
 	publicKey kbfscrypto.TLFEphemeralPublicKey,
-	encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (
+	encryptedClientHalf kbfscrypto.EncryptedTLFCryptKeyClientHalf) (
 	clientHalf kbfscrypto.TLFCryptKeyClientHalf, err error) {
 	c.log.CDebugf(ctx, "Decrypting TLF client key half")
 	defer func() {

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -87,7 +87,7 @@ func (fc FakeCryptoClient) Call(ctx context.Context, s string, args interface{},
 		publicKey := kbfscrypto.MakeTLFEphemeralPublicKey(
 			arg.PeersPublicKey)
 		encryptedClientHalf := kbfscrypto.MakeEncryptedTLFCryptKeyClientHalfForTest(
-			EncryptionSecretbox, arg.EncryptedBytes32[:],
+			kbfscrypto.EncryptionSecretbox, arg.EncryptedBytes32[:],
 			arg.Nonce[:])
 		clientHalf, err := fc.Local.DecryptTLFCryptKeyClientHalf(
 			ctx, publicKey, encryptedClientHalf)
@@ -108,7 +108,7 @@ func (fc FakeCryptoClient) Call(ctx context.Context, s string, args interface{},
 			ePublicKey := kbfscrypto.MakeTLFEphemeralPublicKey(
 				k.PublicKey)
 			encryptedClientHalf := kbfscrypto.MakeEncryptedTLFCryptKeyClientHalfForTest(
-				EncryptionSecretbox,
+				kbfscrypto.EncryptionSecretbox,
 				k.Ciphertext[:],
 				k.Nonce[:])
 			keys = append(keys, EncryptedTLFCryptKeyClientAndEphemeral{
@@ -204,7 +204,7 @@ func TestCryptoClientDecryptTLFCryptKeyClientHalfBoxSeal(t *testing.T) {
 	ephPrivateKeyData := ephPrivateKey.Data()
 	encryptedBytes := box.Seal(nil, clientHalfData[:], &nonce, (*[32]byte)(&dhKeyPair.Public), &ephPrivateKeyData)
 	encryptedClientHalf := kbfscrypto.MakeEncryptedTLFCryptKeyClientHalfForTest(
-		EncryptionSecretbox, encryptedBytes, nonce[:])
+		kbfscrypto.EncryptionSecretbox, encryptedBytes, nonce[:])
 
 	decryptedClientHalf, err := c.DecryptTLFCryptKeyClientHalf(
 		context.Background(), ephPublicKey, encryptedClientHalf)
@@ -237,7 +237,7 @@ func TestCryptoClientDecryptEncryptedTLFCryptKeyClientHalf(t *testing.T) {
 	// performs encryption.
 	encryptedClientHalf, err := kbfscrypto.EncryptTLFCryptKeyClientHalf(ephPrivateKey, cryptPrivateKey.GetPublicKey(), clientHalf)
 	require.NoError(t, err)
-	require.Equal(t, EncryptionSecretbox, encryptedClientHalf.Version)
+	require.Equal(t, kbfscrypto.EncryptionSecretbox, encryptedClientHalf.Version)
 
 	decryptedClientHalf, err := c.DecryptTLFCryptKeyClientHalf(
 		context.Background(), ephPublicKey, encryptedClientHalf)
@@ -290,7 +290,7 @@ func TestCryptoClientDecryptEncryptedTLFCryptKeyClientHalfAny(t *testing.T) {
 		// performs encryption.
 		encryptedClientHalf, err := kbfscrypto.EncryptTLFCryptKeyClientHalf(ephPrivateKey, cryptPrivateKey.GetPublicKey(), clientHalf)
 		require.NoError(t, err)
-		require.Equal(t, EncryptionSecretbox,
+		require.Equal(t, kbfscrypto.EncryptionSecretbox,
 			encryptedClientHalf.Version)
 		keys = append(keys, EncryptedTLFCryptKeyClientAndEphemeral{
 			PubKey:     cryptPrivateKey.GetPublicKey(),

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -90,10 +90,10 @@ func (c CryptoCommon) MakeRandomTLFKeys() (kbfscrypto.TLFPublicKey,
 // EncryptPrivateMetadata implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) EncryptPrivateMetadata(
 	pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (
-	encryptedPmd EncryptedPrivateMetadata, err error) {
+	encryptedPmd kbfscrypto.EncryptedPrivateMetadata, err error) {
 	encodedPmd, err := c.codec.Encode(pmd)
 	if err != nil {
-		return EncryptedPrivateMetadata{}, err
+		return kbfscrypto.EncryptedPrivateMetadata{}, err
 	}
 
 	return kbfscrypto.EncryptEncodedPrivateMetadata(encodedPmd, key)
@@ -101,7 +101,7 @@ func (c CryptoCommon) EncryptPrivateMetadata(
 
 // DecryptPrivateMetadata implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) DecryptPrivateMetadata(
-	encryptedPmd EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (
+	encryptedPmd kbfscrypto.EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (
 	PrivateMetadata, error) {
 	encodedPrivateMetadata, err := kbfscrypto.DecryptPrivateMetadata(
 		encryptedPmd, key)

--- a/libkbfs/crypto_common.go
+++ b/libkbfs/crypto_common.go
@@ -179,21 +179,21 @@ func (c CryptoCommon) depadBlock(paddedBlock []byte) ([]byte, error) {
 
 // EncryptBlock implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (
-	plainSize int, encryptedBlock EncryptedBlock, err error) {
+	plainSize int, encryptedBlock kbfscrypto.EncryptedBlock, err error) {
 	encodedBlock, err := c.codec.Encode(block)
 	if err != nil {
-		return -1, EncryptedBlock{}, err
+		return -1, kbfscrypto.EncryptedBlock{}, err
 	}
 
 	paddedBlock, err := c.padBlock(encodedBlock)
 	if err != nil {
-		return -1, EncryptedBlock{}, err
+		return -1, kbfscrypto.EncryptedBlock{}, err
 	}
 
 	encryptedBlock, err =
 		kbfscrypto.EncryptPaddedEncodedBlock(paddedBlock, key)
 	if err != nil {
-		return -1, EncryptedBlock{}, err
+		return -1, kbfscrypto.EncryptedBlock{}, err
 	}
 
 	plainSize = len(encodedBlock)
@@ -202,7 +202,7 @@ func (c CryptoCommon) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (
 
 // DecryptBlock implements the Crypto interface for CryptoCommon.
 func (c CryptoCommon) DecryptBlock(
-	encryptedBlock EncryptedBlock, key kbfscrypto.BlockCryptKey,
+	encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey,
 	block Block) error {
 	paddedBlock, err := kbfscrypto.DecryptBlock(encryptedBlock, key)
 	if err != nil {

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -103,7 +103,7 @@ func TestCryptoCommonEncryptDecryptBlock(t *testing.T) {
 }
 
 func checkSecretboxOpenPrivateMetadata(t *testing.T, encryptedPrivateMetadata kbfscrypto.EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (encodedData []byte) {
-	require.Equal(t, EncryptionSecretbox, encryptedPrivateMetadata.Version)
+	require.Equal(t, kbfscrypto.EncryptionSecretbox, encryptedPrivateMetadata.Version)
 	require.Equal(t, 24, len(encryptedPrivateMetadata.Nonce))
 
 	var nonce [24]byte
@@ -174,7 +174,7 @@ func makeFakeBlockCryptKey(t *testing.T) kbfscrypto.BlockCryptKey {
 }
 
 func checkSecretboxOpenBlock(t *testing.T, encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey) (encodedData []byte) {
-	require.Equal(t, EncryptionSecretbox, encryptedBlock.Version)
+	require.Equal(t, kbfscrypto.EncryptionSecretbox, encryptedBlock.Version)
 	require.Equal(t, 24, len(encryptedBlock.Nonce))
 
 	var nonce [24]byte

--- a/libkbfs/crypto_local.go
+++ b/libkbfs/crypto_local.go
@@ -38,7 +38,7 @@ func NewCryptoLocal(codec kbfscodec.Codec,
 // CryptoLocal.
 func (c CryptoLocal) DecryptTLFCryptKeyClientHalf(ctx context.Context,
 	publicKey kbfscrypto.TLFEphemeralPublicKey,
-	encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (
+	encryptedClientHalf kbfscrypto.EncryptedTLFCryptKeyClientHalf) (
 	kbfscrypto.TLFCryptKeyClientHalf, error) {
 	return kbfscrypto.DecryptTLFCryptKeyClientHalf(
 		c.cryptPrivateKey, publicKey, encryptedClientHalf)

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -51,8 +51,8 @@ type TeamInfo struct {
 	// a nice type, unfortunately.
 	Name         libkb.NormalizedUsername
 	TID          keybase1.TeamID
-	CryptKeys    map[KeyGen]kbfscrypto.TLFCryptKey
-	LatestKeyGen KeyGen
+	CryptKeys    map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey
+	LatestKeyGen kbfsmd.KeyGen
 	RootID       keybase1.TeamID // for subteams only
 
 	Writers map[keybase1.UID]bool
@@ -81,16 +81,6 @@ type EncryptedTLFCryptKeyClientAndEphemeral struct {
 	// EPubKey contains the ephemeral public key used to encrypt ClientHalf
 	EPubKey kbfscrypto.TLFEphemeralPublicKey
 }
-
-// KeyGen is a temporary alias.
-type KeyGen = kbfsmd.KeyGen
-
-// Temporary aliases.
-const (
-	PublicKeyGen      KeyGen = kbfsmd.PublicKeyGen
-	UnspecifiedKeyGen KeyGen = kbfsmd.UnspecifiedKeyGen
-	FirstValidKeyGen  KeyGen = kbfsmd.FirstValidKeyGen
-)
 
 // MetadataVer is a temporary alias.
 type MetadataVer = kbfsmd.MetadataVer
@@ -209,7 +199,7 @@ func (bdt BlockDirectType) String() string {
 // considering how old clients will handle them.
 type BlockPointer struct {
 	ID         kbfsblock.ID    `codec:"i"`
-	KeyGen     KeyGen          `codec:"k"`           // if valid, which generation of the TLF{Writer,Reader}KeyBundle to use.
+	KeyGen     kbfsmd.KeyGen   `codec:"k"`           // if valid, which generation of the TLF{Writer,Reader}KeyBundle to use.
 	DataVer    DataVer         `codec:"d"`           // if valid, which version of the KBFS data structures is pointed to
 	DirectType BlockDirectType `codec:"t,omitempty"` // the type (direct, indirect, or unknown [if omitted]) of the pointed-to block
 	kbfsblock.Context

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -71,12 +71,6 @@ type SessionInfo struct {
 	VerifyingKey   kbfscrypto.VerifyingKey
 }
 
-// EncryptedTLFCryptKeyClientHalf is a temporary alias.
-type EncryptedTLFCryptKeyClientHalf = kbfscrypto.EncryptedTLFCryptKeyClientHalf
-
-// EncryptedPrivateMetadata is a temporary alias.
-type EncryptedPrivateMetadata = kbfscrypto.EncryptedPrivateMetadata
-
 // EncryptedBlock is a temporary alias.
 type EncryptedBlock = kbfscrypto.EncryptedBlock
 
@@ -89,7 +83,7 @@ type EncryptedTLFCryptKeyClientAndEphemeral struct {
 	// PublicKey contains the wrapped Key ID of the public key
 	PubKey kbfscrypto.CryptPublicKey
 	// ClientHalf contains the encrypted client half of the TLF key
-	ClientHalf EncryptedTLFCryptKeyClientHalf
+	ClientHalf kbfscrypto.EncryptedTLFCryptKeyClientHalf
 	// EPubKey contains the ephemeral public key used to encrypt ClientHalf
 	EPubKey kbfscrypto.TLFEphemeralPublicKey
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -538,8 +538,7 @@ type MergeStatus = kbfsmd.MergeStatus
 
 // Temporary aliases.
 const (
-	Merged   MergeStatus = kbfsmd.Merged
-	Unmerged MergeStatus = kbfsmd.Unmerged
+	Merged MergeStatus = kbfsmd.Merged
 )
 
 // OpSummary describes the changes performed by a single op, and is

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -85,13 +85,7 @@ type EncryptedTLFCryptKeyClientAndEphemeral struct {
 // MetadataVer is a temporary alias.
 type MetadataVer = kbfsmd.MetadataVer
 
-// Temporary aliases.
 const (
-	FirstValidMetadataVer   MetadataVer = kbfsmd.FirstValidMetadataVer
-	PreExtraMetadataVer     MetadataVer = kbfsmd.PreExtraMetadataVer
-	InitialExtraMetadataVer MetadataVer = kbfsmd.InitialExtraMetadataVer
-	SegregatedKeyBundlesVer MetadataVer = kbfsmd.SegregatedKeyBundlesVer
-
 	defaultClientMetadataVer MetadataVer = kbfsmd.SegregatedKeyBundlesVer
 )
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -533,9 +533,6 @@ type ReportedError struct {
 	Stack []uintptr
 }
 
-// MergeStatus is a temporary alias.
-type MergeStatus = kbfsmd.MergeStatus
-
 // OpSummary describes the changes performed by a single op, and is
 // suitable for encoding directly as JSON.
 type OpSummary struct {

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -71,9 +71,6 @@ type SessionInfo struct {
 	VerifyingKey   kbfscrypto.VerifyingKey
 }
 
-// EncryptedTLFCryptKeys is a temporary alias.
-type EncryptedTLFCryptKeys = kbfscrypto.EncryptedTLFCryptKeys
-
 // EncryptedTLFCryptKeyClientAndEphemeral has what's needed to
 // request a client half decryption.
 type EncryptedTLFCryptKeyClientAndEphemeral struct {

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -71,14 +71,6 @@ type SessionInfo struct {
 	VerifyingKey   kbfscrypto.VerifyingKey
 }
 
-// EncryptionVer is a temporary alias.
-type EncryptionVer = kbfscrypto.EncryptionVer
-
-// Temporary aliases.
-const (
-	EncryptionSecretbox EncryptionVer = kbfscrypto.EncryptionSecretbox
-)
-
 // EncryptedTLFCryptKeyClientHalf is a temporary alias.
 type EncryptedTLFCryptKeyClientHalf = kbfscrypto.EncryptedTLFCryptKeyClientHalf
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -71,9 +71,6 @@ type SessionInfo struct {
 	VerifyingKey   kbfscrypto.VerifyingKey
 }
 
-// EncryptedBlock is a temporary alias.
-type EncryptedBlock = kbfscrypto.EncryptedBlock
-
 // EncryptedTLFCryptKeys is a temporary alias.
 type EncryptedTLFCryptKeys = kbfscrypto.EncryptedTLFCryptKeys
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -82,11 +82,8 @@ type EncryptedTLFCryptKeyClientAndEphemeral struct {
 	EPubKey kbfscrypto.TLFEphemeralPublicKey
 }
 
-// MetadataVer is a temporary alias.
-type MetadataVer = kbfsmd.MetadataVer
-
 const (
-	defaultClientMetadataVer MetadataVer = kbfsmd.SegregatedKeyBundlesVer
+	defaultClientMetadataVer kbfsmd.MetadataVer = kbfsmd.SegregatedKeyBundlesVer
 )
 
 // DataVer is the type of a version for marshalled KBFS data

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -536,11 +536,6 @@ type ReportedError struct {
 // MergeStatus is a temporary alias.
 type MergeStatus = kbfsmd.MergeStatus
 
-// Temporary aliases.
-const (
-	Merged MergeStatus = kbfsmd.Merged
-)
-
 // OpSummary describes the changes performed by a single op, and is
 // suitable for encoding directly as JSON.
 type OpSummary struct {

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -586,7 +586,7 @@ func (e UnverifiableTlfUpdateError) Error() string {
 // and key generation wasn't found in cache.
 type KeyCacheMissError struct {
 	tlf    tlf.ID
-	keyGen KeyGen
+	keyGen kbfsmd.KeyGen
 }
 
 // Error implements the error interface for KeyCacheMissError.
@@ -598,7 +598,7 @@ func (e KeyCacheMissError) Error() string {
 // and key generation was found in cache but the object type was unknown.
 type KeyCacheHitError struct {
 	tlf    tlf.ID
-	keyGen KeyGen
+	keyGen kbfsmd.KeyGen
 }
 
 // Error implements the error interface for KeyCacheHitError.

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -324,7 +324,7 @@ func isArchivableOp(op op) bool {
 }
 
 func isArchivableMDOrError(md ReadOnlyRootMetadata) error {
-	if md.MergedStatus() != Merged {
+	if md.MergedStatus() != kbfsmd.Merged {
 		return fmt.Errorf("md rev=%d is not merged", md.Revision())
 	}
 
@@ -341,7 +341,7 @@ func isArchivableMDOrError(md ReadOnlyRootMetadata) error {
 func (fbm *folderBlockManager) archiveUnrefBlocks(md ReadOnlyRootMetadata) {
 	// Don't archive for unmerged revisions, because conflict
 	// resolution might undo some of the unreferences.
-	if md.MergedStatus() != Merged {
+	if md.MergedStatus() != kbfsmd.Merged {
 		return
 	}
 
@@ -360,7 +360,7 @@ func (fbm *folderBlockManager) archiveUnrefBlocks(md ReadOnlyRootMetadata) {
 func (fbm *folderBlockManager) archiveUnrefBlocksNoWait(md ReadOnlyRootMetadata) {
 	// Don't archive for unmerged revisions, because conflict
 	// resolution might undo some of the unreferences.
-	if md.MergedStatus() != Merged {
+	if md.MergedStatus() != kbfsmd.Merged {
 		return
 	}
 
@@ -761,7 +761,7 @@ func (fbm *folderBlockManager) getMostRecentOldEnoughAndGCRevisions(
 		}
 
 		rmds, err := getMDRange(ctx, fbm.config, fbm.id, kbfsmd.NullBranchID, startRev,
-			currHead, Merged, nil)
+			currHead, kbfsmd.Merged, nil)
 		if err != nil {
 			return kbfsmd.RevisionUninitialized,
 				kbfsmd.RevisionUninitialized, err
@@ -867,7 +867,7 @@ outer:
 		}
 
 		rmds, err := getMDRange(ctx, fbm.config, fbm.id, kbfsmd.NullBranchID, startRev,
-			currHead, Merged, nil)
+			currHead, kbfsmd.Merged, nil)
 		if err != nil {
 			return nil, kbfsmd.RevisionUninitialized, false, err
 		}
@@ -1041,7 +1041,7 @@ func (fbm *folderBlockManager) doReclamation(timer *time.Timer) (err error) {
 		return err
 	} else if err := isReadableOrError(ctx, fbm.config.KBPKI(), head.ReadOnly()); err != nil {
 		return err
-	} else if head.MergedStatus() != Merged {
+	} else if head.MergedStatus() != kbfsmd.Merged {
 		return errors.New("Supposedly fully-merged MD is unexpectedly unmerged")
 	} else if head.IsFinal() {
 		return kbfsmd.MetadataIsFinalError{}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -728,7 +728,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 	// If this is the first time the MD is being set, and we are
 	// operating on unmerged data, initialize the state properly and
 	// kick off conflict resolution.
-	if isFirstHead && md.MergedStatus() == Unmerged {
+	if isFirstHead && md.MergedStatus() == kbfsmd.Unmerged {
 		fbo.setBranchIDLocked(lState, md.BID())
 		// Use uninitialized for the merged branch; the unmerged
 		// revision is enough to trigger conflict resolution.
@@ -935,7 +935,7 @@ func (fbo *folderBranchOps) setHeadPredecessorLocked(ctx context.Context,
 		return errors.Errorf("setHeadPredecessorLocked unexpectedly called with revision %d", fbo.head.Revision())
 	}
 
-	if fbo.head.MergedStatus() != Unmerged {
+	if fbo.head.MergedStatus() != kbfsmd.Unmerged {
 		return errors.New("Unexpected merged head in setHeadPredecessorLocked")
 	}
 
@@ -969,7 +969,7 @@ func (fbo *folderBranchOps) setHeadConflictResolvedLocked(ctx context.Context,
 	lState *lockState, md ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-	if fbo.head.MergedStatus() != Unmerged {
+	if fbo.head.MergedStatus() != kbfsmd.Unmerged {
 		return errors.New("Unexpected merged head in setHeadConflictResolvedLocked")
 	}
 	if md.MergedStatus() != Merged {
@@ -1631,7 +1631,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 		fbo.mdWriterLock.Lock(lState)
 		defer fbo.mdWriterLock.Unlock(lState)
 
-		if md.MergedStatus() == Unmerged {
+		if md.MergedStatus() == kbfsmd.Unmerged {
 			mdops := fbo.config.MDOps()
 			mergedMD, err := mdops.GetForTLF(ctx, fbo.id(), nil)
 			if err != nil {
@@ -2165,7 +2165,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 
 			if excl == WithExcl {
 				// If this was caused by an exclusive create, we shouldn't do an
-				// UnmergedPut, but rather try to get newest update from server, and
+				// kbfsmd.UnmergedPut, but rather try to get newest update from server, and
 				// retry afterwards.
 				err = fbo.getAndApplyMDUpdates(ctx,
 					lState, nil, fbo.applyMDUpdatesLocked)
@@ -2200,7 +2200,7 @@ func (fbo *folderBranchOps) finalizeMDWriteLocked(ctx context.Context,
 			// data is cleared and the nodeCache is updated.  If we're
 			// wrong, and the update didn't make it to the server,
 			// then the next call will get an
-			// UnmergedSelfConflictError but fail to find any new
+			// kbfsmd.UnmergedSelfConflictError but fail to find any new
 			// updates and fail the operation, but things will get
 			// fixed up once conflict resolution finally completes.
 			//
@@ -2403,7 +2403,7 @@ func (fbo *folderBranchOps) finalizeGCOp(ctx context.Context, gco *GCOp) (
 		return err
 	}
 
-	if md.MergedStatus() == Unmerged {
+	if md.MergedStatus() == kbfsmd.Unmerged {
 		return UnexpectedUnmergedPutError{}
 	}
 
@@ -6068,7 +6068,7 @@ func (fbo *folderBranchOps) handleTLFBranchChange(ctx context.Context,
 		return
 	}
 
-	if md == (ImmutableRootMetadata{}) || md.MergedStatus() != Unmerged ||
+	if md == (ImmutableRootMetadata{}) || md.MergedStatus() != kbfsmd.Unmerged ||
 		md.BID() != newBID {
 		// This can happen if CR got kicked off in some other way and
 		// completed before we took the lock to process this

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -733,7 +733,7 @@ func (fbo *folderBranchOps) setHeadLocked(
 		// Use uninitialized for the merged branch; the unmerged
 		// revision is enough to trigger conflict resolution.
 		fbo.cr.Resolve(ctx, md.Revision(), kbfsmd.RevisionUninitialized)
-	} else if md.MergedStatus() == Merged {
+	} else if md.MergedStatus() == kbfsmd.Merged {
 		journalEnabled := TLFJournalEnabled(fbo.config, fbo.id())
 		if journalEnabled {
 			if isFirstHead {
@@ -972,7 +972,7 @@ func (fbo *folderBranchOps) setHeadConflictResolvedLocked(ctx context.Context,
 	if fbo.head.MergedStatus() != kbfsmd.Unmerged {
 		return errors.New("Unexpected merged head in setHeadConflictResolvedLocked")
 	}
-	if md.MergedStatus() != Merged {
+	if md.MergedStatus() != kbfsmd.Merged {
 		return errors.New("Unexpected unmerged update in setHeadConflictResolvedLocked")
 	}
 
@@ -1159,7 +1159,7 @@ func (fbo *folderBranchOps) getMostRecentFullyMergedMD(ctx context.Context) (
 
 	// Otherwise, use the specified revision.
 	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
-		mergedRev, Merged, nil)
+		mergedRev, kbfsmd.Merged, nil)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -5005,7 +5005,7 @@ func (fbo *folderBranchOps) undoUnmergedMDUpdatesLocked(
 	fbo.setBranchIDLocked(lState, kbfsmd.NullBranchID)
 
 	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
-		currHead, Merged, nil)
+		currHead, kbfsmd.Merged, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -6128,7 +6128,7 @@ func (fbo *folderBranchOps) handleMDFlush(ctx context.Context, bid kbfsmd.Branch
 
 	// Get that revision.
 	rmd, err := getSingleMD(ctx, fbo.config, fbo.id(), kbfsmd.NullBranchID,
-		rev, Merged, nil)
+		rev, kbfsmd.Merged, nil)
 	if err != nil {
 		fbo.log.CWarningf(ctx, "Couldn't get revision %d for archiving: %v",
 			rev, err)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1422,11 +1422,11 @@ func (fbo *folderBranchOps) initMDLocked(
 			handle, session.Name, handle.GetCanonicalPath())
 	}
 
-	var expectedKeyGen KeyGen
+	var expectedKeyGen kbfsmd.KeyGen
 	var tlfCryptKey *kbfscrypto.TLFCryptKey
 	switch md.TlfID().Type() {
 	case tlf.Public:
-		expectedKeyGen = PublicKeyGen
+		expectedKeyGen = kbfsmd.PublicKeyGen
 	case tlf.Private:
 		var rekeyDone bool
 		// create a new set of keys for this metadata
@@ -1438,7 +1438,7 @@ func (fbo *folderBranchOps) initMDLocked(
 			return errors.Errorf("Initial rekey unexpectedly not done for "+
 				"private TLF %v", md.TlfID())
 		}
-		expectedKeyGen = FirstValidKeyGen
+		expectedKeyGen = kbfsmd.FirstValidKeyGen
 	case tlf.SingleTeam:
 		// Teams get their crypt key from the service, no need to
 		// rekey in KBFS.
@@ -1447,11 +1447,11 @@ func (fbo *folderBranchOps) initMDLocked(
 			return err
 		}
 		keys, keyGen, err := fbo.config.KBPKI().GetTeamTLFCryptKeys(
-			ctx, tid, UnspecifiedKeyGen)
+			ctx, tid, kbfsmd.UnspecifiedKeyGen)
 		if err != nil {
 			return err
 		}
-		if keyGen < FirstValidKeyGen {
+		if keyGen < kbfsmd.FirstValidKeyGen {
 			return errors.WithStack(
 				kbfsmd.InvalidKeyGenerationError{TlfID: md.TlfID(), KeyGen: keyGen})
 		}
@@ -5290,7 +5290,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 
 	// send rekey finish notification
 	handle := md.GetTlfHandle()
-	if currKeyGen >= FirstValidKeyGen && rekeyDone {
+	if currKeyGen >= kbfsmd.FirstValidKeyGen && rekeyDone {
 		fbo.config.Reporter().Notify(ctx,
 			rekeyNotification(ctx, fbo.config, handle, true))
 	}

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -24,7 +24,7 @@ type FolderBranchStatus struct {
 	HeadWriter          libkb.NormalizedUsername
 	DiskUsage           uint64
 	RekeyPending        bool
-	LatestKeyGeneration KeyGen
+	LatestKeyGeneration kbfsmd.KeyGen
 	FolderID            string
 	Revision            kbfsmd.Revision
 	MDVersion           MetadataVer

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -27,7 +27,7 @@ type FolderBranchStatus struct {
 	LatestKeyGeneration kbfsmd.KeyGen
 	FolderID            string
 	Revision            kbfsmd.Revision
-	MDVersion           MetadataVer
+	MDVersion           kbfsmd.MetadataVer
 	RootBlockID         string
 	SyncEnabled         bool
 	PrefetchStatus      string

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
+	"github.com/keybase/kbfs/kbfsmd"
 )
 
 const (
@@ -145,13 +146,13 @@ func defaultMDServer(ctx Context) string {
 func defaultMetadataVersion(ctx Context) MetadataVer {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
-		return SegregatedKeyBundlesVer
+		return kbfsmd.SegregatedKeyBundlesVer
 	case libkb.StagingRunMode:
-		return SegregatedKeyBundlesVer
+		return kbfsmd.SegregatedKeyBundlesVer
 	case libkb.ProductionRunMode:
-		return SegregatedKeyBundlesVer
+		return kbfsmd.SegregatedKeyBundlesVer
 	default:
-		return SegregatedKeyBundlesVer
+		return kbfsmd.SegregatedKeyBundlesVer
 	}
 }
 

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -70,7 +70,7 @@ type InitParams struct {
 
 	// MetadataVersion is the default version of metadata to use
 	// when creating new metadata.
-	MetadataVersion MetadataVer
+	MetadataVersion kbfsmd.MetadataVer
 
 	// LogToFile if true, logs to a default file location.
 	LogToFile bool
@@ -143,7 +143,7 @@ func defaultMDServer(ctx Context) string {
 }
 
 // defaultMetadataVersion returns the default metadata version per run mode.
-func defaultMetadataVersion(ctx Context) MetadataVer {
+func defaultMetadataVersion(ctx Context) kbfsmd.MetadataVer {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
 		return kbfsmd.SegregatedKeyBundlesVer
@@ -601,7 +601,7 @@ func doInit(
 		config.SetKeyBundleCache(keyBundleCache)
 	}
 
-	config.SetMetadataVersion(MetadataVer(params.MetadataVersion))
+	config.SetMetadataVersion(kbfsmd.MetadataVer(params.MetadataVersion))
 	config.SetTLFValidDuration(params.TLFValidDuration)
 	config.SetBGFlushPeriod(params.BGFlushPeriod)
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -659,7 +659,7 @@ type KeyMetadata interface {
 		keyGen KeyGen, user keybase1.UID,
 		key kbfscrypto.CryptPublicKey) (
 		kbfscrypto.TLFEphemeralPublicKey,
-		EncryptedTLFCryptKeyClientHalf,
+		kbfscrypto.EncryptedTLFCryptKeyClientHalf,
 		TLFCryptKeyServerHalfID, bool, error)
 
 	// StoresHistoricTLFCryptKeys returns whether or not history keys are
@@ -1016,10 +1016,10 @@ type cryptoPure interface {
 	// EncryptPrivateMetadata encrypts a PrivateMetadata object.
 	EncryptPrivateMetadata(
 		pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (
-		EncryptedPrivateMetadata, error)
+		kbfscrypto.EncryptedPrivateMetadata, error)
 	// DecryptPrivateMetadata decrypts a PrivateMetadata object.
 	DecryptPrivateMetadata(
-		encryptedPMD EncryptedPrivateMetadata,
+		encryptedPMD kbfscrypto.EncryptedPrivateMetadata,
 		key kbfscrypto.TLFCryptKey) (PrivateMetadata, error)
 
 	// EncryptBlocks encrypts a block. plainSize is the size of the encoded
@@ -1050,7 +1050,7 @@ type Crypto interface {
 	// private key and the TLF's ephemeral public key.
 	DecryptTLFCryptKeyClientHalf(ctx context.Context,
 		publicKey kbfscrypto.TLFEphemeralPublicKey,
-		encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (
+		encryptedClientHalf kbfscrypto.EncryptedTLFCryptKeyClientHalf) (
 		kbfscrypto.TLFCryptKeyClientHalf, error)
 
 	// DecryptTLFCryptKeyClientHalfAny decrypts one of the

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1026,12 +1026,12 @@ type cryptoPure interface {
 	// block; EncryptBlock() must guarantee that plainSize <=
 	// len(encryptedBlock).
 	EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (
-		plainSize int, encryptedBlock EncryptedBlock, err error)
+		plainSize int, encryptedBlock kbfscrypto.EncryptedBlock, err error)
 
 	// DecryptBlock decrypts a block. Similar to EncryptBlock(),
 	// DecryptBlock() must guarantee that (size of the decrypted
 	// block) <= len(encryptedBlock).
-	DecryptBlock(encryptedBlock EncryptedBlock,
+	DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock,
 		key kbfscrypto.BlockCryptKey, block Block) error
 }
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -440,7 +440,7 @@ type KeybaseService interface {
 	// isn't a member of the team yet according to local caches; it
 	// may be set to "" if no server check is required.
 	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
-		desiredKeyGen KeyGen, desiredUser keybase1.UserVersion,
+		desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
 		desiredRole keybase1.TeamRole) (TeamInfo, error)
 
 	// CurrentSession returns a SessionInfo struct with all the
@@ -556,8 +556,8 @@ type teamKeysGetter interface {
 	// check if that particular key gen isn't yet known; it may be set
 	// to UnspecifiedKeyGen if no server check is required.
 	GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID,
-		desiredKeyGen KeyGen) (
-		map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error)
+		desiredKeyGen kbfsmd.KeyGen) (
+		map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error)
 }
 
 type teamRootIDGetter interface {
@@ -628,7 +628,7 @@ type KeyMetadata interface {
 	// LatestKeyGeneration returns the most recent key generation
 	// with key data in this object, or PublicKeyGen if this TLF
 	// is public.
-	LatestKeyGeneration() KeyGen
+	LatestKeyGeneration() kbfsmd.KeyGen
 
 	// GetTlfHandle returns the handle for the TLF. It must not
 	// return nil.
@@ -656,7 +656,7 @@ type KeyMetadata interface {
 	// false if not found. This returns an error if the TLF is
 	// public.
 	GetTLFCryptKeyParams(
-		keyGen KeyGen, user keybase1.UID,
+		keyGen kbfsmd.KeyGen, user keybase1.UID,
 		key kbfscrypto.CryptPublicKey) (
 		kbfscrypto.TLFEphemeralPublicKey,
 		kbfscrypto.EncryptedTLFCryptKeyClientHalf,
@@ -668,7 +668,7 @@ type KeyMetadata interface {
 
 	// GetHistoricTLFCryptKey attempts to symmetrically decrypt the key at the given
 	// generation using the current generation's TLFCryptKey.
-	GetHistoricTLFCryptKey(codec kbfscodec.Codec, keyGen KeyGen,
+	GetHistoricTLFCryptKey(codec kbfscodec.Codec, keyGen kbfsmd.KeyGen,
 		currentKey kbfscrypto.TLFCryptKey) (
 		kbfscrypto.TLFCryptKey, error)
 }
@@ -782,9 +782,9 @@ type MDCache interface {
 // KeyCache handles caching for both TLFCryptKeys and BlockCryptKeys.
 type KeyCache interface {
 	// GetTLFCryptKey gets the crypt key for the given TLF.
-	GetTLFCryptKey(tlf.ID, KeyGen) (kbfscrypto.TLFCryptKey, error)
+	GetTLFCryptKey(tlf.ID, kbfsmd.KeyGen) (kbfscrypto.TLFCryptKey, error)
 	// PutTLFCryptKey stores the crypt key for the given TLF.
-	PutTLFCryptKey(tlf.ID, KeyGen, kbfscrypto.TLFCryptKey) error
+	PutTLFCryptKey(tlf.ID, kbfsmd.KeyGen, kbfscrypto.TLFCryptKey) error
 }
 
 // BlockCacheLifetime denotes the lifetime of an entry in BlockCache.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1084,7 +1084,7 @@ type MDOps interface {
 	// returned, but if it is non-empty, then its ID must match
 	// the returned ID.
 	GetForHandle(
-		ctx context.Context, handle *TlfHandle, mStatus MergeStatus,
+		ctx context.Context, handle *TlfHandle, mStatus kbfsmd.MergeStatus,
 		lockBeforeGet *keybase1.LockID) (tlf.ID, ImmutableRootMetadata, error)
 
 	// GetForTLF returns the current metadata object
@@ -1295,7 +1295,7 @@ type MDServer interface {
 	// returned, but if it is non-nil, then its ID must match the
 	// returned ID.
 	GetForHandle(ctx context.Context, handle tlf.Handle,
-		mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (
+		mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 		tlf.ID, *RootMetadataSigned, error)
 
 	// GetForTLF returns the current (signed/encrypted) metadata object
@@ -1305,7 +1305,7 @@ type MDServer interface {
 	// If lockBeforeGet is not nil, it takes a lock on the lock ID before
 	// trying to get anything. If taking the lock fails, an error is returned.
 	// Note that taking a lock from the mdserver is idempotent.
-	GetForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	GetForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 		lockBeforeGet *keybase1.LockID) (*RootMetadataSigned, error)
 
 	// GetRange returns a range of (signed/encrypted) metadata objects
@@ -1314,7 +1314,7 @@ type MDServer interface {
 	// If lockBeforeGet is not nil, it takes a lock on the lock ID before
 	// trying to get anything. If taking the lock fails, an error is returned.
 	// Note that taking a lock from the mdserver is idempotent.
-	GetRange(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	GetRange(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 		start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) (
 		[]*RootMetadataSigned, error)
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1726,8 +1726,8 @@ type Config interface {
 	SetClock(Clock)
 	ConflictRenamer() ConflictRenamer
 	SetConflictRenamer(ConflictRenamer)
-	MetadataVersion() MetadataVer
-	SetMetadataVersion(MetadataVer)
+	MetadataVersion() kbfsmd.MetadataVer
+	SetMetadataVersion(kbfsmd.MetadataVer)
 	DefaultBlockType() keybase1.BlockType
 	SetDefaultBlockType(blockType keybase1.BlockType)
 	RekeyQueue() RekeyQueue

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -77,7 +77,7 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 // kbfsmd.NullBranchID and mStatus is Unmerged, the branch ID check is
 // skipped.
 func (j journalMDOps) getHeadFromJournal(
-	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 	handle *TlfHandle) (
 	ImmutableRootMetadata, error) {
 	tlfJournal, ok := j.jServer.getTLFJournal(id, handle)
@@ -157,7 +157,7 @@ func (j journalMDOps) getHeadFromJournal(
 }
 
 func (j journalMDOps) getRangeFromJournal(
-	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 	start, stop kbfsmd.Revision) (
 	[]ImmutableRootMetadata, error) {
 	tlfJournal, ok := j.jServer.getTLFJournal(id, nil)
@@ -223,7 +223,7 @@ func (j journalMDOps) getRangeFromJournal(
 }
 
 func (j journalMDOps) GetForHandle(ctx context.Context, handle *TlfHandle,
-	mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (
+	mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	tlfID tlf.ID, rmd ImmutableRootMetadata, err error) {
 	// TODO: Ideally, *TlfHandle would have a nicer String() function.
 	j.jServer.log.LazyTrace(ctx, "jMDOps: GetForHandle %+v %s", handle, mStatus)
@@ -289,7 +289,7 @@ func (j journalMDOps) GetForHandle(ctx context.Context, handle *TlfHandle,
 // TODO: Combine the two GetForTLF functions in MDOps to avoid the
 // need for this helper function.
 func (j journalMDOps) getForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID,
-	mStatus MergeStatus, lockBeforeGet *keybase1.LockID,
+	mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID,
 	delegateFn func(context.Context, tlf.ID, *keybase1.LockID) (
 		ImmutableRootMetadata, error)) (ImmutableRootMetadata, error) {
 	// If the journal has a head, use that.
@@ -335,7 +335,7 @@ func (j journalMDOps) GetUnmergedForTLF(
 // TODO: Combine the two GetRange functions in MDOps to avoid the need
 // for this helper function.
 func (j journalMDOps) getRange(
-	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 	start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID,
 	delegateFn func(ctx context.Context, id tlf.ID,
 		start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) (

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -85,7 +85,7 @@ func (j journalMDOps) getHeadFromJournal(
 		return ImmutableRootMetadata{}, nil
 	}
 
-	if mStatus == Unmerged && bid == kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Unmerged && bid == kbfsmd.NullBranchID {
 		// We need to look up the branch ID because the caller didn't
 		// know it.
 		var err error
@@ -113,7 +113,7 @@ func (j journalMDOps) getHeadFromJournal(
 		return ImmutableRootMetadata{}, nil
 	}
 
-	if mStatus == Unmerged && bid != kbfsmd.NullBranchID && bid != head.BID() {
+	if mStatus == kbfsmd.Unmerged && bid != kbfsmd.NullBranchID && bid != head.BID() {
 		// The given branch ID doesn't match the one in the
 		// journal, which can only be an error.
 		return ImmutableRootMetadata{},
@@ -185,7 +185,7 @@ func (j journalMDOps) getRangeFromJournal(
 		return nil, nil
 	}
 
-	if mStatus == Unmerged && bid != kbfsmd.NullBranchID && bid != head.BID() {
+	if mStatus == kbfsmd.Unmerged && bid != kbfsmd.NullBranchID && bid != head.BID() {
 		// The given branch ID doesn't match the one in the
 		// journal, which can only be an error.
 		return nil, fmt.Errorf("Expected branch ID %s, got %s",
@@ -329,7 +329,7 @@ func (j journalMDOps) GetUnmergedForTLF(
 		ImmutableRootMetadata, error) {
 		return j.MDOps.GetUnmergedForTLF(ctx, id, bid)
 	}
-	return j.getForTLF(ctx, id, bid, Unmerged, nil, delegateFn)
+	return j.getForTLF(ctx, id, bid, kbfsmd.Unmerged, nil, delegateFn)
 }
 
 // TODO: Combine the two GetRange functions in MDOps to avoid the need
@@ -431,7 +431,7 @@ func (j journalMDOps) GetUnmergedRange(
 		[]ImmutableRootMetadata, error) {
 		return j.MDOps.GetUnmergedRange(ctx, id, bid, start, stop)
 	}
-	return j.getRange(ctx, id, bid, Unmerged, start, stop, nil,
+	return j.getRange(ctx, id, bid, kbfsmd.Unmerged, start, stop, nil,
 		delegateFn)
 }
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -247,7 +247,7 @@ func (j journalMDOps) GetForHandle(ctx context.Context, handle *TlfHandle,
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
 	tlfID, _, err = j.jServer.config.MDServer().GetForHandle(
-		ctx, bh, Merged, lockBeforeGet)
+		ctx, bh, kbfsmd.Merged, lockBeforeGet)
 	if err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
@@ -314,7 +314,7 @@ func (j journalMDOps) GetForTLF(
 	}()
 
 	return j.getForTLF(
-		ctx, id, kbfsmd.NullBranchID, Merged, lockBeforeGet, j.MDOps.GetForTLF)
+		ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, lockBeforeGet, j.MDOps.GetForTLF)
 }
 
 func (j journalMDOps) GetUnmergedForTLF(
@@ -414,7 +414,7 @@ func (j journalMDOps) GetRange(ctx context.Context, id tlf.ID, start,
 		j.jServer.deferLog.LazyTrace(ctx, "jMDOps: GetRange %s %d-%d done (err=%v)", id, start, stop, err)
 	}()
 
-	return j.getRange(ctx, id, kbfsmd.NullBranchID, Merged, start, stop, lockBeforeGet,
+	return j.getRange(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, start, stop, lockBeforeGet,
 		j.MDOps.GetRange)
 }
 

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -206,7 +206,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, kbfsmd.Revision(10), head.Revision())
 
-	_, head, err = mdOps.GetForHandle(ctx, h, Unmerged, nil)
+	_, head, err = mdOps.GetForHandle(ctx, h, kbfsmd.Unmerged, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, ImmutableRootMetadata{}, head)
 	require.Equal(t, kbfsmd.Revision(10), head.Revision())

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -112,7 +112,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 
 	mdOps := jServer.mdOps()
 
-	id, irmd, err := mdOps.GetForHandle(ctx, h, Merged, nil)
+	id, irmd, err := mdOps.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
@@ -137,7 +137,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 		prevRoot = irmd.mdID
 	}
 
-	id, head, err := mdOps.GetForHandle(ctx, h, Merged, nil)
+	id, head, err := mdOps.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, tlf.NullID, id)
 	require.NotEqual(t, ImmutableRootMetadata{}, head)
@@ -296,7 +296,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 
 	mdOps := jServer.mdOps()
 
-	id, irmd, err := mdOps.GetForHandle(ctx, h, Merged, nil)
+	id, irmd, err := mdOps.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
@@ -328,7 +328,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 
 	mdOps := jServer.mdOps()
 
-	id, irmd, err := mdOps.GetForHandle(ctx, h, Merged, nil)
+	id, irmd, err := mdOps.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
@@ -357,7 +357,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
-	id, irmd, err := mdOps.GetForHandle(ctx, h, Merged, nil)
+	id, irmd, err := mdOps.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
 	err = jServer.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -784,7 +785,7 @@ func TestJournalServerTeamTLFWithRestart(t *testing.T) {
 
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
-	rmd.bareMd.SetLatestKeyGenerationForTeamTLF(FirstValidKeyGen)
+	rmd.bareMd.SetLatestKeyGenerationForTeamTLF(kbfsmd.FirstValidKeyGen)
 
 	_, err = mdOps.Put(ctx, rmd, session.VerifyingKey,
 		nil, keybase1.MDPriorityNormal)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -396,7 +396,7 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 		return rmd, nil
 	}
 
-	_, rmd, err = fs.config.MDOps().GetForHandle(ctx, tlfHandle, Unmerged, nil)
+	_, rmd, err = fs.config.MDOps().GetForHandle(ctx, tlfHandle, kbfsmd.Unmerged, nil)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -473,7 +473,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 	// Do GetForHandle() unlocked -- no cache lookups, should be fine
 	mdops := fs.config.MDOps()
 	// TODO: only do this the first time, cache the folder ID after that
-	_, md, err := mdops.GetForHandle(ctx, h, Unmerged, nil)
+	_, md, err := mdops.GetForHandle(ctx, h, kbfsmd.Unmerged, nil)
 	if err != nil {
 		return nil, EntryInfo{}, err
 	}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -340,7 +340,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		}
 	}()
 
-	id, md, err = mdops.GetForHandle(ctx, h, Merged, nil)
+	id, md, err = mdops.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, id, err
 	}
@@ -369,7 +369,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		return false, ImmutableRootMetadata{}, id, err
 	}
 
-	id, md, err = mdops.GetForHandle(ctx, h, Merged, nil)
+	id, md, err = mdops.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, id, err
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -334,11 +334,11 @@ func makeImmutableRMDForTest(t *testing.T, config Config, rmd *RootMetadata,
 func injectNewRMD(t *testing.T, config *ConfigMock) (
 	keybase1.UserOrTeamID, tlf.ID, *RootMetadata) {
 	id, h, rmd := createNewRMD(t, config, "alice", tlf.Private)
-	var keyGen KeyGen
+	var keyGen kbfsmd.KeyGen
 	if id.Type() == tlf.Public {
-		keyGen = PublicKeyGen
+		keyGen = kbfsmd.PublicKeyGen
 	} else {
-		keyGen = 1
+		keyGen = kbfsmd.FirstValidKeyGen
 	}
 	rmd.data.Dir = DirEntry{
 		BlockInfo: BlockInfo{
@@ -512,7 +512,7 @@ func fillInNewMD(t *testing.T, config *ConfigMock, rmd *RootMetadata) {
 	}
 	rootPtr := BlockPointer{
 		ID:      kbfsblock.FakeID(42),
-		KeyGen:  1,
+		KeyGen:  kbfsmd.FirstValidKeyGen,
 		DataVer: 1,
 	}
 
@@ -659,7 +659,7 @@ func makeIFP(id kbfsblock.ID, kmd KeyMetadata, config Config,
 func makeBIFromID(id kbfsblock.ID, user keybase1.UserOrTeamID) BlockInfo {
 	return BlockInfo{
 		BlockPointer: BlockPointer{
-			ID: id, KeyGen: 1, DataVer: 1,
+			ID: id, KeyGen: kbfsmd.FirstValidKeyGen, DataVer: 1,
 			Context: kbfsblock.Context{
 				Creator: user,
 			},
@@ -925,7 +925,7 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 	}
 	bPath := ops.nodeCache.PathFromNode(bn)
 	expectedBNode := pathNode{makeBP(bID, rmd, config, u), "b"}
-	expectedBNode.KeyGen = 1
+	expectedBNode.KeyGen = kbfsmd.FirstValidKeyGen
 	if ei != dirBlock.Children["b"].EntryInfo {
 		t.Errorf("Lookup returned a bad entry info: %v vs %v",
 			ei, dirBlock.Children["b"].EntryInfo)
@@ -2250,7 +2250,7 @@ func TestKBFSOpsWriteOverMultipleBlocks(t *testing.T) {
 	id2 := kbfsblock.FakeID(45)
 	rootBlock := NewDirBlock().(*DirBlock)
 	filePtr := BlockPointer{
-		ID: fileID, KeyGen: 1, DataVer: 1,
+		ID: fileID, KeyGen: kbfsmd.FirstValidKeyGen, DataVer: 1,
 		Context: kbfsblock.Context{
 			Creator: uid,
 		},

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -587,7 +587,7 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, kbfsmd.Unmerged,
 		nil).Return(tlf.ID{}, ImmutableRootMetadata{}, nil)
 	config.mockMdops.EXPECT().GetForHandle(
-		gomock.Any(), h, Merged, nil).Return(tlf.ID{},
+		gomock.Any(), h, kbfsmd.Merged, nil).Return(tlf.ID{},
 		makeImmutableRMDForTest(t, config, rmd, kbfsmd.FakeID(1)), nil)
 	ops := getOps(config, id)
 	assert.False(t, fboIdentityDone(ops))

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -584,7 +584,7 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 		},
 	}
 
-	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, Unmerged,
+	config.mockMdops.EXPECT().GetForHandle(gomock.Any(), h, kbfsmd.Unmerged,
 		nil).Return(tlf.ID{}, ImmutableRootMetadata{}, nil)
 	config.mockMdops.EXPECT().GetForHandle(
 		gomock.Any(), h, Merged, nil).Return(tlf.ID{},

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"golang.org/x/net/context"
 )
 
@@ -197,8 +198,8 @@ func (k *KBPKIClient) GetCryptPublicKeys(ctx context.Context,
 
 // GetTeamTLFCryptKeys implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) GetTeamTLFCryptKeys(
-	ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (
-	map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+	ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (
+	map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
 		ctx, tid, desiredKeyGen, keybase1.UserVersion{}, keybase1.TeamRole_NONE)
 	if err != nil {
@@ -252,7 +253,7 @@ func (k *KBPKIClient) IsTeamWriter(
 		EldestSeqno: userInfo.EldestSeqno,
 	}
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, desiredUser, keybase1.TeamRole_WRITER)
+		ctx, tid, kbfsmd.UnspecifiedKeyGen, desiredUser, keybase1.TeamRole_WRITER)
 	if err != nil {
 		return false, err
 	}
@@ -264,7 +265,7 @@ func (k *KBPKIClient) IsTeamReader(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	desiredUser := keybase1.UserVersion{Uid: uid}
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, desiredUser, keybase1.TeamRole_READER)
+		ctx, tid, kbfsmd.UnspecifiedKeyGen, desiredUser, keybase1.TeamRole_READER)
 	if err != nil {
 		return false, err
 	}
@@ -279,7 +280,7 @@ func (k *KBPKIClient) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
 	}
 
 	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, UnspecifiedKeyGen, keybase1.UserVersion{},
+		ctx, tid, kbfsmd.UnspecifiedKeyGen, keybase1.UserVersion{},
 		keybase1.TeamRole_NONE)
 	if err != nil {
 		return keybase1.TeamID(""), err

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"golang.org/x/net/context"
 )
 
@@ -206,7 +207,7 @@ func TestKBPKIClientGetTeamTLFCryptKeys(t *testing.T) {
 
 	for _, team := range localTeams {
 		keys, keyGen, err := c.GetTeamTLFCryptKeys(
-			context.Background(), team.TID, UnspecifiedKeyGen)
+			context.Background(), team.TID, kbfsmd.UnspecifiedKeyGen)
 		if err != nil {
 			t.Error(err)
 		}
@@ -214,7 +215,7 @@ func TestKBPKIClientGetTeamTLFCryptKeys(t *testing.T) {
 			t.Errorf("Team TLF crypt keys don't match: %v vs %v",
 				team.CryptKeys, keys)
 		}
-		if keyGen != FirstValidKeyGen {
+		if keyGen != kbfsmd.FirstValidKeyGen {
 			t.Errorf("Unexpected team key gen: %v", keyGen)
 		}
 	}

--- a/libkbfs/kcache_measured.go
+++ b/libkbfs/kcache_measured.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	metrics "github.com/rcrowley/go-metrics"
 )
@@ -41,7 +42,7 @@ func NewKeyCacheMeasured(delegate KeyCache, r metrics.Registry) KeyCacheMeasured
 // GetTLFCryptKey implements the KeyCache interface for
 // KeyCacheMeasured.
 func (b KeyCacheMeasured) GetTLFCryptKey(
-	tlfID tlf.ID, keyGen KeyGen) (key kbfscrypto.TLFCryptKey, err error) {
+	tlfID tlf.ID, keyGen kbfsmd.KeyGen) (key kbfscrypto.TLFCryptKey, err error) {
 	b.getTimer.Time(func() {
 		key, err = b.delegate.GetTLFCryptKey(tlfID, keyGen)
 	})
@@ -54,7 +55,7 @@ func (b KeyCacheMeasured) GetTLFCryptKey(
 // PutTLFCryptKey implements the KeyCache interface for
 // KeyCacheMeasured.
 func (b KeyCacheMeasured) PutTLFCryptKey(
-	tlfID tlf.ID, keyGen KeyGen, key kbfscrypto.TLFCryptKey) (err error) {
+	tlfID tlf.ID, keyGen kbfsmd.KeyGen, key kbfscrypto.TLFCryptKey) (err error) {
 	b.putTimer.Time(func() {
 		err = b.delegate.PutTLFCryptKey(tlfID, keyGen, key)
 	})

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -60,7 +60,7 @@ func (km *KeyManagerStandard) GetTLFCryptKeyForBlockDecryption(
 func (km *KeyManagerStandard) GetTLFCryptKeyOfAllGenerations(
 	ctx context.Context, kmd KeyMetadata) (
 	keys []kbfscrypto.TLFCryptKey, err error) {
-	for g := FirstValidKeyGen; g <= kmd.LatestKeyGeneration(); g++ {
+	for g := kbfsmd.FirstValidKeyGen; g <= kmd.LatestKeyGeneration(); g++ {
 		var key kbfscrypto.TLFCryptKey
 		key, err = km.getTLFCryptKeyUsingCurrentDevice(ctx, kmd, g, true)
 		if err != nil {
@@ -72,7 +72,7 @@ func (km *KeyManagerStandard) GetTLFCryptKeyOfAllGenerations(
 }
 
 func (km *KeyManagerStandard) getTLFCryptKeyUsingCurrentDevice(
-	ctx context.Context, kmd KeyMetadata, keyGen KeyGen, cache bool) (
+	ctx context.Context, kmd KeyMetadata, keyGen kbfsmd.KeyGen, cache bool) (
 	tlfCryptKey kbfscrypto.TLFCryptKey, err error) {
 	flags := getTLFCryptKeyFlags(0)
 	if cache {
@@ -90,7 +90,7 @@ const (
 )
 
 func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
-	kmd KeyMetadata, keyGen KeyGen, flags getTLFCryptKeyFlags) (
+	kmd KeyMetadata, keyGen kbfsmd.KeyGen, flags getTLFCryptKeyFlags) (
 	kbfscrypto.TLFCryptKey, error) {
 	tlfID := kmd.TlfID()
 
@@ -98,7 +98,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 		return kbfscrypto.PublicTLFCryptKey, nil
 	}
 
-	if keyGen < FirstValidKeyGen {
+	if keyGen < kbfsmd.FirstValidKeyGen {
 		return kbfscrypto.TLFCryptKey{}, kbfsmd.InvalidKeyGenerationError{TlfID: tlfID, KeyGen: keyGen}
 	}
 	// Is this some key we don't know yet?  Shouldn't really ever happen,
@@ -209,7 +209,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 
 func (km *KeyManagerStandard) getTLFCryptKeyParams(
 	ctx context.Context, kmd KeyMetadata,
-	keyGen KeyGen, uid keybase1.UID, username libkb.NormalizedUsername,
+	keyGen kbfsmd.KeyGen, uid keybase1.UID, username libkb.NormalizedUsername,
 	flags getTLFCryptKeyFlags) (
 	clientHalf kbfscrypto.TLFCryptKeyClientHalf,
 	serverHalfID TLFCryptKeyServerHalfID,
@@ -487,11 +487,11 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	}
 
 	currKeyGen := md.LatestKeyGeneration()
-	if (md.TlfID().Type() == tlf.Public) != (currKeyGen == PublicKeyGen) {
+	if (md.TlfID().Type() == tlf.Public) != (currKeyGen == kbfsmd.PublicKeyGen) {
 		return false, nil, errors.Errorf(
 			"ID %v has type=%s but currKeyGen is %d (isPublic=%t)",
 			md.TlfID(), md.TlfID().Type(), currKeyGen,
-			currKeyGen == PublicKeyGen)
+			currKeyGen == kbfsmd.PublicKeyGen)
 	}
 
 	if promptPaper && md.TlfID().Type() != tlf.Private {
@@ -566,7 +566,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// Decide whether we have a new device and/or a revoked device, or neither.
 	// Look up all the device public keys for all writers and readers first.
 
-	incKeyGen := currKeyGen < FirstValidKeyGen
+	incKeyGen := currKeyGen < kbfsmd.FirstValidKeyGen
 
 	if !isWriter && incKeyGen {
 		// Readers cannot create the first key generation
@@ -784,7 +784,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// generation though, since that's not really a "re"key.
 	//
 	// TODO: Shouldn't this happen earlier?
-	if currKeyGen >= FirstValidKeyGen {
+	if currKeyGen >= kbfsmd.FirstValidKeyGen {
 		km.config.Reporter().Notify(ctx, rekeyNotification(
 			ctx, km.config, resolvedHandle, false))
 	}
@@ -795,7 +795,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// the latest key generation.
 	//
 	// TODO: Add test coverage for this.
-	if currKeyGen >= FirstValidKeyGen {
+	if currKeyGen >= kbfsmd.FirstValidKeyGen {
 		allRemovalInfo, err := md.revokeRemovedDevices(
 			updatedWriterKeys, updatedReaderKeys)
 		if err != nil {
@@ -838,7 +838,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	// symmetrically encrypted and appended to a list for MDv3
 	// metadata.
 	var currTLFCryptKey kbfscrypto.TLFCryptKey
-	if md.StoresHistoricTLFCryptKeys() && currKeyGen >= FirstValidKeyGen {
+	if md.StoresHistoricTLFCryptKeys() && currKeyGen >= kbfsmd.FirstValidKeyGen {
 		flags := getTLFCryptKeyAnyDevice
 		if promptPaper {
 			flags |= getTLFCryptKeyPromptPaper

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2349,7 +2349,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 		name: tlf.CanonicalName(name),
 	}
 
-	rmd, err := makeInitialRootMetadata(SegregatedKeyBundlesVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
 	rmd.bareMd.SetLatestKeyGenerationForTeamTLF(teamInfos[0].LatestKeyGen)
 	// Make sure the MD looks readable.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -27,7 +27,7 @@ type shimKMCrypto struct {
 	pure cryptoPure
 }
 
-func keyManagerInit(t *testing.T, ver MetadataVer) (mockCtrl *gomock.Controller,
+func keyManagerInit(t *testing.T, ver kbfsmd.MetadataVer) (mockCtrl *gomock.Controller,
 	config *ConfigMock, ctx context.Context) {
 	ctr := NewSafeTestReporter(t)
 	mockCtrl = gomock.NewController(ctr)
@@ -176,7 +176,7 @@ func (kmd emptyKeyMetadata) GetHistoricTLFCryptKey(
 	return kbfscrypto.TLFCryptKey{}, nil
 }
 
-func testKeyManagerPublicTLFCryptKey(t *testing.T, ver MetadataVer) {
+func testKeyManagerPublicTLFCryptKey(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -217,7 +217,7 @@ func testKeyManagerPublicTLFCryptKey(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testKeyManagerCachedSecretKeyForEncryptionSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerCachedSecretKeyForEncryptionSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -233,7 +233,7 @@ func testKeyManagerCachedSecretKeyForEncryptionSuccess(t *testing.T, ver Metadat
 	require.Equal(t, cachedTLFCryptKey, tlfCryptKey)
 }
 
-func testKeyManagerCachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerCachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -249,7 +249,7 @@ func testKeyManagerCachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver Metad
 	require.Equal(t, cachedTLFCryptKey, tlfCryptKey)
 }
 
-func testKeyManagerCachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerCachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -275,7 +275,7 @@ func makeDirWKeyInfoMap(uid keybase1.UID,
 	}
 }
 
-func testKeyManagerUncachedSecretKeyForEncryptionSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerUncachedSecretKeyForEncryptionSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -308,7 +308,7 @@ func testKeyManagerUncachedSecretKeyForEncryptionSuccess(t *testing.T, ver Metad
 	require.Equal(t, storedTLFCryptKey, tlfCryptKey)
 }
 
-func testKeyManagerUncachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerUncachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -339,7 +339,7 @@ func testKeyManagerUncachedSecretKeyForMDDecryptionSuccess(t *testing.T, ver Met
 	require.Equal(t, storedTLFCryptKey, tlfCryptKey)
 }
 
-func testKeyManagerUncachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerUncachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -388,7 +388,7 @@ func testKeyManagerUncachedSecretKeyForBlockDecryptionSuccess(t *testing.T, ver 
 	require.Equal(t, storedTLFCryptKey1, tlfCryptKey)
 }
 
-func testKeyManagerRekeySuccessPrivate(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeySuccessPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -409,7 +409,7 @@ func testKeyManagerRekeySuccessPrivate(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -449,7 +449,7 @@ func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver MetadataVer)
 	require.NoError(t, err)
 }
 
-func testKeyManagerRekeyResolveAgainSuccessPublicSelf(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyResolveAgainSuccessPublicSelf(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -484,7 +484,7 @@ func testKeyManagerRekeyResolveAgainSuccessPublicSelf(t *testing.T, ver Metadata
 	rmd.tlfHandle = oldHandle
 }
 
-func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -573,7 +573,7 @@ func hasReaderKey(t *testing.T, rmd *RootMetadata, uid keybase1.UID) bool {
 	return len(readers[uid]) > 0
 }
 
-func testKeyManagerPromoteReaderSuccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerPromoteReaderSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	ctx := context.Background()
 
 	config := MakeTestConfigOrBust(t, "alice", "bob")
@@ -621,7 +621,7 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver MetadataVer) {
 		newH.GetCanonicalName())
 }
 
-func testKeyManagerPromoteReaderSelf(t *testing.T, ver MetadataVer) {
+func testKeyManagerPromoteReaderSelf(t *testing.T, ver kbfsmd.MetadataVer) {
 	ctx := context.Background()
 
 	config := MakeTestConfigOrBust(t, "alice", "bob")
@@ -671,7 +671,7 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver MetadataVer) {
 		newH.GetCanonicalName())
 }
 
-func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver MetadataVer) {
+func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver kbfsmd.MetadataVer) {
 	ctx := context.Background()
 
 	config := MakeTestConfigOrBust(t, "alice", "bob", "charlie")
@@ -716,7 +716,7 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver MetadataVer) {
 	require.False(t, hasWriterKey(t, rmd, charlieUID))
 }
 
-func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver MetadataVer) {
+func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -796,7 +796,7 @@ func testKeyManagerReaderRekeyResolveAgainSuccessPrivate(t *testing.T, ver Metad
 	require.Equal(t, newH.ToBareHandleOrBust(), newBareH)
 }
 
-func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := keyManagerInit(t, ver)
 	defer keyManagerShutdown(mockCtrl, config)
 
@@ -864,7 +864,7 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver Met
 	require.Equal(t, newH.ToBareHandleOrBust(), newBareH)
 }
 
-func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1112,7 +1112,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1215,7 +1215,7 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver MetadataVer) 
 	_ = GetRootNodeOrBust(ctx, t, config3, name, tlf.Private)
 }
 
-func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver MetadataVer) {
+func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1309,7 +1309,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testKeyManagerReaderRekey(t *testing.T, ver MetadataVer) {
+func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1398,7 +1398,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver MetadataVer) {
+func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1525,7 +1525,7 @@ func keyManagerTestSimulateSelfRekeyBit(
 // In one case the client is a writer and in the other a reader. They both blindly copy the existing
 // metadata and simply set the rekey bit. Then another participant rekeys the folder and they try to read.
 
-func testKeyManagerRekeyBit(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	doShutdown1 := true
@@ -1718,7 +1718,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver MetadataVer) {
 // Two devices conflict when revoking a 3rd device.
 // Test that after this both can still read the latest version of the folder.
 
-func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1876,7 +1876,7 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 		ctx, keys, promptPaper)
 }
 
-func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -1989,7 +1989,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -2109,7 +2109,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver Metada
 	}
 }
 
-func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -2221,7 +2221,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver Met
 	GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 }
 
-func testKeyManagerRekeyMinimal(t *testing.T, ver MetadataVer) {
+func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
 	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -2381,7 +2381,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 }
 
 func TestKeyManager(t *testing.T) {
-	tests := []func(*testing.T, MetadataVer){
+	tests := []func(*testing.T, kbfsmd.MetadataVer){
 		testKeyManagerPublicTLFCryptKey,
 		testKeyManagerCachedSecretKeyForEncryptionSuccess,
 		testKeyManagerCachedSecretKeyForMDDecryptionSuccess,

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -159,10 +159,10 @@ func (kmd emptyKeyMetadata) HasKeyForUser(user keybase1.UID) (bool, error) {
 
 func (kmd emptyKeyMetadata) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (
-	kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
+	kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf,
 	TLFCryptKeyServerHalfID, bool, error) {
 	return kbfscrypto.TLFEphemeralPublicKey{},
-		EncryptedTLFCryptKeyClientHalf{},
+		kbfscrypto.EncryptedTLFCryptKeyClientHalf{},
 		TLFCryptKeyServerHalfID{}, false, nil
 }
 

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
@@ -258,7 +259,7 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, _ KeyGen, _ keybase1.UserVersion,
+	ctx context.Context, tid keybase1.TeamID, _ kbfsmd.KeyGen, _ keybase1.UserVersion,
 	_ keybase1.TeamRole) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err
@@ -556,7 +557,7 @@ func (k *KeybaseDaemonLocal) addTeamReaderForTest(
 }
 
 func (k *KeybaseDaemonLocal) addTeamKeyForTest(
-	tid keybase1.TeamID, newKeyGen KeyGen,
+	tid keybase1.TeamID, newKeyGen kbfsmd.KeyGen,
 	newKey kbfscrypto.TLFCryptKey) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfsmd"
 	metrics "github.com/rcrowley/go-metrics"
 	"golang.org/x/net/context"
 )
@@ -93,7 +94,7 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
-	tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUser keybase1.UserVersion,
+	tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
 	desiredRole keybase1.TeamRole) (teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(

--- a/libkbfs/keycache.go
+++ b/libkbfs/keycache.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 )
 
@@ -17,7 +18,7 @@ type KeyCacheStandard struct {
 
 type keyCacheKey struct {
 	tlf    tlf.ID
-	keyGen KeyGen
+	keyGen kbfsmd.KeyGen
 }
 
 var _ KeyCache = (*KeyCacheStandard)(nil)
@@ -33,7 +34,7 @@ func NewKeyCacheStandard(capacity int) *KeyCacheStandard {
 }
 
 // GetTLFCryptKey implements the KeyCache interface for KeyCacheStandard.
-func (k *KeyCacheStandard) GetTLFCryptKey(tlf tlf.ID, keyGen KeyGen) (
+func (k *KeyCacheStandard) GetTLFCryptKey(tlf tlf.ID, keyGen kbfsmd.KeyGen) (
 	kbfscrypto.TLFCryptKey, error) {
 	cacheKey := keyCacheKey{tlf, keyGen}
 	if entry, ok := k.lru.Get(cacheKey); ok {
@@ -48,7 +49,7 @@ func (k *KeyCacheStandard) GetTLFCryptKey(tlf tlf.ID, keyGen KeyGen) (
 
 // PutTLFCryptKey implements the KeyCache interface for KeyCacheStandard.
 func (k *KeyCacheStandard) PutTLFCryptKey(
-	tlf tlf.ID, keyGen KeyGen, key kbfscrypto.TLFCryptKey) error {
+	tlf tlf.ID, keyGen kbfsmd.KeyGen, key kbfscrypto.TLFCryptKey) error {
 	cacheKey := keyCacheKey{tlf, keyGen}
 	k.lru.Add(cacheKey, key)
 	return nil

--- a/libkbfs/keycache_test.go
+++ b/libkbfs/keycache_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 )
 
@@ -16,7 +17,7 @@ func TestKeyCacheBasic(t *testing.T) {
 	cache := NewKeyCacheStandard(10)
 	id := tlf.FakeID(100, tlf.Public)
 	key := kbfscrypto.MakeTLFCryptKey([32]byte{0xf})
-	keyGen := FirstValidKeyGen
+	keyGen := kbfsmd.FirstValidKeyGen
 	_, err := cache.GetTLFCryptKey(id, keyGen)
 	if _, ok := err.(KeyCacheMissError); !ok {
 		t.Fatal(errors.New("expected KeyCacheMissError"))

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1223,7 +1223,7 @@ func (j *mdJournal) put(
 	mStatus := rmd.MergedStatus()
 
 	// Make modifications for the Unmerged cases.
-	if mStatus == Unmerged {
+	if mStatus == kbfsmd.Unmerged {
 		var lastMdID kbfsmd.ID
 		if head == (ImmutableBareRootMetadata{}) {
 			lastMdID = j.lastMdID

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -908,7 +908,7 @@ func (j *mdJournal) removeFlushedEntry(
 }
 
 func getMdID(ctx context.Context, mdserver MDServer, codec kbfscodec.Codec,
-	tlfID tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	tlfID tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 	revision kbfsmd.Revision, lockBeforeGet *keybase1.LockID) (kbfsmd.ID, error) {
 	rmdses, err := mdserver.GetRange(
 		ctx, tlfID, bid, mStatus, revision, revision, lockBeforeGet)

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -132,7 +132,7 @@ type mdJournal struct {
 	clock          Clock
 	teamMemChecker kbfsmd.TeamMembershipChecker
 	tlfID          tlf.ID
-	mdVer          MetadataVer
+	mdVer          kbfsmd.MetadataVer
 	dir            string
 
 	log      logger.Logger
@@ -161,7 +161,7 @@ func makeMDJournalWithIDJournal(
 	ctx context.Context, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	codec kbfscodec.Codec, crypto cryptoPure, clock Clock,
 	teamMemChecker kbfsmd.TeamMembershipChecker, tlfID tlf.ID,
-	mdVer MetadataVer, dir string, idJournal mdIDJournal,
+	mdVer kbfsmd.MetadataVer, dir string, idJournal mdIDJournal,
 	log logger.Logger) (*mdJournal, error) {
 	if uid == keybase1.UID("") {
 		return nil, errors.New("Empty user")
@@ -225,7 +225,7 @@ func makeMDJournal(
 	ctx context.Context, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	codec kbfscodec.Codec, crypto cryptoPure, clock Clock,
 	teamMemChecker kbfsmd.TeamMembershipChecker, tlfID tlf.ID,
-	mdVer MetadataVer, dir string,
+	mdVer kbfsmd.MetadataVer, dir string,
 	log logger.Logger) (*mdJournal, error) {
 	journalDir := mdJournalPath(dir)
 	idJournal, err := makeMdIDJournal(codec, journalDir)
@@ -296,14 +296,14 @@ func (j mdJournal) mdInfoPath(id kbfsmd.ID) string {
 // since the Go JSON library doesn't support it natively.
 type mdInfo struct {
 	Timestamp time.Time
-	Version   MetadataVer
+	Version   kbfsmd.MetadataVer
 }
 
-func (j mdJournal) getMDInfo(id kbfsmd.ID) (time.Time, MetadataVer, error) {
+func (j mdJournal) getMDInfo(id kbfsmd.ID) (time.Time, kbfsmd.MetadataVer, error) {
 	var info mdInfo
 	err := ioutil.DeserializeFromJSONFile(j.mdInfoPath(id), &info)
 	if err != nil {
-		return time.Time{}, MetadataVer(-1), err
+		return time.Time{}, kbfsmd.MetadataVer(-1), err
 	}
 
 	return info.Timestamp, info.Version, nil
@@ -312,7 +312,7 @@ func (j mdJournal) getMDInfo(id kbfsmd.ID) (time.Time, MetadataVer, error) {
 // putMDInfo assumes that the parent directory of j.mdInfoPath(id)
 // (which is j.mdPath(id)) has already been created.
 func (j mdJournal) putMDInfo(
-	id kbfsmd.ID, timestamp time.Time, version MetadataVer) error {
+	id kbfsmd.ID, timestamp time.Time, version kbfsmd.MetadataVer) error {
 	info := mdInfo{timestamp, version}
 	return ioutil.SerializeToJSONFile(info, j.mdInfoPath(id))
 }

--- a/libkbfs/md_journal.go
+++ b/libkbfs/md_journal.go
@@ -1269,14 +1269,14 @@ func (j *mdJournal) put(
 
 	// The below is code common to all the cases.
 
-	if (mStatus == Merged) != (rmd.BID() == kbfsmd.NullBranchID) {
+	if (mStatus == kbfsmd.Merged) != (rmd.BID() == kbfsmd.NullBranchID) {
 		return kbfsmd.ID{}, errors.Errorf(
 			"mStatus=%s doesn't match bid=%s", mStatus, rmd.BID())
 	}
 
 	// If we're trying to push a merged MD onto a branch, return a
 	// conflict error so the caller can retry with an unmerged MD.
-	if mStatus == Merged && j.branchID != kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Merged && j.branchID != kbfsmd.NullBranchID {
 		return kbfsmd.ID{}, MDJournalConflictError{}
 	}
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -155,7 +155,7 @@ func putMDRange(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 func checkBRMD(t *testing.T, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	codec kbfscodec.Codec, brmd kbfsmd.RootMetadata,
 	extra kbfsmd.ExtraMetadata, expectedRevision kbfsmd.Revision,
-	expectedPrevRoot kbfsmd.ID, expectedMergeStatus MergeStatus,
+	expectedPrevRoot kbfsmd.ID, expectedMergeStatus kbfsmd.MergeStatus,
 	expectedBranchID kbfsmd.BranchID) {
 	require.Equal(t, expectedRevision, brmd.RevisionNumber())
 	require.Equal(t, expectedPrevRoot, brmd.GetPrevRoot())
@@ -174,7 +174,7 @@ func checkBRMD(t *testing.T, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 func checkIBRMDRange(t *testing.T, uid keybase1.UID,
 	key kbfscrypto.VerifyingKey, codec kbfscodec.Codec,
 	ibrmds []ImmutableBareRootMetadata, firstRevision kbfsmd.Revision,
-	firstPrevRoot kbfsmd.ID, mStatus MergeStatus, bid kbfsmd.BranchID) {
+	firstPrevRoot kbfsmd.ID, mStatus kbfsmd.MergeStatus, bid kbfsmd.BranchID) {
 	checkBRMD(t, uid, key, codec, ibrmds[0], ibrmds[0].extra,
 		firstRevision, firstPrevRoot, mStatus, bid)
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -166,7 +166,7 @@ func checkBRMD(t *testing.T, uid keybase1.UID, key kbfscrypto.VerifyingKey,
 	err = brmd.IsLastModifiedBy(uid, key)
 	require.NoError(t, err)
 
-	require.Equal(t, expectedMergeStatus == Merged,
+	require.Equal(t, expectedMergeStatus == kbfsmd.Merged,
 		expectedBranchID == kbfsmd.NullBranchID)
 	require.Equal(t, expectedBranchID, brmd.BID())
 }
@@ -263,7 +263,7 @@ func testMDJournalBasic(t *testing.T, ver MetadataVer) {
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, j.uid, j.key, codec,
-		ibrmds, firstRevision, firstPrevRoot, Merged, kbfsmd.NullBranchID)
+		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Merged, kbfsmd.NullBranchID)
 
 	head, err = j.getHead(ctx, kbfsmd.NullBranchID)
 	require.NoError(t, err)
@@ -781,7 +781,7 @@ func TestMDJournalBranchConversionAtomic(t *testing.T) {
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, j.uid, j.key, codec,
-		ibrmds, firstRevision, firstPrevRoot, Merged, kbfsmd.NullBranchID)
+		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Merged, kbfsmd.NullBranchID)
 
 	require.Equal(t, uint64(10), j.length())
 
@@ -1005,7 +1005,7 @@ func testMDJournalRestart(t *testing.T, ver MetadataVer) {
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, j.uid, j.key, codec,
-		ibrmds, firstRevision, firstPrevRoot, Merged, kbfsmd.NullBranchID)
+		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Merged, kbfsmd.NullBranchID)
 
 	flushAllMDs(t, context.Background(), signer, j)
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -573,7 +573,7 @@ func listDir(t *testing.T, dir string) []string {
 
 func getMDJournalNames(ver MetadataVer) []string {
 	var expectedNames []string
-	if ver < SegregatedKeyBundlesVer {
+	if ver < kbfsmd.SegregatedKeyBundlesVer {
 		expectedNames = []string{"md_journal", "mds"}
 	} else {
 		expectedNames = []string{
@@ -749,9 +749,9 @@ func (s *limitedCryptoSigner) Sign(ctx context.Context, msg []byte) (
 }
 
 func TestMDJournalBranchConversionAtomic(t *testing.T) {
-	// Do this with InitialExtraMetadataVer only, since any later
+	// Do this with kbfsmd.InitialExtraMetadataVer only, since any later
 	// version doesn't actually do any signing.
-	ver := InitialExtraMetadataVer
+	ver := kbfsmd.InitialExtraMetadataVer
 
 	codec, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t, ver)

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -648,7 +648,7 @@ func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, j.uid, j.key, codec,
-		ibrmds, firstRevision, firstPrevRoot, Unmerged, ibrmds[0].BID())
+		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Unmerged, ibrmds[0].BID())
 
 	require.Equal(t, uint64(10), j.length())
 
@@ -662,7 +662,7 @@ func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
 	newlyCachedMd, err := mdcache.Get(id, firstRevision, bid)
 	require.NoError(t, err)
 	require.Equal(t, newlyCachedMd.BID(), bid)
-	require.Equal(t, newlyCachedMd.MergedStatus(), Unmerged)
+	require.Equal(t, newlyCachedMd.MergedStatus(), kbfsmd.Unmerged)
 	_, err = mdcache.Get(id, firstRevision, kbfsmd.NullBranchID)
 	require.Error(t, err)
 }
@@ -1047,7 +1047,7 @@ func testMDJournalRestartAfterBranchConversion(t *testing.T, ver MetadataVer) {
 	require.Equal(t, mdCount, len(ibrmds))
 
 	checkIBRMDRange(t, j.uid, j.key, codec,
-		ibrmds, firstRevision, firstPrevRoot, Unmerged, ibrmds[0].BID())
+		ibrmds, firstRevision, firstPrevRoot, kbfsmd.Unmerged, ibrmds[0].BID())
 
 	flushAllMDs(t, ctx, signer, j)
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -39,7 +39,7 @@ func (g singleEncryptionKeyGetter) GetTLFCryptKeyForMDDecryption(
 	return g.k, nil
 }
 
-func setupMDJournalTest(t testing.TB, ver MetadataVer) (
+func setupMDJournalTest(t testing.TB, ver kbfsmd.MetadataVer) (
 	codec kbfscodec.Codec, crypto CryptoCommon, tlfID tlf.ID,
 	signer kbfscrypto.Signer, ekg singleEncryptionKeyGetter,
 	bsplit BlockSplitter, tempdir string, j *mdJournal) {
@@ -85,7 +85,7 @@ func teardownMDJournalTest(t testing.TB, tempdir string) {
 	assert.NoError(t, err)
 }
 
-func makeMDForTest(t testing.TB, ver MetadataVer, tlfID tlf.ID,
+func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	revision kbfsmd.Revision, uid keybase1.UID,
 	signer kbfscrypto.Signer, prevRoot kbfsmd.ID) *RootMetadata {
 	nug := testNormalizedUsernameGetter{
@@ -114,7 +114,7 @@ func (cmrg constMerkleRootGetter) GetCurrentMerkleRoot(
 	return keybase1.MerkleRootV2{}, nil
 }
 
-func putMDRangeHelper(t testing.TB, ver MetadataVer, tlfID tlf.ID,
+func putMDRangeHelper(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	signer kbfscrypto.Signer, firstRevision kbfsmd.Revision,
 	firstPrevRoot kbfsmd.ID, mdCount int, uid keybase1.UID,
 	putMD func(context.Context, *RootMetadata) (kbfsmd.ID, error)) (
@@ -141,7 +141,7 @@ func putMDRangeHelper(t testing.TB, ver MetadataVer, tlfID tlf.ID,
 	return mds, prevRoot
 }
 
-func putMDRange(t testing.TB, ver MetadataVer, tlfID tlf.ID,
+func putMDRange(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	signer kbfscrypto.Signer, ekg encryptionKeyGetter,
 	bsplit BlockSplitter, firstRevision kbfsmd.Revision,
 	firstPrevRoot kbfsmd.ID, mdCount int, j *mdJournal) ([]*RootMetadata, kbfsmd.ID) {
@@ -202,7 +202,7 @@ func BenchmarkMDJournalBasic(b *testing.B) {
 	runBenchmarkOverMetadataVers(b, benchmarkMDJournalBasic)
 }
 
-func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer, mdCount int) {
+func benchmarkMDJournalBasicBody(b *testing.B, ver kbfsmd.MetadataVer, mdCount int) {
 	b.StopTimer()
 
 	_, _, id, signer, ekg, bsplit, tempdir, j :=
@@ -218,7 +218,7 @@ func benchmarkMDJournalBasicBody(b *testing.B, ver MetadataVer, mdCount int) {
 		})
 }
 
-func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
+func benchmarkMDJournalBasic(b *testing.B, ver kbfsmd.MetadataVer) {
 	for _, mdCount := range []int{1, 10, 100, 1000, 10000} {
 		mdCount := mdCount // capture range variable.
 		name := fmt.Sprintf("mdCount=%d", mdCount)
@@ -232,7 +232,7 @@ func benchmarkMDJournalBasic(b *testing.B, ver MetadataVer) {
 	}
 }
 
-func testMDJournalBasic(t *testing.T, ver MetadataVer) {
+func testMDJournalBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
@@ -275,7 +275,7 @@ func testMDJournalBasic(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMDJournalGetNextEntry(t *testing.T, ver MetadataVer) {
+func testMDJournalGetNextEntry(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -303,7 +303,7 @@ func testMDJournalGetNextEntry(t *testing.T, ver MetadataVer) {
 
 // Putting the same md twice should return the same MD ID.  Regression
 // for KBFS-1955.
-func testMDJournalPutEntryTwice(t *testing.T, ver MetadataVer) {
+func testMDJournalPutEntryTwice(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -319,7 +319,7 @@ func testMDJournalPutEntryTwice(t *testing.T, ver MetadataVer) {
 	require.Equal(t, id1, id2)
 }
 
-func testMDJournalPutCase1Empty(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase1Empty(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -334,7 +334,7 @@ func testMDJournalPutCase1Empty(t *testing.T, ver MetadataVer) {
 	require.Equal(t, md.extra, head.extra)
 }
 
-func testMDJournalPutCase1Conflict(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase1Conflict(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -354,7 +354,7 @@ func testMDJournalPutCase1Conflict(t *testing.T, ver MetadataVer) {
 
 // The append portion of case 1 is covered by TestMDJournalBasic.
 
-func testMDJournalPutCase1ReplaceHead(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase1ReplaceHead(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -383,7 +383,7 @@ func testMDJournalPutCase1ReplaceHead(t *testing.T, ver MetadataVer) {
 	require.Equal(t, md.extra, head.extra)
 }
 
-func testMDJournalPutCase2NonEmptyReplace(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase2NonEmptyReplace(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -402,7 +402,7 @@ func testMDJournalPutCase2NonEmptyReplace(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testMDJournalPutCase2NonEmptyAppend(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase2NonEmptyAppend(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -422,7 +422,7 @@ func testMDJournalPutCase2NonEmptyAppend(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testMDJournalPutCase2Empty(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase2Empty(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -448,7 +448,7 @@ func testMDJournalPutCase2Empty(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testMDJournalPutCase3NonEmptyAppend(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase3NonEmptyAppend(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -474,7 +474,7 @@ func testMDJournalPutCase3NonEmptyAppend(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testMDJournalPutCase3NonEmptyReplace(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase3NonEmptyReplace(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -499,7 +499,7 @@ func testMDJournalPutCase3NonEmptyReplace(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testMDJournalPutCase3EmptyAppend(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase3EmptyAppend(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -526,7 +526,7 @@ func testMDJournalPutCase3EmptyAppend(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testMDJournalPutCase4(t *testing.T, ver MetadataVer) {
+func testMDJournalPutCase4(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -571,7 +571,7 @@ func listDir(t *testing.T, dir string) []string {
 	return names
 }
 
-func getMDJournalNames(ver MetadataVer) []string {
+func getMDJournalNames(ver kbfsmd.MetadataVer) []string {
 	var expectedNames []string
 	if ver < kbfsmd.SegregatedKeyBundlesVer {
 		expectedNames = []string{"md_journal", "mds"}
@@ -583,7 +583,7 @@ func getMDJournalNames(ver MetadataVer) []string {
 	return expectedNames
 }
 
-func testMDJournalFlushAll(t *testing.T, ver MetadataVer) {
+func testMDJournalFlushAll(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -608,7 +608,7 @@ func testMDJournalFlushAll(t *testing.T, ver MetadataVer) {
 	require.Equal(t, []string{"extra_file"}, names)
 }
 
-func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
+func testMDJournalBranchConversion(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
@@ -667,7 +667,7 @@ func testMDJournalBranchConversion(t *testing.T, ver MetadataVer) {
 	require.Error(t, err)
 }
 
-func testMDJournalResolveAndClear(t *testing.T, ver MetadataVer, bid kbfsmd.BranchID) {
+func testMDJournalResolveAndClear(t *testing.T, ver kbfsmd.MetadataVer, bid kbfsmd.BranchID) {
 	_, _, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
@@ -722,7 +722,7 @@ func testMDJournalResolveAndClear(t *testing.T, ver MetadataVer, bid kbfsmd.Bran
 	flushAllMDs(t, ctx, signer, j)
 }
 
-func testMDJournalResolveAndClearRemoteBranch(t *testing.T, ver MetadataVer) {
+func testMDJournalResolveAndClearRemoteBranch(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec := kbfscodec.NewMsgpack()
 	crypto := MakeCryptoCommon(codec)
 	bid, err := crypto.MakeRandomBranchID()
@@ -730,7 +730,7 @@ func testMDJournalResolveAndClearRemoteBranch(t *testing.T, ver MetadataVer) {
 	testMDJournalResolveAndClear(t, ver, bid)
 }
 
-func testMDJournalResolveAndClearLocalSquash(t *testing.T, ver MetadataVer) {
+func testMDJournalResolveAndClearLocalSquash(t *testing.T, ver kbfsmd.MetadataVer) {
 	testMDJournalResolveAndClear(t, ver, kbfsmd.PendingLocalSquashBranchID)
 }
 
@@ -798,7 +798,7 @@ type mdIDJournalEntryExtra struct {
 	Extra int
 }
 
-func testMDJournalBranchConversionPreservesUnknownFields(t *testing.T, ver MetadataVer) {
+func testMDJournalBranchConversionPreservesUnknownFields(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -855,7 +855,7 @@ func testMDJournalBranchConversionPreservesUnknownFields(t *testing.T, ver Metad
 	flushAllMDs(t, ctx, signer, j)
 }
 
-func testMDJournalClear(t *testing.T, ver MetadataVer) {
+func testMDJournalClear(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -931,7 +931,7 @@ func testMDJournalClear(t *testing.T, ver MetadataVer) {
 	flushAllMDs(t, ctx, signer, j)
 }
 
-func testMDJournalClearPendingWithMaster(t *testing.T, ver MetadataVer) {
+func testMDJournalClearPendingWithMaster(t *testing.T, ver kbfsmd.MetadataVer) {
 	_, _, id, signer, ekg, bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
 
@@ -978,7 +978,7 @@ func testMDJournalClearPendingWithMaster(t *testing.T, ver MetadataVer) {
 	require.Equal(t, kbfsmd.NullBranchID, head.BID())
 }
 
-func testMDJournalRestart(t *testing.T, ver MetadataVer) {
+func testMDJournalRestart(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec, crypto, id, signer, ekg,
 		bsplit, tempdir, j := setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
@@ -1010,7 +1010,7 @@ func testMDJournalRestart(t *testing.T, ver MetadataVer) {
 	flushAllMDs(t, context.Background(), signer, j)
 }
 
-func testMDJournalRestartAfterBranchConversion(t *testing.T, ver MetadataVer) {
+func testMDJournalRestartAfterBranchConversion(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec, crypto, id, signer, ekg, bsplit, tempdir, j :=
 		setupMDJournalTest(t, ver)
 	defer teardownMDJournalTest(t, tempdir)
@@ -1053,7 +1053,7 @@ func testMDJournalRestartAfterBranchConversion(t *testing.T, ver MetadataVer) {
 }
 
 func TestMDJournal(t *testing.T) {
-	tests := []func(*testing.T, MetadataVer){
+	tests := []func(*testing.T, kbfsmd.MetadataVer){
 		testMDJournalBasic,
 		testMDJournalGetNextEntry,
 		testMDJournalPutEntryTwice,

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -336,9 +336,9 @@ func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 	}
 
 	if rmds == nil {
-		if mStatus == Unmerged {
+		if mStatus == kbfsmd.Unmerged {
 			// The caller ignores the id argument for
-			// mStatus == Unmerged.
+			// mStatus == kbfsmd.Unmerged.
 			return tlf.ID{}, ImmutableRootMetadata{}, nil
 		}
 		return id, ImmutableRootMetadata{}, nil
@@ -410,7 +410,7 @@ func (md *MDOpsStandard) getForTLF(ctx context.Context, id tlf.ID,
 		return ImmutableRootMetadata{}, err
 	}
 	if rmds == nil {
-		// Possible if mStatus is Unmerged
+		// Possible if mStatus is kbfsmd.Unmerged
 		return ImmutableRootMetadata{}, nil
 	}
 	extra, err := md.getExtraMD(ctx, rmds.MD)
@@ -443,7 +443,7 @@ func (md *MDOpsStandard) GetForTLF(
 func (md *MDOpsStandard) GetUnmergedForTLF(
 	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID) (
 	ImmutableRootMetadata, error) {
-	return md.getForTLF(ctx, id, bid, Unmerged, nil)
+	return md.getForTLF(ctx, id, bid, kbfsmd.Unmerged, nil)
 }
 
 func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
@@ -583,7 +583,7 @@ func (md *MDOpsStandard) GetRange(ctx context.Context, id tlf.ID,
 func (md *MDOpsStandard) GetUnmergedRange(ctx context.Context, id tlf.ID,
 	bid kbfsmd.BranchID, start, stop kbfsmd.Revision) (
 	[]ImmutableRootMetadata, error) {
-	return md.getRange(ctx, id, bid, Unmerged, start, stop, nil)
+	return md.getRange(ctx, id, bid, kbfsmd.Unmerged, start, stop, nil)
 }
 
 func (md *MDOpsStandard) put(ctx context.Context, rmd *RootMetadata,
@@ -643,7 +643,7 @@ func (md *MDOpsStandard) put(ctx context.Context, rmd *RootMetadata,
 func (md *MDOpsStandard) Put(ctx context.Context, rmd *RootMetadata,
 	verifyingKey kbfscrypto.VerifyingKey, lockContext *keybase1.LockContext,
 	priority keybase1.MDPriority) (ImmutableRootMetadata, error) {
-	if rmd.MergedStatus() == Unmerged {
+	if rmd.MergedStatus() == kbfsmd.Unmerged {
 		return ImmutableRootMetadata{}, UnexpectedUnmergedPutError{}
 	}
 	return md.put(ctx, rmd, verifyingKey, lockContext, priority)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -306,7 +306,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 
 // GetForHandle implements the MDOps interface for MDOpsStandard.
 func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
-	mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (
+	mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	id tlf.ID, rmd ImmutableRootMetadata, err error) {
 	md.log.CDebugf(
 		ctx, "GetForHandle: %s %s", handle.GetCanonicalPath(), mStatus)
@@ -402,7 +402,7 @@ func (md *MDOpsStandard) processMetadataWithID(ctx context.Context,
 }
 
 func (md *MDOpsStandard) getForTLF(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	ImmutableRootMetadata, error) {
 	rmds, err := md.config.MDServer().GetForTLF(
 		ctx, id, bid, mStatus, lockBeforeGet)
@@ -557,7 +557,7 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 }
 
 func (md *MDOpsStandard) getRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	lockBeforeGet *keybase1.LockID) ([]ImmutableRootMetadata, error) {
 	rmds, err := md.config.MDServer().GetRange(
 		ctx, id, bid, mStatus, start, stop, lockBeforeGet)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -97,7 +97,7 @@ func (md *MDOpsStandard) verifyWriterKey(ctx context.Context,
 	// The writer metadata can be copied only for rekeys or
 	// finalizations, neither of which should happen while
 	// unmerged.
-	if rmds.MD.MergedStatus() != Merged {
+	if rmds.MD.MergedStatus() != kbfsmd.Merged {
 		return fmt.Errorf("Revision %d for %s has a copied writer "+
 			"metadata, but is unexpectedly not merged",
 			rmds.MD.RevisionNumber(), rmds.MD.TlfID())
@@ -436,7 +436,7 @@ func (md *MDOpsStandard) getForTLF(ctx context.Context, id tlf.ID,
 func (md *MDOpsStandard) GetForTLF(
 	ctx context.Context, id tlf.ID, lockBeforeGet *keybase1.LockID) (
 	ImmutableRootMetadata, error) {
-	return md.getForTLF(ctx, id, kbfsmd.NullBranchID, Merged, lockBeforeGet)
+	return md.getForTLF(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, lockBeforeGet)
 }
 
 // GetUnmergedForTLF implements the MDOps interface for MDOpsStandard.
@@ -576,7 +576,7 @@ func (md *MDOpsStandard) GetRange(ctx context.Context, id tlf.ID,
 	start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) (
 	[]ImmutableRootMetadata, error) {
 	return md.getRange(
-		ctx, id, kbfsmd.NullBranchID, Merged, start, stop, lockBeforeGet)
+		ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, start, stop, lockBeforeGet)
 }
 
 // GetUnmergedRange implements the MDOps interface for MDOpsStandard.

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -759,7 +759,7 @@ func validatePutPublicRMDS(
 	// Overwrite written fields.
 	expectedRmd.SetLastModifyingWriter(rmds.MD.LastModifyingWriter())
 	expectedRmd.SetLastModifyingUser(rmds.MD.GetLastModifyingUser())
-	if ver < SegregatedKeyBundlesVer {
+	if ver < kbfsmd.SegregatedKeyBundlesVer {
 		expectedRmd.(*kbfsmd.RootMetadataV2).WriterMetadataSigInfo =
 			rmds.MD.(*kbfsmd.RootMetadataV2).WriterMetadataSigInfo
 	}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -215,11 +215,11 @@ func testMDOpsGetForHandlePublicSuccess(t *testing.T, ver MetadataVer) {
 	verifyMDForPublic(config, rmds, nil)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds, nil)
 
 	// Do this first, since rmds is consumed.
 	expectedMD := rmds.MD
-	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged, nil)
+	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedMD, rmd2.bareMd)
 }
@@ -244,12 +244,12 @@ func testMDOpsGetForHandlePrivateSuccess(t *testing.T, ver MetadataVer) {
 	verifyMDForPrivate(config, rmds)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
 	// Do this first, since rmds is consumed.
 	expectedMD := rmds.MD
-	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, Merged, nil)
+	_, rmd2, err := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedMD, rmd2.bareMd)
 }
@@ -269,11 +269,11 @@ func testMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T, ver MetadataVer)
 	require.NoError(t, err)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx,
-		hUnresolved.ToBareHandleOrBust(), Merged, nil).Return(
+		hUnresolved.ToBareHandleOrBust(), kbfsmd.Merged, nil).Return(
 		tlf.NullID, rmds, nil).Times(2)
 
 	// First time should fail.
-	_, _, err = config.MDOps().GetForHandle(ctx, hUnresolved, Merged, nil)
+	_, _, err = config.MDOps().GetForHandle(ctx, hUnresolved, kbfsmd.Merged, nil)
 	if _, ok := err.(MDMismatchError); !ok {
 		t.Errorf("Got unexpected error on bad handle check test: %v", err)
 	}
@@ -282,7 +282,7 @@ func testMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T, ver MetadataVer)
 	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
 
 	// Second time should succeed.
-	if _, _, err := config.MDOps().GetForHandle(ctx, hUnresolved, Merged, nil); err != nil {
+	if _, _, err := config.MDOps().GetForHandle(ctx, hUnresolved, kbfsmd.Merged, nil); err != nil {
 		t.Errorf("Got error on get: %v", err)
 	}
 }
@@ -318,10 +318,10 @@ func testMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T, ver MetadataVe
 	require.NoError(t, err)
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds1, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds1, nil)
 
 	// First time should fail.
-	_, _, err = config.MDOps().GetForHandle(ctx, h, Merged, nil)
+	_, _, err = config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	if _, ok := err.(MDMismatchError); !ok {
 		t.Errorf("Got unexpected error on bad handle check test: %v", err)
 	}
@@ -331,17 +331,17 @@ func testMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T, ver MetadataVe
 	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds2, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds2, nil)
 
 	// Second and time should succeed.
-	if _, _, err := config.MDOps().GetForHandle(ctx, h, Merged, nil); err != nil {
+	if _, _, err := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil); err != nil {
 		t.Errorf("Got error on get: %v", err)
 	}
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds3, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds3, nil)
 
-	if _, _, err := config.MDOps().GetForHandle(ctx, h, Merged, nil); err != nil {
+	if _, _, err := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil); err != nil {
 		t.Errorf("Got error on get: %v", err)
 	}
 }
@@ -361,11 +361,11 @@ func testMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T, ver MetadataVer)
 	daemon.addNewAssertionForTestOrBust("bob", "bob@twitter")
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx,
-		hUnresolved.ToBareHandleOrBust(), Merged, nil).Return(
+		hUnresolved.ToBareHandleOrBust(), kbfsmd.Merged, nil).Return(
 		tlf.NullID, rmds, nil)
 
 	// Should still fail.
-	_, _, err = config.MDOps().GetForHandle(ctx, hUnresolved, Merged, nil)
+	_, _, err = config.MDOps().GetForHandle(ctx, hUnresolved, kbfsmd.Merged, nil)
 	if _, ok := err.(MDMismatchError); !ok {
 		t.Errorf("Got unexpected error on bad handle check test: %v", err)
 	}
@@ -382,9 +382,9 @@ func testMDOpsGetForHandlePublicFailFindKey(t *testing.T, ver MetadataVer) {
 	verifyMDForPublic(config, rmds, VerifyingKeyNotFoundError{})
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds, nil)
 
-	_, _, err := config.MDOps().GetForHandle(ctx, h, Merged, nil)
+	_, _, err := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	if _, ok := err.(UnverifiableTlfUpdateError); !ok {
 		t.Errorf("Got unexpected error on get: %v", err)
 	}
@@ -410,9 +410,9 @@ func testMDOpsGetForHandlePublicFailVerify(t *testing.T, ver MetadataVer) {
 	// which will then cause an MDMismatchError.
 	rmds.MD.(kbfsmd.MutableRootMetadata).SetRefBytes(100)
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds, nil)
 
-	_, _, err := config.MDOps().GetForHandle(ctx, h, Merged, nil)
+	_, _, err := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.IsType(t, MDMismatchError{}, err)
 }
 
@@ -426,9 +426,9 @@ func testMDOpsGetForHandleFailGet(t *testing.T, ver MetadataVer) {
 
 	// only the get happens, no verify needed with a blank sig
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, nil, err)
+		kbfsmd.Merged, nil).Return(tlf.NullID, nil, err)
 
-	if _, _, err2 := config.MDOps().GetForHandle(ctx, h, Merged, nil); err2 != err {
+	if _, _, err2 := config.MDOps().GetForHandle(ctx, h, kbfsmd.Merged, nil); err2 != err {
 		t.Errorf("Got bad error on get: %v", err2)
 	}
 }
@@ -443,10 +443,10 @@ func testMDOpsGetForHandleFailHandleCheck(t *testing.T, ver MetadataVer) {
 	// Make a different handle.
 	otherH := parseTlfHandleOrBust(t, config, "alice", tlf.Private)
 	config.mockMdserv.EXPECT().GetForHandle(ctx, otherH.ToBareHandleOrBust(),
-		Merged, nil).Return(tlf.NullID, rmds, nil)
+		kbfsmd.Merged, nil).Return(tlf.NullID, rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
-	_, _, err := config.MDOps().GetForHandle(ctx, otherH, Merged, nil)
+	_, _, err := config.MDOps().GetForHandle(ctx, otherH, kbfsmd.Merged, nil)
 	if _, ok := err.(MDMismatchError); !ok {
 		t.Errorf("Got unexpected error on bad handle check test: %v", err)
 	}
@@ -463,7 +463,7 @@ func testMDOpsGetSuccess(t *testing.T, ver MetadataVer) {
 	verifyMDForPrivate(config, rmds)
 
 	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), kbfsmd.NullBranchID,
-		Merged, nil).Return(rmds, nil)
+		kbfsmd.Merged, nil).Return(rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
 	// Do this first, since rmds is consumed.
@@ -483,7 +483,7 @@ func testMDOpsGetBlankSigFailure(t *testing.T, ver MetadataVer) {
 
 	// only the get happens, no verify needed with a blank sig
 	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), kbfsmd.NullBranchID,
-		Merged, nil).Return(rmds, nil)
+		kbfsmd.Merged, nil).Return(rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
 	if _, err := config.MDOps().GetForTLF(ctx, rmds.MD.TlfID(), nil); err == nil {
@@ -500,7 +500,7 @@ func testMDOpsGetFailGet(t *testing.T, ver MetadataVer) {
 
 	// only the get happens, no verify needed with a blank sig
 	config.mockMdserv.EXPECT().GetForTLF(ctx, id, kbfsmd.NullBranchID,
-		Merged, nil).Return(nil, err)
+		kbfsmd.Merged, nil).Return(nil, err)
 
 	if _, err2 := config.MDOps().GetForTLF(ctx, id, nil); err2 != err {
 		t.Errorf("Got bad error on get: %v", err2)
@@ -517,7 +517,7 @@ func testMDOpsGetFailIDCheck(t *testing.T, ver MetadataVer) {
 	id2 := tlf.FakeID(2, tlf.Public)
 
 	config.mockMdserv.EXPECT().GetForTLF(ctx, id2, kbfsmd.NullBranchID,
-		Merged, nil).Return(rmds, nil)
+		kbfsmd.Merged, nil).Return(rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)
 
 	if _, err := config.MDOps().GetForTLF(ctx, id2, nil); err == nil {

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -602,7 +602,7 @@ func (mds *keyBundleMDServer) processRMDSes(
 }
 
 func (mds *keyBundleMDServer) GetForTLF(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, _ *keybase1.LockID) (
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, _ *keybase1.LockID) (
 	*RootMetadataSigned, error) {
 	rmd := mds.nextHead
 	mds.nextHead = nil
@@ -610,7 +610,7 @@ func (mds *keyBundleMDServer) GetForTLF(ctx context.Context, id tlf.ID,
 }
 
 func (mds *keyBundleMDServer) GetRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	_ *keybase1.LockID) ([]*RootMetadataSigned, error) {
 	rmdses := mds.nextGetRange
 	mds.nextGetRange = nil

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -197,7 +197,7 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	expectGetTLFCryptKeyForEncryption(config, rmd)
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
 		rmd.data, kbfscrypto.TLFCryptKey{}).Return(
-		EncryptedPrivateMetadata{}, nil)
+		kbfscrypto.EncryptedPrivateMetadata{}, nil)
 	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
 		Return(true)
 	config.mockMdserv.EXPECT().Put(gomock.Any(), gomock.Any(), gomock.Any(),
@@ -837,7 +837,7 @@ func testMDOpsPutFailEncode(t *testing.T, ver MetadataVer) {
 	expectGetTLFCryptKeyForEncryption(config, rmd)
 	config.mockCrypto.EXPECT().EncryptPrivateMetadata(
 		rmd.data, kbfscrypto.TLFCryptKey{}).Return(
-		EncryptedPrivateMetadata{}, nil)
+		kbfscrypto.EncryptedPrivateMetadata{}, nil)
 	config.mockBsplit.EXPECT().ShouldEmbedBlockChanges(gomock.Any()).
 		Return(true)
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -53,7 +53,7 @@ func injectShimCrypto(config Config) {
 	config.SetCrypto(crypto)
 }
 
-func mdOpsInit(t *testing.T, ver MetadataVer) (mockCtrl *gomock.Controller,
+func mdOpsInit(t *testing.T, ver kbfsmd.MetadataVer) (mockCtrl *gomock.Controller,
 	config *ConfigMock, ctx context.Context) {
 	ctr := NewSafeTestReporter(t)
 	mockCtrl = gomock.NewController(ctr)
@@ -205,7 +205,7 @@ func putMDForPrivate(config *ConfigMock, rmd *RootMetadata) {
 	config.mockMdcache.EXPECT().Replace(gomock.Any(), gomock.Any())
 }
 
-func testMDOpsGetForHandlePublicSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForHandlePublicSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -234,7 +234,7 @@ func expectGetKeyBundles(ctx context.Context, config *ConfigMock, extra kbfsmd.E
 	}
 }
 
-func testMDOpsGetForHandlePrivateSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForHandlePrivateSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -254,7 +254,7 @@ func testMDOpsGetForHandlePrivateSuccess(t *testing.T, ver MetadataVer) {
 	require.Equal(t, expectedMD, rmd2.bareMd)
 }
 
-func testMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -287,7 +287,7 @@ func testMDOpsGetForUnresolvedHandlePublicSuccess(t *testing.T, ver MetadataVer)
 	}
 }
 
-func testMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -346,7 +346,7 @@ func testMDOpsGetForUnresolvedMdHandlePublicSuccess(t *testing.T, ver MetadataVe
 	}
 }
 
-func testMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -371,7 +371,7 @@ func testMDOpsGetForUnresolvedHandlePublicFailure(t *testing.T, ver MetadataVer)
 	}
 }
 
-func testMDOpsGetForHandlePublicFailFindKey(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForHandlePublicFailFindKey(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -399,7 +399,7 @@ func (c failVerifyCrypto) Verify(msg []byte, sigInfo kbfscrypto.SignatureInfo) e
 	return c.err
 }
 
-func testMDOpsGetForHandlePublicFailVerify(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForHandlePublicFailVerify(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -416,7 +416,7 @@ func testMDOpsGetForHandlePublicFailVerify(t *testing.T, ver MetadataVer) {
 	require.IsType(t, MDMismatchError{}, err)
 }
 
-func testMDOpsGetForHandleFailGet(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForHandleFailGet(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -433,7 +433,7 @@ func testMDOpsGetForHandleFailGet(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMDOpsGetForHandleFailHandleCheck(t *testing.T, ver MetadataVer) {
+func testMDOpsGetForHandleFailHandleCheck(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -452,7 +452,7 @@ func testMDOpsGetForHandleFailHandleCheck(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMDOpsGetSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -473,7 +473,7 @@ func testMDOpsGetSuccess(t *testing.T, ver MetadataVer) {
 	require.Equal(t, expectedMD, rmd2.bareMd)
 }
 
-func testMDOpsGetBlankSigFailure(t *testing.T, ver MetadataVer) {
+func testMDOpsGetBlankSigFailure(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -491,7 +491,7 @@ func testMDOpsGetBlankSigFailure(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMDOpsGetFailGet(t *testing.T, ver MetadataVer) {
+func testMDOpsGetFailGet(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -507,7 +507,7 @@ func testMDOpsGetFailGet(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMDOpsGetFailIDCheck(t *testing.T, ver MetadataVer) {
+func testMDOpsGetFailIDCheck(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -628,7 +628,7 @@ func (mds *keyBundleMDServer) GetKeyBundles(ctx context.Context, tlfID tlf.ID,
 }
 
 func testMDOpsGetRangeSuccessHelper(
-	t *testing.T, ver MetadataVer, fromStart bool) {
+	t *testing.T, ver kbfsmd.MetadataVer, fromStart bool) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -665,15 +665,15 @@ func testMDOpsGetRangeSuccessHelper(
 	}
 }
 
-func testMDOpsGetRangeSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetRangeSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	testMDOpsGetRangeSuccessHelper(t, ver, false)
 }
 
-func testMDOpsGetRangeFromStartSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetRangeFromStartSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	testMDOpsGetRangeSuccessHelper(t, ver, true)
 }
 
-func testMDOpsGetRangeFailBadPrevRoot(t *testing.T, ver MetadataVer) {
+func testMDOpsGetRangeFailBadPrevRoot(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -726,7 +726,7 @@ func (s *fakeMDServerPut) getLastRmds() *RootMetadataSigned {
 func (s *fakeMDServerPut) Shutdown() {}
 
 func validatePutPublicRMDS(
-	ctx context.Context, t *testing.T, ver MetadataVer, config Config,
+	ctx context.Context, t *testing.T, ver kbfsmd.MetadataVer, config Config,
 	inputRmd kbfsmd.RootMetadata, rmds *RootMetadataSigned) {
 	// TODO: Handle private RMDS, too.
 
@@ -768,7 +768,7 @@ func validatePutPublicRMDS(
 	require.Equal(t, expectedRmd, rmds.MD)
 }
 
-func testMDOpsPutPublicSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsPutPublicSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	ctx := context.Background()
 	config := MakeTestConfigOrBust(t, "alice", "bob")
 	config.SetMetadataVersion(ver)
@@ -795,7 +795,7 @@ func testMDOpsPutPublicSuccess(t *testing.T, ver MetadataVer) {
 	validatePutPublicRMDS(ctx, t, ver, config, rmd.bareMd, rmds)
 }
 
-func testMDOpsPutPrivateSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsPutPrivateSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -825,7 +825,7 @@ func (c failEncodeCodec) Encode(obj interface{}) ([]byte, error) {
 	return nil, c.err
 }
 
-func testMDOpsPutFailEncode(t *testing.T, ver MetadataVer) {
+func testMDOpsPutFailEncode(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -853,7 +853,7 @@ func testMDOpsPutFailEncode(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMDOpsGetRangeFailFinal(t *testing.T, ver MetadataVer) {
+func testMDOpsGetRangeFailFinal(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -881,7 +881,7 @@ func testMDOpsGetRangeFailFinal(t *testing.T, ver MetadataVer) {
 	require.IsType(t, MDMismatchError{}, err)
 }
 
-func testMDOpsGetFinalSuccess(t *testing.T, ver MetadataVer) {
+func testMDOpsGetFinalSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	mockCtrl, config, ctx := mdOpsInit(t, ver)
 	defer mdOpsShutdown(mockCtrl, config)
 
@@ -921,7 +921,7 @@ func testMDOpsGetFinalSuccess(t *testing.T, ver MetadataVer) {
 }
 
 func TestMDOps(t *testing.T) {
-	tests := []func(*testing.T, MetadataVer){
+	tests := []func(*testing.T, kbfsmd.MetadataVer){
 		testMDOpsGetForHandlePublicSuccess,
 		testMDOpsGetForHandlePrivateSuccess,
 		testMDOpsGetForUnresolvedHandlePublicSuccess,

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -78,7 +78,7 @@ func isReadableOrError(
 }
 
 func getMDRange(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.BranchID,
-	start kbfsmd.Revision, end kbfsmd.Revision, mStatus MergeStatus,
+	start kbfsmd.Revision, end kbfsmd.Revision, mStatus kbfsmd.MergeStatus,
 	lockBeforeGet *keybase1.LockID) (rmds []ImmutableRootMetadata, err error) {
 	// The range is invalid.  Don't treat as an error though; it just
 	// indicates that we don't yet know about any revisions.
@@ -167,7 +167,7 @@ func getMDRange(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.Branch
 
 // getSingleMD returns an MD that is required to exist.
 func getSingleMD(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.BranchID,
-	rev kbfsmd.Revision, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (
+	rev kbfsmd.Revision, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	ImmutableRootMetadata, error) {
 	rmds, err := getMDRange(
 		ctx, config, id, bid, rev, rev, mStatus, lockBeforeGet)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -121,7 +121,7 @@ func getMDRange(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.Branch
 		case Merged:
 			fetchedRmds, err = config.MDOps().GetRange(
 				ctx, id, r.start, r.end, lockBeforeGet)
-		case Unmerged:
+		case kbfsmd.Unmerged:
 			fetchedRmds, err = config.MDOps().GetUnmergedRange(
 				ctx, id, bid, r.start, r.end)
 		default:
@@ -306,7 +306,7 @@ func getUnmergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 		}
 
 		rmds, err := getMDRange(ctx, config, id, bid, startRev, currHead,
-			Unmerged, nil)
+			kbfsmd.Unmerged, nil)
 		if err != nil {
 			return kbfsmd.RevisionUninitialized, nil, err
 		}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -494,7 +494,7 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 		}
 	} else {
 		// decrypt the root data for non-public directories
-		var encryptedPrivateMetadata EncryptedPrivateMetadata
+		var encryptedPrivateMetadata kbfscrypto.EncryptedPrivateMetadata
 		if err := codec.Decode(serializedPrivateMetadata,
 			&encryptedPrivateMetadata); err != nil {
 			return PrivateMetadata{}, err

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -118,7 +118,7 @@ func getMDRange(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.Branch
 	for _, r := range toDownload {
 		var fetchedRmds []ImmutableRootMetadata
 		switch mStatus {
-		case Merged:
+		case kbfsmd.Merged:
 			fetchedRmds, err = config.MDOps().GetRange(
 				ctx, id, r.start, r.end, lockBeforeGet)
 		case kbfsmd.Unmerged:
@@ -202,7 +202,7 @@ func getMergedMDUpdates(ctx context.Context, config Config, id tlf.ID,
 	for {
 		end := start + maxMDsAtATime - 1 // range is inclusive
 		rmds, err := getMDRange(ctx, config, id, kbfsmd.NullBranchID, start, end,
-			Merged, lockBeforeGet)
+			kbfsmd.Merged, lockBeforeGet)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -338,7 +338,7 @@ func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
 	}
 
 	// Lookup the branch ID if not supplied
-	if mStatus == Unmerged && bid == kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Unmerged && bid == kbfsmd.NullBranchID {
 		var err error
 		bid, err = md.getBranchID(ctx, id)
 		if err != nil {
@@ -373,7 +373,7 @@ func (md *MDServerDisk) GetRange(ctx context.Context, id tlf.ID,
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
 
 	// Lookup the branch ID if not supplied
-	if mStatus == Unmerged && bid == kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Unmerged && bid == kbfsmd.NullBranchID {
 		var err error
 		bid, err = md.getBranchID(ctx, id)
 		if err != nil {

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -158,7 +158,7 @@ func (md *MDServerDisk) getStorage(tlfID tlf.ID) (*mdServerTlfStorage, error) {
 }
 
 func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
-	mStatus MergeStatus) (tlfID tlf.ID, created bool, err error) {
+	mStatus kbfsmd.MergeStatus) (tlfID tlf.ID, created bool, err error) {
 	handleBytes, err := md.config.Codec().Encode(handle)
 	if err != nil {
 		return tlf.NullID, false, kbfsmd.ServerError{Err: err}
@@ -216,7 +216,7 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 
 // GetForHandle implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForHandle(ctx context.Context, handle tlf.Handle,
-	mStatus MergeStatus, _ *keybase1.LockID) (
+	mStatus kbfsmd.MergeStatus, _ *keybase1.LockID) (
 	tlf.ID, *RootMetadataSigned, error) {
 	if err := checkContext(ctx); err != nil {
 		return tlf.NullID, nil, err
@@ -331,7 +331,7 @@ func (md *MDServerDisk) deleteBranchID(ctx context.Context, id tlf.ID) error {
 
 // GetForTLF implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, _ *keybase1.LockID) (
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, _ *keybase1.LockID) (
 	*RootMetadataSigned, error) {
 	if err := checkContext(ctx); err != nil {
 		return nil, err
@@ -364,7 +364,7 @@ func (md *MDServerDisk) GetForTLF(ctx context.Context, id tlf.ID,
 
 // GetRange implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) GetRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	_ *keybase1.LockID) ([]*RootMetadataSigned, error) {
 	if err := checkContext(ctx); err != nil {
 		return nil, err

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -429,7 +429,7 @@ func (md *MDServerDisk) Put(ctx context.Context, rmds *RootMetadataSigned,
 	}
 
 	mStatus := rmds.MD.MergedStatus()
-	if mStatus == Merged &&
+	if mStatus == kbfsmd.Merged &&
 		// Don't send notifies if it's just a rekey (the real mdserver
 		// sends a "folder needs rekey" notification in this case).
 		!(rmds.MD.IsRekeySet() && rmds.MD.IsWriterMetadataCopiedSet()) {
@@ -477,7 +477,7 @@ func (md *MDServerDisk) PruneBranch(ctx context.Context, id tlf.ID, bid kbfsmd.B
 
 func (md *MDServerDisk) getCurrentMergedHeadRevision(
 	ctx context.Context, id tlf.ID) (rev kbfsmd.Revision, err error) {
-	head, err := md.GetForTLF(ctx, id, kbfsmd.NullBranchID, Merged, nil)
+	head, err := md.GetForTLF(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/libkbfs/mdserver_local_config.go
+++ b/libkbfs/mdserver_local_config.go
@@ -15,7 +15,7 @@ type mdServerLocalConfig interface {
 	Clock() Clock
 	Codec() kbfscodec.Codec
 	currentSessionGetter() CurrentSessionGetter
-	MetadataVersion() MetadataVer
+	MetadataVersion() kbfsmd.MetadataVer
 	logMaker
 	cryptoPureGetter
 	teamMembershipChecker() kbfsmd.TeamMembershipChecker

--- a/libkbfs/mdserver_local_config_test.go
+++ b/libkbfs/mdserver_local_config_test.go
@@ -52,7 +52,7 @@ func (c testMDServerLocalConfig) currentSessionGetter() CurrentSessionGetter {
 	return c.csg
 }
 
-func (c testMDServerLocalConfig) MetadataVersion() MetadataVer {
+func (c testMDServerLocalConfig) MetadataVersion() kbfsmd.MetadataVer {
 	return defaultClientMetadataVer
 }
 

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -46,7 +46,7 @@ type mdBlockMem struct {
 	// An encoded RootMetdataSigned.
 	encodedMd []byte
 	timestamp time.Time
-	version   MetadataVer
+	version   kbfsmd.MetadataVer
 }
 
 type mdBlockMemList struct {

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -215,14 +215,14 @@ func (md *MDServerMemory) GetForHandle(ctx context.Context, handle tlf.Handle,
 func (md *MDServerMemory) checkGetParamsRLocked(
 	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus) (
 	newBid kbfsmd.BranchID, err error) {
-	if mStatus == Merged && bid != kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Merged && bid != kbfsmd.NullBranchID {
 		return kbfsmd.NullBranchID, kbfsmd.ServerErrorBadRequest{Reason: "Invalid branch ID"}
 	}
 
 	// Check permissions
 
 	mergedMasterHead, err :=
-		md.getHeadForTLFRLocked(ctx, id, kbfsmd.NullBranchID, Merged)
+		md.getHeadForTLFRLocked(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged)
 	if err != nil {
 		return kbfsmd.NullBranchID, kbfsmd.ServerError{Err: err}
 	}
@@ -313,7 +313,7 @@ func (md *MDServerMemory) getHeadForTLFRLocked(ctx context.Context, id tlf.ID,
 
 func (md *MDServerMemory) getMDKey(
 	id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus) (mdBlockKey, error) {
-	if (mStatus == Merged) != (bid == kbfsmd.NullBranchID) {
+	if (mStatus == kbfsmd.Merged) != (bid == kbfsmd.NullBranchID) {
 		return mdBlockKey{},
 			errors.Errorf("mstatus=%v is inconsistent with bid=%v",
 				mStatus, bid)
@@ -489,7 +489,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	}
 
 	mergedMasterHead, err :=
-		md.getHeadForTLFRLocked(ctx, id, kbfsmd.NullBranchID, Merged)
+		md.getHeadForTLFRLocked(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged)
 	if err != nil {
 		return kbfsmd.ServerError{Err: err}
 	}
@@ -527,7 +527,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 		// currHead for unmerged history might be on the main branch
 		prevRev := rmds.MD.RevisionNumber() - 1
 		rmdses, ch, err := md.getRangeLocked(
-			ctx, id, kbfsmd.NullBranchID, Merged, prevRev, prevRev, nil)
+			ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, prevRev, prevRev, nil)
 		if err != nil {
 			return kbfsmd.ServerError{Err: err}
 		}
@@ -605,7 +605,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 		md.releaseLockLocked(ctx, id, lc.RequireLockID)
 	}
 
-	if mStatus == Merged &&
+	if mStatus == kbfsmd.Merged &&
 		// Don't send notifies if it's just a rekey (the real mdserver
 		// sends a "folder needs rekey" notification in this case).
 		!(rmds.MD.IsRekeySet() && rmds.MD.IsWriterMetadataCopiedSet()) {
@@ -925,7 +925,7 @@ func (md *MDServerMemory) addNewAssertionForTest(uid keybase1.UID,
 
 func (md *MDServerMemory) getCurrentMergedHeadRevision(
 	ctx context.Context, id tlf.ID) (rev kbfsmd.Revision, err error) {
-	head, err := md.GetForTLF(ctx, id, kbfsmd.NullBranchID, Merged, nil)
+	head, err := md.GetForTLF(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, nil)
 	if err != nil {
 		return 0, err
 	}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -141,7 +141,7 @@ func (md *MDServerMemory) checkShutdownRLocked() error {
 }
 
 func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
-	mStatus MergeStatus) (tlfID tlf.ID, created bool, err error) {
+	mStatus kbfsmd.MergeStatus) (tlfID tlf.ID, created bool, err error) {
 	handleBytes, err := md.config.Codec().Encode(handle)
 	if err != nil {
 		return tlf.NullID, false, kbfsmd.ServerError{Err: err}
@@ -190,7 +190,7 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 
 // GetForHandle implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetForHandle(ctx context.Context, handle tlf.Handle,
-	mStatus MergeStatus, _ *keybase1.LockID) (
+	mStatus kbfsmd.MergeStatus, _ *keybase1.LockID) (
 	tlf.ID, *RootMetadataSigned, error) {
 	if err := checkContext(ctx); err != nil {
 		return tlf.NullID, nil, err
@@ -213,7 +213,7 @@ func (md *MDServerMemory) GetForHandle(ctx context.Context, handle tlf.Handle,
 }
 
 func (md *MDServerMemory) checkGetParamsRLocked(
-	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus) (
+	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus) (
 	newBid kbfsmd.BranchID, err error) {
 	if mStatus == kbfsmd.Merged && bid != kbfsmd.NullBranchID {
 		return kbfsmd.NullBranchID, kbfsmd.ServerErrorBadRequest{Reason: "Invalid branch ID"}
@@ -259,7 +259,7 @@ func (md *MDServerMemory) checkGetParamsRLocked(
 
 // GetForTLF implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetForTLF(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, _ *keybase1.LockID) (
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, _ *keybase1.LockID) (
 	*RootMetadataSigned, error) {
 	if err := checkContext(ctx); err != nil {
 		return nil, err
@@ -284,7 +284,7 @@ func (md *MDServerMemory) GetForTLF(ctx context.Context, id tlf.ID,
 }
 
 func (md *MDServerMemory) getHeadForTLFRLocked(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus) (*RootMetadataSigned, error) {
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus) (*RootMetadataSigned, error) {
 	key, err := md.getMDKey(id, bid, mStatus)
 	if err != nil {
 		return nil, err
@@ -312,7 +312,7 @@ func (md *MDServerMemory) getHeadForTLFRLocked(ctx context.Context, id tlf.ID,
 }
 
 func (md *MDServerMemory) getMDKey(
-	id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus) (mdBlockKey, error) {
+	id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus) (mdBlockKey, error) {
 	if (mStatus == kbfsmd.Merged) != (bid == kbfsmd.NullBranchID) {
 		return mdBlockKey{},
 			errors.Errorf("mstatus=%v is inconsistent with bid=%v",
@@ -342,7 +342,7 @@ func (md *MDServerMemory) getCurrentDeviceKey(ctx context.Context) (
 
 // GetRange implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) getRangeLocked(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	lockBeforeGet *keybase1.LockID) (
 	rmdses []*RootMetadataSigned, lockWaitCh <-chan struct{}, err error) {
 	md.log.CDebugf(ctx, "GetRange %d %d (%s)", start, stop, mStatus)
@@ -415,7 +415,7 @@ func (md *MDServerMemory) getRangeLocked(ctx context.Context, id tlf.ID,
 }
 
 func (md *MDServerMemory) doGetRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	lockBeforeGet *keybase1.LockID) (
 	[]*RootMetadataSigned, <-chan struct{}, error) {
 	md.lock.Lock()
@@ -425,7 +425,7 @@ func (md *MDServerMemory) doGetRange(ctx context.Context, id tlf.ID,
 
 // GetRange implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) GetRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	lockBeforeGet *keybase1.LockID) ([]*RootMetadataSigned, error) {
 	if err := checkContext(ctx); err != nil {
 		return nil, err

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -250,7 +250,7 @@ func (md *MDServerMemory) checkGetParamsRLocked(
 	}
 
 	// Lookup the branch ID if not supplied
-	if mStatus == Unmerged && bid == kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Unmerged && bid == kbfsmd.NullBranchID {
 		return md.getBranchIDRLocked(ctx, id)
 	}
 
@@ -272,7 +272,7 @@ func (md *MDServerMemory) GetForTLF(ctx context.Context, id tlf.ID,
 	if err != nil {
 		return nil, err
 	}
-	if mStatus == Unmerged && bid == kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Unmerged && bid == kbfsmd.NullBranchID {
 		return nil, nil
 	}
 
@@ -363,7 +363,7 @@ func (md *MDServerMemory) getRangeLocked(ctx context.Context, id tlf.ID,
 		}()
 	}
 
-	if mStatus == Unmerged && bid == kbfsmd.NullBranchID {
+	if mStatus == kbfsmd.Unmerged && bid == kbfsmd.NullBranchID {
 		return nil, nil, nil
 	}
 
@@ -523,7 +523,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 
 	var recordBranchID bool
 
-	if mStatus == Unmerged && head == nil {
+	if mStatus == kbfsmd.Unmerged && head == nil {
 		// currHead for unmerged history might be on the main branch
 		prevRev := rmds.MD.RevisionNumber() - 1
 		rmdses, ch, err := md.getRangeLocked(

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -527,7 +527,7 @@ func (md *MDServerRemote) get(ctx context.Context, arg keybase1.GetMetadataArg) 
 
 // GetForHandle implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetForHandle(ctx context.Context,
-	handle tlf.Handle, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (
+	handle tlf.Handle, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	tlfID tlf.ID, rmds *RootMetadataSigned, err error) {
 	ctx = rpc.WithFireNow(ctx)
 	// TODO: Ideally, *tlf.Handle would have a nicer String() function.
@@ -563,7 +563,7 @@ func (md *MDServerRemote) GetForHandle(ctx context.Context,
 
 // GetForTLF implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetForTLF(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (rmds *RootMetadataSigned, err error) {
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (rmds *RootMetadataSigned, err error) {
 	ctx = rpc.WithFireNow(ctx)
 	md.log.LazyTrace(ctx, "MDServer: GetForTLF %s %s %s", id, bid, mStatus)
 	defer func() {
@@ -590,7 +590,7 @@ func (md *MDServerRemote) GetForTLF(ctx context.Context, id tlf.ID,
 
 // GetRange implements the MDServer interface for MDServerRemote.
 func (md *MDServerRemote) GetRange(ctx context.Context, id tlf.ID,
-	bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision,
+	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision,
 	lockBeforeGet *keybase1.LockID) (rmdses []*RootMetadataSigned, err error) {
 	ctx = rpc.WithFireNow(ctx)
 	md.log.LazyTrace(ctx, "MDServer: GetRange %s %s %s %d-%d", id, bid, mStatus, start, stop)

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -641,7 +641,7 @@ func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
 		arg.LockContext = &copied
 	}
 
-	if rmds.Version() < SegregatedKeyBundlesVer {
+	if rmds.Version() < kbfsmd.SegregatedKeyBundlesVer {
 		if extra != nil {
 			return fmt.Errorf("Unexpected non-nil extra: %+v", extra)
 		}
@@ -1155,7 +1155,7 @@ func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 	}
 
 	if response.WriterBundle.Bundle != nil {
-		if response.WriterBundle.Version != int(SegregatedKeyBundlesVer) {
+		if response.WriterBundle.Version != int(kbfsmd.SegregatedKeyBundlesVer) {
 			err = fmt.Errorf("Unsupported writer bundle version: %d",
 				response.WriterBundle.Version)
 			return nil, nil, err
@@ -1178,7 +1178,7 @@ func (md *MDServerRemote) GetKeyBundles(ctx context.Context,
 	}
 
 	if response.ReaderBundle.Bundle != nil {
-		if response.ReaderBundle.Version != int(SegregatedKeyBundlesVer) {
+		if response.ReaderBundle.Version != int(kbfsmd.SegregatedKeyBundlesVer) {
 			err = fmt.Errorf("Unsupported reader bundle version: %d",
 				response.ReaderBundle.Version)
 			return nil, nil, err

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -546,7 +546,7 @@ func (md *MDServerRemote) GetForHandle(ctx context.Context,
 	arg := keybase1.GetMetadataArg{
 		FolderHandle:  encodedHandle,
 		BranchID:      kbfsmd.NullBranchID.String(),
-		Unmerged:      mStatus == Unmerged,
+		Unmerged:      mStatus == kbfsmd.Unmerged,
 		LockBeforeGet: lockBeforeGet,
 	}
 
@@ -573,7 +573,7 @@ func (md *MDServerRemote) GetForTLF(ctx context.Context, id tlf.ID,
 	arg := keybase1.GetMetadataArg{
 		FolderID:      id.String(),
 		BranchID:      bid.String(),
-		Unmerged:      mStatus == Unmerged,
+		Unmerged:      mStatus == kbfsmd.Unmerged,
 		LockBeforeGet: lockBeforeGet,
 	}
 
@@ -601,7 +601,7 @@ func (md *MDServerRemote) GetRange(ctx context.Context, id tlf.ID,
 	arg := keybase1.GetMetadataArg{
 		FolderID:      id.String(),
 		BranchID:      bid.String(),
-		Unmerged:      mStatus == Unmerged,
+		Unmerged:      mStatus == kbfsmd.Unmerged,
 		StartRevision: start.Number(),
 		StopRevision:  stop.Number(),
 		LockBeforeGet: lockBeforeGet,

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -513,7 +513,7 @@ func (md *MDServerRemote) get(ctx context.Context, arg keybase1.GetMetadataArg) 
 	// deserialize blocks
 	rmdses = make([]*RootMetadataSigned, len(response.MdBlocks))
 	for i, block := range response.MdBlocks {
-		ver, max := MetadataVer(block.Version), md.config.MetadataVersion()
+		ver, max := kbfsmd.MetadataVer(block.Version), md.config.MetadataVersion()
 		rmds, err := DecodeRootMetadataSigned(
 			md.config.Codec(), tlfID, ver, max, block.Block,
 			keybase1.FromTime(block.Timestamp))

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -67,7 +67,7 @@ func TestMDServerBasics(t *testing.T) {
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	id, rmds, err := mdServer.GetForHandle(ctx, h, Merged, nil)
+	id, rmds, err := mdServer.GetForHandle(ctx, h, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.Nil(t, rmds)
 
@@ -148,13 +148,13 @@ func TestMDServerBasics(t *testing.T) {
 	require.Equal(t, 0, len(rmdses))
 
 	// (10) check for proper merged head
-	head, err = mdServer.GetForTLF(ctx, id, kbfsmd.NullBranchID, Merged, nil)
+	head, err = mdServer.GetForTLF(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.NotNil(t, head)
 	require.Equal(t, kbfsmd.Revision(10), head.MD.RevisionNumber())
 
 	// (11) try to get merged range
-	rmdses, err = mdServer.GetRange(ctx, id, kbfsmd.NullBranchID, Merged, 1, 100, nil)
+	rmdses, err = mdServer.GetRange(ctx, id, kbfsmd.NullBranchID, kbfsmd.Merged, 1, 100, nil)
 	require.NoError(t, err)
 	require.Equal(t, 10, len(rmdses))
 	for i := kbfsmd.Revision(1); i <= 10; i++ {
@@ -180,7 +180,7 @@ func TestMDServerRegisterForUpdate(t *testing.T) {
 	h1, err := tlf.MakeHandle([]keybase1.UserOrTeamID{id}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	id1, _, err := mdServer.GetForHandle(ctx, h1, Merged, nil)
+	id1, _, err := mdServer.GetForHandle(ctx, h1, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 
 	// Create second TLF, which should end up being different from
@@ -190,7 +190,7 @@ func TestMDServerRegisterForUpdate(t *testing.T) {
 		nil, nil, nil)
 	require.NoError(t, err)
 
-	id2, _, err := mdServer.GetForHandle(ctx, h2, Merged, nil)
+	id2, _, err := mdServer.GetForHandle(ctx, h2, kbfsmd.Merged, nil)
 	require.NoError(t, err)
 	require.NotEqual(t, id1, id2)
 

--- a/libkbfs/mdserver_test.go
+++ b/libkbfs/mdserver_test.go
@@ -112,13 +112,13 @@ func TestMDServerBasics(t *testing.T) {
 	}
 
 	// (5) check for proper unmerged head
-	head, err := mdServer.GetForTLF(ctx, id, bid, Unmerged, nil)
+	head, err := mdServer.GetForTLF(ctx, id, bid, kbfsmd.Unmerged, nil)
 	require.NoError(t, err)
 	require.NotNil(t, head)
 	require.Equal(t, kbfsmd.Revision(40), head.MD.RevisionNumber())
 
 	// (6a) try to get unmerged range
-	rmdses, err := mdServer.GetRange(ctx, id, bid, Unmerged, 1, 100, nil)
+	rmdses, err := mdServer.GetRange(ctx, id, bid, kbfsmd.Unmerged, 1, 100, nil)
 	require.NoError(t, err)
 	require.Equal(t, 35, len(rmdses))
 	for i := kbfsmd.Revision(6); i < 41; i++ {
@@ -126,7 +126,7 @@ func TestMDServerBasics(t *testing.T) {
 	}
 
 	// (6b) try to get unmerged range subset.
-	rmdses, err = mdServer.GetRange(ctx, id, bid, Unmerged, 7, 14, nil)
+	rmdses, err = mdServer.GetRange(ctx, id, bid, kbfsmd.Unmerged, 7, 14, nil)
 	require.NoError(t, err)
 	require.Equal(t, 8, len(rmdses))
 	for i := kbfsmd.Revision(7); i <= 14; i++ {
@@ -138,12 +138,12 @@ func TestMDServerBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	// (8) verify head is pruned
-	head, err = mdServer.GetForTLF(ctx, id, kbfsmd.NullBranchID, Unmerged, nil)
+	head, err = mdServer.GetForTLF(ctx, id, kbfsmd.NullBranchID, kbfsmd.Unmerged, nil)
 	require.NoError(t, err)
 	require.Nil(t, head)
 
 	// (9) verify revision history is pruned
-	rmdses, err = mdServer.GetRange(ctx, id, kbfsmd.NullBranchID, Unmerged, 1, 100, nil)
+	rmdses, err = mdServer.GetRange(ctx, id, kbfsmd.NullBranchID, kbfsmd.Unmerged, 1, 100, nil)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(rmdses))
 

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -453,7 +453,7 @@ func (s *mdServerTlfStorage) put(ctx context.Context,
 		return false, kbfsmd.ServerError{Err: err}
 	}
 
-	if mStatus == Unmerged && head == nil {
+	if mStatus == kbfsmd.Unmerged && head == nil {
 		// currHead for unmerged history might be on the main branch
 		prevRev := rmds.MD.RevisionNumber() - 1
 		rmdses, err := s.getRangeReadLocked(

--- a/libkbfs/mdserver_tlf_storage.go
+++ b/libkbfs/mdserver_tlf_storage.go
@@ -67,7 +67,7 @@ type mdServerTlfStorage struct {
 	crypto         cryptoPure
 	clock          Clock
 	teamMemChecker kbfsmd.TeamMembershipChecker
-	mdVer          MetadataVer
+	mdVer          kbfsmd.MetadataVer
 	dir            string
 
 	// Protects any IO operations in dir or any of its children,
@@ -78,7 +78,7 @@ type mdServerTlfStorage struct {
 
 func makeMDServerTlfStorage(tlfID tlf.ID, codec kbfscodec.Codec,
 	clock Clock, teamMemChecker kbfsmd.TeamMembershipChecker,
-	mdVer MetadataVer, dir string) *mdServerTlfStorage {
+	mdVer kbfsmd.MetadataVer, dir string) *mdServerTlfStorage {
 	journal := &mdServerTlfStorage{
 		tlfID:          tlfID,
 		codec:          codec,
@@ -120,7 +120,7 @@ func (s *mdServerTlfStorage) mdPath(id kbfsmd.ID) string {
 type serializedRMDS struct {
 	EncodedRMDS []byte
 	Timestamp   time.Time
-	Version     MetadataVer
+	Version     kbfsmd.MetadataVer
 }
 
 // getMDReadLocked verifies the MD data (but not the signature) for

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3300,10 +3300,10 @@ func (mr *MockcryptoPureMockRecorder) DecryptPrivateMetadata(encryptedPMD, key i
 }
 
 // EncryptBlock mocks base method
-func (m *MockcryptoPure) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (int, EncryptedBlock, error) {
+func (m *MockcryptoPure) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (int, kbfscrypto.EncryptedBlock, error) {
 	ret := m.ctrl.Call(m, "EncryptBlock", block, key)
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(EncryptedBlock)
+	ret1, _ := ret[1].(kbfscrypto.EncryptedBlock)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -3314,7 +3314,7 @@ func (mr *MockcryptoPureMockRecorder) EncryptBlock(block, key interface{}) *gomo
 }
 
 // DecryptBlock mocks base method
-func (m *MockcryptoPure) DecryptBlock(encryptedBlock EncryptedBlock, key kbfscrypto.BlockCryptKey, block Block) error {
+func (m *MockcryptoPure) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey, block Block) error {
 	ret := m.ctrl.Call(m, "DecryptBlock", encryptedBlock, key, block)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -3469,10 +3469,10 @@ func (mr *MockCryptoMockRecorder) DecryptPrivateMetadata(encryptedPMD, key inter
 }
 
 // EncryptBlock mocks base method
-func (m *MockCrypto) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (int, EncryptedBlock, error) {
+func (m *MockCrypto) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (int, kbfscrypto.EncryptedBlock, error) {
 	ret := m.ctrl.Call(m, "EncryptBlock", block, key)
 	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(EncryptedBlock)
+	ret1, _ := ret[1].(kbfscrypto.EncryptedBlock)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -3483,7 +3483,7 @@ func (mr *MockCryptoMockRecorder) EncryptBlock(block, key interface{}) *gomock.C
 }
 
 // DecryptBlock mocks base method
-func (m *MockCrypto) DecryptBlock(encryptedBlock EncryptedBlock, key kbfscrypto.BlockCryptKey, block Block) error {
+func (m *MockCrypto) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey, block Block) error {
 	ret := m.ctrl.Call(m, "DecryptBlock", encryptedBlock, key, block)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3594,7 +3594,7 @@ func (m *MockMDOps) EXPECT() *MockMDOpsMockRecorder {
 }
 
 // GetForHandle mocks base method
-func (m *MockMDOps) GetForHandle(ctx context.Context, handle *TlfHandle, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (tlf.ID, ImmutableRootMetadata, error) {
+func (m *MockMDOps) GetForHandle(ctx context.Context, handle *TlfHandle, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (tlf.ID, ImmutableRootMetadata, error) {
 	ret := m.ctrl.Call(m, "GetForHandle", ctx, handle, mStatus, lockBeforeGet)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(ImmutableRootMetadata)
@@ -4039,7 +4039,7 @@ func (mr *MockMDServerMockRecorder) RefreshAuthToken(arg0 interface{}) *gomock.C
 }
 
 // GetForHandle mocks base method
-func (m *MockMDServer) GetForHandle(ctx context.Context, handle tlf.Handle, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (tlf.ID, *RootMetadataSigned, error) {
+func (m *MockMDServer) GetForHandle(ctx context.Context, handle tlf.Handle, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (tlf.ID, *RootMetadataSigned, error) {
 	ret := m.ctrl.Call(m, "GetForHandle", ctx, handle, mStatus, lockBeforeGet)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(*RootMetadataSigned)
@@ -4053,7 +4053,7 @@ func (mr *MockMDServerMockRecorder) GetForHandle(ctx, handle, mStatus, lockBefor
 }
 
 // GetForTLF mocks base method
-func (m *MockMDServer) GetForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (*RootMetadataSigned, error) {
+func (m *MockMDServer) GetForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (*RootMetadataSigned, error) {
 	ret := m.ctrl.Call(m, "GetForTLF", ctx, id, bid, mStatus, lockBeforeGet)
 	ret0, _ := ret[0].(*RootMetadataSigned)
 	ret1, _ := ret[1].(error)
@@ -4066,7 +4066,7 @@ func (mr *MockMDServerMockRecorder) GetForTLF(ctx, id, bid, mStatus, lockBeforeG
 }
 
 // GetRange mocks base method
-func (m *MockMDServer) GetRange(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) ([]*RootMetadataSigned, error) {
+func (m *MockMDServer) GetRange(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) ([]*RootMetadataSigned, error) {
 	ret := m.ctrl.Call(m, "GetRange", ctx, id, bid, mStatus, start, stop, lockBeforeGet)
 	ret0, _ := ret[0].([]*RootMetadataSigned)
 	ret1, _ := ret[1].(error)
@@ -4313,7 +4313,7 @@ func (mr *MockmdServerLocalMockRecorder) RefreshAuthToken(arg0 interface{}) *gom
 }
 
 // GetForHandle mocks base method
-func (m *MockmdServerLocal) GetForHandle(ctx context.Context, handle tlf.Handle, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (tlf.ID, *RootMetadataSigned, error) {
+func (m *MockmdServerLocal) GetForHandle(ctx context.Context, handle tlf.Handle, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (tlf.ID, *RootMetadataSigned, error) {
 	ret := m.ctrl.Call(m, "GetForHandle", ctx, handle, mStatus, lockBeforeGet)
 	ret0, _ := ret[0].(tlf.ID)
 	ret1, _ := ret[1].(*RootMetadataSigned)
@@ -4327,7 +4327,7 @@ func (mr *MockmdServerLocalMockRecorder) GetForHandle(ctx, handle, mStatus, lock
 }
 
 // GetForTLF mocks base method
-func (m *MockmdServerLocal) GetForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus, lockBeforeGet *keybase1.LockID) (*RootMetadataSigned, error) {
+func (m *MockmdServerLocal) GetForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (*RootMetadataSigned, error) {
 	ret := m.ctrl.Call(m, "GetForTLF", ctx, id, bid, mStatus, lockBeforeGet)
 	ret0, _ := ret[0].(*RootMetadataSigned)
 	ret1, _ := ret[1].(error)
@@ -4340,7 +4340,7 @@ func (mr *MockmdServerLocalMockRecorder) GetForTLF(ctx, id, bid, mStatus, lockBe
 }
 
 // GetRange mocks base method
-func (m *MockmdServerLocal) GetRange(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus, start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) ([]*RootMetadataSigned, error) {
+func (m *MockmdServerLocal) GetRange(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, start, stop kbfsmd.Revision, lockBeforeGet *keybase1.LockID) ([]*RootMetadataSigned, error) {
 	ret := m.ctrl.Call(m, "GetRange", ctx, id, bid, mStatus, start, stop, lockBeforeGet)
 	ret0, _ := ret[0].([]*RootMetadataSigned)
 	ret1, _ := ret[1].(error)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -6019,9 +6019,9 @@ func (mr *MockConfigMockRecorder) SetConflictRenamer(arg0 interface{}) *gomock.C
 }
 
 // MetadataVersion mocks base method
-func (m *MockConfig) MetadataVersion() MetadataVer {
+func (m *MockConfig) MetadataVersion() kbfsmd.MetadataVer {
 	ret := m.ctrl.Call(m, "MetadataVersion")
-	ret0, _ := ret[0].(MetadataVer)
+	ret0, _ := ret[0].(kbfsmd.MetadataVer)
 	return ret0
 }
 
@@ -6031,7 +6031,7 @@ func (mr *MockConfigMockRecorder) MetadataVersion() *gomock.Call {
 }
 
 // SetMetadataVersion mocks base method
-func (m *MockConfig) SetMetadataVersion(arg0 MetadataVer) {
+func (m *MockConfig) SetMetadataVersion(arg0 kbfsmd.MetadataVer) {
 	m.ctrl.Call(m, "SetMetadataVersion", arg0)
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1441,7 +1441,7 @@ func (mr *MockKeybaseServiceMockRecorder) LoadUnverifiedKeys(ctx, uid interface{
 }
 
 // LoadTeamPlusKeys mocks base method
-func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen, desiredUser keybase1.UserVersion, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredRole keybase1.TeamRole) (TeamInfo, error) {
 	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUser, desiredRole)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
@@ -1838,10 +1838,10 @@ func (m *MockteamKeysGetter) EXPECT() *MockteamKeysGetterMockRecorder {
 }
 
 // GetTeamTLFCryptKeys mocks base method
-func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+func (m *MockteamKeysGetter) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
-	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
-	ret1, _ := ret[1].(KeyGen)
+	ret0, _ := ret[0].(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey)
+	ret1, _ := ret[1].(kbfsmd.KeyGen)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -2004,10 +2004,10 @@ func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock
 }
 
 // GetTeamTLFCryptKeys mocks base method
-func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen KeyGen) (map[KeyGen]kbfscrypto.TLFCryptKey, KeyGen, error) {
+func (m *MockKBPKI) GetTeamTLFCryptKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen) (map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey, kbfsmd.KeyGen, error) {
 	ret := m.ctrl.Call(m, "GetTeamTLFCryptKeys", ctx, tid, desiredKeyGen)
-	ret0, _ := ret[0].(map[KeyGen]kbfscrypto.TLFCryptKey)
-	ret1, _ := ret[1].(KeyGen)
+	ret0, _ := ret[0].(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey)
+	ret1, _ := ret[1].(kbfsmd.KeyGen)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -2164,9 +2164,9 @@ func (mr *MockKeyMetadataMockRecorder) TlfID() *gomock.Call {
 }
 
 // LatestKeyGeneration mocks base method
-func (m *MockKeyMetadata) LatestKeyGeneration() KeyGen {
+func (m *MockKeyMetadata) LatestKeyGeneration() kbfsmd.KeyGen {
 	ret := m.ctrl.Call(m, "LatestKeyGeneration")
-	ret0, _ := ret[0].(KeyGen)
+	ret0, _ := ret[0].(kbfsmd.KeyGen)
 	return ret0
 }
 
@@ -2214,7 +2214,7 @@ func (mr *MockKeyMetadataMockRecorder) HasKeyForUser(user interface{}) *gomock.C
 }
 
 // GetTLFCryptKeyParams mocks base method
-func (m *MockKeyMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+func (m *MockKeyMetadata) GetTLFCryptKeyParams(keyGen kbfsmd.KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
 	ret := m.ctrl.Call(m, "GetTLFCryptKeyParams", keyGen, user, key)
 	ret0, _ := ret[0].(kbfscrypto.TLFEphemeralPublicKey)
 	ret1, _ := ret[1].(kbfscrypto.EncryptedTLFCryptKeyClientHalf)
@@ -2242,7 +2242,7 @@ func (mr *MockKeyMetadataMockRecorder) StoresHistoricTLFCryptKeys() *gomock.Call
 }
 
 // GetHistoricTLFCryptKey mocks base method
-func (m *MockKeyMetadata) GetHistoricTLFCryptKey(codec kbfscodec.Codec, keyGen KeyGen, currentKey kbfscrypto.TLFCryptKey) (kbfscrypto.TLFCryptKey, error) {
+func (m *MockKeyMetadata) GetHistoricTLFCryptKey(codec kbfscodec.Codec, keyGen kbfsmd.KeyGen, currentKey kbfscrypto.TLFCryptKey) (kbfscrypto.TLFCryptKey, error) {
 	ret := m.ctrl.Call(m, "GetHistoricTLFCryptKey", codec, keyGen, currentKey)
 	ret0, _ := ret[0].(kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(error)
@@ -2679,7 +2679,7 @@ func (m *MockKeyCache) EXPECT() *MockKeyCacheMockRecorder {
 }
 
 // GetTLFCryptKey mocks base method
-func (m *MockKeyCache) GetTLFCryptKey(arg0 tlf.ID, arg1 KeyGen) (kbfscrypto.TLFCryptKey, error) {
+func (m *MockKeyCache) GetTLFCryptKey(arg0 tlf.ID, arg1 kbfsmd.KeyGen) (kbfscrypto.TLFCryptKey, error) {
 	ret := m.ctrl.Call(m, "GetTLFCryptKey", arg0, arg1)
 	ret0, _ := ret[0].(kbfscrypto.TLFCryptKey)
 	ret1, _ := ret[1].(error)
@@ -2692,7 +2692,7 @@ func (mr *MockKeyCacheMockRecorder) GetTLFCryptKey(arg0, arg1 interface{}) *gomo
 }
 
 // PutTLFCryptKey mocks base method
-func (m *MockKeyCache) PutTLFCryptKey(arg0 tlf.ID, arg1 KeyGen, arg2 kbfscrypto.TLFCryptKey) error {
+func (m *MockKeyCache) PutTLFCryptKey(arg0 tlf.ID, arg1 kbfsmd.KeyGen, arg2 kbfscrypto.TLFCryptKey) error {
 	ret := m.ctrl.Call(m, "PutTLFCryptKey", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2214,10 +2214,10 @@ func (mr *MockKeyMetadataMockRecorder) HasKeyForUser(user interface{}) *gomock.C
 }
 
 // GetTLFCryptKeyParams mocks base method
-func (m *MockKeyMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
+func (m *MockKeyMetadata) GetTLFCryptKeyParams(keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf, TLFCryptKeyServerHalfID, bool, error) {
 	ret := m.ctrl.Call(m, "GetTLFCryptKeyParams", keyGen, user, key)
 	ret0, _ := ret[0].(kbfscrypto.TLFEphemeralPublicKey)
-	ret1, _ := ret[1].(EncryptedTLFCryptKeyClientHalf)
+	ret1, _ := ret[1].(kbfscrypto.EncryptedTLFCryptKeyClientHalf)
 	ret2, _ := ret[2].(TLFCryptKeyServerHalfID)
 	ret3, _ := ret[3].(bool)
 	ret4, _ := ret[4].(error)
@@ -3274,9 +3274,9 @@ func (mr *MockcryptoPureMockRecorder) MakeRandomBlockCryptKeyServerHalf() *gomoc
 }
 
 // EncryptPrivateMetadata mocks base method
-func (m *MockcryptoPure) EncryptPrivateMetadata(pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (EncryptedPrivateMetadata, error) {
+func (m *MockcryptoPure) EncryptPrivateMetadata(pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (kbfscrypto.EncryptedPrivateMetadata, error) {
 	ret := m.ctrl.Call(m, "EncryptPrivateMetadata", pmd, key)
-	ret0, _ := ret[0].(EncryptedPrivateMetadata)
+	ret0, _ := ret[0].(kbfscrypto.EncryptedPrivateMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3287,7 +3287,7 @@ func (mr *MockcryptoPureMockRecorder) EncryptPrivateMetadata(pmd, key interface{
 }
 
 // DecryptPrivateMetadata mocks base method
-func (m *MockcryptoPure) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (PrivateMetadata, error) {
+func (m *MockcryptoPure) DecryptPrivateMetadata(encryptedPMD kbfscrypto.EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (PrivateMetadata, error) {
 	ret := m.ctrl.Call(m, "DecryptPrivateMetadata", encryptedPMD, key)
 	ret0, _ := ret[0].(PrivateMetadata)
 	ret1, _ := ret[1].(error)
@@ -3443,9 +3443,9 @@ func (mr *MockCryptoMockRecorder) MakeRandomBlockCryptKeyServerHalf() *gomock.Ca
 }
 
 // EncryptPrivateMetadata mocks base method
-func (m *MockCrypto) EncryptPrivateMetadata(pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (EncryptedPrivateMetadata, error) {
+func (m *MockCrypto) EncryptPrivateMetadata(pmd PrivateMetadata, key kbfscrypto.TLFCryptKey) (kbfscrypto.EncryptedPrivateMetadata, error) {
 	ret := m.ctrl.Call(m, "EncryptPrivateMetadata", pmd, key)
-	ret0, _ := ret[0].(EncryptedPrivateMetadata)
+	ret0, _ := ret[0].(kbfscrypto.EncryptedPrivateMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -3456,7 +3456,7 @@ func (mr *MockCryptoMockRecorder) EncryptPrivateMetadata(pmd, key interface{}) *
 }
 
 // DecryptPrivateMetadata mocks base method
-func (m *MockCrypto) DecryptPrivateMetadata(encryptedPMD EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (PrivateMetadata, error) {
+func (m *MockCrypto) DecryptPrivateMetadata(encryptedPMD kbfscrypto.EncryptedPrivateMetadata, key kbfscrypto.TLFCryptKey) (PrivateMetadata, error) {
 	ret := m.ctrl.Call(m, "DecryptPrivateMetadata", encryptedPMD, key)
 	ret0, _ := ret[0].(PrivateMetadata)
 	ret1, _ := ret[1].(error)
@@ -3534,7 +3534,7 @@ func (mr *MockCryptoMockRecorder) SignToString(arg0, arg1 interface{}) *gomock.C
 }
 
 // DecryptTLFCryptKeyClientHalf mocks base method
-func (m *MockCrypto) DecryptTLFCryptKeyClientHalf(ctx context.Context, publicKey kbfscrypto.TLFEphemeralPublicKey, encryptedClientHalf EncryptedTLFCryptKeyClientHalf) (kbfscrypto.TLFCryptKeyClientHalf, error) {
+func (m *MockCrypto) DecryptTLFCryptKeyClientHalf(ctx context.Context, publicKey kbfscrypto.TLFEphemeralPublicKey, encryptedClientHalf kbfscrypto.EncryptedTLFCryptKeyClientHalf) (kbfscrypto.TLFCryptKeyClientHalf, error) {
 	ret := m.ctrl.Call(m, "DecryptTLFCryptKeyClientHalf", ctx, publicKey, encryptedClientHalf)
 	ret0, _ := ret[0].(kbfscrypto.TLFCryptKeyClientHalf)
 	ret1, _ := ret[1].(error)

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -230,7 +230,7 @@ func (md *RootMetadata) MakeSuccessor(
 				return nil, err
 			}
 			_, keyGen, err := teamKeyer.GetTeamTLFCryptKeys(
-				ctx, tid, UnspecifiedKeyGen)
+				ctx, tid, kbfsmd.UnspecifiedKeyGen)
 			if err != nil {
 				return nil, err
 			}
@@ -282,10 +282,10 @@ func (md *RootMetadata) MakeBareTlfHandle() (tlf.Handle, error) {
 func (md *RootMetadata) IsInitialized() bool {
 	keyGen := md.LatestKeyGeneration()
 	if md.TlfID().Type() == tlf.Public {
-		return keyGen == PublicKeyGen
+		return keyGen == kbfsmd.PublicKeyGen
 	}
 	// The data is only initialized once we have at least one set of keys
-	return keyGen >= FirstValidKeyGen
+	return keyGen >= kbfsmd.FirstValidKeyGen
 }
 
 // AddRefBlock adds the newly-referenced block to the add block change list.
@@ -454,19 +454,19 @@ func (md *RootMetadata) loadCachedBlockChanges(
 
 // GetTLFCryptKeyParams wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) GetTLFCryptKeyParams(
-	keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (
+	keyGen kbfsmd.KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (
 	kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf,
 	TLFCryptKeyServerHalfID, bool, error) {
 	return md.bareMd.GetTLFCryptKeyParams(keyGen, user, key, md.extra)
 }
 
 // KeyGenerationsToUpdate wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) KeyGenerationsToUpdate() (KeyGen, KeyGen) {
+func (md *RootMetadata) KeyGenerationsToUpdate() (kbfsmd.KeyGen, kbfsmd.KeyGen) {
 	return md.bareMd.KeyGenerationsToUpdate()
 }
 
 // LatestKeyGeneration wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) LatestKeyGeneration() KeyGen {
+func (md *RootMetadata) LatestKeyGeneration() kbfsmd.KeyGen {
 	return md.bareMd.LatestKeyGeneration()
 }
 
@@ -812,7 +812,7 @@ func (md *RootMetadata) StoresHistoricTLFCryptKeys() bool {
 
 // GetHistoricTLFCryptKey implements the KeyMetadata interface for RootMetadata.
 func (md *RootMetadata) GetHistoricTLFCryptKey(
-	codec kbfscodec.Codec, keyGen KeyGen,
+	codec kbfscodec.Codec, keyGen kbfsmd.KeyGen,
 	currentKey kbfscrypto.TLFCryptKey) (kbfscrypto.TLFCryptKey, error) {
 	return md.bareMd.GetHistoricTLFCryptKey(
 		codec, keyGen, currentKey, md.extra)

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -587,7 +587,7 @@ func (md *RootMetadata) MerkleRoot() keybase1.MerkleRootV2 {
 }
 
 // MergedStatus wraps the respective method of the underlying BareRootMetadata for convenience.
-func (md *RootMetadata) MergedStatus() MergeStatus {
+func (md *RootMetadata) MergedStatus() kbfsmd.MergeStatus {
 	return md.bareMd.MergedStatus()
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -119,7 +119,7 @@ func makeRootMetadata(bareMd kbfsmd.MutableRootMetadata,
 // and handle. Note that if the given ID/handle are private, rekeying
 // must be done separately.
 func makeInitialRootMetadata(
-	ver MetadataVer, tlfID tlf.ID, h *TlfHandle) (*RootMetadata, error) {
+	ver kbfsmd.MetadataVer, tlfID tlf.ID, h *TlfHandle) (*RootMetadata, error) {
 	bh, err := h.ToBareHandle()
 	if err != nil {
 		return nil, err
@@ -190,7 +190,7 @@ func (md *RootMetadata) deepCopy(codec kbfscodec.Codec) (*RootMetadata, error) {
 // with cleared block change lists and cleared serialized metadata),
 // with the revision incremented and a correct backpointer.
 func (md *RootMetadata) MakeSuccessor(
-	ctx context.Context, latestMDVer MetadataVer, codec kbfscodec.Codec,
+	ctx context.Context, latestMDVer kbfsmd.MetadataVer, codec kbfscodec.Codec,
 	keyManager KeyManager, merkleGetter merkleRootGetter,
 	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
 	*RootMetadata, error) {
@@ -602,7 +602,7 @@ func (md *RootMetadata) PrevRoot() kbfsmd.ID {
 }
 
 // Version returns the underlying BareRootMetadata version.
-func (md *RootMetadata) Version() MetadataVer {
+func (md *RootMetadata) Version() kbfsmd.MetadataVer {
 	return md.bareMd.Version()
 }
 
@@ -1009,7 +1009,7 @@ func (rmds *RootMetadataSigned) MakeFinalCopy(
 // DecodeRootMetadataSigned deserializes a metadata block into the
 // specified versioned structure.
 func DecodeRootMetadataSigned(
-	codec kbfscodec.Codec, tlf tlf.ID, ver, max MetadataVer, buf []byte,
+	codec kbfscodec.Codec, tlf tlf.ID, ver, max kbfsmd.MetadataVer, buf []byte,
 	untrustedServerTimestamp time.Time) (
 	*RootMetadataSigned, error) {
 	rmds, err := kbfsmd.DecodeRootMetadataSigned(codec, tlf, ver, max, buf)

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -455,7 +455,7 @@ func (md *RootMetadata) loadCachedBlockChanges(
 // GetTLFCryptKeyParams wraps the respective method of the underlying BareRootMetadata for convenience.
 func (md *RootMetadata) GetTLFCryptKeyParams(
 	keyGen KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (
-	kbfscrypto.TLFEphemeralPublicKey, EncryptedTLFCryptKeyClientHalf,
+	kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf,
 	TLFCryptKeyServerHalfID, bool, error) {
 	return md.bareMd.GetTLFCryptKeyParams(keyGen, user, key, md.extra)
 }

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var testMetadataVers = []MetadataVer{
-	InitialExtraMetadataVer, SegregatedKeyBundlesVer,
+	kbfsmd.InitialExtraMetadataVer, kbfsmd.SegregatedKeyBundlesVer,
 }
 
 // runTestOverMetadataVers runs the given test function over all
@@ -395,11 +395,11 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(t, config, "alice,alice@twitter#bob,charlie@twitter,eve@reddit", tlf.Private)
-	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 
 	// set some dummy numbers
 	diskUsage, refBytes, unrefBytes := uint64(12345), uint64(4321), uint64(1234)
@@ -415,7 +415,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 
@@ -433,7 +433,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
@@ -447,7 +447,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 2, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
@@ -469,12 +469,12 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 2, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
 	// override the metadata version
-	config.metadataVersion = SegregatedKeyBundlesVer
+	config.metadataVersion = kbfsmd.SegregatedKeyBundlesVer
 
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
@@ -484,7 +484,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
-	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
+	require.Equal(t, kbfsmd.SegregatedKeyBundlesVer, rmd2.Version())
 	extra, ok := rmd2.extra.(*kbfsmd.ExtraMetadataV3)
 	require.True(t, ok)
 	require.True(t, extra.IsWriterKeyBundleNew())
@@ -553,11 +553,11 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.Public)
 	h := parseTlfHandleOrBust(
 		t, config, "alice,bob,charlie@twitter", tlf.Public)
-	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.PublicKeyGen, rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 
 	// set some dummy numbers
 	diskUsage, refBytes, unrefBytes := uint64(12345), uint64(4321), uint64(1234)
@@ -566,7 +566,7 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	rmd.SetUnrefBytes(unrefBytes)
 
 	// override the metadata version
-	config.metadataVersion = SegregatedKeyBundlesVer
+	config.metadataVersion = kbfsmd.SegregatedKeyBundlesVer
 
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
@@ -576,7 +576,7 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
-	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
+	require.Equal(t, kbfsmd.SegregatedKeyBundlesVer, rmd2.Version())
 	// Do this instead of require.Nil because we want to assert
 	// that it's untyped nil.
 	require.True(t, rmd2.extra == nil)
@@ -608,11 +608,11 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(
 		t, config, "alice,bob (conflicted copy 2017-08-24)", tlf.Private)
-	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 	require.NotNil(t, h.ConflictInfo())
 
 	// set some dummy numbers
@@ -630,13 +630,13 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 	require.True(t, rmd.IsReadable())
 
 	// override the metadata version
-	config.metadataVersion = SegregatedKeyBundlesVer
+	config.metadataVersion = kbfsmd.SegregatedKeyBundlesVer
 
 	// create an MDv3 successor
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
@@ -646,7 +646,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
-	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
+	require.Equal(t, kbfsmd.SegregatedKeyBundlesVer, rmd2.Version())
 	extra, ok := rmd2.extra.(*kbfsmd.ExtraMetadataV3)
 	require.True(t, ok)
 	require.True(t, extra.IsWriterKeyBundleNew())
@@ -673,7 +673,7 @@ func TestRootMetadataV3NoPanicOnWriterMismatch(t *testing.T) {
 
 	tlfID := tlf.FakeID(0, tlf.Private)
 	h := makeFakeTlfHandle(t, 14, tlf.Private, nil, nil)
-	rmd, err := makeInitialRootMetadata(SegregatedKeyBundlesVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
 	rmd.fakeInitialRekey()
 	rmd.SetLastModifyingWriter(uid)
@@ -705,11 +705,11 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(t, configWriter, "alice#bob", tlf.Private)
-	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, PreExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.PreExtraMetadataVer, rmd.Version())
 
 	// set some dummy numbers
 	diskUsage, refBytes, unrefBytes := uint64(12345), uint64(4321), uint64(1234)
@@ -724,7 +724,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
-	require.Equal(t, PreExtraMetadataVer, rmd.Version())
+	require.Equal(t, kbfsmd.PreExtraMetadataVer, rmd.Version())
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
 
@@ -756,7 +756,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	// Override the metadata version, make a successor, and rekey as
 	// reader.  This should keep the version the same, since readers
 	// can't upconvert.
-	configReader.metadataVersion = SegregatedKeyBundlesVer
+	configReader.metadataVersion = kbfsmd.SegregatedKeyBundlesVer
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		configReader.MetadataVersion(), configReader.Codec(),
 		configReader.KeyManager(), configReader.KBPKI(),
@@ -764,7 +764,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
-	require.Equal(t, PreExtraMetadataVer, rmd2.Version())
+	require.Equal(t, kbfsmd.PreExtraMetadataVer, rmd2.Version())
 	// Do this instead of require.Nil because we want to assert
 	// that it's untyped nil.
 	require.True(t, rmd2.extra == nil)
@@ -774,7 +774,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	require.True(t, done)
 	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
-	require.Equal(t, PreExtraMetadataVer, rmd2.Version())
+	require.Equal(t, kbfsmd.PreExtraMetadataVer, rmd2.Version())
 	require.True(t, rmd2.IsWriterMetadataCopiedSet())
 	require.True(t, bytes.Equal(rmd.GetSerializedPrivateMetadata(),
 		rmd2.GetSerializedPrivateMetadata()))
@@ -805,7 +805,7 @@ func TestRootMetadataTeamMembership(t *testing.T) {
 		},
 		name: "t1",
 	}
-	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 
 	getUser := func(name string) (keybase1.UID, kbfscrypto.VerifyingKey) {
@@ -889,7 +889,7 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 		},
 		name: "t1",
 	}
-	rmd, err := makeInitialRootMetadata(SegregatedKeyBundlesVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(kbfsmd.SegregatedKeyBundlesVer, tlfID, h)
 	require.NoError(t, err)
 	rmd.bareMd.SetLatestKeyGenerationForTeamTLF(teamInfos[0].LatestKeyGen)
 	// Make sure the MD looks readable.

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -268,8 +268,8 @@ func testRootMetadataLatestKeyGenerationPrivate(t *testing.T, ver MetadataVer) {
 		t.Errorf("Expected key generation to be invalid (0)")
 	}
 	rmd.fakeInitialRekey()
-	if rmd.LatestKeyGeneration() != FirstValidKeyGen {
-		t.Errorf("Expected key generation to be valid(%d)", FirstValidKeyGen)
+	if rmd.LatestKeyGeneration() != kbfsmd.FirstValidKeyGen {
+		t.Errorf("Expected key generation to be valid(%d)", kbfsmd.FirstValidKeyGen)
 	}
 }
 
@@ -280,8 +280,8 @@ func testRootMetadataLatestKeyGenerationPublic(t *testing.T, ver MetadataVer) {
 	rmd, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)
 
-	if rmd.LatestKeyGeneration() != PublicKeyGen {
-		t.Errorf("Expected key generation to be public (%d)", PublicKeyGen)
+	if rmd.LatestKeyGeneration() != kbfsmd.PublicKeyGen {
+		t.Errorf("Expected key generation to be public (%d)", kbfsmd.PublicKeyGen)
 	}
 }
 
@@ -365,7 +365,7 @@ func testRootMetadataFinalIsFinal(t *testing.T, ver MetadataVer) {
 func getAllUsersKeysForTest(
 	t *testing.T, config Config, rmd *RootMetadata, un string) []kbfscrypto.TLFCryptKey {
 	var keys []kbfscrypto.TLFCryptKey
-	for keyGen := FirstValidKeyGen; keyGen <= rmd.LatestKeyGeneration(); keyGen++ {
+	for keyGen := kbfsmd.FirstValidKeyGen; keyGen <= rmd.LatestKeyGeneration(); keyGen++ {
 		key, err := config.KeyManager().(*KeyManagerStandard).getTLFCryptKeyUsingCurrentDevice(
 			context.Background(), rmd, keyGen, true)
 		require.NoError(t, err)
@@ -378,11 +378,11 @@ func getAllUsersKeysForTest(
 type dummyNoKeyCache struct {
 }
 
-func (kc *dummyNoKeyCache) GetTLFCryptKey(_ tlf.ID, _ KeyGen) (kbfscrypto.TLFCryptKey, error) {
+func (kc *dummyNoKeyCache) GetTLFCryptKey(_ tlf.ID, _ kbfsmd.KeyGen) (kbfscrypto.TLFCryptKey, error) {
 	return kbfscrypto.TLFCryptKey{}, KeyCacheMissError{}
 }
 
-func (kc *dummyNoKeyCache) PutTLFCryptKey(_ tlf.ID, _ KeyGen, _ kbfscrypto.TLFCryptKey) error {
+func (kc *dummyNoKeyCache) PutTLFCryptKey(_ tlf.ID, _ kbfsmd.KeyGen, _ kbfscrypto.TLFCryptKey) error {
 	return nil
 }
 
@@ -397,7 +397,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	h := parseTlfHandleOrBust(t, config, "alice,alice@twitter#bob,charlie@twitter,eve@reddit", tlf.Private)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, KeyGen(0), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 
@@ -413,7 +413,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err := config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(1), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(1), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
@@ -431,7 +431,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err = config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
@@ -445,7 +445,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err = config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 2, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
@@ -467,7 +467,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	done, _, err = config2.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(2), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(2), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 2, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
@@ -482,7 +482,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
 		true)
 	require.NoError(t, err)
-	require.Equal(t, KeyGen(2), rmd2.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(2), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
 	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
 	extra, ok := rmd2.extra.(*kbfsmd.ExtraMetadataV3)
@@ -555,7 +555,7 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 		t, config, "alice,bob,charlie@twitter", tlf.Public)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, PublicKeyGen, rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.PublicKeyGen, rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 
@@ -574,7 +574,7 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
 		true)
 	require.NoError(t, err)
-	require.Equal(t, PublicKeyGen, rmd2.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.PublicKeyGen, rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
 	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
 	// Do this instead of require.Nil because we want to assert
@@ -610,7 +610,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 		t, config, "alice,bob (conflicted copy 2017-08-24)", tlf.Private)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, KeyGen(0), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 	require.NotNil(t, h.ConflictInfo())
@@ -628,7 +628,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 	done, _, err := config.KeyManager().Rekey(context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(1), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(1), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, InitialExtraMetadataVer, rmd.Version())
 	require.Equal(t, 0, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).RKeys[0].TLFReaderEphemeralPublicKeys))
@@ -644,7 +644,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 		config.KeyManager(), config.KBPKI(), config.KBPKI(), kbfsmd.FakeID(1),
 		true)
 	require.NoError(t, err)
-	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
 	require.Equal(t, SegregatedKeyBundlesVer, rmd2.Version())
 	extra, ok := rmd2.extra.(*kbfsmd.ExtraMetadataV3)
@@ -707,7 +707,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	h := parseTlfHandleOrBust(t, configWriter, "alice#bob", tlf.Private)
 	rmd, err := makeInitialRootMetadata(InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
-	require.Equal(t, KeyGen(0), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, PreExtraMetadataVer, rmd.Version())
 
@@ -722,7 +722,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		context.Background(), rmd, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(1), rmd.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(1), rmd.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(1), rmd.Revision())
 	require.Equal(t, PreExtraMetadataVer, rmd.Version())
 	require.Equal(t, 1, len(rmd.bareMd.(*kbfsmd.RootMetadataV2).WKeys[0].TLFEphemeralPublicKeys))
@@ -762,7 +762,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		configReader.KeyManager(), configReader.KBPKI(),
 		configReader.KBPKI(), kbfsmd.FakeID(1), false)
 	require.NoError(t, err)
-	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
 	require.Equal(t, PreExtraMetadataVer, rmd2.Version())
 	// Do this instead of require.Nil because we want to assert
@@ -772,7 +772,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 		context.Background(), rmd2, false)
 	require.NoError(t, err)
 	require.True(t, done)
-	require.Equal(t, KeyGen(1), rmd2.LatestKeyGeneration())
+	require.Equal(t, kbfsmd.KeyGen(1), rmd2.LatestKeyGeneration())
 	require.Equal(t, kbfsmd.Revision(2), rmd2.Revision())
 	require.Equal(t, PreExtraMetadataVer, rmd2.Version())
 	require.True(t, rmd2.IsWriterMetadataCopiedSet())
@@ -896,7 +896,7 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 	rmd.data.Dir.BlockPointer = BlockPointer{ID: kbfsblock.FakeID(1)}
 
 	firstKeyGen := rmd.LatestKeyGeneration()
-	require.Equal(t, FirstValidKeyGen, firstKeyGen)
+	require.Equal(t, kbfsmd.FirstValidKeyGen, firstKeyGen)
 
 	rmd2, err := rmd.MakeSuccessor(context.Background(),
 		config.MetadataVersion(), config.Codec(),

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var testMetadataVers = []MetadataVer{
+var testMetadataVers = []kbfsmd.MetadataVer{
 	kbfsmd.InitialExtraMetadataVer, kbfsmd.SegregatedKeyBundlesVer,
 }
 
@@ -44,7 +44,7 @@ var testMetadataVers = []MetadataVer{
 //	...
 // }
 func runTestOverMetadataVers(
-	t *testing.T, f func(t *testing.T, ver MetadataVer)) {
+	t *testing.T, f func(t *testing.T, ver kbfsmd.MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
@@ -59,7 +59,7 @@ func runTestOverMetadataVers(
 // be taken to be the strings after that prefix. Example use:
 //
 // func TestFoo(t *testing.T) {
-// 	tests := []func(*testing.T, MetadataVer){
+// 	tests := []func(*testing.T, kbfsmd.MetadataVer){
 //		testFooBar1,
 //		testFooBar2,
 //		testFooBar3,
@@ -68,7 +68,7 @@ func runTestOverMetadataVers(
 //	runTestsOverMetadataVers(t, "testFoo", tests)
 // }
 func runTestsOverMetadataVers(t *testing.T, prefix string,
-	fs []func(t *testing.T, ver MetadataVer)) {
+	fs []func(t *testing.T, ver kbfsmd.MetadataVer)) {
 	for _, f := range fs {
 		f := f // capture range variable.
 		name := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
@@ -92,13 +92,13 @@ func runTestsOverMetadataVers(t *testing.T, prefix string,
 //	runBenchmarkOverMetadataVers(b, testFoo)
 // }
 //
-// func benchmarkFoo(b *testing.B, ver MetadataVer) {
+// func benchmarkFoo(b *testing.B, ver kbfsmd.MetadataVer) {
 //	...
 // 	brmd, err := MakeInitialRootMetadata(ver, ...)
 //	...
 // }
 func runBenchmarkOverMetadataVers(
-	b *testing.B, f func(b *testing.B, ver MetadataVer)) {
+	b *testing.B, f func(b *testing.B, ver kbfsmd.MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		b.Run(ver.String(), func(b *testing.B) {
@@ -193,7 +193,7 @@ func makeFakeTlfHandle(
 
 // Test that GetTlfHandle() and MakeBareTlfHandle() work properly for
 // public TLFs.
-func testRootMetadataGetTlfHandlePublic(t *testing.T, ver MetadataVer) {
+func testRootMetadataGetTlfHandlePublic(t *testing.T, ver kbfsmd.MetadataVer) {
 	uw := []keybase1.SocialAssertion{
 		{
 			User:    "user2",
@@ -220,7 +220,7 @@ func testRootMetadataGetTlfHandlePublic(t *testing.T, ver MetadataVer) {
 
 // Test that GetTlfHandle() and MakeBareTlfHandle() work properly for
 // non-public TLFs.
-func testRootMetadataGetTlfHandlePrivate(t *testing.T, ver MetadataVer) {
+func testRootMetadataGetTlfHandlePrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	uw := []keybase1.SocialAssertion{
 		{
 			User:    "user2",
@@ -258,7 +258,7 @@ func testRootMetadataGetTlfHandlePrivate(t *testing.T, ver MetadataVer) {
 }
 
 // Test that key generations work as expected for private TLFs.
-func testRootMetadataLatestKeyGenerationPrivate(t *testing.T, ver MetadataVer) {
+func testRootMetadataLatestKeyGenerationPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
 	tlfID := tlf.FakeID(0, tlf.Private)
 	h := makeFakeTlfHandle(t, 14, tlf.Private, nil, nil)
 	rmd, err := makeInitialRootMetadata(ver, tlfID, h)
@@ -274,7 +274,7 @@ func testRootMetadataLatestKeyGenerationPrivate(t *testing.T, ver MetadataVer) {
 }
 
 // Test that key generations work as expected for public TLFs.
-func testRootMetadataLatestKeyGenerationPublic(t *testing.T, ver MetadataVer) {
+func testRootMetadataLatestKeyGenerationPublic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tlfID := tlf.FakeID(0, tlf.Public)
 	h := makeFakeTlfHandle(t, 14, tlf.Public, nil, nil)
 	rmd, err := makeInitialRootMetadata(ver, tlfID, h)
@@ -285,7 +285,7 @@ func testRootMetadataLatestKeyGenerationPublic(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testMakeRekeyReadError(t *testing.T, ver MetadataVer) {
+func testMakeRekeyReadError(t *testing.T, ver kbfsmd.MetadataVer) {
 	ctx := context.Background()
 	config := MakeTestConfigOrBust(t, "alice", "bob")
 	config.SetMetadataVersion(ver)
@@ -312,7 +312,7 @@ func testMakeRekeyReadError(t *testing.T, ver MetadataVer) {
 	require.Equal(t, NeedSelfRekeyError{"alice", dummyErr}, err)
 }
 
-func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver MetadataVer) {
+func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver kbfsmd.MetadataVer) {
 	ctx := context.Background()
 	config := MakeTestConfigOrBust(t, "alice", "bob")
 	defer config.Shutdown(ctx)
@@ -349,7 +349,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver MetadataVer) {
 
 // Test that MakeSuccessor fails when the final bit is set.
 
-func testRootMetadataFinalIsFinal(t *testing.T, ver MetadataVer) {
+func testRootMetadataFinalIsFinal(t *testing.T, ver kbfsmd.MetadataVer) {
 	tlfID := tlf.FakeID(0, tlf.Public)
 	h := makeFakeTlfHandle(t, 14, tlf.Public, nil, nil)
 	rmd, err := makeInitialRootMetadata(ver, tlfID, h)
@@ -922,7 +922,7 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 }
 
 func TestRootMetadata(t *testing.T) {
-	tests := []func(*testing.T, MetadataVer){
+	tests := []func(*testing.T, kbfsmd.MetadataVer){
 		testRootMetadataGetTlfHandlePublic,
 		testRootMetadataGetTlfHandlePrivate,
 		testRootMetadataLatestKeyGenerationPrivate,

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -490,7 +490,7 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	}
 
 	ti, err := kbd.LoadTeamPlusKeys(
-		context.Background(), tid, UnspecifiedKeyGen, keybase1.UserVersion{},
+		context.Background(), tid, kbfsmd.UnspecifiedKeyGen, keybase1.UserVersion{},
 		keybase1.TeamRole_NONE)
 	if err != nil {
 		return err

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -408,7 +408,7 @@ func (m *stallingMDOps) maybeStall(ctx context.Context, opName StallableMDOp) {
 }
 
 func (m *stallingMDOps) GetForHandle(
-	ctx context.Context, handle *TlfHandle, mStatus MergeStatus,
+	ctx context.Context, handle *TlfHandle, mStatus kbfsmd.MergeStatus,
 	lockBeforeGet *keybase1.LockID) (
 	tlfID tlf.ID, md ImmutableRootMetadata, err error) {
 	m.maybeStall(ctx, StallableMDGetForHandle)

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -384,7 +384,7 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 	estimates.update(rmds)
 
 	// If unmerged, get all the unmerged updates.
-	if head.MergedStatus() == Unmerged {
+	if head.MergedStatus() == kbfsmd.Unmerged {
 		_, unmergedRmds, err := getUnmergedMDUpdates(ctx, teh.config, head.TlfID(),
 			head.BID(), head.Revision()-1)
 		if err != nil {

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -432,7 +432,7 @@ func (teh *TlfEditHistory) GetComplete(ctx context.Context,
 			}
 
 			olderRmds, err := getMDRange(ctx, teh.config, head.TlfID(), kbfsmd.NullBranchID,
-				startRev, endRev, Merged, nil)
+				startRev, endRev, kbfsmd.Merged, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -35,7 +35,7 @@ type tlfJournalConfig interface {
 	BlockCache() BlockCache
 	BlockOps() BlockOps
 	MDCache() MDCache
-	MetadataVersion() MetadataVer
+	MetadataVersion() kbfsmd.MetadataVer
 	Reporter() Reporter
 	encryptionKeyGetter() encryptionKeyGetter
 	mdDecryptionKeyGetter() mdDecryptionKeyGetter

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -985,7 +985,7 @@ func (j *tlfJournal) checkServerForConflicts(ctx context.Context,
 	// returns the latest revision number, so we don't have to fetch
 	// the entire MD?
 	currHead, err := j.config.MDServer().GetForTLF(
-		ctx, j.tlfID, kbfsmd.NullBranchID, Merged, needLock)
+		ctx, j.tlfID, kbfsmd.NullBranchID, kbfsmd.Merged, needLock)
 	if err != nil {
 		return err
 	}
@@ -1492,7 +1492,7 @@ func (j *tlfJournal) flushOneMDOp(ctx context.Context,
 			}
 			// We must have already flushed this MD, so continue.
 			pushErr = nil
-		} else if rmds.MD.MergedStatus() == Merged {
+		} else if rmds.MD.MergedStatus() == kbfsmd.Merged {
 			j.log.CDebugf(ctx, "Conflict detected %v", pushErr)
 			// Convert MDs to a branch and return -- the journal
 			// pauses until the resolution is complete.

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -174,7 +174,7 @@ func (c testTLFJournalConfig) makeMD(
 
 func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
 	extra kbfsmd.ExtraMetadata, expectedRevision kbfsmd.Revision,
-	expectedPrevRoot kbfsmd.ID, expectedMergeStatus MergeStatus,
+	expectedPrevRoot kbfsmd.ID, expectedMergeStatus kbfsmd.MergeStatus,
 	expectedBranchID kbfsmd.BranchID) {
 	verifyingKey := c.crypto.SigningKeySigner.Key.GetVerifyingKey()
 	checkBRMD(c.t, c.uid, verifyingKey, c.Codec(),
@@ -189,7 +189,7 @@ func (c testTLFJournalConfig) checkMD(rmds *RootMetadataSigned,
 
 func (c testTLFJournalConfig) checkRange(rmdses []rmdsWithExtra,
 	firstRevision kbfsmd.Revision, firstPrevRoot kbfsmd.ID,
-	mStatus MergeStatus, bid kbfsmd.BranchID) {
+	mStatus kbfsmd.MergeStatus, bid kbfsmd.BranchID) {
 	c.checkMD(rmdses[0].rmds, rmdses[0].extra, firstRevision,
 		firstPrevRoot, mStatus, bid)
 
@@ -860,7 +860,7 @@ type shimMDServer struct {
 }
 
 func (s *shimMDServer) GetRange(
-	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus,
+	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus,
 	start, stop kbfsmd.Revision, _ *keybase1.LockID) ([]*RootMetadataSigned, error) {
 	rmdses := s.nextGetRange
 	s.nextGetRange = nil
@@ -886,7 +886,7 @@ func (s *shimMDServer) Put(ctx context.Context, rmds *RootMetadataSigned,
 }
 
 func (s *shimMDServer) GetForTLF(
-	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus MergeStatus, _ *keybase1.LockID) (
+	ctx context.Context, id tlf.ID, bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, _ *keybase1.LockID) (
 	*RootMetadataSigned, error) {
 	s.getForTLFCalled = true
 	if len(s.rmdses) == 0 {

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -81,7 +81,7 @@ type testTLFJournalConfig struct {
 	bcache       BlockCache
 	bops         BlockOps
 	mdcache      MDCache
-	ver          MetadataVer
+	ver          kbfsmd.MetadataVer
 	reporter     Reporter
 	uid          keybase1.UID
 	verifyingKey kbfscrypto.VerifyingKey
@@ -115,7 +115,7 @@ func (c testTLFJournalConfig) MDCache() MDCache {
 	return c.mdcache
 }
 
-func (c testTLFJournalConfig) MetadataVersion() MetadataVer {
+func (c testTLFJournalConfig) MetadataVersion() kbfsmd.MetadataVer {
 	return c.ver
 }
 
@@ -205,7 +205,7 @@ func (c testTLFJournalConfig) checkRange(rmdses []rmdsWithExtra,
 }
 
 func setupTLFJournalTest(
-	t *testing.T, ver MetadataVer, bwStatus TLFJournalBackgroundWorkStatus) (
+	t *testing.T, ver kbfsmd.MetadataVer, bwStatus TLFJournalBackgroundWorkStatus) (
 	tempdir string, config *testTLFJournalConfig, ctx context.Context,
 	cancel context.CancelFunc, tlfJournal *tlfJournal,
 	delegate testBWDelegate) {
@@ -337,7 +337,7 @@ func putOneMD(ctx context.Context, config *testTLFJournalConfig,
 // The tests below primarily test the background work thread's
 // behavior.
 
-func testTLFJournalBasic(t *testing.T, ver MetadataVer) {
+func testTLFJournalBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -351,7 +351,7 @@ func testTLFJournalBasic(t *testing.T, ver MetadataVer) {
 	delegate.requireNextState(ctx, bwIdle)
 }
 
-func testTLFJournalPauseResume(t *testing.T, ver MetadataVer) {
+func testTLFJournalPauseResume(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -370,7 +370,7 @@ func testTLFJournalPauseResume(t *testing.T, ver MetadataVer) {
 	delegate.requireNextState(ctx, bwIdle)
 }
 
-func testTLFJournalPauseShutdown(t *testing.T, ver MetadataVer) {
+func testTLFJournalPauseShutdown(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -415,7 +415,7 @@ func putBlock(ctx context.Context,
 	require.NoError(t, err)
 }
 
-func testTLFJournalBlockOpBasic(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -430,7 +430,7 @@ func testTLFJournalBlockOpBasic(t *testing.T, ver MetadataVer) {
 	require.False(t, converted)
 }
 
-func testTLFJournalBlockOpBusyPause(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpBusyPause(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -451,7 +451,7 @@ func testTLFJournalBlockOpBusyPause(t *testing.T, ver MetadataVer) {
 	delegate.requireNextState(ctx, bwPaused)
 }
 
-func testTLFJournalBlockOpBusyShutdown(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpBusyShutdown(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -469,7 +469,7 @@ func testTLFJournalBlockOpBusyShutdown(t *testing.T, ver MetadataVer) {
 	// Should still be able to shut down while busy.
 }
 
-func testTLFJournalSecondBlockOpWhileBusy(t *testing.T, ver MetadataVer) {
+func testTLFJournalSecondBlockOpWhileBusy(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -488,7 +488,7 @@ func testTLFJournalSecondBlockOpWhileBusy(t *testing.T, ver MetadataVer) {
 	putBlock(ctx, t, config, tlfJournal, []byte{1, 2, 3, 4, 5})
 }
 
-func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -527,7 +527,7 @@ func testTLFJournalBlockOpDiskByteLimit(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -567,7 +567,7 @@ func testTLFJournalBlockOpDiskFileLimit(t *testing.T, ver MetadataVer) {
 	}
 }
 
-func testTLFJournalBlockOpDiskQuotaLimit(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskQuotaLimit(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -614,7 +614,7 @@ func testTLFJournalBlockOpDiskQuotaLimit(t *testing.T, ver MetadataVer) {
 	require.Equal(t, int64(math.MaxInt64), quotaBytes)
 }
 
-func testTLFJournalBlockOpDiskQuotaLimitResolve(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskQuotaLimitResolve(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -675,7 +675,7 @@ func testTLFJournalBlockOpDiskQuotaLimitResolve(t *testing.T, ver MetadataVer) {
 	require.Equal(t, int64(math.MaxInt64), quotaBytes)
 }
 
-func testTLFJournalBlockOpDiskLimitDuplicate(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskLimitDuplicate(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -701,7 +701,7 @@ func testTLFJournalBlockOpDiskLimitDuplicate(t *testing.T, ver MetadataVer) {
 	require.NoError(t, err)
 }
 
-func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -719,7 +719,7 @@ func testTLFJournalBlockOpDiskLimitCancel(t *testing.T, ver MetadataVer) {
 	require.Equal(t, context.Canceled, errors.Cause(err))
 }
 
-func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -742,7 +742,7 @@ func testTLFJournalBlockOpDiskLimitTimeout(t *testing.T, ver MetadataVer) {
 	}, *timeoutErr)
 }
 
-func testTLFJournalBlockOpDiskLimitPutFailure(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpDiskLimitPutFailure(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -785,7 +785,7 @@ func (md hangingMDServer) waitForPut(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testTLFJournalMDServerBusyPause(t *testing.T, ver MetadataVer) {
+func testTLFJournalMDServerBusyPause(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -807,7 +807,7 @@ func testTLFJournalMDServerBusyPause(t *testing.T, ver MetadataVer) {
 	delegate.requireNextState(ctx, bwPaused)
 }
 
-func testTLFJournalMDServerBusyShutdown(t *testing.T, ver MetadataVer) {
+func testTLFJournalMDServerBusyShutdown(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -826,7 +826,7 @@ func testTLFJournalMDServerBusyShutdown(t *testing.T, ver MetadataVer) {
 	// Should still be able to shutdown while busy.
 }
 
-func testTLFJournalBlockOpWhileBusy(t *testing.T, ver MetadataVer) {
+func testTLFJournalBlockOpWhileBusy(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -912,7 +912,7 @@ func requireJournalEntryCounts(t *testing.T, j *tlfJournal,
 
 // The tests below test tlfJournal's MD flushing behavior.
 
-func testTLFJournalFlushMDBasic(t *testing.T, ver MetadataVer) {
+func testTLFJournalFlushMDBasic(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -957,7 +957,7 @@ func testTLFJournalFlushMDBasic(t *testing.T, ver MetadataVer) {
 		rmdses, firstRevision, firstPrevRoot, kbfsmd.Merged, kbfsmd.NullBranchID)
 }
 
-func testTLFJournalFlushMDConflict(t *testing.T, ver MetadataVer) {
+func testTLFJournalFlushMDConflict(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1088,7 +1088,7 @@ func testTLFJournalGCd(t *testing.T, tlfJournal *tlfJournal) {
 // orderings of blocks and MD ops when flushing, i.e. if a block op
 // was added to the block journal before an MD op was added to the MD
 // journal, then that block op will be flushed before that MD op.
-func testTLFJournalFlushOrdering(t *testing.T, ver MetadataVer) {
+func testTLFJournalFlushOrdering(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1176,7 +1176,7 @@ func testTLFJournalFlushOrdering(t *testing.T, ver MetadataVer) {
 // branch is squashed multiple times, and then hits a conflict, the
 // blocks are flushed completely before the conflict-resolving MD.
 func testTLFJournalFlushOrderingAfterSquashAndCR(
-	t *testing.T, ver MetadataVer) {
+	t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1315,7 +1315,7 @@ func testTLFJournalFlushOrderingAfterSquashAndCR(
 // testTLFJournalFlushInterleaving tests that we interleave block and
 // MD ops while respecting the relative orderings of blocks and MD ops
 // when flushing.
-func testTLFJournalFlushInterleaving(t *testing.T, ver MetadataVer) {
+func testTLFJournalFlushInterleaving(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1493,7 +1493,7 @@ func testTLFJournalPauseBlocksAndConvertBranch(t *testing.T,
 
 // testTLFJournalConvertWhileFlushing tests that we can do branch
 // conversion while blocks are still flushing.
-func testTLFJournalConvertWhileFlushing(t *testing.T, ver MetadataVer) {
+func testTLFJournalConvertWhileFlushing(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1519,7 +1519,7 @@ func testTLFJournalConvertWhileFlushing(t *testing.T, ver MetadataVer) {
 
 // testTLFJournalSquashWhileFlushing tests that we can do journal
 // coalescing while blocks are still flushing.
-func testTLFJournalSquashWhileFlushing(t *testing.T, ver MetadataVer) {
+func testTLFJournalSquashWhileFlushing(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1564,7 +1564,7 @@ func (t *testImmediateBackOff) Reset() {
 	close(t.resetCh)
 }
 
-func testTLFJournalFlushRetry(t *testing.T, ver MetadataVer) {
+func testTLFJournalFlushRetry(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1614,7 +1614,7 @@ func testTLFJournalFlushRetry(t *testing.T, ver MetadataVer) {
 	testTLFJournalGCd(t, tlfJournal)
 }
 
-func testTLFJournalResolveBranch(t *testing.T, ver MetadataVer) {
+func testTLFJournalResolveBranch(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1688,7 +1688,7 @@ func testTLFJournalResolveBranch(t *testing.T, ver MetadataVer) {
 	delegate.requireNextState(ctx, bwBusy)
 }
 
-func testTLFJournalSquashByBytes(t *testing.T, ver MetadataVer) {
+func testTLFJournalSquashByBytes(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1722,7 +1722,7 @@ func testTLFJournalSquashByBytes(t *testing.T, ver MetadataVer) {
 }
 
 // Test that the first revision of a TLF doesn't get squashed.
-func testTLFJournalFirstRevNoSquash(t *testing.T, ver MetadataVer) {
+func testTLFJournalFirstRevNoSquash(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalBackgroundWorkPaused)
 	defer teardownTLFJournalTest(
@@ -1772,7 +1772,7 @@ func testTLFJournalFirstRevNoSquash(t *testing.T, ver MetadataVer) {
 // testTLFJournalSingleOp tests that when the journal is in single op
 // mode, it doesn't flush any MDs until `finishSingleOp()` is called,
 // and then it only flushes one squashed MD.
-func testTLFJournalSingleOp(t *testing.T, ver MetadataVer) {
+func testTLFJournalSingleOp(t *testing.T, ver kbfsmd.MetadataVer) {
 	tempdir, config, ctx, cancel, tlfJournal, delegate :=
 		setupTLFJournalTest(t, ver, TLFJournalSingleOpBackgroundWorkEnabled)
 	defer teardownTLFJournalTest(
@@ -1849,7 +1849,7 @@ func testTLFJournalSingleOp(t *testing.T, ver MetadataVer) {
 }
 
 func TestTLFJournal(t *testing.T) {
-	tests := []func(*testing.T, MetadataVer){
+	tests := []func(*testing.T, kbfsmd.MetadataVer){
 		testTLFJournalBasic,
 		testTLFJournalPauseResume,
 		testTLFJournalPauseShutdown,

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -954,7 +954,7 @@ func testTLFJournalFlushMDBasic(t *testing.T, ver MetadataVer) {
 	rmdses := mdserver.rmdses
 	require.Equal(t, mdCount, len(rmdses))
 	config.checkRange(
-		rmdses, firstRevision, firstPrevRoot, Merged, kbfsmd.NullBranchID)
+		rmdses, firstRevision, firstPrevRoot, kbfsmd.Merged, kbfsmd.NullBranchID)
 }
 
 func testTLFJournalFlushMDConflict(t *testing.T, ver MetadataVer) {

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
@@ -32,7 +33,7 @@ const (
 )
 
 type opt struct {
-	ver                      libkbfs.MetadataVer
+	ver                      kbfsmd.MetadataVer
 	usernames                []libkb.NormalizedUsername
 	teams                    teamMap
 	tlfName                  string

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -60,14 +60,14 @@ type opt struct {
 
 // Also copy testMetadataVers, so that we can set it independently
 // from libkbfs tests.
-var testMetadataVers = []libkbfs.MetadataVer{
-	libkbfs.InitialExtraMetadataVer, libkbfs.SegregatedKeyBundlesVer,
+var testMetadataVers = []kbfsmd.MetadataVer{
+	kbfsmd.InitialExtraMetadataVer, kbfsmd.SegregatedKeyBundlesVer,
 }
 
 // runTestOverMetadataVers runs the given test function over all
 // metadata versions to test.
 func runTestOverMetadataVers(
-	t *testing.T, f func(t *testing.T, ver libkbfs.MetadataVer)) {
+	t *testing.T, f func(t *testing.T, ver kbfsmd.MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		t.Run(ver.String(), func(t *testing.T) {
@@ -81,7 +81,7 @@ func runTestOverMetadataVers(
 // runBenchmarkOverMetadataVers runs the given benchmark function over
 // all metadata versions to test.
 func runBenchmarkOverMetadataVers(
-	b *testing.B, f func(b *testing.B, ver libkbfs.MetadataVer)) {
+	b *testing.B, f func(b *testing.B, ver kbfsmd.MetadataVer)) {
 	for _, ver := range testMetadataVers {
 		ver := ver // capture range variable.
 		b.Run(ver.String(), func(b *testing.B) {
@@ -91,7 +91,7 @@ func runBenchmarkOverMetadataVers(
 }
 
 func runOneTestOrBenchmark(
-	tb testing.TB, ver libkbfs.MetadataVer, actions ...optionOp) {
+	tb testing.TB, ver kbfsmd.MetadataVer, actions ...optionOp) {
 	o := &opt{
 		ver:    ver,
 		tb:     tb,
@@ -104,14 +104,14 @@ func runOneTestOrBenchmark(
 }
 
 func test(t *testing.T, actions ...optionOp) {
-	runTestOverMetadataVers(t, func(t *testing.T, ver libkbfs.MetadataVer) {
+	runTestOverMetadataVers(t, func(t *testing.T, ver kbfsmd.MetadataVer) {
 		runOneTestOrBenchmark(t, ver, actions...)
 	})
 }
 
 func benchmark(b *testing.B, tb testing.TB, actions ...optionOp) {
 	runBenchmarkOverMetadataVers(
-		b, func(b *testing.B, ver libkbfs.MetadataVer) {
+		b, func(b *testing.B, ver kbfsmd.MetadataVer) {
 			runOneTestOrBenchmark(tb, ver, actions...)
 		})
 }
@@ -258,7 +258,7 @@ func users(ns ...username) optionOp {
 func team(teamName libkb.NormalizedUsername, writers string,
 	readers string) optionOp {
 	return func(o *opt) {
-		if o.ver == libkbfs.InitialExtraMetadataVer {
+		if o.ver == kbfsmd.InitialExtraMetadataVer {
 			o.tb.Skip("mdv2 doesn't support teams")
 		}
 		if o.teams == nil {

--- a/test/engine.go
+++ b/test/engine.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 )
@@ -44,7 +45,7 @@ type Engine interface {
 	// second; if zero, the engine defaults are used.  opTimeout
 	// specifies a per-operation timeout; if it is more than the
 	// default engine timeout, or if it is zero, it has no effect.
-	InitTest(ver libkbfs.MetadataVer, blockSize int64,
+	InitTest(ver kbfsmd.MetadataVer, blockSize int64,
 		blockChangeSize int64, batchSize int, bwKBps int,
 		opTimeout time.Duration, users []libkb.NormalizedUsername,
 		teams teamMap, clock libkbfs.Clock,

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
@@ -569,7 +570,7 @@ func fiTypeString(fi os.FileInfo) string {
 	return "OTHER"
 }
 
-func (e *fsEngine) InitTest(ver libkbfs.MetadataVer,
+func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
 	opTimeout time.Duration, users []libkb.NormalizedUsername, teams teamMap,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
+	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -43,7 +44,7 @@ func (k *LibKBFS) Name() string {
 }
 
 // InitTest implements the Engine interface.
-func (k *LibKBFS) InitTest(ver libkbfs.MetadataVer,
+func (k *LibKBFS) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
 	opTimeout time.Duration, users []libkb.NormalizedUsername, teams teamMap,
 	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {


### PR DESCRIPTION
Replace some instances of Keygen(1) with FirstValidKeyGen in tests.