### PR TITLE
libkbfs: make the client create an implicit team TLF ID if the server refuses to

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -419,6 +419,12 @@ type KeybaseService interface {
 		ctx context.Context, assertions, suffix string, tlfType tlf.Type,
 		doIdentifies bool, reason string) (ImplicitTeamInfo, error)
 
+	// CreateTeamTLF associates the given TLF ID with the team ID in
+	// the team's sigchain.  If the team already has a TLF ID
+	// associated with it, this overwrites it.
+	CreateTeamTLF(
+		ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error
+
 	// LoadUserPlusKeys returns a UserInfo struct for a
 	// user with the specified UID.
 	// If you have the UID for a user and don't require Identify to
@@ -629,6 +635,12 @@ type KBPKI interface {
 	// FavoriteList returns the list of all favorite folders for
 	// the logged in user.
 	FavoriteList(ctx context.Context) ([]keybase1.Folder, error)
+
+	// CreateTeamTLF associates the given TLF ID with the team ID in
+	// the team's sigchain.  If the team already has a TLF ID
+	// associated with it, this overwrites it.
+	CreateTeamTLF(
+		ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error
 
 	// Notify sends a filesystem notification.
 	Notify(ctx context.Context, notification *keybase1.FSNotification) error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1466,6 +1466,7 @@ type mdServerLocal interface {
 		rev kbfsmd.Revision, err error)
 	isShutdown() bool
 	copy(config mdServerLocalConfig) mdServerLocal
+	enableImplicitTeams()
 }
 
 // BlockServer gets and puts opaque data blocks.  The instantiation

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -329,10 +329,11 @@ func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
 	return ops
 }
 
-// createTlfIDIfNeeded creates a TLF ID for a handle that doesn't have
-// one yet.  If it returns a `nil` error, it may have modified `h` to
-// include the new TLF ID.
-func (fs *KBFSOpsStandard) createTlfIDIfNeeded(
+// createAndStoreTlfIDIfNeeded creates a TLF ID for a team-backed
+// handle that doesn't have one yet, and associates it in the service
+// with the team.  If it returns a `nil` error, it may have modified
+// `h` to include the new TLF ID.
+func (fs *KBFSOpsStandard) createAndStoreTlfIDIfNeeded(
 	ctx context.Context, h *TlfHandle) error {
 	if h.tlfID != tlf.NullID {
 		return nil
@@ -381,7 +382,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		}
 	}()
 
-	err = fs.createTlfIDIfNeeded(ctx, h)
+	err = fs.createAndStoreTlfIDIfNeeded(ctx, h)
 	if err != nil {
 		return false, ImmutableRootMetadata{}, tlf.NullID, err
 	}
@@ -434,7 +435,7 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 		return rmd, nil
 	}
 
-	err = fs.createTlfIDIfNeeded(ctx, tlfHandle)
+	err = fs.createAndStoreTlfIDIfNeeded(ctx, tlfHandle)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -543,7 +544,7 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 		}
 	}
 
-	err = fs.createTlfIDIfNeeded(ctx, h)
+	err = fs.createAndStoreTlfIDIfNeeded(ctx, h)
 	if err != nil {
 		return nil, EntryInfo{}, err
 	}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -355,6 +355,9 @@ func (fs *KBFSOpsStandard) createTlfIDIfNeeded(
 		return err
 	}
 
+	fs.log.CDebugf(ctx, "Creating new TLF ID %s for implicit team %s, %s",
+		tlfID, teamID, h.GetCanonicalName())
+
 	err = fs.config.KBPKI().CreateTeamTLF(ctx, teamID, tlfID)
 	if err != nil {
 		return err

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -306,6 +306,12 @@ func (k *KBPKIClient) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
 	return teamInfo.RootID, nil
 }
 
+// CreateTeamTLF implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) CreateTeamTLF(
+	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error {
+	return k.serviceOwner.KeybaseService().CreateTeamTLF(ctx, teamID, tlfID)
+}
+
 // FavoriteAdd implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) FavoriteAdd(ctx context.Context, folder keybase1.Folder) error {
 	return k.serviceOwner.KeybaseService().FavoriteAdd(ctx, folder)

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -2403,8 +2403,11 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	// These are deterministic, and should add the same
 	// ImplicitTeamInfos for both user configs.
 	iname := "u1,u2"
-	teamID, tlfID := AddImplicitTeamForTestOrBust(t, config1, iname, "", 1, ty)
-	_, _ = AddImplicitTeamForTestOrBust(t, config2, iname, "", 1, ty)
+	err := EnableImplicitTeamsForTest(config1)
+	require.NoError(t, err)
+	teamID := AddImplicitTeamForTestOrBust(t, config1, iname, "", 1, ty)
+	_ = AddImplicitTeamForTestOrBust(t, config2, iname, "", 1, ty)
+	tlfID := tlf.FakeID(1, ty)
 
 	asUserName := libkb.NormalizedUsername(iname)
 	h := &TlfHandle{

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -425,7 +425,7 @@ func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver kbfsmd.Metad
 
 	id := tlf.FakeID(1, tlf.Public)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), nil, "alice,bob@twitter", tlf.Public)
+		ctx, config.KBPKI(), constIDGetter{id}, "alice,bob@twitter", tlf.Public)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
@@ -437,9 +437,9 @@ func testKeyManagerRekeyResolveAgainSuccessPublic(t *testing.T, ver kbfsmd.Metad
 		Return(rmd.tlfHandle.ToBareHandleOrBust(), nil)
 
 	done, cryptKey, err := config.KeyManager().Rekey(ctx, rmd, false)
+	require.NoError(t, err)
 	require.True(t, done)
 	require.Nil(t, cryptKey)
-	require.NoError(t, err)
 
 	newH := rmd.GetTlfHandle()
 	require.Equal(t, tlf.CanonicalName("alice,bob"), newH.GetCanonicalName())
@@ -465,8 +465,8 @@ func testKeyManagerRekeyResolveAgainSuccessPublicSelf(t *testing.T, ver kbfsmd.M
 
 	id := tlf.FakeID(1, tlf.Public)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), nil, "alice@twitter,bob,charlie@twitter",
-		tlf.Public)
+		ctx, config.KBPKI(), constIDGetter{id},
+		"alice@twitter,bob,charlie@twitter", tlf.Public)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), id, h)
 	require.NoError(t, err)
@@ -591,7 +591,7 @@ func testKeyManagerPromoteReaderSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), nil,
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
 		"alice,bob@twitter#bob", tlf.Private)
 	require.NoError(t, err)
 
@@ -639,7 +639,7 @@ func testKeyManagerPromoteReaderSelf(t *testing.T, ver kbfsmd.MetadataVer) {
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), nil,
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
 		"alice,bob@twitter#bob", tlf.Private)
 	require.NoError(t, err)
 
@@ -689,7 +689,7 @@ func testKeyManagerReaderRekeyShouldNotPromote(t *testing.T, ver kbfsmd.Metadata
 	defer CheckConfigAndShutdown(ctx, t, config)
 
 	id := tlf.FakeID(1, tlf.Private)
-	h, err := ParseTlfHandle(ctx, config.KBPKI(), nil,
+	h, err := ParseTlfHandle(ctx, config.KBPKI(), constIDGetter{id},
 		"alice,charlie@twitter#bob,charlie", tlf.Private)
 	require.NoError(t, err)
 

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -446,6 +446,16 @@ func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
 	return infoCopy, nil
 }
 
+// CreateTeamTLF implements the KBPKI interface for
+// KeybaseDaemonLocal.
+func (k *KeybaseDaemonLocal) CreateTeamTLF(
+	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
+	// For now, only support implicit teams; regular teams will get a
+	// NoSuchTeamError.  TODO: when the keybase1 RPCs allow it, store
+	// the TLF ID along with the regular team info.
+	return k.addImplicitTeamTlfID(teamID, tlfID)
+}
+
 // LoadUnverifiedKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadUnverifiedKeys(ctx context.Context, uid keybase1.UID) (
 	[]keybase1.PublicKey, error) {

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -453,6 +453,13 @@ func (k *KeybaseDaemonLocal) CreateTeamTLF(
 	// For now, only support implicit teams; regular teams will get a
 	// NoSuchTeamError.  TODO: when the keybase1 RPCs allow it, store
 	// the TLF ID along with the regular team info.
+	//
+	// Note that this only adds the implicit team TLF to this instance
+	// of KeybaseDaemonLocal; the caller would have to make the call
+	// to all instances to make it global.  However, the IDs are
+	// always deterministic so any client who thinks the ID is missing
+	// will just generate the same one.  TODO: abstract out the users
+	// and teams into a shareable module among all the instances.
 	return k.addImplicitTeamTlfID(teamID, tlfID)
 }
 

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -485,9 +485,7 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 		Suffix:       suffix,
 		DoIdentifies: doIdentifies,
 		Reason:       keybase1.IdentifyReason{Reason: reason},
-		// TODO(KBFS-2621): Change this to `true` when we are ready to
-		// turn on implicit team TLFs.
-		Create: false,
+		Create:       true,
 	}
 
 	ei := getExtendedIdentify(ctx)

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -656,6 +656,16 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	return info, nil
 }
 
+// CreateTeamTLF implements the KBPKI interface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) CreateTeamTLF(
+	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
+	return k.kbfsClient.CreateTLF(ctx, keybase1.CreateTLFArg{
+		TeamID: teamID,
+		TlfID:  keybase1.TLFID(tlfID.String()),
+	})
+}
+
 func (k *KeybaseServiceBase) getCurrentMerkleRoot(ctx context.Context) (
 	keybase1.MerkleRootV2, error) {
 	const merkleFreshnessMs = int(time.Second * 60 / time.Millisecond)

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -23,6 +23,7 @@ type KeybaseServiceMeasured struct {
 	loadUserPlusKeysTimer            metrics.Timer
 	loadTeamPlusKeysTimer            metrics.Timer
 	loadUnverifiedKeysTimer          metrics.Timer
+	createTeamTLFTimer               metrics.Timer
 	getCurrentMerkleRootTimer        metrics.Timer
 	currentSessionTimer              metrics.Timer
 	favoriteAddTimer                 metrics.Timer
@@ -44,6 +45,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 	loadUserPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUserPlusKeys", r)
 	loadTeamPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadTeamPlusKeys", r)
 	loadUnverifiedKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUnverifiedKeys", r)
+	createTeamTLFTimer := metrics.GetOrRegisterTimer("KeybaseService.CreateTeamTLF", r)
 	getCurrentMerkleRootTimer := metrics.GetOrRegisterTimer("KeybaseService.GetCurrentMerkleRoot", r)
 	currentSessionTimer := metrics.GetOrRegisterTimer("KeybaseService.CurrentSession", r)
 	favoriteAddTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteAdd", r)
@@ -60,6 +62,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 		loadUserPlusKeysTimer:            loadUserPlusKeysTimer,
 		loadTeamPlusKeysTimer:            loadTeamPlusKeysTimer,
 		loadUnverifiedKeysTimer:          loadUnverifiedKeysTimer,
+		createTeamTLFTimer:               createTeamTLFTimer,
 		getCurrentMerkleRootTimer:        getCurrentMerkleRootTimer,
 		currentSessionTimer:              currentSessionTimer,
 		favoriteAddTimer:                 favoriteAddTimer,
@@ -118,6 +121,16 @@ func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 			ctx, tid, desiredKeyGen, desiredUser, desiredRole)
 	})
 	return teamInfo, err
+}
+
+// CreateTeamTLF implements the KBPKI interface for
+// KeybaseServiceMeasured.
+func (k KeybaseServiceMeasured) CreateTeamTLF(
+	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
+	k.createTeamTLFTimer.Time(func() {
+		err = k.delegate.CreateTeamTLF(ctx, teamID, tlfID)
+	})
+	return err
 }
 
 // GetCurrentMerkleRoot implements the KeybaseService interface for

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1427,6 +1427,18 @@ func (mr *MockKeybaseServiceMockRecorder) ResolveIdentifyImplicitTeam(ctx, asser
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIdentifyImplicitTeam", reflect.TypeOf((*MockKeybaseService)(nil).ResolveIdentifyImplicitTeam), ctx, assertions, suffix, tlfType, doIdentifies, reason)
 }
 
+// CreateTeamTLF mocks base method
+func (m *MockKeybaseService) CreateTeamTLF(ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error {
+	ret := m.ctrl.Call(m, "CreateTeamTLF", ctx, teamID, tlfID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateTeamTLF indicates an expected call of CreateTeamTLF
+func (mr *MockKeybaseServiceMockRecorder) CreateTeamTLF(ctx, teamID, tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamTLF", reflect.TypeOf((*MockKeybaseService)(nil).CreateTeamTLF), ctx, teamID, tlfID)
+}
+
 // LoadUserPlusKeys mocks base method
 func (m *MockKeybaseService) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID) (UserInfo, error) {
 	ret := m.ctrl.Call(m, "LoadUserPlusKeys", ctx, uid, pollForKID)
@@ -2179,6 +2191,18 @@ func (m *MockKBPKI) FavoriteList(ctx context.Context) ([]keybase1.Folder, error)
 // FavoriteList indicates an expected call of FavoriteList
 func (mr *MockKBPKIMockRecorder) FavoriteList(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FavoriteList", reflect.TypeOf((*MockKBPKI)(nil).FavoriteList), ctx)
+}
+
+// CreateTeamTLF mocks base method
+func (m *MockKBPKI) CreateTeamTLF(ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error {
+	ret := m.ctrl.Call(m, "CreateTeamTLF", ctx, teamID, tlfID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateTeamTLF indicates an expected call of CreateTeamTLF
+func (mr *MockKBPKIMockRecorder) CreateTeamTLF(ctx, teamID, tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamTLF", reflect.TypeOf((*MockKBPKI)(nil).CreateTeamTLF), ctx, teamID, tlfID)
 }
 
 // Notify mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4773,6 +4773,16 @@ func (mr *MockmdServerLocalMockRecorder) copy(config interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "copy", reflect.TypeOf((*MockmdServerLocal)(nil).copy), config)
 }
 
+// enableImplicitTeams mocks base method
+func (m *MockmdServerLocal) enableImplicitTeams() {
+	m.ctrl.Call(m, "enableImplicitTeams")
+}
+
+// enableImplicitTeams indicates an expected call of enableImplicitTeams
+func (mr *MockmdServerLocalMockRecorder) enableImplicitTeams() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "enableImplicitTeams", reflect.TypeOf((*MockmdServerLocal)(nil).enableImplicitTeams))
+}
+
 // MockBlockServer is a mock of BlockServer interface
 type MockBlockServer struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -319,7 +319,7 @@ func testMakeRekeyReadErrorResolvedHandle(t *testing.T, ver kbfsmd.MetadataVer) 
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h, err := ParseTlfHandle(
-		ctx, config.KBPKI(), nil, "alice,bob@twitter", tlf.Private)
+		ctx, config.KBPKI(), config.MDOps(), "alice,bob@twitter", tlf.Private)
 	require.NoError(t, err)
 	rmd, err := makeInitialRootMetadata(config.MetadataVersion(), tlfID, h)
 	require.NoError(t, err)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -557,36 +557,25 @@ func AddEmptyTeamsForTestOrBust(t logger.TestLogBackend,
 // AddImplicitTeamForTest adds an implicit team with a TLF ID.
 func AddImplicitTeamForTest(
 	config Config, name, suffix string, teamNumber byte, ty tlf.Type) (
-	keybase1.TeamID, tlf.ID, error) {
-	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
-	if !ok {
-		return "", tlf.NullID, errors.New("Bad keybase daemon")
-	}
-
-	iteamInfo, err := kbd.ResolveIdentifyImplicitTeam(
+	keybase1.TeamID, error) {
+	iteamInfo, err := config.KeybaseService().ResolveIdentifyImplicitTeam(
 		context.Background(), name, suffix, ty, true, "")
 	if err != nil {
-		return "", tlf.NullID, err
+		return "", err
 	}
-	tlfID := tlf.FakeID(teamNumber, ty)
-	err = kbd.addImplicitTeamTlfID(iteamInfo.TID, tlfID)
-	if err != nil {
-		return "", tlf.NullID, err
-	}
-	return iteamInfo.TID, tlfID, nil
+	return iteamInfo.TID, nil
 }
 
 // AddImplicitTeamForTestOrBust is like AddImplicitTeamForTest, but
 // dies if there's an error.
 func AddImplicitTeamForTestOrBust(t logger.TestLogBackend,
-	config Config, name, suffix string, teamNumber byte, ty tlf.Type) (
-	keybase1.TeamID, tlf.ID) {
-	teamID, tlfID, err := AddImplicitTeamForTest(
-		config, name, suffix, teamNumber, ty)
+	config Config, name, suffix string, teamNumber byte,
+	ty tlf.Type) keybase1.TeamID {
+	teamID, err := AddImplicitTeamForTest(config, name, suffix, teamNumber, ty)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return teamID, tlfID
+	return teamID
 }
 
 // ChangeTeamNameForTest renames a team.
@@ -614,6 +603,17 @@ func ChangeTeamNameForTestOrBust(t logger.TestLogBackend, config Config,
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// EnableImplicitTeamsForTest causes the mdserver to stop returning
+// random TLF IDs for new TLFs.
+func EnableImplicitTeamsForTest(config Config) error {
+	md, ok := config.MDServer().(mdServerLocal)
+	if !ok {
+		return errors.New("Bad md server")
+	}
+	md.enableImplicitTeams()
+	return nil
 }
 
 func testRPCWithCanceledContext(t logger.TestLogBackend,

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -87,7 +87,9 @@ func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 	}
 
 	name := "u2,u3"
-	_, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	_, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, ReadAccessError{User: "u1", Tlf: tlf.CanonicalName(name), Type: tlf.Private, Filename: "/keybase/private/u2,u3"}, err)
 }
@@ -150,7 +152,9 @@ func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 
 	name := "u1,u3#u2"
 	nonCanonicalName := "u1,u3@twitter#u2"
-	_, err := ParseTlfHandle(ctx, kbpki, nil, nonCanonicalName, tlf.Private)
+	_, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)},
+		nonCanonicalName, tlf.Private)
 	// Names with assertions should be identified before the error
 	// is returned.
 	assert.Equal(t, 3, kbpki.getIdentifyCalls())
@@ -172,7 +176,9 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 	}
 
 	name := "u1,u3"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
@@ -200,7 +206,8 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 	}
 
 	name := "u1,u2,u3"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Public)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Public)}, name, tlf.Public)
 	require.NoError(t, err)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
@@ -226,7 +233,9 @@ func TestTlfHandleAccessorsPrivate(t *testing.T) {
 	}
 
 	name := "u1,u2@twitter,u3,u4@twitter#u2,u5@twitter,u6@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	require.NoError(t, err)
 
 	require.False(t, h.Type() == tlf.Public)
@@ -295,7 +304,8 @@ func TestTlfHandleAccessorsPublic(t *testing.T) {
 	}
 
 	name := "u1,u2@twitter,u3,u4@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Public)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Public)}, name, tlf.Public)
 	require.NoError(t, err)
 
 	require.True(t, h.Type() == tlf.Public)
@@ -574,7 +584,9 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 	}
 
 	name := "u1,u2#u3@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
@@ -602,7 +614,8 @@ func TestParseTlfHandleUIDAssertion(t *testing.T) {
 	}
 
 	a := currentUID.String() + "@uid"
-	_, err := ParseTlfHandle(ctx, kbpki, nil, a, tlf.Private)
+	_, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
 	assert.Equal(t, 1, kbpki.getIdentifyCalls())
 	assert.Equal(t, TlfNameNotCanonical{a, "u1"}, err)
 }
@@ -623,7 +636,8 @@ func TestParseTlfHandleAndAssertion(t *testing.T) {
 	}
 
 	a := currentUID.String() + "@uid+u1@twitter"
-	_, err := ParseTlfHandle(ctx, kbpki, nil, a, tlf.Private)
+	_, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
 	// We expect 1 extra identify for compound assertions until
 	// KBFS-2022 is completed.
 	assert.Equal(t, 1+1, kbpki.getIdentifyCalls())
@@ -649,7 +663,8 @@ func TestParseTlfHandleConflictSuffix(t *testing.T) {
 	}
 
 	a := "u1 " + ci.String()
-	h, err := ParseTlfHandle(ctx, kbpki, nil, a, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
 	require.NoError(t, err)
 	require.NotNil(t, h.ConflictInfo())
 	require.Equal(t, ci.String(), h.ConflictInfo().String())
@@ -671,7 +686,8 @@ func TestParseTlfHandleFailConflictingAssertion(t *testing.T) {
 	}
 
 	a := currentUID.String() + "@uid+u2@twitter"
-	_, err := ParseTlfHandle(ctx, kbpki, nil, a, tlf.Private)
+	_, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
 	// We expect 1 extra identify for compound assertions until
 	// KBFS-2022 is completed.
 	assert.Equal(t, 0+1, kbpki.getIdentifyCalls())
@@ -704,7 +720,9 @@ func TestResolveAgainBasic(t *testing.T) {
 	}
 
 	name := "u1,u2#u3@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
@@ -728,7 +746,9 @@ func TestResolveAgainDoubleAsserts(t *testing.T) {
 	}
 
 	name := "u1,u1@github,u1@twitter#u2,u2@github,u2@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
@@ -754,7 +774,9 @@ func TestResolveAgainWriterReader(t *testing.T) {
 	}
 
 	name := "u1,u2@github#u2@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, name,
+		tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
@@ -778,7 +800,9 @@ func TestResolveAgainConflict(t *testing.T) {
 	}
 
 	name := "u1,u2#u3@twitter"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	id := tlf.FakeID(1, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name, tlf.Private)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h.GetCanonicalName())
 
@@ -809,29 +833,34 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	}
 
 	name1 := "u1,u2@twitter,u3,u4@twitter"
-	h1, err := ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	idPub := tlf.FakeID(1, tlf.Public)
+	h1, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err :=
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h1)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h1)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
 
 	// Test different public bit.
 
-	h2, err := ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	id := tlf.FakeID(1, tlf.Private)
+	h2, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name1, tlf.Private)
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
 
 	// Test adding conflict info or finalized info.
 
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h2, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	require.NoError(t, err)
 	info := tlf.HandleExtension{
 		Date:   100,
@@ -842,12 +871,13 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
 
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h2, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   101,
@@ -857,14 +887,15 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h2.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
 
 	// Test differing conflict info or finalized info.
 
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h2, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   100,
@@ -882,13 +913,15 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
-	h1, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h1, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	require.NoError(t, err)
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h2, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	require.NoError(t, err)
 	info = tlf.HandleExtension{
 		Date:   101,
@@ -904,13 +937,14 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h1.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
 	// Try to add conflict info to a finalized handle.
 
-	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Public)
+	h2, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
 	info = tlf.HandleExtension{
 		Date:   100,
 		Number: 50,
@@ -920,13 +954,14 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.Error(t, err)
 
 	// Test positive resolution cases.
 
 	name1 = "u1,u2@twitter,u5#u3,u4@twitter"
-	h1, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
+	h1, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name1, tlf.Private)
 	require.NoError(t, err)
 
 	type testCase struct {
@@ -942,13 +977,14 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		// Resolve to existing reader.
 		{"u1,u3,u5#u4@twitter", "u3"},
 	} {
-		h2, err = ParseTlfHandle(ctx, kbpki, nil, tc.name2, tlf.Private)
+		h2, err = ParseTlfHandle(
+			ctx, kbpki, constIDGetter{id}, tc.name2, tlf.Private)
 		require.NoError(t, err)
 
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
 		require.NoError(t, err)
 		assert.True(t, resolvesTo, tc.name2)
 		require.Equal(t, h2, partialResolvedH1, tc.name2)
@@ -965,13 +1001,14 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		{"u1,u2,u5#u3,u4@twitter", "u1"},
 		{"u1,u2,u5#u3,u4@twitter", "u3"},
 	} {
-		h2, err = ParseTlfHandle(ctx, kbpki, nil, tc.name2, tlf.Private)
+		h2, err = ParseTlfHandle(
+			ctx, kbpki, constIDGetter{id}, tc.name2, tlf.Private)
 		require.NoError(t, err)
 
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, nil, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
 		require.NoError(t, err)
 		assert.False(t, resolvesTo, tc.name2)
 
@@ -992,7 +1029,9 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	}
 
 	name := "u1,u2#u3 (conflicted copy 2016-03-14 #3) (files before u2 account reset 2016-03-14 #2)"
-	h, err := ParseTlfHandle(ctx, kbpki, nil, name, tlf.Private)
+	id := tlf.FakeID(1, tlf.Private)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name, tlf.Private)
 	require.Nil(t, err)
 	assert.Equal(t, tlf.HandleExtension{
 		Type:   tlf.HandleExtensionConflict,
@@ -1007,7 +1046,8 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	}, *h.FinalizedInfo())
 
 	nonCanonicalName := "u1,u2#u3 (files before u2 account reset 2016-03-14 #2) (conflicted copy 2016-03-14 #3)"
-	_, err = ParseTlfHandle(ctx, kbpki, nil, nonCanonicalName, tlf.Private)
+	_, err = ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, nonCanonicalName, tlf.Private)
 	assert.Equal(t, TlfNameNotCanonical{nonCanonicalName, name}, err)
 }
 

--- a/test/engine_common.go
+++ b/test/engine_common.go
@@ -71,6 +71,13 @@ func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
 
 func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
 	implicitTeams teamMap, users map[libkb.NormalizedUsername]User) {
+	if len(implicitTeams) > 0 {
+		err := libkbfs.EnableImplicitTeamsForTest(config)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	counter := byte(1)
 	for name, members := range implicitTeams {
 		ty := tlf.Private
@@ -79,7 +86,7 @@ func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
 			ty = tlf.Public
 		}
 
-		teamID, _ := libkbfs.AddImplicitTeamForTestOrBust(
+		teamID := libkbfs.AddImplicitTeamForTestOrBust(
 			t, config, name.String(), "", counter, ty)
 		counter++
 

--- a/tlf/id_test.go
+++ b/tlf/id_test.go
@@ -7,6 +7,7 @@ package tlf
 import (
 	"testing"
 
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/stretchr/testify/require"
 )
@@ -29,4 +30,32 @@ func TestIDEncodeDecode(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, id, id2)
+}
+
+func TestMakeIDFromTeam(t *testing.T) {
+	privateTID := keybase1.MakeTestTeamID(1, false)
+	publicTID := keybase1.MakeTestTeamID(2, true)
+
+	epochIndex := idByteLen - 2
+	check := func(ty Type, tid keybase1.TeamID, epoch byte) {
+		id, err := MakeIDFromTeam(ty, tid, epoch)
+		require.NoError(t, err)
+		require.Equal(t, id.Type(), ty)
+		require.Equal(t, tid.ToBytes()[:epochIndex], id.Bytes()[:epochIndex])
+		require.Equal(t, epoch, id.Bytes()[epochIndex])
+	}
+	check(Private, privateTID, 0)
+	check(Public, publicTID, 0)
+	check(SingleTeam, privateTID, 0)
+	check(Private, privateTID, 15)
+
+	_, err := MakeIDFromTeam(Public, privateTID, 0)
+	require.NotNil(t, err)
+	_, err = MakeIDFromTeam(Private, publicTID, 0)
+	require.NotNil(t, err)
+	_, err = MakeIDFromTeam(SingleTeam, publicTID, 0)
+	require.NotNil(t, err)
+	_, err = MakeIDFromTeam(
+		Private, keybase1.TeamID("extra"+privateTID.String()), 0)
+	require.NotNil(t, err)
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/constants.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/constants.go
@@ -35,6 +35,7 @@ const (
 	StatusCode_SCNoSession                 StatusCode = 283
 	StatusCode_SCAccountReset              StatusCode = 290
 	StatusCode_SCIdentifiesFailed          StatusCode = 295
+	StatusCode_SCNoSpaceOnDevice           StatusCode = 297
 	StatusCode_SCBadEmail                  StatusCode = 472
 	StatusCode_SCBadSignupUsernameTaken    StatusCode = 701
 	StatusCode_SCBadInvitationCode         StatusCode = 707
@@ -180,6 +181,7 @@ var StatusCodeMap = map[string]StatusCode{
 	"SCNoSession":                 283,
 	"SCAccountReset":              290,
 	"SCIdentifiesFailed":          295,
+	"SCNoSpaceOnDevice":           297,
 	"SCBadEmail":                  472,
 	"SCBadSignupUsernameTaken":    701,
 	"SCBadInvitationCode":         707,
@@ -323,6 +325,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	283:  "SCNoSession",
 	290:  "SCAccountReset",
 	295:  "SCIdentifiesFailed",
+	297:  "SCNoSpaceOnDevice",
 	472:  "SCBadEmail",
 	701:  "SCBadSignupUsernameTaken",
 	707:  "SCBadInvitationCode",

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -1036,6 +1036,14 @@ func (t TLFID) String() string {
 	return string(t)
 }
 
+func (t TLFID) IsNil() bool {
+	return len(t) == 0
+}
+
+func (t TLFID) Exists() bool {
+	return !t.IsNil()
+}
+
 func (t TLFID) ToBytes() []byte {
 	b, err := hex.DecodeString(string(t))
 	if err != nil {
@@ -1619,25 +1627,12 @@ func (t TeamMembers) AllUIDs() []UID {
 	return all
 }
 
-func (t TeamMembers) AllUserVersions() []UserVersion {
-	m := make(map[UID]UserVersion)
-	for _, u := range t.Owners {
-		m[u.Uid] = u
-	}
-	for _, u := range t.Admins {
-		m[u.Uid] = u
-	}
-	for _, u := range t.Writers {
-		m[u.Uid] = u
-	}
-	for _, u := range t.Readers {
-		m[u.Uid] = u
-	}
-	var all []UserVersion
-	for _, uv := range m {
-		all = append(all, uv)
-	}
-	return all
+func (t TeamMembers) AllUserVersions() (res []UserVersion) {
+	res = append(res, t.Owners...)
+	res = append(res, t.Admins...)
+	res = append(res, t.Writers...)
+	res = append(res, t.Readers...)
+	return res
 }
 
 func (t TeamMember) IsReset() bool {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -708,6 +708,7 @@ type AnnotatedTeamInvite struct {
 	Inviter         UserVersion    `codec:"inviter" json:"inviter"`
 	InviterUsername string         `codec:"inviterUsername" json:"inviterUsername"`
 	TeamName        string         `codec:"teamName" json:"teamName"`
+	UserActive      bool           `codec:"userActive" json:"userActive"`
 }
 
 func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
@@ -720,6 +721,7 @@ func (o AnnotatedTeamInvite) DeepCopy() AnnotatedTeamInvite {
 		Inviter:         o.Inviter.DeepCopy(),
 		InviterUsername: o.InviterUsername,
 		TeamName:        o.TeamName,
+		UserActive:      o.UserActive,
 	}
 }
 
@@ -742,6 +744,7 @@ type TeamSigChainState struct {
 	ActiveInvites  map[TeamInviteID]TeamInvite         `codec:"activeInvites" json:"activeInvites"`
 	Open           bool                                `codec:"open" json:"open"`
 	OpenTeamJoinAs TeamRole                            `codec:"openTeamJoinAs" json:"openTeamJoinAs"`
+	TlfID          TLFID                               `codec:"tlfID" json:"tlfID"`
 }
 
 func (o TeamSigChainState) DeepCopy() TeamSigChainState {
@@ -866,6 +869,7 @@ func (o TeamSigChainState) DeepCopy() TeamSigChainState {
 		})(o.ActiveInvites),
 		Open:           o.Open,
 		OpenTeamJoinAs: o.OpenTeamJoinAs.DeepCopy(),
+		TlfID:          o.TlfID.DeepCopy(),
 	}
 }
 
@@ -1420,6 +1424,8 @@ type AnnotatedMemberInfo struct {
 	Implicit       *ImplicitRole `codec:"implicit,omitempty" json:"implicit,omitempty"`
 	NeedsPUK       bool          `codec:"needsPUK" json:"needsPUK"`
 	MemberCount    int           `codec:"memberCount" json:"member_count"`
+	EldestSeqno    Seqno         `codec:"eldestSeqno" json:"member_eldest_seqno"`
+	Active         bool          `codec:"active" json:"active"`
 }
 
 func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
@@ -1440,6 +1446,8 @@ func (o AnnotatedMemberInfo) DeepCopy() AnnotatedMemberInfo {
 		})(o.Implicit),
 		NeedsPUK:    o.NeedsPUK,
 		MemberCount: o.MemberCount,
+		EldestSeqno: o.EldestSeqno.DeepCopy(),
+		Active:      o.Active,
 	}
 }
 
@@ -1733,6 +1741,7 @@ type LookupImplicitTeamRes struct {
 	TeamID      TeamID                  `codec:"teamID" json:"teamID"`
 	Name        TeamName                `codec:"name" json:"name"`
 	DisplayName ImplicitTeamDisplayName `codec:"displayName" json:"displayName"`
+	TlfID       TLFID                   `codec:"tlfID" json:"tlfID"`
 }
 
 func (o LookupImplicitTeamRes) DeepCopy() LookupImplicitTeamRes {
@@ -1740,6 +1749,7 @@ func (o LookupImplicitTeamRes) DeepCopy() LookupImplicitTeamRes {
 		TeamID:      o.TeamID.DeepCopy(),
 		Name:        o.Name.DeepCopy(),
 		DisplayName: o.DisplayName.DeepCopy(),
+		TlfID:       o.TlfID.DeepCopy(),
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -231,10 +231,10 @@
 			"revisionTime": "2017-11-03T20:00:56Z"
 		},
 		{
-			"checksumSHA1": "MWjI3EywWVCheiYJn1s3E4oxzEg=",
+			"checksumSHA1": "EEnErI8BBFR86mUfhlsDzUbXVog=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "f35826eefd55d682452d5ffaf8d358dbca9244bd",
-			"revisionTime": "2017-11-29T22:38:30Z"
+			"revision": "e961f9f2a7e58ae0562cf347e03bc2e5a66b8e48",
+			"revisionTime": "2017-12-01T22:03:36Z"
 		},
 		{
 			"checksumSHA1": "o26ztx0R+4h9il8gTztHccctK+4=",


### PR DESCRIPTION
If the mdserver returns a null TLF ID when responding to a get-by-handle request for a non-existent TLF, the client will now create an implicit team and deterministically generate a TLF ID and store it in that team's sigchain (via the service).

This mode is now enabled in the DSL implicit team tests.

Issue: KBFS-2621