### PR TITLE
folder_branch_status: don't hold locks while accessing journal

### DIFF
--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -191,7 +191,7 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 
 	var fbs FolderBranchStatus
 
-	var tlfID tlf.ID
+	tlfID := tlf.NullID
 	if fbsk.md != (ImmutableRootMetadata{}) {
 		tlfID = fbsk.md.TlfID()
 		fbs.Staged = fbsk.md.IsUnmergedSet()


### PR DESCRIPTION
Getting the journal status can end up calling into `folderBlockOps` and taking `blockLock`, in order to populate unflushed paths.

However, `folderBranchStatus.rmNode()` can also be called while holding `folderBlockOps.blockLock`, via `folderBlockOps.UpdatePointers()`.  Thus, these two things can interleave and cause a deadlock.

There's no reason to hold the status lock while calling into the journal, so refactor things a bit to avoid this deadlock.

Issue: KBFS-2614