### PR TITLE
[KBFS-2650, KBFS-2651] Don't store actual block data in the prefetcher

### DIFF
--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -283,35 +283,43 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 }
 
 // Request implements the BlockRetriever interface for blockRetrievalQueue.
-func (brq *blockRetrievalQueue) Request(ctx context.Context,
+func (brq *blockRetrievalQueue) request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
-	lifetime BlockCacheLifetime) <-chan error {
+	lifetime BlockCacheLifetime, doPrefetch bool) <-chan error {
 	// Only continue if we haven't been shut down
 	ch := make(chan error, 1)
 	select {
 	case <-brq.doneCh:
 		ch <- io.EOF
-		brq.Prefetcher().CancelPrefetch(ptr.ID)
+		if doPrefetch {
+			brq.Prefetcher().CancelPrefetch(ptr.ID)
+		}
 		return ch
 	default:
 	}
 	if block == nil {
 		ch <- errors.New("nil block passed to blockRetrievalQueue.Request")
-		brq.Prefetcher().CancelPrefetch(ptr.ID)
+		if doPrefetch {
+			brq.Prefetcher().CancelPrefetch(ptr.ID)
+		}
 		return ch
 	}
 
 	// Check caches before locking the mutex.
 	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block)
 	if err == nil {
-		brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
-			priority, lifetime, prefetchStatus)
+		if doPrefetch {
+			brq.Prefetcher().ProcessBlockForPrefetch(ctx, ptr, block, kmd,
+				priority, lifetime, prefetchStatus)
+		}
 		ch <- nil
 		return ch
 	}
 	err = checkDataVersion(brq.config, path{}, ptr)
 	if err != nil {
-		brq.Prefetcher().CancelPrefetch(ptr.ID)
+		if doPrefetch {
+			brq.Prefetcher().CancelPrefetch(ptr.ID)
+		}
 		ch <- err
 		return ch
 	}
@@ -383,6 +391,20 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 		}
 	}
 	return ch
+}
+
+// Request implements the BlockRetriever interface for blockRetrievalQueue.
+func (brq *blockRetrievalQueue) Request(ctx context.Context,
+	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
+	lifetime BlockCacheLifetime) <-chan error {
+	return brq.request(ctx, priority, kmd, ptr, block, lifetime, true)
+}
+
+// Request implements the BlockRetriever interface for blockRetrievalQueue.
+func (brq *blockRetrievalQueue) RequestNoPrefetch(ctx context.Context,
+	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
+	lifetime BlockCacheLifetime) <-chan error {
+	return brq.request(ctx, priority, kmd, ptr, block, lifetime, false)
 }
 
 // FinalizeRequest is the last step of a retrieval request once a block has

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -282,7 +282,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	return prefetchStatus, err
 }
 
-// Request implements the BlockRetriever interface for blockRetrievalQueue.
+// request retrieves blocks asynchronously.
 func (brq *blockRetrievalQueue) request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime, doPrefetch bool) <-chan error {
@@ -400,7 +400,8 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	return brq.request(ctx, priority, kmd, ptr, block, lifetime, true)
 }
 
-// Request implements the BlockRetriever interface for blockRetrievalQueue.
+// RequestNoPrefetch implements the BlockRetriever interface for
+// blockRetrievalQueue.
 func (brq *blockRetrievalQueue) RequestNoPrefetch(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime) <-chan error {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3375,7 +3375,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 				lifetime)
 		}
 		// remove any prefetches for the old pointer from the prefetcher.
-		fbo.config.BlockOps().Prefetcher().RemovePrefetch(oldPtr.ID)
+		fbo.config.BlockOps().Prefetcher().CancelPrefetch(oldPtr.ID)
 	}
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3374,6 +3374,8 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 				updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
 				lifetime)
 		}
+		// remove any prefetches for the old pointer from the prefetcher.
+		fbo.config.BlockOps().Prefetcher().RemovePrefetch(oldPtr.ID)
 	}
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3374,7 +3374,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 				updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
 				lifetime)
 		}
-		// remove any prefetches for the old pointer from the prefetcher.
+		// Cancel any prefetches for the old pointer from the prefetcher.
 		fbo.config.BlockOps().Prefetcher().CancelPrefetch(oldPtr.ID)
 	}
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4663,6 +4663,10 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			return nil
 		}
 	}
+	// Remove any unreferenced blocks from the prefetcher.
+	for _, ptr := range op.Unrefs() {
+		fbo.config.BlockOps.Prefetcher().CancelPrefetch(ptr.ID)
+	}
 
 	fbo.observers.batchChanges(ctx, changes)
 	return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4663,9 +4663,9 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 			return nil
 		}
 	}
-	// Remove any unreferenced blocks from the prefetcher.
+	// Cancel any block prefetches for unreferenced blocks.
 	for _, ptr := range op.Unrefs() {
-		fbo.config.BlockOps.Prefetcher().CancelPrefetch(ptr.ID)
+		fbo.config.BlockOps().Prefetcher().CancelPrefetch(ptr.ID)
 	}
 
 	fbo.observers.batchChanges(ctx, changes)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4456,6 +4456,11 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		return err
 	}
 
+	// Cancel any block prefetches for unreferenced blocks.
+	for _, ptr := range op.Unrefs() {
+		fbo.config.BlockOps().Prefetcher().CancelPrefetch(ptr.ID)
+	}
+
 	var changes []NodeChange
 	switch realOp := op.(type) {
 	default:
@@ -4662,10 +4667,6 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 		if len(changes) == 0 {
 			return nil
 		}
-	}
-	// Cancel any block prefetches for unreferenced blocks.
-	for _, ptr := range op.Unrefs() {
-		fbo.config.BlockOps().Prefetcher().CancelPrefetch(ptr.ID)
 	}
 
 	fbo.observers.batchChanges(ctx, changes)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2015,6 +2015,10 @@ type BlockRetriever interface {
 	// Request retrieves blocks asynchronously.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+	// Request retrieves blocks asynchronously, but doesn't trigger a prefetch
+	// unless the block had to be retrieved from the server.
+	RequestNoPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
+		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
 	// PutInCaches puts the block into the in-memory cache, and ensures that
 	// the disk cache metadata is updated.
 	PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1246,9 +1246,6 @@ type Prefetcher interface {
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)
-	// RemovePrefetch notifies the prefetcher that a prefetch should be
-	// removed from the prefetcher, but not canceled.
-	RemovePrefetch(kbfsblock.ID)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2015,8 +2015,8 @@ type BlockRetriever interface {
 	// Request retrieves blocks asynchronously.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
-	// Request retrieves blocks asynchronously, but doesn't trigger a prefetch
-	// unless the block had to be retrieved from the server.
+	// RequestNoPrefetch retrieves blocks asynchronously, but doesn't trigger a
+	// prefetch unless the block had to be retrieved from the server.
 	RequestNoPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
 	// PutInCaches puts the block into the in-memory cache, and ensures that

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1246,6 +1246,9 @@ type Prefetcher interface {
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)
+	// RemovePrefetch notifies the prefetcher that a prefetch should be
+	// removed from the prefetcher, but not canceled.
+	RemovePrefetch(kbfsblock.ID)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -6969,6 +6969,18 @@ func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime)
 }
 
+// RequestNoPrefetch mocks base method
+func (m *MockBlockRetriever) RequestNoPrefetch(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
+	ret := m.ctrl.Call(m, "RequestNoPrefetch", ctx, priority, kmd, ptr, block, lifetime)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+// RequestNoPrefetch indicates an expected call of RequestNoPrefetch
+func (mr *MockBlockRetrieverMockRecorder) RequestNoPrefetch(ctx, priority, kmd, ptr, block, lifetime interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestNoPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestNoPrefetch), ctx, priority, kmd, ptr, block, lifetime)
+}
+
 // PutInCaches mocks base method
 func (m *MockBlockRetriever) PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
 	ret := m.ctrl.Call(m, "PutInCaches", ctx, ptr, tlfID, block, lifetime, prefetchStatus)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4036,16 +4036,6 @@ func (mr *MockPrefetcherMockRecorder) CancelPrefetch(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).CancelPrefetch), arg0)
 }
 
-// RemovePrefetch mocks base method
-func (m *MockPrefetcher) RemovePrefetch(arg0 kbfsblock.ID) {
-	m.ctrl.Call(m, "RemovePrefetch", arg0)
-}
-
-// RemovePrefetch indicates an expected call of RemovePrefetch
-func (mr *MockPrefetcherMockRecorder) RemovePrefetch(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePrefetch", reflect.TypeOf((*MockPrefetcher)(nil).RemovePrefetch), arg0)
-}
-
 // Shutdown mocks base method
 func (m *MockPrefetcher) Shutdown() <-chan struct{} {
 	ret := m.ctrl.Call(m, "Shutdown")

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4036,6 +4036,16 @@ func (mr *MockPrefetcherMockRecorder) CancelPrefetch(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).CancelPrefetch), arg0)
 }
 
+// RemovePrefetch mocks base method
+func (m *MockPrefetcher) RemovePrefetch(arg0 kbfsblock.ID) {
+	m.ctrl.Call(m, "RemovePrefetch", arg0)
+}
+
+// RemovePrefetch indicates an expected call of RemovePrefetch
+func (mr *MockPrefetcherMockRecorder) RemovePrefetch(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePrefetch", reflect.TypeOf((*MockPrefetcher)(nil).RemovePrefetch), arg0)
+}
+
 // Shutdown mocks base method
 func (m *MockPrefetcher) Shutdown() <-chan struct{} {
 	ret := m.ctrl.Call(m, "Shutdown")

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -195,15 +195,15 @@ func (p *blockPrefetcher) completePrefetch(
 			b := pp.req.block.NewEmpty()
 			// TODO: after we split out priority from whether to prefetch, make
 			// this a much higher priority.
-			err := <-p.retriever.Request(pre.ctx,
-				lowestTriggerPrefetchPriority-1, req.kmd, req.ptr, b,
-				req.lifetime)
+			err := <-p.retriever.Request(pp.ctx,
+				lowestTriggerPrefetchPriority-1, pp.req.kmd, pp.req.ptr, b,
+				pp.req.lifetime)
 			if err != nil {
 				p.log.CWarningf(pp.ctx, "failed to retrieve block to "+
 					"complete its prefetch, canceled it instead: %+v", err)
 				return
 			}
-			err := p.retriever.PutInCaches(pp.ctx, pp.req.ptr,
+			err = p.retriever.PutInCaches(pp.ctx, pp.req.ptr,
 				pp.req.kmd.TlfID(), b, pp.req.lifetime,
 				FinishedPrefetch)
 			if err != nil {
@@ -414,7 +414,7 @@ func (p *blockPrefetcher) handlePrefetch(pre *prefetch, isPrefetchNew,
 	err = <-p.retriever.Request(pre.ctx, lowestTriggerPrefetchPriority-1,
 		req.kmd, req.ptr, b, req.lifetime)
 	if err != nil {
-		p.log.CDebugf(ctx, "failed to retrieve block %s to handle its "+
+		p.log.CDebugf(pre.ctx, "failed to retrieve block %s to handle its "+
 			"prefetch: %+v", req.ptr.ID, err)
 		return 0, false, err
 	}

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -286,11 +286,8 @@ func (p *blockPrefetcher) calculatePriority(basePriority int,
 	return basePriority
 }
 
-// request maps the parent->child block relationship. `numBlocks` represents
-// the number of blocks that need to be accounted in `parentBlockID`.
-// `needNewFetch` represents whether we need to fetch `ptr.ID`, or
-// whether such a fetch has already been triggered. Finally, it triggers child
-// prefetches that aren't already in progress.
+// request maps the parent->child block relationship in the prefetcher, and it
+// triggers child prefetches that aren't already in progress.
 func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime, parentBlockID kbfsblock.ID,

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -195,7 +195,7 @@ func (p *blockPrefetcher) completePrefetch(
 			b := pp.req.block.NewEmpty()
 			// TODO: after we split out priority from whether to prefetch, make
 			// this a much higher priority.
-			err := <-p.retriever.Request(pp.ctx,
+			err := <-p.retriever.RequestNoPrefetch(pp.ctx,
 				lowestTriggerPrefetchPriority-1, pp.req.kmd, pp.req.ptr, b,
 				pp.req.lifetime)
 			if err != nil {
@@ -411,8 +411,8 @@ func (p *blockPrefetcher) handlePrefetch(pre *prefetch, isPrefetchNew,
 	b := req.block.NewEmpty()
 	// TODO: after we split out priority from whether to prefetch, make this a
 	// much higher priority.
-	err = <-p.retriever.Request(pre.ctx, lowestTriggerPrefetchPriority-1,
-		req.kmd, req.ptr, b, req.lifetime)
+	err = <-p.retriever.RequestNoPrefetch(pre.ctx,
+		lowestTriggerPrefetchPriority-1, req.kmd, req.ptr, b, req.lifetime)
 	if err != nil {
 		p.log.CDebugf(pre.ctx, "failed to retrieve block %s to handle its "+
 			"prefetch: %+v", req.ptr.ID, err)

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -77,8 +77,6 @@ type blockPrefetcher struct {
 	prefetchRequestCh channels.Channel
 	// channel to cancel prefetches
 	prefetchCancelCh channels.Channel
-	// channel to remove prefetches
-	prefetchRemovalCh channels.Channel
 	// channel to allow synchronization on completion
 	inFlightFetches channels.Channel
 	// protects shutdownCh
@@ -104,7 +102,6 @@ func newBlockPrefetcher(retriever BlockRetriever,
 		retriever:         retriever,
 		prefetchRequestCh: newInfiniteChannelWrapper(),
 		prefetchCancelCh:  newInfiniteChannelWrapper(),
-		prefetchRemovalCh: newInfiniteChannelWrapper(),
 		inFlightFetches:   newInfiniteChannelWrapper(),
 		shutdownCh:        make(chan struct{}),
 		almostDoneCh:      make(chan struct{}, 1),
@@ -210,25 +207,6 @@ func (p *blockPrefetcher) completePrefetch(
 				p.log.CWarningf(pp.ctx, "failed to complete prefetch due to "+
 					"cache error, canceled it instead: %+v", err)
 			}
-		}
-	}
-}
-
-// Walk up the block tree subtracting `numBlocks` from each node. Any zeroes we
-// hit get deleted from the prefetcher (but not cached).
-func (p *blockPrefetcher) removePrefetch(
-	numBlocks int) func(kbfsblock.ID, *prefetch) {
-	return func(blockID kbfsblock.ID, pp *prefetch) {
-		pp.subtreeBlockCount -= numBlocks
-		if pp.subtreeBlockCount < 0 {
-			// Both log and panic so that we get the PFID in the log.
-			p.log.CErrorf(pp.ctx, "panic: removePrefetch "+
-				"overstepped its bounds")
-			panic("removePrefetch overstepped its bounds")
-		}
-		if pp.subtreeBlockCount == 0 {
-			delete(p.prefetches, blockID)
-			pp.Close()
 		}
 	}
 }
@@ -480,7 +458,6 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 		close(p.doneCh)
 		p.prefetchRequestCh.Close()
 		p.prefetchCancelCh.Close()
-		p.prefetchRemovalCh.Close()
 		p.inFlightFetches.Close()
 	}()
 	isShuttingDown := false
@@ -489,7 +466,6 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 		if isShuttingDown {
 			if p.inFlightFetches.Len() == 0 &&
 				p.prefetchRequestCh.Len() == 0 &&
-				p.prefetchRemovalCh.Len() == 0 &&
 				p.prefetchCancelCh.Len() == 0 {
 				return
 			}
@@ -512,17 +488,6 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 			p.log.Debug("canceling prefetch for block %s", blockID)
 			// Walk up the block tree and delete every parent.
 			p.applyToParentsRecursive(p.cancelPrefetch, blockID, pre)
-		case bid := <-p.prefetchRemovalCh.Out():
-			blockID := bid.(kbfsblock.ID)
-			pre, ok := p.prefetches[blockID]
-			if !ok {
-				p.log.Debug("nothing to remove for block %s", blockID)
-				continue
-			}
-			p.log.Debug("removing prefetch for block %s", blockID)
-			// Walk up the block tree and delete every parent.
-			p.applyToParentsRecursive(
-				p.removePrefetch(pre.subtreeBlockCount), blockID, pre)
 		case reqInt := <-p.prefetchRequestCh.Out():
 			req := reqInt.(*prefetchRequest)
 			pre, isPrefetchWaiting := p.prefetches[req.ptr.ID]
@@ -766,15 +731,6 @@ func (p *blockPrefetcher) CancelPrefetch(blockID kbfsblock.ID) {
 	case p.prefetchCancelCh.In() <- blockID:
 	case <-p.shutdownCh:
 		p.log.Warning("Skipping prefetch cancel for block %v since "+
-			"the prefetcher is shutdown", blockID)
-	}
-}
-
-func (p *blockPrefetcher) RemovePrefetch(blockID kbfsblock.ID) {
-	select {
-	case p.prefetchRemovalCh.In() <- blockID:
-	case <-p.shutdownCh:
-		p.log.Warning("Skipping prefetch removal for block %v since "+
 			"the prefetcher is shutdown", blockID)
 	}
 }


### PR DESCRIPTION
* We no longer store actual block data in the prefetcher so it doesn't run out of memory. Instead, we store an empty block of the correct type.
  * To facilitate this, I made a new API for `BlockRetriever` that allows the prefetcher to fetch a block on-demand without triggering prefetches when the block is available in one of the caches.
* Added an API to remove blocks from the prefetcher without automatically canceling their parent blocks.
  * Consume that API in `updatePointer`, to remove old blocks still being prefetched.
  * In-flight prefetches get automatically canceled by the prefetch context being closed.