### PR TITLE
kbfsgit: avoid infinite loops when a "." entry is present

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -838,6 +838,9 @@ func (r *runner) recursiveByteCount(
 
 	for _, fi := range fileInfos {
 		if fi.IsDir() {
+			if fi.Name() == "." {
+				continue
+			}
 			chrootFS, err := fs.Chroot(fi.Name())
 			if err != nil {
 				return 0, 0, err
@@ -970,6 +973,9 @@ func (r *runner) recursiveCopy(
 
 	for _, fi := range fileInfos {
 		if fi.IsDir() {
+			if fi.Name() == "." {
+				continue
+			}
 			err := to.MkdirAll(fi.Name(), 0775)
 			if err != nil {
 				return err

--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -93,6 +93,9 @@ func recursiveDelete(
 		return err
 	}
 	for _, childFI := range children {
+		if childFI.Name() == "." {
+			continue
+		}
 		err := recursiveDelete(ctx, subdirFS.(*libfs.FS), childFI)
 		if err != nil {
 			return err


### PR DESCRIPTION
Early repos may have been created before the check for "." was done on create, and go-git could have caused it to be created.  Then when cloning, the recursive byte count function would enter an infinite loop.  So just ignore "." during any recursion.

Issue: keybase/client#10189