### PR TITLE
folder_branch_ops: fix Lookup data race

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1961,6 +1961,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	var n Node
 	var de DirEntry
 	err = runUnlessCanceled(ctx, func() error {
+		var err error
 		n, de, err = fbo.lookup(ctx, dir, name)
 		return err
 	})
@@ -1980,6 +1981,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 
 		fbo.log.CDebugf(ctx, "Retrying lookup of an empty directory")
 		err = runUnlessCanceled(ctx, func() error {
+			var err error
 			n, de, err = fbo.lookup(ctx, dir, name)
 			return err
 		})


### PR DESCRIPTION
Avoid `runUnlessCanceled` and the goroutine it spawns trying to write to the same `err` variable.

Causing some test failures, like: https://ci.keyba.se/job/kbfs/job/PR-1433/1/execution/node/301/log/