### PR TITLE
libgit: don't lock during the whole reset, just make a file

### DIFF
--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -163,6 +163,8 @@ func (am *AutogitManager) canWorkOnRepo(
 		closeErr := lockFile.Close()
 		if err == nil {
 			err = closeErr
+		} else if closeErr != nil {
+			am.log.CDebugf(ctx, "Lock close error: %+v", closeErr)
 		}
 	}()
 	err = lockFile.Lock()
@@ -232,6 +234,8 @@ func (am *AutogitManager) workDoneOnRepo(
 			err = closeErr
 			// TODO: if `closeErr != nil`, write it to the lasterr
 			// file somehow, even though we're no longer under lock?
+		} else if closeErr != nil {
+			am.log.CDebugf(ctx, "Lock close error: %+v", closeErr)
 		}
 	}()
 	err = lockFile.Lock()


### PR DESCRIPTION
Resets can take way longer than the server lock expiration time.  So just lock while creating a "working" file, and set the mtime on that file to our best estimate of a common time derived based on our time offset with the mdserver we're connected to.

Then resets can take up to an hour, and when they're done the worker can delete the file and write any errors into a new "lasterr" file.
