### PR TITLE
libkbfs: no longer init loggers with extra depth

### DIFF
--- a/kbfstool/main.go
+++ b/kbfstool/main.go
@@ -69,7 +69,7 @@ func realMain() (exitStatus int) {
 		return 1
 	}
 
-	log := logger.NewWithCallDepth("", 1)
+	log := logger.New("")
 
 	// Turn these off to not interfere with a running kbfs daemon.
 	kbfsParams.EnableJournal = false

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -438,7 +438,7 @@ func InitLogWithPrefix(
 	if params.LogFileConfig.Path != "" {
 		err = logger.SetLogFileConfig(&params.LogFileConfig)
 	}
-	log := logger.NewWithCallDepth(prefix, 1)
+	log := logger.New(prefix)
 
 	log.Configure("", params.Debug, "")
 	log.Info("KBFS version %s", VersionString())
@@ -571,9 +571,7 @@ func doInit(
 		if module != "" {
 			mname += fmt.Sprintf("(%s)", module)
 		}
-		// Add log depth so that context-based messages get the right
-		// file printed out.
-		lg := logger.NewWithCallDepth(mname, 1)
+		lg := logger.New(mname)
 		if params.Debug {
 			// Turn on debugging.  TODO: allow a proper log file and
 			// style to be specified.

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -59,7 +59,7 @@ func NewKeybaseDaemonRPC(config Config, kbCtx Context, log logger.Logger,
 ) *KeybaseDaemonRPC {
 	k := newKeybaseDaemonRPC(config, kbCtx, log)
 	k.config = config
-	k.daemonLog = logger.NewWithCallDepth("daemon", 1)
+	k.daemonLog = logger.New("daemon")
 	if createSimpleFS != nil {
 		k.simplefs = createSimpleFS(config)
 	}


### PR DESCRIPTION
The logger package was fixed so that this isn't needed anymore.  This makes KBFS logging great again.