### PR TITLE
libgit: prevent goroutine leaks by canceling contexts

### DIFF
--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -218,8 +218,10 @@ func (am *AutogitManager) resetWorker(wg *sync.WaitGroup) {
 	defer wg.Done()
 	for reqInt := range am.resetQueue.Out() {
 		req := reqInt.(resetReq)
-		ctx := libkbfs.CtxWithRandomIDReplayable(
-			context.Background(), ctxIDKey, ctxOpID, am.log)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		ctx = libkbfs.CtxWithRandomIDReplayable(
+			ctx, ctxIDKey, ctxOpID, am.log)
 		for {
 			waitCh := am.markResetReqInProgress(req)
 			if waitCh == nil {

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -136,6 +136,8 @@ func (rh *RPCHandler) CreateRepo(
 		rh.log.CDebugf(ctx, "Done creating repo: %+v", err)
 	}()
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
 		ctx, arg.Folder)
 	if err != nil {
@@ -170,8 +172,10 @@ func (rh *RPCHandler) scheduleCleaning(folder keybase1.Folder) {
 	time.AfterFunc(minDeletedAgeForCleaning+1*time.Second, func() {
 		log := rh.config.MakeLogger("")
 
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
-			context.Background(), folder)
+			ctx, folder)
 		if err != nil {
 			log.CDebugf(nil, "Couldn't init for scheduled cleaning of %s: %+v",
 				folder.Name, err)
@@ -213,6 +217,8 @@ func (rh *RPCHandler) DeleteRepo(
 		rh.log.CDebugf(ctx, "Done deleting repo: %+v", err)
 	}()
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
 		ctx, arg.Folder)
 	if err != nil {
@@ -250,6 +256,8 @@ func (rh *RPCHandler) Gc(
 		rh.log.CDebugf(ctx, "Done garbage-collecting repo: %+v", err)
 	}()
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
 		ctx, arg.Folder)
 	if err != nil {
@@ -288,6 +296,8 @@ func (rh *RPCHandler) RenameRepo(ctx context.Context,
 		rh.log.CDebugf(ctx, "Done renaming repo: %+v", err)
 	}()
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	ctx, gitConfig, tlfHandle, tempDir, err := rh.getHandleAndConfig(
 		ctx, folder)
 	if err != nil {


### PR DESCRIPTION
Pointed out by jzila on #1427.