### PR TITLE
 tlf_handle_resolve: support for resolving implicit team IDs

### DIFF
--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -160,7 +160,7 @@ func newChainMDForTest(t *testing.T) rootMetadataWithKeyAndTimestamp {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nug, nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nil, nug, nil)
 	require.NoError(t, err)
 
 	rmd, err := makeInitialRootMetadata(defaultClientMetadataVer, tlfID, h)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5601,7 +5601,7 @@ func (fbo *folderBranchOps) locallyFinalizeTLF(ctx context.Context) {
 	}
 	handle, err := MakeTlfHandle(
 		ctx, bareHandle, fbo.id().Type(), fbo.config.KBPKI(),
-		fbo.config.MDOps())
+		fbo.config.KBPKI(), fbo.config.MDOps())
 	if err != nil {
 		fbo.log.CErrorf(ctx, "Couldn't get finalized handle: %+v", err)
 		return

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -156,7 +156,8 @@ func defaultMetadataVersion(ctx Context) kbfsmd.MetadataVer {
 	case libkb.StagingRunMode:
 		return kbfsmd.ImplicitTeamsVer
 	case libkb.ProductionRunMode:
-		return kbfsmd.ImplicitTeamsVer
+		// TODO(KBFS-2621): flip this.
+		return kbfsmd.SegregatedKeyBundlesVer
 	default:
 		return kbfsmd.ImplicitTeamsVer
 	}

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -156,7 +156,7 @@ func defaultMetadataVersion(ctx Context) kbfsmd.MetadataVer {
 	case libkb.StagingRunMode:
 		return kbfsmd.ImplicitTeamsVer
 	case libkb.ProductionRunMode:
-		// TODO(KBFS-2621): flip this.
+		// TODO(KBFS-2652): flip this.
 		return kbfsmd.SegregatedKeyBundlesVer
 	default:
 		return kbfsmd.ImplicitTeamsVer

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -156,8 +156,7 @@ func defaultMetadataVersion(ctx Context) kbfsmd.MetadataVer {
 	case libkb.StagingRunMode:
 		return kbfsmd.ImplicitTeamsVer
 	case libkb.ProductionRunMode:
-		// TODO(KBFS-2621): flip this.
-		return kbfsmd.SegregatedKeyBundlesVer
+		return kbfsmd.ImplicitTeamsVer
 	default:
 		return kbfsmd.ImplicitTeamsVer
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -419,6 +419,11 @@ type KeybaseService interface {
 		ctx context.Context, assertions, suffix string, tlfType tlf.Type,
 		doIdentifies bool, reason string) (ImplicitTeamInfo, error)
 
+	// ResolveImplicitTeamByID resolves an implicit team to a team
+	// name, given a team ID.
+	ResolveImplicitTeamByID(
+		ctx context.Context, teamID keybase1.TeamID) (string, error)
+
 	// CreateTeamTLF associates the given TLF ID with the team ID in
 	// the team's sigchain.  If the team already has a TLF ID
 	// associated with it, this overwrites it.
@@ -526,6 +531,11 @@ type resolver interface {
 	// ResolveImplicitTeam resolves the given implicit team.
 	ResolveImplicitTeam(
 		ctx context.Context, assertions, suffix string, tlfType tlf.Type) (
+		ImplicitTeamInfo, error)
+	// ResolveImplicitTeamByID resolves the given implicit team, given
+	// a team ID.
+	ResolveImplicitTeamByID(
+		ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type) (
 		ImplicitTeamInfo, error)
 }
 

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -129,7 +129,7 @@ func (j journalMDOps) getHeadFromJournal(
 	if handle == nil {
 		handle, err = MakeTlfHandle(
 			ctx, headBareHandle, id.Type(), j.jServer.config.KBPKI(),
-			constIDGetter{id})
+			j.jServer.config.KBPKI(), constIDGetter{id})
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
@@ -137,7 +137,7 @@ func (j journalMDOps) getHeadFromJournal(
 		// Check for mutual handle resolution.
 		headHandle, err := MakeTlfHandle(
 			ctx, headBareHandle, id.Type(), j.jServer.config.KBPKI(),
-			constIDGetter{id})
+			j.jServer.config.KBPKI(), constIDGetter{id})
 		if err != nil {
 			return ImmutableRootMetadata{}, err
 		}
@@ -199,7 +199,8 @@ func (j journalMDOps) getRangeFromJournal(
 		return nil, err
 	}
 	handle, err := MakeTlfHandle(
-		ctx, bareHandle, id.Type(), j.jServer.config.KBPKI(), constIDGetter{id})
+		ctx, bareHandle, id.Type(), j.jServer.config.KBPKI(),
+		j.jServer.config.KBPKI(), constIDGetter{id})
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/journal_md_ops_test.go
+++ b/libkbfs/journal_md_ops_test.go
@@ -107,7 +107,8 @@ func TestJournalMDOpsBasics(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
+	h, err := MakeTlfHandle(
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -283,7 +284,8 @@ func TestJournalMDOpsPutUnmerged(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
+	h, err := MakeTlfHandle(
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -317,7 +319,8 @@ func TestJournalMDOpsPutUnmergedError(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
+	h, err := MakeTlfHandle(
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()
@@ -349,7 +352,8 @@ func TestJournalMDOpsLocalSquashBranch(t *testing.T) {
 		[]keybase1.UserOrTeamID{session.UID.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
 
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), config.KBPKI(), nil)
+	h, err := MakeTlfHandle(
+		ctx, bh, bh.Type(), config.KBPKI(), config.KBPKI(), nil)
 	require.NoError(t, err)
 
 	mdOps := jServer.mdOps()

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -65,6 +65,25 @@ func (k *KBPKIClient) ResolveImplicitTeam(
 		ctx, assertions, suffix, tlfType, false, "")
 }
 
+// ResolveImplicitTeamByID implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) ResolveImplicitTeamByID(
+	ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type) (
+	ImplicitTeamInfo, error) {
+	name, err := k.serviceOwner.KeybaseService().ResolveImplicitTeamByID(
+		ctx, teamID)
+	if err != nil {
+		return ImplicitTeamInfo{}, err
+	}
+
+	assertions, suffix, err := tlf.SplitExtension(name)
+	if err != nil {
+		return ImplicitTeamInfo{}, err
+	}
+
+	return k.serviceOwner.KeybaseService().ResolveIdentifyImplicitTeam(
+		ctx, assertions, suffix, tlfType, false, "")
+}
+
 // IdentifyImplicitTeam identifies (and creates if necessary) the
 // given implicit team.
 func (k *KBPKIClient) IdentifyImplicitTeam(

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -239,12 +239,11 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
-	// TODO(KBFS-2621): Resolve shouldn't work for implicit teams, but
-	// until CORE-6623 is done, this is required.
-	iti, err := k.localImplicitTeams.getLocalImplicitTeam(id.AsTeamOrBust())
-	if err == nil {
-		// An implicit team exists, so use the display name.
-		return iti.Name, id, nil
+	_, ok := k.localImplicitTeams[id.AsTeamOrBust()]
+	if ok {
+		// An implicit team exists, so Resolve shouldn't work.
+		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+			fmt.Errorf("Team ID %s is an implicit team", id)
 	}
 
 	return ti.Name, id, nil

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -241,7 +241,8 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 
 	_, ok := k.localImplicitTeams[id.AsTeamOrBust()]
 	if ok {
-		// An implicit team exists, so Resolve shouldn't work.
+		// An implicit team exists, so Resolve shouldn't work.  The
+		// caller should use `ResolveImplicitTeamByID` instead.
 		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			fmt.Errorf("Team ID %s is an implicit team", id)
 	}

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -387,6 +387,24 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 	return iteamInfo, nil
 }
 
+// ResolveImplicitTeamByID implements the KeybaseService interface for
+// KeybaseDaemonLocal.
+func (k *KeybaseDaemonLocal) ResolveImplicitTeamByID(
+	ctx context.Context, teamID keybase1.TeamID) (name string, err error) {
+	if err := checkContext(ctx); err != nil {
+		return "", err
+	}
+
+	k.lock.Lock()
+	defer k.lock.Unlock()
+
+	info, ok := k.localImplicitTeams[teamID]
+	if !ok {
+		return "", NoSuchTeamError{teamID.String()}
+	}
+	return info.Name.String(), nil
+}
+
 func (k *KeybaseDaemonLocal) addImplicitTeamTlfID(
 	tid keybase1.TeamID, tlfID tlf.ID) error {
 	// TODO: add check to make sure the private/public suffix of the

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -521,6 +521,21 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 	return iteamInfo, nil
 }
 
+// ResolveImplicitTeamByID implements the KeybaseService interface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) ResolveImplicitTeamByID(
+	ctx context.Context, teamID keybase1.TeamID) (name string, err error) {
+	arg := keybase1.ResolveImplicitTeamArg{
+		Id: teamID,
+	}
+
+	res, err := k.identifyClient.ResolveImplicitTeam(ctx, arg)
+	if err != nil {
+		return "", err
+	}
+	return res.Name, nil
+}
+
 // LoadUserPlusKeys implements the KeybaseService interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -20,6 +20,7 @@ type KeybaseServiceMeasured struct {
 	resolveTimer                     metrics.Timer
 	identifyTimer                    metrics.Timer
 	resolveIdentifyImplicitTeamTimer metrics.Timer
+	resolveImplicitTeamByIDTimer     metrics.Timer
 	loadUserPlusKeysTimer            metrics.Timer
 	loadTeamPlusKeysTimer            metrics.Timer
 	loadUnverifiedKeysTimer          metrics.Timer
@@ -42,6 +43,8 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 	identifyTimer := metrics.GetOrRegisterTimer("KeybaseService.Identify", r)
 	resolveIdentifyImplicitTeamTimer := metrics.GetOrRegisterTimer(
 		"KeybaseService.ResolveIdentifyImplicitTeam", r)
+	resolveImplicitTeamByIDTimer := metrics.GetOrRegisterTimer(
+		"KeybaseService.ResolveImplicitTeamByID", r)
 	loadUserPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUserPlusKeys", r)
 	loadTeamPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadTeamPlusKeys", r)
 	loadUnverifiedKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUnverifiedKeys", r)
@@ -59,6 +62,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 		resolveTimer:                     resolveTimer,
 		identifyTimer:                    identifyTimer,
 		resolveIdentifyImplicitTeamTimer: resolveIdentifyImplicitTeamTimer,
+		resolveImplicitTeamByIDTimer:     resolveImplicitTeamByIDTimer,
 		loadUserPlusKeysTimer:            loadUserPlusKeysTimer,
 		loadTeamPlusKeysTimer:            loadTeamPlusKeysTimer,
 		loadUnverifiedKeysTimer:          loadUnverifiedKeysTimer,
@@ -101,6 +105,16 @@ func (k KeybaseServiceMeasured) ResolveIdentifyImplicitTeam(
 			ctx, assertions, suffix, tlfType, doIdentifies, reason)
 	})
 	return info, err
+}
+
+// ResolveImplicitTeamByID implements the KeybaseService interface for
+// KeybaseServiceMeasured.
+func (k KeybaseServiceMeasured) ResolveImplicitTeamByID(
+	ctx context.Context, teamID keybase1.TeamID) (name string, err error) {
+	k.resolveImplicitTeamByIDTimer.Time(func() {
+		name, err = k.delegate.ResolveImplicitTeamByID(ctx, teamID)
+	})
+	return name, err
 }
 
 // LoadUserPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -94,7 +94,8 @@ func makeMDForTest(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	bh, err := tlf.MakeHandle(
 		[]keybase1.UserOrTeamID{uid.AsUserOrTeam()}, nil, nil, nil, nil)
 	require.NoError(t, err)
-	h, err := MakeTlfHandle(context.Background(), bh, bh.Type(), nug, nil)
+	h, err := MakeTlfHandle(
+		context.Background(), bh, bh.Type(), nil, nug, nil)
 	require.NoError(t, err)
 	md, err := makeInitialRootMetadata(ver, tlfID, h)
 	require.NoError(t, err)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -372,7 +372,7 @@ func (md *MDOpsStandard) getForHandle(ctx context.Context, handle *TlfHandle,
 	}
 
 	mdHandle, err := MakeTlfHandle(
-		ctx, bareMdHandle, id.Type(), md.config.KBPKI(), nil)
+		ctx, bareMdHandle, id.Type(), md.config.KBPKI(), md.config.KBPKI(), nil)
 	if err != nil {
 		return tlf.ID{}, ImmutableRootMetadata{}, err
 	}
@@ -482,7 +482,7 @@ func (md *MDOpsStandard) getForTLF(ctx context.Context, id tlf.ID,
 	}
 	handle, err := MakeTlfHandle(
 		ctx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-		constIDGetter{id})
+		md.config.KBPKI(), constIDGetter{id})
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
@@ -533,7 +533,7 @@ func (md *MDOpsStandard) processRange(ctx context.Context, id tlf.ID,
 			}
 			handle, err := MakeTlfHandle(
 				groupCtx, bareHandle, rmds.MD.TlfID().Type(), md.config.KBPKI(),
-				constIDGetter{id})
+				md.config.KBPKI(), constIDGetter{id})
 			if err != nil {
 				return err
 			}

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -29,7 +29,7 @@ func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
 	}
 
 	ctx := context.Background()
-	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nug, nil)
+	h, err := MakeTlfHandle(ctx, bh, bh.Type(), nil, nug, nil)
 	require.NoError(t, err)
 	return h
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1427,6 +1427,19 @@ func (mr *MockKeybaseServiceMockRecorder) ResolveIdentifyImplicitTeam(ctx, asser
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveIdentifyImplicitTeam", reflect.TypeOf((*MockKeybaseService)(nil).ResolveIdentifyImplicitTeam), ctx, assertions, suffix, tlfType, doIdentifies, reason)
 }
 
+// ResolveImplicitTeamByID mocks base method
+func (m *MockKeybaseService) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID) (string, error) {
+	ret := m.ctrl.Call(m, "ResolveImplicitTeamByID", ctx, teamID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID
+func (mr *MockKeybaseServiceMockRecorder) ResolveImplicitTeamByID(ctx, teamID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*MockKeybaseService)(nil).ResolveImplicitTeamByID), ctx, teamID)
+}
+
 // CreateTeamTLF mocks base method
 func (m *MockKeybaseService) CreateTeamTLF(ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error {
 	ret := m.ctrl.Call(m, "CreateTeamTLF", ctx, teamID, tlfID)
@@ -1692,6 +1705,19 @@ func (m *Mockresolver) ResolveImplicitTeam(ctx context.Context, assertions, suff
 // ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam
 func (mr *MockresolverMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tlfType interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*Mockresolver)(nil).ResolveImplicitTeam), ctx, assertions, suffix, tlfType)
+}
+
+// ResolveImplicitTeamByID mocks base method
+func (m *Mockresolver) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type) (ImplicitTeamInfo, error) {
+	ret := m.ctrl.Call(m, "ResolveImplicitTeamByID", ctx, teamID, tlfType)
+	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID
+func (mr *MockresolverMockRecorder) ResolveImplicitTeamByID(ctx, teamID, tlfType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*Mockresolver)(nil).ResolveImplicitTeamByID), ctx, teamID, tlfType)
 }
 
 // Mockidentifier is a mock of identifier interface
@@ -1999,6 +2025,19 @@ func (m *MockKBPKI) ResolveImplicitTeam(ctx context.Context, assertions, suffix 
 // ResolveImplicitTeam indicates an expected call of ResolveImplicitTeam
 func (mr *MockKBPKIMockRecorder) ResolveImplicitTeam(ctx, assertions, suffix, tlfType interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeam", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeam), ctx, assertions, suffix, tlfType)
+}
+
+// ResolveImplicitTeamByID mocks base method
+func (m *MockKBPKI) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type) (ImplicitTeamInfo, error) {
+	ret := m.ctrl.Call(m, "ResolveImplicitTeamByID", ctx, teamID, tlfType)
+	ret0, _ := ret[0].(ImplicitTeamInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID
+func (mr *MockKBPKIMockRecorder) ResolveImplicitTeamByID(ctx, teamID, tlfType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeamByID), ctx, teamID, tlfType)
 }
 
 // Identify mocks base method

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -275,6 +275,12 @@ func (ruid resolvableID) resolve(ctx context.Context) (
 		iteamInfo, err := ruid.resolver.ResolveImplicitTeamByID(
 			ctx, ruid.id.AsTeamOrBust(), ruid.tlfType)
 		if err == nil {
+			if ruid.id != iteamInfo.TID.AsUserOrTeam() {
+				return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID,
+					fmt.Errorf("Implicit team ID %s doesn't match ID in "+
+						"handle %s", iteamInfo.TID, ruid.id)
+			}
+
 			return nameIDPair{
 				name: iteamInfo.Name,
 				id:   iteamInfo.TID.AsUserOrTeam(),

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -186,7 +186,8 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 	// Make sure that generating another handle doesn't change the
 	// name.
 	h2, err := MakeTlfHandle(
-		context.Background(), h.ToBareHandleOrBust(), tlf.Private, kbpki, nil)
+		context.Background(), h.ToBareHandleOrBust(), tlf.Private,
+		kbpki, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -215,7 +216,8 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 	// Make sure that generating another handle doesn't change the
 	// name.
 	h2, err := MakeTlfHandle(
-		context.Background(), h.ToBareHandleOrBust(), tlf.Public, kbpki, nil)
+		context.Background(), h.ToBareHandleOrBust(), tlf.Public,
+		kbpki, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }
@@ -594,7 +596,8 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 	// Make sure that generating another handle doesn't change the
 	// name.
 	h2, err := MakeTlfHandle(
-		context.Background(), h.ToBareHandleOrBust(), tlf.Private, kbpki, nil)
+		context.Background(), h.ToBareHandleOrBust(), tlf.Private,
+		kbpki, kbpki, nil)
 	require.NoError(t, err)
 	assert.Equal(t, tlf.CanonicalName(name), h2.GetCanonicalName())
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -41,6 +41,7 @@ type tlfJournalConfig interface {
 	mdDecryptionKeyGetter() mdDecryptionKeyGetter
 	MDServer() MDServer
 	usernameGetter() normalizedUsernameGetter
+	resolver() resolver
 	MakeLogger(module string) logger.Logger
 	diskLimitTimeout() time.Duration
 	teamMembershipChecker() kbfsmd.TeamMembershipChecker
@@ -63,6 +64,10 @@ func (ca tlfJournalConfigAdapter) mdDecryptionKeyGetter() mdDecryptionKeyGetter 
 }
 
 func (ca tlfJournalConfigAdapter) usernameGetter() normalizedUsernameGetter {
+	return ca.Config.KBPKI()
+}
+
+func (ca tlfJournalConfigAdapter) resolver() resolver {
 	return ca.Config.KBPKI()
 }
 
@@ -1649,8 +1654,8 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 	}
 
 	handle, err := MakeTlfHandle(
-		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.usernameGetter(),
-		j.config.tlfIDGetter())
+		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.resolver(),
+		j.config.usernameGetter(), j.config.tlfIDGetter())
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -139,6 +139,10 @@ func (c testTLFJournalConfig) usernameGetter() normalizedUsernameGetter {
 	return c.nug
 }
 
+func (c testTLFJournalConfig) resolver() resolver {
+	return nil
+}
+
 func (c testTLFJournalConfig) MDServer() MDServer {
 	return c.mdserver
 }

--- a/vendor/github.com/keybase/client/go/libkb/account.go
+++ b/vendor/github.com/keybase/client/go/libkb/account.go
@@ -157,10 +157,13 @@ func (a *Account) LoginSession() *LoginSession {
 }
 
 func (a *Account) Logout() error {
+	a.G().Log.Debug("+ Account.Logout()")
 	a.ClearStreamCache()
 
-	if err := a.localSession.Logout(); err != nil {
-		return err
+	err := a.localSession.Logout()
+	if err != nil {
+		a.G().Log.Debug("error in localSession.Logout(): %s", err)
+		a.G().Log.Debug("(continuing with the rest of the logout process, but this error will be returned)")
 	}
 
 	a.UnloadLocalSession()
@@ -173,8 +176,9 @@ func (a *Account) Logout() error {
 	a.ClearCachedSecretKeys()
 
 	a.lksec = nil
+	a.G().Log.Debug("- Account.Logout() - all clears complete, localSession.Logout() -> %s", ErrToOk(err))
 
-	return nil
+	return err
 }
 
 func (a *Account) CreateStreamCache(tsec Triplesec, pps *PassphraseStream) {

--- a/vendor/github.com/keybase/client/go/libkb/assertion.go
+++ b/vendor/github.com/keybase/client/go/libkb/assertion.go
@@ -747,12 +747,12 @@ func ParseImplicitTeamDisplayNameSuffix(suffix string) (ret *keybase1.ImplicitTe
 	}
 
 	generation, err := strconv.Atoi(matches[2])
-	if err != nil || generation < 0 {
+	if err != nil || generation <= 0 {
 		return ret, NewImplicitTeamDisplayNameError("malformed suffix generation: %v", matches[2])
 	}
 
 	return &keybase1.ImplicitTeamConflictInfo{
-		Generation: generation,
+		Generation: keybase1.ConflictGeneration(generation),
 		Time:       keybase1.ToTime(conflictTime.UTC()),
 	}, nil
 }

--- a/vendor/github.com/keybase/client/go/libkb/chain_link_v2.go
+++ b/vendor/github.com/keybase/client/go/libkb/chain_link_v2.go
@@ -50,8 +50,9 @@ const (
 	SigchainV2TypeTeamDeleteRoot       SigchainV2Type = 42
 	SigchainV2TypeTeamDeleteSubteam    SigchainV2Type = 43
 	SigchainV2TypeTeamDeleteUpPointer  SigchainV2Type = 44
-	SigchainV2TypeTeamLegacyTLFUpgrade SigchainV2Type = 45
-	SigchainV2TypeTeamSettings         SigchainV2Type = 46
+	// Note that 45 is skipped, since it's retired; used to be LegacyTLFUpgrade
+	SigchainV2TypeTeamSettings     SigchainV2Type = 46
+	SigchainV2TypeTeamKBFSSettings SigchainV2Type = 47
 )
 
 func (t SigchainV2Type) NeedsSignature() bool {
@@ -79,7 +80,7 @@ func (t SigchainV2Type) IsSupportedTeamType() bool {
 		SigchainV2TypeTeamDeleteRoot,
 		SigchainV2TypeTeamDeleteSubteam,
 		SigchainV2TypeTeamDeleteUpPointer,
-		SigchainV2TypeTeamLegacyTLFUpgrade,
+		SigchainV2TypeTeamKBFSSettings,
 		SigchainV2TypeTeamSettings:
 		return true
 	default:
@@ -94,8 +95,7 @@ func (t SigchainV2Type) RequiresAdminPermission() bool {
 	switch t {
 	case SigchainV2TypeTeamRoot,
 		SigchainV2TypeTeamRotateKey,
-		SigchainV2TypeTeamLeave,
-		SigchainV2TypeTeamLegacyTLFUpgrade:
+		SigchainV2TypeTeamLeave:
 		return false
 	default:
 		return true
@@ -295,8 +295,8 @@ func SigchainV2TypeFromV1TypeTeams(s string) (ret SigchainV2Type, err error) {
 		ret = SigchainV2TypeTeamDeleteSubteam
 	case LinkTypeDeleteUpPointer:
 		ret = SigchainV2TypeTeamDeleteUpPointer
-	case LinkTypeLegacyTLFUpgrade:
-		ret = SigchainV2TypeTeamLegacyTLFUpgrade
+	case LinkTypeKBFSSettings:
+		ret = SigchainV2TypeTeamKBFSSettings
 	case LinkTypeSettings:
 		ret = SigchainV2TypeTeamSettings
 	default:

--- a/vendor/github.com/keybase/client/go/libkb/constants.go
+++ b/vendor/github.com/keybase/client/go/libkb/constants.go
@@ -109,8 +109,9 @@ const (
 	LinkCacheSize     = 0x10000
 	LinkCacheCleanDur = 1 * time.Minute
 
-	UPAKCacheSize           = 2000
-	UIDMapFullNameCacheSize = 100000
+	UPAKCacheSize                     = 2000
+	UIDMapFullNameCacheSize           = 100000
+	ImplicitTeamConflictInfoCacheSize = 10000
 
 	SigShortIDBytes  = 27
 	LocalTrackMaxAge = 48 * time.Hour
@@ -279,6 +280,7 @@ const (
 	SCGitRepoDoesntExist       = int(keybase1.StatusCode_SCGitRepoDoesntExist)
 	SCTeamBanned               = int(keybase1.StatusCode_SCTeamBanned)
 	SCTeamInvalidBan           = int(keybase1.StatusCode_SCTeamInvalidBan)
+	SCNoSpaceOnDevice          = int(keybase1.StatusCode_SCNoSpaceOnDevice)
 )
 
 const (
@@ -317,7 +319,7 @@ const (
 	LinkTypeDeleteRoot       LinkType = "team.delete_root"
 	LinkTypeDeleteSubteam    LinkType = "team.delete_subteam"
 	LinkTypeDeleteUpPointer  LinkType = "team.delete_up_pointer"
-	LinkTypeLegacyTLFUpgrade LinkType = "team.legacy_tlf_upgrade"
+	LinkTypeKBFSSettings     LinkType = "team.kbfs"
 	LinkTypeSettings         LinkType = "team.settings"
 
 	DelegationTypeEldest    DelegationType = "eldest"

--- a/vendor/github.com/keybase/client/go/libkb/db.go
+++ b/vendor/github.com/keybase/client/go/libkb/db.go
@@ -170,33 +170,34 @@ const (
 	// NOTE: This file needs to stay consistent with config/id.iced on the
 	// website, and that one has IDs on the lower end of the range that aren't
 	// represented here.
-	DBUidToFullName           = 0xdd
-	DBUidToUsername           = 0xde
-	DBUserPlusKeysVersioned   = 0xdf
-	DBLink                    = 0xe0
-	DBLocalTrack              = 0xe1
-	DBPGPKey                  = 0xe3
-	DBSigHints                = 0xe4
-	DBProofCheck              = 0xe5
-	DBUserSecretKeys          = 0xe6
-	DBSigChainTailPublic      = 0xe7
-	DBSigChainTailSemiprivate = 0xe8
-	DBSigChainTailEncrypted   = 0xe9
-	DBMerkleRoot              = 0xf0
-	DBTrackers                = 0xf1
-	DBGregor                  = 0xf2
-	DBTrackers2               = 0xf3
-	DBTrackers2Reverse        = 0xf4
-	DBNotificationDismiss     = 0xf5
-	DBChatBlockIndex          = 0xf6
-	DBChatBlocks              = 0xf7
-	DBChatOutbox              = 0xf8
-	DBChatInbox               = 0xf9
-	DBIdentify                = 0xfa
-	DBResolveUsernameToUID    = 0xfb
-	DBChatBodyHashIndex       = 0xfc
-	DBPvl                     = 0xfd
-	DBChatConvFailures        = 0xfe
+	DBImplicitTeamConflictInfo = 0xdc
+	DBUidToFullName            = 0xdd
+	DBUidToUsername            = 0xde
+	DBUserPlusKeysVersioned    = 0xdf
+	DBLink                     = 0xe0
+	DBLocalTrack               = 0xe1
+	DBPGPKey                   = 0xe3
+	DBSigHints                 = 0xe4
+	DBProofCheck               = 0xe5
+	DBUserSecretKeys           = 0xe6
+	DBSigChainTailPublic       = 0xe7
+	DBSigChainTailSemiprivate  = 0xe8
+	DBSigChainTailEncrypted    = 0xe9
+	DBMerkleRoot               = 0xf0
+	DBTrackers                 = 0xf1
+	DBGregor                   = 0xf2
+	DBTrackers2                = 0xf3
+	DBTrackers2Reverse         = 0xf4
+	DBNotificationDismiss      = 0xf5
+	DBChatBlockIndex           = 0xf6
+	DBChatBlocks               = 0xf7
+	DBChatOutbox               = 0xf8
+	DBChatInbox                = 0xf9
+	DBIdentify                 = 0xfa
+	DBResolveUsernameToUID     = 0xfb
+	DBChatBodyHashIndex        = 0xfc
+	DBPvl                      = 0xfd
+	DBChatConvFailures         = 0xfe
 )
 
 const (

--- a/vendor/github.com/keybase/client/go/libkb/env.go
+++ b/vendor/github.com/keybase/client/go/libkb/env.go
@@ -1257,7 +1257,7 @@ func (e *Env) RunningInCI() bool {
 func (e *Env) WantsSystemd() bool {
 	return (e.GetRunMode() == ProductionRunMode &&
 		systemd.IsRunningSystemd() &&
-		os.Getenv("KEYBASE_SYSTEMD") == "1")
+		os.Getenv("KEYBASE_SYSTEMD") != "0")
 }
 
 func (e *Env) DarwinForceSecretStoreFile() bool {

--- a/vendor/github.com/keybase/client/go/libkb/errors.go
+++ b/vendor/github.com/keybase/client/go/libkb/errors.go
@@ -2206,3 +2206,13 @@ type NoOpError struct {
 func (e NoOpError) Error() string {
 	return e.Desc
 }
+
+//=============================================================================
+
+type NoSpaceOnDeviceError struct {
+	Desc string
+}
+
+func (e NoSpaceOnDeviceError) Error() string {
+	return e.Desc
+}

--- a/vendor/github.com/keybase/client/go/libkb/full_self_cacher.go
+++ b/vendor/github.com/keybase/client/go/libkb/full_self_cacher.go
@@ -186,7 +186,9 @@ func (m *CachedFullSelf) WithUser(arg LoadUserArg, f func(u *User) error) (err e
 			m.G().Log.CDebugf(ctx, "| CachedFullSelf#WithUser: cache populate")
 			m.cacheMe(u)
 			if ldr := m.G().GetUPAKLoader(); ldr != nil {
-				ldr.PutUserToCache(ctx, u)
+				if err := ldr.PutUserToCache(ctx, u); err != nil {
+					m.G().Log.CDebugf(ctx, "| CachedFullSelf#WithUser: continuing past error putting user to cache: %s", err)
+				}
 			}
 		} else {
 			m.G().Log.CDebugf(ctx, "| CachedFullSelf#WithUser: other user")

--- a/vendor/github.com/keybase/client/go/libkb/globals.go
+++ b/vendor/github.com/keybase/client/go/libkb/globals.go
@@ -71,6 +71,7 @@ type GlobalContext struct {
 	LinkCache      *LinkCache      // cache of ChainLinks
 	upakLoader     UPAKLoader      // Load flat users with the ability to hit the cache
 	teamLoader     TeamLoader      // Play back teams for id/name properties
+	itciCacher     LRUer           // Cacher for implicit team conflict info
 	CardCache      *UserCardCache  // cache of keybase1.UserCard objects
 	fullSelfer     FullSelfer      // a loader that gets the full self object
 	pvlSource      PvlSource       // a cache and fetcher for pvl
@@ -460,6 +461,18 @@ func (g *GlobalContext) GetTeamLoader() TeamLoader {
 	g.cacheMu.RLock()
 	defer g.cacheMu.RUnlock()
 	return g.teamLoader
+}
+
+func (g *GlobalContext) GetImplicitTeamConflictInfoCacher() LRUer {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	return g.itciCacher
+}
+
+func (g *GlobalContext) SetImplicitTeamConflictInfoCacher(l LRUer) {
+	g.cacheMu.RLock()
+	defer g.cacheMu.RUnlock()
+	g.itciCacher = l
 }
 
 func (g *GlobalContext) GetFullSelfer() FullSelfer {

--- a/vendor/github.com/keybase/client/go/libkb/interfaces.go
+++ b/vendor/github.com/keybase/client/go/libkb/interfaces.go
@@ -606,8 +606,29 @@ type TeamLoader interface {
 	ClearMem()
 }
 
+type ImplicitTeamConflictInfoCacher interface {
+	Get(context.Context, bool, keybase1.TeamID) *keybase1.ImplicitTeamConflictInfo
+	Put(context.Context, bool, keybase1.TeamID, keybase1.ImplicitTeamConflictInfo) error
+}
+
 type KVStoreContext interface {
 	GetKVStore() KVStorer
+}
+
+type LRUContext interface {
+	VLogContext
+	KVStoreContext
+	ClockContext
+}
+
+type LRUKeyer interface {
+	MemKey() string
+	DbKey() DbKey
+}
+
+type LRUer interface {
+	Get(context.Context, LRUContext, LRUKeyer) (interface{}, error)
+	Put(context.Context, LRUContext, LRUKeyer, interface{}) error
 }
 
 type ClockContext interface {

--- a/vendor/github.com/keybase/client/go/libkb/json.go
+++ b/vendor/github.com/keybase/client/go/libkb/json.go
@@ -61,12 +61,9 @@ func (f *JSONFile) Load(warnOnNotFound bool) error {
 			return nil
 		}
 
+		MobilePermissionDeniedCheck(f.G(), err, fmt.Sprintf("%s: %s", f.which, f.filename))
+
 		if os.IsPermission(err) {
-			// Let's just panic and die here on mobile, there is no reason to continue, since the user
-			// will either need to enter a password or force kill the app anyway
-			if f.G().GetAppType() == MobileAppType {
-				panic("permission denied on mobile app reading config file, thats it!")
-			}
 			f.G().Log.Warning("Permission denied opening %s file %s", f.which, f.filename)
 			return nil
 		}

--- a/vendor/github.com/keybase/client/go/libkb/notify_router.go
+++ b/vendor/github.com/keybase/client/go/libkb/notify_router.go
@@ -57,13 +57,15 @@ type NotifyListener interface {
 	PGPKeyInSecretStoreFile()
 	BadgeState(badgeState keybase1.BadgeState)
 	ReachabilityChanged(r keybase1.Reachability)
-	TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet)
-	TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet)
+	TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet)
+	TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet)
 	TeamDeleted(teamID keybase1.TeamID)
 	TeamExit(teamID keybase1.TeamID)
 }
 
 type NoopNotifyListener struct{}
+
+var _ NotifyListener = (*NoopNotifyListener)(nil)
 
 func (n *NoopNotifyListener) Logout()                                                       {}
 func (n *NoopNotifyListener) Login(username string)                                         {}
@@ -99,9 +101,9 @@ func (n *NoopNotifyListener) ChatResetConversation(uid keybase1.UID, convID chat
 func (n *NoopNotifyListener) PGPKeyInSecretStoreFile()                                            {}
 func (n *NoopNotifyListener) BadgeState(badgeState keybase1.BadgeState)                           {}
 func (n *NoopNotifyListener) ReachabilityChanged(r keybase1.Reachability)                         {}
-func (n *NoopNotifyListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
+func (n *NoopNotifyListener) TeamChangedByID(teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet) {
 }
-func (n *NoopNotifyListener) TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
+func (n *NoopNotifyListener) TeamChangedByName(teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet) {
 }
 func (n *NoopNotifyListener) TeamDeleted(teamID keybase1.TeamID) {}
 func (n *NoopNotifyListener) TeamExit(teamID keybase1.TeamID)    {}
@@ -1022,24 +1024,30 @@ func (n *NotifyRouter) HandleReachability(r keybase1.Reachability) {
 }
 
 // teamID and teamName are not necessarily the same team
-func (n *NotifyRouter) HandleTeamChangedByBothKeys(ctx context.Context, teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
-	n.HandleTeamChangedByID(ctx, teamID, latestSeqno, changes)
-	n.HandleTeamChangedByName(ctx, teamName, latestSeqno, changes)
+func (n *NotifyRouter) HandleTeamChangedByBothKeys(ctx context.Context,
+	teamID keybase1.TeamID, teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet) {
+
+	n.HandleTeamChangedByID(ctx, teamID, latestSeqno, implicitTeam, changes)
+	n.HandleTeamChangedByName(ctx, teamName, latestSeqno, implicitTeam, changes)
 }
 
-func (n *NotifyRouter) HandleTeamChangedByID(ctx context.Context, teamID keybase1.TeamID, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
+func (n *NotifyRouter) HandleTeamChangedByID(ctx context.Context,
+	teamID keybase1.TeamID, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet) {
+
 	if n == nil {
 		return
 	}
 
 	arg := keybase1.TeamChangedByIDArg{
-		TeamID:      teamID,
-		Changes:     changes,
-		LatestSeqno: latestSeqno,
+		TeamID:       teamID,
+		LatestSeqno:  latestSeqno,
+		ImplicitTeam: implicitTeam,
+		Changes:      changes,
 	}
 
 	var wg sync.WaitGroup
-	n.G().Log.CDebugf(ctx, "+ Sending TeamChangedByID notification (team:%v)", teamID)
+	n.G().Log.CDebugf(ctx, "+ Sending TeamChangedByID notification (team:%v, seqno:%v, implicit:%v)",
+		teamID, latestSeqno, implicitTeam)
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
 		if n.getNotificationChannels(id).Team {
 			wg.Add(1)
@@ -1054,24 +1062,28 @@ func (n *NotifyRouter) HandleTeamChangedByID(ctx context.Context, teamID keybase
 	})
 	wg.Wait()
 	if n.listener != nil {
-		n.listener.TeamChangedByID(teamID, latestSeqno, changes)
+		n.listener.TeamChangedByID(teamID, latestSeqno, implicitTeam, changes)
 	}
 	n.G().Log.CDebugf(ctx, "- Sent TeamChangedByID notification")
 }
 
-func (n *NotifyRouter) HandleTeamChangedByName(ctx context.Context, teamName string, latestSeqno keybase1.Seqno, changes keybase1.TeamChangeSet) {
+func (n *NotifyRouter) HandleTeamChangedByName(ctx context.Context,
+	teamName string, latestSeqno keybase1.Seqno, implicitTeam bool, changes keybase1.TeamChangeSet) {
+
 	if n == nil {
 		return
 	}
 
 	arg := keybase1.TeamChangedByNameArg{
-		TeamName:    teamName,
-		Changes:     changes,
-		LatestSeqno: latestSeqno,
+		TeamName:     teamName,
+		LatestSeqno:  latestSeqno,
+		ImplicitTeam: implicitTeam,
+		Changes:      changes,
 	}
 
 	var wg sync.WaitGroup
-	n.G().Log.CDebugf(ctx, "+ Sending TeamChangedByName notification (team:%v)", teamName)
+	n.G().Log.CDebugf(ctx, "+ Sending TeamChangedByName notification (team:%v, seqno:%v, implicit:%v)",
+		teamName, latestSeqno, implicitTeam)
 	n.cm.ApplyAll(func(id ConnectionID, xp rpc.Transporter) bool {
 		if n.getNotificationChannels(id).Team {
 			wg.Add(1)
@@ -1086,7 +1098,7 @@ func (n *NotifyRouter) HandleTeamChangedByName(ctx context.Context, teamName str
 	})
 	wg.Wait()
 	if n.listener != nil {
-		n.listener.TeamChangedByName(teamName, latestSeqno, changes)
+		n.listener.TeamChangedByName(teamName, latestSeqno, implicitTeam, changes)
 	}
 	n.G().Log.CDebugf(ctx, "- Sent TeamChanged notification")
 }

--- a/vendor/github.com/keybase/client/go/libkb/rpc_exim.go
+++ b/vendor/github.com/keybase/client/go/libkb/rpc_exim.go
@@ -653,6 +653,8 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		return e
 	case SCNoOp:
 		return NoOpError{Desc: s.Desc}
+	case SCNoSpaceOnDevice:
+		return NoSpaceOnDeviceError{Desc: s.Desc}
 	default:
 		ase := AppStatusError{
 			Code:   s.Code,
@@ -2164,6 +2166,13 @@ func (e RepoDoesntExistError) ToStatus() (s keybase1.Status) {
 func (e NoOpError) ToStatus() (s keybase1.Status) {
 	s.Code = SCNoOp
 	s.Name = "SC_NO_OP"
+	s.Desc = e.Desc
+	return
+}
+
+func (e NoSpaceOnDeviceError) ToStatus() (s keybase1.Status) {
+	s.Code = SCNoSpaceOnDevice
+	s.Name = "NO_SPACE_ON_DEVICE"
 	s.Desc = e.Desc
 	return
 }

--- a/vendor/github.com/keybase/client/go/libkb/sig_chain.go
+++ b/vendor/github.com/keybase/client/go/libkb/sig_chain.go
@@ -1207,9 +1207,9 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	if err = l.chain.VerifyChain(l.ctx); err != nil {
 		return
 	}
-	stage("Store")
+	stage("StoreChain")
 	if err = l.chain.Store(l.ctx); err != nil {
-		return
+		l.G().Log.CDebugf(l.ctx, "| continuing past error storing chain links: %s", err)
 	}
 	stage("VerifySig")
 	if err = l.VerifySigsAndComputeKeys(); err != nil {
@@ -1217,8 +1217,8 @@ func (l *SigChainLoader) Load() (ret *SigChain, err error) {
 	}
 	stage("Store")
 	if err = l.Store(); err != nil {
-		return
+		l.G().Log.CDebugf(l.ctx, "| continuing past error storing chain: %s", err)
 	}
 
-	return
+	return ret, nil
 }

--- a/vendor/github.com/keybase/client/go/libkb/skb_keyring.go
+++ b/vendor/github.com/keybase/client/go/libkb/skb_keyring.go
@@ -82,8 +82,9 @@ func (k *SKBKeyringFile) loadLocked() (err error) {
 			k.G().Log.Debug("| Keybase secret keyring doesn't exist: %s", k.filename)
 		} else {
 			k.G().Log.Warning("Error opening %s: %s", k.filename, err)
-		}
 
+			MobilePermissionDeniedCheck(k.G(), err, fmt.Sprintf("skb keyring: %s", k.filename))
+		}
 	} else if err == nil {
 		k.Blocks, err = packets.ToListOfSKBs(k.G())
 	}

--- a/vendor/github.com/keybase/client/go/libkb/team_stub.go
+++ b/vendor/github.com/keybase/client/go/libkb/team_stub.go
@@ -49,7 +49,7 @@ func (n nullTeamLoader) Delete(context.Context, keybase1.TeamID) error {
 	return nil
 }
 
-func (l *nullTeamLoader) HintLatestSeqno(ctx context.Context, id keybase1.TeamID, seqno keybase1.Seqno) error {
+func (n *nullTeamLoader) HintLatestSeqno(ctx context.Context, id keybase1.TeamID, seqno keybase1.Seqno) error {
 	return nil
 }
 

--- a/vendor/github.com/keybase/client/go/libkb/upak_loader.go
+++ b/vendor/github.com/keybase/client/go/libkb/upak_loader.go
@@ -341,7 +341,9 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 			upak.Uvv.CachedAt = keybase1.ToTime(g.Clock().Now())
 			// This is only necessary to update the levelDB representation,
 			// since the previous line updates the in-memory cache satisfactorially.
-			u.putUPAKToCache(ctx, upak)
+			if err := u.putUPAKToCache(ctx, upak); err != nil {
+				u.G().Log.CDebugf(ctx, "continuing past error in putUPAKToCache: %s", err)
+			}
 
 			return returnUPAK(upak, true)
 		}
@@ -382,7 +384,9 @@ func (u *CachedUPAKLoader) loadWithInfo(arg LoadUserArg, info *CachedUserLoadInf
 		return nil, nil, UserNotFoundError{UID: arg.uid, Msg: "LoadUser failed"}
 	}
 
-	err = u.putUPAKToCache(ctx, ret)
+	if err := u.putUPAKToCache(ctx, ret); err != nil {
+		u.G().Log.CDebugf(ctx, "continuing past error in putUPAKToCache: %s", err)
+	}
 
 	if u.TestDeadlocker != nil {
 		u.TestDeadlocker()

--- a/vendor/github.com/keybase/client/go/libkb/util.go
+++ b/vendor/github.com/keybase/client/go/libkb/util.go
@@ -23,6 +23,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 	"unicode"
 
@@ -788,4 +789,39 @@ var adminFeatureList = map[keybase1.UID]bool{
 // IsKeybaseAdmin returns true if uid is a keybase admin.
 func IsKeybaseAdmin(uid keybase1.UID) bool {
 	return adminFeatureList[uid]
+}
+
+// MobilePermissionDeniedCheck panics if err is a permission denied error
+// and if app is a mobile app. This has caused issues opening config.json
+// and secretkeys files, where it seems to be stuck in a permission
+// denied state and force-killing the app is the only option.
+func MobilePermissionDeniedCheck(g *GlobalContext, err error, msg string) {
+	if !os.IsPermission(err) {
+		return
+	}
+	if g.GetAppType() != MobileAppType {
+		return
+	}
+	g.Log.Warning("file open permission denied on mobile (%s): %s", msg, err)
+	panic(fmt.Sprintf("panic due to file open permission denied on mobile (%s)", msg))
+}
+
+// IsNoSpaceOnDeviceError will return true if err is an `os` error
+// for "no space left on device".
+func IsNoSpaceOnDeviceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch err := err.(type) {
+	case NoSpaceOnDeviceError:
+		return true
+	case *os.PathError:
+		return err.Err == syscall.ENOSPC
+	case *os.LinkError:
+		return err.Err == syscall.ENOSPC
+	case *os.SyscallError:
+		return err.Err == syscall.ENOSPC
+	}
+
+	return false
 }

--- a/vendor/github.com/keybase/client/go/libkb/version.go
+++ b/vendor/github.com/keybase/client/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "1.0.36"
+const Version = "1.0.37"

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -1627,12 +1627,25 @@ func (t TeamMembers) AllUIDs() []UID {
 	return all
 }
 
-func (t TeamMembers) AllUserVersions() (res []UserVersion) {
-	res = append(res, t.Owners...)
-	res = append(res, t.Admins...)
-	res = append(res, t.Writers...)
-	res = append(res, t.Readers...)
-	return res
+func (t TeamMembers) AllUserVersions() []UserVersion {
+	m := make(map[UID]UserVersion)
+	for _, u := range t.Owners {
+		m[u.Uid] = u
+	}
+	for _, u := range t.Admins {
+		m[u.Uid] = u
+	}
+	for _, u := range t.Writers {
+		m[u.Uid] = u
+	}
+	for _, u := range t.Readers {
+		m[u.Uid] = u
+	}
+	var all []UserVersion
+	for _, uv := range m {
+		all = append(all, uv)
+	}
+	return all
 }
 
 func (t TeamMember) IsReset() bool {
@@ -1991,6 +2004,10 @@ func (n ImplicitTeamDisplayName) String() string {
 	}
 
 	return name
+}
+
+func (c ImplicitTeamConflictInfo) IsConflict() bool {
+	return c.Generation > ConflictGeneration(0)
 }
 
 const (

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/identify_ui.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/identify_ui.go
@@ -291,6 +291,8 @@ type UserTeamShowcase struct {
 	TeamIsShowcased bool     `codec:"teamIsShowcased" json:"team_is_showcased"`
 	Description     string   `codec:"description" json:"description"`
 	Role            TeamRole `codec:"role" json:"role"`
+	PublicAdmins    []string `codec:"publicAdmins" json:"public_admins"`
+	NumMembers      int      `codec:"numMembers" json:"num_members"`
 }
 
 func (o UserTeamShowcase) DeepCopy() UserTeamShowcase {
@@ -300,6 +302,18 @@ func (o UserTeamShowcase) DeepCopy() UserTeamShowcase {
 		TeamIsShowcased: o.TeamIsShowcased,
 		Description:     o.Description,
 		Role:            o.Role.DeepCopy(),
+		PublicAdmins: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			var ret []string
+			for _, v := range x {
+				vCopy := v
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.PublicAdmins),
+		NumMembers: o.NumMembers,
 	}
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/notify_team.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/notify_team.go
@@ -23,15 +23,17 @@ func (o TeamChangeSet) DeepCopy() TeamChangeSet {
 }
 
 type TeamChangedByIDArg struct {
-	TeamID      TeamID        `codec:"teamID" json:"teamID"`
-	LatestSeqno Seqno         `codec:"latestSeqno" json:"latestSeqno"`
-	Changes     TeamChangeSet `codec:"changes" json:"changes"`
+	TeamID       TeamID        `codec:"teamID" json:"teamID"`
+	LatestSeqno  Seqno         `codec:"latestSeqno" json:"latestSeqno"`
+	ImplicitTeam bool          `codec:"implicitTeam" json:"implicitTeam"`
+	Changes      TeamChangeSet `codec:"changes" json:"changes"`
 }
 
 type TeamChangedByNameArg struct {
-	TeamName    string        `codec:"teamName" json:"teamName"`
-	LatestSeqno Seqno         `codec:"latestSeqno" json:"latestSeqno"`
-	Changes     TeamChangeSet `codec:"changes" json:"changes"`
+	TeamName     string        `codec:"teamName" json:"teamName"`
+	LatestSeqno  Seqno         `codec:"latestSeqno" json:"latestSeqno"`
+	ImplicitTeam bool          `codec:"implicitTeam" json:"implicitTeam"`
+	Changes      TeamChangeSet `codec:"changes" json:"changes"`
 }
 
 type TeamDeletedArg struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -201,10 +201,10 @@
 			"revisionTime": "2017-11-03T20:00:56Z"
 		},
 		{
-			"checksumSHA1": "oXqmd1jisrEbLi8ddHjWSbC0Q4Y=",
+			"checksumSHA1": "tZK0lOfBL913SA4v+HPSt82qFPk=",
 			"path": "github.com/keybase/client/go/libkb",
-			"revision": "f35826eefd55d682452d5ffaf8d358dbca9244bd",
-			"revisionTime": "2017-11-29T22:38:30Z"
+			"revision": "3e2c0a458f275240a9f72cac1d4a915bc006f819",
+			"revisionTime": "2017-12-08T18:15:30Z"
 		},
 		{
 			"checksumSHA1": "7hmQDQK0qYzI18c7+7n7eWl9JPQ=",
@@ -231,10 +231,10 @@
 			"revisionTime": "2017-11-03T20:00:56Z"
 		},
 		{
-			"checksumSHA1": "EEnErI8BBFR86mUfhlsDzUbXVog=",
+			"checksumSHA1": "IUx1QAaYro5K+GakiEQoLpwm1JM=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "e961f9f2a7e58ae0562cf347e03bc2e5a66b8e48",
-			"revisionTime": "2017-12-01T22:03:36Z"
+			"revision": "0115f511284c7d7f84f1c2e85883c6c0693afd45",
+			"revisionTime": "2017-12-08T20:02:30Z"
 		},
 		{
 			"checksumSHA1": "o26ztx0R+4h9il8gTztHccctK+4=",


### PR DESCRIPTION
Previously we were only resolving from a TLF name -> implicit team ID.  But KBFS also needs to do the reverse, and the service just added an RPC to make it possible, so now we can make use of it.

Issue: KBFS-2621
