### PR TITLE
folder_branch_ops: enable journal when setting first TLF head

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -805,6 +805,13 @@ func (fbo *folderBranchOps) setHeadLocked(
 			fbo.updateDoneChan = make(chan struct{})
 			go fbo.registerAndWaitForUpdates()
 		}
+		// If journaling is enabled, we should make sure to enable it
+		// for this TLF.  That's because we may have received the TLF
+		// ID from the service, rather than via a GetIDForHandle call,
+		// and so we might have skipped the journal.
+		if jServer, err := GetJournalServer(fbo.config); err == nil {
+			_, _ = jServer.getTLFJournal(fbo.id(), md.GetTlfHandle())
+		}
 	}
 	if !wasReadable && md.IsReadable() {
 		// Let any listeners know that this folder is now readable,


### PR DESCRIPTION
Once iteams are enabled and TLF IDs are stored in the team's sigchain, `KBFSOpsStandard` will be able to create a `folderBranchOps` without ever passing the TLF's handle through `journalMDOps`.  This is a problem, because the handle is required to enable a journal.  Without this, the journal won't get created until the first MD put with a revision > 1, which is too late because that will happen when the TLF is locally dirty, and we can't enable journals then.

So instead, enable the journal (if needed) the first time a head is set inside the FBO.

Issue: KBFS-2621