### PR TITLE
cache error returned from GetUserQuotaInfo and GetTeamQuotaInfo

### DIFF
--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -170,7 +170,7 @@ func (f *FS) GetDiskFreeSpace(ctx context.Context) (freeSpace dokan.FreeSpace, e
 		}
 	}()
 	_, usageBytes, limitBytes, err := f.quotaUsage.Get(
-		ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
+		ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance, libkbfs.QuotaUsageErrorTolerance)
 	if err != nil {
 		return dokan.FreeSpace{}, errToDokan(err)
 	}

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -379,7 +379,7 @@ func (f *FS) Statfs(ctx context.Context, req *fuse.StatfsRequest, resp *fuse.Sta
 		return nil
 	}
 	_, usageBytes, limitBytes, err := f.quotaUsage.Get(
-		ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
+		ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance, libkbfs.QuotaUsageErrorTolerance)
 	if err != nil {
 		f.log.CDebugf(ctx, "Getting quota usage error: %v", err)
 		return err

--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -716,7 +716,7 @@ func makeDefaultBackpressureDiskLimiterParams(
 		quotaFn: func(ctx context.Context, chargedTo keybase1.UserOrTeamID) (
 			int64, int64) {
 			timestamp, usageBytes, limitBytes, err :=
-				quotaUsage(chargedTo).Get(ctx, 1*time.Minute, math.MaxInt64)
+				quotaUsage(chargedTo).Get(ctx, 1*time.Minute, math.MaxInt64, QuotaUsageErrorTolerance)
 			if err != nil {
 				return 0, math.MaxInt64
 			}

--- a/libkbfs/constants.go
+++ b/libkbfs/constants.go
@@ -31,3 +31,7 @@ const registerForUpdatesFireNowThreshold = 10 * time.Minute
 // dialerTimeout is the TCP dial timeout used by mdserver and bserver RPC
 // connections.
 const dialerTimeout = 16 * time.Second
+
+// QuotaUsageErrorTolerance is the amount of time an error encountered
+// for GetUserQuotaInfo/GetTeamQuotaInfo will be cached and reused
+const QuotaUsageErrorTolerance = 5 * time.Second

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -233,7 +233,7 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 			}
 		}
 		_, usageBytes, limitBytes, gitUsageBytes, gitLimitBytes, quErr :=
-			fbsk.quotaUsage.GetAllTypes(ctx, 0, 0)
+			fbsk.quotaUsage.GetAllTypes(ctx, 0, 0, QuotaUsageErrorTolerance)
 		if quErr != nil {
 			// The error is ignored here so that other fields can
 			// still be populated even if this fails.

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -165,12 +165,12 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 
 	// Set initial quota usage and refresh quotaUsage's cache.
 	qbs.setUserQuotaInfo(1010, 1000, 2010, 2000)
-	_, _, _, err = quotaUsage.Get(ctx, 0, 0)
+	_, _, _, err = quotaUsage.Get(ctx, 0, 0, 0)
 	require.NoError(t, err)
 
 	// Set team quota to be under the limit for now.
 	qbs.setTeamQuotaInfo(teamID, 0, 1000)
-	_, _, _, err = teamQuotaUsage.Get(ctx, 0, 0)
+	_, _, _, err = teamQuotaUsage.Get(ctx, 0, 0, 0)
 	require.NoError(t, err)
 
 	tlfID1 := tlf.FakeID(1, tlf.Private)
@@ -239,7 +239,7 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 	// Now up the team usage, so teams (and their subteams) should get
 	// an error.
 	qbs.setTeamQuotaInfo(teamID, 1010, 1000)
-	_, _, _, err = teamQuotaUsage.Get(ctx, 0, 0)
+	_, _, _, err = teamQuotaUsage.Get(ctx, 0, 0, 0)
 	require.NoError(t, err)
 	clock.Add(time.Minute)
 	err = blockServer.Put(ctx, tlfID2, bID, bCtx, data, serverHalf)
@@ -278,7 +278,7 @@ func TestJournalServerOverDiskLimitError(t *testing.T) {
 
 	// Set initial quota usage and refresh quotaUsage's cache.
 	qbs.setUserQuotaInfo(1010, 1000, 2010, 2000)
-	_, _, _, err := quotaUsage.Get(ctx, 0, 0)
+	_, _, _, err := quotaUsage.Get(ctx, 0, 0, 0)
 	require.NoError(t, err)
 
 	tlfID1 := tlf.FakeID(1, tlf.Private)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -852,7 +852,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	if err == nil && fs.config.MDServer().IsConnected() {
 		var quErr error
 		_, usageBytes, limitBytes, gitUsageBytes, gitLimitBytes, quErr =
-			fs.quotaUsage.GetAllTypes(ctx, 0, 0)
+			fs.quotaUsage.GetAllTypes(ctx, 0, 0, QuotaUsageErrorTolerance)
 		if quErr != nil {
 			// The error is ignored here so that other fields can still be populated
 			// even if this fails.

--- a/libkbfs/quota_usage.go
+++ b/libkbfs/quota_usage.go
@@ -130,7 +130,7 @@ func (q *EventuallyConsistentQuotaUsage) Get(
 	timestamp time.Time, usageBytes, limitBytes int64, err error) {
 	c := q.getCached()
 
-	// check if i have recently encountered error, if so, do not query again
+	// Check if I have recently encountered an error. If so, do not query again.
 	if c.cachedError != nil && errorTolerance > q.config.Clock().Now().Sub(c.errorTimestamp) {
 		return time.Time{}, -1, -1, c.cachedError
 	}
@@ -160,7 +160,7 @@ func (q *EventuallyConsistentQuotaUsage) GetAllTypes(
 	usageBytes, limitBytes, gitUsageBytes, getLimitBytes int64, err error) {
 	c := q.getCached()
 
-	// check if i have recently encountered error, if so, do not query again
+	// Check if I have recently encountered an error. If so, do not query again.
 	if c.cachedError != nil && errorTolerance > q.config.Clock().Now().Sub(c.errorTimestamp) {
 		return time.Time{}, -1, -1, -1, -1, c.cachedError
 	}


### PR DESCRIPTION
Cache the error returned from GetUserQuotaInfo and GetTeamQuotaInfo for 5 seconds. So bserver does not get peppered with GetUserQuotaInfo and GetTeamQuotaInfo that fail.