### PR TITLE
[KBFS-2570] Increase bserver and mdserver token expiry times

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,8 +201,7 @@ helpers.rootLinuxNode(env, {
                             },
                             integrate: {
                                 build([
-                                    // TODO: Switch this back to master before merging.
-                                    job: "/kbfs-server/PR-441",
+                                    job: "/kbfs-server/master",
                                     parameters: [
                                         [$class: 'StringParameterValue',
                                             name: 'kbfsProjectName',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,8 @@ helpers.rootLinuxNode(env, {
                             },
                             integrate: {
                                 build([
-                                    job: "/kbfs-server/master",
+                                    // TODO: Switch this back to master before merging.
+                                    job: "/kbfs-server/PR-441",
                                     parameters: [
                                         [$class: 'StringParameterValue',
                                             name: 'kbfsProjectName',

--- a/kbfsblock/bserver_constants.go
+++ b/kbfsblock/bserver_constants.go
@@ -8,5 +8,5 @@ const (
 	// ServerTokenServer is the expected server type for bserver authentication.
 	ServerTokenServer = "kbfs_block"
 	// ServerTokenExpireIn is the TTL to use when constructing an authentication token.
-	ServerTokenExpireIn = 2 * 60 * 60 // 2 hours
+	ServerTokenExpireIn = 24 * 60 * 60 // 24 hours
 )

--- a/kbfsmd/server_constants.go
+++ b/kbfsmd/server_constants.go
@@ -8,5 +8,5 @@ const (
 	// ServerTokenServer is the expected server type for mdserver authentication.
 	ServerTokenServer = "kbfs_md"
 	// ServerTokenExpireIn is the TTL to use when constructing an authentication token.
-	ServerTokenExpireIn = 2 * 60 * 60 // 2 hours
+	ServerTokenExpireIn = 24 * 60 * 60 // 24 hours
 )


### PR DESCRIPTION
This needs to be vendored into the servers and deployed before any clients start sending such expire times, otherwise clients will get errors.