### PR TITLE
libgit: a better autogit lock name prefix

### DIFF
--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -49,7 +49,7 @@ const (
 )
 
 func autogitLockName(srcRepo string) string {
-	return fmt.Sprintf(".%s.lock", srcRepo)
+	return fmt.Sprintf(".autogit_%s.lock", srcRepo)
 }
 
 type getNewConfigFn func(context.Context) (


### PR DESCRIPTION
Otherwise you couldn't autogit repos that start with "kbfs", because ".kbfs" is a reserved prefix.