### PR TITLE
populate basename to fix mime type

### DIFF
--- a/libfs/httpfs.go
+++ b/libfs/httpfs.go
@@ -104,12 +104,14 @@ func (fod fileOrDir) Stat() (fi os.FileInfo, err error) {
 			fs:   fod.file.fs,
 			ei:   fod.ei,
 			node: fod.file.node,
+			name: fod.file.node.GetBasename(),
 		}, nil
 	} else if fod.dir != nil {
 		return &FileInfo{
 			fs:   fod.dir.fs,
 			ei:   fod.ei,
 			node: fod.dir.node,
+			name: fod.dir.node.GetBasename(),
 		}, nil
 	}
 	return nil, errors.New("invalid fod")


### PR DESCRIPTION
This is a bug reported in keybasefriends, where we are reporting `text/plain` for css resources.

The `name` field here is used eventually in `.Name()` which is used by `http` package to determine the mime type. I forgot to populate it when implementing the wrapper for `http.FileSystem` in the first place and missed this bug in testing because of my browser cache ...

Tested on staging to make sure it fixes the mime bug.