### PR TITLE
libfs: use `Node.Readonly()` to determine FS permissions

### DIFF
--- a/libfs/file_info.go
+++ b/libfs/file_info.go
@@ -16,14 +16,14 @@ import (
 type FileInfo struct {
 	fs   *FS
 	ei   libkbfs.EntryInfo
-	name string
+	node libkbfs.Node
 }
 
 var _ os.FileInfo = (*FileInfo)(nil)
 
 // Name implements the os.FileInfo interface for FileInfo.
 func (fi *FileInfo) Name() string {
-	return fi.name
+	return fi.node.GetBasename()
 }
 
 // Size implements the os.FileInfo interface for FileInfo.
@@ -35,10 +35,10 @@ func (fi *FileInfo) Size() int64 {
 // Mode implements the os.FileInfo interface for FileInfo.
 func (fi *FileInfo) Mode() os.FileMode {
 	mode, err := WritePermMode(
-		fi.fs.ctx, os.FileMode(0), fi.fs.config.KBPKI(), fi.fs.h)
+		fi.fs.ctx, fi.node, os.FileMode(0), fi.fs.config.KBPKI(), fi.fs.h)
 	if err != nil {
 		fi.fs.log.CWarningf(
-			fi.fs.ctx, "Couldn't get mode for file %s: %+v", fi.name, err)
+			fi.fs.ctx, "Couldn't get mode for file %s: %+v", fi.Name(), err)
 		mode = os.FileMode(0)
 	}
 

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -463,7 +463,7 @@ func (fs *FS) Stat(filename string) (fi os.FileInfo, err error) {
 	return &FileInfo{
 		fs:   fs,
 		ei:   ei,
-		name: n.GetBasename(),
+		node: n,
 	}, nil
 }
 
@@ -547,10 +547,15 @@ func (fs *FS) readDir(n libkbfs.Node) (fis []os.FileInfo, err error) {
 
 	fis = make([]os.FileInfo, 0, len(children))
 	for name, ei := range children {
+		child, _, err := fs.config.KBFSOps().Lookup(fs.ctx, n, name)
+		if err != nil {
+			return nil, err
+		}
+
 		fis = append(fis, &FileInfo{
 			fs:   fs,
 			ei:   ei,
-			name: name,
+			node: child,
 		})
 	}
 	return fis, nil
@@ -594,7 +599,7 @@ func (fs *FS) Lstat(filename string) (fi os.FileInfo, err error) {
 		return nil, err
 	}
 
-	_, ei, err := fs.config.KBFSOps().Lookup(fs.ctx, n, base)
+	n, ei, err := fs.config.KBFSOps().Lookup(fs.ctx, n, base)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +607,7 @@ func (fs *FS) Lstat(filename string) (fi os.FileInfo, err error) {
 	return &FileInfo{
 		fs:   fs,
 		ei:   ei,
-		name: base,
+		node: n,
 	}, nil
 }
 

--- a/libfs/httpfs.go
+++ b/libfs/httpfs.go
@@ -103,13 +103,13 @@ func (fod fileOrDir) Stat() (fi os.FileInfo, err error) {
 		return &FileInfo{
 			fs:   fod.file.fs,
 			ei:   fod.ei,
-			name: fod.file.filename,
+			node: fod.file.node,
 		}, nil
 	} else if fod.dir != nil {
 		return &FileInfo{
 			fs:   fod.dir.fs,
 			ei:   fod.ei,
-			name: fod.dir.dirname,
+			node: fod.dir.node,
 		}, nil
 	}
 	return nil, errors.New("invalid fod")

--- a/libfs/mode.go
+++ b/libfs/mode.go
@@ -43,9 +43,13 @@ func IsWriter(ctx context.Context, kbpki libkbfs.KBPKI,
 // currently logged-in user is a valid writer for the folder described
 // by `h`.
 func WritePermMode(
-	ctx context.Context, original os.FileMode, kbpki libkbfs.KBPKI,
-	h *libkbfs.TlfHandle) (os.FileMode, error) {
+	ctx context.Context, node libkbfs.Node, original os.FileMode,
+	kbpki libkbfs.KBPKI, h *libkbfs.TlfHandle) (os.FileMode, error) {
 	original &^= os.FileMode(0222) // clear write perm bits
+
+	if node.Readonly(ctx) {
+		return original, nil
+	}
 
 	isWriter, err := IsWriter(ctx, kbpki, h)
 	if err != nil {

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -65,7 +65,8 @@ var _ fs.Node = (*File)(nil)
 
 func (f *File) fillAttrWithMode(
 	ctx context.Context, ei *libkbfs.EntryInfo, a *fuse.Attr) (err error) {
-	if err = f.folder.fillAttrWithUIDAndWritePerm(ctx, ei, a); err != nil {
+	if err = f.folder.fillAttrWithUIDAndWritePerm(
+		ctx, f.node, ei, a); err != nil {
 		return err
 	}
 	a.Mode |= 0400

--- a/libfuse/symlink.go
+++ b/libfuse/symlink.go
@@ -41,8 +41,8 @@ func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 		return err
 	}
 
-	s.parent.folder.fillAttrWithUIDAndWritePerm(ctx, &de, a)
-	a.Mode = os.ModeSymlink | 0777
+	s.parent.folder.fillAttrWithUIDAndWritePerm(ctx, s.parent.node, &de, a)
+	a.Mode = os.ModeSymlink | a.Mode | 0400
 	return nil
 }
 

--- a/libfuse/symlink.go
+++ b/libfuse/symlink.go
@@ -42,7 +42,7 @@ func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	}
 
 	s.parent.folder.fillAttrWithUIDAndWritePerm(ctx, s.parent.node, &de, a)
-	a.Mode = os.ModeSymlink | a.Mode | 0400
+	a.Mode = os.ModeSymlink | a.Mode | 0500
 	return nil
 }
 


### PR DESCRIPTION
If a node is read-only, it shouldn't look writable to the OS.

Issue: KBFS-2678