### PR TITLE
lazy loading site root to avoid caching obsolete Node

### DIFF
--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -714,8 +714,8 @@ func (fs *FS) Chtimes(name string, atime time.Time, mtime time.Time) (
 	return fs.config.KBFSOps().SetMtime(fs.ctx, n, &mtime)
 }
 
-// Chrute returns a *FS whose root is p.
-func (fs *FS) Chrute(p string) (newFS *FS, err error) {
+// ChrootAsLibFS returns a *FS whose root is p.
+func (fs *FS) ChrootAsLibFS(p string) (newFS *FS, err error) {
 	fs.log.CDebugf(fs.ctx, "Chroot %s", p)
 	defer func() {
 		fs.deferLog.CDebugf(fs.ctx, "Chroot done: %+v", err)
@@ -753,7 +753,7 @@ func (fs *FS) Chrute(p string) (newFS *FS, err error) {
 
 // Chroot implements the billy.Filesystem interface for FS.
 func (fs *FS) Chroot(p string) (newFS billy.Filesystem, err error) {
-	return fs.Chrute(p)
+	return fs.ChrootAsLibFS(p)
 }
 
 // Root implements the billy.Filesystem interface for FS.

--- a/libpages/root.go
+++ b/libpages/root.go
@@ -68,7 +68,7 @@ type Root struct {
 	PathUnparsed    string
 }
 
-// CacheableFS is a wrapper around a *libfs.FS and a subdir. Use use() to get a
+// CacheableFS is a wrapper around a *libfs.FS and a subdir. Use Use() to get a
 // *libfs.FS that roots at subdir. This essentially delays "cd"ing into subdir,
 // and is useful for caching a *libfs.FS object without the downside of caching
 // a libkbfs.Node that can be obsolete when it's renamed or removed.
@@ -79,12 +79,12 @@ type CacheableFS struct {
 
 // Use returns a *libfs.FS to use.
 func (fs CacheableFS) Use() (*libfs.FS, error) {
-	return fs.fs.Chrute(fs.subdir)
+	return fs.fs.ChrootAsLibFS(fs.subdir)
 }
 
 // MakeFS makes a CacheableFS from *r, which can be adapted to a http.FileSystem
 // (through ToHTTPFileSystem) to be used by http package to serve through HTTP.
-// Caller must call use() to get a usable FS.
+// Caller must call Use() to get a usable FS.
 func (r *Root) MakeFS(
 	ctx context.Context, log *zap.Logger, kbfsConfig libkbfs.Config) (
 	fs CacheableFS, tlfID tlf.ID, shutdown func(), err error) {
@@ -121,10 +121,14 @@ func (r *Root) MakeFS(
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
-		return CacheableFS{
+		cacheableFS := CacheableFS{
 			fs:     tlfFS,
 			subdir: r.PathUnparsed,
-		}, tlfHandle.TlfID(), cancel, nil
+		}
+		if _, err = cacheableFS.Use(); err != nil {
+			return CacheableFS{}, tlf.ID{}, nil, err
+		}
+		return cacheableFS, tlfHandle.TlfID(), cancel, nil
 	case GitRoot:
 		session, err := kbfsConfig.KeybaseService().CurrentSession(ctx, 0)
 		if err != nil {
@@ -146,10 +150,14 @@ func (r *Root) MakeFS(
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
-		return CacheableFS{
+		cacheableFS := CacheableFS{
 			fs:     autogitTLFFS,
 			subdir: r.PathUnparsed,
-		}, tlfHandle.TlfID(), cancel, nil
+		}
+		if _, err = cacheableFS.Use(); err != nil {
+			return CacheableFS{}, tlf.ID{}, nil, err
+		}
+		return cacheableFS, tlfHandle.TlfID(), cancel, nil
 	default:
 		return CacheableFS{}, tlf.ID{}, nil, ErrInvalidKeybasePagesRecord{}
 	}


### PR DESCRIPTION
This fixes a bug that `e38383` reported in keybasefriends. In short, if the directory corresponding to the site root is moved or removed, kbpagesd kept track of the old `Node` that doesn't represent the real site root anymore, thus serves outdated data.

I tried to use the `libkbfs.Observer` but it seemed fairly complicated since I'd need to keep track of all intermediate nodes too. So this PR just changes the `Site` to cache a `*libfs.FS` of either the TLF, or the `<tlf>` dir in autogit, instead of the actual site root. The server does a `chroot` on each request. This way it always gets the newest site root. I don't think this handles TLF resets yet, which is tracked in a different ticket (KBFS-2657).

Let me know if you guys have better ideas!