### PR TITLE
libkbfs: add RootMetadata support for implicit teams

### DIFF
--- a/kbfsmd/root_metadata.go
+++ b/kbfsmd/root_metadata.go
@@ -20,6 +20,8 @@ import (
 type RootMetadata interface {
 	// TlfID returns the ID of the TLF this RootMetadata is for.
 	TlfID() tlf.ID
+	// TypeForKeying returns the keying type for this RootMetadata.
+	TypeForKeying() tlf.KeyingType
 	// KeyGenerationsToUpdate returns a range that has to be
 	// updated when rekeying. start is included, but end is not
 	// included. This range can be empty (i.e., start >= end), in

--- a/kbfsmd/root_metadata_v2.go
+++ b/kbfsmd/root_metadata_v2.go
@@ -194,6 +194,11 @@ func (md *RootMetadataV2) TlfID() tlf.ID {
 	return md.ID
 }
 
+// TypeForKeying implements the RootMetadata interface for RootMetadataV2.
+func (md *RootMetadataV2) TypeForKeying() tlf.KeyingType {
+	return md.TlfID().Type().ToKeyingType()
+}
+
 // KeyGenerationsToUpdate implements the RootMetadata interface
 // for RootMetadataV2.
 func (md *RootMetadataV2) KeyGenerationsToUpdate() (KeyGen, KeyGen) {

--- a/kbfsmd/root_metadata_v3.go
+++ b/kbfsmd/root_metadata_v3.go
@@ -270,7 +270,7 @@ func (md *RootMetadataV3) KeyGenerationsToUpdate() (KeyGen, KeyGen) {
 // LatestKeyGeneration implements the RootMetadata interface for
 // RootMetadataV3.
 func (md *RootMetadataV3) LatestKeyGeneration() KeyGen {
-	if md.TlfID().Type() == tlf.Public {
+	if md.TypeForKeying() == tlf.PublicKeying {
 		return PublicKeyGen
 	}
 	return md.WriterMetadata.LatestKeyGen
@@ -498,6 +498,10 @@ func (md *RootMetadataV3) IsReader(
 			return false, err
 		}
 
+		if tid.IsPublic() {
+			return true, nil
+		}
+
 		// TODO: Eventually this will have to use a Merkle sequence
 		// number to check historic versions.
 		isReader, err := teamMemChecker.IsTeamReader(ctx, tid, user)
@@ -665,7 +669,7 @@ func (md *RootMetadataV3) isBackedByTeam() bool {
 	return true
 }
 
-// TypeForKeying returns the keying type for md.
+// TypeForKeying implements the RootMetadata interface for RootMetadataV3.
 func (md *RootMetadataV3) TypeForKeying() tlf.KeyingType {
 	if md.isBackedByTeam() {
 		return tlf.TeamKeying

--- a/libfs/mode.go
+++ b/libfs/mode.go
@@ -24,7 +24,7 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 	if err != nil {
 		return false, err
 	}
-	if h.Type() == tlf.SingleTeam {
+	if h.TypeForKeying() == tlf.TeamKeying {
 		tid, err := h.FirstResolvedWriter().AsTeam()
 		if err != nil {
 			return false, err

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -277,8 +277,10 @@ func MakeLocalUserCryptPublicKeyOrBust(
 // for a TLF.
 func MakeLocalTLFCryptKeyOrBust(
 	name string, keyGen kbfsmd.KeyGen) kbfscrypto.TLFCryptKey {
+	// Put the key gen first to make it more likely to fit into the
+	// 32-character "random" seed.
 	return kbfscrypto.MakeFakeTLFCryptKeyOrBust(
-		string(name) + " crypt key " + string(keyGen))
+		string(name) + " " + string(keyGen) + " crypt key ")
 }
 
 // MakeLocalUsers is a helper function to generate a list of

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -160,7 +160,7 @@ func newChainMDForTest(t *testing.T) rootMetadataWithKeyAndTimestamp {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, nug, nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nug, nil)
 	require.NoError(t, err)
 
 	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, tlfID, h)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5593,7 +5593,8 @@ func (fbo *folderBranchOps) locallyFinalizeTLF(ctx context.Context) {
 		return
 	}
 	handle, err := MakeTlfHandle(
-		ctx, bareHandle, fbo.config.KBPKI(), fbo.config.MDOps())
+		ctx, bareHandle, fbo.id().Type(), fbo.config.KBPKI(),
+		fbo.config.MDOps())
 	if err != nil {
 		fbo.log.CErrorf(ctx, "Couldn't get finalized handle: %+v", err)
 		return

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1425,10 +1425,10 @@ func (fbo *folderBranchOps) initMDLocked(
 
 	var expectedKeyGen kbfsmd.KeyGen
 	var tlfCryptKey *kbfscrypto.TLFCryptKey
-	switch md.TlfID().Type() {
-	case tlf.Public:
+	switch md.TypeForKeying() {
+	case tlf.PublicKeying:
 		expectedKeyGen = kbfsmd.PublicKeyGen
-	case tlf.Private:
+	case tlf.PrivateKeying:
 		var rekeyDone bool
 		// create a new set of keys for this metadata
 		rekeyDone, tlfCryptKey, err = fbo.config.KeyManager().Rekey(ctx, md, false)
@@ -1440,7 +1440,7 @@ func (fbo *folderBranchOps) initMDLocked(
 				"private TLF %v", md.TlfID())
 		}
 		expectedKeyGen = kbfsmd.FirstValidKeyGen
-	case tlf.SingleTeam:
+	case tlf.TeamKeying:
 		// Teams get their crypt key from the service, no need to
 		// rekey in KBFS.
 		tid, err := handle.FirstResolvedWriter().AsTeam()

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -641,6 +641,9 @@ type KeyMetadata interface {
 	// key info.
 	TlfID() tlf.ID
 
+	// TypeForKeying returns the keying type for this MD.
+	TypeForKeying() tlf.KeyingType
+
 	// LatestKeyGeneration returns the most recent key generation
 	// with key data in this object, or PublicKeyGen if this TLF
 	// is public.

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -128,14 +128,16 @@ func (j journalMDOps) getHeadFromJournal(
 
 	if handle == nil {
 		handle, err = MakeTlfHandle(
-			ctx, headBareHandle, j.jServer.config.KBPKI(), j.MDOps)
+			ctx, headBareHandle, id.Type(), j.jServer.config.KBPKI(),
+			constIDGetter{id})
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
 	} else {
 		// Check for mutual handle resolution.
-		headHandle, err := MakeTlfHandle(ctx, headBareHandle,
-			j.jServer.config.KBPKI(), j.MDOps)
+		headHandle, err := MakeTlfHandle(
+			ctx, headBareHandle, id.Type(), j.jServer.config.KBPKI(),
+			constIDGetter{id})
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
@@ -197,7 +199,7 @@ func (j journalMDOps) getRangeFromJournal(
 		return nil, err
 	}
 	handle, err := MakeTlfHandle(
-		ctx, bareHandle, j.jServer.config.KBPKI(), j.MDOps)
+		ctx, bareHandle, id.Type(), j.jServer.config.KBPKI(), constIDGetter{id})
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -107,7 +107,7 @@ func TestJournalMDOpsBasics(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -283,7 +283,7 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -317,7 +317,7 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -349,7 +349,7 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, config.KBPKI(), nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -514,7 +514,7 @@ func (p ptrMatcher) String() string {
 }
 
 func fillInNewMD(t *testing.T, config *ConfigMock, rmd *RootMetadata) {
-	if rmd.TlfID().Type() != tlf.Public {
+	if rmd.TypeForKeying() != tlf.PublicKeying {
 		rmd.fakeInitialRekey()
 	}
 	rootPtr := BlockPointer{

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -287,7 +287,7 @@ func (k *KBPKIClient) IsTeamReader(
 	if err != nil {
 		return false, err
 	}
-	return teamInfo.Writers[uid] || teamInfo.Readers[uid], nil
+	return tid.IsPublic() || teamInfo.Writers[uid] || teamInfo.Readers[uid], nil
 }
 
 // GetTeamRootID implements the KBPKI interface for KBPKIClient.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -142,6 +142,10 @@ func (kmd emptyKeyMetadata) TlfID() tlf.ID {
 	return kmd.tlfID
 }
 
+func (kmd emptyKeyMetadata) TypeForKeying() tlf.KeyingType {
+	return kmd.TlfID().Type().ToKeyingType()
+}
+
 // GetTlfHandle just returns nil. This contradicts the requirements
 // for KeyMetadata, but emptyKeyMetadata shouldn't be used in contexts
 // that actually use GetTlfHandle().

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -335,7 +335,7 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 	// Need to make the team info as well, so get the list of user
 	// names and resolve them.  Auto-generate an implicit team name.
 	implicitName := libkb.NormalizedUsername(
-		"_implicit_" + string(len(k.localTeams)))
+		fmt.Sprintf("_implicit_%d", len(k.localTeams)))
 	teams := makeLocalTeams(
 		[]libkb.NormalizedUsername{implicitName}, len(k.localTeams), tlfType)
 	info := teams[0]

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -238,6 +238,15 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 	if err != nil {
 		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
+
+	// TODO(KBFS-2621): Resolve shouldn't work for implicit teams, but
+	// until CORE-6623 is done, this is required.
+	iti, err := k.localImplicitTeams.getLocalImplicitTeam(id.AsTeamOrBust())
+	if err == nil {
+		// An implicit team exists, so use the display name.
+		return iti.Name, id, nil
+	}
+
 	return ti.Name, id, nil
 }
 

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -94,7 +94,7 @@ func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	bh, err := tlf.MakeHandle(
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	h, err := MakeTlfHandle(context.Background(), bh, nug, nil)
+	h, err := MakeTlfHandle(context.Background(), bh, bh.Type(), nug, nil)
 	require.NoError(t, err)
 	md, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -252,7 +252,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 
 	// Get the UID unless this is a public tlf - then proceed with empty uid.
 	var uid keybase1.UID
-	if handle.Type() != tlf.Public {
+	if handle.TypeForKeying() != tlf.PublicKeying {
 		session, err := md.config.KBPKI().GetCurrentSession(ctx)
 		if err != nil {
 			return ImmutableRootMetadata{}, err
@@ -371,7 +371,8 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
 
-	mdHandle, err := MakeTlfHandle(ctx, bareMdHandle, md.config.KBPKI(), nil)
+	mdHandle, err := MakeTlfHandle(
+		ctx, bareMdHandle, id.Type(), md.config.KBPKI(), nil)
 	if err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
@@ -475,7 +476,8 @@ func (md *MDOpsStandard) getForTLF(ctx context.Context, id tlf.ID,
 		return ImmutableRootMetadata{}, err
 	}
 	handle, err := MakeTlfHandle(
-		ctx, bareHandle, md.config.KBPKI(), constIDGetter{id})
+		ctx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
+		constIDGetter{id})
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -525,7 +527,8 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 				return err
 			}
 			handle, err := MakeTlfHandle(
-				groupCtx, bareHandle, md.config.KBPKI(), constIDGetter{id})
+				groupCtx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
+				constIDGetter{id})
 			if err != nil {
 				return err
 			}

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -337,8 +337,9 @@ func testMDOpsGetIDForUnresolvedMdHandlePublicSuccess(
 		ctx, config.KBPKI(), nil, "alice,bob,charlie@twitter", tlf.Public)
 	require.NoError(t, err)
 
+	id := tlf.FakeID(1, tlf.Public)
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		kbfsmd.Merged, nil).Return(tlf.NullID, rmds1, nil)
+		kbfsmd.Merged, nil).Return(id, rmds1, nil)
 
 	// First time should fail.
 	_, err = config.MDOps().GetIDForHandle(ctx, h)
@@ -351,7 +352,7 @@ func testMDOpsGetIDForUnresolvedMdHandlePublicSuccess(
 	daemon.addNewAssertionForTestOrBust("charlie", "charlie@twitter")
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		kbfsmd.Merged, nil).Return(tlf.NullID, rmds2, nil)
+		kbfsmd.Merged, nil).Return(id, rmds2, nil)
 
 	// Second and time should succeed.
 	if _, err := config.MDOps().GetIDForHandle(ctx, h); err != nil {
@@ -359,7 +360,7 @@ func testMDOpsGetIDForUnresolvedMdHandlePublicSuccess(
 	}
 
 	config.mockMdserv.EXPECT().GetForHandle(ctx, h.ToBareHandleOrBust(),
-		kbfsmd.Merged, nil).Return(tlf.NullID, rmds3, nil)
+		kbfsmd.Merged, nil).Return(id, rmds3, nil)
 
 	if _, err := config.MDOps().GetIDForHandle(ctx, h); err != nil {
 		t.Errorf("Got error on get: %v", err)
@@ -556,8 +557,6 @@ func testMDOpsGetFailIDCheck(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	if _, err := config.MDOps().GetForTLF(ctx, id2, nil); err == nil {
 		t.Errorf("Got no error on bad id check test")
-	} else if _, ok := err.(MDMismatchError); !ok {
-		t.Errorf("Got unexpected error on bad id check test: %v", err)
 	}
 }
 

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -488,7 +488,7 @@ func decryptMDPrivateData(ctx context.Context, codec kbfscodec.Codec,
 	handle := rmdToDecrypt.GetTlfHandle()
 
 	var pmd PrivateMetadata
-	if handle.Type() == tlf.Public {
+	if handle.TypeForKeying() == tlf.PublicKeying {
 		if err := codec.Decode(serializedPrivateMetadata,
 			&pmd); err != nil {
 			return PrivateMetadata{}, err

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -348,11 +348,12 @@ func encryptMDPrivateData(
 	brmd := rmd.bareMd
 	privateData := rmd.data
 
-	if brmd.TlfID().Type() == tlf.Public || !brmd.IsWriterMetadataCopiedSet() {
+	if brmd.TypeForKeying() == tlf.PublicKeying ||
+		!brmd.IsWriterMetadataCopiedSet() {
 		// Record the last writer to modify this writer metadata
 		brmd.SetLastModifyingWriter(me)
 
-		if brmd.TlfID().Type() == tlf.Public {
+		if brmd.TypeForKeying() == tlf.PublicKeying {
 			// Encode the private metadata
 			encodedPrivateMetadata, err := codec.Encode(privateData)
 			if err != nil {

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -29,7 +29,7 @@ func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, nug, nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nug, nil)
 	require.NoError(t, err)
 	return h
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2228,6 +2228,18 @@ func (mr *MockKeyMetadataMockRecorder) TlfID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TlfID", reflect.TypeOf((*MockKeyMetadata)(nil).TlfID))
 }
 
+// TypeForKeying mocks base method
+func (m *MockKeyMetadata) TypeForKeying() tlf.KeyingType {
+	ret := m.ctrl.Call(m, "TypeForKeying")
+	ret0, _ := ret[0].(tlf.KeyingType)
+	return ret0
+}
+
+// TypeForKeying indicates an expected call of TypeForKeying
+func (mr *MockKeyMetadataMockRecorder) TypeForKeying() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TypeForKeying", reflect.TypeOf((*MockKeyMetadata)(nil).TypeForKeying))
+}
+
 // LatestKeyGeneration mocks base method
 func (m *MockKeyMetadata) LatestKeyGeneration() kbfsmd.KeyGen {
 	ret := m.ctrl.Call(m, "LatestKeyGeneration")

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -146,7 +146,7 @@ func (md *RootMetadata) Extra() kbfsmd.ExtraMetadata {
 
 // IsReadable returns true if the private metadata can be read.
 func (md *RootMetadata) IsReadable() bool {
-	return md.TypeForKeying() == tlf.PublicKeying || md.data.Dir.IsInitialized()
+	return md.TlfID().Type() == tlf.Public || md.data.Dir.IsInitialized()
 }
 
 func (md *RootMetadata) clearLastRevision() {

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -303,9 +303,9 @@ func (rsa resolvableSocialAssertion) resolve(ctx context.Context) (
 }
 
 // MakeTlfHandle creates a TlfHandle from the given tlf.Handle and the
-// given normalizedUsernameGetter (which is usually a KBPKI). Note
-// that `t` could be different from `bareHandle.Type()`, if this is an
-// implicit team TLF.
+// given normalizedUsernameGetter (which is usually a KBPKI). `t` is
+// the `tlf.Type` of the new handle.  (Note this could be different
+// from `bareHandle.Type()`, if this is an implicit team TLF.)
 func MakeTlfHandle(
 	ctx context.Context, bareHandle tlf.Handle, t tlf.Type,
 	nug normalizedUsernameGetter, idGetter tlfIDGetter) (*TlfHandle, error) {

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -180,7 +180,7 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 	// Make sure that generating another handle doesn't change the
 	// name.
 	h2, err := MakeTlfHandle(
-		context.Background(), h.ToBareHandleOrBust(), kbpki, nil)
+		context.Background(), h.ToBareHandleOrBust(), tlf.Private, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -208,7 +208,7 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 	// Make sure that generating another handle doesn't change the
 	// name.
 	h2, err := MakeTlfHandle(
-		context.Background(), h.ToBareHandleOrBust(), kbpki, nil)
+		context.Background(), h.ToBareHandleOrBust(), tlf.Public, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -582,7 +582,7 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 	// Make sure that generating another handle doesn't change the
 	// name.
 	h2, err := MakeTlfHandle(
-		context.Background(), h.ToBareHandleOrBust(), kbpki, nil)
+		context.Background(), h.ToBareHandleOrBust(), tlf.Private, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1649,7 +1649,8 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 	}
 
 	handle, err := MakeTlfHandle(
-		ctx, ibrmdBareHandle, j.config.usernameGetter(), j.config.tlfIDGetter())
+		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.usernameGetter(),
+		j.config.tlfIDGetter())
 	if err != nil {
 		return nil, err
 	}

--- a/test/engine.go
+++ b/test/engine.go
@@ -48,7 +48,7 @@ type Engine interface {
 	InitTest(ver kbfsmd.MetadataVer, blockSize int64,
 		blockChangeSize int64, batchSize int, bwKBps int,
 		opTimeout time.Duration, users []libkb.NormalizedUsername,
-		teams teamMap, clock libkbfs.Clock,
+		teams, implicitTeams teamMap, clock libkbfs.Clock,
 		journal bool) map[libkb.NormalizedUsername]User
 	// GetUID is called by the test harness to retrieve a user instance's UID.
 	GetUID(u User) keybase1.UID

--- a/test/engine_common.go
+++ b/test/engine_common.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
 )
 
 func setBlockSizes(t testing.TB, config libkbfs.Config, blockSize, blockChangeSize int64) {
@@ -64,6 +65,33 @@ func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
 		for _, r := range members.readers {
 			libkbfs.AddTeamReaderForTestOrBust(t, config, tid,
 				e.GetUID(users[r]))
+		}
+	}
+}
+
+func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
+	implicitTeams teamMap, users map[libkb.NormalizedUsername]User) {
+	counter := byte(1)
+	for name, members := range implicitTeams {
+		ty := tlf.Private
+		if len(members.readers) == 1 &&
+			members.readers[0] == libkb.NormalizedUsername("public") {
+			ty = tlf.Public
+		}
+
+		teamID, _ := libkbfs.AddImplicitTeamForTestOrBust(
+			t, config, name.String(), "", counter, ty)
+		counter++
+
+		for _, w := range members.writers {
+			libkbfs.AddTeamWriterForTestOrBust(t, config, teamID,
+				e.GetUID(users[w]))
+		}
+		if ty == tlf.Private {
+			for _, r := range members.readers {
+				libkbfs.AddTeamReaderForTestOrBust(t, config, teamID,
+					e.GetUID(users[r]))
+			}
 		}
 	}
 }

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -573,8 +573,9 @@ func fiTypeString(fi os.FileInfo) string {
 
 func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []libkb.NormalizedUsername, teams teamMap,
-	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {
+	opTimeout time.Duration, users []libkb.NormalizedUsername,
+	teams, implicitTeams teamMap, clock libkbfs.Clock,
+	journal bool) map[libkb.NormalizedUsername]User {
 	res := map[libkb.NormalizedUsername]User{}
 	initSuccess := false
 	defer func() {
@@ -647,6 +648,7 @@ func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 
 	for _, c := range cfgs {
 		makeTeams(e.tb, c, e, teams, res)
+		makeImplicitTeams(e.tb, c, e, implicitTeams, res)
 	}
 
 	initSuccess = true

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -46,8 +46,9 @@ func (k *LibKBFS) Name() string {
 // InitTest implements the Engine interface.
 func (k *LibKBFS) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []libkb.NormalizedUsername, teams teamMap,
-	clock libkbfs.Clock, journal bool) map[libkb.NormalizedUsername]User {
+	opTimeout time.Duration, users []libkb.NormalizedUsername,
+	teams, implicitTeams teamMap, clock libkbfs.Clock,
+	journal bool) map[libkb.NormalizedUsername]User {
 	userMap := make(map[libkb.NormalizedUsername]User)
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(k.tb, users...)
@@ -108,6 +109,7 @@ func (k *LibKBFS) InitTest(ver kbfsmd.MetadataVer,
 	for _, u := range userMap {
 		c := u.(libkbfs.Config)
 		makeTeams(k.tb, c, k, teams, userMap)
+		makeImplicitTeams(k.tb, c, k, implicitTeams, userMap)
 	}
 
 	return userMap

--- a/test/implicit_teams_test.go
+++ b/test/implicit_teams_test.go
@@ -1,0 +1,125 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"testing"
+)
+
+func TestImplicitTeamsTwoWritersPrivate(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		implicitTeam("alice,bob", ""),
+		inPrivateTlf("alice,bob"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}
+
+func TestImplicitTeamsTwoWritersPublic(t *testing.T) {
+	test(t,
+		users("alice", "bob", "charlie"),
+		implicitTeam("alice,bob", "public"),
+		inPublicTlf("alice,bob"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+		as(charlie,
+			read("b", "world"),
+			expectError(mkfile("foo.txt", "hello world"),
+				"charlie does not have write access to directory /keybase/public/alice,bob"),
+		),
+	)
+}
+
+func TestImplicitTeamsTwoWritersPrivateNonCanonical(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		implicitTeam("alice,bob", ""),
+		inPrivateTlfNonCanonical("bob,alice", "alice,bob"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}
+
+func TestImplicitTeamsTwoWritersOneReaderPrivate(t *testing.T) {
+	test(t,
+		users("alice", "bob", "charlie"),
+		implicitTeam("alice,bob", "charlie"),
+		inPrivateTlf("alice,bob#charlie"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+		as(charlie,
+			read("b", "world"),
+			expectError(mkfile("foo.txt", "hello world"),
+				"charlie does not have write access to directory /keybase/private/alice,bob#charlie"),
+		),
+	)
+}
+
+func TestImplicitTeamsTwoWritersJournal(t *testing.T) {
+	test(t, journal(),
+		users("alice", "bob"),
+		implicitTeam("alice,bob", ""),
+		inPrivateTlf("alice,bob"),
+		as(alice,
+			// The tests don't support enabling journaling on a
+			// non-existent TLF, so force the TLF creation first.
+			mkfile("foo", "bar"),
+			rm("foo"),
+		),
+		as(alice,
+			enableJournal(),
+			mkfile("a", "hello"),
+		),
+		as(alice,
+			// Wait for the flush, after doing a SyncAll().
+			flushJournal(),
+		),
+		as(bob,
+			enableJournal(),
+			read("a", "hello"),
+			mkfile("b", "world"),
+		),
+		as(bob,
+			// Wait for the flush, after doing a SyncAll().
+			flushJournal(),
+		),
+		as(alice,
+			read("b", "world"),
+		),
+	)
+}

--- a/tlf/handle.go
+++ b/tlf/handle.go
@@ -194,7 +194,7 @@ func (h Handle) findUserInList(user keybase1.UserOrTeamID,
 // IsWriter returns whether or not the given user is a writer for the
 // top-level folder represented by this Handle.
 func (h Handle) IsWriter(user keybase1.UserOrTeamID) bool {
-	if h.Type() == SingleTeam {
+	if h.TypeForKeying() == TeamKeying {
 		panic("Can't call Handle.IsWriter() for a single team TLF")
 	}
 	return h.findUserInList(user, h.Writers)
@@ -203,10 +203,11 @@ func (h Handle) IsWriter(user keybase1.UserOrTeamID) bool {
 // IsReader returns whether or not the given user is a reader for the
 // top-level folder represented by this Handle.
 func (h Handle) IsReader(user keybase1.UserOrTeamID) bool {
-	if h.Type() == SingleTeam {
+	if h.TypeForKeying() == TeamKeying {
 		panic("Can't call Handle.IsReader() for a single team TLF")
 	}
-	return h.Type() == Public || h.findUserInList(user, h.Readers) ||
+	return h.TypeForKeying() == PublicKeying ||
+		h.findUserInList(user, h.Readers) ||
 		h.IsWriter(user)
 }
 
@@ -216,7 +217,7 @@ func (h Handle) IsReader(user keybase1.UserOrTeamID) bool {
 func (h Handle) ResolvedUsers() []keybase1.UserOrTeamID {
 	var resolvedUsers []keybase1.UserOrTeamID
 	resolvedUsers = append(resolvedUsers, h.Writers...)
-	if h.Type() == Private {
+	if h.TypeForKeying() == PrivateKeying {
 		resolvedUsers = append(resolvedUsers, h.Readers...)
 	}
 	return resolvedUsers


### PR DESCRIPTION
This PR adds MD support for implicit teams, including initializing them, keying them like regular teams, and creating them from a bare MD/handle.  The latter requires passing an explicit type into `MakeTlfHandle`, because the bare handle is ambiguous.

It also adds DSL tests for implicit teams.

This PR assumes that public-implicit-team TLFs will be able to fetch "keys" from the service, just like with any other team.  I still need to confirm that with CORE.

Issue: KBFS-2600