### PR TITLE
libgit: increase timeout for autogit manager tests

### DIFF
--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -33,7 +33,7 @@ func initConfigForAutogit(t *testing.T) (
 	success := false
 	ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, kbfsRepoDir)
 
-	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel = context.WithTimeout(ctx, 60*time.Second)
 
 	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
 	require.NoError(t, err)


### PR DESCRIPTION
These are pretty disk intensive and can lead to timeouts when CI
machines are loaded I think.

Hopefully future autogit optimizations will improve performance here.