### PR TITLE
[KBFS-2650] Remove prefetches for updated pointers

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3374,6 +3374,8 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 				updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
 				lifetime)
 		}
+		// remove any prefetches for the old pointer from the prefetcher.
+		fbo.config.BlockOps().Prefetcher().RemovePrefetch(oldPtr.ID)
 	}
 }
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1246,6 +1246,9 @@ type Prefetcher interface {
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)
+	// RemovePrefetch notifies the prefetcher that a prefetch should be
+	// removed from the prefetcher, but not canceled.
+	RemovePrefetch(kbfsblock.ID)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4036,6 +4036,16 @@ func (mr *MockPrefetcherMockRecorder) CancelPrefetch(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).CancelPrefetch), arg0)
 }
 
+// RemovePrefetch mocks base method
+func (m *MockPrefetcher) RemovePrefetch(arg0 kbfsblock.ID) {
+	m.ctrl.Call(m, "RemovePrefetch", arg0)
+}
+
+// RemovePrefetch indicates an expected call of RemovePrefetch
+func (mr *MockPrefetcherMockRecorder) RemovePrefetch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePrefetch", reflect.TypeOf((*MockPrefetcher)(nil).RemovePrefetch), arg0)
+}
+
 // Shutdown mocks base method
 func (m *MockPrefetcher) Shutdown() <-chan struct{} {
 	ret := m.ctrl.Call(m, "Shutdown")


### PR DESCRIPTION
This will address when non-tail blocks are removed, but I'm not sure about tail blocks.