### PR TITLE
folder_branch_ops: use `constIDGetter` for `ResolvesTo()`

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -893,8 +893,8 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	// unmerged branch. Add checks for this.
 	resolvesTo, partialResolvedOldHandle, err :=
 		oldHandle.ResolvesTo(
-			ctx, fbo.config.Codec(), fbo.config.KBPKI(), fbo.config.MDOps(),
-			*newHandle)
+			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
+			constIDGetter{fbo.id()}, *newHandle)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -46,7 +46,6 @@ type tlfJournalConfig interface {
 	diskLimitTimeout() time.Duration
 	teamMembershipChecker() kbfsmd.TeamMembershipChecker
 	BGFlushDirOpBatchSize() int
-	tlfIDGetter() tlfIDGetter
 }
 
 // tlfJournalConfigWrapper is an adapter for Config objects to the
@@ -73,10 +72,6 @@ func (ca tlfJournalConfigAdapter) resolver() resolver {
 
 func (ca tlfJournalConfigAdapter) teamMembershipChecker() kbfsmd.TeamMembershipChecker {
 	return ca.Config.KBPKI()
-}
-
-func (ca tlfJournalConfigAdapter) tlfIDGetter() tlfIDGetter {
-	return ca.Config.MDOps()
 }
 
 func (ca tlfJournalConfigAdapter) diskLimitTimeout() time.Duration {
@@ -1655,7 +1650,7 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 
 	handle, err := MakeTlfHandle(
 		ctx, ibrmdBareHandle, j.tlfID.Type(), j.config.resolver(),
-		j.config.usernameGetter(), j.config.tlfIDGetter())
+		j.config.usernameGetter(), constIDGetter{j.tlfID})
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -152,10 +152,6 @@ func (c testTLFJournalConfig) teamMembershipChecker() kbfsmd.TeamMembershipCheck
 	return nil
 }
 
-func (c testTLFJournalConfig) tlfIDGetter() tlfIDGetter {
-	return nil
-}
-
 func (c testTLFJournalConfig) diskLimitTimeout() time.Duration {
 	return c.dlTimeout
 }


### PR DESCRIPTION
If we use `MDOps()` on a folder that's transitioning to be a conflict folder, we could end up looking up a now fully-resolved handle that matches the handle of the winning, non-conflict folder, and getting back the wrong TLF ID.

Also use one in `tlfJournal` because it's safer and faster, and why not?

Issue: KBFS-2708