### PR TITLE
kbfs_ops: some optimizations for single op mode (and some cleanup)

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1016,9 +1016,9 @@ func (fbo *folderBranchOps) identifyOnce(
 	return nil
 }
 
-// getMDForReadLocked returns an existing md for a read
-// operation. Note that mds will not be fetched here.
-func (fbo *folderBranchOps) getMDForReadLocked(
+// getMDForRead returns an existing md for a read operation. Note that
+// mds will not be fetched here.
+func (fbo *folderBranchOps) getMDForRead(
 	ctx context.Context, lState *lockState, rtype mdReadType) (
 	md ImmutableRootMetadata, err error) {
 	if rtype != mdReadNeedIdentify && rtype != mdReadNoIdentify {
@@ -1119,7 +1119,7 @@ func (fbo *folderBranchOps) getMDForWriteOrRekeyLocked(
 
 func (fbo *folderBranchOps) getMDForReadHelper(
 	ctx context.Context, lState *lockState, rtype mdReadType) (ImmutableRootMetadata, error) {
-	md, err := fbo.getMDForReadLocked(ctx, lState, rtype)
+	md, err := fbo.getMDForRead(ctx, lState, rtype)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -1188,7 +1188,7 @@ func (fbo *folderBranchOps) getMDForReadNeedIdentify(
 // one must be created by the caller.
 func (fbo *folderBranchOps) getMDForReadNeedIdentifyOnMaybeFirstAccess(
 	ctx context.Context, lState *lockState) (ImmutableRootMetadata, error) {
-	md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDForRead(ctx, lState, mdReadNeedIdentify)
 
 	if _, ok := err.(MDWriteNeededInRequest); ok {
 		fbo.mdWriterLock.Lock(lState)
@@ -1727,7 +1727,7 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 	lState := makeFBOLockState()
 
 	var md ImmutableRootMetadata
-	md, err = fbo.getMDForReadLocked(ctx, lState, mdReadNoIdentify)
+	md, err = fbo.getMDForRead(ctx, lState, mdReadNoIdentify)
 	if _, ok := err.(MDWriteNeededInRequest); ok {
 		func() {
 			fbo.mdWriterLock.Lock(lState)
@@ -3545,7 +3545,7 @@ func (fbo *folderBranchOps) Write(
 		// Get the MD for reading.  We won't modify it; we'll track the
 		// unref changes on the side, and put them into the MD during the
 		// sync.
-		md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+		md, err := fbo.getMDForRead(ctx, lState, mdReadNeedIdentify)
 		if err != nil {
 			return err
 		}
@@ -3581,7 +3581,7 @@ func (fbo *folderBranchOps) Truncate(
 		// Get the MD for reading.  We won't modify it; we'll track the
 		// unref changes on the side, and put them into the MD during the
 		// sync.
-		md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+		md, err := fbo.getMDForRead(ctx, lState, mdReadNeedIdentify)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -396,6 +396,10 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 		return rmd, nil
 	}
 
+	// Check for an unmerged MD first, unless we're in single-op
+	// mode.  If this is a single-op, we can skip this check because
+	// there's basically no way for a TLF to start off as unmerged
+	// since single-ops should be using a fresh journal.
 	if fs.config.Mode() != InitSingleOp {
 		_, rmd, err = fs.config.MDOps().GetForHandle(
 			ctx, tlfHandle, kbfsmd.Unmerged, nil)
@@ -500,9 +504,12 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		}
 	}
 
-	// Do GetForHandle() unlocked -- no cache lookups, should be fine
 	mdops := fs.config.MDOps()
 	var md ImmutableRootMetadata
+	// Check for an unmerged MD first, unless we're in single-op
+	// mode.  If this is a single-op, we can skip this check because
+	// there's basically no way for a TLF to start off as unmerged
+	// since single-ops should be using a fresh journal.
 	if fs.config.Mode() != InitSingleOp {
 		_, md, err = mdops.GetForHandle(ctx, h, kbfsmd.Unmerged, nil)
 		if err != nil {

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -396,9 +396,12 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 		return rmd, nil
 	}
 
-	_, rmd, err = fs.config.MDOps().GetForHandle(ctx, tlfHandle, kbfsmd.Unmerged, nil)
-	if err != nil {
-		return ImmutableRootMetadata{}, err
+	if fs.config.Mode() != InitSingleOp {
+		_, rmd, err = fs.config.MDOps().GetForHandle(
+			ctx, tlfHandle, kbfsmd.Unmerged, nil)
+		if err != nil {
+			return ImmutableRootMetadata{}, err
+		}
 	}
 
 	if rmd == (ImmutableRootMetadata{}) {
@@ -499,9 +502,12 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 
 	// Do GetForHandle() unlocked -- no cache lookups, should be fine
 	mdops := fs.config.MDOps()
-	_, md, err := mdops.GetForHandle(ctx, h, kbfsmd.Unmerged, nil)
-	if err != nil {
-		return nil, EntryInfo{}, err
+	var md ImmutableRootMetadata
+	if fs.config.Mode() != InitSingleOp {
+		_, md, err = mdops.GetForHandle(ctx, h, kbfsmd.Unmerged, nil)
+		if err != nil {
+			return nil, EntryInfo{}, err
+		}
 	}
 
 	if md == (ImmutableRootMetadata{}) {

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -662,7 +662,7 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 		t.Errorf("Couldn't sync: %v", syncErr)
 	}
 
-	md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDForRead(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		t.Errorf("Couldn't get MD: %v", err)
 	}
@@ -752,7 +752,7 @@ func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 		t.Fatalf("Timeout waiting for sync: %v", ctx.Err())
 	}
 
-	md, err := fbo.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	md, err := fbo.getMDForRead(ctx, lState, mdReadNeedIdentify)
 	if err != nil {
 		t.Errorf("Couldn't get MD: %v", err)
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -387,7 +387,7 @@ func TestKBFSOpsGetRootNodeCacheSuccess(t *testing.T) {
 
 	// Trigger identify.
 	lState := makeFBOLockState()
-	_, err = ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	_, err = ops.getMDForRead(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 }
@@ -416,7 +416,7 @@ func TestKBFSOpsGetRootNodeReIdentify(t *testing.T) {
 
 	// Trigger identify.
 	lState := makeFBOLockState()
-	_, err = ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	_, err = ops.getMDForRead(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 
@@ -430,7 +430,7 @@ func TestKBFSOpsGetRootNodeReIdentify(t *testing.T) {
 
 	// Trigger new identify.
 	lState = makeFBOLockState()
-	_, err = ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	_, err = ops.getMDForRead(ctx, lState, mdReadNeedIdentify)
 	require.NoError(t, err)
 	assert.True(t, fboIdentityDone(ops))
 }
@@ -470,7 +470,7 @@ func TestKBFSOpsGetRootNodeCacheIdentifyFail(t *testing.T) {
 
 	// Trigger identify.
 	lState := makeFBOLockState()
-	_, err := ops.getMDForReadLocked(ctx, lState, mdReadNeedIdentify)
+	_, err := ops.getMDForRead(ctx, lState, mdReadNeedIdentify)
 	assert.Equal(t, expectedErr, err)
 	assert.False(t, fboIdentityDone(ops))
 }


### PR DESCRIPTION
This PR does a couple different things:

* `folderBranchOps.getMDForReadLocked` doesn't actually require any locks to be taken, so rename it.
* use cached root node in `kbfsOps.getMaybeCreateRootNode` if possible.  `git-remote-keybase` calls this function several times (each time it constructs a `libfs.FS` instance), and there's no reason to check with the servers each time.
* don't fetch unmerged MDs when initializing a TLF in single op mode, because there's basically no way for a TLF to start off as unmerged when in single op mode.

These optimizations bring a simple git push down from 12-14s to 9-10s.