### PR TITLE
journal_server: check for writership before creating journal

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -527,6 +527,12 @@ func (r *runner) waitForJournal(ctx context.Context) error {
 		return nil
 	}
 
+	_, err = jServer.JournalStatus(rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		r.log.CDebugf(ctx, "No journal: %+v", err)
+		return nil
+	}
+
 	printDoneCh := make(chan struct{})
 	waitDoneCh := make(chan struct{})
 	go func() {

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -63,6 +63,12 @@ func (rh *RPCHandler) waitForJournal(
 		return nil
 	}
 
+	_, err = jServer.JournalStatus(rootNode.GetFolderBranch().Tlf)
+	if err != nil {
+		rh.log.CDebugf(ctx, "No journal: %+v", err)
+		return nil
+	}
+
 	// This squashes everything written to the journal into a single
 	// revision, to make sure that no partial states of the bare repo
 	// are seen by other readers of the TLF.  It also waits for any

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -748,7 +748,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	require.Len(t, tlfIDs, 1)
 }
 
-func TestJournalServerPublicTLF(t *testing.T) {
+func TestJournalServerReaderTLFs(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -847,18 +847,7 @@ func (md *RootMetadata) IsWriter(
 	uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (
 	bool, error) {
 	h := md.GetTlfHandle()
-	if md.TypeForKeying() != tlf.TeamKeying {
-		return h.IsWriter(uid), nil
-	}
-
-	// Team membership needs to be checked with the service.  For a
-	// SingleTeam TLF, there is always only a single writer in the
-	// handle.
-	tid, err := h.FirstResolvedWriter().AsTeam()
-	if err != nil {
-		return false, err
-	}
-	return checker.IsTeamWriter(ctx, tid, uid, verifyingKey)
+	return isWriterFromHandle(ctx, h, checker, uid, verifyingKey)
 }
 
 // IsReader checks that the given user is a valid reader of the TLF


### PR DESCRIPTION
So we don't create worthless on-disk journals for public TLFs, etc.

Issue: KBFS-2643