### PR TITLE
kbfsmd: return version error if incorrectly asked to make iteam MD

### DIFF
--- a/kbfsmd/root_metadata.go
+++ b/kbfsmd/root_metadata.go
@@ -322,8 +322,7 @@ func MakeInitialRootMetadata(
 	}
 	if ver < ImplicitTeamsVer && tlfID.Type() != tlf.SingleTeam &&
 		h.TypeForKeying() == tlf.TeamKeying {
-		return nil, errors.Errorf(
-			"Can't make an implicit teams TLF with version %s", ver)
+		return nil, NewMetadataVersionError{tlfID, ImplicitTeamsVer}
 	}
 
 	if ver < SegregatedKeyBundlesVer {


### PR DESCRIPTION
If the mdserver turns on support for iteams, but we are running without that support turned on yet (i.e., in prod mode), we should return a NewMetadataVersionError instead of a generic error, so that the user will get a popup about needing to upgrade instead of just a plain EIO.

Issue: KBFS-2621