### PR TITLE
identify_util: call IdentifyImplicitTeam when needed

### DIFF
--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/net/context"
 )
 
@@ -71,6 +71,12 @@ func (ti *testIdentifier) Identify(
 
 	ei.userBreak(userInfo.Name, userInfo.UID, nil)
 	return userInfo.Name, userInfo.UID.AsUserOrTeam(), nil
+}
+
+func (ti *testIdentifier) IdentifyImplicitTeam(
+	_ context.Context, _, _ string, _ tlf.Type, _ string) (
+	ImplicitTeamInfo, error) {
+	return ImplicitTeamInfo{}, errors.New("Implicit teams not supported")
 }
 
 func makeNugAndTIForTest() (testNormalizedUsernameGetter, *testIdentifier) {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -517,6 +517,10 @@ type resolver interface {
 	// need updating.
 	Resolve(ctx context.Context, assertion string) (
 		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
+	// ResolveImplicitTeam resolves the given implicit team.
+	ResolveImplicitTeam(
+		ctx context.Context, assertions, suffix string, tlfType tlf.Type) (
+		ImplicitTeamInfo, error)
 }
 
 type identifier interface {
@@ -526,13 +530,6 @@ type identifier interface {
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (
 		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
-}
-
-type iteamHandler interface {
-	// ResolveImplicitTeam resolves the given implicit team.
-	ResolveImplicitTeam(
-		ctx context.Context, assertions, suffix string, tlfType tlf.Type) (
-		ImplicitTeamInfo, error)
 	// IdentifyImplicitTeam identifies (and creates if necessary) the
 	// given implicit team.
 	IdentifyImplicitTeam(
@@ -597,7 +594,6 @@ type KBPKI interface {
 	teamKeysGetter
 	teamRootIDGetter
 	gitMetadataPutter
-	iteamHandler
 
 	// HasVerifyingKey returns nil if the given user has the given
 	// VerifyingKey, and an error otherwise.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1669,6 +1669,19 @@ func (mr *MockresolverMockRecorder) Resolve(ctx, assertion interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*Mockresolver)(nil).Resolve), ctx, assertion)
 }
 
+// ResolveImplicitTeam mocks base method
+func (m *Mockresolver) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type) (ImplicitTeamInfo, error) {
+	ret := m.ctrl.Call(m, "ResolveImplicitTeam", ctx, assertions, suffix, tlfType)
+	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam
+func (mr *MockresolverMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tlfType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*Mockresolver)(nil).ResolveImplicitTeam), ctx, assertions, suffix, tlfType)
+}
+
 // Mockidentifier is a mock of identifier interface
 type Mockidentifier struct {
 	ctrl     *gomock.Controller
@@ -1706,44 +1719,8 @@ func (mr *MockidentifierMockRecorder) Identify(ctx, assertion, reason interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*Mockidentifier)(nil).Identify), ctx, assertion, reason)
 }
 
-// MockiteamHandler is a mock of iteamHandler interface
-type MockiteamHandler struct {
-	ctrl     *gomock.Controller
-	recorder *MockiteamHandlerMockRecorder
-}
-
-// MockiteamHandlerMockRecorder is the mock recorder for MockiteamHandler
-type MockiteamHandlerMockRecorder struct {
-	mock *MockiteamHandler
-}
-
-// NewMockiteamHandler creates a new mock instance
-func NewMockiteamHandler(ctrl *gomock.Controller) *MockiteamHandler {
-	mock := &MockiteamHandler{ctrl: ctrl}
-	mock.recorder = &MockiteamHandlerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockiteamHandler) EXPECT() *MockiteamHandlerMockRecorder {
-	return m.recorder
-}
-
-// ResolveImplicitTeam mocks base method
-func (m *MockiteamHandler) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type) (ImplicitTeamInfo, error) {
-	ret := m.ctrl.Call(m, "ResolveImplicitTeam", ctx, assertions, suffix, tlfType)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam
-func (mr *MockiteamHandlerMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tlfType interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*MockiteamHandler)(nil).ResolveImplicitTeam), ctx, assertions, suffix, tlfType)
-}
-
 // IdentifyImplicitTeam mocks base method
-func (m *MockiteamHandler) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string) (ImplicitTeamInfo, error) {
+func (m *Mockidentifier) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string) (ImplicitTeamInfo, error) {
 	ret := m.ctrl.Call(m, "IdentifyImplicitTeam", ctx, assertions, suffix, tlfType, reason)
 	ret0, _ := ret[0].(ImplicitTeamInfo)
 	ret1, _ := ret[1].(error)
@@ -1751,8 +1728,8 @@ func (m *MockiteamHandler) IdentifyImplicitTeam(ctx context.Context, assertions,
 }
 
 // IdentifyImplicitTeam indicates an expected call of IdentifyImplicitTeam
-func (mr *MockiteamHandlerMockRecorder) IdentifyImplicitTeam(ctx, assertions, suffix, tlfType, reason interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyImplicitTeam", reflect.TypeOf((*MockiteamHandler)(nil).IdentifyImplicitTeam), ctx, assertions, suffix, tlfType, reason)
+func (mr *MockidentifierMockRecorder) IdentifyImplicitTeam(ctx, assertions, suffix, tlfType, reason interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyImplicitTeam", reflect.TypeOf((*Mockidentifier)(nil).IdentifyImplicitTeam), ctx, assertions, suffix, tlfType, reason)
 }
 
 // MocknormalizedUsernameGetter is a mock of normalizedUsernameGetter interface
@@ -1999,6 +1976,19 @@ func (mr *MockKBPKIMockRecorder) Resolve(ctx, assertion interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resolve", reflect.TypeOf((*MockKBPKI)(nil).Resolve), ctx, assertion)
 }
 
+// ResolveImplicitTeam mocks base method
+func (m *MockKBPKI) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type) (ImplicitTeamInfo, error) {
+	ret := m.ctrl.Call(m, "ResolveImplicitTeam", ctx, assertions, suffix, tlfType)
+	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam
+func (mr *MockKBPKIMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tlfType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeam), ctx, assertions, suffix, tlfType)
+}
+
 // Identify mocks base method
 func (m *MockKBPKI) Identify(ctx context.Context, assertion, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Identify", ctx, assertion, reason)
@@ -2011,6 +2001,19 @@ func (m *MockKBPKI) Identify(ctx context.Context, assertion, reason string) (lib
 // Identify indicates an expected call of Identify
 func (mr *MockKBPKIMockRecorder) Identify(ctx, assertion, reason interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Identify", reflect.TypeOf((*MockKBPKI)(nil).Identify), ctx, assertion, reason)
+}
+
+// IdentifyImplicitTeam mocks base method
+func (m *MockKBPKI) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string) (ImplicitTeamInfo, error) {
+	ret := m.ctrl.Call(m, "IdentifyImplicitTeam", ctx, assertions, suffix, tlfType, reason)
+	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IdentifyImplicitTeam indicates an expected call of IdentifyImplicitTeam
+func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(ctx, assertions, suffix, tlfType, reason interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).IdentifyImplicitTeam), ctx, assertions, suffix, tlfType, reason)
 }
 
 // GetNormalizedUsername mocks base method
@@ -2102,32 +2105,6 @@ func (m *MockKBPKI) PutGitMetadata(ctx context.Context, folder keybase1.Folder, 
 // PutGitMetadata indicates an expected call of PutGitMetadata
 func (mr *MockKBPKIMockRecorder) PutGitMetadata(ctx, folder, repoID, repoName interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutGitMetadata", reflect.TypeOf((*MockKBPKI)(nil).PutGitMetadata), ctx, folder, repoID, repoName)
-}
-
-// ResolveImplicitTeam mocks base method
-func (m *MockKBPKI) ResolveImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type) (ImplicitTeamInfo, error) {
-	ret := m.ctrl.Call(m, "ResolveImplicitTeam", ctx, assertions, suffix, tlfType)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam
-func (mr *MockKBPKIMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tlfType interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeam), ctx, assertions, suffix, tlfType)
-}
-
-// IdentifyImplicitTeam mocks base method
-func (m *MockKBPKI) IdentifyImplicitTeam(ctx context.Context, assertions, suffix string, tlfType tlf.Type, reason string) (ImplicitTeamInfo, error) {
-	ret := m.ctrl.Call(m, "IdentifyImplicitTeam", ctx, assertions, suffix, tlfType, reason)
-	ret0, _ := ret[0].(ImplicitTeamInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IdentifyImplicitTeam indicates an expected call of IdentifyImplicitTeam
-func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(ctx, assertions, suffix, tlfType, reason interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IdentifyImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).IdentifyImplicitTeam), ctx, assertions, suffix, tlfType, reason)
 }
 
 // HasVerifyingKey mocks base method

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -710,7 +710,7 @@ func TestResolveAgainBasic(t *testing.T) {
 
 	// ResolveAgain shouldn't rely on resolving the original names again.
 	daemon.addNewAssertionForTestOrBust("u3", "u3@twitter")
-	newH, err := h.ResolveAgain(ctx, daemon, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1,u2#u3"), newH.GetCanonicalName())
 }
@@ -736,7 +736,7 @@ func TestResolveAgainDoubleAsserts(t *testing.T) {
 	daemon.addNewAssertionForTestOrBust("u1", "u1@github")
 	daemon.addNewAssertionForTestOrBust("u2", "u2@twitter")
 	daemon.addNewAssertionForTestOrBust("u2", "u2@github")
-	newH, err := h.ResolveAgain(ctx, daemon, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1#u2"), newH.GetCanonicalName())
 }
@@ -760,7 +760,7 @@ func TestResolveAgainWriterReader(t *testing.T) {
 
 	daemon.addNewAssertionForTestOrBust("u2", "u2@twitter")
 	daemon.addNewAssertionForTestOrBust("u2", "u2@github")
-	newH, err := h.ResolveAgain(ctx, daemon, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1,u2"), newH.GetCanonicalName())
 }
@@ -788,7 +788,7 @@ func TestResolveAgainConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 	h.conflictInfo = ext
-	newH, err := h.ResolveAgain(ctx, daemon, nil)
+	newH, err := h.ResolveAgain(ctx, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName("u1,u2#u3"+
 		tlf.HandleExtensionSep+ext.String()), newH.GetCanonicalName())


### PR DESCRIPTION
This also gets rid of `iteamHandler` in favor of using existing interfaces, to avoid passing around an extra object for no reason.

Please review after #1345, this depends on that one and its parents.

Issue: KBFS-2598