### PR TITLE
 libgit: support auto-clone and auto-pull of repos

### DIFF
--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -371,7 +371,7 @@ func (fs *FS) mkdirAll(filename string, perm os.FileMode) (err error) {
 		switch errors.Cause(err).(type) {
 		case libkbfs.NameExistsError:
 			// The child directory already exists.
-		case libkbfs.WriteAccessError:
+		case libkbfs.WriteAccessError, libkbfs.WriteToReadonlyNodeError:
 			// If the child already exists, this doesn't matter.
 			var lookupErr error
 			child, _, lookupErr = fs.config.KBFSOps().Lookup(fs.ctx, n, p)

--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -205,9 +205,8 @@ func (am *AutogitManager) resetWorker(wg *sync.WaitGroup) {
 	defer wg.Done()
 	for reqInt := range am.resetQueue.Out() {
 		req := reqInt.(resetReq)
-		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
-		ctx = libkbfs.CtxWithRandomIDReplayable(
-			ctx, ctxIDKey, ctxOpID, am.log)
+		ctx := libkbfs.CtxWithRandomIDReplayable(
+			context.Background(), ctxIDKey, ctxOpID, am.log)
 		for {
 			waitCh := am.markResetReqInProgress(req)
 			if waitCh == nil {

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -82,6 +82,10 @@ func (nc *newConfigger) shutdown(t *testing.T, ctx context.Context) {
 func (nc *newConfigger) getNewConfigForTest(ctx context.Context) (
 	newCtx context.Context, gitConfig libkbfs.Config,
 	tempDir string, err error) {
+	ctx, err = libkbfs.NewContextWithCancellationDelayer(ctx)
+	if err != nil {
+		return nil, nil, "", err
+	}
 	config := libkbfs.ConfigAsUser(nc.config, nc.user)
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
 	if err != nil {
@@ -165,7 +169,7 @@ func TestAutogitManager(t *testing.T) {
 		ctx, config, h, "", "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
 
-	t.Log("Init a new repo directly into git.")
+	t.Log("Init a new repo directly into KBFS.")
 	dotgitFS, _, err := GetOrCreateRepoAndID(ctx, config, h, "test", "")
 	require.NoError(t, err)
 	err = rootFS.MkdirAll("worktree", 0600)

--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -31,9 +31,25 @@ import (
 //   `readonlyNode`, and an `tlfTypeNode`.
 // * `tlfTypeNode` allows the auto-creation of subdirectories
 //   representing TLFs, e.g. .kbfs_autogit/private/max or
-//   .kbfs_autogit/team/keybase.  It wraps child nodes as a
-//   `readOnlyNode`.  TODO(KBFS-2678): allow repo autocreation under
-//   a `tlfTypeNode`.
+//   .kbfs_autogit/team/keybase.  It wraps child nodes in two ways, as
+//   a `readOnlyNode` and a `tlfNode`.
+// * `tlfNode` allows auto-creation of subdirectories representing
+//   valid repository checkouts of the corresponding TLF, e.g.
+//   `.kbfs_autogit/private/chris/dotfiles`.  It wraps child nodes in
+//   two ways, as both a `readonlyNode` and a `repoNode`.
+// * `repoNode` allow auto-clone and auto-pull of the corresponding
+//   repository on its first access.  When the directory corresponding
+//   to the node is read for the first time for this KBFS instance,
+//   the `repoNode` asks `AutogitManager` to either kick off a clone
+//   or a pull for the repository in question, which will checkout a
+//   copy of the source repo under that directory.  The operation will
+//   block on that clone/pull operation until it is finished, until
+//   the given context is canceled, or until 10 seconds is up.  But if
+//   it doesn't finish in time, the operation continues in the
+//   background and should update the directory asynchronously.  If
+//   the operation is a clone, a "CLONING" file will be visible in the
+//   directory until the clone completes.  `repoNode` wraps each child
+//   node as a `readonlyNode`.
 
 type ctxReadWriteKeyType int
 type ctxSkipPopulateKeyType int

--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -6,6 +6,9 @@ package libgit
 
 import (
 	"context"
+	"path"
+	"sync"
+	"time"
 
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
@@ -33,15 +36,195 @@ import (
 //   a `tlfTypeNode`.
 
 type ctxReadWriteKeyType int
+type ctxSkipPopulateKeyType int
 
 const (
-	autogitRoot                         = ".kbfs_autogit"
-	ctxReadWriteKey ctxReadWriteKeyType = 1
+	autogitRoot = ".kbfs_autogit"
+
+	populateTimeout = 10 * time.Second
+
+	ctxReadWriteKey    ctxReadWriteKeyType    = 1
+	ctxSkipPopulateKey ctxSkipPopulateKeyType = 1
 
 	public  = "public"
 	private = "private"
 	team    = "team"
 )
+
+type repoNode struct {
+	libkbfs.Node
+	am       *AutogitManager
+	h        *libkbfs.TlfHandle
+	repoName string
+
+	lock                 sync.Mutex
+	populated            bool
+	populatingInProgress chan struct{}
+}
+
+var _ libkbfs.Node = (*repoNode)(nil)
+
+func newRepoNode(n libkbfs.Node, am *AutogitManager, h *libkbfs.TlfHandle,
+	repoName string) *repoNode {
+	return &repoNode{
+		Node:     n,
+		am:       am,
+		h:        h,
+		repoName: repoName,
+	}
+}
+
+func (rn *repoNode) dstDir() string {
+	var typeStr string
+	switch rn.h.Type() {
+	case tlf.Public:
+		typeStr = public
+	case tlf.Private:
+		typeStr = private
+	case tlf.SingleTeam:
+		typeStr = team
+	}
+
+	return path.Join(
+		autogitRoot, typeStr, string(rn.h.GetCanonicalName()))
+}
+
+func (rn *repoNode) populate(ctx context.Context) bool {
+	ctx = context.WithValue(ctx, ctxSkipPopulateKey, 1)
+	children, err := rn.am.config.KBFSOps().GetDirChildren(ctx, rn)
+	if err != nil {
+		rn.am.log.CDebugf(ctx, "Error getting children: %+v", err)
+		return false
+	}
+
+	h, err := rn.am.config.KBFSOps().GetTLFHandle(ctx, rn)
+	if err != nil {
+		rn.am.log.CDebugf(ctx, "Error getting handle: %+v", err)
+		return false
+	}
+
+	// If the directory is empty, clone it.  Otherwise, pull it.
+	var doneCh <-chan struct{}
+	cloneNeeded := len(children) == 0
+	ctx = context.WithValue(ctx, ctxReadWriteKey, 1)
+	if cloneNeeded {
+		doneCh, err = rn.am.Clone(
+			ctx, rn.h, rn.repoName, "master", h, rn.dstDir())
+	} else {
+		doneCh, err = rn.am.Pull(
+			ctx, rn.h, rn.repoName, "master", h, rn.dstDir())
+	}
+	if err != nil {
+		rn.am.log.CDebugf(ctx, "Error starting population: %+v", err)
+		return false
+	}
+
+	select {
+	case <-doneCh:
+		return true
+	case <-ctx.Done():
+		rn.am.log.CDebugf(ctx, "Error waiting for population: %+v", ctx.Err())
+		// If we did a clone, ask for a refresh anyway, so they will
+		// see the CLONING file at least.
+		return cloneNeeded
+	}
+}
+
+func (rn *repoNode) shouldPopulate() (bool, <-chan struct{}) {
+	rn.lock.Lock()
+	defer rn.lock.Unlock()
+	if rn.populated {
+		return false, nil
+	}
+	if rn.populatingInProgress != nil {
+		return false, rn.populatingInProgress
+	}
+	rn.populatingInProgress = make(chan struct{})
+	return true, rn.populatingInProgress
+}
+
+func (rn *repoNode) finishPopulate(populated bool) {
+	rn.lock.Lock()
+	defer rn.lock.Unlock()
+	rn.populated = populated
+	close(rn.populatingInProgress)
+	rn.populatingInProgress = nil
+}
+
+// ShouldRetryOnDirRead implements the Node interface for
+// repoNode.
+func (rn *repoNode) ShouldRetryOnDirRead(ctx context.Context) (
+	shouldRetry bool) {
+	if ctx.Value(ctxSkipPopulateKey) != nil {
+		return false
+	}
+
+	// Don't let this operation take more than a fixed amount of time.
+	// We should just let the caller see the CLONING file if it takes
+	// too long.
+	ctx, cancel := context.WithTimeout(ctx, populateTimeout)
+	defer cancel()
+
+	for {
+		doPopulate, ch := rn.shouldPopulate()
+		if !doPopulate && ch == nil {
+			return shouldRetry
+		}
+		// If it wasn't populated on the first check, always force the
+		// caller to retry.
+		shouldRetry = true
+
+		if doPopulate {
+			rn.am.log.CDebugf(ctx, "Populating repo node on first access")
+			shouldRetry = rn.populate(ctx)
+			rn.finishPopulate(shouldRetry)
+			return shouldRetry
+		}
+
+		// Wait for the existing populate to succeed or fail.
+		rn.am.log.CDebugf(ctx, "Waiting for existing populate to finish")
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			rn.am.log.CDebugf(ctx, "Error waiting for populate: %+v", ctx.Err())
+			return false
+		}
+	}
+}
+
+type tlfNode struct {
+	libkbfs.Node
+	am *AutogitManager
+	h  *libkbfs.TlfHandle
+}
+
+var _ libkbfs.Node = (*tlfNode)(nil)
+
+// ShouldCreateMissedLookup implements the Node interface for
+// tlfNode.
+func (tn tlfNode) ShouldCreateMissedLookup(
+	ctx context.Context, name string) (
+	bool, context.Context, libkbfs.EntryType, string) {
+	normalizedRepoName := normalizeRepoName(name)
+
+	// Is this a legit repo?
+	_, _, err := GetRepoAndID(ctx, tn.am.config, tn.h, name, "")
+	if err != nil {
+		return false, ctx, libkbfs.File, ""
+	}
+
+	ctx = context.WithValue(ctx, ctxReadWriteKey, 1)
+	if name != normalizedRepoName {
+		return true, ctx, libkbfs.Sym, normalizedRepoName
+	}
+	return true, ctx, libkbfs.Dir, ""
+}
+
+// WrapChild implements the Node interface for tlfNode.
+func (tn tlfNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	child = tn.Node.WrapChild(child)
+	return newRepoNode(child, tn.am, tn.h, child.GetBasename())
+}
 
 // tlfTypeNode represents an autogit subdirectory corresponding to a
 // specific TLF type.  It can only contain subdirectories that
@@ -73,6 +256,25 @@ func (ttn tlfTypeNode) ShouldCreateMissedLookup(
 			"Error parsing handle for name %s: %+v", name, err)
 		return ttn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
+}
+
+// WrapChild implements the Node interface for tlfTypeNode.
+func (ttn tlfTypeNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	child = ttn.Node.WrapChild(child)
+	ctx, cancel := context.WithTimeout(context.Background(), populateTimeout)
+	defer cancel()
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, ttn.am.config.KBPKI(), ttn.am.config.MDOps(),
+		child.GetBasename(), ttn.tlfType)
+	if err != nil {
+		// If we have a node for the child already, it can't be
+		// non-canonical because symlinks don't have Nodes.
+		ttn.am.log.CDebugf(ctx,
+			"Error parsing handle for tlfTypeNode child: %+v", err)
+		return child
+	}
+
+	return &tlfNode{child, ttn.am, h}
 }
 
 // autogitRootNode represents the .kbfs_autogit folder, and can only

--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -5,6 +5,8 @@
 package libgit
 
 import (
+	"context"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
+	gogit "gopkg.in/src-d/go-git.v4"
 )
 
 func TestAutogitNodeWrappers(t *testing.T) {
@@ -54,4 +57,79 @@ func TestAutogitNodeWrappers(t *testing.T) {
 	t.Log("Other autocreates in the root won't work")
 	_, err = rootFS.ReadDir("a")
 	require.NotNil(t, err)
+}
+
+func TestAutogitRepoNode(t *testing.T) {
+	ctx, config, cancel, tempdir := initConfigForAutogit(t)
+	defer cancel()
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+	defer os.RemoveAll(tempdir)
+
+	kbCtx := env.NewContext()
+	kbfsInitParams := libkbfs.DefaultInitParams(kbCtx)
+	am := NewAutogitManager(config, kbCtx, &kbfsInitParams, 1)
+	defer am.Shutdown()
+	nc := &newConfigger{config: config, user: "user1"}
+	am.getNewConfig = nc.getNewConfigForTest
+	rw := rootWrapper{am}
+	config.AddRootNodeWrapper(rw.wrap)
+
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Public)
+	require.NoError(t, err)
+	rootFS, err := libfs.NewFS(
+		ctx, config, h, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+
+	t.Log("Init a new repo directly into KBFS.")
+	dotgitFS, _, err := GetOrCreateRepoAndID(ctx, config, h, "test", "")
+	require.NoError(t, err)
+	err = rootFS.MkdirAll("worktree", 0600)
+	require.NoError(t, err)
+	worktreeFS, err := rootFS.Chroot("worktree")
+	require.NoError(t, err)
+	dotgitStorage, err := NewGitConfigWithoutRemotesStorer(dotgitFS)
+	require.NoError(t, err)
+	repo, err := gogit.Init(dotgitStorage, worktreeFS)
+	require.NoError(t, err)
+	addFileToWorktreeAndCommit(
+		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
+
+	t.Log("Use autogit to clone it using ReadDir")
+	checkAutogit := func(rootFS *libfs.FS) {
+		fis, err := rootFS.ReadDir(".kbfs_autogit/public/user1/test")
+		require.NoError(t, err)
+		require.Len(t, fis, 2) // foo and .git
+		f, err := rootFS.Open(".kbfs_autogit/public/user1/test/foo")
+		require.NoError(t, err)
+		defer f.Close()
+		data, err := ioutil.ReadAll(f)
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(data))
+	}
+	checkAutogit(rootFS)
+
+	t.Log("Use autogit to open it in another user's TLF")
+	nc2 := &newConfigger{config: config, user: "user2"}
+	ctx2 := libkbfs.NewContextReplayable(
+		context.Background(), func(c context.Context) context.Context {
+			return c
+		})
+	ctx2, config2, tempdir2, err := nc2.getNewConfigForTest(ctx2)
+	require.NoError(t, err)
+	defer libkbfs.CheckConfigAndShutdown(ctx2, t, config2)
+	defer os.RemoveAll(tempdir2)
+	am2 := NewAutogitManager(config2, kbCtx, &kbfsInitParams, 1)
+	defer am2.Shutdown()
+	am2.getNewConfig = nc2.getNewConfigForTest
+	rw2 := rootWrapper{am2}
+	config2.AddRootNodeWrapper(rw2.wrap)
+
+	h2, err := libkbfs.ParseTlfHandle(
+		ctx2, config2.KBPKI(), config2.MDOps(), "user2", tlf.Private)
+	require.NoError(t, err)
+	rootFS2, err := libfs.NewFS(
+		ctx2, config2, h2, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+	checkAutogit(rootFS2)
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1047,6 +1047,14 @@ func (fbo *folderBranchOps) getMDForRead(
 	return ImmutableRootMetadata{}, MDWriteNeededInRequest{}
 }
 
+// GetTLFHandle implements the KBFSOps interface for folderBranchOps.
+func (fbo *folderBranchOps) GetTLFHandle(ctx context.Context, node Node) (
+	*TlfHandle, error) {
+	lState := makeFBOLockState()
+	md, _ := fbo.getHead(lState)
+	return md.GetTlfHandle(), nil
+}
+
 // getMDForWriteOrRekeyLocked can fetch MDs, identify them and
 // contains the fancy logic. For reading use getMDLockedForRead.
 // Here we actually can fetch things from the server.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -221,6 +221,9 @@ type KBFSOps interface {
 	// GetTLFID gets the TLF ID for tlfHandle.
 	GetTLFID(ctx context.Context, tlfHandle *TlfHandle) (tlf.ID, error)
 
+	// GetTLFHandle returns the TLF handle for a given node.
+	GetTLFHandle(ctx context.Context, node Node) (*TlfHandle, error)
+
 	// GetOrCreateRootNode returns the root node and root entry
 	// info associated with the given TLF handle and branch, if
 	// the logged-in user has read permissions to the top-level

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -144,6 +144,12 @@ type Node interface {
 	// decides not to return `true` on its own.
 	ShouldCreateMissedLookup(ctx context.Context, name string) (
 		shouldCreate bool, newCtx context.Context, et EntryType, sympath string)
+	// ShouldRetryOnDirRead is called for Nodes representing
+	// directories, whenever a `Lookup` or `GetDirChildren` is done on
+	// them.  It should return true to instruct the caller that it
+	// should re-sync its view of the directory and retry the
+	// operation.
+	ShouldRetryOnDirRead(ctx context.Context) bool
 	// WrapChild returns a wrapped version of child, if desired, to
 	// add custom behavior to the child node. An implementation that
 	// wraps another `Node` (`inner`) must first call

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -513,6 +513,16 @@ func (fs *KBFSOpsStandard) GetTLFID(ctx context.Context,
 	return rmd.TlfID(), err
 }
 
+// GetTLFHandle implements the KBFSOps interface for KBFSOpsStandard.
+func (fs *KBFSOpsStandard) GetTLFHandle(ctx context.Context, node Node) (
+	*TlfHandle, error) {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	ops := fs.getOpsByNode(ctx, node)
+	return ops.GetTLFHandle(ctx, node)
+}
+
 // getMaybeCreateRootNode is called for GetOrCreateRootNode and GetRootNode.
 func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 	ctx context.Context, h *TlfHandle, branch BranchName, create bool) (

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -937,6 +937,19 @@ func (mr *MockKBFSOpsMockRecorder) GetTLFID(ctx, tlfHandle interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFID", reflect.TypeOf((*MockKBFSOps)(nil).GetTLFID), ctx, tlfHandle)
 }
 
+// GetTLFHandle mocks base method
+func (m *MockKBFSOps) GetTLFHandle(ctx context.Context, node Node) (*TlfHandle, error) {
+	ret := m.ctrl.Call(m, "GetTLFHandle", ctx, node)
+	ret0, _ := ret[0].(*TlfHandle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTLFHandle indicates an expected call of GetTLFHandle
+func (mr *MockKBFSOpsMockRecorder) GetTLFHandle(ctx, node interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFHandle", reflect.TypeOf((*MockKBFSOps)(nil).GetTLFHandle), ctx, node)
+}
+
 // GetOrCreateRootNode mocks base method
 func (m *MockKBFSOps) GetOrCreateRootNode(ctx context.Context, h *TlfHandle, branch BranchName) (Node, EntryInfo, error) {
 	ret := m.ctrl.Call(m, "GetOrCreateRootNode", ctx, h, branch)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -804,6 +804,18 @@ func (mr *MockNodeMockRecorder) ShouldCreateMissedLookup(ctx, name interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldCreateMissedLookup", reflect.TypeOf((*MockNode)(nil).ShouldCreateMissedLookup), ctx, name)
 }
 
+// ShouldRetryOnDirRead mocks base method
+func (m *MockNode) ShouldRetryOnDirRead(ctx context.Context) bool {
+	ret := m.ctrl.Call(m, "ShouldRetryOnDirRead", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ShouldRetryOnDirRead indicates an expected call of ShouldRetryOnDirRead
+func (mr *MockNodeMockRecorder) ShouldRetryOnDirRead(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldRetryOnDirRead", reflect.TypeOf((*MockNode)(nil).ShouldRetryOnDirRead), ctx)
+}
+
 // WrapChild mocks base method
 func (m *MockNode) WrapChild(child Node) Node {
 	ret := m.ctrl.Call(m, "WrapChild", child)

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -87,6 +87,10 @@ func (n *nodeStandard) ShouldCreateMissedLookup(ctx context.Context, _ string) (
 	return false, ctx, File, ""
 }
 
+func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {
+	return false
+}
+
 func (n *nodeStandard) WrapChild(child Node) Node {
 	return child
 }


### PR DESCRIPTION
This PR:
* adds a `Node.ShouldRetryOnDirRead` function. This method instructs folderBranchOps about whether or not a re-read is needed after a `GetDirChlidren` or `Lookup` call.  It will be used in future commits to allow autogit to auto-clone and auto-pull repos on the first access to a directory.
* adds a `KBFSOps.GetTLFHandle` function. This allows translating a `Node` object into a `TlfHandle` for the corresponding TLF.
* fixes a small nit in libfs to support the new write error on read-only nodes.
* adds auto-cloned/pulled autogit repo nodes. Currently this just clones or pulls, as needed, a repo during the first access to a `.kbfs_autogit/tlftype/tlfname/repo` directory.  It blocks until the clone/pull is complete, or until a 10-second timeout is hit, whichever comes first. A future PR will deal with keeping the directory up-to-date when the repo changes -- I realized that's going to be a little complex and didn't want to pollute this PR.

This PR depends on #1420, which should be reviewed/merged first.
