### PR TITLE
key_manager: use a dummy crypt key for public i-team TLFs

### DIFF
--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -94,7 +94,8 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 	kbfscrypto.TLFCryptKey, error) {
 	tlfID := kmd.TlfID()
 
-	if kmd.TypeForKeying() == tlf.PublicKeying {
+	// Classic public TLFs and public implicit teams use a dummy crypt key.
+	if kmd.TypeForKeying() == tlf.PublicKeying || tlfID.Type() == tlf.Public {
 		return kbfscrypto.PublicTLFCryptKey, nil
 	}
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2447,7 +2447,12 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	key2b, err := config2.KeyManager().GetTLFCryptKeyForEncryption(ctx, rmd2)
 	require.NoError(t, err)
 	require.Equal(t, key1b, key2b)
-	require.NotEqual(t, key1, key1b)
+	if ty == tlf.Public {
+		// Bumping the key generation shouldn't do anything for public TLFs.
+		require.Equal(t, key1, key1b)
+	} else {
+		require.NotEqual(t, key1, key1b)
+	}
 }
 
 func TestKeyManagerGetPrivateImplicitTeamTLFCryptKey(t *testing.T) {


### PR DESCRIPTION
Miles let me know that random users won't be able to read the dummy crypt key from a public i-team's sigchain.