### PR TITLE
libfs: explicitly pass name to FileInfo, so that symlinks work

### DIFF
--- a/libfs/file_info.go
+++ b/libfs/file_info.go
@@ -17,13 +17,14 @@ type FileInfo struct {
 	fs   *FS
 	ei   libkbfs.EntryInfo
 	node libkbfs.Node
+	name string
 }
 
 var _ os.FileInfo = (*FileInfo)(nil)
 
 // Name implements the os.FileInfo interface for FileInfo.
 func (fi *FileInfo) Name() string {
-	return fi.node.GetBasename()
+	return fi.name
 }
 
 // Size implements the os.FileInfo interface for FileInfo.

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -474,6 +474,7 @@ func (fs *FS) Stat(filename string) (fi os.FileInfo, err error) {
 		fs:   fs,
 		ei:   ei,
 		node: n,
+		name: n.GetBasename(),
 	}, nil
 }
 
@@ -566,6 +567,7 @@ func (fs *FS) readDir(n libkbfs.Node) (fis []os.FileInfo, err error) {
 			fs:   fs,
 			ei:   ei,
 			node: child,
+			name: name,
 		})
 	}
 	return fis, nil
@@ -618,6 +620,7 @@ func (fs *FS) Lstat(filename string) (fi os.FileInfo, err error) {
 		fs:   fs,
 		ei:   ei,
 		node: n,
+		name: base,
 	}, nil
 }
 

--- a/libfs/fs_test.go
+++ b/libfs/fs_test.go
@@ -493,6 +493,10 @@ func TestSymlink(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "b/c/foo", link)
 
+	fi, err := fs.Lstat("a/bar")
+	require.NoError(t, err)
+	require.Equal(t, "bar", fi.Name())
+
 	err = fs.SyncAll()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Issue: KBFS-2714