### PR TITLE
test: cancel SyncAll contexts properly

### DIFF
--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -537,7 +537,8 @@ func (*fsEngine) GetMtime(u User, file Node) (mtime time.Time, err error) {
 func (e *fsEngine) SyncAll(
 	user User, tlfName string, t tlf.Type) (err error) {
 	u := user.(*fsUser)
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ctx, err = libkbfs.NewContextWithCancellationDelayer(
 		libkbfs.NewContextReplayable(
 			ctx, func(ctx context.Context) context.Context { return ctx }))

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -148,7 +148,7 @@ func (k *LibKBFS) newContext(u User) (context.Context, context.CancelFunc) {
 	if k.opTimeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, k.opTimeout)
 	} else {
-		cancel = func() {}
+		ctx, cancel = context.WithCancel(ctx)
 	}
 
 	id, errRandomRequestID := libkbfs.MakeRandomRequestID()


### PR DESCRIPTION
Just something I noticed while debugging something else.