### PR TITLE
libgit: implement a Clone function

### DIFF
--- a/libgit/worktree.go
+++ b/libgit/worktree.go
@@ -14,6 +14,18 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/filesystem"
 )
 
+// repoFromStorageAndWorktree returns a repo instance where the dotgit
+// storage layer points to the bare repo represented by `repoFS`, but
+// the worktree storage layer uses `worktreeFS`.  This is useful for
+// checking out the git repo without having to read and copy the
+// complete git history.  The index and the HEAD commit of the
+// worktree are stored in `worktreeFS/.git`.  The caller should make
+// no modifying calls into the repo, other than checkout/reset-related
+// calls.
+//
+// For the convenience of the caller, it also returns `currentHead`,
+// which is the current commit at the HEAD of `branch`, according to
+// the bare repo represented by `repoFS`.
 func repoFromStorageAndWorktree(
 	repoFS billy.Filesystem, worktreeFS billy.Filesystem,
 	branch plumbing.ReferenceName) (

--- a/libgit/worktree.go
+++ b/libgit/worktree.go
@@ -1,0 +1,101 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"context"
+
+	billy "gopkg.in/src-d/go-billy.v4"
+	gogit "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem"
+)
+
+func repoFromStorageAndWorktree(
+	repoFS billy.Filesystem, worktreeFS billy.Filesystem,
+	branch plumbing.ReferenceName) (
+	repo *gogit.Repository, currentHead plumbing.Hash, err error) {
+	repoStorer, err := filesystem.NewStorage(repoFS)
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+
+	// Wrap it in an on-demand storer, so we don't try to read all the
+	// objects of big repos into memory at once.
+	storage, err := NewOnDemandStorer(repoStorer)
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+
+	currentHeadRef, err := storer.ResolveReference(storage, branch)
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+
+	err = worktreeFS.MkdirAll(".git", 0600)
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+	wtDotgitFS, err := worktreeFS.Chroot(".git")
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+	wtDotgit, err := filesystem.NewStorage(wtDotgitFS)
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+
+	wtStorage := &worktreeStorer{storage, storage, wtDotgit}
+
+	// Override the `IndexStorer` methods with an `IndexStorage` that
+	// points to worktreeFS/.git.  And also also reroutes HEAD
+	// reference management to worktreeFS/.git as well.
+	repo, err = gogit.Open(wtStorage, worktreeFS)
+	if err != nil {
+		return nil, plumbing.ZeroHash, err
+	}
+	return repo, currentHeadRef.Hash(), nil
+}
+
+// Clone "clones" a repo from a billy filesystem, into another billy
+// filesystem.  However, it doesn't make a true git clone, for two
+// reasons.
+//
+// 1. This will be used to clone KBFS repos, and go-git doesn't
+//    natively understand the keybase:// protocol.  There might be a
+//    way around this with the `InstallProtocol` go-git method, but I
+//    haven't investigated that yet and it would be some extra work.
+//
+// 2. These clones are intended for autogit, which will display them
+//    as read-only directories.  They do not need to be real git
+//    repos, and so there's no need to copy object files or much else
+//    in the .git repo.  All we really need is an index, to compute
+//    the differences.  Making a full git clone, or even a "shallow"
+//    git clone, would be wasteful in that it would read and write way
+//    more data than we really need.
+//
+// The resulting clone in `worktreeFS` is therefore not a functional
+// git repo.  The caller should only interact with `worktreeFS` in a
+// read-only way, and should not attempt any git operations on it.
+func Clone(
+	ctx context.Context, repoFS billy.Filesystem, worktreeFS billy.Filesystem,
+	branch plumbing.ReferenceName) error {
+	repo, currentHead, err := repoFromStorageAndWorktree(
+		repoFS, worktreeFS, branch)
+	if err != nil {
+		return err
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	return wt.Reset(&gogit.ResetOptions{
+		Commit: currentHead,
+		Mode:   gogit.HardReset,
+	})
+}

--- a/libgit/worktree_storer.go
+++ b/libgit/worktree_storer.go
@@ -1,0 +1,72 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/index"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+	"gopkg.in/src-d/go-git.v4/storage"
+)
+
+// worktreeStorer fake out the storage layer in such a way that it
+// stores its index, and any reference modifications, in a .git/
+// directory in the worktree, but everything else goes through the
+// main bare repo's .git directory.  This is useful for making a quick
+// checkout of a git repo in a new directory, without making a full
+// git clone.
+type worktreeStorer struct {
+	storage.Storer // main dotgit where all the objects/refs are
+	delta          storer.DeltaObjectStorer
+	wtDotgit       storage.Storer // worktree dotgit where the index and HEAD are
+}
+
+var _ storage.Storer = (*worktreeStorer)(nil)
+var _ storer.DeltaObjectStorer = (*worktreeStorer)(nil)
+
+// DeltaObject implements the storer.DeltaObjectStorer interface for
+// worktreeStorer.
+func (wts *worktreeStorer) DeltaObject(
+	ot plumbing.ObjectType, hash plumbing.Hash) (
+	plumbing.EncodedObject, error) {
+	return wts.delta.DeltaObject(ot, hash)
+}
+
+// SetIndex implements the storer.IndexStorer interface for worktreeStorer.
+func (wts *worktreeStorer) SetIndex(in *index.Index) error {
+	return wts.wtDotgit.SetIndex(in)
+}
+
+// Index implements the storer.IndexStorer interface for worktreeStorer.
+func (wts *worktreeStorer) Index() (*index.Index, error) {
+	return wts.wtDotgit.Index()
+}
+
+// SetReference implements the storer.ReferenceStorer interface for
+// worktreeStorer.
+func (wts *worktreeStorer) SetReference(ref *plumbing.Reference) error {
+	// Steal the hash and set HEAD to it in the worktree, so next time
+	// we can read it.
+	if ref.Type() != plumbing.HashReference {
+		return errors.New("Can't set a non-hash reference")
+	}
+
+	headRef := plumbing.NewHashReference(plumbing.HEAD, ref.Hash())
+	return wts.wtDotgit.SetReference(headRef)
+}
+
+// Reference implements the storer.ReferenceStorer interface for
+// worktreeStorer
+func (wts *worktreeStorer) Reference(name plumbing.ReferenceName) (
+	*plumbing.Reference, error) {
+	if name == plumbing.HEAD {
+		ref, err := wts.wtDotgit.Reference(name)
+		if err == nil {
+			return ref, nil
+		}
+	}
+	return wts.Storer.Reference(name)
+}

--- a/libgit/worktree_storer.go
+++ b/libgit/worktree_storer.go
@@ -17,7 +17,23 @@ import (
 // directory in the worktree, but everything else goes through the
 // main bare repo's .git directory.  This is useful for making a quick
 // checkout of a git repo in a new directory, without making a full
-// git clone.
+// git clone. For example, consider the following instance:
+//
+// * `storage.Storer` points to a bare repo stored in KBFS, say
+//   `/keybase/team/keybase/.kbfs_git/secrets/.git`.
+// * `delta` is the same as above, but cast as a `DeltaObjectStorer`.
+// * `wtDotgit` can be pointed anywhere else in KBFS where you want to
+//   expose a checked-out version of the keybase secrets repo, say
+//   `/keybase/private/strib/.kbfs_autogit/team/keybase/secrets/`
+//
+// Any calls to update the index or set a reference will be routed to
+// `wtDotgit`, and everything else goes to `storage.Storer`.  That
+// means that the caller can use this to "reset" the autogit worktree
+// to some commit stored in the main bare repo, without having to do a
+// full clone and copy the git history, etc.
+//
+// This storage layer should only be used for read-only workloads,
+// where the entire git history isn't needed.
 type worktreeStorer struct {
 	storage.Storer // main dotgit where all the objects/refs are
 	delta          storer.DeltaObjectStorer

--- a/libgit/worktree_test.go
+++ b/libgit/worktree_test.go
@@ -1,0 +1,123 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-billy.v4/osfs"
+)
+
+// Helper functions duplicated from kbfsgit for now, to avoid pulling
+// them into the main build.  TODO: a new package for git testing
+// code?
+func gitExec(t *testing.T, gitDir, workTree string, command ...string) {
+	cmd := exec.Command("git",
+		append([]string{"--git-dir", gitDir, "--work-tree", workTree},
+			command...)...)
+	err := cmd.Run()
+	require.NoError(t, err)
+}
+
+func makeLocalRepoWithOneFile(t *testing.T,
+	gitDir, filename, contents, branch string) {
+	t.Logf("Make a new repo in %s with one file", gitDir)
+	err := ioutil.WriteFile(
+		filepath.Join(gitDir, filename), []byte(contents), 0600)
+	require.NoError(t, err)
+	dotgit := filepath.Join(gitDir, ".git")
+	gitExec(t, dotgit, gitDir, "init")
+
+	if branch != "" {
+		gitExec(t, dotgit, gitDir, "checkout", "-b", branch)
+	}
+
+	gitExec(t, dotgit, gitDir, "add", filename)
+	gitExec(t, dotgit, gitDir, "-c", "user.name=Foo",
+		"-c", "user.email=foo@foo.com", "commit", "-a", "-m", "foo")
+}
+
+func addOneFileToRepo(t *testing.T, gitDir, filename, contents string) {
+	t.Logf("Make a new repo in %s with one file", gitDir)
+	err := ioutil.WriteFile(
+		filepath.Join(gitDir, filename), []byte(contents), 0600)
+	require.NoError(t, err)
+	dotgit := filepath.Join(gitDir, ".git")
+
+	gitExec(t, dotgit, gitDir, "add", filename)
+	gitExec(t, dotgit, gitDir, "-c", "user.name=Foo",
+		"-c", "user.email=foo@foo.com", "commit", "-a", "-m", "foo")
+}
+
+func TestWorktreeClone(t *testing.T) {
+	git1, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git1)
+
+	// Test our clone functions on regular file system paths, since
+	// cloning a repo into KBFS here isn't simple.
+	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
+
+	git2, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git2)
+
+	dotgit1FS := osfs.New(filepath.Join(git1, ".git"))
+	git2FS := osfs.New(git2)
+
+	ctx := context.Background()
+	err = Clone(ctx, dotgit1FS, git2FS, "refs/heads/master")
+	require.NoError(t, err)
+
+	f, err := git2FS.Open("foo")
+	require.NoError(t, err)
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(data))
+}
+
+func TestWorktreeCloneFromBranch(t *testing.T) {
+	git1, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git1)
+
+	// Test our clone functions on regular file system paths, since
+	// cloning a repo into KBFS here isn't simple.
+	makeLocalRepoWithOneFile(t, git1, "foo", "hello", "")
+	dotgit1 := filepath.Join(git1, ".git")
+	gitExec(t, dotgit1, git1, "checkout", "-b", "test")
+	addOneFileToRepo(t, git1, "foo2", "hello2")
+	// Switch back to master so regular HEAD can't be used.
+	gitExec(t, dotgit1, git1, "checkout", "master")
+
+	git2, err := ioutil.TempDir(os.TempDir(), "kbfsgittest")
+	require.NoError(t, err)
+	defer os.RemoveAll(git2)
+
+	dotgit1FS := osfs.New(dotgit1)
+	git2FS := osfs.New(git2)
+
+	ctx := context.Background()
+	err = Clone(ctx, dotgit1FS, git2FS, "refs/heads/test")
+	require.NoError(t, err)
+
+	f, err := git2FS.Open("foo")
+	require.NoError(t, err)
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(data))
+
+	f2, err := git2FS.Open("foo2")
+	require.NoError(t, err)
+	data2, err := ioutil.ReadAll(f2)
+	require.NoError(t, err)
+	require.Equal(t, "hello2", string(data2))
+}


### PR DESCRIPTION
This function "clones" a repo from a billy filesystem, into another billy filesystem.  However, it doesn't make a true git clone, for two reasons.

1. This will be used to clone KBFS repos, and go-git doesn't natively understand the keybase:// protocol.  There might be a way around this with the `InstallProtocol` go-git method, but I haven't investigated that yet and it would be some extra work.
2. These clones are intended for autogit, which will display them as read-only directories.  They do not need to be real git repos, and so there's no need to copy object files or much else in the .git repo. All we really need is an index, to compute the differences.  Making a full git clone, or even a "shallow" git clone, would be wasteful in that it would read and write way more data than we really need.

To make this happen, we open the existing bare repo, but fake out the storage layer in such a way that it stores its index, and any reference modifications, in a .git/ directory in the worktree, but everything else goes through the main bare repo's .git directory.  Then we can just use a simple `Reset` call to set up the cloned files.

Issue: KBFS-2672