### PR TITLE
node_cache: add Node wrappers for custom behavior

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -124,6 +124,9 @@ type Node interface {
 	// GetBasename returns the current basename of the node, or ""
 	// if the node has been unlinked.
 	GetBasename() string
+	// WrapChild returns a wrapped version of `child`, if desired, to
+	// add custom behavior to the child node.
+	WrapChild(child Node) Node
 }
 
 // KBFSOps handles all file system operations.  Expands all indirect

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -125,8 +125,14 @@ type Node interface {
 	// if the node has been unlinked.
 	GetBasename() string
 	// WrapChild returns a wrapped version of `child`, if desired, to
-	// add custom behavior to the child node.
+	// add custom behavior to the child node.  If the Node instance
+	// receiving this call is itself a wrapped node, it should call
+	// `WrapChild(child)` on its internal wrapped node as well, in
+	// case there are multiple wrapping layers available.
 	WrapChild(child Node) Node
+	// Unwrap returns the initial, unwrapped Node that was used to
+	// create this Node.
+	Unwrap() Node
 }
 
 // KBFSOps handles all file system operations.  Expands all indirect
@@ -1926,6 +1932,9 @@ type NodeCache interface {
 	PathFromNode(node Node) path
 	// AllNodes returns the complete set of nodes currently in the cache.
 	AllNodes() []Node
+	// AddRootWrapper adds a new wrapper function that will be applied
+	// whenever a root Node is created.
+	AddRootWrapper(func(Node) Node)
 }
 
 // fileBlockDeepCopier fetches a file block, makes a deep copy of it

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -777,6 +777,18 @@ func (mr *MockNodeMockRecorder) GetBasename() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBasename", reflect.TypeOf((*MockNode)(nil).GetBasename))
 }
 
+// WrapChild mocks base method
+func (m *MockNode) WrapChild(child Node) Node {
+	ret := m.ctrl.Call(m, "WrapChild", child)
+	ret0, _ := ret[0].(Node)
+	return ret0
+}
+
+// WrapChild indicates an expected call of WrapChild
+func (mr *MockNodeMockRecorder) WrapChild(child interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WrapChild", reflect.TypeOf((*MockNode)(nil).WrapChild), child)
+}
+
 // MockKBFSOps is a mock of KBFSOps interface
 type MockKBFSOps struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -789,6 +789,18 @@ func (mr *MockNodeMockRecorder) WrapChild(child interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WrapChild", reflect.TypeOf((*MockNode)(nil).WrapChild), child)
 }
 
+// Unwrap mocks base method
+func (m *MockNode) Unwrap() Node {
+	ret := m.ctrl.Call(m, "Unwrap")
+	ret0, _ := ret[0].(Node)
+	return ret0
+}
+
+// Unwrap indicates an expected call of Unwrap
+func (mr *MockNodeMockRecorder) Unwrap() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unwrap", reflect.TypeOf((*MockNode)(nil).Unwrap))
+}
+
 // MockKBFSOps is a mock of KBFSOps interface
 type MockKBFSOps struct {
 	ctrl     *gomock.Controller
@@ -6777,6 +6789,16 @@ func (m *MockNodeCache) AllNodes() []Node {
 // AllNodes indicates an expected call of AllNodes
 func (mr *MockNodeCacheMockRecorder) AllNodes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllNodes", reflect.TypeOf((*MockNodeCache)(nil).AllNodes))
+}
+
+// AddRootWrapper mocks base method
+func (m *MockNodeCache) AddRootWrapper(arg0 func(Node) Node) {
+	m.ctrl.Call(m, "AddRootWrapper", arg0)
+}
+
+// AddRootWrapper indicates an expected call of AddRootWrapper
+func (mr *MockNodeCacheMockRecorder) AddRootWrapper(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootWrapper", reflect.TypeOf((*MockNodeCache)(nil).AddRootWrapper), arg0)
 }
 
 // MockcrAction is a mock of crAction interface

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -12,14 +12,14 @@ import (
 // nodeCore holds info shared among one or more nodeStandard objects.
 type nodeCore struct {
 	pathNode *pathNode
-	parent   *nodeStandard
+	parent   Node
 	cache    *nodeCacheStandard
 	// used only when parent is nil (the object has been unlinked)
 	cachedPath path
 	cachedDe   DirEntry
 }
 
-func newNodeCore(ptr BlockPointer, name string, parent *nodeStandard,
+func newNodeCore(ptr BlockPointer, name string, parent Node,
 	cache *nodeCacheStandard) *nodeCore {
 	return &nodeCore{
 		pathNode: &pathNode{
@@ -79,4 +79,8 @@ func (n *nodeStandard) GetBasename() string {
 
 func (n *nodeStandard) WrapChild(child Node) Node {
 	return child
+}
+
+func (n *nodeStandard) Unwrap() Node {
+	return n
 }

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -76,3 +76,7 @@ func (n *nodeStandard) GetBasename() string {
 	}
 	return n.core.pathNode.Name
 }
+
+func (n *nodeStandard) WrapChild(child Node) Node {
+	return child
+}

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -75,9 +75,13 @@ func (ncs *nodeCacheStandard) newChildForParentLocked(parent Node) (*nodeStandar
 	return nodeStandard, nil
 }
 
-func makeNodeStandardForEntry(entry *nodeCacheEntry) *nodeStandard {
+func makeNodeStandardForEntry(entry *nodeCacheEntry) Node {
 	entry.refCount++
-	return makeNodeStandard(entry.core)
+	n := makeNodeStandard(entry.core)
+	if entry.core.parent != nil {
+		return entry.core.parent.WrapChild(n)
+	}
+	return n
 }
 
 // GetOrCreate implements the NodeCache interface for nodeCacheStandard.

--- a/libkbfs/node_cache_test.go
+++ b/libkbfs/node_cache_test.go
@@ -476,12 +476,12 @@ func TestNodeCacheGCReal(t *testing.T) {
 
 type wrappedTestNode struct {
 	Node
-	wrapCalled bool
+	wrapChildCalled bool
 }
 
 func (wtn *wrappedTestNode) WrapChild(child Node) Node {
 	child = wtn.Node.WrapChild(child)
-	wtn.wrapCalled = true
+	wtn.wrapChildCalled = true
 	return child
 }
 
@@ -509,6 +509,6 @@ func TestNodeCacheWrapChild(t *testing.T) {
 	childName := "child1"
 	_, err = ncs.GetOrCreate(childPtr, childName, rootNode)
 	require.NoError(t, err)
-	require.True(t, wtn1.wrapCalled)
-	require.True(t, wtn2.wrapCalled)
+	require.True(t, wtn1.wrapChildCalled)
+	require.True(t, wtn2.wrapChildCalled)
 }


### PR DESCRIPTION
This PR adds a way to "wrap" Nodes as they get created by the `NodeCache`.  The idea is that this will allow us to add custom behavior to each Node, which can be controlled from outside of the `libkbfs` package.  The caller can add a root wrapper function that can transform a root node whenever one is created.  Then, that wrapper can choose to transform any child nodes that are created, via the `WrapChild` function.  And so on, down the tree of nodes, as needed.

This will be used by the autogit implementation in the `libgit` package, to control Node properties that will be added in future PRs: read-only-ness, and hooks for reads, updates and lookup misses which will automatically kick off clones and pulls.  (See KBFS-2654 for the design.)

Issue: KBFS-2675