### PR TITLE
WithFireNow in CheckForRekeys

### DIFF
--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -931,6 +931,10 @@ func (md *MDServerRemote) CheckForRekeys(ctx context.Context) <-chan error {
 		return c
 	}
 
+	// This is likely called in response to a service event from
+	// keybase_service_base. So attach it with FireNow.
+	ctx = rpc.WithFireNow(ctx)
+
 	time.AfterFunc(5*time.Second, func() {
 		md.log.CInfof(ctx, "CheckForRekeys: checking for rekeys")
 		select {


### PR DESCRIPTION
As suggested by @strib in https://github.com/keybase/client/issues/9312 . 

I didn't add it in `getFoldersForRekey` so that the background rekey timer shouldn't trigger it. Let me know if anybody thinks otherwise.