### PR TITLE
kbfs_ops: handle TeamNameChanged notifications for i-teams

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6177,6 +6177,7 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	defer cancelFunc()
 	fbo.log.CDebugf(ctx, "Starting name change for team %s", tid)
 
+	// TODO(KBFS-2621): resolve the i-team display name correctly.
 	newName, err := fbo.config.KBPKI().GetNormalizedUsername(
 		ctx, tid.AsUserOrTeam())
 	if err != nil {

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -927,14 +927,14 @@ func (fs *KBFSOpsStandard) TeamNameChanged(
 	// We have to search for the tid since we don't know the old name
 	// of the team here.  Should we add an index for this?
 	for fb, fbo := range ops {
-		if fb.Tlf.Type() != tlf.SingleTeam {
-			continue
-		}
-
 		_, _, handle, err := fbo.getRootNode(ctx)
 		if err != nil {
 			fs.log.CDebugf(
 				ctx, "Error getting root node for %s: %+v", fb.Tlf, err)
+			continue
+		}
+
+		if handle.TypeForKeying() != tlf.TeamKeying {
 			continue
 		}
 


### PR DESCRIPTION
We need the handle to tell if a TLF is team-backed or not, we can't just go off the TLF ID type anymore.

Issue: KBFS-2601