### PR TITLE
mdserver: respond correctly when the server supports iteams

### DIFF
--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -232,6 +232,9 @@ func (j journalMDOps) GetIDForHandle(
 	if err != nil {
 		return tlf.NullID, err
 	}
+	if id == tlf.NullID {
+		return id, nil
+	}
 	// Create the journal if needed, while we have access to `handle`.
 	_, _ = j.jServer.getTLFJournal(id, handle)
 	return id, nil

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -413,7 +413,12 @@ func (md *MDOpsStandard) GetIDForHandle(
 		return tlf.NullID, err
 	}
 	id, _, err = md.getForHandle(ctx, handle, kbfsmd.Merged, nil)
-	if err != nil {
+	switch errors.Cause(err).(type) {
+	case kbfsmd.ServerErrorClassicTLFDoesNotExist:
+		// The server thinks we should create an implicit team for this TLF.
+		return tlf.NullID, nil
+	case nil:
+	default:
 		return tlf.NullID, err
 	}
 	err = mdcache.PutIDForHandle(handle, id)

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -209,7 +209,7 @@ func (md *MDServerDisk) getHandleID(ctx context.Context, handle tlf.Handle,
 	}
 
 	if md.implicitTeamsEnabled {
-		return tlf.NullID, false, nil
+		return tlf.NullID, false, kbfsmd.ServerErrorClassicTLFDoesNotExist{}
 	}
 
 	// Allocate a new random ID.

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -185,7 +185,7 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 	}
 
 	if md.implicitTeamsEnabled {
-		return tlf.NullID, false, nil
+		return tlf.NullID, false, kbfsmd.ServerErrorClassicTLFDoesNotExist{}
 	}
 
 	// Allocate a new random ID.


### PR DESCRIPTION
I forgot that mdserver returned an error, instead of just a null ID, in that case.