### PR TITLE
require explicitly setting / permission

### DIFF
--- a/libpages/config/acl_checker_v1.go
+++ b/libpages/config/acl_checker_v1.go
@@ -79,9 +79,9 @@ func makeAccessControlV1Internal(
 	return ac, nil
 }
 
-func defaultAccessControlV1InternalForRoot() *accessControlV1 {
+func emptyAccessControlV1InternalForRoot() *accessControlV1 {
 	return &accessControlV1{
-		anonymous: permissionsV1{read: true, list: true},
+		anonymous: permissionsV1{}, // no permission
 		p:         "/",
 	}
 }
@@ -195,7 +195,7 @@ func (c *aclCheckerV1) getPermissions(p string, username *string) (
 // corresponding checker, and all intermediate nodes have a checker populated.
 func makeACLCheckerV1(acl map[string]AccessControlV1,
 	users map[string]string) (*aclCheckerV1, error) {
-	root := &aclCheckerV1{ac: defaultAccessControlV1InternalForRoot()}
+	root := &aclCheckerV1{ac: emptyAccessControlV1InternalForRoot()}
 	if acl == nil {
 		return root, nil
 	}

--- a/libpages/config/config_v1.go
+++ b/libpages/config/config_v1.go
@@ -59,6 +59,11 @@ func DefaultV1() *V1 {
 		Common: Common{
 			Version: Version1Str,
 		},
+		ACLs: map[string]AccessControlV1{
+			"/": AccessControlV1{
+				AnonymousPermissions: "read,list",
+			},
+		},
 	}
 	v1.EnsureInit()
 	return v1

--- a/libpages/config/config_v1_test.go
+++ b/libpages/config/config_v1_test.go
@@ -99,6 +99,9 @@ func TestConfigV1Full(t *testing.T) {
 			"bob":   string(generatePasswordHashForTestOrBust(t, "54321")),
 		},
 		ACLs: map[string]AccessControlV1{
+			"/": AccessControlV1{
+				AnonymousPermissions: "read,list",
+			},
 			"/alice-and-bob": AccessControlV1{
 				WhitelistAdditionalPermissions: map[string]string{
 					"alice": PermReadAndList,


### PR DESCRIPTION
So we've been auto-populating permission for root (`/`) with `"read,list"` if it's not defined in the config file. Now that we have the CLI, this seems redundant and doing more harm than good, since the default config it first writes can have that root permission populated. So this PR changes the ACL constructors to not give root any permissions at all if 1) config file is present; and 2) root doesn't appear in the config file. This is easier to understand by user I think.

If the config file is missing, ACL constructors will continue making a default one which has `"read,list"` for root.