### PR TITLE
kbfsmd: add a new ImplicitTeamsVer (MDv4!)

### DIFF
--- a/kbfsmd/metadata_ver.go
+++ b/kbfsmd/metadata_ver.go
@@ -24,6 +24,15 @@ const (
 	// SegregatedKeyBundlesVer is the first metadata version to allow separate
 	// storage of key bundles.
 	SegregatedKeyBundlesVer MetadataVer = 3
+	// ImplicitTeamsVer is the first metadata version to allow private
+	// and public TLFs to be backed by implicit teams (and thus use
+	// service-provided encryption keys).  An MD of this version is
+	// data-compatible with `SegregatedKeyBundlesVer`, it's just the
+	// keys-getting process that's different.  This version bump is
+	// more intended to provide older clients with a nice "you need to
+	// upgrade" message, rather than to represent any underlying
+	// incompatibility.
+	ImplicitTeamsVer MetadataVer = 4
 )
 
 func (v MetadataVer) String() string {
@@ -36,6 +45,8 @@ func (v MetadataVer) String() string {
 		return "MDVer(InitialExtra)"
 	case SegregatedKeyBundlesVer:
 		return "MDVer(SegregatedKeyBundles)"
+	case ImplicitTeamsVer:
+		return "MDVer(ImplicitTeams)"
 	default:
 		return fmt.Sprintf("MDVer(%d)", v)
 	}

--- a/kbfsmd/root_metadata_v3.go
+++ b/kbfsmd/root_metadata_v3.go
@@ -202,10 +202,11 @@ func (extra ExtraMetadataV3) IsReaderKeyBundleNew() bool {
 	return extra.rkbNew
 }
 
-// MakeInitialRootMetadataV3 creates a new RootMetadataV3
-// object with revision RevisionInitial, and the given TLF ID
-// and handle. Note that if the given ID/handle are private, rekeying
-// must be done separately.
+// MakeInitialRootMetadataV3 creates a new RootMetadataV3 object with
+// revision RevisionInitial, and the given TLF ID and handle. Note
+// that if the given ID/handle are private, rekeying must be done
+// separately.  Since they are data-compatible, this also creates V4
+// MD objects.
 func MakeInitialRootMetadataV3(tlfID tlf.ID, h tlf.Handle) (
 	*RootMetadataV3, error) {
 	switch {
@@ -1437,6 +1438,10 @@ func (md *RootMetadataV3) ClearFinalBit() {
 
 // Version implements the MutableRootMetadata interface for RootMetadataV3.
 func (md *RootMetadataV3) Version() MetadataVer {
+	if md.TlfID().Type() != tlf.SingleTeam &&
+		md.TypeForKeying() == tlf.TeamKeying {
+		return ImplicitTeamsVer
+	}
 	return SegregatedKeyBundlesVer
 }
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -94,7 +94,7 @@ type EncryptedTLFCryptKeyClientAndEphemeral struct {
 }
 
 const (
-	defaultClientMetadataVer kbfsmd.MetadataVer = kbfsmd.SegregatedKeyBundlesVer
+	defaultClientMetadataVer kbfsmd.MetadataVer = kbfsmd.ImplicitTeamsVer
 )
 
 // DataVer is the type of a version for marshalled KBFS data

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -152,13 +152,14 @@ func defaultMDServer(ctx Context) string {
 func defaultMetadataVersion(ctx Context) kbfsmd.MetadataVer {
 	switch ctx.GetRunMode() {
 	case libkb.DevelRunMode:
-		return kbfsmd.SegregatedKeyBundlesVer
+		return kbfsmd.ImplicitTeamsVer
 	case libkb.StagingRunMode:
-		return kbfsmd.SegregatedKeyBundlesVer
+		return kbfsmd.ImplicitTeamsVer
 	case libkb.ProductionRunMode:
+		// TODO(KBFS-2621): flip this.
 		return kbfsmd.SegregatedKeyBundlesVer
 	default:
-		return kbfsmd.SegregatedKeyBundlesVer
+		return kbfsmd.ImplicitTeamsVer
 	}
 }
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2419,8 +2419,7 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	_, latestKeyGen, err := config1.KBPKI().GetTeamTLFCryptKeys(
 		ctx, teamID, kbfsmd.UnspecifiedKeyGen)
 
-	rmd, err := makeInitialRootMetadata(
-		kbfsmd.SegregatedKeyBundlesVer, tlfID, h)
+	rmd, err := makeInitialRootMetadata(config1.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)
 	rmd.bareMd.SetLatestKeyGenerationForTeamTLF(latestKeyGen)
 	// Make sure the MD looks readable.

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -643,7 +643,7 @@ func (md *MDServerRemote) Put(ctx context.Context, rmds *RootMetadataSigned,
 		arg.LockContext = &copied
 	}
 
-	if rmds.Version() < kbfsmd.SegregatedKeyBundlesVer {
+	if rmds.Version() != kbfsmd.SegregatedKeyBundlesVer {
 		if extra != nil {
 			return fmt.Errorf("Unexpected non-nil extra: %+v", extra)
 		}

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var testMetadataVers = []kbfsmd.MetadataVer{
-	kbfsmd.InitialExtraMetadataVer, kbfsmd.SegregatedKeyBundlesVer,
+	kbfsmd.InitialExtraMetadataVer, kbfsmd.ImplicitTeamsVer,
 }
 
 // runTestOverMetadataVers runs the given test function over all

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -62,7 +62,7 @@ type opt struct {
 // Also copy testMetadataVers, so that we can set it independently
 // from libkbfs tests.
 var testMetadataVers = []kbfsmd.MetadataVer{
-	kbfsmd.InitialExtraMetadataVer, kbfsmd.SegregatedKeyBundlesVer,
+	kbfsmd.InitialExtraMetadataVer, kbfsmd.ImplicitTeamsVer,
 }
 
 // runTestOverMetadataVers runs the given test function over all
@@ -259,7 +259,7 @@ func users(ns ...username) optionOp {
 func team(teamName libkb.NormalizedUsername, writers string,
 	readers string) optionOp {
 	return func(o *opt) {
-		if o.ver == kbfsmd.InitialExtraMetadataVer {
+		if o.ver < kbfsmd.SegregatedKeyBundlesVer {
 			o.tb.Skip("mdv2 doesn't support teams")
 		}
 		if o.teams == nil {
@@ -280,7 +280,7 @@ func team(teamName libkb.NormalizedUsername, writers string,
 
 func implicitTeam(writers string, readers string) optionOp {
 	return func(o *opt) {
-		if o.ver == kbfsmd.InitialExtraMetadataVer {
+		if o.ver < kbfsmd.ImplicitTeamsVer {
 			o.tb.Skip("mdv2 doesn't support teams")
 		}
 		if o.implicitTeams == nil {


### PR DESCRIPTION
This adds a new metadata version (4) that is data-compatible with v3
and uses the same struct.  It only uses the new version for
i-team-backed TLFs, otherwise it continues to use v3.  For now, prod
still uses v3 no matter what, until we get a little more testing done.

Issue: KBFS-2621