### PR TITLE
libkbfs: add a way to mark nodes as read-only

### DIFF
--- a/libfuse/errors.go
+++ b/libfuse/errors.go
@@ -50,6 +50,8 @@ func filterError(err error) error {
 		return errorWithErrno{err, syscall.EACCES}
 	case libkbfs.WriteUnsupportedError:
 		return errorWithErrno{err, syscall.ENOENT}
+	case libkbfs.WriteToReadonlyNodeError:
+		return errorWithErrno{err, syscall.EACCES}
 	case libkbfs.UnsupportedOpInUnlinkedDirError:
 		return errorWithErrno{err, syscall.ENOENT}
 	case libkbfs.NeedSelfRekeyError:

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -105,6 +105,7 @@ type ConfigLocal struct {
 	defaultBlockType keybase1.BlockType
 	kbfsService      *KBFSService
 	kbCtx            Context
+	rootNodeWrappers []func(Node) Node
 
 	maxNameBytes  uint32
 	maxDirBytes   uint64
@@ -1458,4 +1459,20 @@ func (c *ConfigLocal) SetKBFSService(k *KBFSService) {
 		c.kbfsService.Shutdown()
 	}
 	c.kbfsService = k
+}
+
+// RootNodeWrappers implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) RootNodeWrappers() []func(Node) Node {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	ret := make([]func(Node) Node, len(c.rootNodeWrappers))
+	copy(ret, c.rootNodeWrappers)
+	return ret
+}
+
+// AddRootNodeWrapper implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) AddRootNodeWrapper(f func(Node) Node) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.rootNodeWrappers = append(c.rootNodeWrappers, f)
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1465,9 +1465,7 @@ func (c *ConfigLocal) SetKBFSService(k *KBFSService) {
 func (c *ConfigLocal) RootNodeWrappers() []func(Node) Node {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
-	ret := make([]func(Node) Node, len(c.rootNodeWrappers))
-	copy(ret, c.rootNodeWrappers)
-	return ret
+	return c.rootNodeWrappers[:]
 }
 
 // AddRootNodeWrapper implements the Config interface for ConfigLocal.

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -210,6 +210,17 @@ func (e WriteUnsupportedError) Error() string {
 	return fmt.Sprintf("Writing to %s is unsupported", e.Filename)
 }
 
+// WriteToReadonlyNodeError indicates an error when trying to write a
+// node that's marked as read-only.
+type WriteToReadonlyNodeError struct {
+	Filename string
+}
+
+// Error implements the error interface for WriteToReadonlyNodeError
+func (e WriteToReadonlyNodeError) Error() string {
+	return fmt.Sprintf("%s is read-only and writes are not allowed", e.Filename)
+}
+
 // UnsupportedOpInUnlinkedDirError indicates an error when trying to
 // create a file.
 type UnsupportedOpInUnlinkedDirError struct {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -124,6 +124,14 @@ type Node interface {
 	// GetBasename returns the current basename of the node, or ""
 	// if the node has been unlinked.
 	GetBasename() string
+	// Readonly returns true if KBFS should outright reject any write
+	// attempts on data or directory structures of this node.  Though
+	// note that even if it returns false, KBFS can reject writes to
+	// the node for other reasons, such as TLF permissions.  An
+	// implementation that wraps another `Node` (`inner`) must return
+	// `inner.Readonly()` if it decides not to return `true` on its
+	// own.
+	Readonly(ctx context.Context) bool
 	// WrapChild returns a wrapped version of child, if desired, to
 	// add custom behavior to the child node. An implementation that
 	// wraps another `Node` (`inner`) must first call
@@ -1884,6 +1892,15 @@ type Config interface {
 
 	// GetRekeyFSMLimiter returns the global rekey FSM limiter.
 	GetRekeyFSMLimiter() *OngoingWorkLimiter
+
+	// RootNodeWrappers returns the set of root node wrapper functions
+	// that will be applied to each newly-created root node.
+	RootNodeWrappers() []func(Node) Node
+	// AddRootNodeWrapper adds a new wrapper function that will be
+	// applied whenever a root Node is created.  This will only apply
+	// to TLFs that are first accessed after `AddRootNodeWrapper` is
+	// called.
+	AddRootNodeWrapper(func(Node) Node)
 }
 
 // NodeCache holds Nodes, and allows libkbfs to update them when

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -777,6 +777,18 @@ func (mr *MockNodeMockRecorder) GetBasename() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBasename", reflect.TypeOf((*MockNode)(nil).GetBasename))
 }
 
+// Readonly mocks base method
+func (m *MockNode) Readonly(ctx context.Context) bool {
+	ret := m.ctrl.Call(m, "Readonly", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Readonly indicates an expected call of Readonly
+func (mr *MockNodeMockRecorder) Readonly(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readonly", reflect.TypeOf((*MockNode)(nil).Readonly), ctx)
+}
+
 // WrapChild mocks base method
 func (m *MockNode) WrapChild(child Node) Node {
 	ret := m.ctrl.Call(m, "WrapChild", child)
@@ -6656,6 +6668,28 @@ func (m *MockConfig) GetRekeyFSMLimiter() *OngoingWorkLimiter {
 // GetRekeyFSMLimiter indicates an expected call of GetRekeyFSMLimiter
 func (mr *MockConfigMockRecorder) GetRekeyFSMLimiter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRekeyFSMLimiter", reflect.TypeOf((*MockConfig)(nil).GetRekeyFSMLimiter))
+}
+
+// RootNodeWrappers mocks base method
+func (m *MockConfig) RootNodeWrappers() []func(Node) Node {
+	ret := m.ctrl.Call(m, "RootNodeWrappers")
+	ret0, _ := ret[0].([]func(Node) Node)
+	return ret0
+}
+
+// RootNodeWrappers indicates an expected call of RootNodeWrappers
+func (mr *MockConfigMockRecorder) RootNodeWrappers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootNodeWrappers", reflect.TypeOf((*MockConfig)(nil).RootNodeWrappers))
+}
+
+// AddRootNodeWrapper mocks base method
+func (m *MockConfig) AddRootNodeWrapper(arg0 func(Node) Node) {
+	m.ctrl.Call(m, "AddRootNodeWrapper", arg0)
+}
+
+// AddRootNodeWrapper indicates an expected call of AddRootNodeWrapper
+func (mr *MockConfigMockRecorder) AddRootNodeWrapper(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRootNodeWrapper", reflect.TypeOf((*MockConfig)(nil).AddRootNodeWrapper), arg0)
 }
 
 // MockNodeCache is a mock of NodeCache interface

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 )
@@ -75,6 +76,10 @@ func (n *nodeStandard) GetBasename() string {
 		return ""
 	}
 	return n.core.pathNode.Name
+}
+
+func (n *nodeStandard) Readonly(_ context.Context) bool {
+	return false
 }
 
 func (n *nodeStandard) WrapChild(child Node) Node {


### PR DESCRIPTION
This will be used by autogit in a future PR, to make everything under the .kbfs_autogit directory read-only unless it's being accessed by the autogit manager itself.

Also add a global list of root node wrappers in the Config object, that are applied automatically to every newly-created node cache.

Issue: KBFS-2676