### PR TITLE
libgit: use node ID updates to figure out when a repo was updated

### DIFF
--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -148,7 +148,8 @@ func (f *Folder) LocalChange(ctx context.Context, node libkbfs.Node, write libkb
 
 // BatchChanges is called for changes originating anywhere, including
 // other hosts.
-func (f *Folder) BatchChanges(ctx context.Context, changes []libkbfs.NodeChange) {
+func (f *Folder) BatchChanges(
+	ctx context.Context, changes []libkbfs.NodeChange, _ []libkbfs.NodeID) {
 	f.fs.queueNotification(func() {})
 }
 

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -798,6 +798,7 @@ func (fs *FS) ToHTTPFileSystem(ctx context.Context) http.FileSystem {
 	return httpFileSystem{fs: fs.WithContext(ctx)}
 }
 
+// RootNode returns the Node of the root directory of this FS.
 func (fs *FS) RootNode() libkbfs.Node {
 	return fs.root
 }

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -797,3 +797,7 @@ func (fs *FS) WithContext(ctx context.Context) *FS {
 func (fs *FS) ToHTTPFileSystem(ctx context.Context) http.FileSystem {
 	return httpFileSystem{fs: fs.WithContext(ctx)}
 }
+
+func (fs *FS) RootNode() libkbfs.Node {
+	return fs.root
+}

--- a/libfuse/dir.go
+++ b/libfuse/dir.go
@@ -239,7 +239,8 @@ func (f *Folder) localChangeInvalidate(ctx context.Context, node libkbfs.Node,
 
 // BatchChanges is called for changes originating anywhere, including
 // other hosts.
-func (f *Folder) BatchChanges(ctx context.Context, changes []libkbfs.NodeChange) {
+func (f *Folder) BatchChanges(
+	ctx context.Context, changes []libkbfs.NodeChange, _ []libkbfs.NodeID) {
 	if !f.fs.conn.Protocol().HasInvalidate() {
 		// OSXFUSE 2.x does not support notifications
 		return

--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -506,7 +506,8 @@ func (am *AutogitManager) LocalChange(
 
 // BatchChanges implements the libkbfs.Observer interface for AutogitManager.
 func (am *AutogitManager) BatchChanges(
-	ctx context.Context, changes []libkbfs.NodeChange) {
+	ctx context.Context, changes []libkbfs.NodeChange,
+	affectedNodeIDs []libkbfs.NodeID) {
 	am.registryLock.RLock()
 	defer am.registryLock.RUnlock()
 	for _, change := range changes {

--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -26,7 +26,7 @@ func (fn *FakeObserver) LocalChange(ctx context.Context,
 }
 
 func (fn *FakeObserver) BatchChanges(
-	ctx context.Context, nodeChanges []NodeChange) {
+	ctx context.Context, nodeChanges []NodeChange, _ []NodeID) {
 	fn.batchChanges = nodeChanges
 	fn.ctx = ctx
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1697,9 +1697,14 @@ type Observer interface {
 	// updated locally, but not yet saved at the server.
 	LocalChange(ctx context.Context, node Node, write WriteRange)
 	// BatchChanges announces that the nodes have all been updated
-	// together atomically.  Each NodeChange in changes affects the
-	// same top-level folder and branch.
-	BatchChanges(ctx context.Context, changes []NodeChange)
+	// together atomically.  Each NodeChange in `changes` affects the
+	// same top-level folder and branch. `allAffectedNodeIDs` is a
+	// list of all the nodes that had their underlying data changed,
+	// even if it wasn't an user-visible change (e.g., if a
+	// subdirectory was updated, the directory block for the TLF root
+	// is updated but that wouldn't be visible to a user).
+	BatchChanges(ctx context.Context, changes []NodeChange,
+		allAffectedNodeIDs []NodeID)
 	// TlfHandleChange announces that the handle of the corresponding
 	// folder branch has changed, likely due to previously-unresolved
 	// assertions becoming resolved.  This indicates that the listener
@@ -1940,8 +1945,9 @@ type NodeCache interface {
 	Get(ref BlockRef) Node
 	// UpdatePointer updates the BlockPointer for the corresponding
 	// Node.  NodeCache ignores this call when oldRef is not cached in
-	// any Node. Returns whether the pointer was updated.
-	UpdatePointer(oldRef BlockRef, newPtr BlockPointer) bool
+	// any Node. Returns whether the ID of the node that was updated,
+	// or `nil` if nothing was updated.
+	UpdatePointer(oldRef BlockRef, newPtr BlockPointer) NodeID
 	// Move swaps the parent node for the corresponding Node, and
 	// updates the node's name.  NodeCache ignores the call when ptr
 	// is not cached.  If newParent is nil, it treats the ptr's

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -43,9 +43,11 @@ func (t *testCRObserver) LocalChange(ctx context.Context, node Node,
 }
 
 func (t *testCRObserver) BatchChanges(ctx context.Context,
-	changes []NodeChange) {
+	changes []NodeChange, _ []NodeID) {
 	t.changes = append(t.changes, changes...)
-	t.c <- struct{}{}
+	if len(changes) > 0 {
+		t.c <- struct{}{}
+	}
 }
 
 func (t *testCRObserver) TlfHandleChange(ctx context.Context,
@@ -365,7 +367,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 		rootNode1B.GetFolderBranch())
 	require.NoError(t, err)
 
-	// we should have had two updates, one for the unstaging and one
+	// we should have had at least two updates, one for the unstaging and one
 	// for the fast-forward
 	select {
 	case <-c:

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1076,7 +1076,7 @@ func (kofo *kbfsOpsFavoriteObserver) LocalChange(
 }
 
 func (kofo *kbfsOpsFavoriteObserver) BatchChanges(
-	_ context.Context, _ []NodeChange) {
+	_ context.Context, _ []NodeChange, _ []NodeID) {
 }
 
 func (kofo *kbfsOpsFavoriteObserver) TlfHandleChange(

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -2368,7 +2368,7 @@ type stallingNodeCache struct {
 }
 
 func (snc *stallingNodeCache) UpdatePointer(
-	oldRef BlockRef, newPtr BlockPointer) bool {
+	oldRef BlockRef, newPtr BlockPointer) NodeID {
 	select {
 	case <-snc.doStallUpdate:
 		<-snc.unstallUpdate

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5424,13 +5424,13 @@ func (mr *MockObserverMockRecorder) LocalChange(ctx, node, write interface{}) *g
 }
 
 // BatchChanges mocks base method
-func (m *MockObserver) BatchChanges(ctx context.Context, changes []NodeChange) {
-	m.ctrl.Call(m, "BatchChanges", ctx, changes)
+func (m *MockObserver) BatchChanges(ctx context.Context, changes []NodeChange, allAffectedNodeIDs []NodeID) {
+	m.ctrl.Call(m, "BatchChanges", ctx, changes, allAffectedNodeIDs)
 }
 
 // BatchChanges indicates an expected call of BatchChanges
-func (mr *MockObserverMockRecorder) BatchChanges(ctx, changes interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchChanges", reflect.TypeOf((*MockObserver)(nil).BatchChanges), ctx, changes)
+func (mr *MockObserverMockRecorder) BatchChanges(ctx, changes, allAffectedNodeIDs interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BatchChanges", reflect.TypeOf((*MockObserver)(nil).BatchChanges), ctx, changes, allAffectedNodeIDs)
 }
 
 // TlfHandleChange mocks base method
@@ -6781,9 +6781,9 @@ func (mr *MockNodeCacheMockRecorder) Get(ref interface{}) *gomock.Call {
 }
 
 // UpdatePointer mocks base method
-func (m *MockNodeCache) UpdatePointer(oldRef BlockRef, newPtr BlockPointer) bool {
+func (m *MockNodeCache) UpdatePointer(oldRef BlockRef, newPtr BlockPointer) NodeID {
 	ret := m.ctrl.Call(m, "UpdatePointer", oldRef, newPtr)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(NodeID)
 	return ret0
 }
 

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -157,9 +157,9 @@ func (ncs *nodeCacheStandard) Get(ref BlockRef) Node {
 
 // UpdatePointer implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) UpdatePointer(
-	oldRef BlockRef, newPtr BlockPointer) (updated bool) {
+	oldRef BlockRef, newPtr BlockPointer) (updatedNode NodeID) {
 	if oldRef == (BlockRef{}) && newPtr == (BlockPointer{}) {
-		return false
+		return nil
 	}
 
 	if !oldRef.IsValid() {
@@ -174,18 +174,18 @@ func (ncs *nodeCacheStandard) UpdatePointer(
 	defer ncs.lock.Unlock()
 	entry, ok := ncs.nodes[oldRef]
 	if !ok {
-		return false
+		return nil
 	}
 
 	// Cannot update the pointer for an unlinked node.
 	if entry.core.cachedPath.isValid() {
-		return false
+		return nil
 	}
 
 	entry.core.pathNode.BlockPointer = newPtr
 	delete(ncs.nodes, oldRef)
 	ncs.nodes[newPtr.Ref()] = entry
-	return true
+	return entry.core
 }
 
 // Move implements the NodeCache interface for nodeCacheStandard.

--- a/libkbfs/observer_list.go
+++ b/libkbfs/observer_list.go
@@ -49,11 +49,11 @@ func (ol *observerList) localChange(
 }
 
 func (ol *observerList) batchChanges(
-	ctx context.Context, changes []NodeChange) {
+	ctx context.Context, changes []NodeChange, affectedNodeIDs []NodeID) {
 	ol.lock.RLock()
 	defer ol.lock.RUnlock()
 	for _, o := range ol.observers {
-		o.BatchChanges(ctx, changes)
+		o.BatchChanges(ctx, changes, affectedNodeIDs)
 	}
 }
 


### PR DESCRIPTION
This PR lets TLF observers see the complete set of nodes that have been updated.  Previously, the observer could only see nodes that had operations done directly on them (like a write, create, etc).  Now the observer can also see nodes that had their underlying blocks updated, even if that didn't result in user-visible changes (e.g., `mkdir a/b/c` affects the underlying data of node `a`).

Then we use that in autogit to watch the entire top directory for a repo to see when something changed, rather than watching just the branch reference node.  That's because the branch ref could be in `packed-refs`, and moreover it could jump back and forth for the lifetime of the repo.

The downside is now we will check for updates whenever _anything_ changes in the git repo directory, which will result in some unneeded reset requests.  But we can optimize those pretty well in future PRs I think.

Issue: KBFS-2678