### PR TITLE
vendor: update go-git to keybase/go-git master

### DIFF
--- a/libgit/ephemeral_git_config_with_fixed_pack_window.go
+++ b/libgit/ephemeral_git_config_with_fixed_pack_window.go
@@ -6,6 +6,7 @@ package libgit
 
 import (
 	"io"
+	"time"
 
 	gogitcfg "gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -20,6 +21,8 @@ type ephemeralGitConfigWithFixedPackWindow struct {
 	storage.Storer
 	initer     storer.Initializer
 	pfWriter   storer.PackfileWriter
+	los        storer.LooseObjectStorer
+	pos        storer.PackedObjectStorer
 	packWindow uint
 }
 
@@ -53,6 +56,39 @@ func (e *ephemeralGitConfigWithFixedPackWindow) SetConfig(c *gogitcfg.Config) (
 	return nil
 }
 
+// ForEachObjectHash implements the `storer.LooseObjectStorer` interface.
+func (e *ephemeralGitConfigWithFixedPackWindow) ForEachObjectHash(
+	f func(plumbing.Hash) error) error {
+	return e.los.ForEachObjectHash(f)
+}
+
+// LooseObjectHash implements the `storer.LooseObjectStorer` interface.
+func (e *ephemeralGitConfigWithFixedPackWindow) LooseObjectTime(
+	h plumbing.Hash) (time.Time, error) {
+	return e.los.LooseObjectTime(h)
+}
+
+// DeleteLooseObject implements the `storer.LooseObjectStorer` interface.
+func (e *ephemeralGitConfigWithFixedPackWindow) DeleteLooseObject(
+	h plumbing.Hash) error {
+	return e.los.DeleteLooseObject(h)
+}
+
+// ObjectPacks implements the `storer.PackedObjectStorer` interface.
+func (e *ephemeralGitConfigWithFixedPackWindow) ObjectPacks() (
+	[]plumbing.Hash, error) {
+	return e.pos.ObjectPacks()
+}
+
+// DeleteOldObjectPackAndIndex implements the
+// `storer.PackedObjectStorer` interface.
+func (e *ephemeralGitConfigWithFixedPackWindow) DeleteOldObjectPackAndIndex(
+	h plumbing.Hash, t time.Time) error {
+	return e.pos.DeleteOldObjectPackAndIndex(h, t)
+}
+
 var _ storage.Storer = (*ephemeralGitConfigWithFixedPackWindow)(nil)
 var _ storer.Initializer = (*ephemeralGitConfigWithFixedPackWindow)(nil)
 var _ storer.PackfileWriter = (*ephemeralGitConfigWithFixedPackWindow)(nil)
+var _ storer.LooseObjectStorer = (*ephemeralGitConfigWithFixedPackWindow)(nil)
+var _ storer.PackedObjectStorer = (*ephemeralGitConfigWithFixedPackWindow)(nil)

--- a/vendor/gopkg.in/src-d/go-git.v4/README.md
+++ b/vendor/gopkg.in/src-d/go-git.v4/README.md
@@ -76,18 +76,17 @@ Info("git log")
 ref, err := r.Head()
 CheckIfError(err)
 
-// ... retrieves the commit object
-commit, err := r.CommitObject(ref.Hash())
-CheckIfError(err)
 
 // ... retrieves the commit history
-history, err := commit.History()
+cIter, err := r.Log(&git.LogOptions{From: ref.Hash()})
 CheckIfError(err)
 
 // ... just iterates over the commits, printing it
-for _, c := range history {
-    fmt.Println(c)
-}
+err = cIter.ForEach(func(c *object.Commit) error {
+	fmt.Println(c)
+	return nil
+})
+CheckIfError(err)
 ```
 
 Outputs:

--- a/vendor/gopkg.in/src-d/go-git.v4/blame.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/blame.go
@@ -147,10 +147,7 @@ func (b *blame) fillRevs() error {
 	var err error
 
 	b.revs, err = references(b.fRev, b.path)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // build graph of a file from its revision history
@@ -244,7 +241,7 @@ func (b *blame) GoString() string {
 
 	lines := strings.Split(contents, "\n")
 	// max line number length
-	mlnl := len(fmt.Sprintf("%s", strconv.Itoa(len(lines))))
+	mlnl := len(strconv.Itoa(len(lines)))
 	// max author length
 	mal := b.maxAuthorLength()
 	format := fmt.Sprintf("%%s (%%-%ds %%%dd) %%s\n",

--- a/vendor/gopkg.in/src-d/go-git.v4/config/config.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/config/config.go
@@ -65,8 +65,8 @@ type Config struct {
 // NewConfig returns a new empty Config.
 func NewConfig() *Config {
 	return &Config{
-		Remotes:    make(map[string]*RemoteConfig, 0),
-		Submodules: make(map[string]*Submodule, 0),
+		Remotes:    make(map[string]*RemoteConfig),
+		Submodules: make(map[string]*Submodule),
 		Raw:        format.New(),
 	}
 }
@@ -290,13 +290,8 @@ func (c *RemoteConfig) unmarshal(s *format.Subsection) error {
 		fetch = append(fetch, rs)
 	}
 
-	var urls []string
-	for _, f := range c.raw.Options.GetAll(urlKey) {
-		urls = append(urls, f)
-	}
-
 	c.Name = c.raw.Name
-	c.URLs = urls
+	c.URLs = append([]string(nil), c.raw.Options.GetAll(urlKey)...)
 	c.Fetch = fetch
 
 	return nil

--- a/vendor/gopkg.in/src-d/go-git.v4/config/modules.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/config/modules.go
@@ -24,7 +24,7 @@ type Modules struct {
 // NewModules returns a new empty Modules
 func NewModules() *Modules {
 	return &Modules{
-		Submodules: make(map[string]*Submodule, 0),
+		Submodules: make(map[string]*Submodule),
 		raw:        format.New(),
 	}
 }

--- a/vendor/gopkg.in/src-d/go-git.v4/config/refspec.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/config/refspec.go
@@ -51,20 +51,12 @@ func (s RefSpec) Validate() error {
 
 // IsForceUpdate returns if update is allowed in non fast-forward merges.
 func (s RefSpec) IsForceUpdate() bool {
-	if s[0] == refSpecForce[0] {
-		return true
-	}
-
-	return false
+	return s[0] == refSpecForce[0]
 }
 
 // IsDelete returns true if the refspec indicates a delete (empty src).
 func (s RefSpec) IsDelete() bool {
-	if s[0] == refSpecSeparator[0] {
-		return true
-	}
-
-	return false
+	return s[0] == refSpecSeparator[0]
 }
 
 // Src return the src side.
@@ -87,7 +79,7 @@ func (s RefSpec) Match(n plumbing.ReferenceName) bool {
 
 // IsWildcard returns true if the RefSpec contains a wildcard.
 func (s RefSpec) IsWildcard() bool {
-	return strings.Index(string(s), refSpecWildcard) != -1
+	return strings.Contains(string(s), refSpecWildcard)
 }
 
 func (s RefSpec) matchExact(n plumbing.ReferenceName) bool {

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/config/encoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/config/encoder.go
@@ -53,17 +53,13 @@ func (e *Encoder) encodeSubsection(sectionName string, s *Subsection) error {
 		return err
 	}
 
-	if err := e.encodeOptions(s.Options); err != nil {
-		return err
-	}
-
-	return nil
+	return e.encodeOptions(s.Options)
 }
 
 func (e *Encoder) encodeOptions(opts Options) error {
 	for _, o := range opts {
 		pattern := "\t%s = %s\n"
-		if strings.Index(o.Value, "\\") != -1 {
+		if strings.Contains(o.Value, "\\") {
 			pattern = "\t%s = %q\n"
 		}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/index/decoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/index/decoder.go
@@ -200,11 +200,8 @@ func (d *Decoder) padEntry(idx *Index, e *Entry, read int) error {
 
 	entrySize := read + len(e.Name)
 	padLen := 8 - entrySize%8
-	if _, err := io.CopyN(ioutil.Discard, d.r, int64(padLen)); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := io.CopyN(ioutil.Discard, d.r, int64(padLen))
+	return err
 }
 
 func (d *Decoder) readExtensions(idx *Index) error {
@@ -288,7 +285,7 @@ func (d *Decoder) readChecksum(expected []byte, alreadyRead [4]byte) error {
 		return err
 	}
 
-	if bytes.Compare(h[:], expected) != 0 {
+	if !bytes.Equal(h[:], expected) {
 		return ErrInvalidChecksum
 	}
 
@@ -407,7 +404,7 @@ func (d *resolveUndoDecoder) Decode(ru *ResolveUndo) error {
 
 func (d *resolveUndoDecoder) readEntry() (*ResolveUndoEntry, error) {
 	e := &ResolveUndoEntry{
-		Stages: make(map[Stage]plumbing.Hash, 0),
+		Stages: make(map[Stage]plumbing.Hash),
 	}
 
 	path, err := binary.ReadUntil(d.r, '\x00')

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/objfile/reader.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/objfile/reader.go
@@ -110,9 +110,5 @@ func (r *Reader) Hash() plumbing.Hash {
 // Close releases any resources consumed by the Reader. Calling Close does not
 // close the wrapped io.Reader originally passed to NewReader.
 func (r *Reader) Close() error {
-	if err := r.zlib.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return r.zlib.Close()
 }

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/decoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/decoder.go
@@ -105,7 +105,7 @@ func NewDecoderForType(s *Scanner, o storer.EncodedObjectStorer,
 		o: o,
 
 		idx:          NewIndex(0),
-		offsetToType: make(map[int64]plumbing.ObjectType, 0),
+		offsetToType: make(map[int64]plumbing.ObjectType),
 		decoderType:  t,
 	}, nil
 }

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_index.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/delta_index.go
@@ -215,12 +215,10 @@ var len8tab = [256]uint8{
 }
 
 func hashBlock(raw []byte, ptr int) int {
-	var hash uint32
-
 	// The first 4 steps collapse out into a 4 byte big-endian decode,
 	// with a larger right shift as we combined shift lefts together.
 	//
-	hash = ((uint32(raw[ptr]) & 0xff) << 24) |
+	hash := ((uint32(raw[ptr]) & 0xff) << 24) |
 		((uint32(raw[ptr+1]) & 0xff) << 16) |
 		((uint32(raw[ptr+2]) & 0xff) << 8) |
 		(uint32(raw[ptr+3]) & 0xff)

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/object_pack.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/object_pack.go
@@ -84,11 +84,7 @@ func (o *ObjectToPack) Size() int64 {
 }
 
 func (o *ObjectToPack) IsDelta() bool {
-	if o.Base != nil {
-		return true
-	}
-
-	return false
+	return o.Base != nil
 }
 
 func (o *ObjectToPack) SetDelta(base *ObjectToPack, delta plumbing.EncodedObject) {

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/patch_delta.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/packfile/patch_delta.go
@@ -38,11 +38,8 @@ func ApplyDelta(target, base plumbing.EncodedObject, delta []byte) error {
 
 	target.SetSize(int64(len(dst)))
 
-	if _, err := w.Write(dst); err != nil {
-		return err
-	}
-
-	return nil
+	_, err = w.Write(dst)
+	return err
 }
 
 var (

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/encoder.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/format/pktline/encoder.go
@@ -63,21 +63,15 @@ func (e *Encoder) encodeLine(p []byte) error {
 	}
 
 	if bytes.Equal(p, Flush) {
-		if err := e.Flush(); err != nil {
-			return err
-		}
-		return nil
+		return e.Flush()
 	}
 
 	n := len(p) + 4
 	if _, err := e.w.Write(asciiHex16(n)); err != nil {
 		return err
 	}
-	if _, err := e.w.Write(p); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := e.w.Write(p)
+	return err
 }
 
 // Returns the hexadecimal ascii representation of the 16 less

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/advrefs_encode.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/advrefs_encode.go
@@ -133,7 +133,7 @@ func encodeRefs(e *advRefsEncoder) encoderStateFn {
 			continue
 		}
 
-		hash, _ := e.data.References[r]
+		hash := e.data.References[r]
 		if e.err = e.pe.Encodef("%s %s\n", hash.String(), r); e.err != nil {
 			return nil
 		}

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/shallowupd.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/shallowupd.go
@@ -32,7 +32,7 @@ func (r *ShallowUpdate) Decode(reader io.Reader) error {
 			err = r.decodeShallowLine(line)
 		case bytes.HasPrefix(line, unshallow):
 			err = r.decodeUnshallowLine(line)
-		case bytes.Compare(line, pktline.Flush) == 0:
+		case bytes.Equal(line, pktline.Flush):
 			return nil
 		}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/srvresp.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/srvresp.go
@@ -77,7 +77,7 @@ func (r *ServerResponse) stopReading(reader *bufio.Reader) (bool, error) {
 func (r *ServerResponse) isValidCommand(b []byte) bool {
 	commands := [][]byte{ack, nak}
 	for _, c := range commands {
-		if bytes.Compare(b, c) == 0 {
+		if bytes.Equal(b, c) {
 			return true
 		}
 	}
@@ -90,11 +90,11 @@ func (r *ServerResponse) decodeLine(line []byte) error {
 		return fmt.Errorf("unexpected flush")
 	}
 
-	if bytes.Compare(line[0:3], ack) == 0 {
+	if bytes.Equal(line[0:3], ack) {
 		return r.decodeACKLine(line)
 	}
 
-	if bytes.Compare(line[0:3], nak) == 0 {
+	if bytes.Equal(line[0:3], nak) {
 		return nil
 	}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/ulreq_encode.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/ulreq_encode.go
@@ -70,7 +70,7 @@ func (e *ulReqEncoder) encodeFirstWant() stateFn {
 func (e *ulReqEncoder) encodeAditionalWants() stateFn {
 	last := e.data.Wants[0]
 	for _, w := range e.data.Wants[1:] {
-		if bytes.Compare(last[:], w[:]) == 0 {
+		if bytes.Equal(last[:], w[:]) {
 			continue
 		}
 
@@ -90,7 +90,7 @@ func (e *ulReqEncoder) encodeShallows() stateFn {
 
 	var last plumbing.Hash
 	for _, s := range e.data.Shallows {
-		if bytes.Compare(last[:], s[:]) == 0 {
+		if bytes.Equal(last[:], s[:]) {
 			continue
 		}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/uppackreq.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/uppackreq.go
@@ -77,7 +77,7 @@ func (u *UploadHaves) Encode(w io.Writer, flush bool) error {
 
 	var last plumbing.Hash
 	for _, have := range u.Haves {
-		if bytes.Compare(last[:], have[:]) == 0 {
+		if bytes.Equal(last[:], have[:]) {
 			continue
 		}
 

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/object.go
@@ -40,24 +40,6 @@ type EncodedObjectStorer interface {
 	// HasEncodedObject returns ErrObjNotFound if the object doesn't
 	// exist.  If the object does exist, it returns nil.
 	HasEncodedObject(plumbing.Hash) error
-	// ForEachObjectHash iterates over all the (loose) object hashes
-	// in the repository without necessarily having to read those objects.
-	// Objects only inside pack files may be omitted.
-	// If ErrStop is sent the iteration is stop but no error is returned.
-	ForEachObjectHash(func(plumbing.Hash) error) error
-	// LooseObjectTime looks up the (m)time associated with the
-	// loose object (that is not in a pack file). Some
-	// implementations (e.g. without loose objects)
-	// always return an error.
-	LooseObjectTime(plumbing.Hash) (time.Time, error)
-	// DeleteLooseObject deletes a loose object if it exists.
-	DeleteLooseObject(plumbing.Hash) error
-	// ObjectPacks returns hashes of object packs if the underlying
-	// implementation has pack files.
-	ObjectPacks() ([]plumbing.Hash, error)
-	// DeleteOldObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
-	// Deletion is only performed if the pack is older than the supplied time (or the time is zero).
-	DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error
 }
 
 // DeltaObjectStorer is an EncodedObjectStorer that can return delta
@@ -73,6 +55,34 @@ type DeltaObjectStorer interface {
 type Transactioner interface {
 	// Begin starts a transaction.
 	Begin() Transaction
+}
+
+// LooseObjectStorer is an optional interface for managing "loose"
+// objects, i.e. those not in packfiles.
+type LooseObjectStorer interface {
+	// ForEachObjectHash iterates over all the (loose) object hashes
+	// in the repository without necessarily having to read those objects.
+	// Objects only inside pack files may be omitted.
+	// If ErrStop is sent the iteration is stop but no error is returned.
+	ForEachObjectHash(func(plumbing.Hash) error) error
+	// LooseObjectTime looks up the (m)time associated with the
+	// loose object (that is not in a pack file). Some
+	// implementations (e.g. without loose objects)
+	// always return an error.
+	LooseObjectTime(plumbing.Hash) (time.Time, error)
+	// DeleteLooseObject deletes a loose object if it exists.
+	DeleteLooseObject(plumbing.Hash) error
+}
+
+// PackedObjectStorer is an optional interface for managing objects in
+// packfiles.
+type PackedObjectStorer interface {
+	// ObjectPacks returns hashes of object packs if the underlying
+	// implementation has pack files.
+	ObjectPacks() ([]plumbing.Hash, error)
+	// DeleteOldObjectPackAndIndex deletes an object pack and the corresponding index file if they exist.
+	// Deletion is only performed if the pack is older than the supplied time (or the time is zero).
+	DeleteOldObjectPackAndIndex(plumbing.Hash, time.Time) error
 }
 
 // PackfileWriter is a optional method for ObjectStorer, it enable direct write

--- a/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/plumbing/storer/reference.go
@@ -16,6 +16,10 @@ var ErrMaxResolveRecursion = errors.New("max. recursion level reached")
 // ReferenceStorer is a generic storage of references.
 type ReferenceStorer interface {
 	SetReference(*plumbing.Reference) error
+	// CheckAndSetReference sets the reference `new`, but if `old` is
+	// not `nil`, it first checks that the current stored value for
+	// `old.Name()` matches the given reference value in `old`.  If
+	// not, it returns an error and doesn't update `new`.
 	CheckAndSetReference(new, old *plumbing.Reference) error
 	Reference(plumbing.ReferenceName) (*plumbing.Reference, error)
 	IterReferences() (ReferenceIter, error)

--- a/vendor/gopkg.in/src-d/go-git.v4/references.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/references.go
@@ -26,7 +26,7 @@ import (
 // to fix this).
 func references(c *object.Commit, path string) ([]*object.Commit, error) {
 	var result []*object.Commit
-	seen := make(map[plumbing.Hash]struct{}, 0)
+	seen := make(map[plumbing.Hash]struct{})
 	if err := walkGraph(&result, &seen, c, path); err != nil {
 		return nil, err
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/remote.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/remote.go
@@ -600,7 +600,7 @@ func getHaves(
 	}
 
 	for _, ref := range localRefs {
-		if haves[ref.Hash()] == true {
+		if haves[ref.Hash()] {
 			continue
 		}
 
@@ -638,7 +638,7 @@ func calculateRefs(
 		return nil, err
 	}
 
-	refs := make(memory.ReferenceStorage, 0)
+	refs := make(memory.ReferenceStorage)
 	return refs, iter.ForEach(func(ref *plumbing.Reference) error {
 		if !config.MatchAny(spec, ref.Name()) {
 			return nil

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
@@ -312,6 +312,7 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 			return err
 		}
 	}
+
 	if ref.Hash() != old.Hash() {
 		return fmt.Errorf("reference has changed concurrently")
 	}
@@ -319,11 +320,7 @@ func (d *DotGit) checkReferenceAndTruncate(f billy.File, old *plumbing.Reference
 	if err != nil {
 		return err
 	}
-	err = f.Truncate(0)
-	if err != nil {
-		return err
-	}
-	return nil
+	return f.Truncate(0)
 }
 
 func (d *DotGit) SetRef(r, old *plumbing.Reference) (err error) {
@@ -397,17 +394,7 @@ func (d *DotGit) Ref(name plumbing.ReferenceName) (*plumbing.Reference, error) {
 	return d.packedRef(name)
 }
 
-func (d *DotGit) findPackedRefs() ([]*plumbing.Reference, error) {
-	f, err := d.fs.Open(packedRefsPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	defer ioutil.CheckClose(f, &err)
-
+func (d *DotGit) findPackedRefsInFile(f billy.File) ([]*plumbing.Reference, error) {
 	s := bufio.NewScanner(f)
 	var refs []*plumbing.Reference
 	for s.Scan() {
@@ -422,6 +409,19 @@ func (d *DotGit) findPackedRefs() ([]*plumbing.Reference, error) {
 	}
 
 	return refs, s.Err()
+}
+
+func (d *DotGit) findPackedRefs() ([]*plumbing.Reference, error) {
+	f, err := d.fs.Open(packedRefsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	defer ioutil.CheckClose(f, &err)
+	return d.findPackedRefsInFile(f)
 }
 
 func (d *DotGit) packedRef(name plumbing.ReferenceName) (*plumbing.Reference, error) {
@@ -470,38 +470,82 @@ func (d *DotGit) addRefsFromPackedRefs(refs *[]*plumbing.Reference, seen map[plu
 	return nil
 }
 
-func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err error) {
-	f, err := d.fs.Open(packedRefsPath)
+func (d *DotGit) addRefsFromPackedRefsFile(refs *[]*plumbing.Reference, f billy.File, seen map[plumbing.ReferenceName]bool) (err error) {
+	packedRefs, err := d.findPackedRefsInFile(f)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+		return err
+	}
+
+	for _, ref := range packedRefs {
+		if !seen[ref.Name()] {
+			*refs = append(*refs, ref)
+			seen[ref.Name()] = true
 		}
-
-		return err
 	}
-	defer ioutil.CheckClose(f, &err)
+	return nil
+}
 
-	err = f.Lock()
-	if err != nil {
-		return err
-	}
-
-	// Re-open the file after locking, since it could have been
-	// renamed over by a new file during the Lock process.
-	pr, err := d.fs.Open(packedRefsPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return err
-	}
-	doClosePR := true
+func (d *DotGit) openAndLockPackedRefs(doCreate bool) (
+	pr billy.File, err error) {
+	var f billy.File
 	defer func() {
-		if doClosePR {
-			ioutil.CheckClose(pr, &err)
+		if err != nil && f != nil {
+			ioutil.CheckClose(f, &err)
 		}
 	}()
+
+	openFlags := os.O_RDWR
+	if doCreate {
+		openFlags |= os.O_CREATE
+	}
+
+	// Keep trying to open and lock the file until we're sure the file
+	// didn't change between the open and the lock.
+	for {
+		f, err = d.fs.OpenFile(packedRefsPath, openFlags, 0600)
+		if err != nil {
+			if os.IsNotExist(err) && !doCreate {
+				return nil, nil
+			}
+
+			return nil, err
+		}
+		fi, err := d.fs.Stat(packedRefsPath)
+		if err != nil {
+			return nil, err
+		}
+		mtime := fi.ModTime()
+
+		err = f.Lock()
+		if err != nil {
+			return nil, err
+		}
+
+		fi, err = d.fs.Stat(packedRefsPath)
+		if err != nil {
+			return nil, err
+		}
+		if mtime == fi.ModTime() {
+			break
+		}
+		// The file has changed since we opened it.  Close and retry.
+		err = f.Close()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return f, nil
+}
+
+func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err error) {
+	pr, err := d.openAndLockPackedRefs(false)
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return nil
+	}
+	defer ioutil.CheckClose(pr, &err)
 
 	// Creating the temp file in the same directory as the target file
 	// improves our chances for rename operation to be atomic.
@@ -509,11 +553,10 @@ func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err e
 	if err != nil {
 		return err
 	}
-	doCloseTmp := true
+	tmpName := tmp.Name()
 	defer func() {
-		if doCloseTmp {
-			ioutil.CheckClose(tmp, &err)
-		}
+		ioutil.CheckClose(tmp, &err)
+		_ = d.fs.Remove(tmpName) // don't check err, we might have renamed it
 	}()
 
 	s := bufio.NewScanner(pr)
@@ -540,26 +583,10 @@ func (d *DotGit) rewritePackedRefsWithoutRef(name plumbing.ReferenceName) (err e
 	}
 
 	if !found {
-		doCloseTmp = false
-		ioutil.CheckClose(tmp, &err)
-		if err != nil {
-			return err
-		}
-		// Delete the temp file if nothing needed to be removed.
-		return d.fs.Remove(tmp.Name())
+		return nil
 	}
 
-	doClosePR = false
-	if err := pr.Close(); err != nil {
-		return err
-	}
-
-	doCloseTmp = false
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-
-	return d.fs.Rename(tmp.Name(), packedRefsPath)
+	return d.rewritePackedRefsWhileLocked(tmp, pr)
 }
 
 // process lines from a packed-refs file
@@ -699,45 +726,29 @@ func (d *DotGit) CountLooseRefs() (int, error) {
 // PackRefs packs all loose refs into the packed-refs file.
 //
 // This implementation only works under the assumption that the view
-// of the file system won't be updated during this operation, which is
-// true for kbfsgit after the Lock() operation is complete (and before
-// the Unlock()/Close() of the locked file).  If another process
-// concurrently updates one of the loose refs we delete, then KBFS
-// conflict resolution would just end up ignoring our delete.  Also
-// note that deleting a ref requires locking packed-refs, so a ref
-// deleted by the user shouldn't be revived by ref-packing.
-//
-// The strategy would not work on a general file system though,
-// without locking each loose reference and checking it again before
-// deleting the file, because otherwise an updated reference could
-// sneak in and then be deleted by the packed-refs process.
-// Alternatively, every ref update could also lock packed-refs, so
-// only one lock is required during ref-packing.  But that would
-// worsen performance in the common case.
-//
-// TODO: before trying to get this merged upstream, move it into a
-// custom kbfsgit Storer implementation, and rewrite this function to
-// work correctly on a general filesystem.
+// of the file system won't be updated during this operation.  This
+// strategy would not work on a general file system though, without
+// locking each loose reference and checking it again before deleting
+// the file, because otherwise an updated reference could sneak in and
+// then be deleted by the packed-refs process.  Alternatively, every
+// ref update could also lock packed-refs, so only one lock is
+// required during ref-packing.  But that would worsen performance in
+// the common case.
 //
 // TODO: add an "all" boolean like the `git pack-refs --all` flag.
 // When `all` is false, it would only pack refs that have already been
 // packed, plus all tags.
 func (d *DotGit) PackRefs() (err error) {
 	// Lock packed-refs, and create it if it doesn't exist yet.
-	f, err := d.fs.OpenFile(packedRefsPath, os.O_RDWR|os.O_CREATE, 0600)
+	f, err := d.openAndLockPackedRefs(true)
 	if err != nil {
 		return err
 	}
 	defer ioutil.CheckClose(f, &err)
 
-	err = f.Lock()
-	if err != nil {
-		return err
-	}
-
 	// Gather all refs using addRefsFromRefDir and addRefsFromPackedRefs.
 	var refs []*plumbing.Reference
-	var seen = make(map[plumbing.ReferenceName]bool)
+	seen := make(map[plumbing.ReferenceName]bool)
 	if err := d.addRefsFromRefDir(&refs, seen); err != nil {
 		return err
 	}
@@ -746,7 +757,7 @@ func (d *DotGit) PackRefs() (err error) {
 		return nil
 	}
 	numLooseRefs := len(refs)
-	if err := d.addRefsFromPackedRefs(&refs, seen); err != nil {
+	if err := d.addRefsFromPackedRefsFile(&refs, f, seen); err != nil {
 		return err
 	}
 
@@ -755,12 +766,12 @@ func (d *DotGit) PackRefs() (err error) {
 	if err != nil {
 		return err
 	}
-	doCloseTmp := true
+	tmpName := tmp.Name()
 	defer func() {
-		if doCloseTmp {
-			ioutil.CheckClose(tmp, &err)
-		}
+		ioutil.CheckClose(tmp, &err)
+		_ = d.fs.Remove(tmpName) // don't check err, we might have renamed it
 	}()
+
 	w := bufio.NewWriter(tmp)
 	for _, ref := range refs {
 		_, err := w.WriteString(ref.String() + "\n")
@@ -774,11 +785,7 @@ func (d *DotGit) PackRefs() (err error) {
 	}
 
 	// Rename the temp packed-refs file.
-	doCloseTmp = false
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	err = d.fs.Rename(tmp.Name(), packedRefsPath)
+	err = d.rewritePackedRefsWhileLocked(tmp, f)
 	if err != nil {
 		return err
 	}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_nix.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_nix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package dotgit
+
+import "gopkg.in/src-d/go-billy.v4"
+
+func (d *DotGit) rewritePackedRefsWhileLocked(
+	tmp billy.File, pr billy.File) error {
+	// On non-Windows platforms, we can have atomic rename.
+	return d.fs.Rename(tmp.Name(), pr.Name())
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_windows.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit_rewrite_packed_refs_windows.go
@@ -1,0 +1,39 @@
+// +build windows
+
+package dotgit
+
+import (
+	"io"
+
+	"gopkg.in/src-d/go-billy.v4"
+)
+
+func (d *DotGit) rewritePackedRefsWhileLocked(
+	tmp billy.File, pr billy.File) error {
+	// If we aren't using the bare Windows filesystem as the storage
+	// layer, we might be able to get away with a rename over a locked
+	// file.
+	err := d.fs.Rename(tmp.Name(), pr.Name())
+	if err == nil {
+		return nil
+	}
+
+	// Otherwise, Windows doesn't let us rename over a locked file, so
+	// we have to do a straight copy.  Unfortunately this could result
+	// in a partially-written file if the process fails before the
+	// copy completes.
+	_, err = pr.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	err = pr.Truncate(0)
+	if err != nil {
+		return err
+	}
+	_, err = tmp.Seek(0, io.SeekStart)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(pr, tmp)
+	return err
+}

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/object.go
@@ -42,7 +42,7 @@ func (s *ObjectStorage) requireIndex() error {
 		return nil
 	}
 
-	s.index = make(map[plumbing.Hash]*packfile.Index, 0)
+	s.index = make(map[plumbing.Hash]*packfile.Index)
 	packs, err := s.dir.ObjectPacks()
 	if err != nil {
 		return err
@@ -346,7 +346,7 @@ func (s *ObjectStorage) IterEncodedObjects(t plumbing.ObjectType) (storer.Encode
 		return nil, err
 	}
 
-	seen := make(map[plumbing.Hash]bool, 0)
+	seen := make(map[plumbing.Hash]bool)
 	var iters []storer.EncodedObjectIter
 	if len(objects) != 0 {
 		iters = append(iters, &objectsIter{s: s, t: t, h: objects})
@@ -509,13 +509,10 @@ func hashListAsMap(l []plumbing.Hash) map[plumbing.Hash]bool {
 
 func (s *ObjectStorage) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 	err := s.dir.ForEachObjectHash(fun)
-	if err != nil {
-		if err == storer.ErrStop {
-			return nil
-		}
-		return err
+	if err == storer.ErrStop {
+		return nil
 	}
-	return nil
+	return err
 }
 
 func (s *ObjectStorage) LooseObjectTime(hash plumbing.Hash) (time.Time, error) {

--- a/vendor/gopkg.in/src-d/go-git.v4/storage/memory/storage.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/memory/storage.go
@@ -31,17 +31,17 @@ type Storage struct {
 // NewStorage returns a new Storage base on memory
 func NewStorage() *Storage {
 	return &Storage{
-		ReferenceStorage: make(ReferenceStorage, 0),
+		ReferenceStorage: make(ReferenceStorage),
 		ConfigStorage:    ConfigStorage{},
 		ShallowStorage:   ShallowStorage{},
 		ObjectStorage: ObjectStorage{
-			Objects: make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Commits: make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Trees:   make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Blobs:   make(map[plumbing.Hash]plumbing.EncodedObject, 0),
-			Tags:    make(map[plumbing.Hash]plumbing.EncodedObject, 0),
+			Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
+			Commits: make(map[plumbing.Hash]plumbing.EncodedObject),
+			Trees:   make(map[plumbing.Hash]plumbing.EncodedObject),
+			Blobs:   make(map[plumbing.Hash]plumbing.EncodedObject),
+			Tags:    make(map[plumbing.Hash]plumbing.EncodedObject),
 		},
-		ModuleStorage: make(ModuleStorage, 0),
+		ModuleStorage: make(ModuleStorage),
 	}
 }
 
@@ -116,8 +116,7 @@ func (o *ObjectStorage) SetEncodedObject(obj plumbing.EncodedObject) (plumbing.H
 }
 
 func (o *ObjectStorage) HasEncodedObject(h plumbing.Hash) (err error) {
-	_, ok := o.Objects[h]
-	if !ok {
+	if _, ok := o.Objects[h]; !ok {
 		return plumbing.ErrObjectNotFound
 	}
 	return nil
@@ -161,7 +160,7 @@ func flattenObjectMap(m map[plumbing.Hash]plumbing.EncodedObject) []plumbing.Enc
 func (o *ObjectStorage) Begin() storer.Transaction {
 	return &TxObjectStorage{
 		Storage: o,
-		Objects: make(map[plumbing.Hash]plumbing.EncodedObject, 0),
+		Objects: make(map[plumbing.Hash]plumbing.EncodedObject),
 	}
 }
 
@@ -227,7 +226,7 @@ func (tx *TxObjectStorage) Commit() error {
 }
 
 func (tx *TxObjectStorage) Rollback() error {
-	tx.Objects = make(map[plumbing.Hash]plumbing.EncodedObject, 0)
+	tx.Objects = make(map[plumbing.Hash]plumbing.EncodedObject)
 	return nil
 }
 
@@ -242,16 +241,17 @@ func (r ReferenceStorage) SetReference(ref *plumbing.Reference) error {
 }
 
 func (r ReferenceStorage) CheckAndSetReference(ref, old *plumbing.Reference) error {
-	if ref != nil {
-		if old != nil {
-			tmp := r[ref.Name()]
-			if tmp != nil && tmp.Hash() != old.Hash() {
-				return ErrRefHasChanged
-			}
-		}
-		r[ref.Name()] = ref
+	if ref == nil {
+		return nil
 	}
 
+	if old != nil {
+		tmp := r[ref.Name()]
+		if tmp != nil && tmp.Hash() != old.Hash() {
+			return ErrRefHasChanged
+		}
+	}
+	r[ref.Name()] = ref
 	return nil
 }
 

--- a/vendor/gopkg.in/src-d/go-git.v4/worktree_status.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/worktree_status.go
@@ -39,7 +39,7 @@ func (w *Worktree) Status() (Status, error) {
 }
 
 func (w *Worktree) status(commit plumbing.Hash) (Status, error) {
-	s := make(Status, 0)
+	s := make(Status)
 
 	left, err := w.diffCommitWithStaging(commit, false)
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -827,284 +827,284 @@
 			"revisionTime": "2017-09-13T19:37:46Z"
 		},
 		{
-			"checksumSHA1": "62PR0NaB1HbtQAybtL5MgfjlnGE=",
+			"checksumSHA1": "5eYgnR+mi1IWAmLJkJEPodCqyd8=",
 			"origin": "github.com/keybase/go-git",
 			"path": "gopkg.in/src-d/go-git.v4",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "4cylnEynmT2tnR2o6fj6xQ+oWAQ=",
+			"checksumSHA1": "TSoIlaADKlw3Zx0ysCCBn6kyXNE=",
 			"origin": "github.com/keybase/go-git/config",
 			"path": "gopkg.in/src-d/go-git.v4/config",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "B2OLPJ4wnJIM2TMjTyzusYluUeI=",
 			"origin": "github.com/keybase/go-git/internal/revision",
 			"path": "gopkg.in/src-d/go-git.v4/internal/revision",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "e5UthIeeVSzLfEPnEe0GPQO6+bM=",
 			"origin": "github.com/keybase/go-git/plumbing",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "neTbLTzQ9+vo97D5i+3K9iprn5c=",
 			"origin": "github.com/keybase/go-git/plumbing/cache",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/cache",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "pHPMiAzXG/TJqTLEKj2SHjxX4zs=",
 			"origin": "github.com/keybase/go-git/plumbing/filemode",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/filemode",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "RzTdA6jLPwD/m6mq+rgS2CB04d4=",
+			"checksumSHA1": "UGIM9BX7w3MhiadsuN6f8Bx0VZU=",
 			"origin": "github.com/keybase/go-git/plumbing/format/config",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/config",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "vOD599V5I9EsWuGT9BIU8ZAyiNY=",
 			"origin": "github.com/keybase/go-git/plumbing/format/diff",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/diff",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "WYWvhmnLX0LQpacGYAk5w3nOsIM=",
 			"origin": "github.com/keybase/go-git/plumbing/format/gitignore",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/gitignore",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "+lR7seogVk2qZb8dSLBv8juivxc=",
 			"origin": "github.com/keybase/go-git/plumbing/format/idxfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/idxfile",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "naVExGq1c3bXZ4+Em3slvB7I8so=",
+			"checksumSHA1": "q7HtzrSzVE9qN5N3QOxkLFcZI1U=",
 			"origin": "github.com/keybase/go-git/plumbing/format/index",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/index",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "RYeQffgqVS4Kbbk2YVcaPadXCiI=",
+			"checksumSHA1": "0IxJpGMfdnr3cuuVE59u+1B5n9o=",
 			"origin": "github.com/keybase/go-git/plumbing/format/objfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/objfile",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "InI9Xrj8Dcx/6t+TdJD3+pzCueo=",
+			"checksumSHA1": "5MP2UCR7L7nnhwGmS6j3lFudybo=",
 			"origin": "github.com/keybase/go-git/plumbing/format/packfile",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/packfile",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "rA6jJ2fxdcALXL7EaP8Ja37xXjw=",
+			"checksumSHA1": "T8efjPxCKp23RvSBI51qugHzgxw=",
 			"origin": "github.com/keybase/go-git/plumbing/format/pktline",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/format/pktline",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "Af3n4HWOnNWRIKx7oqNvIehlCkk=",
 			"origin": "github.com/keybase/go-git/plumbing/object",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/object",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "khujIdwgqUlSUDM0h+OjT4zoTvc=",
+			"checksumSHA1": "PQmY1mHiPdNBNrh3lESZe3QH36c=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "JjHHYoWDYf0H//nP2FIS05ZLgj8=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/capability",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "wVfbzV5BNhjW/HFFJuTCjkPSJ5M=",
 			"origin": "github.com/keybase/go-git/plumbing/protocol/packp/sideband",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "eEZ5nFvBguv43DME9TmS4pFTFys=",
 			"origin": "github.com/keybase/go-git/plumbing/revlist",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/revlist",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "Ue2fegQK/D6gR5cpUdDaE1nGNLk=",
+			"checksumSHA1": "SWco9bumu0eoxmYJ9acmMbDb7nI=",
 			"origin": "github.com/keybase/go-git/plumbing/storer",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/storer",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "AVSX04sTj3cBv1muAmIbPE9D9FY=",
 			"origin": "github.com/keybase/go-git/plumbing/transport",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "cmOntUALmiRvvblEXAQXNO4Oous=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/client",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/client",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "gaKy+c/OjPQFLhENnSAFEZUngok=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/file",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/file",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "chcAwbm6J5uXXn6IV58+G6RKCjU=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/git",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/git",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "m9TNeIIGUBdZ0qdSl5Xa/0TIvfo=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/http",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/http",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "6asrmcjb98FpRr83ICCODXdGWdE=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/internal/common",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "4g80eOsDOo7kSC965vvPViDx+Vg=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/server",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/server",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "c+SEqWG5Eo2HaGeUQTEIjWcAH9U=",
 			"origin": "github.com/keybase/go-git/plumbing/transport/ssh",
 			"path": "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "FlVLBdu4cjlXj9zjRRNDurRLABU=",
 			"origin": "github.com/keybase/go-git/storage",
 			"path": "gopkg.in/src-d/go-git.v4/storage",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "jtUzE9+krEys6JLsNrP3at1Yce8=",
+			"checksumSHA1": "a+Pc0ns3q47MQKyfOSVsXYA1R70=",
 			"origin": "github.com/keybase/go-git/storage/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "MPqrgKeuWOzJFzlv6uVP6/7oEOo=",
+			"checksumSHA1": "rZYExDgnlRGQip6eHLzV+ptdKFI=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "Afe7pKZDRevEu/cg3M21QTkatF4=",
+			"checksumSHA1": "4xP9AhC2OWXL3oUsZ/k6n7oMs8s=",
 			"origin": "github.com/keybase/go-git/storage/memory",
 			"path": "gopkg.in/src-d/go-git.v4/storage/memory",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "AzdUpuGqSNnNK6DgdNjWrn99i3o=",
 			"origin": "github.com/keybase/go-git/utils/binary",
 			"path": "gopkg.in/src-d/go-git.v4/utils/binary",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "vniUxB6bbDYazl21cOfmhdZZiY8=",
 			"origin": "github.com/keybase/go-git/utils/diff",
 			"path": "gopkg.in/src-d/go-git.v4/utils/diff",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "cspCXRxvzvoNOEUB7wRgOKYrVjQ=",
 			"origin": "github.com/keybase/go-git/utils/ioutil",
 			"path": "gopkg.in/src-d/go-git.v4/utils/ioutil",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "shsY2I1OFbnjopNWF21Tkfx+tac=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "QiHHx1Qb/Vv4W6uQb+mJU2zMqLo=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/filesystem",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "M+6y9mdBFksksEGBceBh9Se3W7Y=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/index",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/index",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "7eEw/xsSrFLfSppRf/JIt9u7lbU=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/internal/frame",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"checksumSHA1": "qCb9d3cwnPHVLqS/U9NAzK+1Ptg=",
 			"origin": "github.com/keybase/go-git/utils/merkletrie/noder",
 			"path": "gopkg.in/src-d/go-git.v4/utils/merkletrie/noder",
-			"revision": "18d48ec4f2287a7eff9c03a3dcb0c03710a401bd",
-			"revisionTime": "2017-11-27T23:42:25Z"
+			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
+			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
 			"path": "gopkg.in/warnings.v0",


### PR DESCRIPTION
This includes all the review changes requested from the go-git devs for the garbage collection code.  They wanted to split off several of the new methods into optional interfaces, which makes it a little more complicated for us to build a "passthrough" storage layer.