### PR TITLE
revendor go-framed-msgpack-rpc

### DIFF
--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -77,7 +77,7 @@ func newBlockServerRemoteClientHandler(name string, log logger.Logger,
 		TagsFunc:                      libkb.LogTagsFromContext,
 		ReconnectBackoff:              func() backoff.BackOff { return constBackoff },
 		DialerTimeout:                 dialerTimeout,
-		InitialReconnectBackoffWindow: bserverReconnectBackoffWindow,
+		InitialReconnectBackoffWindow: func() time.Duration { return bserverReconnectBackoffWindow },
 	}
 	b.initNewConnection()
 	return b

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -113,7 +113,7 @@ func NewMDServerRemote(config Config, srvRemote rpc.Remote,
 		TagsFunc:                      libkb.LogTagsFromContext,
 		ReconnectBackoff:              func() backoff.BackOff { return constBackoff },
 		DialerTimeout:                 dialerTimeout,
-		InitialReconnectBackoffWindow: mdserverReconnectBackoffWindow,
+		InitialReconnectBackoffWindow: func() time.Duration { return mdserverReconnectBackoffWindow },
 	}
 	mdServer.initNewConnection()
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -353,10 +353,10 @@
 			"revisionTime": "2016-12-08T01:54:25Z"
 		},
 		{
-			"checksumSHA1": "2coH3or2TjH+4j2KCnfHlToMir8=",
+			"checksumSHA1": "ub85JBvVGqt8k0uYhH4n0JmeOaA=",
 			"path": "github.com/keybase/go-framed-msgpack-rpc/rpc",
-			"revision": "375cb8d53f23800421ccff862afad54905ddf580",
-			"revisionTime": "2017-12-04T02:34:24Z"
+			"revision": "7aa85fb3f2e5b0c8ebfa508b2ed361cd3e6f629b",
+			"revisionTime": "2017-12-05T16:38:33Z"
 		},
 		{
 			"checksumSHA1": "RLs8GIV4e+D350pyzZh5RC3mgQg=",


### PR DESCRIPTION
r? @songgao @jzila 

There are upstream API changes that we're vendoring in here, so I think CI will break for this PR and for https://github.com/keybase/client/pull/9720 until both of them land at the same time.