### PR TITLE
libkbfs: misc fixes needed for implicit teams

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -896,6 +896,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
 			constIDGetter{fbo.id()}, *newHandle)
 	if err != nil {
+		fbo.log.CDebugf(ctx, "oldHandle=%+v, newHandle=%+v: err=%+v", oldHandle, newHandle, err)
 		return err
 	}
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -475,6 +475,10 @@ type KeybaseService interface {
 	CreateTeamTLF(
 		ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) error
 
+	// GetTeamSettings returns the KBFS settings for the given team.
+	GetTeamSettings(ctx context.Context, teamID keybase1.TeamID) (
+		keybase1.KBFSTeamSettings, error)
+
 	// LoadUserPlusKeys returns a UserInfo struct for a
 	// user with the specified UID.
 	// If you have the UID for a user and don't require Identify to
@@ -582,6 +586,11 @@ type resolver interface {
 	ResolveImplicitTeamByID(
 		ctx context.Context, teamID keybase1.TeamID, tlfType tlf.Type) (
 		ImplicitTeamInfo, error)
+	// ResolveTeamTLFID returns the TLF ID associated with a given
+	// team ID, or tlf.NullID if no ID is yet associated with that
+	// team.
+	ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID) (
+		tlf.ID, error)
 }
 
 type identifier interface {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -84,6 +84,24 @@ func (k *KBPKIClient) ResolveImplicitTeamByID(
 		ctx, assertions, suffix, tlfType, false, "")
 }
 
+// ResolveTeamTLFID implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) ResolveTeamTLFID(
+	ctx context.Context, teamID keybase1.TeamID) (tlf.ID, error) {
+	settings, err := k.serviceOwner.KeybaseService().GetTeamSettings(
+		ctx, teamID)
+	if err != nil {
+		return tlf.NullID, err
+	}
+	if settings.TlfID.IsNil() {
+		return tlf.NullID, err
+	}
+	tlfID, err := tlf.ParseID(settings.TlfID.String())
+	if err != nil {
+		return tlf.NullID, err
+	}
+	return tlfID, nil
+}
+
 // IdentifyImplicitTeam identifies (and creates if necessary) the
 // given implicit team.
 func (k *KBPKIClient) IdentifyImplicitTeam(

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -671,7 +671,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	return info, nil
 }
 
-// CreateTeamTLF implements the KBPKI interface for
+// CreateTeamTLF implements the KeybaseService interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) CreateTeamTLF(
 	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
@@ -679,6 +679,15 @@ func (k *KeybaseServiceBase) CreateTeamTLF(
 		TeamID: teamID,
 		TlfID:  keybase1.TLFID(tlfID.String()),
 	})
+}
+
+// GetTeamSettings implements the KeybaseService interface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) GetTeamSettings(
+	ctx context.Context, teamID keybase1.TeamID) (
+	keybase1.KBFSTeamSettings, error) {
+	// TODO: get invalidations from the server and cache the settings?
+	return k.kbfsClient.GetKBFSTeamSettings(ctx, teamID)
 }
 
 func (k *KeybaseServiceBase) getCurrentMerkleRoot(ctx context.Context) (

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -25,6 +25,7 @@ type KeybaseServiceMeasured struct {
 	loadTeamPlusKeysTimer            metrics.Timer
 	loadUnverifiedKeysTimer          metrics.Timer
 	createTeamTLFTimer               metrics.Timer
+	getTeamSettingsTimer             metrics.Timer
 	getCurrentMerkleRootTimer        metrics.Timer
 	currentSessionTimer              metrics.Timer
 	favoriteAddTimer                 metrics.Timer
@@ -49,6 +50,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 	loadTeamPlusKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadTeamPlusKeys", r)
 	loadUnverifiedKeysTimer := metrics.GetOrRegisterTimer("KeybaseService.LoadUnverifiedKeys", r)
 	createTeamTLFTimer := metrics.GetOrRegisterTimer("KeybaseService.CreateTeamTLF", r)
+	getTeamSettingsTimer := metrics.GetOrRegisterTimer("KeybaseService.GetTeamSettings", r)
 	getCurrentMerkleRootTimer := metrics.GetOrRegisterTimer("KeybaseService.GetCurrentMerkleRoot", r)
 	currentSessionTimer := metrics.GetOrRegisterTimer("KeybaseService.CurrentSession", r)
 	favoriteAddTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteAdd", r)
@@ -67,6 +69,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 		loadTeamPlusKeysTimer:            loadTeamPlusKeysTimer,
 		loadUnverifiedKeysTimer:          loadUnverifiedKeysTimer,
 		createTeamTLFTimer:               createTeamTLFTimer,
+		getTeamSettingsTimer:             getTeamSettingsTimer,
 		getCurrentMerkleRootTimer:        getCurrentMerkleRootTimer,
 		currentSessionTimer:              currentSessionTimer,
 		favoriteAddTimer:                 favoriteAddTimer,
@@ -137,7 +140,7 @@ func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
 	return teamInfo, err
 }
 
-// CreateTeamTLF implements the KBPKI interface for
+// CreateTeamTLF implements the KeybaseService interface for
 // KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) CreateTeamTLF(
 	ctx context.Context, teamID keybase1.TeamID, tlfID tlf.ID) (err error) {
@@ -145,6 +148,17 @@ func (k KeybaseServiceMeasured) CreateTeamTLF(
 		err = k.delegate.CreateTeamTLF(ctx, teamID, tlfID)
 	})
 	return err
+}
+
+// GetTeamSettings implements the KeybaseService interface for
+// KeybaseServiceMeasured.
+func (k KeybaseServiceMeasured) GetTeamSettings(
+	ctx context.Context, teamID keybase1.TeamID) (
+	settings keybase1.KBFSTeamSettings, err error) {
+	k.getTeamSettingsTimer.Time(func() {
+		settings, err = k.delegate.GetTeamSettings(ctx, teamID)
+	})
+	return settings, err
 }
 
 // GetCurrentMerkleRoot implements the KeybaseService interface for

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1541,6 +1541,19 @@ func (mr *MockKeybaseServiceMockRecorder) CreateTeamTLF(ctx, teamID, tlfID inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTeamTLF", reflect.TypeOf((*MockKeybaseService)(nil).CreateTeamTLF), ctx, teamID, tlfID)
 }
 
+// GetTeamSettings mocks base method
+func (m *MockKeybaseService) GetTeamSettings(ctx context.Context, teamID keybase1.TeamID) (keybase1.KBFSTeamSettings, error) {
+	ret := m.ctrl.Call(m, "GetTeamSettings", ctx, teamID)
+	ret0, _ := ret[0].(keybase1.KBFSTeamSettings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTeamSettings indicates an expected call of GetTeamSettings
+func (mr *MockKeybaseServiceMockRecorder) GetTeamSettings(ctx, teamID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTeamSettings", reflect.TypeOf((*MockKeybaseService)(nil).GetTeamSettings), ctx, teamID)
+}
+
 // LoadUserPlusKeys mocks base method
 func (m *MockKeybaseService) LoadUserPlusKeys(ctx context.Context, uid keybase1.UID, pollForKID keybase1.KID) (UserInfo, error) {
 	ret := m.ctrl.Call(m, "LoadUserPlusKeys", ctx, uid, pollForKID)
@@ -1807,6 +1820,19 @@ func (m *Mockresolver) ResolveImplicitTeamByID(ctx context.Context, teamID keyba
 // ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID
 func (mr *MockresolverMockRecorder) ResolveImplicitTeamByID(ctx, teamID, tlfType interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*Mockresolver)(nil).ResolveImplicitTeamByID), ctx, teamID, tlfType)
+}
+
+// ResolveTeamTLFID mocks base method
+func (m *Mockresolver) ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID) (tlf.ID, error) {
+	ret := m.ctrl.Call(m, "ResolveTeamTLFID", ctx, teamID)
+	ret0, _ := ret[0].(tlf.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveTeamTLFID indicates an expected call of ResolveTeamTLFID
+func (mr *MockresolverMockRecorder) ResolveTeamTLFID(ctx, teamID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*Mockresolver)(nil).ResolveTeamTLFID), ctx, teamID)
 }
 
 // Mockidentifier is a mock of identifier interface
@@ -2127,6 +2153,19 @@ func (m *MockKBPKI) ResolveImplicitTeamByID(ctx context.Context, teamID keybase1
 // ResolveImplicitTeamByID indicates an expected call of ResolveImplicitTeamByID
 func (mr *MockKBPKIMockRecorder) ResolveImplicitTeamByID(ctx, teamID, tlfType interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveImplicitTeamByID", reflect.TypeOf((*MockKBPKI)(nil).ResolveImplicitTeamByID), ctx, teamID, tlfType)
+}
+
+// ResolveTeamTLFID mocks base method
+func (m *MockKBPKI) ResolveTeamTLFID(ctx context.Context, teamID keybase1.TeamID) (tlf.ID, error) {
+	ret := m.ctrl.Call(m, "ResolveTeamTLFID", ctx, teamID)
+	ret0, _ := ret[0].(tlf.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ResolveTeamTLFID indicates an expected call of ResolveTeamTLFID
+func (mr *MockKBPKIMockRecorder) ResolveTeamTLFID(ctx, teamID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveTeamTLFID", reflect.TypeOf((*MockKBPKI)(nil).ResolveTeamTLFID), ctx, teamID)
 }
 
 // Identify mocks base method

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -607,7 +607,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(
-		t, config, "alice,bob (conflicted copy 2017-08-24)", tlf.Private, tlfID)
+		t, config, "alice,bob (conflicted copy 2017-08-24 #1)", tlf.Private, tlfID)
 	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -607,7 +607,7 @@ func TestRootMetadataUpconversionPrivateConflict(t *testing.T) {
 
 	tlfID := tlf.FakeID(1, tlf.Private)
 	h := parseTlfHandleOrBust(
-		t, config, "alice,bob (conflicted copy 2017-08-24 #1)", tlf.Private, tlfID)
+		t, config, "alice,bob (conflicted copy 2017-08-24)", tlf.Private, tlfID)
 	rmd, err := makeInitialRootMetadata(kbfsmd.InitialExtraMetadataVer, tlfID, h)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.KeyGen(0), rmd.LatestKeyGeneration())

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -199,7 +199,11 @@ func (h TlfHandle) recomputeNameWithExtensions() tlf.CanonicalName {
 	newName := components[0]
 	extensionList := tlf.HandleExtensionList(h.Extensions())
 	sort.Sort(extensionList)
-	newName += extensionList.Suffix()
+	if h.IsBackedByTeam() {
+		newName += extensionList.SuffixForTeamHandle()
+	} else {
+		newName += extensionList.Suffix()
+	}
 	return tlf.CanonicalName(newName)
 }
 

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -458,21 +458,27 @@ func (h TlfHandle) ResolvesTo(
 		other.finalizedInfo = nil
 	}
 
-	unresolvedAssertions := make(map[string]bool)
-	for _, uw := range other.unresolvedWriters {
-		unresolvedAssertions[uw.String()] = true
-	}
-	for _, ur := range other.unresolvedReaders {
-		unresolvedAssertions[ur.String()] = true
-	}
+	if h.TypeForKeying() == tlf.TeamKeying {
+		// Nothing to resolve for team-based TLFs, just use `other` by
+		// itself.
+		partialResolvedH = other.deepCopy()
+	} else {
+		unresolvedAssertions := make(map[string]bool)
+		for _, uw := range other.unresolvedWriters {
+			unresolvedAssertions[uw.String()] = true
+		}
+		for _, ur := range other.unresolvedReaders {
+			unresolvedAssertions[ur.String()] = true
+		}
 
-	// TODO: Once we keep track of the original assertions in
-	// TlfHandle, restrict the resolver to use other's assertions
-	// only, so that we don't hit the network at all.
-	partialResolvedH, err = h.ResolveAgain(
-		ctx, partialResolver{resolver, unresolvedAssertions}, idGetter)
-	if err != nil {
-		return false, nil, err
+		// TODO: Once we keep track of the original assertions in
+		// TlfHandle, restrict the resolver to use other's assertions
+		// only, so that we don't hit the network at all.
+		partialResolvedH, err = h.ResolveAgain(
+			ctx, partialResolver{resolver, unresolvedAssertions}, idGetter)
+		if err != nil {
+			return false, nil, err
+		}
 	}
 
 	if conflictAdded || finalizedAdded {

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -1074,7 +1074,7 @@ func TestParseTlfHandleImplicitTeams(t *testing.T) {
 		require.NoError(t, err)
 		tlfID := tlf.FakeID(counter, ty)
 		counter++
-		err = daemon.addImplicitTeamTlfID(iteamInfo.TID, tlfID)
+		err = daemon.CreateTeamTLF(ctx, iteamInfo.TID, tlfID)
 		require.NoError(t, err)
 		return iteamInfo.TID, tlfID
 	}

--- a/tlf/handle_extension.go
+++ b/tlf/handle_extension.go
@@ -126,7 +126,7 @@ type HandleExtension struct {
 func (e HandleExtension) String() string {
 	date := time.Unix(e.Date, 0).UTC().Format(handleExtensionDateFormat)
 	var num string
-	if e.Number > 1 {
+	if e.Number > 0 {
 		num = " #"
 		num += strconv.FormatUint(uint64(e.Number), 10)
 	}
@@ -187,7 +187,7 @@ func parseHandleExtension(fields []string) (*HandleExtension, error) {
 		if err != nil {
 			return nil, err
 		}
-		if num < 2 {
+		if num < 1 {
 			return nil, errHandleExtensionInvalidNumber
 		}
 	}

--- a/tlf/handle_extension_test.go
+++ b/tlf/handle_extension_test.go
@@ -102,7 +102,7 @@ func TestHandleExtensionKnownTime(t *testing.T) {
 		Type:     HandleExtensionFinalized,
 		Username: "alice",
 	}
-	expect := "(files before alice account reset 2016-05-10)"
+	expect := "(files before alice account reset 2016-05-10 #1)"
 	if e.String() != expect {
 		t.Fatalf("Expected %s, got: %s", expect, e)
 	}
@@ -132,10 +132,6 @@ func TestHandleExtensionErrors(t *testing.T) {
 		t.Fatalf("Expected errHandleExtensionInvalidNumber, got: %v", err)
 	}
 	_, err = ParseHandleExtensionSuffix("(conflicted copy 2016-05-10 #0)")
-	if err != errHandleExtensionInvalidNumber {
-		t.Fatalf("Expected errHandleExtensionInvalidNumber, got: %v", err)
-	}
-	_, err = ParseHandleExtensionSuffix("(conflicted copy 2016-05-10 #1)")
 	if err != errHandleExtensionInvalidNumber {
 		t.Fatalf("Expected errHandleExtensionInvalidNumber, got: %v", err)
 	}
@@ -191,7 +187,7 @@ func TestHandleExtensionMultiple(t *testing.T) {
 	}
 	exts := []HandleExtension{*e, *e2}
 	suffix := newHandleExtensionSuffix(exts)
-	expectSuffix := " (conflicted copy 2016-03-14) (files before charlie account reset 2016-03-14 #2)"
+	expectSuffix := " (conflicted copy 2016-03-14 #1) (files before charlie account reset 2016-03-14 #2)"
 	if suffix != expectSuffix {
 		t.Fatalf("Expected suffix '%s', got: '%s'", expectSuffix, suffix)
 	}
@@ -229,7 +225,7 @@ func TestHandleExtensionMultipleSingleUser(t *testing.T) {
 	}
 	exts := []HandleExtension{*e, *e2}
 	suffix := newHandleExtensionSuffix(exts)
-	expectSuffix := " (conflicted copy 2016-03-14 #2) (files before account reset 2016-03-14)"
+	expectSuffix := " (conflicted copy 2016-03-14 #2) (files before account reset 2016-03-14 #1)"
 	if suffix != expectSuffix {
 		t.Fatalf("Expected suffix '%s', got: '%s'", expectSuffix, suffix)
 	}

--- a/tlf/handle_extension_test.go
+++ b/tlf/handle_extension_test.go
@@ -102,7 +102,7 @@ func TestHandleExtensionKnownTime(t *testing.T) {
 		Type:     HandleExtensionFinalized,
 		Username: "alice",
 	}
-	expect := "(files before alice account reset 2016-05-10 #1)"
+	expect := "(files before alice account reset 2016-05-10)"
 	if e.String() != expect {
 		t.Fatalf("Expected %s, got: %s", expect, e)
 	}
@@ -186,8 +186,8 @@ func TestHandleExtensionMultiple(t *testing.T) {
 		t.Fatal(err)
 	}
 	exts := []HandleExtension{*e, *e2}
-	suffix := newHandleExtensionSuffix(exts)
-	expectSuffix := " (conflicted copy 2016-03-14 #1) (files before charlie account reset 2016-03-14 #2)"
+	suffix := newHandleExtensionSuffix(exts, false)
+	expectSuffix := " (conflicted copy 2016-03-14) (files before charlie account reset 2016-03-14 #2)"
 	if suffix != expectSuffix {
 		t.Fatalf("Expected suffix '%s', got: '%s'", expectSuffix, suffix)
 	}
@@ -224,8 +224,8 @@ func TestHandleExtensionMultipleSingleUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	exts := []HandleExtension{*e, *e2}
-	suffix := newHandleExtensionSuffix(exts)
-	expectSuffix := " (conflicted copy 2016-03-14 #2) (files before account reset 2016-03-14 #1)"
+	suffix := newHandleExtensionSuffix(exts, false)
+	expectSuffix := " (conflicted copy 2016-03-14 #2) (files before account reset 2016-03-14)"
 	if suffix != expectSuffix {
 		t.Fatalf("Expected suffix '%s', got: '%s'", expectSuffix, suffix)
 	}


### PR DESCRIPTION
* Get TLF IDs for regular, non-implicit teams from the sigchain via the service.
* Always use a number at the end of a conflict suffix, i.e. "(conflicted copy 2016-03-14 #1)" instead of "(conflicted copy 2016-03-14)", because that's how the API server does it now.
* Fix some handle resolution issues for team-backed handles.

Issue: KBFS-2652