### PR TITLE
[KBFS-2588] prefetcher: Add test for simple prefetching and fix a race.

### DIFF
--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -321,9 +321,9 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	brq.mtx.Lock()
 	defer brq.mtx.Unlock()
 	// We might have to retry if the context has been canceled.  This loop will
-	// iterate a maximum of 2 times. It either hits the `return` statement at
+	// iterate a maximum of 2 times. It either hits the `break` statement at
 	// the bottom on the first iteration, or the `continue` statement first
-	// which causes it to `return` on the next iteration.
+	// which causes it to `break` on the next iteration.
 	var br *blockRetrieval
 	for {
 		exists := false

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -324,8 +324,10 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	// iterate a maximum of 2 times. It either hits the `return` statement at
 	// the bottom on the first iteration, or the `continue` statement first
 	// which causes it to `return` on the next iteration.
+	var br *blockRetrieval
 	for {
-		br, exists := brq.ptrs[bpLookup]
+		exists := false
+		br, exists = brq.ptrs[bpLookup]
 		if !exists {
 			// Add to the heap
 			br = &blockRetrieval{
@@ -350,36 +352,37 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 				continue
 			}
 		}
-		br.reqMtx.Lock()
-		defer br.reqMtx.Unlock()
-		br.requests = append(br.requests, &blockRetrievalRequest{
-			block:  block,
-			doneCh: ch,
-		})
-		if lifetime > br.cacheLifetime {
-			br.cacheLifetime = lifetime
-		}
-		oldPriority := br.priority
-		if priority > oldPriority {
-			br.priority = priority
-			// If the new request priority is higher, elevate the retrieval in the
-			// queue.  Skip this if the request is no longer in the queue (which
-			// means it's actively being processed).
-			if br.index != -1 {
-				heap.Fix(brq.heap, br.index)
-				if oldPriority < defaultOnDemandRequestPriority &&
-					priority >= defaultOnDemandRequestPriority {
-					// We've crossed the priority threshold for prefetch workers,
-					// so we now need an on-demand worker to pick up the request.
-					// This means that we might have up to two workers "activated"
-					// per request. However, they won't leak because if a worker
-					// sees an empty queue, it continues merrily along.
-					brq.notifyWorker(priority)
-				}
+		break
+	}
+	br.reqMtx.Lock()
+	defer br.reqMtx.Unlock()
+	br.requests = append(br.requests, &blockRetrievalRequest{
+		block:  block,
+		doneCh: ch,
+	})
+	if lifetime > br.cacheLifetime {
+		br.cacheLifetime = lifetime
+	}
+	oldPriority := br.priority
+	if priority > oldPriority {
+		br.priority = priority
+		// If the new request priority is higher, elevate the retrieval in the
+		// queue.  Skip this if the request is no longer in the queue (which
+		// means it's actively being processed).
+		if br.index != -1 {
+			heap.Fix(brq.heap, br.index)
+			if oldPriority < defaultOnDemandRequestPriority &&
+				priority >= defaultOnDemandRequestPriority {
+				// We've crossed the priority threshold for prefetch workers,
+				// so we now need an on-demand worker to pick up the request.
+				// This means that we might have up to two workers "activated"
+				// per request. However, they won't leak because if a worker
+				// sees an empty queue, it continues merrily along.
+				brq.notifyWorker(priority)
 			}
 		}
-		return ch
 	}
+	return ch
 }
 
 // FinalizeRequest is the last step of a retrieval request once a block has

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -267,10 +267,11 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	require.Len(t, br.requests, 1)
 	require.Equal(t, block, br.requests[0].block)
 
-	t.Log("Request another block retrieval for ptr1 before it has finished. Verify that the priority is unchanged but there are now 2 requests.")
+	t.Log("Request another block retrieval for ptr1 before it has finished. " +
+		"Verify that the priority has elevated and there are now 2 requests.")
 	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
 		block, NoCacheEntry)
-	require.Equal(t, defaultOnDemandRequestPriority, br.priority)
+	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 2)
 	require.Equal(t, block, br.requests[0].block)

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -277,7 +277,10 @@ func (p *blockPrefetcher) recordPrefetchParent(childBlockID kbfsblock.ID,
 		pre.parents[parentBlockID] = true
 		return pre.subtreeBlockCount, needNewFetch
 	}
-	return 0, needNewFetch
+	// If we return 0, then a prefetch was waiting, and the parent->child
+	// relationship was already known. Thus `needNewFetch` is necessarily
+	// false.
+	return 0, false
 }
 
 func (p *blockPrefetcher) prefetchIndirectFileBlock(ctx context.Context,
@@ -336,6 +339,9 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(ctx context.Context,
 			block = &FileBlock{}
 		case Exec:
 			block = &FileBlock{}
+		case Sym:
+			// Skip symbolic links because there's nothing to prefetch.
+			continue
 		default:
 			p.log.CDebugf(ctx, "Skipping prefetch for entry of "+
 				"unknown type %d", entry.Type)

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -558,7 +558,6 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				// If the prefetch is to be tracked, then the 0
 				// `subtreeBlockCount` will be incremented by `numBlocks`
 				// below, once we've ensured that `numBlocks` is not 0.
-				// TODO (KBFS-2588): potential bug here?
 				pre = p.newPrefetch(0, true, req)
 				p.prefetches[req.ptr.ID] = pre
 				ctx = pre.ctx

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -535,6 +535,9 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 						// now one has been created.
 						pre.req.isDeepSync = true
 					} else {
+						// Short circuit prefetches if the subtree was already
+						// triggered, unless, as in the above case, we've
+						// changed from a regular prefetch to a deep sync.
 						continue
 					}
 				} else {
@@ -561,6 +564,8 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				pre = p.newPrefetch(0, true, req)
 				p.prefetches[req.ptr.ID] = pre
 				ctx = pre.ctx
+				p.log.CDebugf(ctx, "created new prefetch for block %s",
+					req.ptr.ID)
 			}
 			// TODO: There is a potential optimization here that we can
 			// consider: Currently every time a prefetch is triggered, we

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -1260,10 +1260,10 @@ func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
 	waitForPrefetchOrBust(t, q.Prefetcher().Shutdown())
 }
 
-func TestPrefetcherUnsyncedPrefetchChildEvictedCanceled(t *testing.T) {
+func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
 	t.Log("Partial regression test for KBFS-2588: when a prefetched block " +
-		"has children waiting on a prefetch, and it is canceled, subsequent " +
-		"attempts to prefetch that parent block panic.")
+		"has children waiting on a prefetch, a child cancelation should not " +
+		"result in a panic for a future parent prefetch.")
 	// Note: this test actually passes, because as long as the block count of
 	// the parent is non-zero, the first child that completes it will also
 	// remove it from the tree. See
@@ -1371,7 +1371,7 @@ func TestPrefetcherUnsyncedPrefetchChildEvictedCanceled(t *testing.T) {
 	waitForPrefetchOrBust(t, q.Prefetcher().Shutdown())
 }
 
-func TestPrefetcherUnsyncedPrefetchRootEvictedCanceled(t *testing.T) {
+func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
 	t.Log("Regression test for KBFS-2588: when a prefetched block has " +
 		"children waiting on a prefetch, and it is canceled, subsequent " +
 		"attempts to prefetch that parent block panic.")


### PR DESCRIPTION
OK I added a bunch of tests as part of finding the repro.

This happened because of a bug that occurred when a block in the middle of the prefetch tree was evicted and got its prefetch canceled. The next time such a block was re-requested, it would get added back into the tree but its children still thought they knew about it, so the prefetcher used the wrong value in accounting the size of the subtree for the new block. I've fixed this accounting by tracking whether a block is newly being added to the tree, in which case it'll always use its children's block values.