### PR TITLE
Make 'kbfstool md dump' dump more info

### DIFF
--- a/kbfsmd/errors.go
+++ b/kbfsmd/errors.go
@@ -183,3 +183,13 @@ type MutableRootMetadataNoImplError struct {
 func (e MutableRootMetadataNoImplError) Error() string {
 	return "Does not implement MutableRootMetadata"
 }
+
+// InvalidIDError indicates that a metadata ID string is not parseable
+// or invalid.
+type InvalidIDError struct {
+	id string
+}
+
+func (e InvalidIDError) Error() string {
+	return fmt.Sprintf("Invalid metadata ID %q", e.id)
+}

--- a/kbfsmd/root_metadata.go
+++ b/kbfsmd/root_metadata.go
@@ -383,29 +383,28 @@ func DumpConfig() *spew.ConfigState {
 // DumpRootMetadata returns a detailed dump of the given
 // RootMetadata's contents.
 func DumpRootMetadata(
-	codec kbfscodec.Codec, brmd RootMetadata) (string, error) {
-	serializedBRMD, err := codec.Encode(brmd)
+	codec kbfscodec.Codec, rmd RootMetadata) (string, error) {
+	serializedRMD, err := codec.Encode(rmd)
 	if err != nil {
 		return "", err
 	}
 
 	// Make a copy so we can zero out SerializedPrivateMetadata.
-	brmdCopy, err := brmd.DeepCopy(codec)
+	rmdCopy, err := rmd.DeepCopy(codec)
 	if err != nil {
 		return "", err
 	}
 
-	switch brmdCopy := brmdCopy.(type) {
-	case *RootMetadataV2:
-		brmdCopy.SerializedPrivateMetadata = nil
-	case *RootMetadataV3:
-		brmdCopy.WriterMetadata.SerializedPrivateMetadata = nil
-	default:
-		// Do nothing, and let SerializedPrivateMetadata get
-		// spewed, I guess.
-	}
-	s := fmt.Sprintf("MD size: %d bytes\n"+
-		"MD version: %s\n\n", len(serializedBRMD), brmd.Version())
-	s += DumpConfig().Sdump(brmdCopy)
+	rmdCopy.SetSerializedPrivateMetadata(nil)
+	fmt.Printf("MD revision: %s\n", rmd.RevisionNumber())
+	s := fmt.Sprintf("MD revision: %s\n"+
+		"MD size: %d bytes\n"+
+		"Private MD size: %d bytes\n"+
+		"MD version: %s\n\n",
+		rmd.Version(),
+		len(serializedRMD),
+		len(rmd.GetSerializedPrivateMetadata()),
+		rmd.Version())
+	s += DumpConfig().Sdump(rmdCopy)
 	return s, nil
 }

--- a/kbfsmd/root_metadata.go
+++ b/kbfsmd/root_metadata.go
@@ -396,12 +396,11 @@ func DumpRootMetadata(
 	}
 
 	rmdCopy.SetSerializedPrivateMetadata(nil)
-	fmt.Printf("MD revision: %s\n", rmd.RevisionNumber())
 	s := fmt.Sprintf("MD revision: %s\n"+
 		"MD size: %d bytes\n"+
 		"Private MD size: %d bytes\n"+
 		"MD version: %s\n\n",
-		rmd.Version(),
+		rmd.RevisionNumber(),
 		len(serializedRMD),
 		len(rmd.GetSerializedPrivateMetadata()),
 		rmd.Version())

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -12,7 +12,9 @@ import (
 const mdCheckUsageStr = `Usage:
   kbfstool md check input [inputs...]
 
-Each input must be in the same format as in md dump.
+Each input must be in the same format as in md dump. However,
+revisions in a revision range rev1-rev2 are always checked in
+descending order, regardless of whether rev1 <= rev2 or rev1 > rev2.
 
 `
 

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -224,6 +224,9 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 			return 1
 		}
 
+		// The returned RMDs are already verified, so we don't
+		// have to do anything else.
+		//
 		// TODO: Chunk the range between start and stop.
 		irmds, reversed, err :=
 			mdGet(ctx, config, tlfID, branchID, start, stop)

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -176,7 +176,7 @@ func mdCheckChain(ctx context.Context, config libkbfs.Config,
 	return reversedIRMDsWithRoots
 }
 
-func mdCheckOne(ctx context.Context, config libkbfs.Config,
+func mdCheckIRMDs(ctx context.Context, config libkbfs.Config,
 	tlfStr, branchStr string, reversedIRMDs []libkbfs.ImmutableRootMetadata,
 	verbose bool) error {
 	reversedIRMDsWithRoots :=
@@ -247,7 +247,7 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 		}
 
 		reversedIRMDs := reverseIRMDList(irmds)
-		err = mdCheckOne(ctx, config, tlfStr, branchStr, reversedIRMDs, *verbose)
+		err = mdCheckIRMDs(ctx, config, tlfStr, branchStr, reversedIRMDs, *verbose)
 		if err != nil {
 			printError("md check", err)
 			return 1

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -213,7 +213,15 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 	}
 
 	for _, input := range inputs {
-		irmds, reversed, err := mdParseAndGet(ctx, config, input)
+		tlfID, branchID, start, stop, err := mdParse(ctx, config, input)
+		if err != nil {
+			printError("md check", err)
+			return 1
+		}
+
+		// TODO: Chunk the range between start and stop.
+		irmds, reversed, err :=
+			mdGet(ctx, config, tlfID, branchID, start, stop)
 		if err != nil {
 			printError("md check", err)
 			return 1

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -213,7 +213,8 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 	}
 
 	for _, input := range inputs {
-		tlfID, branchID, start, stop, err := mdParse(ctx, config, input)
+		tlfID, branchID, start, stop, err :=
+			mdParseInput(ctx, config, input)
 		if err != nil {
 			printError("md check", err)
 			return 1

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -101,9 +101,9 @@ func checkFileBlock(ctx context.Context, config libkbfs.Config,
 	return nil
 }
 
-// mdCheckChain checks that the every MD object in the given list is a
-// valid successor of the next object in the list. Along the way,
-// it also checks that the root blocks that haven't been
+// mdCheckChain checks that every MD object in the given list is a
+// valid successor of the next object in the list. Along the way, it
+// also checks that the root blocks that haven't been
 // garbage-collected are present. It returns a list of MD objects with
 // valid roots, in reverse revision order. If multiple MD objects have
 // the same root (which are assumed to all be adjacent), the most

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -224,12 +224,18 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 			return 1
 		}
 
+		min := start
+		max := stop
+		if start > stop {
+			min = stop
+			max = start
+		}
+
 		// The returned RMDs are already verified, so we don't
 		// have to do anything else.
 		//
 		// TODO: Chunk the range between start and stop.
-		irmds, reversed, err :=
-			mdGet(ctx, config, tlfID, branchID, start, stop)
+		irmds, err := mdGet(ctx, config, tlfID, branchID, min, max)
 		if err != nil {
 			printError("md check", err)
 			return 1
@@ -240,11 +246,7 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 			continue
 		}
 
-		reversedIRMDs := irmds
-		if !reversed {
-			reversedIRMDs = reverseIRMDList(irmds)
-		}
-
+		reversedIRMDs := reverseIRMDList(irmds)
 		err = mdCheckOne(ctx, config, tlfStr, branchStr, reversedIRMDs, *verbose)
 		if err != nil {
 			printError("md check", err)

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -213,8 +213,14 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 	}
 
 	for _, input := range inputs {
+		tlfStr, branchStr, startStr, stopStr, err := mdSplitInput(input)
+		if err != nil {
+			printError("md check", err)
+			return 1
+		}
+
 		tlfID, branchID, start, stop, err :=
-			mdParseInput(ctx, config, input)
+			mdParseInput(ctx, config, tlfStr, branchStr, startStr, stopStr)
 		if err != nil {
 			printError("md check", err)
 			return 1

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -177,7 +177,7 @@ func mdCheckChain(ctx context.Context, config libkbfs.Config,
 }
 
 func mdCheckOne(ctx context.Context, config libkbfs.Config,
-	input string, reversedIRMDs []libkbfs.ImmutableRootMetadata,
+	tlfStr, branchStr string, reversedIRMDs []libkbfs.ImmutableRootMetadata,
 	verbose bool) error {
 	reversedIRMDsWithRoots :=
 		mdCheckChain(ctx, config, reversedIRMDs, verbose)
@@ -185,12 +185,10 @@ func mdCheckOne(ctx context.Context, config libkbfs.Config,
 	fmt.Printf("Retrieved %d MD objects with roots\n", len(reversedIRMDsWithRoots))
 
 	for _, irmd := range reversedIRMDsWithRoots {
-		fmt.Printf("Checking revision %d...\n", irmd.Revision())
-
 		// No need to check the blocks for unembedded changes,
 		// since they're already checked upon retrieval.
-
-		_ = checkDirBlock(ctx, config, input, irmd,
+		name := mdJoinInput(tlfStr, branchStr, irmd.Revision().String(), "")
+		_ = checkDirBlock(ctx, config, name, irmd,
 			irmd.Data().Dir.BlockInfo, verbose)
 	}
 	return nil
@@ -244,7 +242,7 @@ func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 			reversedIRMDs = reverseIRMDList(irmds)
 		}
 
-		err = mdCheckOne(ctx, config, input, reversedIRMDs, *verbose)
+		err = mdCheckOne(ctx, config, tlfStr, branchStr, reversedIRMDs, *verbose)
 		if err != nil {
 			printError("md check", err)
 			return 1

--- a/kbfstool/md_check.go
+++ b/kbfstool/md_check.go
@@ -230,6 +230,7 @@ func mdCheckOne(ctx context.Context, config libkbfs.Config,
 func mdCheck(ctx context.Context, config libkbfs.Config, args []string) (
 	exitStatus int) {
 	flags := flag.NewFlagSet("kbfs md check", flag.ContinueOnError)
+	// TODO: Remove in favor of revision ranges.
 	mdLimit := flags.Int("fetch-limit", 100,
 		"Maximum number of MD objects to fetch (per argument).")
 	verbose := flags.Bool("v", false, "Print verbose output.")

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -201,7 +201,7 @@ func mdParseAndGet(ctx context.Context, config libkbfs.Config, input string) (
 		return nil, err
 	}
 
-	// TODO: Chunk start and stop.
+	// TODO: Chunk the range between start and stop.
 
 	stop := start
 	if stopStr != "" {

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -78,8 +78,7 @@ func getRevision(ctx context.Context, config libkbfs.Config,
 		if branchID == kbfsmd.NullBranchID {
 			irmd, err := config.MDOps().GetForTLF(ctx, tlfID, nil)
 			if err != nil {
-				return kbfsmd.RevisionUninitialized,
-					err
+				return kbfsmd.RevisionUninitialized, err
 			}
 			return irmd.Revision(), nil
 		}

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -12,6 +11,7 @@ import (
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -44,7 +44,7 @@ func getTlfID(
 	tlfID, err := tlf.ParseID(tlfStr)
 	if err == nil {
 		return tlfID, nil
-	} else if _, ok := err.(tlf.InvalidIDError); !ok {
+	} else if _, ok := errors.Cause(err).(tlf.InvalidIDError); !ok {
 		return tlf.ID{}, err
 	}
 

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -36,6 +36,11 @@ func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI,
 func getTlfID(
 	ctx context.Context, config libkbfs.Config, tlfStr string) (
 	tlf.ID, error) {
+	_, err := kbfsmd.ParseID(tlfStr)
+	if err == nil {
+		return tlf.ID{}, errors.New("Cannot handle metadata IDs")
+	}
+
 	tlfID, err := tlf.ParseID(tlfStr)
 	if err == nil {
 		return tlfID, nil

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var mdGetRegexp = regexp.MustCompile("^(.+?)(?::(.*?))?(?:\\^(.*?))?$")
+var mdGetRegexp = regexp.MustCompile("^(.+?)(?::(.*?))?(?:\\^(.*?)(?:-(.*?))?)?$")
 
 func parseTLFPath(ctx context.Context, kbpki libkbfs.KBPKI,
 	mdOps libkbfs.MDOps, tlfStr string) (*libkbfs.TlfHandle, error) {

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -38,6 +38,8 @@ func getTlfID(
 	tlfID, err := tlf.ParseID(tlfStr)
 	if err == nil {
 		return tlfID, nil
+	} else if _, ok := err.(tlf.InvalidIDError); !ok {
+		return tlf.ID{}, err
 	}
 
 	handle, err := parseTLFPath(ctx, config.KBPKI(), config.MDOps(), tlfStr)

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -27,6 +27,20 @@ func mdSplitInput(input string) (
 	return matches[1], matches[2], matches[3], matches[4], nil
 }
 
+func mdJoinInput(tlfStr, branchStr, startStr, stopStr string) string {
+	s := tlfStr
+	if branchStr != "" {
+		s += ":" + branchStr
+	}
+	if startStr != "" || stopStr != "" {
+		s += "^" + startStr
+		if stopStr != "" {
+			s += "-" + stopStr
+		}
+	}
+	return s
+}
+
 func mdParseInput(ctx context.Context, config libkbfs.Config, input string) (
 	tlfID tlf.ID, branchID kbfsmd.BranchID, start, stop kbfsmd.Revision, err error) {
 	tlfStr, branchStr, startStr, stopStr, err := mdSplitInput(input)

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -192,6 +192,10 @@ func mdParseAndGet(ctx context.Context, config libkbfs.Config, input string) (
 		}
 	}
 
+	if start > stop {
+		return nil, fmt.Errorf("start=%s > stop=%s", start, stop)
+	}
+
 	return mdGet(ctx, config, tlfID, branchID, start, stop)
 }
 

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -124,8 +124,8 @@ func mdGet(ctx context.Context, config libkbfs.Config, tlfID tlf.ID,
 
 	var latestIRMD libkbfs.ImmutableRootMetadata
 	var uid keybase1.UID
-	for i, rmd := range irmds {
-		if !rmd.IsReadable() {
+	for i, irmd := range irmds {
+		if !irmd.IsReadable() {
 			if latestIRMD == (libkbfs.ImmutableRootMetadata{}) {
 				if branchID == kbfsmd.NullBranchID {
 					latestIRMD, err = config.MDOps().GetForTLF(ctx, tlfID, nil)
@@ -146,7 +146,7 @@ func mdGet(ctx context.Context, config libkbfs.Config, tlfID tlf.ID,
 			}
 
 			irmdCopy, err := libkbfs.MakeCopyWithDecryptedPrivateData(
-				ctx, config, rmd, latestIRMD, uid)
+				ctx, config, irmd, latestIRMD, uid)
 			if err != nil {
 				return nil, err
 			}

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -41,14 +41,9 @@ func mdJoinInput(tlfStr, branchStr, startStr, stopStr string) string {
 	return s
 }
 
-func mdParseInput(ctx context.Context, config libkbfs.Config, input string) (
+func mdParseInput(ctx context.Context, config libkbfs.Config,
+	tlfStr, branchStr, startStr, stopStr string) (
 	tlfID tlf.ID, branchID kbfsmd.BranchID, start, stop kbfsmd.Revision, err error) {
-	tlfStr, branchStr, startStr, stopStr, err := mdSplitInput(input)
-	if err != nil {
-		return tlf.ID{}, kbfsmd.BranchID{}, kbfsmd.RevisionUninitialized,
-			kbfsmd.RevisionUninitialized, fmt.Errorf("Could not parse %q", input)
-	}
-
 	tlfID, err = getTlfID(ctx, config, tlfStr)
 	if err != nil {
 		return tlf.ID{}, kbfsmd.BranchID{}, kbfsmd.RevisionUninitialized,

--- a/kbfstool/md_common.go
+++ b/kbfstool/md_common.go
@@ -201,6 +201,8 @@ func mdParseAndGet(ctx context.Context, config libkbfs.Config, input string) (
 		return nil, err
 	}
 
+	// TODO: Chunk start and stop.
+
 	stop := start
 	if stopStr != "" {
 		stop, err = getRevision(ctx, config, tlfID, branchID, stopStr)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -24,6 +24,7 @@ func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 	fmt.Printf("Local timestamp: %s\n", irmd.LocalTimestamp())
 	fmt.Printf("Last modifying writer verifying key: %s\n",
 		mdDumpReplaceAll(irmd.LastModifyingWriterVerifyingKey().String(), replacements))
+	fmt.Print("\n")
 
 	return mdDumpReadOnlyRMDWithReplacements(
 		ctx, config.Codec(), irmd.ReadOnly(), replacements)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -19,9 +19,8 @@ func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 
 	fmt.Printf("MD ID: %s\n", irmd.MdID())
 	fmt.Printf("Local timestamp: %s\n", irmd.LocalTimestamp())
-	// TODO: Make this human-readable.
 	fmt.Printf("Last modifying writer verifying key: %s\n",
-		irmd.LastModifyingWriterVerifyingKey())
+		mdDumpReplaceAll(irmd.LastModifyingWriterVerifyingKey().String(), replacements))
 
 	return mdDumpReadOnlyRMDWithReplacements(
 		ctx, config.Codec(), irmd.ReadOnly(), replacements)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -36,6 +36,8 @@ func mdDumpGetReplacements(ctx context.Context, codec kbfscodec.Codec,
 		return nil, err
 	}
 
+	// TODO: Add caching for the service calls.
+
 	replacements := make(map[string]string)
 	for _, userKeys := range []kbfsmd.UserDevicePublicKeys{writers, readers} {
 		for u, deviceKeys := range userKeys {

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -9,10 +9,11 @@ import (
 )
 
 func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
-	irmd libkbfs.ImmutableRootMetadata) error {
-	replacements, err := mdDumpGetReplacements(
+	irmd libkbfs.ImmutableRootMetadata,
+	replacements map[string]string) error {
+	err := mdDumpFillReplacements(
 		ctx, "md dump", config.Codec(), config.KeybaseService(),
-		irmd.GetBareRootMetadata(), irmd.Extra())
+		irmd.GetBareRootMetadata(), irmd.Extra(), replacements)
 	if err != nil {
 		printError("md dump", err)
 	}
@@ -84,6 +85,8 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 		return 1
 	}
 
+	replacements := make(map[string]string)
+
 	for _, input := range inputs {
 		irmds, err := mdParseAndGet(ctx, config, input)
 		if err != nil {
@@ -94,7 +97,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 		fmt.Printf("%d results for %q:\n\n", len(irmds), input)
 
 		for _, irmd := range irmds {
-			err = mdDumpImmutableRMD(ctx, config, irmd)
+			err = mdDumpImmutableRMD(ctx, config, irmd, replacements)
 			if err != nil {
 				printError("md dump", err)
 				return 1

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -38,7 +38,7 @@ Each input must be in the following format:
 
   TLF
   TLF:Branch
-  TLF^Revisions
+  TLF^RevisionRange
   TLF:Branch^RevisionRange
 
 where TLF can be:

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -197,7 +197,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 			return 1
 		}
 
-		fmt.Printf("%s results for %q:\n\n", len(irmds), input)
+		fmt.Printf("%d results for %q:\n\n", len(irmds), input)
 
 		for _, irmd := range irmds {
 			err = mdDumpImmutableRMD(ctx, config, irmd)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -82,6 +82,11 @@ func mdDumpOne(ctx context.Context, config libkbfs.Config,
 		return err
 	}
 
+	// TODO: Ideally we'd fetch MDs concurrently with dumping
+	// them, but this works well enough for now.
+	//
+	// TODO: Make maxChunkSize configurable.
+
 	const maxChunkSize = 100
 
 	if start <= stop {

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -23,7 +23,7 @@ func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 
 	fmt.Printf("MD ID: %s\n", irmd.MdID())
 	fmt.Printf("Local timestamp: %s\n", irmd.LocalTimestamp())
-	fmt.Printf("Last modifying writer verifying key: %s\n",
+	fmt.Printf("Last modifying device (verifying key): %s\n",
 		mdDumpReplaceAll(irmd.LastModifyingWriterVerifyingKey().String(), replacements))
 	fmt.Print("\n")
 

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -14,7 +14,7 @@ func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 	replacements map[string]string,
 	irmd libkbfs.ImmutableRootMetadata) error {
 	err := mdDumpFillReplacements(
-		ctx, "md dump", config.Codec(), config.KeybaseService(),
+		ctx, config.Codec(), config.KeybaseService(), "md dump",
 		irmd.GetBareRootMetadata(), irmd.Extra(), replacements)
 	if err != nil {
 		printError("md dump", err)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -128,6 +128,10 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 	irmd libkbfs.ImmutableRootMetadata) error {
 	fmt.Printf("MD ID: %s\n", irmd.MdID())
+	fmt.Printf("Local timestamp: %s\n", irmd.LocalTimestamp())
+	// TODO: Make this human-readable.
+	fmt.Printf("Last modifying writer verifying key: %s\n",
+		irmd.LastModifyingWriterVerifyingKey())
 
 	return mdDumpReadOnlyRMD(ctx, config, irmd.ReadOnly())
 }

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -193,15 +193,9 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 			return 1
 		}
 
-		if len(irmds) == 0 {
-			fmt.Printf("No result found for %q\n\n", input)
-			continue
-		}
+		fmt.Printf("%s results for %q:\n\n", len(irmds), input)
 
-		// TODO: clean up.
 		for _, irmd := range irmds {
-			fmt.Printf("Result for %q:\n\n", input)
-
 			err = mdDumpImmutableRMD(ctx, config, irmd)
 			if err != nil {
 				printError("md dump", err)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -180,23 +180,26 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 	}
 
 	for _, input := range inputs {
-		irmd, err := mdParseAndGet(ctx, config, input)
+		irmds, err := mdParseAndGet(ctx, config, input)
 		if err != nil {
 			printError("md dump", err)
 			return 1
 		}
 
-		if irmd == (libkbfs.ImmutableRootMetadata{}) {
+		if len(irmds) == 0 {
 			fmt.Printf("No result found for %q\n\n", input)
 			continue
 		}
 
-		fmt.Printf("Result for %q:\n\n", input)
+		// TODO: clean up.
+		for _, irmd := range irmds {
+			fmt.Printf("Result for %q:\n\n", input)
 
-		err = mdDumpImmutableRMD(ctx, config, irmd)
-		if err != nil {
-			printError("md dump", err)
-			return 1
+			err = mdDumpImmutableRMD(ctx, config, irmd)
+			if err != nil {
+				printError("md dump", err)
+				return 1
+			}
 		}
 
 		fmt.Print("\n")

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -17,6 +17,9 @@ func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 		printError("md dump", err)
 	}
 
+	fmt.Print("Immutable metadata\n")
+	fmt.Print("------------------\n")
+
 	fmt.Printf("MD ID: %s\n", irmd.MdID())
 	fmt.Printf("Local timestamp: %s\n", irmd.LocalTimestamp())
 	fmt.Printf("Last modifying writer verifying key: %s\n",

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -69,7 +69,7 @@ func mdDumpChunk(ctx context.Context, config libkbfs.Config,
 	return nil
 }
 
-func mdDumpOne(ctx context.Context, config libkbfs.Config,
+func mdDumpInput(ctx context.Context, config libkbfs.Config,
 	replacements map[string]string, input string) error {
 	tlfStr, branchStr, startStr, stopStr, err := mdSplitInput(input)
 	if err != nil {
@@ -174,7 +174,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 	replacements := make(map[string]string)
 
 	for _, input := range inputs {
-		err := mdDumpOne(ctx, config, replacements, input)
+		err := mdDumpInput(ctx, config, replacements, input)
 		if err != nil {
 			printError("md dump", err)
 			return 1

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -82,9 +82,31 @@ func mdDumpOne(ctx context.Context, config libkbfs.Config,
 		return err
 	}
 
-	err = mdDumpChunk(ctx, config, replacements, tlfStr, branchStr, tlfID, branchID, start, stop)
-	if err != nil {
-		return err
+	const maxChunkSize = 100
+
+	if start <= stop {
+		for chunkStart := start; chunkStart <= stop; chunkStart += maxChunkSize {
+			chunkStop := chunkStart + maxChunkSize - 1
+			if chunkStop > stop {
+				chunkStop = stop
+			}
+			err = mdDumpChunk(ctx, config, replacements, tlfStr, branchStr, tlfID, branchID, chunkStart, chunkStop)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		for chunkStart := start; chunkStart >= stop; chunkStart -= maxChunkSize {
+			chunkStop := chunkStart - maxChunkSize + 1
+			if chunkStop < stop {
+				chunkStop = stop
+			}
+
+			err = mdDumpChunk(ctx, config, replacements, tlfStr, branchStr, tlfID, branchID, chunkStart, chunkStop)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -11,7 +11,7 @@ import (
 )
 
 func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
-	replacements map[string]string,
+	replacements replacementMap,
 	irmd libkbfs.ImmutableRootMetadata) error {
 	err := mdDumpFillReplacements(
 		ctx, config.Codec(), config.KeybaseService(), "md dump",
@@ -34,7 +34,7 @@ func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
 }
 
 func mdDumpChunk(ctx context.Context, config libkbfs.Config,
-	replacements map[string]string, tlfStr, branchStr string,
+	replacements replacementMap, tlfStr, branchStr string,
 	tlfID tlf.ID, branchID kbfsmd.BranchID,
 	start, stop kbfsmd.Revision) error {
 	min := start
@@ -70,7 +70,7 @@ func mdDumpChunk(ctx context.Context, config libkbfs.Config,
 }
 
 func mdDumpInput(ctx context.Context, config libkbfs.Config,
-	replacements map[string]string, input string) error {
+	replacements replacementMap, input string) error {
 	tlfStr, branchStr, startStr, stopStr, err := mdSplitInput(input)
 	if err != nil {
 		return err
@@ -175,7 +175,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 		return 1
 	}
 
-	replacements := make(map[string]string)
+	replacements := make(replacementMap)
 
 	for _, input := range inputs {
 		err := mdDumpInput(ctx, config, replacements, input)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -126,10 +126,10 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 }
 
 func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
-	rmd libkbfs.ImmutableRootMetadata) error {
-	fmt.Printf("MD ID: %s\n", rmd.MdID())
+	irmd libkbfs.ImmutableRootMetadata) error {
+	fmt.Printf("MD ID: %s\n", irmd.MdID())
 
-	return mdDumpReadOnlyRMD(ctx, config, rmd.ReadOnly())
+	return mdDumpReadOnlyRMD(ctx, config, irmd.ReadOnly())
 }
 
 const mdDumpUsageStr = `Usage:

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -88,7 +88,14 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 	replacements := make(map[string]string)
 
 	for _, input := range inputs {
-		irmds, _, err := mdParseAndGet(ctx, config, input)
+		tlfID, branchID, start, stop, err := mdParse(ctx, config, input)
+		if err != nil {
+			printError("md dump", err)
+			return 1
+		}
+
+		// TODO: Chunk the range between start and stop.
+		irmds, _, err := mdGet(ctx, config, tlfID, branchID, start, stop)
 		if err != nil {
 			printError("md dump", err)
 			return 1

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -3,175 +3,28 @@ package main
 import (
 	"flag"
 	"fmt"
-	"strings"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/keybase/kbfs/kbfscodec"
-	"github.com/keybase/kbfs/kbfscrypto"
-	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
 
-func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
-	string, bool) {
-	deviceName, ok := ui.KIDNames[k.KID()]
-	if !ok {
-		return "", false
-	}
-
-	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
-		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Unix.Time(), k), true
-	}
-
-	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
-}
-
-func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.UserInfo) (
-	string, bool) {
-	deviceName, ok := ui.KIDNames[k.KID()]
-	if !ok {
-		return "", false
-	}
-
-	if revokedTime, ok := ui.RevokedVerifyingKeys[k]; ok {
-		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Unix.Time(), k), true
-	}
-
-	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
-}
-
-func mdDumpGetReplacements(ctx context.Context, codec kbfscodec.Codec,
-	service libkbfs.KeybaseService, rmd kbfsmd.RootMetadata,
-	extra kbfsmd.ExtraMetadata) (map[string]string, error) {
-	writers, readers, err := rmd.GetUserDevicePublicKeys(extra)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: Add caching for the service calls.
-
-	replacements := make(map[string]string)
-	for _, userKeys := range []kbfsmd.UserDevicePublicKeys{writers, readers} {
-		for u, deviceKeys := range userKeys {
-			if _, ok := replacements[u.String()]; ok {
-				continue
-			}
-
-			username, _, err := service.Resolve(
-				ctx, fmt.Sprintf("uid:%s", u))
-			if err == nil {
-				replacements[u.String()] = fmt.Sprintf(
-					"%s (uid:%s)", username, u)
-			} else {
-				printError("md dump", err)
-			}
-
-			ui, err := service.LoadUserPlusKeys(ctx, u, "")
-			if err != nil {
-				continue
-			}
-
-			for k := range deviceKeys {
-				if _, ok := replacements[k.String()]; ok {
-					continue
-				}
-
-				if deviceStr, ok := mdDumpGetDeviceStringForCryptPublicKey(k, ui); ok {
-					replacements[k.String()] = deviceStr
-				}
-			}
-
-			// The MD doesn't know about verifying keys,
-			// so just go through all of them.
-
-			for _, k := range ui.VerifyingKeys {
-				if _, ok := replacements[k.String()]; ok {
-					continue
-				}
-
-				if deviceStr, ok := mdDumpGetDeviceStringForVerifyingKey(k, ui); ok {
-					replacements[k.String()] = deviceStr
-				}
-			}
-
-			for k := range ui.RevokedVerifyingKeys {
-				if _, ok := replacements[k.String()]; ok {
-					continue
-				}
-
-				if deviceStr, ok := mdDumpGetDeviceStringForVerifyingKey(k, ui); ok {
-					replacements[k.String()] = deviceStr
-				}
-			}
-		}
-	}
-
-	return replacements, nil
-}
-
-func mdDumpReplaceAll(s string, replacements map[string]string) string {
-	for old, new := range replacements {
-		s = strings.Replace(s, old, new, -1)
-	}
-	return s
-}
-
-func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
-	rmd libkbfs.ReadOnlyRootMetadata) error {
-	c := spew.NewDefaultConfig()
-	c.Indent = "  "
-	c.DisablePointerAddresses = true
-	c.DisableCapacities = true
-	c.SortKeys = true
-
-	brmd := rmd.GetBareRootMetadata()
-	extra := rmd.Extra()
-
+func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
+	irmd libkbfs.ImmutableRootMetadata) error {
 	replacements, err := mdDumpGetReplacements(
-		ctx, config.Codec(), config.KeybaseService(), brmd, extra)
+		ctx, "md dump", config.Codec(), config.KeybaseService(),
+		irmd.GetBareRootMetadata(), irmd.Extra())
 	if err != nil {
 		printError("md dump", err)
 	}
 
-	brmdDump, err := kbfsmd.DumpRootMetadata(config.Codec(), brmd)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s\n", mdDumpReplaceAll(brmdDump, replacements))
-
-	fmt.Print("Extra metadata\n")
-	fmt.Print("--------------\n")
-	extraDump, err := kbfsmd.DumpExtraMetadata(config.Codec(), extra)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s\n", mdDumpReplaceAll(extraDump, replacements))
-
-	fmt.Print("Private metadata\n")
-	fmt.Print("----------------\n")
-	pmdDump, err := libkbfs.DumpPrivateMetadata(
-		config.Codec(), rmd.GetSerializedPrivateMetadata(), *rmd.Data())
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s", mdDumpReplaceAll(pmdDump, replacements))
-
-	return nil
-}
-
-func mdDumpImmutableRMD(ctx context.Context, config libkbfs.Config,
-	irmd libkbfs.ImmutableRootMetadata) error {
 	fmt.Printf("MD ID: %s\n", irmd.MdID())
 	fmt.Printf("Local timestamp: %s\n", irmd.LocalTimestamp())
 	// TODO: Make this human-readable.
 	fmt.Printf("Last modifying writer verifying key: %s\n",
 		irmd.LastModifyingWriterVerifyingKey())
 
-	return mdDumpReadOnlyRMD(ctx, config, irmd.ReadOnly())
+	return mdDumpReadOnlyRMDWithReplacements(
+		ctx, config.Codec(), irmd.ReadOnly(), replacements)
 }
 
 const mdDumpUsageStr = `Usage:

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -129,8 +129,8 @@ Each input must be in the following format:
 
 where TLF can be:
 
-  - a TLF ID string (32 hex digits),
-  - or a keybase TLF path (e.g., "/keybase/public/user1,user2", or
+  - a TLF ID string (32 hex digits), or
+  - a keybase TLF path (e.g., "/keybase/public/user1,user2", or
     "/keybase/private/user1,assertion2");
 
 Branch can be:
@@ -155,6 +155,10 @@ where Revision can be:
     branch, or
   - omitted, in which case it is treated as if it were the string "latest".
 
+If a single revision "rev" is specified, it's treated as if the range
+"rev-rev" was specified. If a range "rev1-rev2" is specified, then the
+revisions are dumped in ascending order if rev1 <= rev2, and descending
+order if rev1 > rev2.
 `
 
 func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStatus int) {

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func mdDumpGetDeviceString(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
+func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
 	string, bool) {
 	deviceName, ok := ui.KIDNames[k.KID()]
 	if !ok {
@@ -64,7 +64,7 @@ func mdDumpGetReplacements(ctx context.Context, codec kbfscodec.Codec,
 					continue
 				}
 
-				if deviceStr, ok := mdDumpGetDeviceString(k, ui); ok {
+				if deviceStr, ok := mdDumpGetDeviceStringForCryptPublicKey(k, ui); ok {
 					replacements[k.String()] = deviceStr
 				}
 			}

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -88,7 +88,7 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 	replacements := make(map[string]string)
 
 	for _, input := range inputs {
-		irmds, err := mdParseAndGet(ctx, config, input)
+		irmds, _, err := mdParseAndGet(ctx, config, input)
 		if err != nil {
 			printError("md dump", err)
 			return 1

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -200,9 +200,9 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 				printError("md dump", err)
 				return 1
 			}
-		}
 
-		fmt.Print("\n")
+			fmt.Print("\n")
+		}
 	}
 
 	return 0

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -88,7 +88,8 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 	replacements := make(map[string]string)
 
 	for _, input := range inputs {
-		tlfID, branchID, start, stop, err := mdParse(ctx, config, input)
+		tlfID, branchID, start, stop, err :=
+			mdParseInput(ctx, config, input)
 		if err != nil {
 			printError("md dump", err)
 			return 1

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -139,8 +139,8 @@ Each input must be in the following format:
 
   TLF
   TLF:Branch
-  TLF^Revision
-  TLF:Branch^Revision
+  TLF^Revisions
+  TLF:Branch^RevisionRange
 
 where TLF can be:
 
@@ -157,7 +157,12 @@ Branch can be:
     the ID of the master branch "00000000000000000000000000000000", or
   - omitted, in which case it is treated as if it were the string "device";
 
-and Revision can be:
+and RevisionRange can be in the following format:
+
+  Revision
+  Revision-Revision
+
+where Revision can be:
 
   - a hex number prefixed with "0x",
   - a decimal number with no prefix,

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -88,8 +88,14 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 	replacements := make(map[string]string)
 
 	for _, input := range inputs {
+		tlfStr, branchStr, startStr, stopStr, err := mdSplitInput(input)
+		if err != nil {
+			printError("md dump", err)
+			return 1
+		}
+
 		tlfID, branchID, start, stop, err :=
-			mdParseInput(ctx, config, input)
+			mdParseInput(ctx, config, tlfStr, branchStr, startStr, stopStr)
 		if err != nil {
 			printError("md dump", err)
 			return 1

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -101,11 +101,24 @@ func mdDump(ctx context.Context, config libkbfs.Config, args []string) (exitStat
 			return 1
 		}
 
+		min := start
+		max := stop
+		reversed := false
+		if start > stop {
+			min = stop
+			max = start
+			reversed = true
+		}
+
 		// TODO: Chunk the range between start and stop.
-		irmds, _, err := mdGet(ctx, config, tlfID, branchID, start, stop)
+		irmds, err := mdGet(ctx, config, tlfID, branchID, min, max)
 		if err != nil {
 			printError("md dump", err)
 			return 1
+		}
+
+		if reversed {
+			irmds = reverseIRMDList(irmds)
 		}
 
 		fmt.Printf("%d results for %q:\n\n", len(irmds), input)

--- a/kbfstool/md_dump.go
+++ b/kbfstool/md_dump.go
@@ -113,7 +113,8 @@ func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
 
 	fmt.Print("Private metadata\n")
 	fmt.Print("----------------\n")
-	pmdDump, err := libkbfs.DumpPrivateMetadata(config.Codec(), *rmd.Data())
+	pmdDump, err := libkbfs.DumpPrivateMetadata(
+		config.Codec(), rmd.GetSerializedPrivateMetadata(), *rmd.Data())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -131,7 +131,7 @@ func mdDumpReplaceAll(s string, replacements map[string]string) string {
 
 func mdDumpReadOnlyRMDWithReplacements(
 	ctx context.Context, codec kbfscodec.Codec,
-	rmd libkbfs.ReadOnlyRootMetadata, replacements map[string]string) error {
+	replacements map[string]string, rmd libkbfs.ReadOnlyRootMetadata) error {
 	c := spew.NewDefaultConfig()
 	c.Indent = "  "
 	c.DisablePointerAddresses = true
@@ -169,8 +169,8 @@ func mdDumpReadOnlyRMDWithReplacements(
 }
 
 func mdDumpReadOnlyRMD(ctx context.Context, prefix string,
-	config libkbfs.Config, rmd libkbfs.ReadOnlyRootMetadata,
-	replacements map[string]string) error {
+	config libkbfs.Config, replacements map[string]string,
+	rmd libkbfs.ReadOnlyRootMetadata) error {
 	err := mdDumpFillReplacements(
 		ctx, prefix, config.Codec(), config.KeybaseService(),
 		rmd.GetBareRootMetadata(), rmd.Extra(), replacements)
@@ -179,5 +179,5 @@ func mdDumpReadOnlyRMD(ctx context.Context, prefix string,
 	}
 
 	return mdDumpReadOnlyRMDWithReplacements(
-		ctx, config.Codec(), rmd, replacements)
+		ctx, config.Codec(), replacements, rmd)
 }

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -159,7 +159,7 @@ func mdDumpReadOnlyRMDWithReplacements(
 	fmt.Print("Private metadata\n")
 	fmt.Print("----------------\n")
 	pmdDump, err := libkbfs.DumpPrivateMetadata(
-		codec, rmd.GetSerializedPrivateMetadata(), *rmd.Data())
+		codec, len(rmd.GetSerializedPrivateMetadata()), *rmd.Data())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -157,38 +157,13 @@ func mdDumpReadOnlyRMDWithReplacements(
 
 func mdDumpReadOnlyRMD(ctx context.Context, prefix string,
 	config libkbfs.Config, rmd libkbfs.ReadOnlyRootMetadata) error {
-	brmd := rmd.GetBareRootMetadata()
-	extra := rmd.Extra()
 	replacements, err := mdDumpGetReplacements(
 		ctx, prefix, config.Codec(), config.KeybaseService(),
-		brmd, extra)
+		rmd.GetBareRootMetadata(), rmd.Extra())
 	if err != nil {
 		printError(prefix, err)
 	}
 
-	brmdDump, err := kbfsmd.DumpRootMetadata(config.Codec(), brmd)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s\n", mdDumpReplaceAll(brmdDump, replacements))
-
-	fmt.Print("Extra metadata\n")
-	fmt.Print("--------------\n")
-	extraDump, err := kbfsmd.DumpExtraMetadata(config.Codec(), extra)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s\n", mdDumpReplaceAll(extraDump, replacements))
-
-	fmt.Print("Private metadata\n")
-	fmt.Print("----------------\n")
-	pmdDump, err := libkbfs.DumpPrivateMetadata(
-		config.Codec(), rmd.GetSerializedPrivateMetadata(), *rmd.Data())
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s", mdDumpReplaceAll(pmdDump, replacements))
-
-	return nil
+	return mdDumpReadOnlyRMDWithReplacements(
+		ctx, config.Codec(), rmd, replacements)
 }

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
+	string, bool) {
+	deviceName, ok := ui.KIDNames[k.KID()]
+	if !ok {
+		return "", false
+	}
+
+	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
+		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
+			deviceName, revokedTime.Unix.Time(), k), true
+	}
+
+	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
+}
+
+func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.UserInfo) (
+	string, bool) {
+	deviceName, ok := ui.KIDNames[k.KID()]
+	if !ok {
+		return "", false
+	}
+
+	if revokedTime, ok := ui.RevokedVerifyingKeys[k]; ok {
+		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
+			deviceName, revokedTime.Unix.Time(), k), true
+	}
+
+	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
+}
+
+func mdDumpGetReplacements(ctx context.Context, prefix string,
+	codec kbfscodec.Codec, service libkbfs.KeybaseService,
+	rmd kbfsmd.RootMetadata, extra kbfsmd.ExtraMetadata) (
+	map[string]string, error) {
+	writers, readers, err := rmd.GetUserDevicePublicKeys(extra)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Add caching for the service calls.
+
+	replacements := make(map[string]string)
+	for _, userKeys := range []kbfsmd.UserDevicePublicKeys{writers, readers} {
+		for u, deviceKeys := range userKeys {
+			if _, ok := replacements[u.String()]; ok {
+				continue
+			}
+
+			username, _, err := service.Resolve(
+				ctx, fmt.Sprintf("uid:%s", u))
+			if err == nil {
+				replacements[u.String()] = fmt.Sprintf(
+					"%s (uid:%s)", username, u)
+			} else {
+				printError(prefix, err)
+			}
+
+			ui, err := service.LoadUserPlusKeys(ctx, u, "")
+			if err != nil {
+				continue
+			}
+
+			for k := range deviceKeys {
+				if _, ok := replacements[k.String()]; ok {
+					continue
+				}
+
+				if deviceStr, ok := mdDumpGetDeviceStringForCryptPublicKey(k, ui); ok {
+					replacements[k.String()] = deviceStr
+				}
+			}
+
+			// The MD doesn't know about verifying keys,
+			// so just go through all of them.
+
+			for _, k := range ui.VerifyingKeys {
+				if _, ok := replacements[k.String()]; ok {
+					continue
+				}
+
+				if deviceStr, ok := mdDumpGetDeviceStringForVerifyingKey(k, ui); ok {
+					replacements[k.String()] = deviceStr
+				}
+			}
+
+			for k := range ui.RevokedVerifyingKeys {
+				if _, ok := replacements[k.String()]; ok {
+					continue
+				}
+
+				if deviceStr, ok := mdDumpGetDeviceStringForVerifyingKey(k, ui); ok {
+					replacements[k.String()] = deviceStr
+				}
+			}
+		}
+	}
+
+	return replacements, nil
+}
+
+func mdDumpReplaceAll(s string, replacements map[string]string) string {
+	for old, new := range replacements {
+		s = strings.Replace(s, old, new, -1)
+	}
+	return s
+}
+
+func mdDumpReadOnlyRMDWithReplacements(
+	ctx context.Context, codec kbfscodec.Codec,
+	rmd libkbfs.ReadOnlyRootMetadata, replacements map[string]string) error {
+	c := spew.NewDefaultConfig()
+	c.Indent = "  "
+	c.DisablePointerAddresses = true
+	c.DisableCapacities = true
+	c.SortKeys = true
+
+	brmdDump, err := kbfsmd.DumpRootMetadata(codec, rmd.GetBareRootMetadata())
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", mdDumpReplaceAll(brmdDump, replacements))
+
+	fmt.Print("Extra metadata\n")
+	fmt.Print("--------------\n")
+	extraDump, err := kbfsmd.DumpExtraMetadata(codec, rmd.Extra())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", mdDumpReplaceAll(extraDump, replacements))
+
+	fmt.Print("Private metadata\n")
+	fmt.Print("----------------\n")
+	pmdDump, err := libkbfs.DumpPrivateMetadata(
+		codec, rmd.GetSerializedPrivateMetadata(), *rmd.Data())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", mdDumpReplaceAll(pmdDump, replacements))
+
+	return nil
+}
+
+func mdDumpReadOnlyRMD(ctx context.Context, prefix string,
+	config libkbfs.Config, rmd libkbfs.ReadOnlyRootMetadata) error {
+	brmd := rmd.GetBareRootMetadata()
+	extra := rmd.Extra()
+	replacements, err := mdDumpGetReplacements(
+		ctx, prefix, config.Codec(), config.KeybaseService(),
+		brmd, extra)
+	if err != nil {
+		printError(prefix, err)
+	}
+
+	brmdDump, err := kbfsmd.DumpRootMetadata(config.Codec(), brmd)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s\n", mdDumpReplaceAll(brmdDump, replacements))
+
+	fmt.Print("Extra metadata\n")
+	fmt.Print("--------------\n")
+	extraDump, err := kbfsmd.DumpExtraMetadata(config.Codec(), extra)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", mdDumpReplaceAll(extraDump, replacements))
+
+	fmt.Print("Private metadata\n")
+	fmt.Print("----------------\n")
+	pmdDump, err := libkbfs.DumpPrivateMetadata(
+		config.Codec(), rmd.GetSerializedPrivateMetadata(), *rmd.Data())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s", mdDumpReplaceAll(pmdDump, replacements))
+
+	return nil
+}

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -12,6 +12,13 @@ import (
 	"golang.org/x/net/context"
 )
 
+// replacementMap is a map from a string to its replacement, intended
+// to provide human-readable strings to UIDs and KIDs. It is usually
+// created once per invocation and plumbed through everything that
+// uses it, filling it on-demand so as to avoid needless calls to the
+// service.
+type replacementMap map[string]string
+
 func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libkbfs.UserInfo) (
 	string, bool) {
 	deviceName, ok := ui.KIDNames[k.KID()]
@@ -45,7 +52,7 @@ func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.
 func mdDumpFillReplacements(ctx context.Context, codec kbfscodec.Codec,
 	service libkbfs.KeybaseService, prefix string,
 	rmd kbfsmd.RootMetadata, extra kbfsmd.ExtraMetadata,
-	replacements map[string]string) error {
+	replacements replacementMap) error {
 	writers, readers, err := rmd.GetUserDevicePublicKeys(extra)
 	if err != nil {
 		return err
@@ -122,7 +129,7 @@ func mdDumpFillReplacements(ctx context.Context, codec kbfscodec.Codec,
 	return nil
 }
 
-func mdDumpReplaceAll(s string, replacements map[string]string) string {
+func mdDumpReplaceAll(s string, replacements replacementMap) string {
 	for old, new := range replacements {
 		s = strings.Replace(s, old, new, -1)
 	}
@@ -131,7 +138,7 @@ func mdDumpReplaceAll(s string, replacements map[string]string) string {
 
 func mdDumpReadOnlyRMDWithReplacements(
 	ctx context.Context, codec kbfscodec.Codec,
-	replacements map[string]string, rmd libkbfs.ReadOnlyRootMetadata) error {
+	replacements replacementMap, rmd libkbfs.ReadOnlyRootMetadata) error {
 	c := spew.NewDefaultConfig()
 	c.Indent = "  "
 	c.DisablePointerAddresses = true
@@ -170,7 +177,7 @@ func mdDumpReadOnlyRMDWithReplacements(
 }
 
 func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
-	prefix string, replacements map[string]string,
+	prefix string, replacements replacementMap,
 	rmd libkbfs.ReadOnlyRootMetadata) error {
 	err := mdDumpFillReplacements(
 		ctx, config.Codec(), config.KeybaseService(),

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -128,6 +128,9 @@ func mdDumpReadOnlyRMDWithReplacements(
 	c.DisableCapacities = true
 	c.SortKeys = true
 
+	fmt.Print("Root metadata\n")
+	fmt.Print("-------------\n")
+
 	brmdDump, err := kbfsmd.DumpRootMetadata(codec, rmd.GetBareRootMetadata())
 	if err != nil {
 		return err

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -53,7 +53,10 @@ func mdDumpFillReplacements(ctx context.Context, prefix string,
 
 	for _, userKeys := range []kbfsmd.UserDevicePublicKeys{writers, readers} {
 		for u := range userKeys {
-			if _, ok := replacements[u.String()]; !ok {
+			// Make sure to only make one Resolve and one
+			// LoadUserPlusKeys call per user for a single
+			// replacements map.
+			if _, ok := replacements[u.String()]; ok {
 				continue
 			}
 
@@ -63,6 +66,8 @@ func mdDumpFillReplacements(ctx context.Context, prefix string,
 				replacements[u.String()] = fmt.Sprintf(
 					"%s (uid:%s)", username, u)
 			} else {
+				replacements[u.String()] = fmt.Sprintf(
+					"<unknown username> (uid:%s)", u)
 				printError(prefix, err)
 			}
 

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -42,8 +42,8 @@ func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.
 	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
 }
 
-func mdDumpFillReplacements(ctx context.Context, prefix string,
-	codec kbfscodec.Codec, service libkbfs.KeybaseService,
+func mdDumpFillReplacements(ctx context.Context, codec kbfscodec.Codec,
+	service libkbfs.KeybaseService, prefix string,
 	rmd kbfsmd.RootMetadata, extra kbfsmd.ExtraMetadata,
 	replacements map[string]string) error {
 	writers, readers, err := rmd.GetUserDevicePublicKeys(extra)
@@ -169,12 +169,12 @@ func mdDumpReadOnlyRMDWithReplacements(
 	return nil
 }
 
-func mdDumpReadOnlyRMD(ctx context.Context, prefix string,
-	config libkbfs.Config, replacements map[string]string,
+func mdDumpReadOnlyRMD(ctx context.Context, config libkbfs.Config,
+	prefix string, replacements map[string]string,
 	rmd libkbfs.ReadOnlyRootMetadata) error {
 	err := mdDumpFillReplacements(
-		ctx, prefix, config.Codec(), config.KeybaseService(),
-		rmd.GetBareRootMetadata(), rmd.Extra(), replacements)
+		ctx, config.Codec(), config.KeybaseService(),
+		prefix, rmd.GetBareRootMetadata(), rmd.Extra(), replacements)
 	if err != nil {
 		printError(prefix, err)
 	}

--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -163,6 +163,7 @@ func mdDumpReadOnlyRMDWithReplacements(
 	if err != nil {
 		return err
 	}
+	// Let the caller provide a trailing newline (if desired).
 	fmt.Printf("%s", mdDumpReplaceAll(pmdDump, replacements))
 
 	return nil

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -35,7 +35,7 @@ func mdForceQROne(
 
 	fmt.Printf(
 		"Will put a forced QR op up to revision %d:\n", irmd.Revision())
-	err = mdDumpReadOnlyRMD(ctx, config, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, "md forceQR", config, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -11,7 +11,7 @@ import (
 
 func mdForceQROne(
 	ctx context.Context, config libkbfs.Config, tlfPath string,
-	dryRun bool) error {
+	replacements map[string]string, dryRun bool) error {
 	// Get the latest head, and add a QR record up to that point.
 	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
@@ -35,7 +35,7 @@ func mdForceQROne(
 
 	fmt.Printf(
 		"Will put a forced QR op up to revision %d:\n", irmd.Revision())
-	err = mdDumpReadOnlyRMD(ctx, "md forceQR", config, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, "md forceQR", config, rmdNext.ReadOnly(), replacements)
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,9 @@ func mdForceQR(ctx context.Context, config libkbfs.Config,
 		return 1
 	}
 
-	err = mdForceQROne(ctx, config, inputs[0], *dryRun)
+	replacements := make(map[string]string)
+
+	err = mdForceQROne(ctx, config, inputs[0], replacements, *dryRun)
 	if err != nil {
 		printError("md forceQR", err)
 		return 1

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -35,7 +35,7 @@ func mdForceQROne(
 
 	fmt.Printf(
 		"Will put a forced QR op up to revision %d:\n", irmd.Revision())
-	err = mdDumpReadOnlyRMD(ctx, "md forceQR", config, replacements, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, config, "md forceQR", replacements, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -10,8 +10,8 @@ import (
 )
 
 func mdForceQROne(
-	ctx context.Context, config libkbfs.Config, tlfPath string,
-	replacements map[string]string, dryRun bool) error {
+	ctx context.Context, config libkbfs.Config,
+	replacements map[string]string, tlfPath string, dryRun bool) error {
 	// Get the latest head, and add a QR record up to that point.
 	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
@@ -35,7 +35,7 @@ func mdForceQROne(
 
 	fmt.Printf(
 		"Will put a forced QR op up to revision %d:\n", irmd.Revision())
-	err = mdDumpReadOnlyRMD(ctx, "md forceQR", config, rmdNext.ReadOnly(), replacements)
+	err = mdDumpReadOnlyRMD(ctx, "md forceQR", config, replacements, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func mdForceQR(ctx context.Context, config libkbfs.Config,
 
 	replacements := make(map[string]string)
 
-	err = mdForceQROne(ctx, config, inputs[0], replacements, *dryRun)
+	err = mdForceQROne(ctx, config, replacements, inputs[0], *dryRun)
 	if err != nil {
 		printError("md forceQR", err)
 		return 1

--- a/kbfstool/md_force_qr.go
+++ b/kbfstool/md_force_qr.go
@@ -11,7 +11,7 @@ import (
 
 func mdForceQROne(
 	ctx context.Context, config libkbfs.Config,
-	replacements map[string]string, tlfPath string, dryRun bool) error {
+	replacements replacementMap, tlfPath string, dryRun bool) error {
 	// Get the latest head, and add a QR record up to that point.
 	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
@@ -84,7 +84,7 @@ func mdForceQR(ctx context.Context, config libkbfs.Config,
 		return 1
 	}
 
-	replacements := make(map[string]string)
+	replacements := make(replacementMap)
 
 	err = mdForceQROne(ctx, config, replacements, inputs[0], *dryRun)
 	if err != nil {

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -14,7 +14,7 @@ import (
 
 func mdResetOne(
 	ctx context.Context, config libkbfs.Config, tlfPath string,
-	checkValid, dryRun, force bool) error {
+	replacements map[string]string, checkValid, dryRun, force bool) error {
 	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func mdResetOne(
 		"Will put an empty root block for tlfID=%s with blockInfo=%s and bufLen=%d\n",
 		rmdNext.TlfID(), info, readyBlockData.GetEncodedSize())
 	fmt.Print("Will put MD:\n")
-	err = mdDumpReadOnlyRMD(ctx, "md reset", config, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, "md reset", config, rmdNext.ReadOnly(), replacements)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,9 @@ func mdReset(ctx context.Context, config libkbfs.Config, args []string) (exitSta
 		return 1
 	}
 
-	err = mdResetOne(ctx, config, inputs[0], *checkValid, *dryRun, *force)
+	replacements := make(map[string]string)
+
+	err = mdResetOne(ctx, config, inputs[0], replacements, *checkValid, *dryRun, *force)
 	if err != nil {
 		printError("md reset", err)
 		return 1

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -62,7 +62,7 @@ func mdResetOne(
 		"Will put an empty root block for tlfID=%s with blockInfo=%s and bufLen=%d\n",
 		rmdNext.TlfID(), info, readyBlockData.GetEncodedSize())
 	fmt.Print("Will put MD:\n")
-	err = mdDumpReadOnlyRMD(ctx, config, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, "md reset", config, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -14,7 +14,7 @@ import (
 
 func mdResetOne(
 	ctx context.Context, config libkbfs.Config, tlfPath string,
-	replacements map[string]string, checkValid, dryRun, force bool) error {
+	replacements replacementMap, checkValid, dryRun, force bool) error {
 	irmd, err := mdGetMergedHeadForWriter(ctx, config, tlfPath)
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ func mdReset(ctx context.Context, config libkbfs.Config, args []string) (exitSta
 		return 1
 	}
 
-	replacements := make(map[string]string)
+	replacements := make(replacementMap)
 
 	err = mdResetOne(ctx, config, inputs[0], replacements, *checkValid, *dryRun, *force)
 	if err != nil {

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -62,7 +62,7 @@ func mdResetOne(
 		"Will put an empty root block for tlfID=%s with blockInfo=%s and bufLen=%d\n",
 		rmdNext.TlfID(), info, readyBlockData.GetEncodedSize())
 	fmt.Print("Will put MD:\n")
-	err = mdDumpReadOnlyRMD(ctx, "md reset", config, replacements, rmdNext.ReadOnly())
+	err = mdDumpReadOnlyRMD(ctx, config, "md reset", replacements, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -62,7 +62,7 @@ func mdResetOne(
 		"Will put an empty root block for tlfID=%s with blockInfo=%s and bufLen=%d\n",
 		rmdNext.TlfID(), info, readyBlockData.GetEncodedSize())
 	fmt.Print("Will put MD:\n")
-	err = mdDumpReadOnlyRMD(ctx, "md reset", config, rmdNext.ReadOnly(), replacements)
+	err = mdDumpReadOnlyRMD(ctx, "md reset", config, replacements, rmdNext.ReadOnly())
 	if err != nil {
 		return err
 	}

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -182,30 +182,32 @@ func getSingleMD(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.Branc
 	return rmds[0], nil
 }
 
-// MakeCopyWithDecryptedPrivateData makes a copy of the given rmd,
-// decrypting it with the given latest RMD.
+// MakeCopyWithDecryptedPrivateData makes a copy of the given IRMD,
+// decrypting it with the given IRMD with keys.
 func MakeCopyWithDecryptedPrivateData(
 	ctx context.Context, config Config,
-	rmd, latestRMD ImmutableRootMetadata, uid keybase1.UID) (
+	irmdToDecrypt, irmdWithKeys ImmutableRootMetadata, uid keybase1.UID) (
 	rmdDecrypted ImmutableRootMetadata, err error) {
 	pmd, err := decryptMDPrivateData(
 		ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(),
 		config.KeyManager(), config.Mode(), uid,
-		rmd.GetSerializedPrivateMetadata(),
-		rmd, latestRMD, config.MakeLogger(""))
+		irmdToDecrypt.GetSerializedPrivateMetadata(),
+		irmdToDecrypt, irmdWithKeys, config.MakeLogger(""))
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
 
-	rmdCopy, err := rmd.deepCopy(config.Codec())
+	rmdCopy, err := irmdToDecrypt.deepCopy(config.Codec())
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}
 	rmdCopy.data = pmd
 	return MakeImmutableRootMetadata(rmdCopy,
-		rmd.LastModifyingWriterVerifyingKey(), rmd.MdID(),
-		rmd.LocalTimestamp(), rmd.putToServer), nil
+		irmdToDecrypt.LastModifyingWriterVerifyingKey(),
+		irmdToDecrypt.MdID(),
+		irmdToDecrypt.LocalTimestamp(),
+		irmdToDecrypt.putToServer), nil
 }
 
 // getMergedMDUpdates returns a slice of all the merged MDs for a TLF,

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -182,6 +182,8 @@ func getSingleMD(ctx context.Context, config Config, id tlf.ID, bid kbfsmd.Branc
 	return rmds[0], nil
 }
 
+// MakeCopyWithDecryptedPrivateData makes a copy of the given rmd,
+// decrypting it with the given latest RMD.
 func MakeCopyWithDecryptedPrivateData(
 	ctx context.Context, config Config,
 	rmd, latestRMD ImmutableRootMetadata, uid keybase1.UID) (

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -29,7 +29,7 @@ type op interface {
 	Refs() []BlockPointer
 	Unrefs() []BlockPointer
 	String() string
-	StringWithRefs(numRefIndents int) string
+	StringWithRefs(indent string) string
 	setWriterInfo(writerInfo)
 	getWriterInfo() writerInfo
 	setFinalPath(p path)
@@ -270,8 +270,7 @@ func (oc *OpCommon) checkUpdatesValid() error {
 	return nil
 }
 
-func (oc *OpCommon) stringWithRefs(numRefIndents int) string {
-	indent := strings.Repeat("\t", numRefIndents)
+func (oc *OpCommon) stringWithRefs(indent string) string {
 	res := ""
 	for i, update := range oc.Updates {
 		res += indent + fmt.Sprintf(
@@ -384,11 +383,10 @@ func (co *createOp) String() string {
 	return res
 }
 
-func (co *createOp) StringWithRefs(numRefIndents int) string {
+func (co *createOp) StringWithRefs(indent string) string {
 	res := co.String() + "\n"
-	indent := strings.Repeat("\t", numRefIndents)
 	res += indent + fmt.Sprintf("Dir: %v -> %v\n", co.Dir.Unref, co.Dir.Ref)
-	res += co.stringWithRefs(numRefIndents)
+	res += co.stringWithRefs(indent)
 	return res
 }
 
@@ -539,11 +537,10 @@ func (ro *rmOp) String() string {
 	return fmt.Sprintf("rm %s", ro.OldName)
 }
 
-func (ro *rmOp) StringWithRefs(numRefIndents int) string {
+func (ro *rmOp) StringWithRefs(indent string) string {
 	res := ro.String() + "\n"
-	indent := strings.Repeat("\t", numRefIndents)
 	res += indent + fmt.Sprintf("Dir: %v -> %v\n", ro.Dir.Unref, ro.Dir.Ref)
-	res += ro.stringWithRefs(numRefIndents)
+	res += ro.stringWithRefs(indent)
 	return res
 }
 
@@ -679,9 +676,8 @@ func (ro *renameOp) String() string {
 		ro.OldName, ro.NewName, ro.RenamedType)
 }
 
-func (ro *renameOp) StringWithRefs(numRefIndents int) string {
+func (ro *renameOp) StringWithRefs(indent string) string {
 	res := ro.String() + "\n"
-	indent := strings.Repeat("\t", numRefIndents)
 	res += indent + fmt.Sprintf("OldDir: %v -> %v\n",
 		ro.OldDir.Unref, ro.OldDir.Ref)
 	if ro.NewDir != (blockUpdate{}) {
@@ -691,7 +687,7 @@ func (ro *renameOp) StringWithRefs(numRefIndents int) string {
 		res += indent + fmt.Sprintf("NewDir: same as above\n")
 	}
 	res += indent + fmt.Sprintf("Renamed: %v\n", ro.Renamed)
-	res += ro.stringWithRefs(numRefIndents)
+	res += ro.stringWithRefs(indent)
 	return res
 }
 
@@ -841,11 +837,10 @@ func (so *syncOp) String() string {
 	return fmt.Sprintf("sync [%s]", strings.Join(writes, ", "))
 }
 
-func (so *syncOp) StringWithRefs(numRefIndents int) string {
+func (so *syncOp) StringWithRefs(indent string) string {
 	res := so.String() + "\n"
-	indent := strings.Repeat("\t", numRefIndents)
 	res += indent + fmt.Sprintf("File: %v -> %v\n", so.File.Unref, so.File.Ref)
-	res += so.stringWithRefs(numRefIndents)
+	res += so.stringWithRefs(indent)
 	return res
 }
 
@@ -1111,12 +1106,11 @@ func (sao *setAttrOp) String() string {
 	return fmt.Sprintf("setAttr %s (%s)", sao.Name, sao.Attr)
 }
 
-func (sao *setAttrOp) StringWithRefs(numRefIndents int) string {
+func (sao *setAttrOp) StringWithRefs(indent string) string {
 	res := sao.String() + "\n"
-	indent := strings.Repeat("\t", numRefIndents)
 	res += indent + fmt.Sprintf("Dir: %v -> %v\n", sao.Dir.Unref, sao.Dir.Ref)
 	res += indent + fmt.Sprintf("File: %v\n", sao.File)
-	res += sao.stringWithRefs(numRefIndents)
+	res += sao.stringWithRefs(indent)
 	return res
 }
 
@@ -1203,9 +1197,9 @@ func (ro *resolutionOp) String() string {
 	return "resolution"
 }
 
-func (ro *resolutionOp) StringWithRefs(numRefIndents int) string {
+func (ro *resolutionOp) StringWithRefs(indent string) string {
 	res := ro.String() + "\n"
-	res += ro.stringWithRefs(numRefIndents)
+	res += ro.stringWithRefs(indent)
 	return res
 }
 
@@ -1251,9 +1245,9 @@ func (ro *rekeyOp) String() string {
 	return "rekey"
 }
 
-func (ro *rekeyOp) StringWithRefs(numRefIndents int) string {
+func (ro *rekeyOp) StringWithRefs(indent string) string {
 	res := ro.String() + "\n"
-	res += ro.stringWithRefs(numRefIndents)
+	res += ro.stringWithRefs(indent)
 	return res
 }
 
@@ -1313,9 +1307,9 @@ func (gco *GCOp) String() string {
 }
 
 // StringWithRefs implements the op interface for GCOp.
-func (gco *GCOp) StringWithRefs(numRefIndents int) string {
+func (gco *GCOp) StringWithRefs(indent string) string {
 	res := gco.String() + "\n"
-	res += gco.stringWithRefs(numRefIndents)
+	res += gco.stringWithRefs(indent)
 	return res
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -46,8 +46,8 @@ type PrivateMetadata struct {
 // DumpPrivateMetadata returns a detailed dump of the given
 // PrivateMetadata's contents.
 func DumpPrivateMetadata(
-	codec kbfscodec.Codec, serializedPMD []byte, pmd PrivateMetadata) (string, error) {
-	s := fmt.Sprintf("Size: %d bytes\n", len(serializedPMD))
+	codec kbfscodec.Codec, serializedPMDLength int, pmd PrivateMetadata) (string, error) {
+	s := fmt.Sprintf("Size: %d bytes\n", serializedPMDLength)
 
 	eq, err := kbfscodec.Equal(codec, pmd, PrivateMetadata{})
 	if err != nil {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -46,14 +46,19 @@ type PrivateMetadata struct {
 // DumpPrivateMetadata returns a detailed dump of the given
 // PrivateMetadata's contents.
 func DumpPrivateMetadata(
-	codec kbfscodec.Codec, pmd PrivateMetadata) (string, error) {
-	serializedPMD, err := codec.Encode(pmd)
+	codec kbfscodec.Codec, serializedPMD []byte, pmd PrivateMetadata) (string, error) {
+	s := fmt.Sprintf("Size: %d bytes\n", len(serializedPMD))
+
+	eq, err := kbfscodec.Equal(codec, pmd, PrivateMetadata{})
 	if err != nil {
 		return "", err
 	}
 
-	s := fmt.Sprintf("Size: %d bytes\n", len(serializedPMD))
-	s += kbfsmd.DumpConfig().Sdump(pmd)
+	if eq {
+		s += "<Undecryptable>\n"
+	} else {
+		s += kbfsmd.DumpConfig().Sdump(pmd)
+	}
 	return s, nil
 }
 

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -48,7 +48,7 @@ type verboseOp struct {
 }
 
 func (o verboseOp) String() string {
-	return o.op.StringWithRefs(0)
+	return o.op.StringWithRefs("")
 }
 
 // DumpPrivateMetadata returns a detailed dump of the given

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/keybase/client/go/logger"
@@ -45,10 +46,11 @@ type PrivateMetadata struct {
 
 type verboseOp struct {
 	op
+	indent string
 }
 
 func (o verboseOp) String() string {
-	return o.op.StringWithRefs("")
+	return o.op.StringWithRefs(o.indent)
 }
 
 // DumpPrivateMetadata returns a detailed dump of the given
@@ -65,13 +67,19 @@ func DumpPrivateMetadata(
 	if eq {
 		s += "<Undecryptable>\n"
 	} else {
+		c := kbfsmd.DumpConfig()
+		// Hardcode the indent level, which depends on the
+		// position of the Ops list.
+		indent := strings.Repeat(c.Indent, 4)
+
 		var pmdCopy PrivateMetadata
 		kbfscodec.Update(codec, &pmdCopy, pmd)
 		ops := pmdCopy.Changes.Ops
 		for i, op := range ops {
-			ops[i] = verboseOp{op}
+			ops[i] = verboseOp{op, indent}
 		}
-		s += kbfsmd.DumpConfig().Sdump(pmdCopy)
+
+		s += c.Sdump(pmdCopy)
 	}
 	return s, nil
 }

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -43,6 +43,14 @@ type PrivateMetadata struct {
 	cachedChanges BlockChanges
 }
 
+type verboseOp struct {
+	op
+}
+
+func (o verboseOp) String() string {
+	return o.op.StringWithRefs(0)
+}
+
 // DumpPrivateMetadata returns a detailed dump of the given
 // PrivateMetadata's contents.
 func DumpPrivateMetadata(
@@ -57,7 +65,13 @@ func DumpPrivateMetadata(
 	if eq {
 		s += "<Undecryptable>\n"
 	} else {
-		s += kbfsmd.DumpConfig().Sdump(pmd)
+		var pmdCopy PrivateMetadata
+		kbfscodec.Update(codec, &pmdCopy, pmd)
+		ops := pmdCopy.Changes.Ops
+		for i, op := range ops {
+			ops[i] = verboseOp{op}
+		}
+		s += kbfsmd.DumpConfig().Sdump(pmdCopy)
 	}
 	return s, nil
 }


### PR DESCRIPTION
In particular, have it dump:

- MD timestamps,
- Name/KID of last modifying device
- Block pointers in ops.

Also decode old MDs with the keys from the most recent one.

Don't make so many calls to the service when looking up usernames / keys.

Also add support for ranges, and process those efficiently. Make 'md check' also use ranges.

I keep forgetting that 'md dump' can't take MD IDs as input (since the server can't)
so detect those and print out a specific error message for that case.