### PR TITLE
kbp: 403 instead of 401 when appropriate; add a simple test; status code logging/stat fix

### DIFF
--- a/kbpagesconfig/editor.go
+++ b/kbpagesconfig/editor.go
@@ -203,7 +203,7 @@ func (e *kbpConfigEditor) removeUserFromACL(username string, pathStr string) {
 
 func (e *kbpConfigEditor) getUserOnPath(
 	username string, pathStr string) (read, list bool, err error) {
-	read, list, _, err = e.kbpConfig.GetPermissionsForUsername(
-		pathStr, username)
+	read, list, _, _, _, err = e.kbpConfig.GetPermissions(
+		pathStr, &username)
 	return read, list, err
 }

--- a/kbpagesconfig/editor_test.go
+++ b/kbpagesconfig/editor_test.go
@@ -97,7 +97,7 @@ func TestEditor(t *testing.T) {
 	require.NoError(t, err)
 	// We don't have any permission set, so we should get the default read,list
 	// for root.
-	read, list, _, err := editor.kbpConfig.GetPermissionsForAnonymous("/")
+	read, list, _, _, _, err := editor.kbpConfig.GetPermissions("/", nil)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
@@ -109,16 +109,17 @@ func TestEditor(t *testing.T) {
 	// Re-read the config file and make sure the user is gone.
 	editor, err = newKBPConfigEditorWithPrompter(configDir, prompter)
 	require.NoError(t, err)
-	read, list, _, err = editor.kbpConfig.GetPermissionsForAnonymous("/")
+	read, list, _, _, _, err = editor.kbpConfig.GetPermissions("/", nil)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.False(t, list)
 
+	alice := "alice"
 	// grant alice additional permissions
 	editor, err = newKBPConfigEditorWithPrompter(configDir, prompter)
 	require.NoError(t, err)
-	read, list, _, err = editor.kbpConfig.GetPermissionsForUsername(
-		"/", "alice")
+	read, list, _, _, _, err = editor.kbpConfig.GetPermissions(
+		"/", &alice)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.False(t, list)
@@ -130,8 +131,8 @@ func TestEditor(t *testing.T) {
 	// Re-read the config file and make sure the user is gone.
 	editor, err = newKBPConfigEditorWithPrompter(configDir, prompter)
 	require.NoError(t, err)
-	read, list, _, err = editor.kbpConfig.GetPermissionsForUsername(
-		"/", "alice")
+	read, list, _, _, _, err = editor.kbpConfig.GetPermissions(
+		"/", &alice)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)

--- a/libpages/config/config.go
+++ b/libpages/config/config.go
@@ -64,9 +64,15 @@ func parseVersion(s string) (Version, error) {
 type Config interface {
 	Version() Version
 	Authenticate(username, password string) bool
-	GetPermissionsForAnonymous(path string) (read, list bool, realm string, err error)
-	GetPermissionsForUsername(
-		path, username string) (read, list bool, realm string, err error)
+	// GetPermissions returns permission info. If username is nil, anonymous
+	// permissions are returned. Otherwise, permissions for *username is
+	// returned. Additionally, "maximum possible permissions" are returned,
+	// which indicates whether a permission (read or list) is possible to be
+	// granted on the path if proper authentication is provided.
+	GetPermissions(path string, username *string) (
+		read, list bool,
+		possibleRead, possibleList bool,
+		realm string, err error)
 
 	Encode(w io.Writer, prettify bool) error
 }

--- a/libpages/config/config_v1.go
+++ b/libpages/config/config_v1.go
@@ -101,26 +101,17 @@ func (c *V1) Authenticate(username, password string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) == nil
 }
 
-// GetPermissionsForAnonymous implements the Config interface.
-func (c *V1) GetPermissionsForAnonymous(path string) (
-	read, list bool, realm string, err error) {
+// GetPermissions implements the Config interface.
+func (c *V1) GetPermissions(path string, username *string) (
+	read, list bool,
+	possibleRead, possibleList bool,
+	realm string, err error) {
 	if err = c.EnsureInit(); err != nil {
-		return false, false, "", err
+		return false, false, false, false, "", err
 	}
 
-	perms, realm := c.aclChecker.getPermissions(path, nil)
-	return perms.read, perms.list, realm, nil
-}
-
-// GetPermissionsForUsername implements the Config interface.
-func (c *V1) GetPermissionsForUsername(path, username string) (
-	read, list bool, realm string, err error) {
-	if err = c.EnsureInit(); err != nil {
-		return false, false, "", err
-	}
-
-	perms, realm := c.aclChecker.getPermissions(path, &username)
-	return perms.read, perms.list, realm, nil
+	perms, maxPerms, realm := c.aclChecker.getPermissions(path, username)
+	return perms.read, perms.list, maxPerms.read, maxPerms.list, realm, nil
 }
 
 // Encode implements the Config interface.

--- a/libpages/config/config_v1_test.go
+++ b/libpages/config/config_v1_test.go
@@ -13,10 +13,14 @@ import (
 
 func TestConfigV1Default(t *testing.T) {
 	config := DefaultV1()
-	read, list, realm, err := config.GetPermissionsForAnonymous("/")
+	read, list,
+		possibleRead, possibleList,
+		realm, err := config.GetPermissions("/", nil)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/", realm)
 }
 
@@ -89,6 +93,10 @@ func generatePasswordHashForTestOrBust(t *testing.T, password string) []byte {
 	return passwordHash
 }
 
+func stringPtr(str string) *string {
+	return &str
+}
+
 func TestConfigV1Full(t *testing.T) {
 	config := V1{
 		Common: Common{
@@ -130,131 +138,203 @@ func TestConfigV1Full(t *testing.T) {
 	authenticated := config.Authenticate("alice", "12345")
 	require.True(t, authenticated)
 
-	read, list, realm, err := config.GetPermissionsForAnonymous("/")
+	read, list, possibleRead, possibleList,
+		realm, err := config.GetPermissions("/", nil)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/", stringPtr("alice"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/", stringPtr("bob"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/alice-and-bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/alice-and-bob", nil)
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/alice-and-bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/alice-and-bob", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/alice-and-bob", stringPtr("alice"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/alice-and-bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/alice-and-bob", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/alice-and-bob", stringPtr("bob"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/alice-and-bob", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob", nil)
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob", stringPtr("alice"))
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob", stringPtr("bob"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/public")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/public", nil)
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/public", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/public", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/public", stringPtr("alice"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/public", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/public", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/public", stringPtr("bob"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/public", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/public/not-really")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/public/not-really", nil)
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/public/not-really", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/public/not-really", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/public/not-really", stringPtr("alice"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/public/not-really", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/public/not-really", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/public/not-really", stringPtr("bob"))
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/public/not-really", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/bob/dir")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir", nil)
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob/dir", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir", stringPtr("alice"))
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob/dir", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir", stringPtr("bob"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/bob/dir/sub")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir/sub", nil)
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob/dir/sub", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir/sub", stringPtr("alice"))
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob/dir/sub", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir/sub", stringPtr("bob"))
 	require.NoError(t, err)
 	require.True(t, read)
 	require.True(t, list)
+	require.True(t, possibleRead)
+	require.True(t, possibleList)
 	require.Equal(t, "/bob", realm)
 
-	read, list, realm, err = config.GetPermissionsForAnonymous("/bob/dir/deep-dir/deep-deep-dir")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir/deep-dir/deep-deep-dir", nil)
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.False(t, possibleRead)
+	require.False(t, possibleList)
 	require.Equal(t, "/bob/dir/deep-dir/deep-deep-dir", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob/dir/deep-dir/deep-deep-dir", "alice")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir/deep-dir/deep-deep-dir", stringPtr("alice"))
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.False(t, possibleRead)
+	require.False(t, possibleList)
 	require.Equal(t, "/bob/dir/deep-dir/deep-deep-dir", realm)
-	read, list, realm, err = config.GetPermissionsForUsername("/bob/dir/deep-dir/deep-deep-dir", "bob")
+	read, list, possibleRead, possibleList,
+		realm, err = config.GetPermissions("/bob/dir/deep-dir/deep-deep-dir", stringPtr("bob"))
 	require.NoError(t, err)
 	require.False(t, read)
 	require.False(t, list)
+	require.False(t, possibleRead)
+	require.False(t, possibleList)
 	require.Equal(t, "/bob/dir/deep-dir/deep-deep-dir", realm)
 }

--- a/libpages/server.go
+++ b/libpages/server.go
@@ -113,13 +113,18 @@ func (s *Server) handleErrorAndPopulateSRI(
 	// TODO: have a nicer error page for configuration errors?
 	switch err.(type) {
 	case nil:
-	case ErrKeybasePagesRecordNotFound:
+	case ErrKeybasePagesRecordNotFound, ErrDomainNotAllowedInWhitelist:
 		sri.HTTPStatus = http.StatusServiceUnavailable
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	case ErrKeybasePagesRecordTooMany, ErrInvalidKeybasePagesRecord:
 		sri.HTTPStatus = http.StatusPreconditionFailed
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
+		return
+	case config.ErrDuplicateAccessControlPath, config.ErrInvalidPermissions,
+		config.ErrInvalidVersion, config.ErrUndefinedUsername:
+		sri.HTTPStatus = http.StatusPreconditionFailed
+		http.Error(w, "invalid .kbp_config", http.StatusPreconditionFailed)
 		return
 	default:
 		sri.HTTPStatus = http.StatusInternalServerError

--- a/libpages/server.go
+++ b/libpages/server.go
@@ -319,6 +319,7 @@ func (s *Server) logRequest(sri *ServedRequestInfo, requestPath string) {
 		zap.Bool("invalid_config", sri.InvalidConfig),
 	)
 }
+
 func (s *Server) setCommonResponseHeaders(w http.ResponseWriter) {
 	// Enforce XSS protection. References:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection

--- a/libpages/server_test.go
+++ b/libpages/server_test.go
@@ -1,0 +1,77 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libpages
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/keybase/kbfs/ioutil"
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func makeTestKBFSConfig(t *testing.T) (
+	kbfsConfig libkbfs.Config, shutdown func()) {
+	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
+	cfg := libkbfs.MakeTestConfigOrBustLoggedInWithMode(
+		t, 0, libkbfs.InitSingleOp, "bot", "user")
+
+	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
+	require.NoError(t, err)
+	err = cfg.EnableDiskLimiter(tempdir)
+	require.NoError(t, err)
+	err = cfg.EnableJournaling(
+		ctx, tempdir, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
+	require.NoError(t, err)
+	shutdown = func() {
+		libkbfs.CheckConfigAndShutdown(ctx, t, cfg)
+		err := ioutil.RemoveAll(tempdir)
+		require.NoError(t, err)
+	}
+
+	return cfg, shutdown
+}
+
+type TestRootLoader map[string]string
+
+func (l TestRootLoader) LoadRoot(domain string) (root Root, err error) {
+	str, ok := l[domain]
+	if !ok {
+		return Root{}, ErrKeybasePagesRecordNotFound{}
+	}
+	return ParseRoot(str)
+}
+
+func TestServerDefault(t *testing.T) {
+	kbfsConfig, shutdown := makeTestKBFSConfig(t)
+	defer shutdown()
+
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	server := Server{
+		kbfsConfig: kbfsConfig,
+		config: &ServerConfig{
+			Logger: logger,
+		},
+		rootLoader: TestRootLoader{
+			"example.com": "/keybase/private/user,bot",
+		},
+	}
+	server.siteCache, err = lru.NewWithEvict(fsCacheSize, server.siteCacheEvict)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	server.ServeHTTP(w, httptest.NewRequest("GET", "/", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+
+	w = httptest.NewRecorder()
+	server.ServeHTTP(w, httptest.NewRequest("GET", "/non-existent", nil))
+	require.Equal(t, http.StatusNotFound, w.Code)
+}


### PR DESCRIPTION
Sorry for adding out-of-sprint stuff for review! I've made a few small changes for keybase pages over the weekend, mainly:

1. When `.kbp_config` doesn't have more permissive permissions defined for a given path, it's not possible to get the required permission even with authentication. So return 403 rather than 401. ([more](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) on MDN)

2. I noticed a bug where we were logging status code 200 and reporting 200 to stathat for non-200 responses generated by `http.FileServer`. This PR introduces a simple wrapper around `http.ResponseWriter` to make sure we are getting correct status code for logging and stats.

3. Added boilerplates for server.go tests.

It might be easier to look at individual commits rather than the whole thing together.

Thanks!!