### PR TITLE
rename ServerErrorRequiredLockIsNotHeld to ServerErrorLockConflict

### DIFF
--- a/kbfsmd/server_errors.go
+++ b/kbfsmd/server_errors.go
@@ -49,11 +49,11 @@ const (
 	// to indicate that a reader has requested to read a TLF ID that
 	// has been finalized, which isn't allowed.
 	StatusCodeServerErrorCannotReadFinalizedTLF = 2812
-	// StatusCodeServerErrorRequiredLockIsNotHeld is the error code returned by
+	// StatusCodeServerErrorLockConflict is the error code returned by
 	// a MD write operation to indicate that a lockID that client required the
 	// write to be contingent on is not held at the time server tries to commit
 	// the MD, and as a result the MD is not written.
-	StatusCodeServerErrorRequiredLockIsNotHeld = 2813
+	StatusCodeServerErrorLockConflict = 2813
 	// StatusCodeServerErrorClassicTLFDoesNotExist is the error code returned by a
 	// MD get operation to indicate that a classic TLF is not found, and client
 	// has specified not to create one. Normally upon this error, KBFS client
@@ -349,19 +349,19 @@ func (e ServerErrorCannotReadFinalizedTLF) ToStatus() (s keybase1.Status) {
 	return
 }
 
-// ServerErrorRequiredLockIsNotHeld is the error type for
-// StatusCodeServerErrorRequiredLockIsNotHeld.
-type ServerErrorRequiredLockIsNotHeld struct{}
+// ServerErrorLockConflict is the error type for
+// StatusCodeServerErrorLockConflict.
+type ServerErrorLockConflict struct{}
 
 // Error implements the Error interface.
-func (e ServerErrorRequiredLockIsNotHeld) Error() string {
-	return "ServerErrorRequiredLockIsNotHeld{}"
+func (e ServerErrorLockConflict) Error() string {
+	return "ServerErrorLockConflict{}"
 }
 
 // ToStatus implements the ExportableError interface.
-func (e ServerErrorRequiredLockIsNotHeld) ToStatus() (s keybase1.Status) {
-	s.Code = StatusCodeServerErrorRequiredLockIsNotHeld
-	s.Name = "REQUIRED_LOCK_IS_NOT_HELD"
+func (e ServerErrorLockConflict) ToStatus() (s keybase1.Status) {
+	s.Code = StatusCodeServerErrorLockConflict
+	s.Name = "REQUIRED_LOCK_CONFLICT"
 	s.Desc = e.Error()
 	return
 }
@@ -477,8 +477,8 @@ func (eu ServerErrorUnwrapper) UnwrapError(arg interface{}) (appError error, dis
 	case StatusCodeServerErrorCannotReadFinalizedTLF:
 		appError = ServerErrorCannotReadFinalizedTLF{}
 		break
-	case StatusCodeServerErrorRequiredLockIsNotHeld:
-		appError = ServerErrorRequiredLockIsNotHeld{}
+	case StatusCodeServerErrorLockConflict:
+		appError = ServerErrorLockConflict{}
 		break
 	case StatusCodeServerErrorClassicTLFDoesNotExist:
 		appError = ServerErrorClassicTLFDoesNotExist{}

--- a/kbfsmd/server_errors.go
+++ b/kbfsmd/server_errors.go
@@ -50,9 +50,13 @@ const (
 	// has been finalized, which isn't allowed.
 	StatusCodeServerErrorCannotReadFinalizedTLF = 2812
 	// StatusCodeServerErrorLockConflict is the error code returned by
-	// a MD write operation to indicate that a lockID that client required the
-	// write to be contingent on is not held at the time server tries to commit
-	// the MD, and as a result the MD is not written.
+	// a MD write operation to indicate a lock conflict has happened and the MD
+	// has not been written. The lock conflict could be due to:
+	//   1) a lockID that client required the write to be contingent on is not
+	//      held at the time server tries to commit the MD, or
+	//   2) a implicit team migration lock is held on server, and the MD that
+	//      the client tried to write was either a rekey MD update or a MDv2
+	//      update, and was blocked by server.
 	StatusCodeServerErrorLockConflict = 2813
 	// StatusCodeServerErrorClassicTLFDoesNotExist is the error code returned by a
 	// MD get operation to indicate that a classic TLF is not found, and client

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -485,7 +485,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 	defer md.lock.Unlock()
 
 	if lc != nil && !md.isLockedLocked(ctx, id, lc.RequireLockID) {
-		return kbfsmd.ServerErrorRequiredLockIsNotHeld{}
+		return kbfsmd.ServerErrorLockConflict{}
 	}
 
 	mergedMasterHead, err :=

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -2419,7 +2419,7 @@ func (j *tlfJournal) finishSingleOp(ctx context.Context,
 		if err != nil {
 			return err
 		}
-		_, noLock := j.lastFlushErr.(kbfsmd.ServerErrorRequiredLockIsNotHeld)
+		_, noLock := j.lastFlushErr.(kbfsmd.ServerErrorLockConflict)
 		if noLock {
 			return j.lastFlushErr
 		}


### PR DESCRIPTION
It's easiest if we return the same error for 1) git lock missing; and 2) migration lock is blocking rekey, since we wouldn't need to lookup DB to determine what's prevent the row to be inserted (in the server PR I'm about to put up). So this PR just renames the error into a more generic one.

Since the status code is preserved, I don't *think* this breaks anything. The error's `Name` field is changed, but it seems it's not used anywhere in Go code. But please let me know if you think otherwise.