### PR TITLE
*: promote `SyncFromServerForTesting`

### DIFF
--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -779,7 +779,7 @@ func TestPackRefsAndOverwritePackedRef(t *testing.T) {
 	rootNode, _, err := config2.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config2.KBFSOps().SyncFromServerForTesting(
+	err = config2.KBFSOps().SyncFromServer(
 		ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	heads = testListAndGetHeadsWithName(t, ctx, config2, git2,
@@ -897,7 +897,7 @@ func TestPackRefsAndDeletePackedRef(t *testing.T) {
 	rootNode, _, err := config2.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config2.KBFSOps().SyncFromServerForTesting(
+	err = config2.KBFSOps().SyncFromServer(
 		ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	testListAndGetHeadsWithName(t, ctx, config2, git2,

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -1809,7 +1809,7 @@ func syncFolderToServerHelper(t *testing.T, tlf string, ty tlf.Type, fs *FS) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	defer libkbfs.CleanupCancellationDelayer(ctx)
 	root := libkbfs.GetRootNodeOrBust(ctx, t, fs.config, tlf, ty)
-	err := fs.config.KBFSOps().SyncFromServerForTesting(
+	err := fs.config.KBFSOps().SyncFromServer(
 		ctx, root.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)

--- a/libdokan/sync_from_server_file.go
+++ b/libdokan/sync_from_server_file.go
@@ -38,7 +38,7 @@ func (f *SyncFromServerFile) WriteFile(ctx context.Context, fi *dokan.FileInfo, 
 		// Nothing to do.
 		return len(bs), nil
 	}
-	err = f.folder.fs.config.KBFSOps().SyncFromServerForTesting(
+	err = f.folder.fs.config.KBFSOps().SyncFromServer(
 		ctx, folderBranch, nil)
 	if err != nil {
 		return 0, err

--- a/libfs/file.go
+++ b/libfs/file.go
@@ -175,7 +175,7 @@ func (f *File) Lock() (err error) {
 	// Now, sync up with the server, while making sure a lock is held by us. If
 	// lock taking fails, RPC layer retries automatically.
 	lockID := f.getLockID()
-	return f.fs.config.KBFSOps().SyncFromServerForTesting(f.fs.ctx,
+	return f.fs.config.KBFSOps().SyncFromServer(f.fs.ctx,
 		f.fs.root.GetFolderBranch(), &lockID)
 }
 

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -2442,7 +2442,7 @@ func syncFolderToServerHelper(t *testing.T, tlf string, ty tlf.Type, fs *FS) {
 	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 	defer libkbfs.CleanupCancellationDelayer(ctx)
 	root := libkbfs.GetRootNodeOrBust(ctx, t, fs.config, tlf, ty)
-	err := fs.config.KBFSOps().SyncFromServerForTesting(ctx,
+	err := fs.config.KBFSOps().SyncFromServer(ctx,
 		root.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)

--- a/libfuse/sync_from_server_file.go
+++ b/libfuse/sync_from_server_file.go
@@ -58,7 +58,7 @@ func (f *SyncFromServerFile) Write(ctx context.Context, req *fuse.WriteRequest,
 	// Use a context with a nil CtxAppIDKey value so that
 	// notifications generated from this sync won't be discarded.
 	syncCtx := context.WithValue(ctx, libfs.CtxAppIDKey, nil)
-	err = f.folder.fs.config.KBFSOps().SyncFromServerForTesting(
+	err = f.folder.fs.config.KBFSOps().SyncFromServer(
 		syncCtx, folderBranch, nil)
 	if err != nil {
 		return err

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -152,7 +152,7 @@ func checkFileInRootFS(
 	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config.KBFSOps().SyncFromServerForTesting(
+	err = config.KBFSOps().SyncFromServer(
 		ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -142,13 +142,13 @@ func TestAutogitRepoNode(t *testing.T) {
 	srcRootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config.KBFSOps().SyncFromServerForTesting(
+	err = config.KBFSOps().SyncFromServer(
 		ctx, srcRootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	srcRootNode2, _, err := config2.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config2.KBFSOps().SyncFromServerForTesting(
+	err = config2.KBFSOps().SyncFromServer(
 		ctx, srcRootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -166,13 +166,13 @@ func TestAutogitRepoNode(t *testing.T) {
 	dstRootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
 		ctx, h, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config.KBFSOps().SyncFromServerForTesting(
+	err = config.KBFSOps().SyncFromServer(
 		ctx, dstRootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	dstRootNode2, _, err := config2.KBFSOps().GetOrCreateRootNode(
 		ctx, h2, libkbfs.MasterBranch)
 	require.NoError(t, err)
-	err = config2.KBFSOps().SyncFromServerForTesting(
+	err = config2.KBFSOps().SyncFromServer(
 		ctx, dstRootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -270,7 +270,7 @@ func testCRSharedFolderForUsers(
 		}
 
 		kbfsOps := config.KBFSOps()
-		kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+		kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 		rootNode := GetRootNodeOrBust(ctx, t, config, name, tlf.Private)
 		dir := rootNode
 		for _, d := range dirs {
@@ -794,7 +794,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 		t.Fatalf("Couldn't sync all: %v", err)
 	}
 
-	config2.KBFSOps().SyncFromServerForTesting(ctx, fb, nil)
+	config2.KBFSOps().SyncFromServer(ctx, fb, nil)
 
 	// pause user 2
 	_, err = DisableUpdatesForTesting(config2, fb)
@@ -1139,7 +1139,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 	}
 
 	// user2 lookup
-	err = config2.KBFSOps().SyncFromServerForTesting(ctx, fb, nil)
+	err = config2.KBFSOps().SyncFromServer(ctx, fb, nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync user 2")
 	}
@@ -1353,7 +1353,7 @@ func TestCRDoActionsWriteConflict(t *testing.T) {
 	}
 
 	// user2 lookup
-	err = config2.KBFSOps().SyncFromServerForTesting(ctx, fb, nil)
+	err = config2.KBFSOps().SyncFromServer(ctx, fb, nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync user 2")
 	}

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -53,7 +53,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 	}
 
 	// Wait for outstanding archives
-	err = kbfsOps.SyncFromServerForTesting(ctx,
+	err = kbfsOps.SyncFromServer(ctx,
 		rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -338,7 +338,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	}
 
 	// Wait for outstanding archives
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -376,7 +376,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	}
 
 	// Sync u2
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -403,7 +403,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 		t.Fatalf("Couldn't write file: %+v", err)
 	}
 	// Wait for outstanding archives
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -447,7 +447,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 	}
 
 	// Wait for outstanding archives
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -552,7 +552,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 
 	// Rekey from another device.
 	kbfsOps1 := config1.KBFSOps()
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -564,7 +564,7 @@ func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
 	}
 
 	// Retry the QR; should work now.
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -613,7 +613,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	}
 
 	// Wait for outstanding archives
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -685,7 +685,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 	}
 
 	// Wait for outstanding archives
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -456,7 +456,7 @@ func (fbo *folderBranchOps) Shutdown(ctx context.Context) error {
 			fbo.log.CDebugf(ctx, "Skipping state-checking due to being staged")
 		} else {
 			// Make sure we're up to date first
-			if err := fbo.SyncFromServerForTesting(ctx,
+			if err := fbo.SyncFromServer(ctx,
 				fbo.folderBranch, nil); err != nil {
 				return err
 			}
@@ -873,7 +873,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
 	if fbo.head == (ImmutableRootMetadata{}) {
-		// This can happen in tests via SyncFromServerForTesting().
+		// This can happen in tests via SyncFromServer().
 		return fbo.setInitialHeadTrustedLocked(ctx, lState, md)
 	}
 
@@ -1866,7 +1866,7 @@ func (fbo *folderBranchOps) GetDirChildren(ctx context.Context, dir Node) (
 	}
 
 	if dir.ShouldRetryOnDirRead(ctx) {
-		err2 := fbo.SyncFromServerForTesting(ctx, fbo.folderBranch, nil)
+		err2 := fbo.SyncFromServer(ctx, fbo.folderBranch, nil)
 		if err2 != nil {
 			fbo.log.CDebugf(ctx, "Error syncing before retry: %+v", err2)
 			return nil, nil
@@ -1973,7 +1973,7 @@ func (fbo *folderBranchOps) Lookup(ctx context.Context, dir Node, name string) (
 	}
 
 	if dir.ShouldRetryOnDirRead(ctx) {
-		err2 := fbo.SyncFromServerForTesting(ctx, fbo.folderBranch, nil)
+		err2 := fbo.SyncFromServer(ctx, fbo.folderBranch, nil)
 		if err2 != nil {
 			fbo.log.CDebugf(ctx, "Error syncing before retry: %+v", err2)
 			return n, de.EntryInfo, err
@@ -5457,12 +5457,11 @@ func (fbo *folderBranchOps) RequestRekey(_ context.Context, tlf tlf.ID) {
 	fbo.rekeyFSM.Event(NewRekeyRequestEvent())
 }
 
-func (fbo *folderBranchOps) SyncFromServerForTesting(ctx context.Context,
+func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 	folderBranch FolderBranch, lockBeforeGet *keybase1.LockID) (err error) {
-	fbo.log.CDebugf(ctx, "SyncFromServerForTesting")
+	fbo.log.CDebugf(ctx, "SyncFromServer")
 	defer func() {
-		fbo.deferLog.CDebugf(ctx,
-			"SyncFromServerForTesting done: %+v", err)
+		fbo.deferLog.CDebugf(ctx, "SyncFromServer done: %+v", err)
 	}()
 
 	if folderBranch != fbo.folderBranch {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -361,14 +361,14 @@ type KBFSOps interface {
 	// RequestRekey requests to rekey this folder. Note that this asynchronously
 	// requests a rekey, so canceling ctx doesn't cancel the rekey.
 	RequestRekey(ctx context.Context, id tlf.ID)
-	// SyncFromServerForTesting blocks until the local client has
-	// contacted the server and guaranteed that all known updates
-	// for the given top-level folder have been applied locally
-	// (and notifications sent out to any observers).  It returns
-	// an error if this folder-branch is currently unmerged or
-	// dirty locally. If lockBeforeGet is non-nil, it blocks on idempotently
-	// taking the lock from server at the time it gets any metadata.
-	SyncFromServerForTesting(ctx context.Context,
+	// SyncFromServer blocks until the local client has contacted the
+	// server and guaranteed that all known updates for the given
+	// top-level folder have been applied locally (and notifications
+	// sent out to any observers).  It returns an error if this
+	// folder-branch is currently unmerged or dirty locally. If
+	// lockBeforeGet is non-nil, it blocks on idempotently taking the
+	// lock from server at the time it gets any metadata.
+	SyncFromServer(ctx context.Context,
 		folderBranch FolderBranch, lockBeforeGet *keybase1.LockID) error
 	// GetUpdateHistory returns a complete history of all the merged
 	// updates of the given folder, in a data structure that's

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -90,7 +90,7 @@ func TestBasicMDUpdate(t *testing.T) {
 	err = kbfsOps1.SyncAll(ctx, rootNode1.GetFolderBranch())
 	require.NoError(t, err)
 
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -150,7 +150,7 @@ func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	require.NoError(t, err)
 
 	kbfsOps2 := config2.KBFSOps()
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -390,11 +390,11 @@ func TestUnmergedAfterRestart(t *testing.T) {
 		}
 	}
 
-	err = config1B.KBFSOps().SyncFromServerForTesting(
+	err = config1B.KBFSOps().SyncFromServer(
 		ctx, fileNode1B.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	err = config2B.KBFSOps().
-		SyncFromServerForTesting(ctx,
+		SyncFromServer(ctx,
 			rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -455,7 +455,7 @@ func TestMultiUserWrite(t *testing.T) {
 
 	readAndCompareData(t, config2, ctx, name, data3, userName2)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	readAndCompareData(t, config1, ctx, name, data3, userName2)
@@ -523,11 +523,11 @@ func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -740,11 +740,11 @@ func TestBasicCRFileConflict(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -830,11 +830,11 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -943,7 +943,7 @@ func TestCRDouble(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -964,7 +964,7 @@ func TestCRDouble(t *testing.T) {
 	ops.fbm.waitForDeletingBlocks(ctx)
 
 	// Sync user 1, then start another round of CR.
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	// disable updates and CR on user 2
@@ -993,7 +993,7 @@ func TestCRDouble(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 }
@@ -1056,7 +1056,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	require.IsType(t, NeedSelfRekeyError{}, err)
 
 	// User 2 syncs
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -1080,7 +1080,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	require.NoError(t, err)
 
 	// User 1 syncs
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -1098,19 +1098,19 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	// wait for the rekey to happen
 	RequestRekeyAndWaitForOneFinishEvent(ctx,
 		config2.KBFSOps(), rootNode2.GetFolderBranch().Tlf)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	// Look it up on user 2 dev 2 after syncing.
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
@@ -1197,7 +1197,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	require.IsType(t, NeedSelfRekeyError{}, err)
 
 	// User 2 syncs
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -1227,7 +1227,7 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config1,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	require.NoError(t, err)
@@ -1235,16 +1235,16 @@ func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	RequestRekeyAndWaitForOneFinishEvent(ctx,
 		config1.KBFSOps(), rootNode1.GetFolderBranch().Tlf)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	// Look it up on user 2 dev 2 after syncing.
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	rootNode2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
@@ -1403,7 +1403,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 }
@@ -1479,7 +1479,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 		err = RestartCRForTesting(putCtx, config2,
 			rootNode2.GetFolderBranch())
 		assert.NoError(t, err)
-		err = kbfsOps2.SyncFromServerForTesting(putCtx,
+		err = kbfsOps2.SyncFromServer(putCtx,
 			rootNode2.GetFolderBranch(), nil)
 		assert.Error(t, err)
 	}()
@@ -1504,7 +1504,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -1601,7 +1601,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		err = kbfsOps2.SyncFromServerForTesting(firstPutCtx,
+		err = kbfsOps2.SyncFromServer(firstPutCtx,
 			rootNode2.GetFolderBranch(), nil)
 		if !assert.Error(t, err) {
 			return
@@ -1751,7 +1751,7 @@ func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 		BackgroundContextWithCancellationDelayer(), config2,
 		rootNode2.GetFolderBranch())
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -919,14 +919,14 @@ func (fs *KBFSOpsStandard) RequestRekey(ctx context.Context, id tlf.ID) {
 	ops.RequestRekey(ctx, id)
 }
 
-// SyncFromServerForTesting implements the KBFSOps interface for KBFSOpsStandard
-func (fs *KBFSOpsStandard) SyncFromServerForTesting(ctx context.Context,
+// SyncFromServer implements the KBFSOps interface for KBFSOpsStandard
+func (fs *KBFSOpsStandard) SyncFromServer(ctx context.Context,
 	folderBranch FolderBranch, lockBeforeGet *keybase1.LockID) error {
 	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
 	defer timeTrackerDone()
 
 	ops := fs.getOps(ctx, folderBranch, FavoritesOpAdd)
-	return ops.SyncFromServerForTesting(ctx, folderBranch, lockBeforeGet)
+	return ops.SyncFromServer(ctx, folderBranch, lockBeforeGet)
 }
 
 // GetUpdateHistory implements the KBFSOps interface for KBFSOpsStandard

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -832,7 +832,7 @@ func TestKBFSOpsTruncateAndOverwriteDeferredWithArchivedBlock(t *testing.T) {
 	}
 
 	// Wait for the archiving to finish
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server")
 	}
@@ -1521,7 +1521,7 @@ func testKBFSOpsMultiBlockWriteDuringRetriedSync(t *testing.T, nFiles int) {
 		t.Fatalf("Couldn't remove file: %v", err)
 	}
 
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
@@ -1677,7 +1677,7 @@ func testKBFSOpsMultiBlockWriteWithRetryAndError(t *testing.T, nFiles int) {
 		t.Fatalf("Couldn't remove file: %v", err)
 	}
 
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
@@ -2025,9 +2025,9 @@ func TestKBFSOpsConcurCanceledSyncSucceeds(t *testing.T) {
 		t.Fatalf("Blocks left to delete after sync")
 	}
 
-	// The first put actually succeeded, so
-	// SyncFromServerForTesting and make sure it worked.
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	// The first put actually succeeded, so SyncFromServer and make
+	// sure it worked.
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
@@ -2140,7 +2140,7 @@ func TestKBFSOpsConcurCanceledSyncFailsAfterCanceledSyncSucceeds(t *testing.T) {
 	}
 
 	// Wait for CR to finish
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
@@ -2176,7 +2176,7 @@ func TestKBFSOpsTruncateWithDupBlockCanceled(t *testing.T) {
 		t.Fatalf("Couldn't sync file: %v", err)
 	}
 
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %v", err)
 	}
@@ -2431,7 +2431,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	}
 
 	// u2 syncs and then disables updates.
-	if err := kbfsOps2.SyncFromServerForTesting(
+	if err := kbfsOps2.SyncFromServer(
 		ctx, rootNode2.GetFolderBranch(), nil); err != nil {
 		t.Fatal("Couldn't sync user 2 from server")
 	}
@@ -2476,7 +2476,7 @@ func TestKBFSOpsLookupSyncRace(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if err := kbfsOps2.SyncFromServerForTesting(
+		if err := kbfsOps2.SyncFromServer(
 			ctx, rootNode2.GetFolderBranch(), nil); err != nil {
 			t.Errorf("Couldn't sync user 2 from server: %v", err)
 		}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3176,7 +3176,7 @@ func TestKBFSOpsCreateFileWithArchivedBlock(t *testing.T) {
 	}
 
 	// Wait for the archiving to finish
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server")
 	}
@@ -3235,7 +3235,7 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	}
 
 	// Wait for the archiving to finish
-	err = kbfsOps.SyncFromServerForTesting(ctx, rootNode.GetFolderBranch(), nil)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server")
 	}
@@ -3377,7 +3377,7 @@ func TestKBFSOpsMaliciousMDServerRange(t *testing.T) {
 
 	// Simulate the server triggering alice to update.
 	config1.SetKeyCache(NewKeyCacheStandard(1))
-	err = kbfsOps1.SyncFromServerForTesting(ctx, fb1, nil)
+	err = kbfsOps1.SyncFromServer(ctx, fb1, nil)
 	// TODO: We can actually fake out the PrevRoot pointer, too
 	// and then we'll be caught by the handle check. But when we
 	// have MDOps do the handle check, that'll trigger first.

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -973,7 +973,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	}
 
 	// u2 syncs after the rekey
-	if err := kbfsOps2.SyncFromServerForTesting(ctx,
+	if err := kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil); err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
 	}
@@ -1012,7 +1012,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 		t.Fatalf("Couldn't rekey: %+v", err)
 	}
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1044,7 +1044,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	root2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		root2Dev2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1063,7 +1063,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	// all its cached data and refuse to serve any more.  (However, in
 	// production the device's session would likely be revoked,
 	// probably leading to NoCurrentSession errors anyway.)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	if err == nil {
 		// This is not expected to succeed; the node will be unable to
@@ -1308,7 +1308,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 	}
 
 	t.Log("User 1 syncs from the server")
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1620,7 +1620,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 		t, ctx, config2Dev2, rootNode1.GetFolderBranch().Tlf)
 
 	// user 1 syncs from server
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1634,7 +1634,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	}
 
 	// user 2 syncs from server
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1685,7 +1685,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	}
 
 	// user 2 dev 2 syncs from server
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1699,7 +1699,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 	}
 
 	// user 3 dev 2 syncs from server
-	err = kbfsOps3Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps3Dev2.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1834,7 +1834,7 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.
 		t.Fatalf("Expected failure due to conflict")
 	}
 
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		root2Dev2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1851,7 +1851,7 @@ func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.
 	}
 
 	// device 1 should still work
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -1990,7 +1990,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 	}
 
 	// device 1 should be able to read the new file
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)
@@ -2296,7 +2296,7 @@ func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	root2Dev2 := GetRootNodeOrBust(ctx, t, config2Dev2, name, tlf.Private)
 	kbfsOps2Dev2 := config2Dev2.KBFSOps()
-	err = kbfsOps2Dev2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2Dev2.SyncFromServer(ctx,
 		root2Dev2.GetFolderBranch(), nil)
 	if err != nil {
 		t.Fatalf("Couldn't sync from server: %+v", err)

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -399,7 +399,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	require.NoError(t, err)
 
 	kbfsOps2 := config2.KBFSOps()
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -408,7 +408,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1218,16 +1218,16 @@ func (mr *MockKBFSOpsMockRecorder) RequestRekey(ctx, id interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRekey", reflect.TypeOf((*MockKBFSOps)(nil).RequestRekey), ctx, id)
 }
 
-// SyncFromServerForTesting mocks base method
-func (m *MockKBFSOps) SyncFromServerForTesting(ctx context.Context, folderBranch FolderBranch, lockBeforeGet *keybase1.LockID) error {
-	ret := m.ctrl.Call(m, "SyncFromServerForTesting", ctx, folderBranch, lockBeforeGet)
+// SyncFromServer mocks base method
+func (m *MockKBFSOps) SyncFromServer(ctx context.Context, folderBranch FolderBranch, lockBeforeGet *keybase1.LockID) error {
+	ret := m.ctrl.Call(m, "SyncFromServer", ctx, folderBranch, lockBeforeGet)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SyncFromServerForTesting indicates an expected call of SyncFromServerForTesting
-func (mr *MockKBFSOpsMockRecorder) SyncFromServerForTesting(ctx, folderBranch, lockBeforeGet interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFromServerForTesting", reflect.TypeOf((*MockKBFSOps)(nil).SyncFromServerForTesting), ctx, folderBranch, lockBeforeGet)
+// SyncFromServer indicates an expected call of SyncFromServer
+func (mr *MockKBFSOpsMockRecorder) SyncFromServer(ctx, folderBranch, lockBeforeGet interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFromServer", reflect.TypeOf((*MockKBFSOps)(nil).SyncFromServer), ctx, folderBranch, lockBeforeGet)
 }
 
 // GetUpdateHistory mocks base method

--- a/libkbfs/tlf_edit_history_test.go
+++ b/libkbfs/tlf_edit_history_test.go
@@ -58,7 +58,7 @@ func TestBasicTlfEditHistory(t *testing.T) {
 	require.NoError(t, err)
 
 	kbfsOps2 := config2.KBFSOps()
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestBasicTlfEditHistory(t *testing.T) {
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestBasicTlfEditHistory(t *testing.T) {
 func testDoTlfEdit(t *testing.T, ctx context.Context, tlfName string,
 	kbfsOps KBFSOps, rootNode Node, i int, uid keybase1.UID, now time.Time,
 	createRemainders map[keybase1.UID]int, edits TlfWriterEdits) {
-	err := kbfsOps.SyncFromServerForTesting(ctx,
+	err := kbfsOps.SyncFromServer(ctx,
 		rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -225,10 +225,10 @@ func TestLongTlfEditHistory(t *testing.T) {
 			createRemainders, expectedEdits)
 	}
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
@@ -294,7 +294,7 @@ func TestLongTlfEditHistory(t *testing.T) {
 		renameFile+".New")
 	require.NoError(t, err)
 
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 	editNode, _, err := kbfsOps2.Lookup(ctx, rootNode2, editFile)
@@ -304,10 +304,10 @@ func TestLongTlfEditHistory(t *testing.T) {
 	err = kbfsOps2.SyncAll(ctx, editNode.GetFolderBranch())
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServerForTesting(ctx,
+	err = kbfsOps1.SyncFromServer(ctx,
 		rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	err = kbfsOps2.SyncFromServerForTesting(ctx,
+	err = kbfsOps2.SyncFromServer(ctx,
 		rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -501,7 +501,7 @@ func initRoot() fileOp {
 		if !c.noSyncInit {
 			// Do this before GetRootDir so that we pick
 			// up any TLF name changes.
-			err := c.engine.SyncFromServerForTesting(c.user, c.tlfName, c.tlfType)
+			err := c.engine.SyncFromServer(c.user, c.tlfName, c.tlfType)
 			if err != nil {
 				return err
 			}
@@ -714,7 +714,7 @@ func rename(src, dst string) fileOp {
 
 func disableUpdates() fileOp {
 	return fileOp{func(c *ctx) error {
-		err := c.engine.SyncFromServerForTesting(c.user, c.tlfName, c.tlfType)
+		err := c.engine.SyncFromServer(c.user, c.tlfName, c.tlfType)
 		if err != nil {
 			return err
 		}
@@ -876,7 +876,7 @@ func reenableUpdates() fileOp {
 		if err != nil {
 			return err
 		}
-		return c.engine.SyncFromServerForTesting(c.user, c.tlfName, c.tlfType)
+		return c.engine.SyncFromServer(c.user, c.tlfName, c.tlfType)
 	}, IsInit, "reenableUpdates()"}
 }
 
@@ -893,7 +893,7 @@ func forceQuotaReclamation() fileOp {
 			return err
 		}
 		// Wait for QR to finish.
-		return c.engine.SyncFromServerForTesting(c.user, c.tlfName, c.tlfType)
+		return c.engine.SyncFromServer(c.user, c.tlfName, c.tlfType)
 	}, IsInit, "forceQuotaReclamation()"}
 }
 

--- a/test/engine.go
+++ b/test/engine.go
@@ -114,10 +114,9 @@ type Engine interface {
 	// ReenableUpdates is called by the test harness as the given
 	// user to resume updates if previously disabled for testing.
 	ReenableUpdates(u User, tlfName string, t tlf.Type) (err error)
-	// SyncFromServerForTesting is called by the test harness as
-	// the given user to actively retrieve new metadata for a
-	// folder.
-	SyncFromServerForTesting(u User, tlfName string, t tlf.Type) (err error)
+	// SyncFromServer is called by the test harness as the given user
+	// to actively retrieve new metadata for a folder.
+	SyncFromServer(u User, tlfName string, t tlf.Type) (err error)
 	// ForceQuotaReclamation starts quota reclamation by the given
 	// user in the TLF corresponding to the given node.
 	ForceQuotaReclamation(u User, tlfName string, t tlf.Type) (err error)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -302,9 +302,9 @@ func (*fsEngine) ReenableUpdates(user User, tlfName string, t tlf.Type) (err err
 		[]byte("on"), 0644)
 }
 
-// SyncFromServerForTesting is called by the test harness as the given
-// user to actively retrieve new metadata for a folder.
-func (e *fsEngine) SyncFromServerForTesting(user User, tlfName string, t tlf.Type) (err error) {
+// SyncFromServer is called by the test harness as the given user to
+// actively retrieve new metadata for a folder.
+func (e *fsEngine) SyncFromServer(user User, tlfName string, t tlf.Type) (err error) {
 	u := user.(*fsUser)
 	path := buildTlfPath(u, tlfName, t)
 	return ioutil.WriteFile(

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -575,8 +575,8 @@ func (k *LibKBFS) ReenableUpdates(u User, tlfName string, t tlf.Type) error {
 	return nil
 }
 
-// SyncFromServerForTesting implements the Engine interface.
-func (k *LibKBFS) SyncFromServerForTesting(u User, tlfName string, t tlf.Type) (err error) {
+// SyncFromServer implements the Engine interface.
+func (k *LibKBFS) SyncFromServer(u User, tlfName string, t tlf.Type) (err error) {
 	config := u.(*libkbfs.ConfigLocal)
 
 	ctx, cancel := k.newContext(u)
@@ -586,7 +586,7 @@ func (k *LibKBFS) SyncFromServerForTesting(u User, tlfName string, t tlf.Type) (
 		return err
 	}
 
-	return config.KBFSOps().SyncFromServerForTesting(ctx,
+	return config.KBFSOps().SyncFromServer(ctx,
 		dir.GetFolderBranch(), nil)
 }
 


### PR DESCRIPTION
Now that we're using it liberally in non-test situations.

Issue: KBFS-2678