### PR TITLE
libgit: check existence of config file directly when creating repo

### DIFF
--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -344,13 +344,18 @@ func createNewRepoAndID(
 		}
 	}()
 
-	f, err := fs.Create(kbfsConfigName)
-	if err != nil && !os.IsExist(err) {
-		return NullID, err
-	} else if os.IsExist(err) {
+	_, err = fs.Stat(kbfsConfigName)
+	if err == nil {
 		// The config file already exists, so someone else already
 		// initialized the repo.
 		return NullID, makeExistingRepoError(ctx, config, fs, repoName)
+	} else if !os.IsNotExist(err) {
+		return NullID, err
+	}
+
+	f, err := fs.Create(kbfsConfigName)
+	if err != nil {
+		return NullID, err
 	}
 	defer f.Close()
 

--- a/libgit/repo_test.go
+++ b/libgit/repo_test.go
@@ -194,11 +194,6 @@ func TestCreateDuplicateRepo(t *testing.T) {
 	select {
 	case <-onStalled2:
 	case <-ctx.Done():
-		select {
-		case err := <-err2ch:
-			t.Log("2nd create finished: %+v", err)
-		default:
-		}
 		t.Fatal(ctx.Err())
 	}
 


### PR DESCRIPTION
Because libfs.Create doesn't return an error if the file already exists, it succeeds silently.

Issue: keybase/keybase-issues#3157