### PR TITLE
implement access control using HTTP basic auth

### DIFF
--- a/libpages/config/acl_checker_v1.go
+++ b/libpages/config/acl_checker_v1.go
@@ -44,8 +44,8 @@ type accessControlV1 struct {
 	// for more details. It's a map of username -> permissionsV1.
 	whitelistAdditional map[string]permissionsV1
 	anonymous           permissionsV1
-	// p stores the path (from Config declaration) that a *accessControlV1
-	// object is constructed for. When a *aclCheckerV1 is picked for a path,
+	// p stores the path (from Config declaration) that an *accessControlV1
+	// object is constructed for. When an *aclCheckerV1 is picked for a path,
 	// the p field can be used as a realm for HTTP Basic Authentication.
 	p string
 }

--- a/libpages/config/acl_checker_v1.go
+++ b/libpages/config/acl_checker_v1.go
@@ -54,7 +54,7 @@ type accessControlV1 struct {
 // *AccessControlV1. The users map is used to check if every username defined
 // in WhitelistAdditionalPermissions is defined.
 func makeAccessControlV1Internal(
-	a *AccessControlV1, users map[string][]byte, p string) (
+	a *AccessControlV1, users map[string]string, p string) (
 	ac *accessControlV1, err error) {
 	if a == nil {
 		return nil, errors.New("nil AccessControlV1")
@@ -194,7 +194,7 @@ func (c *aclCheckerV1) getPermissions(p string, username *string) (
 // recursively constructs nested *aclCheckerV1 so that each defined path has a
 // corresponding checker, and all intermediate nodes have a checker populated.
 func makeACLCheckerV1(acl map[string]AccessControlV1,
-	users map[string][]byte) (*aclCheckerV1, error) {
+	users map[string]string) (*aclCheckerV1, error) {
 	root := &aclCheckerV1{ac: defaultAccessControlV1InternalForRoot()}
 	if acl == nil {
 		return root, nil

--- a/libpages/config/config.go
+++ b/libpages/config/config.go
@@ -57,9 +57,9 @@ func parseVersion(s string) (Version, error) {
 type Config interface {
 	Version() Version
 	Authenticate(username, password string) bool
-	GetPermissionsForAnonymous(path string) (read, list bool, err error)
+	GetPermissionsForAnonymous(path string) (read, list bool, realm string, err error)
 	GetPermissionsForUsername(
-		path, username string) (read, list bool, err error)
+		path, username string) (read, list bool, realm string, err error)
 }
 
 // ParseConfig parses a config from reader.

--- a/libpages/config/config_test.go
+++ b/libpages/config/config_test.go
@@ -17,9 +17,9 @@ func TestParseConfig(t *testing.T) {
 		Common: Common{
 			Version: Version1Str,
 		},
-		Users: map[string][]byte{
-			"alice": generatePasswordHashForTestOrBust(t, "12345"),
-			"bob":   generatePasswordHashForTestOrBust(t, "54321"),
+		Users: map[string]string{
+			"alice": string(generatePasswordHashForTestOrBust(t, "12345")),
+			"bob":   string(generatePasswordHashForTestOrBust(t, "54321")),
 		},
 		ACLs: map[string]AccessControlV1{
 			"/alice-and-bob": AccessControlV1{

--- a/libpages/config/config_v1.go
+++ b/libpages/config/config_v1.go
@@ -39,7 +39,7 @@ type V1 struct {
 
 	// Users is a [username -> bcrypt-hashed password] map that defines how
 	// users should be authenticated.
-	Users map[string][]byte `json:"users"`
+	Users map[string]string `json:"users"`
 
 	// ACLs is a path -> AccessControlV1 map that defines ACLs for different
 	// paths.
@@ -87,7 +87,7 @@ func (c *V1) Authenticate(username, password string) bool {
 	if !ok {
 		return false
 	}
-	return bcrypt.CompareHashAndPassword(passwordHash, []byte(password)) == nil
+	return bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) == nil
 }
 
 // GetPermissionsForAnonymous implements the Config interface.

--- a/libpages/config/config_v1.go
+++ b/libpages/config/config_v1.go
@@ -50,6 +50,8 @@ type V1 struct {
 	aclCheckerInitErr error
 }
 
+var _ Config = (*V1)(nil)
+
 // DefaultV1 returns a default V1 config, which allows anonymous read to
 // everything.
 func DefaultV1() *V1 {
@@ -90,22 +92,22 @@ func (c *V1) Authenticate(username, password string) bool {
 
 // GetPermissionsForAnonymous implements the Config interface.
 func (c *V1) GetPermissionsForAnonymous(thePath string) (
-	read, list bool, err error) {
+	read, list bool, realm string, err error) {
 	if err = c.EnsureInit(); err != nil {
-		return false, false, err
+		return false, false, "", err
 	}
 
-	perms := c.aclChecker.getPermissions(thePath, nil)
-	return perms.read, perms.list, nil
+	perms, realm := c.aclChecker.getPermissions(thePath, nil)
+	return perms.read, perms.list, realm, nil
 }
 
 // GetPermissionsForUsername implements the Config interface.
 func (c *V1) GetPermissionsForUsername(thePath, username string) (
-	read, list bool, err error) {
+	read, list bool, realm string, err error) {
 	if err = c.EnsureInit(); err != nil {
-		return false, false, err
+		return false, false, "", err
 	}
 
-	perms := c.aclChecker.getPermissions(thePath, &username)
-	return perms.read, perms.list, nil
+	perms, realm := c.aclChecker.getPermissions(thePath, &username)
+	return perms.read, perms.list, realm, nil
 }

--- a/libpages/config/config_v1_test.go
+++ b/libpages/config/config_v1_test.go
@@ -94,9 +94,9 @@ func TestConfigV1Full(t *testing.T) {
 		Common: Common{
 			Version: Version1Str,
 		},
-		Users: map[string][]byte{
-			"alice": generatePasswordHashForTestOrBust(t, "12345"),
-			"bob":   generatePasswordHashForTestOrBust(t, "54321"),
+		Users: map[string]string{
+			"alice": string(generatePasswordHashForTestOrBust(t, "12345")),
+			"bob":   string(generatePasswordHashForTestOrBust(t, "54321")),
 		},
 		ACLs: map[string]AccessControlV1{
 			"/alice-and-bob": AccessControlV1{

--- a/libpages/root.go
+++ b/libpages/root.go
@@ -49,7 +49,8 @@ func (t RootType) String() string {
 	}
 }
 
-// Root defines the root of a static site hosted by Keybase Pages.
+// Root defines the root of a static site hosted by Keybase Pages. It is
+// normally constructed from DNS records directly and is cheap to make.
 type Root struct {
 	Type            RootType
 	TlfType         tlf.Type

--- a/libpages/server.go
+++ b/libpages/server.go
@@ -145,6 +145,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	cfg, err := st.getConfig(false)
 	if err != nil {
+		// TODO: error page to show the error message?
+		s.config.Logger.Info("getConfig", zap.String("host", r.Host), zap.Error(err))
 		s.handleError(w, err)
 		return
 	}

--- a/libpages/site.go
+++ b/libpages/site.go
@@ -1,0 +1,77 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libpages
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libpages/config"
+)
+
+const configCacheTime = 16 * time.Second
+
+type site struct {
+	// fs should never once constructed.
+	fs *libfs.FS
+
+	// TODO: replace this with a notification mechanism from the FBO.
+	cachedConfigLock      sync.RWMutex
+	cachedConfig          config.Config
+	cachedConfigExpiresAt time.Time
+}
+
+const kbpConfigPath = "/.kbp_config"
+
+func makeSite(fs *libfs.FS) *site {
+	return &site{fs: fs}
+}
+
+func (s *site) getCachedConfig() (cfg config.Config, expiresAt time.Time) {
+	s.cachedConfigLock.RLock()
+	defer s.cachedConfigLock.RUnlock()
+	return s.cachedConfig, s.cachedConfigExpiresAt
+}
+
+func (s *site) fetchConfigAndRefreshCache() (cfg config.Config, err error) {
+	// Take the lock early to block other reads, since otherwise they would
+	// also reach here, causing unnecessary multiple fetches.
+	s.cachedConfigLock.Lock()
+	defer s.cachedConfigLock.Unlock()
+
+	f, err := s.fs.Open(kbpConfigPath)
+	switch {
+	case os.IsNotExist(err):
+		cfg = config.DefaultV1()
+	case err == nil:
+		cfg, err = config.ParseConfig(f)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, err
+	}
+
+	s.cachedConfig = cfg
+	s.cachedConfigExpiresAt = time.Now()
+
+	return cfg, nil
+}
+
+func (s *site) getConfig(forceRefresh bool) (cfg config.Config, err error) {
+	cachedConfig, cacheExpiresAt := s.getCachedConfig()
+	if !forceRefresh && cacheExpiresAt.After(time.Now()) {
+		return cachedConfig, nil
+	}
+	return s.fetchConfigAndRefreshCache()
+}
+
+func (s *site) getHTTPFileSystem(ctx context.Context) http.FileSystem {
+	return s.fs.ToHTTPFileSystem(ctx)
+}


### PR DESCRIPTION
Also made some changes to the Config package to support `realm`, which is needed for HTTP Basic Authentication, as an identifier for resources sharing the same credentials.

I updated the staging instance and did some simple test and it seems to have worked well. The config I'm using for kbp-test2.song.gao.io for now is:

```json
{
  "version": "v1",
  "users": {
    "alice": "$2a$10$XDG6k7.k3942gm4pY42oJeJl//HeiNr5X9GgF9AzonNzyKuhFq6ra",
    "bob": "$2a$10$KBzG6TTGkCRr7ZEm6Z7RVOICrOfunmyiLZC6X4uLkEgx5yAWPBAnu"
  },
  "acls": {
    "/alice-and-bob": {
      "whitelist_additional_permissions": {
        "alice": "read,list",
        "bob": "read"
      },
      "anonymous_permissions": ""
    },
    "/bob": {
      "whitelist_additional_permissions": {
        "bob": "read,list"
      },
      "anonymous_permissions": ""
    },
    "/bob/dir/deep-dir/deep-deep-dir": {
      "whitelist_additional_permissions": null,
      "anonymous_permissions": ""
    },
    "/public": {
      "whitelist_additional_permissions": null,
      "anonymous_permissions": "read,list"
    },
    "/public/not-really": {
      "whitelist_additional_permissions": {
        "alice": "read,list"
      },
      "anonymous_permissions": ""
    }
  }
}
```

where `alice` and `bob`'s passwords are gloriously "12345" and "54321".