### PR TITLE
libgit: allow autogit removal via rmdir

### DIFF
--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -161,6 +161,15 @@ func TestAutogitRepoNode(t *testing.T) {
 	require.NoError(t, err)
 
 	checkAutogitTwoFiles(t, rootFS, "private")
+
+	// Delete the checkout.
+	err = rootFS.Remove(".kbfs_autogit/private/user1/test")
+	require.NoError(t, err)
+	err = config.KBFSOps().SyncFromServer(
+		ctx, dstRootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
+	fis, err := rootFS.ReadDir(".kbfs_autogit/private/user1")
+	require.Len(t, fis, 0)
 }
 
 func TestAutogitRepoNodeReadonly(t *testing.T) {
@@ -265,4 +274,13 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 	require.NoError(t, err)
 
 	checkAutogitTwoFiles(t, rootFS2, "public")
+
+	// Delete the checkout.
+	err = rootFS2.Remove(".kbfs_autogit/public/user1/test")
+	require.NoError(t, err)
+	err = config2.KBFSOps().SyncFromServer(
+		ctx, dstRootNode2.GetFolderBranch(), nil)
+	require.NoError(t, err)
+	fis, err = rootFS2.ReadDir(".kbfs_autogit/public/user1")
+	require.Len(t, fis, 0)
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3414,9 +3414,17 @@ func (fbo *folderBranchOps) RemoveDir(
 			getNodeIDStr(dir), dirName, err)
 	}()
 
+	removeDone, err := dir.RemoveDir(ctx, dirName)
+	if err != nil {
+		return err
+	}
+	if removeDone {
+		return nil
+	}
+
 	err = fbo.checkNodeForWrite(ctx, dir)
 	if err != nil {
-		return
+		return err
 	}
 
 	return fbo.doMDWriteWithRetryUnlessCanceled(ctx,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -150,6 +150,12 @@ type Node interface {
 	// should re-sync its view of the directory and retry the
 	// operation.
 	ShouldRetryOnDirRead(ctx context.Context) bool
+	// RemoveDir is called on a `Node` before going through the normal
+	// `RemoveDir` flow, to give the Node a chance to handle it in a
+	// custom way.  If the `Node` handles it internally, it should
+	// return `true`.
+	RemoveDir(ctx context.Context, dirName string) (
+		removeHandled bool, err error)
 	// WrapChild returns a wrapped version of child, if desired, to
 	// add custom behavior to the child node. An implementation that
 	// wraps another `Node` (`inner`) must first call

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -816,6 +816,19 @@ func (mr *MockNodeMockRecorder) ShouldRetryOnDirRead(ctx interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldRetryOnDirRead", reflect.TypeOf((*MockNode)(nil).ShouldRetryOnDirRead), ctx)
 }
 
+// RemoveDir mocks base method
+func (m *MockNode) RemoveDir(ctx context.Context, dirName string) (bool, error) {
+	ret := m.ctrl.Call(m, "RemoveDir", ctx, dirName)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveDir indicates an expected call of RemoveDir
+func (mr *MockNodeMockRecorder) RemoveDir(ctx, dirName interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDir", reflect.TypeOf((*MockNode)(nil).RemoveDir), ctx, dirName)
+}
+
 // WrapChild mocks base method
 func (m *MockNode) WrapChild(child Node) Node {
 	ret := m.ctrl.Call(m, "WrapChild", child)

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -91,6 +91,11 @@ func (n *nodeStandard) ShouldRetryOnDirRead(ctx context.Context) bool {
 	return false
 }
 
+func (n *nodeStandard) RemoveDir(_ context.Context, _ string) (
+	removeHandled bool, err error) {
+	return false, nil
+}
+
 func (n *nodeStandard) WrapChild(child Node) Node {
 	return child
 }


### PR DESCRIPTION
This PR allows you to remove autogit repo directories via `rmdir` in the filesystem.  It launches the removal in the background, and blocks for 10s waiting for it to finish, returning with no error if it doesn't finish in time.

It adds another function (`RemoveDir`) to the node interface to allow for custom deletions.

Issue: KBFS-2681