### PR TITLE
libkbfs: add tlfID to TlfHandle, and an ID-getting interface

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1113,6 +1113,8 @@ type MDOps interface {
 	//
 	// An empty ImmutableRootMetadata may be returned, but if it is
 	// non-empty, then its ID must match the returned ID.
+	//
+	// TODO: remove this once `GetIDForHandle` is used everywhere.
 	GetForHandle(
 		ctx context.Context, handle *TlfHandle, mStatus kbfsmd.MergeStatus,
 		lockBeforeGet *keybase1.LockID) (tlf.ID, ImmutableRootMetadata, error)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1087,22 +1087,32 @@ type Crypto interface {
 	Shutdown()
 }
 
+type tlfIDGetter interface {
+	// GetIDForHandle returns the tlf.ID associated with the given
+	// handle, if the logged-in user has read permission on the
+	// folder.  It may or may not create the folder if it doesn't
+	// exist yet, and it may return `tlf.NullID` with a `nil` error if
+	// it doesn't create a missing folder.
+	GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error)
+}
+
 // MDOps gets and puts root metadata to an MDServer.  On a get, it
 // verifies the metadata is signed by the metadata's signing key.
 type MDOps interface {
-	// GetForHandle returns the current metadata object
-	// corresponding to the given top-level folder's handle and
-	// merge status, if the logged-in user has read permission on
-	// the folder.  It creates the folder if one doesn't exist
-	// yet, and the logged-in user has permission to do so.
+	tlfIDGetter
+
+	// GetForHandle returns the current metadata object corresponding
+	// to the given top-level folder's handle and merge status, if the
+	// logged-in user has read permission on the folder.  It may or
+	// may not create the folder if it doesn't exist yet, and it may
+	// return `tlf.NullID` with a `nil` error if it doesn't create a
+	// missing folder.
 	//
 	// If lockBeforeGet is not nil, it causes mdserver to take the lock on the
 	// lock ID before the get.
 	//
-	// If there is no returned error, then the returned ID must
-	// always be non-null. An empty ImmutableRootMetadata may be
-	// returned, but if it is non-empty, then its ID must match
-	// the returned ID.
+	// An empty ImmutableRootMetadata may be returned, but if it is
+	// non-empty, then its ID must match the returned ID.
 	GetForHandle(
 		ctx context.Context, handle *TlfHandle, mStatus kbfsmd.MergeStatus,
 		lockBeforeGet *keybase1.LockID) (tlf.ID, ImmutableRootMetadata, error)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -303,6 +303,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 }
 
 // GetForHandle implements the MDOps interface for MDOpsStandard.
+// TODO: unexport this when no longer part of the MDOps interface.
 func (md *MDOpsStandard) GetForHandle(ctx context.Context, handle *TlfHandle,
 	mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	id tlf.ID, rmd ImmutableRootMetadata, err error) {

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -119,7 +119,7 @@ func verifyMDForPublic(config *ConfigMock, rmds *RootMetadataSigned,
 	config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 		gomock.Any(), gomock.Any()).AnyTimes().Return(hasVerifyingKeyErr)
 	if hasVerifyingKeyErr == nil {
-		config.mockMdcache.EXPECT().Replace(gomock.Any(), gomock.Any())
+		config.mockMdcache.EXPECT().Put(gomock.Any())
 	}
 }
 
@@ -185,7 +185,7 @@ func verifyMDForPrivateHelper(
 		config.mockKbpki.EXPECT().HasVerifyingKey(gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
 	}
-	config.mockMdcache.EXPECT().Replace(gomock.Any(), gomock.Any()).AnyTimes()
+	config.mockMdcache.EXPECT().Put(gomock.Any()).AnyTimes()
 }
 
 func verifyMDForPrivate(

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3658,6 +3658,42 @@ func (mr *MockCryptoMockRecorder) Shutdown() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockCrypto)(nil).Shutdown))
 }
 
+// MocktlfIDGetter is a mock of tlfIDGetter interface
+type MocktlfIDGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MocktlfIDGetterMockRecorder
+}
+
+// MocktlfIDGetterMockRecorder is the mock recorder for MocktlfIDGetter
+type MocktlfIDGetterMockRecorder struct {
+	mock *MocktlfIDGetter
+}
+
+// NewMocktlfIDGetter creates a new mock instance
+func NewMocktlfIDGetter(ctrl *gomock.Controller) *MocktlfIDGetter {
+	mock := &MocktlfIDGetter{ctrl: ctrl}
+	mock.recorder = &MocktlfIDGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MocktlfIDGetter) EXPECT() *MocktlfIDGetterMockRecorder {
+	return m.recorder
+}
+
+// GetIDForHandle mocks base method
+func (m *MocktlfIDGetter) GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error) {
+	ret := m.ctrl.Call(m, "GetIDForHandle", ctx, handle)
+	ret0, _ := ret[0].(tlf.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIDForHandle indicates an expected call of GetIDForHandle
+func (mr *MocktlfIDGetterMockRecorder) GetIDForHandle(ctx, handle interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MocktlfIDGetter)(nil).GetIDForHandle), ctx, handle)
+}
+
 // MockMDOps is a mock of MDOps interface
 type MockMDOps struct {
 	ctrl     *gomock.Controller
@@ -3679,6 +3715,19 @@ func NewMockMDOps(ctrl *gomock.Controller) *MockMDOps {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockMDOps) EXPECT() *MockMDOpsMockRecorder {
 	return m.recorder
+}
+
+// GetIDForHandle mocks base method
+func (m *MockMDOps) GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error) {
+	ret := m.ctrl.Call(m, "GetIDForHandle", ctx, handle)
+	ret0, _ := ret[0].(tlf.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIDForHandle indicates an expected call of GetIDForHandle
+func (mr *MockMDOpsMockRecorder) GetIDForHandle(ctx, handle interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MockMDOps)(nil).GetIDForHandle), ctx, handle)
 }
 
 // GetForHandle mocks base method

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -422,6 +422,11 @@ func (m *stallingMDOps) GetForHandle(
 	return tlfID, md, err
 }
 
+func (m *stallingMDOps) GetIDForHandle(
+	ctx context.Context, handle *TlfHandle) (tlfID tlf.ID, err error) {
+	return m.delegate.GetIDForHandle(ctx, handle)
+}
+
 func (m *stallingMDOps) GetForTLF(ctx context.Context, id tlf.ID,
 	lockBeforeGet *keybase1.LockID) (md ImmutableRootMetadata, err error) {
 	m.maybeStall(ctx, StallableMDGetForTLF)


### PR DESCRIPTION
This PR doesn't populate the TLF ID yet, only adds it to the data structures and adds the method for getting it.

This is PR 2/3 for the implicit team handle stuff.

Issue: KBFS-2598