### PR TITLE
libgit: allow auto-creation of basic autogit directory structure

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1846,6 +1846,8 @@ func (r *runner) processCommands(ctx context.Context) (err error) {
 	reader := bufio.NewReader(r.input)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+	// Allow the creation of .kbfs_git within KBFS.
+	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 
 	// Process the commands with a separate queue in a separate
 	// goroutine, so we can exit as soon as EOF is received

--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -61,6 +61,7 @@ func initConfigForRunner(t *testing.T) (
 	config = libkbfs.MakeTestConfigOrBustLoggedInWithMode(
 		t, 0, libkbfs.InitSingleOp, "user1", "user2")
 	success := false
+	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
 	require.NoError(t, err)

--- a/kbfstool/git_rename.go
+++ b/kbfstool/git_rename.go
@@ -51,7 +51,8 @@ func gitRename(ctx context.Context, config libkbfs.Config, args []string) (exitS
 	}
 
 	kbfsCtx := env.NewContext()
-	rpcHandler := libgit.NewRPCHandlerWithCtx(kbfsCtx, config, nil)
+	rpcHandler, shutdown := libgit.NewRPCHandlerWithCtx(kbfsCtx, config, nil)
+	defer shutdown()
 
 	err = doGitRename(ctx, rpcHandler, inputs[0], inputs[1], inputs[2])
 	if err != nil {

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -87,10 +87,16 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	// Hook simplefs implementation in.
 	options.KbfsParams.CreateSimpleFSInstance = simplefs.NewSimpleFS
 	// Hook git implementation in.
+	shutdownGit := func() {}
 	options.KbfsParams.CreateGitHandlerInstance =
-		func(config libkbfs.Config) keybase1.KBFSGitInterface {
-			return libgit.NewRPCHandlerWithCtx(kbCtx, config, &options.KbfsParams)
+		func(config libkbfs.Config) (i keybase1.KBFSGitInterface) {
+			i, shutdownGit = libgit.NewRPCHandlerWithCtx(
+				kbCtx, config, &options.KbfsParams)
+			return i
 		}
+	defer func() {
+		shutdownGit()
+	}()
 
 	log, err := libkbfs.InitLog(options.KbfsParams, kbCtx)
 	if err != nil {

--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -409,3 +409,13 @@ func (am *AutogitManager) Pull(
 	}
 	return am.queueReset(ctx, req)
 }
+
+// startAutogit launches autogit, and returns a function that should
+// be called on shutdown.
+func startAutogit(kbCtx libkbfs.Context, config libkbfs.Config,
+	kbfsInitParams *libkbfs.InitParams, numWorkers int) func() {
+	am := NewAutogitManager(config, kbCtx, kbfsInitParams, numWorkers)
+	rw := rootWrapper{am}
+	config.AddRootNodeWrapper(rw.wrap)
+	return am.Shutdown
+}

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -31,6 +31,7 @@ func initConfigForAutogit(t *testing.T) (
 	config = libkbfs.MakeTestConfigOrBustLoggedInWithMode(
 		t, 0, libkbfs.InitSingleOp, "user1", "user2")
 	success := false
+	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 
 	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
 

--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -75,11 +75,6 @@ func (ttn tlfTypeNode) ShouldCreateMissedLookup(
 	}
 }
 
-// WrapChild implements the Node interface for tlfTypeNode.
-func (ttn tlfTypeNode) WrapChild(child libkbfs.Node) libkbfs.Node {
-	return &readonlyNode{child}
-}
-
 // autogitRootNode represents the .kbfs_autogit folder, and can only
 // contain subdirectories corresponding to TLF types.
 type autogitRootNode struct {
@@ -117,7 +112,7 @@ func (arn autogitRootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 	default:
 		return child
 	}
-	return &tlfTypeNode{&readonlyNode{child}, arn.am, tlfType}
+	return &tlfTypeNode{child, arn.am, tlfType}
 }
 
 // readonlyNode is a read-only node by default, unless `ctxReadWriteKey`
@@ -131,6 +126,11 @@ var _ libkbfs.Node = (*readonlyNode)(nil)
 // Readonly implements the Node interface for readonlyNode.
 func (rn readonlyNode) Readonly(ctx context.Context) bool {
 	return ctx.Value(ctxReadWriteKey) == nil
+}
+
+// WrapChild implements the Node interface for readonlyNode.
+func (rn readonlyNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	return &readonlyNode{rn.Node.WrapChild(child)}
 }
 
 // rootNode is a Node wrapper around a TLF root node, that causes the

--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -1,0 +1,174 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"context"
+
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+)
+
+// This file contains libkbfs.Node wrappers for implementing the
+// .kbfs_autogit directory structure. It breaks down like this:
+//
+// * `rootWrapper.wrap()` is installed as a root node wrapper, and wraps
+//   the root node for each TLF in a `rootNode` instance.
+// * `rootNode` allows .kbfs_autogit to be auto-created when it is
+//   looked up, and wraps it two ways, as both a `readonlyNode`, and
+//   an `autogitRootNode`.
+// * `readonlyNode` is always marked as read-only, unless
+//   `ctxReadWriteKey` has a non-nil value in the context.
+// * `autogitRootNode` allows the auto-creation of subdirectories
+//   representing TLF types, e.g.. .kbfs_autogit/private or
+//   .kbfs_autogit/public.  It wraps child nodes two ways, as both a
+//   `readonlyNode`, and an `tlfTypeNode`.
+// * `tlfTypeNode` allows the auto-creation of subdirectories
+//   representing TLFs, e.g. .kbfs_autogit/private/max or
+//   .kbfs_autogit/team/keybase.  It wraps child nodes as a
+//   `readOnlyNode`.  TODO(KBFS-2678): allow repo autocreation under
+//   a `tlfTypeNode`.
+
+type ctxReadWriteKeyType int
+
+const (
+	autogitRoot                         = ".kbfs_autogit"
+	ctxReadWriteKey ctxReadWriteKeyType = 1
+
+	public  = "public"
+	private = "private"
+	team    = "team"
+)
+
+// tlfTypeNode represents an autogit subdirectory corresponding to a
+// specific TLF type.  It can only contain subdirectories that
+// correspond to valid TLF name for the TLF type.
+type tlfTypeNode struct {
+	libkbfs.Node
+	am      *AutogitManager
+	tlfType tlf.Type
+}
+
+var _ libkbfs.Node = (*tlfTypeNode)(nil)
+
+// ShouldCreateMissedLookup implements the Node interface for
+// tlfTypeNode.
+func (ttn tlfTypeNode) ShouldCreateMissedLookup(
+	ctx context.Context, name string) (
+	bool, context.Context, libkbfs.EntryType, string) {
+	_, err := libkbfs.ParseTlfHandle(
+		ctx, ttn.am.config.KBPKI(), ttn.am.config.MDOps(), name, ttn.tlfType)
+
+	ctx = context.WithValue(ctx, ctxReadWriteKey, 1)
+	switch e := errors.Cause(err).(type) {
+	case nil:
+		return true, ctx, libkbfs.Dir, ""
+	case libkbfs.TlfNameNotCanonical:
+		return true, ctx, libkbfs.Sym, e.NameToTry
+	default:
+		ttn.am.log.CDebugf(ctx,
+			"Error parsing handle for name %s: %+v", name, err)
+		return ttn.Node.ShouldCreateMissedLookup(ctx, name)
+	}
+}
+
+// WrapChild implements the Node interface for tlfTypeNode.
+func (ttn tlfTypeNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	return &readonlyNode{child}
+}
+
+// autogitRootNode represents the .kbfs_autogit folder, and can only
+// contain subdirectories corresponding to TLF types.
+type autogitRootNode struct {
+	libkbfs.Node
+	am *AutogitManager
+}
+
+var _ libkbfs.Node = (*autogitRootNode)(nil)
+
+// ShouldCreateMissedLookup implements the Node interface for
+// autogitRootNode.
+func (arn autogitRootNode) ShouldCreateMissedLookup(
+	ctx context.Context, name string) (
+	bool, context.Context, libkbfs.EntryType, string) {
+	switch name {
+	case public, private, team:
+		ctx = context.WithValue(ctx, ctxReadWriteKey, 1)
+		return true, ctx, libkbfs.Dir, ""
+	default:
+		return arn.Node.ShouldCreateMissedLookup(ctx, name)
+	}
+}
+
+// WrapChild implements the Node interface for autogitRootNode.
+func (arn autogitRootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	child = arn.Node.WrapChild(child)
+	var tlfType tlf.Type
+	switch child.GetBasename() {
+	case public:
+		tlfType = tlf.Public
+	case private:
+		tlfType = tlf.Private
+	case team:
+		tlfType = tlf.SingleTeam
+	default:
+		return child
+	}
+	return &tlfTypeNode{&readonlyNode{child}, arn.am, tlfType}
+}
+
+// readonlyNode is a read-only node by default, unless `ctxReadWriteKey`
+// has a value set in the context.
+type readonlyNode struct {
+	libkbfs.Node
+}
+
+var _ libkbfs.Node = (*readonlyNode)(nil)
+
+// Readonly implements the Node interface for readonlyNode.
+func (rn readonlyNode) Readonly(ctx context.Context) bool {
+	return ctx.Value(ctxReadWriteKey) == nil
+}
+
+// rootNode is a Node wrapper around a TLF root node, that causes the
+// autogit root to be created when it is accessed.
+type rootNode struct {
+	libkbfs.Node
+	am *AutogitManager
+}
+
+var _ libkbfs.Node = (*rootNode)(nil)
+
+// ShouldCreateMissedLookup implements the Node interface for
+// rootNode.
+func (rn rootNode) ShouldCreateMissedLookup(ctx context.Context, name string) (
+	bool, context.Context, libkbfs.EntryType, string) {
+	if name == autogitRoot {
+		ctx = context.WithValue(ctx, ctxReadWriteKey, 1)
+		ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, autogitRoot)
+		return true, ctx, libkbfs.Dir, ""
+	}
+	return rn.Node.ShouldCreateMissedLookup(ctx, name)
+}
+
+// WrapChild implements the Node interface for rootNode.
+func (rn rootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	child = rn.Node.WrapChild(child)
+	if child.GetBasename() == autogitRoot {
+		return &autogitRootNode{&readonlyNode{child}, rn.am}
+	}
+	return child
+}
+
+// rootWrapper is a struct that manages wrapping root nodes with
+// autogit-related context.
+type rootWrapper struct {
+	am *AutogitManager
+}
+
+func (rw rootWrapper) wrap(node libkbfs.Node) libkbfs.Node {
+	return &rootNode{node, rw.am}
+}

--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"os"
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/env"
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutogitNodeWrappers(t *testing.T) {
+	ctx, config, cancel, tempdir := initConfigForAutogit(t)
+	defer cancel()
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+	defer os.RemoveAll(tempdir)
+
+	kbCtx := env.NewContext()
+	kbfsInitParams := libkbfs.DefaultInitParams(kbCtx)
+	shutdown := startAutogit(kbCtx, config, &kbfsInitParams, 1)
+	defer shutdown()
+
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+	require.NoError(t, err)
+	rootFS, err := libfs.NewFS(
+		ctx, config, h, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+
+	t.Log("Looking at user1's autogit directory should succeed, and " +
+		"autocreate all the necessary directories")
+	fis, err := rootFS.ReadDir(rootFS.Join(autogitRoot, private, "user1"))
+	require.NoError(t, err)
+	require.Len(t, fis, 0)
+	fis, err = rootFS.ReadDir(rootFS.Join(autogitRoot, public, "user1"))
+	require.NoError(t, err)
+	require.Len(t, fis, 0)
+
+	t.Log("Looking up a non-existent user won't work")
+	_, err = rootFS.ReadDir(rootFS.Join(autogitRoot, private, "user2"))
+	require.NotNil(t, err)
+
+	t.Log("Looking up the wrong TLF type won't work")
+	_, err = rootFS.ReadDir(rootFS.Join(autogitRoot, "faketlftype", "user1"))
+	require.NotNil(t, err)
+
+	t.Log("Other autocreates in the root won't work")
+	_, err = rootFS.ReadDir("a")
+	require.NotNil(t, err)
+}

--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -612,6 +612,7 @@ func DeleteRepo(
 		return castNoSuchNameError(err, repoName)
 	}
 
+	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsDeletedReposDir)
 	deletedReposNode, err := lookupOrCreateDir(
 		ctx, config, repoNode, kbfsDeletedReposDir)
 	if err != nil {

--- a/libgit/repo_test.go
+++ b/libgit/repo_test.go
@@ -25,6 +25,7 @@ func initConfig(t *testing.T) (
 	config = libkbfs.MakeTestConfigOrBustLoggedInWithMode(
 		t, 0, libkbfs.InitSingleOp, "user1")
 	success := false
+	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
 	require.NoError(t, err)

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -27,13 +27,14 @@ type RPCHandler struct {
 
 // NewRPCHandlerWithCtx returns a new instance of a Git RPC handler.
 func NewRPCHandlerWithCtx(kbCtx libkbfs.Context, config libkbfs.Config,
-	kbfsInitParams *libkbfs.InitParams) *RPCHandler {
+	kbfsInitParams *libkbfs.InitParams) (*RPCHandler, func()) {
+	shutdown := startAutogit(kbCtx, config, kbfsInitParams, 10)
 	return &RPCHandler{
 		kbCtx:          kbCtx,
 		config:         config,
 		kbfsInitParams: kbfsInitParams,
 		log:            config.MakeLogger(""),
-	}
+	}, shutdown
 }
 
 var _ keybase1.KBFSGitInterface = (*RPCHandler)(nil)

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -149,6 +149,7 @@ func (rh *RPCHandler) CreateRepo(
 	}()
 	defer gitConfig.Shutdown(ctx)
 
+	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 	gitID, err := CreateRepoAndID(ctx, gitConfig, tlfHandle, string(arg.Name))
 	if err != nil {
 		return "", err

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1354,7 +1354,8 @@ func (fbo *folderBlockOps) GetDirtyDir(
 }
 
 var hiddenEntries = map[string]bool{
-	".kbfs_git": true,
+	".kbfs_git":     true,
+	".kbfs_autogit": true,
 }
 
 // GetDirtyDirChildren returns a map of EntryInfos for the (possibly

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1918,6 +1918,12 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 		n, de, err = fbo.blocks.Lookup(ctx, lState, md.ReadOnly(), dir, name)
 		if _, isMiss := errors.Cause(err).(NoSuchNameError); isMiss {
 			n, de.EntryInfo, err = fbo.processMissedLookup(ctx, dir, name, err)
+			if _, exists := errors.Cause(err).(NameExistsError); exists {
+				// Someone raced us to create the entry, so return the
+				// new entry.
+				n, de, err = fbo.blocks.Lookup(
+					ctx, lState, md.ReadOnly(), dir, name)
+			}
 		}
 		return err
 	})

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2530,7 +2530,8 @@ type CtxAllowNameKeyType int
 const (
 	// CtxAllowNameKey can be used to set a value in a context, and
 	// that value will be treated as an allowable directory entry
-	// name, even if it also matches a disallowed prefix.
+	// name, even if it also matches a disallowed prefix.  The value
+	// must be of type `string`, or it will panic.
 	CtxAllowNameKey CtxAllowNameKeyType = iota
 )
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1858,7 +1858,7 @@ func (fbo *folderBranchOps) processMissedLookup(
 	ctx context.Context, dir Node, name string, missErr error) (
 	node Node, ei EntryInfo, err error) {
 	// Check if the directory node wants to autocreate this.
-	autocreate, et, sympath := dir.ShouldCreateMissedLookup(ctx, name)
+	autocreate, ctx, et, sympath := dir.ShouldCreateMissedLookup(ctx, name)
 	if !autocreate {
 		return nil, EntryInfo{}, missErr
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -136,14 +136,14 @@ type Node interface {
 	// directories, whenever `name` is looked up but is not found in
 	// the directory.  If the Node decides a new entry should be
 	// created matching this lookup, it should return `true` as well
-	// as the type of the new entry and the symbolic link contents is
-	// the entry is a Sym; the caller should then create this entry.
-	// Otherwise it should return false.  An implementation that wraps
-	// another `Node` (`inner`) must return
-	// `inner.ShouldCreateMissedLookup()` if it decides not to return
-	// `true` on its own.
-	ShouldCreateMissedLookup(
-		ctx context.Context, name string) (bool, EntryType, string)
+	// as a context to use for the creation, the type of the new entry
+	// and the symbolic link contents is the entry is a Sym; the
+	// caller should then create this entry.  Otherwise it should
+	// return false.  An implementation that wraps another `Node`
+	// (`inner`) must return `inner.ShouldCreateMissedLookup()` if it
+	// decides not to return `true` on its own.
+	ShouldCreateMissedLookup(ctx context.Context, name string) (
+		bool, context.Context, EntryType, string)
 	// WrapChild returns a wrapped version of child, if desired, to
 	// add custom behavior to the child node. An implementation that
 	// wraps another `Node` (`inner`) must first call

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -137,13 +137,13 @@ type Node interface {
 	// the directory.  If the Node decides a new entry should be
 	// created matching this lookup, it should return `true` as well
 	// as a context to use for the creation, the type of the new entry
-	// and the symbolic link contents is the entry is a Sym; the
+	// and the symbolic link contents if the entry is a Sym; the
 	// caller should then create this entry.  Otherwise it should
 	// return false.  An implementation that wraps another `Node`
 	// (`inner`) must return `inner.ShouldCreateMissedLookup()` if it
 	// decides not to return `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name string) (
-		bool, context.Context, EntryType, string)
+		shouldCreate bool, newCtx context.Context, et EntryType, sympath string)
 	// WrapChild returns a wrapped version of child, if desired, to
 	// add custom behavior to the child node. An implementation that
 	// wraps another `Node` (`inner`) must first call

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -132,6 +132,18 @@ type Node interface {
 	// `inner.Readonly()` if it decides not to return `true` on its
 	// own.
 	Readonly(ctx context.Context) bool
+	// ShouldCreateMissedLookup is called for Nodes representing
+	// directories, whenever `name` is looked up but is not found in
+	// the directory.  If the Node decides a new entry should be
+	// created matching this lookup, it should return `true` as well
+	// as the type of the new entry and the symbolic link contents is
+	// the entry is a Sym; the caller should then create this entry.
+	// Otherwise it should return false.  An implementation that wraps
+	// another `Node` (`inner`) must return
+	// `inner.ShouldCreateMissedLookup()` if it decides not to return
+	// `true` on its own.
+	ShouldCreateMissedLookup(
+		ctx context.Context, name string) (bool, EntryType, string)
 	// WrapChild returns a wrapped version of child, if desired, to
 	// add custom behavior to the child node. An implementation that
 	// wraps another `Node` (`inner`) must first call

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3654,8 +3654,8 @@ type wrappedAutocreateNode struct {
 }
 
 func (wan wrappedAutocreateNode) ShouldCreateMissedLookup(
-	_ context.Context, _ string) (bool, EntryType, string) {
-	return true, wan.et, wan.sympath
+	ctx context.Context, _ string) (bool, context.Context, EntryType, string) {
+	return true, ctx, wan.et, wan.sympath
 }
 
 func testKBFSOpsAutocreateNodes(t *testing.T, et EntryType, sympath string) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -789,6 +789,20 @@ func (mr *MockNodeMockRecorder) Readonly(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readonly", reflect.TypeOf((*MockNode)(nil).Readonly), ctx)
 }
 
+// ShouldCreateMissedLookup mocks base method
+func (m *MockNode) ShouldCreateMissedLookup(ctx context.Context, name string) (bool, EntryType, string) {
+	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", ctx, name)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(EntryType)
+	ret2, _ := ret[2].(string)
+	return ret0, ret1, ret2
+}
+
+// ShouldCreateMissedLookup indicates an expected call of ShouldCreateMissedLookup
+func (mr *MockNodeMockRecorder) ShouldCreateMissedLookup(ctx, name interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldCreateMissedLookup", reflect.TypeOf((*MockNode)(nil).ShouldCreateMissedLookup), ctx, name)
+}
+
 // WrapChild mocks base method
 func (m *MockNode) WrapChild(child Node) Node {
 	ret := m.ctrl.Call(m, "WrapChild", child)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -790,12 +790,13 @@ func (mr *MockNodeMockRecorder) Readonly(ctx interface{}) *gomock.Call {
 }
 
 // ShouldCreateMissedLookup mocks base method
-func (m *MockNode) ShouldCreateMissedLookup(ctx context.Context, name string) (bool, EntryType, string) {
+func (m *MockNode) ShouldCreateMissedLookup(ctx context.Context, name string) (bool, context.Context, EntryType, string) {
 	ret := m.ctrl.Call(m, "ShouldCreateMissedLookup", ctx, name)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(EntryType)
-	ret2, _ := ret[2].(string)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(context.Context)
+	ret2, _ := ret[2].(EntryType)
+	ret3, _ := ret[3].(string)
+	return ret0, ret1, ret2, ret3
 }
 
 // ShouldCreateMissedLookup indicates an expected call of ShouldCreateMissedLookup

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -82,6 +82,11 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 	return false
 }
 
+func (n *nodeStandard) ShouldCreateMissedLookup(_ context.Context, _ string) (
+	bool, EntryType, string) {
+	return false, File, ""
+}
+
 func (n *nodeStandard) WrapChild(child Node) Node {
 	return child
 }

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -82,9 +82,9 @@ func (n *nodeStandard) Readonly(_ context.Context) bool {
 	return false
 }
 
-func (n *nodeStandard) ShouldCreateMissedLookup(_ context.Context, _ string) (
-	bool, EntryType, string) {
-	return false, File, ""
+func (n *nodeStandard) ShouldCreateMissedLookup(ctx context.Context, _ string) (
+	bool, context.Context, EntryType, string) {
+	return false, ctx, File, ""
 }
 
 func (n *nodeStandard) WrapChild(child Node) Node {


### PR DESCRIPTION
This PR does a few things:
* `folderBranchOps` has a check for disallowed prefixes when creating new directory entries, currently just ".kbfs" is disallowed.  We had an override for SingleOp mode to allow `.kbfs_git` to be auto-created, but now that we need a second name to be auto-created, I've changed this to be overridable with a context value rather than using the mode.
* The `Node` interface now has a `ShouldCreateMissedLookup` function, which allows `Node` implementations to cause the auto-creation of a directory entry when a lookup misses.
* `kbfsfuse` and `kbfsdokan` now enable several layers of the basic autogit directory structure via different `Node` implementations.  For now, it autocreates up to the TLF name, e.g. `.kbfs_autogit/private/strib`.  A future PR will add repo clones/pull under that directory structure.  All nodes under `.kbfs_autogit` are read-only when accessed via regular file system calls.

Issue: KBFS-2677