### PR TITLE
folder_branch_ops: don't fast forward while dirty

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5511,6 +5511,11 @@ func (fbo *folderBranchOps) maybeFastForward(ctx context.Context,
 
 	fbo.mdWriterLock.Lock(lState)
 	defer fbo.mdWriterLock.Unlock(lState)
+	// Don't update while the in-memory state is dirty.
+	if fbo.blocks.GetState(lState) != cleanState {
+		return false, nil
+	}
+
 	// If the journal has anything in it, don't fast-forward since we
 	// haven't finished flushing yet.  If there was really a remote
 	// update on the server, we'll end up in CR eventually.


### PR DESCRIPTION
Fast-forward while dirty can cause the device to unlink unflushed nodes that have been made while disconnected, but it won't actually delete the dir entries from the dirty blocks.  So when the flush finally happens, the journal will reference non-existent blocks, and all hell will break loose during CR.

Issue: keybase/client#9566