### PR TITLE
libgit: change Clone() to Reset() and add tests

### DIFF
--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -155,7 +155,7 @@ func makeLocalRepoWithOneFile(t *testing.T,
 }
 
 func addOneFileToRepo(t *testing.T, gitDir, filename, contents string) {
-	t.Logf("Make a new repo in %s with one file", gitDir)
+	t.Logf("Add a new file to %s", gitDir)
 	err := ioutil.WriteFile(
 		filepath.Join(gitDir, filename), []byte(contents), 0600)
 	require.NoError(t, err)
@@ -954,7 +954,7 @@ func TestRepackObjects(t *testing.T) {
 	checkFile("foo4", "hello4")
 }
 
-func TestRunnerWithKBFSClone(t *testing.T) {
+func TestRunnerWithKBFSReset(t *testing.T) {
 	ctx, config, tempdir := initConfigForRunner(t)
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	defer os.RemoveAll(tempdir)
@@ -973,7 +973,7 @@ func TestRunnerWithKBFSClone(t *testing.T) {
 
 	testPush(t, ctx, config, git1, "refs/heads/master:refs/heads/master")
 
-	// Clone using worktree.
+	// Reset using worktree.
 	repoFS, _, err := libgit.GetRepoAndID(ctx, config, h, "test", "")
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(ctx, config, h, "", "", 0)
@@ -982,7 +982,7 @@ func TestRunnerWithKBFSClone(t *testing.T) {
 	require.NoError(t, err)
 	wtFS, err := rootFS.Chroot("test-checkout")
 	require.NoError(t, err)
-	err = libgit.Clone(ctx, repoFS, wtFS.(*libfs.FS), "refs/heads/master")
+	err = libgit.Reset(ctx, repoFS, wtFS.(*libfs.FS), "refs/heads/master")
 	require.NoError(t, err)
 
 	f, err := wtFS.Open("foo")

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -987,6 +987,7 @@ func TestRunnerWithKBFSReset(t *testing.T) {
 
 	f, err := wtFS.Open("foo")
 	require.NoError(t, err)
+	defer f.Close()
 	data, err := ioutil.ReadAll(f)
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(data))

--- a/libgit/worktree.go
+++ b/libgit/worktree.go
@@ -72,7 +72,7 @@ func repoFromStorageAndWorktree(
 	return repo, currentHeadRef.Hash(), nil
 }
 
-// Clone "clones" a repo from a billy filesystem, into another billy
+// Reset checks out a repo from a billy filesystem, into another billy
 // filesystem.  However, it doesn't make a true git clone, for two
 // reasons.
 //
@@ -89,10 +89,10 @@ func repoFromStorageAndWorktree(
 //    git clone, would be wasteful in that it would read and write way
 //    more data than we really need.
 //
-// The resulting clone in `worktreeFS` is therefore not a functional
+// The resulting checkout in `worktreeFS` is therefore not a functional
 // git repo.  The caller should only interact with `worktreeFS` in a
 // read-only way, and should not attempt any git operations on it.
-func Clone(
+func Reset(
 	ctx context.Context, repoFS billy.Filesystem, worktreeFS billy.Filesystem,
 	branch plumbing.ReferenceName) error {
 	repo, currentHead, err := repoFromStorageAndWorktree(

--- a/libgit/worktree_test.go
+++ b/libgit/worktree_test.go
@@ -62,6 +62,7 @@ func testCheckFile(t *testing.T, fs billy.Filesystem,
 	name, expectedData string) {
 	f, err := fs.Open(name)
 	require.NoError(t, err)
+	defer f.Close()
 	data, err := ioutil.ReadAll(f)
 	require.NoError(t, err)
 	require.Equal(t, expectedData, string(data))


### PR DESCRIPTION
Turns out that, from the perspective of the worktree, there's no real difference between clone and pull for autogit, now that we're just doing a hard reset to do the checkout.  So rename and add tests.

A later PR will still distinguish between clone and pull at a higher level, within the autogit manager.

Issue: KBFS-2673