### PR TITLE
md_ops: don't look up session for public implicit team TLFs

### DIFF
--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -252,7 +252,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 
 	// Get the UID unless this is a public tlf - then proceed with empty uid.
 	var uid keybase1.UID
-	if handle.TypeForKeying() != tlf.PublicKeying {
+	if handle.Type() != tlf.Public {
 		session, err := md.config.KBPKI().GetCurrentSession(ctx)
 		if err != nil {
 			return ImmutableRootMetadata{}, err


### PR DESCRIPTION
TLF type, not keying type, is what matters.

Issue: KBFS-2652