### PR TITLE
[KBFS-2747] Quick and dirty 'fixes' to unblock mobile

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -401,7 +401,7 @@ func NewConfigLocal(mode InitMode, loggerFn func(module string) logger.Logger,
 
 	// Don't bother creating the registry if UseNilMetrics is set, or
 	// if we're in minimal mode.
-	if !metrics.UseNilMetrics && config.Mode() != InitMinimal {
+	if !metrics.UseNilMetrics {
 		registry := metrics.NewRegistry()
 		config.SetMetricsRegistry(registry)
 	}
@@ -926,12 +926,6 @@ func (c *ConfigLocal) resetCachesWithoutShutdown() DirtyBlockCache {
 			capacity)
 	}
 	c.bcache = NewBlockCacheStandard(10000, capacity)
-
-	if c.Mode() == InitMinimal {
-		// No blocks will be dirtied in minimal mode, so don't bother
-		// with the dirty block cache.
-		return nil
-	}
 
 	oldDirtyBcache := c.dirtyBcache
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -352,15 +352,9 @@ var _ fbmHelper = (*folderBranchOps)(nil)
 // newFolderBranchOps constructs a new folderBranchOps object.
 func newFolderBranchOps(ctx context.Context, config Config, fb FolderBranch,
 	bType branchType) *folderBranchOps {
-	var nodeCache NodeCache
-	if config.Mode() == InitMinimal {
-		// If we're in minimal mode, let the node cache remain nil to
-		// ensure that the user doesn't try any data reads or writes.
-	} else {
-		nodeCache = newNodeCacheStandard(fb)
-		for _, f := range config.RootNodeWrappers() {
-			nodeCache.AddRootWrapper(f)
-		}
+	nodeCache := newNodeCacheStandard(fb)
+	for _, f := range config.RootNodeWrappers() {
+		nodeCache.AddRootWrapper(f)
 	}
 
 	// make logger
@@ -4580,12 +4574,6 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 	shouldPrefetch bool) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
-
-	if fbo.config.Mode() == InitMinimal {
-		// There is no node cache in minimal mode, so there's nothing
-		// to update.
-		return nil
-	}
 
 	// We need to get unlinkPath before calling UpdatePointers so that
 	// nodeCache.Unlink can properly update cachedPath.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -594,7 +594,7 @@ func doInit(
 	if config.Mode() == InitMinimal {
 		// In minimal mode, block re-embedding is not required, so we don't
 		// fetch the unembedded blocks..
-		workers = 0
+		workers = 1
 		prefetchWorkers = 0
 	}
 	config.SetBlockOps(NewBlockOpsStandard(config, workers, prefetchWorkers))

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -436,15 +436,6 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 		return nil
 	}
 
-	if mode == InitMinimal {
-		// Leave the block changes unembedded -- they aren't needed in
-		// minimal mode since there's no node cache, and thus there
-		// are no Nodes that needs to be updated due to BlockChange
-		// pointers in those blocks.
-		log.CDebugf(ctx, "Skipping block change reembedding in mode: %s", mode)
-		return nil
-	}
-
 	// Treat the unembedded block change like a file so we can reuse
 	// the file reading code.
 	file := path{FolderBranch{tlfID, MasterBranch},


### PR DESCRIPTION
I don't expect these to be the final fixes.

In this PR:
* Enable the dirty block cache for `InitMinimal`
* Enable the node cache for `InitMinimal`
* Enable the metrics registry for `InitMinimal`, because why not.

We have a lot of unguarded access for the dirty block cache and the node cache. I suspect that we need the node cache because of `GetOrCreateRootNode`, but the dirty block cache can probably get a no-op version of itself that does nothing.