### PR TITLE
tlf_handle_resolve: revive implicit team check, but not for chats

### DIFF
--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -627,23 +627,19 @@ func parseTlfHandleLoose(
 		return nil, err
 	}
 
-	/**
-	    * COMMENTED OUT FOR PERFORMANCE REASONS FOR NOW
-		*
-				// First try resolving this full name as an implicit team.  If
-				// that doesn't work, fall through to individual name resolution.
-				rit := resolvableImplicitTeam{kbpki, name, t}
-				iteamHandle, err := makeTlfHandleHelper(
-					ctx, t, []resolvableUser{rit}, nil, nil, idGetter)
-				if err == nil && iteamHandle.tlfID != tlf.NullID {
-					// The iteam already has a TLF ID, let's use it.
-					return iteamHandle, nil
-				}
-				// This is not an implicit team, so continue on to check for a
-				// normal team.  TODO: return non-nil errors immediately if they
-				// don't simply indicate the implicit team doesn't exist yet
-				// (i.e., when we start creating them by default).
-	*/
+	// First try resolving this full name as an implicit team.  If
+	// that doesn't work, fall through to individual name resolution.
+	rit := resolvableImplicitTeam{kbpki, name, t}
+	iteamHandle, err := makeTlfHandleHelper(
+		ctx, t, []resolvableUser{rit}, nil, nil, idGetter)
+	if err == nil && iteamHandle.tlfID != tlf.NullID {
+		// The iteam already has a TLF ID, let's use it.
+		return iteamHandle, nil
+	}
+	// This is not an implicit team, so continue on to check for a
+	// normal team.  TODO: return non-nil errors immediately if they
+	// don't simply indicate the implicit team doesn't exist yet
+	// (i.e., when we start creating them by default).
 
 	// Before parsing the tlf handle (which results in identify
 	// calls that cause tracker popups), first see if there's any

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -1012,8 +1012,6 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 }
 
 func TestParseTlfHandleImplicitTeams(t *testing.T) {
-	t.Skip("Performance issues")
-
 	ctx := context.Background()
 
 	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})


### PR DESCRIPTION
Chat will never ask us for the handle of an implicit team.

Issue: KBFS-2598
