### PR TITLE
md_ops: use a cache for handle->ID mappings

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -916,6 +916,18 @@ func (e NoSuchTlfHandleError) Error() string {
 	return fmt.Sprintf("Folder handle for %s not found", e.ID)
 }
 
+// NoSuchTlfIDError indicates we were unable to resolve a folder
+// handle to a folder ID.
+type NoSuchTlfIDError struct {
+	handle *TlfHandle
+}
+
+// Error implements the error interface for NoSuchTlfIDError
+func (e NoSuchTlfIDError) Error() string {
+	return fmt.Sprintf("Folder ID for %s not found",
+		e.handle.GetCanonicalPath())
+}
+
 // IncompatibleHandleError indicates that somethine tried to update
 // the head of a TLF with a RootMetadata with an incompatible handle.
 type IncompatibleHandleError struct {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -909,6 +909,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 		fbo.log.CDebugf(ctx, "Handle changed (%s -> %s)",
 			oldName, newName)
 
+		fbo.config.MDCache().ChangeHandleForID(oldHandle, newHandle)
 		// If the handle has changed, send out a notification.
 		fbo.observers.tlfHandleChange(ctx, fbo.head.GetTlfHandle())
 		// Also the folder should be re-identified given the
@@ -6228,6 +6229,7 @@ func (fbo *folderBranchOps) TeamNameChanged(
 		return
 	}
 
+	fbo.config.MDCache().ChangeHandleForID(oldHandle, newHandle)
 	fbo.observers.tlfHandleChange(ctx, newHandle)
 }
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -793,6 +793,11 @@ type MDCache interface {
 	// MarkPutToServer sets `PutToServer` to true for the specified
 	// MD, if it already exists in the cache.
 	MarkPutToServer(tlf tlf.ID, rev kbfsmd.Revision, bid kbfsmd.BranchID)
+	// GetIDForHandle retrieves a cached, trusted TLF ID for the given
+	// handle, if one exists.
+	GetIDForHandle(handle *TlfHandle) (tlf.ID, error)
+	// PutIDForHandle caches a trusted TLF ID for the given handle.
+	PutIDForHandle(handle *TlfHandle, id tlf.ID) error
 }
 
 // KeyCache handles caching for both TLFCryptKeys and BlockCryptKeys.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -798,6 +798,9 @@ type MDCache interface {
 	GetIDForHandle(handle *TlfHandle) (tlf.ID, error)
 	// PutIDForHandle caches a trusted TLF ID for the given handle.
 	PutIDForHandle(handle *TlfHandle, id tlf.ID) error
+	// ChangeHandleForID moves an ID to be under a new handle, if the
+	// ID is cached already.
+	ChangeHandleForID(oldHandle *TlfHandle, newHandle *TlfHandle)
 }
 
 // KeyCache handles caching for both TLFCryptKeys and BlockCryptKeys.

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -74,6 +74,11 @@ func mdOpsInit(t *testing.T, ver kbfsmd.MetadataVer) (mockCtrl *gomock.Controlle
 	config.mockKbpki.EXPECT().ResolveImplicitTeam(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(ImplicitTeamInfo{}, errors.New("No such team"))
+	// Don't cache IDs.
+	config.mockMdcache.EXPECT().GetIDForHandle(gomock.Any()).AnyTimes().
+		Return(tlf.NullID, NoSuchTlfIDError{nil})
+	config.mockMdcache.EXPECT().PutIDForHandle(gomock.Any(), gomock.Any()).
+		AnyTimes().Return(nil)
 
 	return mockCtrl, config, ctx
 }

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -144,3 +144,20 @@ func (md *MDCacheStandard) PutIDForHandle(handle *TlfHandle, id tlf.ID) error {
 	md.idLRU.Add(key, id)
 	return nil
 }
+
+// ChangeHandleForID implements the MDCache interface for
+// MDCacheStandard.
+func (md *MDCacheStandard) ChangeHandleForID(
+	oldHandle *TlfHandle, newHandle *TlfHandle) {
+	md.lock.RLock()
+	defer md.lock.RUnlock()
+	oldKey := oldHandle.GetCanonicalPath()
+	tmp, ok := md.idLRU.Get(oldKey)
+	if !ok {
+		return
+	}
+	md.idLRU.Remove(oldKey)
+	newKey := newHandle.GetCanonicalPath()
+	md.idLRU.Add(newKey, tmp)
+	return
+}

--- a/libkbfs/mdcache.go
+++ b/libkbfs/mdcache.go
@@ -126,7 +126,7 @@ func (md *MDCacheStandard) GetIDForHandle(handle *TlfHandle) (tlf.ID, error) {
 	key := handle.GetCanonicalPath()
 	tmp, ok := md.idLRU.Get(key)
 	if !ok {
-		return tlf.NullID, errors.WithStack(NoSuchTlfIDError{handle})
+		return tlf.NullID, NoSuchTlfIDError{handle}
 	}
 	id, ok := tmp.(tlf.ID)
 	if !ok {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2745,6 +2745,16 @@ func (mr *MockMDCacheMockRecorder) PutIDForHandle(handle, id interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutIDForHandle", reflect.TypeOf((*MockMDCache)(nil).PutIDForHandle), handle, id)
 }
 
+// ChangeHandleForID mocks base method
+func (m *MockMDCache) ChangeHandleForID(oldHandle, newHandle *TlfHandle) {
+	m.ctrl.Call(m, "ChangeHandleForID", oldHandle, newHandle)
+}
+
+// ChangeHandleForID indicates an expected call of ChangeHandleForID
+func (mr *MockMDCacheMockRecorder) ChangeHandleForID(oldHandle, newHandle interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeHandleForID", reflect.TypeOf((*MockMDCache)(nil).ChangeHandleForID), oldHandle, newHandle)
+}
+
 // MockKeyCache is a mock of KeyCache interface
 type MockKeyCache struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2720,6 +2720,31 @@ func (mr *MockMDCacheMockRecorder) MarkPutToServer(tlf, rev, bid interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkPutToServer", reflect.TypeOf((*MockMDCache)(nil).MarkPutToServer), tlf, rev, bid)
 }
 
+// GetIDForHandle mocks base method
+func (m *MockMDCache) GetIDForHandle(handle *TlfHandle) (tlf.ID, error) {
+	ret := m.ctrl.Call(m, "GetIDForHandle", handle)
+	ret0, _ := ret[0].(tlf.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIDForHandle indicates an expected call of GetIDForHandle
+func (mr *MockMDCacheMockRecorder) GetIDForHandle(handle interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MockMDCache)(nil).GetIDForHandle), handle)
+}
+
+// PutIDForHandle mocks base method
+func (m *MockMDCache) PutIDForHandle(handle *TlfHandle, id tlf.ID) error {
+	ret := m.ctrl.Call(m, "PutIDForHandle", handle, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutIDForHandle indicates an expected call of PutIDForHandle
+func (mr *MockMDCacheMockRecorder) PutIDForHandle(handle, id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutIDForHandle", reflect.TypeOf((*MockMDCache)(nil).PutIDForHandle), handle, id)
+}
+
 // MockKeyCache is a mock of KeyCache interface
 type MockKeyCache struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
`GetIDForHandle` is called frequently by chat now that we need to get the ID when parsing a handle, so cache it so we don't end up having to go to the journal/server to get the ID.

cc: @mmaxim I believe this gets us back to the previous performance levels for everything but the first `GetTLFCryptKeys` call for a given TLF, which involves server RTTs anyway.

Issue: KBFS-2598