### PR TITLE
 libkbfs: populate the TlfHandle with a TLF ID, and resolve i-team

### DIFF
--- a/fsrpc/path.go
+++ b/fsrpc/path.go
@@ -248,13 +248,13 @@ func (p Path) Join(childName string) (childPath Path, err error) {
 // ParseTlfHandle is a wrapper around libkbfs.ParseTlfHandle that
 // automatically resolves non-canonical names.
 func ParseTlfHandle(
-	ctx context.Context, kbpki libkbfs.KBPKI, name string, t tlf.Type) (
-	*libkbfs.TlfHandle, error) {
+	ctx context.Context, kbpki libkbfs.KBPKI, mdOps libkbfs.MDOps,
+	name string, t tlf.Type) (*libkbfs.TlfHandle, error) {
 	var tlfHandle *libkbfs.TlfHandle
 outer:
 	for {
 		var parseErr error
-		tlfHandle, parseErr = libkbfs.ParseTlfHandle(ctx, kbpki, name, t)
+		tlfHandle, parseErr = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, name, t)
 		switch parseErr := parseErr.(type) {
 		case nil:
 			// No error.
@@ -282,7 +282,8 @@ func (p Path) GetNode(ctx context.Context, config libkbfs.Config) (libkbfs.Node,
 		return nil, entryInfo, nil
 	}
 
-	tlfHandle, err := ParseTlfHandle(ctx, config.KBPKI(), p.TLFName, p.TLFType)
+	tlfHandle, err := ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), p.TLFName, p.TLFType)
 	if err != nil {
 		return nil, libkbfs.EntryInfo{}, err
 	}

--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -153,7 +153,7 @@ func newRunner(ctx context.Context, config libkbfs.Config,
 	}
 
 	h, err := libkbfs.GetHandleFromFolderNameAndType(
-		ctx, config.KBPKI(), parts[1], t)
+		ctx, config.KBPKI(), config.MDOps(), parts[1], t)
 	if err != nil {
 		return nil, err
 	}

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -91,7 +91,8 @@ func testRunnerInitRepo(t *testing.T, tlfType tlf.Type, typeString string) {
 		inputWriter.Write([]byte("list\n\n"))
 	}()
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlfType)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlfType)
 	require.NoError(t, err)
 	if tlfType != tlf.Public {
 		_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
@@ -279,7 +280,8 @@ func testRunnerPushFetch(t *testing.T, cloning bool, secondRepoHasBranch bool) {
 
 	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -357,7 +359,8 @@ func TestRunnerDeleteBranch(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -386,7 +389,8 @@ func TestRunnerExitEarlyOnEOF(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
@@ -424,7 +428,8 @@ func TestForcePush(t *testing.T) {
 
 	makeLocalRepoWithOneFile(t, git, "foo", "hello", "")
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -462,7 +467,8 @@ func TestPushAllWithPackedRefs(t *testing.T) {
 	dotgit := filepath.Join(git, ".git")
 	gitExec(t, dotgit, git, "pack-refs", "--all")
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -484,7 +490,8 @@ func TestPushSomeWithPackedRefs(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(git)
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -607,7 +614,8 @@ func TestRunnerDeletePackedRef(t *testing.T) {
 
 	gitExec(t, dotgit1, git1, "pack-refs", "--all")
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	_, err = libgit.CreateRepoAndID(ctx, config, h, "test")
 	require.NoError(t, err)
@@ -710,7 +718,7 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
 	packErrCh := make(chan error)
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config2.KBPKI(), "user1,user2", tlf.Private)
+		ctx, config2.KBPKI(), config.MDOps(), "user1,user2", tlf.Private)
 	require.NoError(t, err)
 	go func() {
 		packErrCh <- libgit.GCRepo(
@@ -794,7 +802,7 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 		ctx, config2, libkbfs.StallableMDAfterGetRange, 1)
 	packErrCh := make(chan error)
 	h, err := libkbfs.ParseTlfHandle(
-		ctx, config2.KBPKI(), "user1,user2", tlf.Private)
+		ctx, config2.KBPKI(), config.MDOps(), "user1,user2", tlf.Private)
 	require.NoError(t, err)
 	go func() {
 		packErrCh <- libgit.GCRepo(

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -15,8 +15,8 @@ import (
 
 var mdGetRegexp = regexp.MustCompile("^(.+?)(?::(.*?))?(?:\\^(.*?))?$")
 
-func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI, tlfStr string) (
-	*libkbfs.TlfHandle, error) {
+func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI,
+	mdOps libkbfs.MDOps, tlfStr string) (*libkbfs.TlfHandle, error) {
 	p, err := fsrpc.NewPath(tlfStr)
 	if err != nil {
 		return nil, err
@@ -28,7 +28,7 @@ func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI, tlfStr string) (
 		return nil, fmt.Errorf(
 			"%q is not the root path of a TLF", tlfStr)
 	}
-	return fsrpc.ParseTlfHandle(ctx, kbpki, p.TLFName, p.TLFType)
+	return fsrpc.ParseTlfHandle(ctx, kbpki, mdOps, p.TLFName, p.TLFType)
 }
 
 func getTlfID(
@@ -39,7 +39,7 @@ func getTlfID(
 		return tlfID, nil
 	}
 
-	handle, err := parseTLFPath(ctx, config.KBPKI(), tlfStr)
+	handle, err := parseTLFPath(ctx, config.KBPKI(), config.MDOps(), tlfStr)
 	if err != nil {
 		return tlf.ID{}, err
 	}
@@ -169,7 +169,7 @@ func mdParseAndGet(ctx context.Context, config libkbfs.Config, input string) (
 
 func mdGetMergedHeadForWriter(ctx context.Context, config libkbfs.Config,
 	tlfPath string) (libkbfs.ImmutableRootMetadata, error) {
-	handle, err := parseTLFPath(ctx, config.KBPKI(), tlfPath)
+	handle, err := parseTLFPath(ctx, config.KBPKI(), config.MDOps(), tlfPath)
 	if err != nil {
 		return libkbfs.ImmutableRootMetadata{}, err
 	}

--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -163,6 +163,7 @@ func (f *Folder) TlfHandleChange(ctx context.Context,
 	// Handle in the background because we shouldn't lock during
 	// the notification
 	f.fs.queueNotification(func() {
+		ctx := context.Background()
 		session, err := libkbfs.GetCurrentSessionIfPossible(ctx, f.fs.config.KBPKI(), f.list.tlfType == tlf.Public)
 		// Here we get an error, but there is little that can be done.
 		// session will be empty in the error case in which case we will default to the

--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -196,6 +196,19 @@ func canonicalNameIfNotNil(h *libkbfs.TlfHandle) string {
 }
 
 func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
+	if f.h.TlfID() == tlf.NullID {
+		// If the handle doesn't have a TLF ID yet, fetch it now.
+		handle, err := libkbfs.ParseTlfHandlePreferred(
+			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(),
+			string(f.hPreferredName), f.h.Type())
+		if err != nil {
+			return nil, err
+		}
+		// Update the handle.
+		f.TlfHandleChange(ctx, handle)
+		return handle, nil
+	}
+
 	// In case there were any unresolved assertions, try them again on
 	// the first load.  Otherwise, since we haven't subscribed to
 	// updates yet for this folder, we might have missed a name

--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -200,7 +200,8 @@ func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
 	// the first load.  Otherwise, since we haven't subscribed to
 	// updates yet for this folder, we might have missed a name
 	// change.
-	handle, err := f.h.ResolveAgain(ctx, f.fs.config.KBPKI())
+	handle, err := f.h.ResolveAgain(
+		ctx, f.fs.config.KBPKI(), f.fs.config.MDOps())
 	if err != nil {
 		return nil, err
 	}

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -127,7 +127,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 		}
 
 		h, err := libkbfs.ParseTlfHandlePreferred(
-			ctx, fl.fs.config.KBPKI(), name, fl.tlfType)
+			ctx, fl.fs.config.KBPKI(), fl.fs.config.MDOps(), name, fl.tlfType)
 		fl.fs.log.CDebugf(ctx, "FL Lookup continuing -> %v,%v", h, err)
 		switch err := err.(type) {
 		case nil:

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/kbfs/dokan"
+	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -126,8 +127,8 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			continue
 		}
 
-		h, err := libkbfs.ParseTlfHandlePreferred(
-			ctx, fl.fs.config.KBPKI(), fl.fs.config.MDOps(), name, fl.tlfType)
+		h, err := libfs.ParseTlfHandlePreferredQuick(
+			ctx, fl.fs.config.KBPKI(), name, fl.tlfType)
 		fl.fs.log.CDebugf(ctx, "FL Lookup continuing -> %v,%v", h, err)
 		switch err := err.(type) {
 		case nil:

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -564,7 +564,8 @@ func (f *FS) folderListRename(ctx context.Context, fl *FolderList, oc *openConte
 	dstName := dstPath[len(dstPath)-1]
 	// Yes, this is slow, but that is ok here.
 	if _, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, f.config.KBPKI(), dstName, fl.tlfType); err != nil {
+		ctx, f.config.KBPKI(), f.config.MDOps(), dstName,
+		fl.tlfType); err != nil {
 		return dokan.ErrObjectNameNotFound
 	}
 	fl.mu.Lock()

--- a/libfs/fs_test.go
+++ b/libfs/fs_test.go
@@ -26,7 +26,8 @@ func makeFS(t *testing.T, subdir string) (
 	context.Context, *libkbfs.TlfHandle, *FS) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	config := libkbfs.MakeTestConfigOrBust(t, "user1", "user2")
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFS(ctx, config, h, subdir, "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
@@ -57,7 +58,8 @@ func makeFSWithJournal(t *testing.T, subdir string) (
 		assert.NoError(t, err)
 	}
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	fs, err := NewFS(ctx, config, h, subdir, "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
@@ -265,7 +267,7 @@ func TestStat(t *testing.T) {
 	config2.SetClock(clock)
 
 	h2, err := libkbfs.ParseTlfHandle(
-		ctx, config2.KBPKI(), "user2#user1", tlf.Private)
+		ctx, config2.KBPKI(), config2.MDOps(), "user2#user1", tlf.Private)
 	require.NoError(t, err)
 	fs2U2, err := NewFS(ctx, config2, h2, "", "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)

--- a/libfs/tlf_handle_util.go
+++ b/libfs/tlf_handle_util.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"context"
+
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+)
+
+type noImplicitTeamKBPKI struct {
+	libkbfs.KBPKI
+}
+
+// ResolveImplicitTeam implements the KBPKI interface for noImplicitTeamKBPKI.
+func (nitk noImplicitTeamKBPKI) ResolveImplicitTeam(
+	_ context.Context, _, _ string, _ tlf.Type) (
+	libkbfs.ImplicitTeamInfo, error) {
+	return libkbfs.ImplicitTeamInfo{},
+		errors.New("Skipping implicit team lookup for quick handle parsing")
+}
+
+type nullIDGetter struct {
+}
+
+func (n nullIDGetter) GetIDForHandle(_ context.Context, _ *libkbfs.TlfHandle) (
+	tlf.ID, error) {
+	return tlf.NullID, nil
+}
+
+// ParseTlfHandlePreferredQuick parses a handle from a name, without
+// doing this time consuming checks needed for implicit-team checking
+// or TLF-ID-fetching.
+func ParseTlfHandlePreferredQuick(
+	ctx context.Context, kbpki libkbfs.KBPKI, name string, ty tlf.Type) (
+	handle *libkbfs.TlfHandle, err error) {
+	// Override the KBPKI with one that doesn't try to resolve
+	// implicit teams.
+	kbpki = noImplicitTeamKBPKI{kbpki}
+	return libkbfs.ParseTlfHandlePreferred(
+		ctx, kbpki, nullIDGetter{}, name, ty)
+}

--- a/libfs/tlf_handle_util.go
+++ b/libfs/tlf_handle_util.go
@@ -24,14 +24,6 @@ func (nitk noImplicitTeamKBPKI) ResolveImplicitTeam(
 		errors.New("Skipping implicit team lookup for quick handle parsing")
 }
 
-type nullIDGetter struct {
-}
-
-func (n nullIDGetter) GetIDForHandle(_ context.Context, _ *libkbfs.TlfHandle) (
-	tlf.ID, error) {
-	return tlf.NullID, nil
-}
-
 // ParseTlfHandlePreferredQuick parses a handle from a name, without
 // doing this time consuming checks needed for implicit-team checking
 // or TLF-ID-fetching.
@@ -41,6 +33,5 @@ func ParseTlfHandlePreferredQuick(
 	// Override the KBPKI with one that doesn't try to resolve
 	// implicit teams.
 	kbpki = noImplicitTeamKBPKI{kbpki}
-	return libkbfs.ParseTlfHandlePreferred(
-		ctx, kbpki, nullIDGetter{}, name, ty)
+	return libkbfs.ParseTlfHandlePreferred(ctx, kbpki, nil, name, ty)
 }

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -143,6 +143,19 @@ func (f *Folder) forgetNode(node libkbfs.Node) {
 var _ libkbfs.Observer = (*Folder)(nil)
 
 func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
+	if f.h.TlfID() == tlf.NullID {
+		// If the handle doesn't have a TLF ID yet, fetch it now.
+		handle, err := libkbfs.ParseTlfHandlePreferred(
+			ctx, f.fs.config.KBPKI(), f.fs.config.MDOps(),
+			string(f.hPreferredName), f.h.Type())
+		if err != nil {
+			return nil, err
+		}
+		// Update the handle.
+		f.TlfHandleChange(ctx, handle)
+		return handle, nil
+	}
+
 	// In case there were any unresolved assertions, try them again on
 	// the first load.  Otherwise, since we haven't subscribed to
 	// updates yet for this folder, we might have missed a name

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -147,7 +147,8 @@ func (f *Folder) resolve(ctx context.Context) (*libkbfs.TlfHandle, error) {
 	// the first load.  Otherwise, since we haven't subscribed to
 	// updates yet for this folder, we might have missed a name
 	// change.
-	handle, err := f.h.ResolveAgain(ctx, f.fs.config.KBPKI())
+	handle, err := f.h.ResolveAgain(
+		ctx, f.fs.config.KBPKI(), f.fs.config.MDOps())
 	if err != nil {
 		return nil, err
 	}

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -312,7 +312,7 @@ func (f *Folder) TlfHandleChange(ctx context.Context,
 	// Handle in the background because we shouldn't lock during the
 	// notification
 	f.fs.queueNotification(func() {
-		f.tlfHandleChangeInvalidate(ctx, newHandle)
+		f.tlfHandleChangeInvalidate(context.Background(), newHandle)
 	})
 }
 

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -183,7 +183,7 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 	}
 
 	h, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, fl.fs.config.KBPKI(), req.Name, fl.tlfType)
+		ctx, fl.fs.config.KBPKI(), fl.fs.config.MDOps(), req.Name, fl.tlfType)
 	switch err := err.(type) {
 	case nil:
 		// no error
@@ -278,7 +278,7 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	defer func() { err = fl.fs.processError(ctx, libkbfs.WriteMode, err) }()
 
 	h, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, fl.fs.config.KBPKI(), req.Name, fl.tlfType)
+		ctx, fl.fs.config.KBPKI(), fl.fs.config.MDOps(), req.Name, fl.tlfType)
 
 	switch err := err.(type) {
 	case nil:

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -15,6 +15,7 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -182,8 +183,8 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		return nil, fuse.ENOENT
 	}
 
-	h, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, fl.fs.config.KBPKI(), fl.fs.config.MDOps(), req.Name, fl.tlfType)
+	h, err := libfs.ParseTlfHandlePreferredQuick(
+		ctx, fl.fs.config.KBPKI(), req.Name, fl.tlfType)
 	switch err := err.(type) {
 	case nil:
 		// no error

--- a/libgit/repo_test.go
+++ b/libgit/repo_test.go
@@ -48,7 +48,8 @@ func TestGetOrCreateRepoAndID(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 
 	fs, id1, err := GetOrCreateRepoAndID(ctx, config, h, "Repo1", "")
@@ -101,7 +102,8 @@ func TestCreateRepoAndID(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 
 	id1, err := CreateRepoAndID(ctx, config, h, "Repo1")
@@ -135,7 +137,8 @@ func TestGetRepoAndID(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 
 	_, _, err = GetRepoAndID(ctx, config, h, "Repo1", "")
@@ -170,7 +173,8 @@ func TestDeleteRepo(t *testing.T) {
 	clock.Set(time.Now())
 	config.SetClock(clock)
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 
 	_, err = CreateRepoAndID(ctx, config, h, "Repo1")
@@ -226,7 +230,8 @@ func TestRepoRename(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
-	h, err := libkbfs.ParseTlfHandle(ctx, config.KBPKI(), "user1", tlf.Private)
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 
 	id1, err := CreateRepoAndID(ctx, config, h, "Repo1")

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -112,7 +112,7 @@ func (rh *RPCHandler) getHandleAndConfig(
 	tlfHandle *libkbfs.TlfHandle, tempDir string, err error) {
 	// Make sure we have a legit folder name.
 	tlfHandle, err = libkbfs.GetHandleFromFolderNameAndType(
-		ctx, rh.config.KBPKI(), folder.Name,
+		ctx, rh.config.KBPKI(), rh.config.MDOps(), folder.Name,
 		tlf.TypeFromFolderType(folder.FolderType))
 	if err != nil {
 		return nil, nil, nil, "", err

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -160,7 +160,7 @@ func newChainMDForTest(t *testing.T) rootMetadataWithKeyAndTimestamp {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, nug)
+	h, err := MakeTlfHandle(ctx, bh, nug, nil)
 	require.NoError(t, err)
 
 	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, tlfID, h)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -883,7 +883,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	// unmerged branch. Add checks for this.
 	resolvesTo, partialResolvedOldHandle, err :=
 		oldHandle.ResolvesTo(
-			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
+			ctx, fbo.config.Codec(), fbo.config.KBPKI(), fbo.config.MDOps(),
 			*newHandle)
 	if err != nil {
 		return err
@@ -5591,7 +5591,8 @@ func (fbo *folderBranchOps) locallyFinalizeTLF(ctx context.Context) {
 		fbo.log.CErrorf(ctx, "Couldn't get finalized bare handle: %+v", err)
 		return
 	}
-	handle, err := MakeTlfHandle(ctx, bareHandle, fbo.config.KBPKI())
+	handle, err := MakeTlfHandle(
+		ctx, bareHandle, fbo.config.KBPKI(), fbo.config.MDOps())
 	if err != nil {
 		fbo.log.CErrorf(ctx, "Couldn't get finalized handle: %+v", err)
 		return

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -26,6 +27,9 @@ func fbStatusTestInit(t *testing.T) (*gomock.Controller, *ConfigMock,
 	ctr := NewSafeTestReporter(t)
 	mockCtrl := gomock.NewController(ctr)
 	config := NewConfigMock(mockCtrl, ctr)
+	config.mockKbpki.EXPECT().ResolveImplicitTeam(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+		Return(ImplicitTeamInfo{}, errors.New("No such team"))
 	nodeCache := NewMockNodeCache(mockCtrl)
 	fbsk := newFolderBranchStatusKeeper(config, nodeCache)
 	interposeDaemonKBPKI(config, "alice", "bob")
@@ -108,7 +112,7 @@ func TestFBStatusAllFields(t *testing.T) {
 
 	// make a new root metadata
 	id := tlf.FakeID(1, tlf.Private)
-	h := parseTlfHandleOrBust(t, config, "alice", tlf.Private)
+	h := parseTlfHandleOrBust(t, config, "alice", tlf.Private, id)
 	u := h.FirstResolvedWriter()
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -128,21 +128,21 @@ func (j journalMDOps) getHeadFromJournal(
 
 	if handle == nil {
 		handle, err = MakeTlfHandle(
-			ctx, headBareHandle, j.jServer.config.KBPKI())
+			ctx, headBareHandle, j.jServer.config.KBPKI(), j.MDOps)
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 	} else {
 		// Check for mutual handle resolution.
 		headHandle, err := MakeTlfHandle(ctx, headBareHandle,
-			j.jServer.config.KBPKI())
+			j.jServer.config.KBPKI(), j.MDOps)
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 
 		if err := headHandle.MutuallyResolvesTo(ctx, j.jServer.config.Codec(),
-			j.jServer.config.KBPKI(), *handle, head.RevisionNumber(),
-			head.TlfID(), j.jServer.log); err != nil {
+			j.jServer.config.KBPKI(), j.jServer.config.MDOps(), *handle,
+			head.RevisionNumber(), head.TlfID(), j.jServer.log); err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 	}
@@ -196,7 +196,8 @@ func (j journalMDOps) getRangeFromJournal(
 	if err != nil {
 		return nil, err
 	}
-	handle, err := MakeTlfHandle(ctx, bareHandle, j.jServer.config.KBPKI())
+	handle, err := MakeTlfHandle(
+		ctx, bareHandle, j.jServer.config.KBPKI(), j.MDOps)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -107,7 +107,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -116,6 +116,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEqual(t, tlf.NullID, id)
 	require.Equal(t, ImmutableRootMetadata{}, irmd)
+	h.tlfID = id
 
 	err = jServer.Enable(ctx, id, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -291,7 +292,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -323,7 +324,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -353,7 +354,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI())
+	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -175,12 +175,12 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 	err = jServer.Enable(ctx, tlfID1, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	tlfID2 := tlf.FakeID(2, tlf.SingleTeam)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "t1", tlf.SingleTeam)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), nil, "t1", tlf.SingleTeam)
 	require.NoError(t, err)
 	err = jServer.Enable(ctx, tlfID2, h, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
 	tlfID3 := tlf.FakeID(2, tlf.SingleTeam)
-	h, err = ParseTlfHandle(ctx, config.KBPKI(), "t1.sub", tlf.SingleTeam)
+	h, err = ParseTlfHandle(ctx, config.KBPKI(), nil, "t1.sub", tlf.SingleTeam)
 	require.NoError(t, err)
 	err = jServer.Enable(ctx, tlfID3, h, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 	blockServer := config.BlockServer()
 
 	h, err = ParseTlfHandle(
-		ctx, config.KBPKI(), "test_user1,test_user2", tlf.Private)
+		ctx, config.KBPKI(), nil, "test_user1,test_user2", tlf.Private)
 	require.NoError(t, err)
 	id1 := h.ResolvedWriters()[0]
 
@@ -298,7 +298,7 @@ func TestJournalServerOverDiskLimitError(t *testing.T) {
 	blockServer := config.BlockServer()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), "test_user1,test_user2", tlf.Private)
+		ctx, config.KBPKI(), nil, "test_user1,test_user2", tlf.Private)
 	require.NoError(t, err)
 	id1 := h.ResolvedWriters()[0]
 
@@ -363,7 +363,8 @@ func TestJournalServerRestart(t *testing.T) {
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 
@@ -435,7 +436,8 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	blockServer := config.BlockServer()
 	mdOps := config.MDOps()
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 
@@ -542,7 +544,7 @@ func TestJournalServerMultiUser(t *testing.T) {
 	mdOps := config.MDOps()
 
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), "test_user1,test_user2", tlf.Private)
+		ctx, config.KBPKI(), nil, "test_user1,test_user2", tlf.Private)
 	require.NoError(t, err)
 	id1 := h.ResolvedWriters()[0]
 	id2 := h.ResolvedWriters()[1]
@@ -704,7 +706,8 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	blockServer := config.BlockServer()
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), "test_user1", tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), nil, "test_user1", tlf.Private)
 	require.NoError(t, err)
 	id := h.ResolvedWriters()[0]
 
@@ -759,7 +762,8 @@ func TestJournalServerTeamTLFWithRestart(t *testing.T) {
 	// journal tries to access it.
 	jServer.delegateBlockServer = shutdownOnlyBlockServer{}
 
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), string(name), tlf.SingleTeam)
+	h, err := ParseTlfHandle(
+		ctx, config.KBPKI(), nil, string(name), tlf.SingleTeam)
 	require.NoError(t, err)
 
 	tlfID := tlf.FakeID(2, tlf.SingleTeam)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -255,7 +255,8 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 
 	DisableCRForTesting(config1B, rootNode1.GetFolderBranch())
 
-	tlfHandle, err := ParseTlfHandle(ctx, config1B.KBPKI(), name, tlf.Private)
+	tlfHandle, err := ParseTlfHandle(
+		ctx, config1B.KBPKI(), config1B.MDOps(), name, tlf.Private)
 	require.NoError(t, err)
 
 	_, _, err = config1B.KBFSOps().GetTLFCryptKeys(ctx, tlfHandle)

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -506,7 +506,9 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 		return false, nil, err
 	}
 
-	resolvedHandle, err := handle.ResolveAgain(ctx, km.config.KBPKI())
+	idGetter := constIDGetter{md.TlfID()}
+	resolvedHandle, err := handle.ResolveAgain(
+		ctx, km.config.KBPKI(), idGetter)
 	if err != nil {
 		return false, nil, err
 	}
@@ -520,8 +522,8 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 				"already a reader; reverting back to the original handle")
 		} else {
 			// Only allow yourself to change
-			resolvedHandle, err =
-				handle.ResolveAgainForUser(ctx, km.config.KBPKI(), session.UID)
+			resolvedHandle, err = handle.ResolveAgainForUser(
+				ctx, km.config.KBPKI(), idGetter, session.UID)
 			if err != nil {
 				return false, nil, err
 			}

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -914,7 +914,8 @@ func (k *KeybaseServiceBase) FSEditListRequest(ctx context.Context,
 	k.log.CDebugf(ctx, "Edit list request for %s (public: %t)",
 		req.Folder.Name, !req.Folder.Private)
 	tlfHandle, err := getHandleFromFolderName(
-		ctx, k.config.KBPKI(), req.Folder.Name, !req.Folder.Private)
+		ctx, k.config.KBPKI(), k.config.MDOps(), req.Folder.Name,
+		!req.Folder.Private)
 	if err != nil {
 		return err
 	}
@@ -1020,7 +1021,7 @@ func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,
 	}
 
 	tlfHandle, err := getHandleFromFolderName(
-		ctx, k.config.KBPKI(), query.TlfName, false)
+		ctx, k.config.KBPKI(), k.config.MDOps(), query.TlfName, false)
 	if err != nil {
 		return res, err
 	}
@@ -1062,7 +1063,8 @@ func (k *KeybaseServiceBase) GetPublicCanonicalTLFNameAndID(
 	}
 
 	tlfHandle, err := getHandleFromFolderName(
-		ctx, k.config.KBPKI(), query.TlfName, true /* public */)
+		ctx, k.config.KBPKI(), k.config.MDOps(), query.TlfName,
+		true /* public */)
 	if err != nil {
 		return res, err
 	}

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -94,7 +94,7 @@ func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	bh, err := tlf.MakeHandle(
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	h, err := MakeTlfHandle(context.Background(), bh, nug)
+	h, err := MakeTlfHandle(context.Background(), bh, nug, nil)
 	require.NoError(t, err)
 	md, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -49,7 +49,7 @@ func makeRekeyReadError(
 	ctx context.Context, err error, kbpki KBPKI, kmd KeyMetadata,
 	uid keybase1.UID, username libkb.NormalizedUsername) error {
 	h := kmd.GetTlfHandle()
-	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki)
+	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki, nil)
 	if resolveErr != nil {
 		// Ignore error and pretend h is already fully
 		// resolved.

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -29,7 +29,7 @@ func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, nug)
+	h, err := MakeTlfHandle(ctx, bh, nug, nil)
 	require.NoError(t, err)
 	return h
 }

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -292,7 +292,7 @@ func testMakeRekeyReadError(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer config.Shutdown(ctx)
 
 	tlfID := tlf.FakeID(1, tlf.Private)
-	h := parseTlfHandleOrBust(t, config, "alice", tlf.Private)
+	h := parseTlfHandleOrBust(t, config, "alice", tlf.Private, tlfID)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
 
@@ -319,7 +319,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver kbfsmd.MetadataVer) 
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), "alice,bob@twitter", tlf.Private)
+		ctx, config.KBPKI(), nil, "alice,bob@twitter", tlf.Private)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver kbfsmd.MetadataVer) 
 	config.KeybaseService().(*KeybaseDaemonLocal).addNewAssertionForTestOrBust(
 		"bob", "bob@twitter")
 
-	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI())
+	resolvedHandle, err := h.ResolveAgain(ctx, config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	dummyErr := errors.New("dummy")
@@ -394,7 +394,7 @@ func TestRootMetadataUpconversionPrivate(t *testing.T) {
 	defer config.Shutdown(ctx)
 
 	tlfID := tlf.FakeID(1, tlf.Private)
-	h := parseTlfHandleOrBust(t, config, "alice,alice@twitter#bob,charlie@twitter,eve@reddit", tlf.Private)
+	h := parseTlfHandleOrBust(t, config, "alice,alice@twitter#bob,charlie@twitter,eve@reddit", tlf.Private, tlfID)
 	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
@@ -552,7 +552,7 @@ func TestRootMetadataUpconversionPublic(t *testing.T) {
 
 	tlfID := tlf.FakeID(1, tlf.Public)
 	h := parseTlfHandleOrBust(
-		t, config, "alice,bob,charlie@twitter", tlf.Public)
+		t, config, "alice,bob,charlie@twitter", tlf.Public, tlfID)
 	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.PublicKeyGen, rmd.LatestKeyGeneration())
@@ -607,7 +607,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(
-		t, config, "alice,bob (conflicted copy 2017-08-24)", tlf.Private)
+		t, config, "alice,bob (conflicted copy 2017-08-24)", tlf.Private, tlfID)
 	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())
@@ -704,7 +704,7 @@ func TestRootMetadataReaderUpconversionPrivate(t *testing.T) {
 	defer configWriter.Shutdown(ctx)
 
 	tlfID := tlf.FakeID(1, tlf.Private)
-	h := parseTlfHandleOrBust(t, configWriter, "alice#bob", tlf.Private)
+	h := parseTlfHandleOrBust(t, configWriter, "alice#bob", tlf.Private, tlfID)
 	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -712,7 +712,7 @@ func CheckConfigAndShutdown(
 func GetRootNodeForTest(
 	ctx context.Context, config Config, name string,
 	t tlf.Type) (Node, error) {
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), name, t)
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), config.MDOps(), name, t)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -1047,7 +1047,7 @@ func TestParseTlfHandleImplicitTeams(t *testing.T) {
 		require.Equal(t, tlfID, h.tlfID)
 	}
 
-	// Private implicit teams.
+	t.Log("Private implicit teams")
 	tid1, tlfID1 := newITeam("u1", "", tlf.Private)
 	check("u1", tid1, tlfID1, tlf.Private)
 	tid2, tlfID2 := newITeam("u1,u2", "", tlf.Private)
@@ -1055,18 +1055,18 @@ func TestParseTlfHandleImplicitTeams(t *testing.T) {
 	tid3, tlfID3 := newITeam("u1,u2,u3", "", tlf.Private)
 	check("u1,u2,u3", tid3, tlfID3, tlf.Private)
 
-	// Public implicit teams.
+	t.Log("Public implicit teams")
 	tid4, tlfID4 := newITeam("u1", "", tlf.Public)
 	check("u1", tid4, tlfID4, tlf.Public)
 	tid5, tlfID5 := newITeam("u1,u2", "", tlf.Public)
 	check("u1,u2", tid5, tlfID5, tlf.Public)
 
-	// Implicit team with a suffix.
+	t.Log("Implicit team with a suffix")
 	tid6, tlfID6 := newITeam(
 		"u1,u2", "(conflicted copy 2016-03-14 #3)", tlf.Private)
 	check("u1,u2 (conflicted copy 2016-03-14 #3)", tid6, tlfID6, tlf.Private)
 
-	// Implicit team with readers.
+	t.Log("Implicit team with readers")
 	tid7, tlfID7 := newITeam("u1,u2#u3", "", tlf.Private)
 	check("u1,u2#u3", tid7, tlfID7, tlf.Private)
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -45,6 +45,7 @@ type tlfJournalConfig interface {
 	diskLimitTimeout() time.Duration
 	teamMembershipChecker() kbfsmd.TeamMembershipChecker
 	BGFlushDirOpBatchSize() int
+	tlfIDGetter() tlfIDGetter
 }
 
 // tlfJournalConfigWrapper is an adapter for Config objects to the
@@ -67,6 +68,10 @@ func (ca tlfJournalConfigAdapter) usernameGetter() normalizedUsernameGetter {
 
 func (ca tlfJournalConfigAdapter) teamMembershipChecker() kbfsmd.TeamMembershipChecker {
 	return ca.Config.KBPKI()
+}
+
+func (ca tlfJournalConfigAdapter) tlfIDGetter() tlfIDGetter {
+	return ca.Config.MDOps()
 }
 
 func (ca tlfJournalConfigAdapter) diskLimitTimeout() time.Duration {
@@ -1644,7 +1649,7 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 	}
 
 	handle, err := MakeTlfHandle(
-		ctx, ibrmdBareHandle, j.config.usernameGetter())
+		ctx, ibrmdBareHandle, j.config.usernameGetter(), j.config.tlfIDGetter())
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -148,6 +148,10 @@ func (c testTLFJournalConfig) teamMembershipChecker() kbfsmd.TeamMembershipCheck
 	return nil
 }
 
+func (c testTLFJournalConfig) tlfIDGetter() tlfIDGetter {
+	return nil
+}
+
 func (c testTLFJournalConfig) diskLimitTimeout() time.Duration {
 	return c.dlTimeout
 }

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -150,10 +150,10 @@ func chargedToForTLF(ctx context.Context, sessionGetter CurrentSessionGetter,
 // GetHandleFromFolderNameAndType returns a TLFHandle given a folder
 // name (e.g., "u1,u2#u3") and a TLF type.
 func GetHandleFromFolderNameAndType(
-	ctx context.Context, kbpki KBPKI, tlfName string, t tlf.Type) (
-	*TlfHandle, error) {
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, tlfName string,
+	t tlf.Type) (*TlfHandle, error) {
 	for {
-		tlfHandle, err := ParseTlfHandle(ctx, kbpki, tlfName, t)
+		tlfHandle, err := ParseTlfHandle(ctx, kbpki, idGetter, tlfName, t)
 		switch e := err.(type) {
 		case TlfNameNotCanonical:
 			tlfName = e.NameToTry
@@ -168,13 +168,13 @@ func GetHandleFromFolderNameAndType(
 // getHandleFromFolderName returns a TLFHandle given a folder
 // name (e.g., "u1,u2#u3") and a public/private bool.  DEPRECATED.
 func getHandleFromFolderName(
-	ctx context.Context, kbpki KBPKI, tlfName string, public bool) (
-	*TlfHandle, error) {
+	ctx context.Context, kbpki KBPKI, idGetter tlfIDGetter, tlfName string,
+	public bool) (*TlfHandle, error) {
 	// TODO(KBFS-2185): update the protocol to support requests
 	// for single-team TLFs.
 	t := tlf.Private
 	if public {
 		t = tlf.Public
 	}
-	return GetHandleFromFolderNameAndType(ctx, kbpki, tlfName, t)
+	return GetHandleFromFolderNameAndType(ctx, kbpki, idGetter, tlfName, t)
 }

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -730,7 +730,7 @@ func (k *SimpleFS) getRemoteRootNode(ctx context.Context, path keybase1.Path) (
 		return nil, libkbfs.EntryInfo{}, nil, err
 	}
 	tlf, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, k.config.KBPKI(), ps[0], t)
+		ctx, k.config.KBPKI(), k.config.MDOps(), ps[0], t)
 	if err != nil {
 		return nil, libkbfs.EntryInfo{}, nil, err
 	}

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -197,12 +197,12 @@ func (k *LibKBFS) GetUID(u User) (uid keybase1.UID) {
 }
 
 func parseTlfHandle(
-	ctx context.Context, kbpki libkbfs.KBPKI, tlfName string, t tlf.Type) (
-	h *libkbfs.TlfHandle, err error) {
+	ctx context.Context, kbpki libkbfs.KBPKI, mdOps libkbfs.MDOps,
+	tlfName string, t tlf.Type) (h *libkbfs.TlfHandle, err error) {
 	// Limit to one non-canonical name for now.
 outer:
 	for i := 0; i < 2; i++ {
-		h, err = libkbfs.ParseTlfHandle(ctx, kbpki, tlfName, t)
+		h, err = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, tlfName, t)
 		switch err := err.(type) {
 		case nil:
 			break outer
@@ -244,7 +244,7 @@ func (k *LibKBFS) GetRootDir(u User, tlfName string, t tlf.Type, expectedCanonic
 
 	ctx, cancel := k.newContext(u)
 	defer cancel()
-	h, err := parseTlfHandle(ctx, config.KBPKI(), tlfName, t)
+	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
 	if err != nil {
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (k *LibKBFS) GetMtime(u User, file Node) (mtime time.Time, err error) {
 // name.
 func getRootNode(ctx context.Context, config libkbfs.Config, tlfName string,
 	t tlf.Type) (libkbfs.Node, error) {
-	h, err := parseTlfHandle(ctx, config.KBPKI(), tlfName, t)
+	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +647,7 @@ func (k *LibKBFS) EnableJournal(u User, tlfName string, t tlf.Type) error {
 		return err
 	}
 
-	h, err := parseTlfHandle(ctx, config.KBPKI(), tlfName, t)
+	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
 	if err != nil {
 		return err
 	}

--- a/tlf/name.go
+++ b/tlf/name.go
@@ -19,18 +19,28 @@ const (
 	ReaderSep = "#"
 )
 
-// SplitName splits a TLF name into components.
-func SplitName(name string) (writerNames, readerNames []string,
-	extensionSuffix string, err error) {
+// SplitExtension separates any extension suffix from the assertions.
+func SplitExtension(name string) (
+	assertions, extensionSuffix string, err error) {
 	names := strings.SplitN(name, HandleExtensionSep, 2)
 	if len(names) > 2 {
-		return nil, nil, "", BadNameError{name}
+		return "", "", BadNameError{name}
 	}
 	if len(names) > 1 {
 		extensionSuffix = names[1]
 	}
+	return names[0], extensionSuffix, nil
+}
 
-	splitNames := strings.SplitN(names[0], ReaderSep, 3)
+// SplitName splits a TLF name into components.
+func SplitName(name string) (writerNames, readerNames []string,
+	extensionSuffix string, err error) {
+	assertions, extensionSuffix, err := SplitExtension(name)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	splitNames := strings.SplitN(assertions, ReaderSep, 3)
 	if len(splitNames) > 2 {
 		return nil, nil, "", BadNameError{name}
 	}


### PR DESCRIPTION
When parsing a TLF handle, we now first check whether there's a matching implicit team with a TLF ID populated.  If so, we use that handle.  Right now this will never happen, since the service doesn't return a TLF ID for any implicit team.

For all other handles, we look up the TLF ID as part of the handle-making process, and put it in the handle.

This adds at least one extra RTT to the servers during handle parsing, which is unfortunate while e.g. listing favorites, but it's necessary for the implicit team design.  This would hurt us badly when listing favorites, but luckily we don't need to know these until someone actually tries to access data within the folder.  So this also adds a method in `libfs` for faking out these time-consuming calls during favorites listing, and then updating the handle later when it is really needed.

PR 3/3 for the implicit team handle stuff.

Issue: KBFS-2598
