### PR TITLE
Exit kbfs when service shuts down, even with no fs mount

### DIFF
--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -435,6 +435,7 @@ func (s NotifyServiceHandler) Shutdown(_ context.Context) error {
 	return nil
 }
 
+// NewNotifyServiceHandler makes a new NotifyServiceHandler
 func NewNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifyServiceInterface {
 	s := NotifyServiceHandler{config: config, log: log}
 	return s

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -83,7 +83,7 @@ func NewKeybaseDaemonRPC(config Config, kbCtx Context, log logger.Logger,
 		k.keepAliveCancel = cancel
 		go k.keepAliveLoop(ctx)
 	}
-	k.notifyService = NewNotifyServiceHandler(config, log)
+	k.notifyService = newNotifyServiceHandler(config, log)
 
 	return k
 }
@@ -422,12 +422,13 @@ func (k *KeybaseDaemonRPC) TeamExit(context.Context, keybase1.TeamID) error {
 	return nil
 }
 
-type NotifyServiceHandler struct {
+// notifyServiceHandler implements keybase1.NotifyServiceInterface
+type notifyServiceHandler struct {
 	config Config
 	log    logger.Logger
 }
 
-func (s NotifyServiceHandler) Shutdown(_ context.Context) error {
+func (s notifyServiceHandler) Shutdown(_ context.Context) error {
 	s.log.Warning("NotifyService: Shutdown")
 	if runtime.GOOS == "windows" {
 		os.Exit(0)
@@ -435,8 +436,8 @@ func (s NotifyServiceHandler) Shutdown(_ context.Context) error {
 	return nil
 }
 
-// NewNotifyServiceHandler makes a new NotifyServiceHandler
-func NewNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifyServiceInterface {
-	s := NotifyServiceHandler{config: config, log: log}
+// newNotifyServiceHandler makes a new NotifyServiceHandler
+func newNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifyServiceInterface {
+	s := notifyServiceHandler{config: config, log: log}
 	return s
 }

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -428,7 +428,7 @@ type notifyServiceHandler struct {
 	log    logger.Logger
 }
 
-func (s notifyServiceHandler) Shutdown(_ context.Context) error {
+func (s *notifyServiceHandler) Shutdown(_ context.Context) error {
 	s.log.Warning("NotifyService: Shutdown")
 	if runtime.GOOS == "windows" {
 		os.Exit(0)
@@ -438,6 +438,6 @@ func (s notifyServiceHandler) Shutdown(_ context.Context) error {
 
 // newNotifyServiceHandler makes a new NotifyServiceHandler
 func newNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifyServiceInterface {
-	s := notifyServiceHandler{config: config, log: log}
+	s := &notifyServiceHandler{config: config, log: log}
 	return s
 }

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/keybase/client/go/libkb"
@@ -402,6 +403,10 @@ func (k *KeybaseDaemonRPC) Shutdown() {
 	}
 	if k.keepAliveCancel != nil {
 		k.keepAliveCancel()
+	}
+	k.log.Warning("Keybase service shutdown")
+	if runtime.GOOS == "windows" {
+		os.Exit(0)
 	}
 }
 


### PR DESCRIPTION
so it can be more like other platforms, for cleaner shutdown and updating.
The separate NotifyServiceHandler seemed necessary because there already was a Shutdown() (no argument) satisfying some other interface.
Related to DESKTOP-5956, which will be blocked until this is merged.
Tested in a few production builds today.
@taruti @maxtaco @jzila 