### PR TITLE
update vendor and force debug logging for rpc package in KBFS

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -97,7 +97,7 @@ type ConfigLocal struct {
 	kbpki            KBPKI
 	renamer          ConflictRenamer
 	registry         metrics.Registry
-	loggerFn         func(prefix string) logger.Logger
+	loggerFn         func(prefix string, overrideEnableDebug bool) logger.Logger
 	noBGFlush        bool // logic opposite so the default value is the common setting
 	rwpWaitTime      time.Duration
 	diskLimiter      DiskLimiter
@@ -369,7 +369,8 @@ func getDefaultCleanBlockCacheCapacity() uint64 {
 //
 // TODO: Now that NewConfigLocal takes loggerFn, add more default
 // components.
-func NewConfigLocal(mode InitMode, loggerFn func(module string) logger.Logger,
+func NewConfigLocal(mode InitMode,
+	loggerFn func(module string, overrideEnableDebug bool) logger.Logger,
 	storageRoot string, diskCacheMode DiskCacheMode, kbCtx Context) *ConfigLocal {
 	config := &ConfigLocal{
 		loggerFn:      loggerFn,
@@ -987,7 +988,11 @@ func (c *ConfigLocal) ResetCaches() {
 func (c *ConfigLocal) MakeLogger(module string) logger.Logger {
 	// No need to lock since c.loggerFn is initialized once at
 	// construction. Also resetCachesWithoutShutdown would deadlock.
-	return c.loggerFn(module)
+	return c.loggerFn(module, false)
+}
+
+func (c *ConfigLocal) MakeLoggerForceEnableDebug(module string) logger.Logger {
+	return c.loggerFn(module, true)
 }
 
 // MetricsRegistry implements the Config interface for ConfigLocal.

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -97,7 +97,7 @@ type ConfigLocal struct {
 	kbpki            KBPKI
 	renamer          ConflictRenamer
 	registry         metrics.Registry
-	loggerFn         func(prefix string, overrideEnableDebug bool) logger.Logger
+	loggerFn         func(prefix string, overrideDebug bool) logger.Logger
 	noBGFlush        bool // logic opposite so the default value is the common setting
 	rwpWaitTime      time.Duration
 	diskLimiter      DiskLimiter
@@ -370,7 +370,7 @@ func getDefaultCleanBlockCacheCapacity() uint64 {
 // TODO: Now that NewConfigLocal takes loggerFn, add more default
 // components.
 func NewConfigLocal(mode InitMode,
-	loggerFn func(module string, overrideEnableDebug bool) logger.Logger,
+	loggerFn func(module string, overrideDebug bool) logger.Logger,
 	storageRoot string, diskCacheMode DiskCacheMode, kbCtx Context) *ConfigLocal {
 	config := &ConfigLocal{
 		loggerFn:      loggerFn,
@@ -991,6 +991,8 @@ func (c *ConfigLocal) MakeLogger(module string) logger.Logger {
 	return c.loggerFn(module, false)
 }
 
+// MakeLoggerForceEnableDebug implements the Config interface for ConfigLocal.
+// The returned logger always has Debug level enabled.
 func (c *ConfigLocal) MakeLoggerForceEnableDebug(module string) logger.Logger {
 	return c.loggerFn(module, true)
 }

--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -68,7 +68,7 @@ type ConfigMock struct {
 func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config := &ConfigMock{
 		ConfigLocal: ConfigLocal{
-			loggerFn: func(m string) logger.Logger {
+			loggerFn: func(m string, _ bool) logger.Logger {
 				return logger.NewTestLogger(ctr.t)
 			},
 		},

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -566,19 +566,20 @@ func doInit(
 		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}
 
-	config := NewConfigLocal(mode, func(module string) logger.Logger {
-		mname := logPrefix
-		if module != "" {
-			mname += fmt.Sprintf("(%s)", module)
-		}
-		lg := logger.New(mname)
-		if params.Debug {
-			// Turn on debugging.  TODO: allow a proper log file and
-			// style to be specified.
-			lg.Configure("", true, "")
-		}
-		return lg
-	}, params.StorageRoot, params.DiskCacheMode, kbCtx)
+	config := NewConfigLocal(mode,
+		func(module string, overrideEnableDebug bool) logger.Logger {
+			mname := logPrefix
+			if module != "" {
+				mname += fmt.Sprintf("(%s)", module)
+			}
+			lg := logger.New(mname)
+			if params.Debug || overrideEnableDebug {
+				// Turn on debugging.  TODO: allow a proper log file and
+				// style to be specified.
+				lg.Configure("", true, "")
+			}
+			return lg
+		}, params.StorageRoot, params.DiskCacheMode, kbCtx)
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.CDebugf(

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -567,13 +567,13 @@ func doInit(
 	}
 
 	config := NewConfigLocal(mode,
-		func(module string, overrideEnableDebug bool) logger.Logger {
+		func(module string, overrideDebug bool) logger.Logger {
 			mname := logPrefix
 			if module != "" {
 				mname += fmt.Sprintf("(%s)", module)
 			}
 			lg := logger.New(mname)
-			if params.Debug || overrideEnableDebug {
+			if params.Debug || overrideDebug {
 				// Turn on debugging.  TODO: allow a proper log file and
 				// style to be specified.
 				lg.Configure("", true, "")

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -28,10 +28,6 @@ type logMaker interface {
 	MakeLogger(module string) logger.Logger
 }
 
-type debugForcedLogMaker interface {
-	MakeLoggerForceEnableDebug(module string) logger.Logger
-}
-
 type blockCacher interface {
 	BlockCache() BlockCache
 }
@@ -1697,7 +1693,6 @@ type initModeGetter interface {
 type Config interface {
 	dataVersioner
 	logMaker
-	debugForcedLogMaker
 	blockCacher
 	blockServerGetter
 	codecGetter
@@ -1713,6 +1708,7 @@ type Config interface {
 	syncedTlfGetterSetter
 	initModeGetter
 	Tracer
+	MakeLoggerForceEnableDebug(module string) logger.Logger
 	KBFSOps() KBFSOps
 	SetKBFSOps(KBFSOps)
 	KBPKI() KBPKI

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -28,6 +28,10 @@ type logMaker interface {
 	MakeLogger(module string) logger.Logger
 }
 
+type debugForcedLogMaker interface {
+	MakeLoggerForceEnableDebug(module string) logger.Logger
+}
+
 type blockCacher interface {
 	BlockCache() BlockCache
 }
@@ -1693,6 +1697,7 @@ type initModeGetter interface {
 type Config interface {
 	dataVersioner
 	logMaker
+	debugForcedLogMaker
 	blockCacher
 	blockServerGetter
 	codecGetter

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -150,7 +150,7 @@ func (md *MDServerRemote) initNewConnection() {
 	md.conn = rpc.NewTLSConnection(md.mdSrvRemote, kbfscrypto.GetRootCerts(
 		md.mdSrvRemote.Peek(), libkb.GetBundledCAsFromHost),
 		kbfsmd.ServerErrorUnwrapper{}, md, md.rpcLogFactory,
-		md.config.MakeLogger(""), md.connOpts)
+		md.config.MakeLoggerForceEnableDebug(""), md.connOpts)
 	md.client = keybase1.MetadataClient{Cli: md.conn.GetClient()}
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -90,6 +90,41 @@ func (mr *MocklogMakerMockRecorder) MakeLogger(module interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLogger", reflect.TypeOf((*MocklogMaker)(nil).MakeLogger), module)
 }
 
+// MockdebugForcedLogMaker is a mock of debugForcedLogMaker interface
+type MockdebugForcedLogMaker struct {
+	ctrl     *gomock.Controller
+	recorder *MockdebugForcedLogMakerMockRecorder
+}
+
+// MockdebugForcedLogMakerMockRecorder is the mock recorder for MockdebugForcedLogMaker
+type MockdebugForcedLogMakerMockRecorder struct {
+	mock *MockdebugForcedLogMaker
+}
+
+// NewMockdebugForcedLogMaker creates a new mock instance
+func NewMockdebugForcedLogMaker(ctrl *gomock.Controller) *MockdebugForcedLogMaker {
+	mock := &MockdebugForcedLogMaker{ctrl: ctrl}
+	mock.recorder = &MockdebugForcedLogMakerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdebugForcedLogMaker) EXPECT() *MockdebugForcedLogMakerMockRecorder {
+	return m.recorder
+}
+
+// MakeLoggerForceEnableDebug mocks base method
+func (m *MockdebugForcedLogMaker) MakeLoggerForceEnableDebug(module string) logger.Logger {
+	ret := m.ctrl.Call(m, "MakeLoggerForceEnableDebug", module)
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// MakeLoggerForceEnableDebug indicates an expected call of MakeLoggerForceEnableDebug
+func (mr *MockdebugForcedLogMakerMockRecorder) MakeLoggerForceEnableDebug(module interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLoggerForceEnableDebug", reflect.TypeOf((*MockdebugForcedLogMaker)(nil).MakeLoggerForceEnableDebug), module)
+}
+
 // MockblockCacher is a mock of blockCacher interface
 type MockblockCacher struct {
 	ctrl     *gomock.Controller
@@ -5525,6 +5560,18 @@ func (m *MockConfig) MakeLogger(module string) logger.Logger {
 // MakeLogger indicates an expected call of MakeLogger
 func (mr *MockConfigMockRecorder) MakeLogger(module interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLogger", reflect.TypeOf((*MockConfig)(nil).MakeLogger), module)
+}
+
+// MakeLoggerForceEnableDebug mocks base method
+func (m *MockConfig) MakeLoggerForceEnableDebug(module string) logger.Logger {
+	ret := m.ctrl.Call(m, "MakeLoggerForceEnableDebug", module)
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// MakeLoggerForceEnableDebug indicates an expected call of MakeLoggerForceEnableDebug
+func (mr *MockConfigMockRecorder) MakeLoggerForceEnableDebug(module interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLoggerForceEnableDebug", reflect.TypeOf((*MockConfig)(nil).MakeLoggerForceEnableDebug), module)
 }
 
 // BlockCache mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -90,41 +90,6 @@ func (mr *MocklogMakerMockRecorder) MakeLogger(module interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLogger", reflect.TypeOf((*MocklogMaker)(nil).MakeLogger), module)
 }
 
-// MockdebugForcedLogMaker is a mock of debugForcedLogMaker interface
-type MockdebugForcedLogMaker struct {
-	ctrl     *gomock.Controller
-	recorder *MockdebugForcedLogMakerMockRecorder
-}
-
-// MockdebugForcedLogMakerMockRecorder is the mock recorder for MockdebugForcedLogMaker
-type MockdebugForcedLogMakerMockRecorder struct {
-	mock *MockdebugForcedLogMaker
-}
-
-// NewMockdebugForcedLogMaker creates a new mock instance
-func NewMockdebugForcedLogMaker(ctrl *gomock.Controller) *MockdebugForcedLogMaker {
-	mock := &MockdebugForcedLogMaker{ctrl: ctrl}
-	mock.recorder = &MockdebugForcedLogMakerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockdebugForcedLogMaker) EXPECT() *MockdebugForcedLogMakerMockRecorder {
-	return m.recorder
-}
-
-// MakeLoggerForceEnableDebug mocks base method
-func (m *MockdebugForcedLogMaker) MakeLoggerForceEnableDebug(module string) logger.Logger {
-	ret := m.ctrl.Call(m, "MakeLoggerForceEnableDebug", module)
-	ret0, _ := ret[0].(logger.Logger)
-	return ret0
-}
-
-// MakeLoggerForceEnableDebug indicates an expected call of MakeLoggerForceEnableDebug
-func (mr *MockdebugForcedLogMakerMockRecorder) MakeLoggerForceEnableDebug(module interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLoggerForceEnableDebug", reflect.TypeOf((*MockdebugForcedLogMaker)(nil).MakeLoggerForceEnableDebug), module)
-}
-
 // MockblockCacher is a mock of blockCacher interface
 type MockblockCacher struct {
 	ctrl     *gomock.Controller
@@ -5562,18 +5527,6 @@ func (mr *MockConfigMockRecorder) MakeLogger(module interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLogger", reflect.TypeOf((*MockConfig)(nil).MakeLogger), module)
 }
 
-// MakeLoggerForceEnableDebug mocks base method
-func (m *MockConfig) MakeLoggerForceEnableDebug(module string) logger.Logger {
-	ret := m.ctrl.Call(m, "MakeLoggerForceEnableDebug", module)
-	ret0, _ := ret[0].(logger.Logger)
-	return ret0
-}
-
-// MakeLoggerForceEnableDebug indicates an expected call of MakeLoggerForceEnableDebug
-func (mr *MockConfigMockRecorder) MakeLoggerForceEnableDebug(module interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLoggerForceEnableDebug", reflect.TypeOf((*MockConfig)(nil).MakeLoggerForceEnableDebug), module)
-}
-
 // BlockCache mocks base method
 func (m *MockConfig) BlockCache() BlockCache {
 	ret := m.ctrl.Call(m, "BlockCache")
@@ -5786,6 +5739,18 @@ func (m *MockConfig) MaybeFinishTrace(ctx context.Context, err error) {
 // MaybeFinishTrace indicates an expected call of MaybeFinishTrace
 func (mr *MockConfigMockRecorder) MaybeFinishTrace(ctx, err interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeFinishTrace", reflect.TypeOf((*MockConfig)(nil).MaybeFinishTrace), ctx, err)
+}
+
+// MakeLoggerForceEnableDebug mocks base method
+func (m *MockConfig) MakeLoggerForceEnableDebug(module string) logger.Logger {
+	ret := m.ctrl.Call(m, "MakeLoggerForceEnableDebug", module)
+	ret0, _ := ret[0].(logger.Logger)
+	return ret0
+}
+
+// MakeLoggerForceEnableDebug indicates an expected call of MakeLoggerForceEnableDebug
+func (mr *MockConfigMockRecorder) MakeLoggerForceEnableDebug(module interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeLoggerForceEnableDebug", reflect.TypeOf((*MockConfig)(nil).MakeLoggerForceEnableDebug), module)
 }
 
 // KBFSOps mocks base method

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -44,7 +44,8 @@ const (
 //
 // TODO: Move more common code here.
 func newConfigForTest(mode InitMode,
-	loggerFn func(module string) logger.Logger) *ConfigLocal {
+	loggerFn func(module string, overrideEnableDebug bool) logger.Logger,
+) *ConfigLocal {
 	config := NewConfigLocal(mode|InitTest, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
 
 	bops := NewBlockOpsStandard(config,
@@ -119,7 +120,7 @@ func MakeTestConfigOrBustLoggedInWithMode(
 	t logger.TestLogBackend, loggedInIndex int,
 	mode InitMode, users ...libkb.NormalizedUsername) *ConfigLocal {
 	log := logger.NewTestLogger(t)
-	config := newConfigForTest(mode, func(m string) logger.Logger {
+	config := newConfigForTest(mode, func(m string, _ bool) logger.Logger {
 		return log
 	})
 

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -44,7 +44,7 @@ const (
 //
 // TODO: Move more common code here.
 func newConfigForTest(mode InitMode,
-	loggerFn func(module string, overrideEnableDebug bool) logger.Logger,
+	loggerFn func(module string, overrideDebug bool) logger.Logger,
 ) *ConfigLocal {
 	config := NewConfigLocal(mode|InitTest, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
 


### PR DESCRIPTION
Now that everything in `rpc` is back to Debug level again, we won't get any `rpc` logging on mobile. This forces the Debug logging in `rpc` package on mobile.