### PR TITLE
simplefs: refactor to use libfs

### DIFF
--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -750,9 +750,9 @@ func (k *SimpleFS) startReadWriteOp(ctx context.Context, opid keybase1.OpID, des
 }
 
 func (k *SimpleFS) doneReadWriteOp(ctx context.Context, opID keybase1.OpID, err error) {
-	k.lock.RLock()
+	k.lock.Lock()
 	delete(k.inProgress, opID)
-	k.lock.RUnlock()
+	k.lock.Unlock()
 	k.log.CDebugf(ctx, "doneReadWriteOp, status=%v", err)
 	if ctx != nil {
 		libkbfs.CleanupCancellationDelayer(ctx)

--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -270,7 +270,8 @@ func TestCopyRecursive(t *testing.T) {
 	err = ioutil.WriteFile(
 		filepath.Join(tempdir, "testdir", "test2.txt"), []byte("bar"), 0600)
 	require.NoError(t, err)
-	path1 := keybase1.NewPathWithLocal(filepath.Join(tempdir, "testdir"))
+	path1 := keybase1.NewPathWithLocal(
+		filepath.ToSlash(filepath.Join(tempdir, "testdir")))
 	path2 := keybase1.NewPathWithKbfs(`/private/jdoe/testdir`)
 
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
@@ -297,7 +298,8 @@ func TestCopyRecursive(t *testing.T) {
 	tempdir2, err := ioutil.TempDir("", "simpleFstest")
 	require.NoError(t, err)
 	defer os.RemoveAll(tempdir2)
-	path3 := keybase1.NewPathWithLocal(filepath.Join(tempdir2, "testdir"))
+	path3 := keybase1.NewPathWithLocal(
+		filepath.ToSlash(filepath.Join(tempdir2, "testdir")))
 	opid2, err := sfs.SimpleFSMakeOpid(ctx)
 	require.NoError(t, err)
 	err = sfs.SimpleFSCopyRecursive(ctx, keybase1.SimpleFSCopyRecursiveArg{
@@ -340,7 +342,8 @@ func TestCopyToRemote(t *testing.T) {
 	opid, err := sfs.SimpleFSMakeOpid(ctx)
 	require.NoError(t, err)
 
-	srcPath := keybase1.NewPathWithLocal(filepath.Join(path1.Local(), "test1.txt"))
+	srcPath := keybase1.NewPathWithLocal(
+		filepath.ToSlash(filepath.Join(path1.Local(), "test1.txt")))
 	destPath := pathAppend(path2, "test1.txt")
 	err = sfs.SimpleFSCopy(ctx, keybase1.SimpleFSCopyArg{
 		OpID: opid,


### PR DESCRIPTION
I tried to keep it as backwards- and bug-compatible as possible for now, though in the future we'll probably want to have better support for symlinks, and faster/atomic moves within a TLF.

I re-ordered many of the functions for readability, so that might make viewing the diff a bit hard.  You might consider reviewing the entire `simplefs.go` file from top to bottom, rather than using the diff.

Issue: KBFS-2661