### PR TITLE
show non-existent TLF as empty dir in simplefs

### DIFF
--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -147,33 +147,37 @@ func remoteTlfAndPath(path keybase1.Path) (
 }
 
 func (k *SimpleFS) getFS(ctx context.Context, path keybase1.Path) (
-	fs billy.Filesystem, finalElem string, err error) {
+	fs billy.Filesystem, finalElem string, exitEarly bool, err error) {
 	pt, err := path.PathType()
 	if err != nil {
-		return nil, "", err
+		return nil, "", false, err
 	}
 	switch pt {
 	case keybase1.PathType_KBFS:
 		t, tlfName, restOfPath, finalElem, err := remoteTlfAndPath(path)
 		if err != nil {
-			return nil, "", err
+			return nil, "", false, err
 		}
 		tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
 			ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
 		if err != nil {
-			return nil, "", err
+			return nil, "", false, err
 		}
 		fs, err := libfs.NewFS(
 			ctx, k.config, tlfHandle, restOfPath, "", keybase1.MDPriorityNormal)
 		if err != nil {
-			return nil, "", err
+			if exitEarly, err := libfs.FilterTLFEarlyExitError(
+				ctx, err, k.log, tlfHandle.GetCanonicalName()); exitEarly {
+				return nil, finalElem, true, err
+			}
+			return nil, "", false, err
 		}
-		return fs, finalElem, nil
+		return fs, finalElem, false, nil
 	case keybase1.PathType_LOCAL:
 		fs = osfs.New(stdpath.Dir(path.Local()))
-		return fs, stdpath.Base(path.Local()), nil
+		return fs, stdpath.Base(path.Local()), false, nil
 	default:
-		return nil, "", simpleFSError{"Invalid path type"}
+		return nil, "", false, simpleFSError{"Invalid path type"}
 	}
 }
 
@@ -311,8 +315,12 @@ func (k *SimpleFS) SimpleFSList(ctx context.Context, arg keybase1.SimpleFSListAr
 		case rawPath == `/team`:
 			res, err = k.favoriteList(ctx, arg.Path, tlf.SingleTeam)
 		default:
-			fs, finalElem, err := k.getFS(ctx, arg.Path)
-			if err != nil {
+			fs, finalElem, exitEarly, err := k.getFS(ctx, arg.Path)
+			if exitEarly {
+				// TLF doesn't exist yet; just return an empty result.
+				k.setResult(arg.OpID, keybase1.SimpleFSListResult{})
+				return nil
+			} else if err != nil {
 				return err
 			}
 
@@ -349,10 +357,15 @@ func (k *SimpleFS) SimpleFSListRecursive(ctx context.Context, arg keybase1.Simpl
 		// Here we don't walk symlinks, so no loops possible.
 		var paths []string
 
-		fs, finalElem, err := k.getFS(ctx, arg.Path)
-		if err != nil {
+		fs, finalElem, exitEarly, err := k.getFS(ctx, arg.Path)
+		if exitEarly {
+			// TLF doesn't exist yet; just return an empty result.
+			k.setResult(arg.OpID, keybase1.SimpleFSListResult{})
+			return nil
+		} else if err != nil {
 			return err
 		}
+
 		fi, err := fs.Stat(finalElem)
 		if err != nil {
 			return err
@@ -433,7 +446,7 @@ func copyWithCancellation(ctx context.Context, dst io.Writer, src io.Reader) err
 func (k *SimpleFS) doCopyFromSource(
 	ctx context.Context, srcFS billy.Filesystem, srcFI os.FileInfo,
 	destPath keybase1.Path) error {
-	dstFS, finalDstElem, err := k.getFS(ctx, destPath)
+	dstFS, finalDstElem, _, err := k.getFS(ctx, destPath)
 	if err != nil {
 		return err
 	}
@@ -461,7 +474,7 @@ func (k *SimpleFS) doCopyFromSource(
 func (k *SimpleFS) doCopy(ctx context.Context, srcPath, destPath keybase1.Path) error {
 	// Note this is also used by move, so if this changes update SimpleFSMove
 	// code also.
-	srcFS, finalSrcElem, err := k.getFS(ctx, srcPath)
+	srcFS, finalSrcElem, _, err := k.getFS(ctx, srcPath)
 	if err != nil {
 		return err
 	}
@@ -515,7 +528,7 @@ func (k *SimpleFS) SimpleFSCopyRecursive(ctx context.Context,
 					path := paths[len(paths)-1]
 					paths = paths[:len(paths)-1]
 
-					srcFS, finalSrcElem, err := k.getFS(ctx, path.src)
+					srcFS, finalSrcElem, _, err := k.getFS(ctx, path.src)
 					if err != nil {
 						return err
 					}
@@ -550,7 +563,7 @@ func (k *SimpleFS) SimpleFSCopyRecursive(ctx context.Context,
 }
 
 func (k *SimpleFS) doRemove(ctx context.Context, path keybase1.Path) error {
-	fs, finalElem, err := k.getFS(ctx, path)
+	fs, finalElem, _, err := k.getFS(ctx, path)
 	if err != nil {
 		return err
 	}
@@ -653,7 +666,7 @@ func (k *SimpleFS) SimpleFSOpen(ctx context.Context, arg keybase1.SimpleFSOpenAr
 	}
 	defer func() { k.doneSyncOp(ctx, err) }()
 
-	fs, finalElem, err := k.getFS(ctx, arg.Dest)
+	fs, finalElem, _, err := k.getFS(ctx, arg.Dest)
 	if err != nil {
 		return err
 	}
@@ -710,7 +723,7 @@ func (k *SimpleFS) SimpleFSSetStat(ctx context.Context, arg keybase1.SimpleFSSet
 	}
 	defer func() { k.doneSyncOp(ctx, err) }()
 
-	fs, finalElem, err := k.getFS(ctx, arg.Dest)
+	fs, finalElem, _, err := k.getFS(ctx, arg.Dest)
 	if err != nil {
 		return err
 	}
@@ -868,7 +881,7 @@ func (k *SimpleFS) SimpleFSStat(ctx context.Context, path keybase1.Path) (_ keyb
 	}
 	defer func() { k.doneSyncOp(ctx, err) }()
 
-	fs, finalElem, err := k.getFS(ctx, path)
+	fs, finalElem, _, err := k.getFS(ctx, path)
 	if err != nil {
 		return keybase1.Dirent{}, err
 	}

--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -28,7 +28,7 @@ func closeSimpleFS(ctx context.Context, t *testing.T, fs *SimpleFS) {
 	// the journal.
 	ctx, err := fs.startOpWrapContext(ctx)
 	require.NoError(t, err)
-	remoteFS, _, _, err := fs.getFS(ctx, keybase1.NewPathWithKbfs("/private/jdoe"))
+	remoteFS, _, err := fs.getFS(ctx, keybase1.NewPathWithKbfs("/private/jdoe"))
 	require.NoError(t, err)
 	err = remoteFS.(*libfs.FS).SyncAll()
 	require.NoError(t, err)

--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -28,7 +28,7 @@ func closeSimpleFS(ctx context.Context, t *testing.T, fs *SimpleFS) {
 	// the journal.
 	ctx, err := fs.startOpWrapContext(ctx)
 	require.NoError(t, err)
-	remoteFS, _, err := fs.getFS(ctx, keybase1.NewPathWithKbfs("/private/jdoe"))
+	remoteFS, _, _, err := fs.getFS(ctx, keybase1.NewPathWithKbfs("/private/jdoe"))
 	require.NoError(t, err)
 	err = remoteFS.(*libfs.FS).SyncAll()
 	require.NoError(t, err)


### PR DESCRIPTION
This is KBFS side of [KBFS-2781](https://keybase.atlassian.net/browse/KBFS-2781) where we return an empty result for Readdir on non-existent TLFs. A separate client side PR will fix displaying empty folders.