### PR TITLE
Jenkins changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,19 +365,19 @@ def runNixTest(prefix) {
     tests[prefix+'libpages'] = {
         dir('libpages') {
             sh 'go test -race -c'
-            sh './libpages.test -test.timeout 10s'
+            sh './libpages.test -test.timeout 30s'
         }
     }
     tests[prefix+'libpages_config'] = {
         dir('libpages/config') {
             sh 'go test -race -c'
-            sh './config.test -test.timeout 10s'
+            sh './config.test -test.timeout 30s'
         }
     }
     tests[prefix+'kbpagesconfig'] = {
         dir('kbpagesconfig') {
             sh 'go test -race -c'
-            sh './kbpagesconfig.test -test.timeout 10s'
+            sh './kbpagesconfig.test -test.timeout 30s'
         }
     }
     parallel (tests)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -378,21 +378,27 @@ def runNixTest(prefix) {
     }
     tests[prefix+'libpages'] = {
         dir('libpages') {
-            sh 'go test -timeout 30s'
+            sh 'go test -i'
+            sh 'go test -c'
+            retry (3) {
+              sh './libpages.test -test.timeout 10s'
+            }
         }
     }
     tests[prefix+'libpages_config'] = {
         dir('libpages/config') {
             sh 'go test -i'
             sh 'go test -c'
-            sh './config.test -test.timeout 30s'
+            sh './config.test -test.timeout 10s'
         }
     }
     tests[prefix+'kbpagesconfig'] = {
         dir('kbpagesconfig') {
             sh 'go test -i'
             sh 'go test -c'
-            sh './kbpagesconfig.test -test.timeout 30s'
+            retry (3) {
+              sh './kbpagesconfig.test -test.timeout 10s'
+            }
         }
     }
     parallel (tests)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -419,9 +419,7 @@ def runNixTest(prefix) {
     }
     tests[prefix+'libpages'] = {
         dir('libpages') {
-            retry (3) {
-              sh './libpages.test -test.timeout 10s'
-            }
+            sh './libpages.test -test.timeout 10s'
         }
     }
     tests[prefix+'libpages_config'] = {
@@ -431,9 +429,7 @@ def runNixTest(prefix) {
     }
     tests[prefix+'kbpagesconfig'] = {
         dir('kbpagesconfig') {
-            retry (3) {
-              sh './kbpagesconfig.test -test.timeout 10s'
-            }
+            sh './kbpagesconfig.test -test.timeout 10s'
         }
     }
     parallel (tests)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -268,97 +268,138 @@ def runNixTest(prefix) {
         sh 'go test -i -tags fuse'
     }
 
-    // Build out the vendored gogit dependency first, otherwise the
-    // git-remote-helper binary and the kbfsgit tests might have
-    // concurrent build issues when running in parallel.
+    // Build out the test dependencies and binaries (in most cases) first,
+    // otherwise the we might have concurrent build issues when running in
+    // parallel.
     dir('kbfsgit') {
         sh 'go test -i'
     }
-    tests = [:]
-    tests[prefix+'install'] = {
-        sh 'go install github.com/keybase/kbfs/...'
+    dir('kbfsblock') {
+        sh 'go test -i'
+        sh 'go test -race -c'
     }
+    dir('kbfscodec') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('kbfscrypto') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('kbfshash') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('kbfssync') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('tlf') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('libfs') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('libgit') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('libkbfs') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('libfuse') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('simplefs') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('kbfsgit') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('test') {
+        sh 'go test -i'
+        // Don't build test binaries here since we build them separately in two
+        // tests for fuse/race configurations.
+    }
+    dir('libpages') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('libpages/config') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+    dir('kbpagesconfig') {
+        sh 'go test -i'
+        sh 'go test -race -c'
+    }
+
+    sh 'go install github.com/keybase/kbfs/...'
+
+    tests = [:]
     tests[prefix+'kbfsblock'] = {
         dir('kbfsblock') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './kbfsblock.test -test.timeout 30s'
         }
     }
     tests[prefix+'kbfscodec'] = {
         dir('kbfscodec') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './kbfscodec.test -test.timeout 10m'
         }
     }
     tests[prefix+'kbfscrypto'] = {
         dir('kbfscrypto') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './kbfscrypto.test -test.timeout 10m'
         }
     }
     tests[prefix+'kbfshash'] = {
         dir('kbfshash') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './kbfshash.test -test.timeout 10m'
         }
     }
     tests[prefix+'kbfssync'] = {
         dir('kbfssync') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './kbfssync.test -test.timeout 10m'
         }
     }
     tests[prefix+'tlf'] = {
         dir('tlf') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './tlf.test -test.timeout 10m'
         }
     }
     tests[prefix+'libfs'] = {
         dir('libfs') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './libfs.test -test.timeout 10m'
         }
     }
     tests[prefix+'libgit'] = {
         dir('libgit') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './libgit.test -test.timeout 10m'
         }
     }
     tests[prefix+'libkbfs'] = {
         dir('libkbfs') {
-            sh 'go test -i'
-            sh 'go test -race -c'
             sh './libkbfs.test -test.timeout 5m'
         }
     }
     tests[prefix+'libfuse'] = {
         dir('libfuse') {
-            sh 'go test -i'
-            sh 'go test -c'
             sh './libfuse.test -test.timeout 3m'
         }
     }
     tests[prefix+'simplefs'] = {
         dir('simplefs') {
-            sh 'go test -i'
-            sh 'go test -c'
             sh './simplefs.test -test.timeout 2m'
         }
     }
     tests[prefix+'kbfsgit'] = {
         dir('kbfsgit') {
-            // test dependencies pre-built above
-            sh 'go test -race -c'
             sh './kbfsgit.test -test.timeout 10m'
         }
     }
@@ -378,8 +419,6 @@ def runNixTest(prefix) {
     }
     tests[prefix+'libpages'] = {
         dir('libpages') {
-            sh 'go test -i'
-            sh 'go test -c'
             retry (3) {
               sh './libpages.test -test.timeout 10s'
             }
@@ -387,15 +426,11 @@ def runNixTest(prefix) {
     }
     tests[prefix+'libpages_config'] = {
         dir('libpages/config') {
-            sh 'go test -i'
-            sh 'go test -c'
             sh './config.test -test.timeout 10s'
         }
     }
     tests[prefix+'kbpagesconfig'] = {
         dir('kbpagesconfig') {
-            sh 'go test -i'
-            sh 'go test -c'
             retry (3) {
               sh './kbpagesconfig.test -test.timeout 10s'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -312,11 +312,11 @@ def runNixTest(prefix) {
     }
     dir('libfuse') {
         sh 'go test -i'
-        sh 'go test -race -c'
+        sh 'go test -c'
     }
     dir('simplefs') {
         sh 'go test -i'
-        sh 'go test -race -c'
+        sh 'go test -c'
     }
     dir('kbfsgit') {
         sh 'go test -i'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -271,135 +271,80 @@ def runNixTest(prefix) {
     // Build out the test dependencies and binaries (in most cases) first,
     // otherwise the we might have concurrent build issues when running in
     // parallel.
-    dir('kbfsgit') {
-        sh 'go test -i'
-    }
-    dir('kbfsblock') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('kbfscodec') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('kbfscrypto') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('kbfshash') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('kbfssync') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('tlf') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('libfs') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('libgit') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('libkbfs') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('libfuse') {
-        sh 'go test -i'
-        sh 'go test -c'
-    }
-    dir('simplefs') {
-        sh 'go test -i'
-        sh 'go test -c'
-    }
-    dir('kbfsgit') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('test') {
-        sh 'go test -i'
-        // Don't build test binaries here since we build them separately in two
-        // tests for fuse/race configurations.
-    }
-    dir('libpages') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('libpages/config') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
-    dir('kbpagesconfig') {
-        sh 'go test -i'
-        sh 'go test -race -c'
-    }
+    sh 'go test -i -tags fuse ./...'
 
     sh 'go install github.com/keybase/kbfs/...'
 
     tests = [:]
     tests[prefix+'kbfsblock'] = {
         dir('kbfsblock') {
+            sh 'go test -race -c'
             sh './kbfsblock.test -test.timeout 30s'
         }
     }
     tests[prefix+'kbfscodec'] = {
         dir('kbfscodec') {
+            sh 'go test -race -c'
             sh './kbfscodec.test -test.timeout 10m'
         }
     }
     tests[prefix+'kbfscrypto'] = {
         dir('kbfscrypto') {
+            sh 'go test -race -c'
             sh './kbfscrypto.test -test.timeout 10m'
         }
     }
     tests[prefix+'kbfshash'] = {
         dir('kbfshash') {
+            sh 'go test -race -c'
             sh './kbfshash.test -test.timeout 10m'
         }
     }
     tests[prefix+'kbfssync'] = {
         dir('kbfssync') {
+            sh 'go test -race -c'
             sh './kbfssync.test -test.timeout 10m'
         }
     }
     tests[prefix+'tlf'] = {
         dir('tlf') {
+            sh 'go test -race -c'
             sh './tlf.test -test.timeout 10m'
         }
     }
     tests[prefix+'libfs'] = {
         dir('libfs') {
+            sh 'go test -race -c'
             sh './libfs.test -test.timeout 10m'
         }
     }
     tests[prefix+'libgit'] = {
         dir('libgit') {
+            sh 'go test -race -c'
             sh './libgit.test -test.timeout 10m'
         }
     }
     tests[prefix+'libkbfs'] = {
         dir('libkbfs') {
+            sh 'go test -race -c'
             sh './libkbfs.test -test.timeout 5m'
         }
     }
     tests[prefix+'libfuse'] = {
         dir('libfuse') {
+            sh 'go test -c'
             sh './libfuse.test -test.timeout 3m'
         }
     }
     tests[prefix+'simplefs'] = {
         dir('simplefs') {
+            sh 'go test -c'
             sh './simplefs.test -test.timeout 2m'
         }
     }
     tests[prefix+'kbfsgit'] = {
         dir('kbfsgit') {
+            sh 'go test -race -c'
             sh './kbfsgit.test -test.timeout 10m'
         }
     }
@@ -419,16 +364,19 @@ def runNixTest(prefix) {
     }
     tests[prefix+'libpages'] = {
         dir('libpages') {
+            sh 'go test -race -c'
             sh './libpages.test -test.timeout 10s'
         }
     }
     tests[prefix+'libpages_config'] = {
         dir('libpages/config') {
+            sh 'go test -race -c'
             sh './config.test -test.timeout 10s'
         }
     }
     tests[prefix+'kbpagesconfig'] = {
         dir('kbpagesconfig') {
+            sh 'go test -race -c'
             sh './kbpagesconfig.test -test.timeout 10s'
         }
     }


### PR DESCRIPTION
It's happened twice that `libpages.test` just times out. It runs within 0.01s on my laptop, so not sure how it could happen.

I reduced the `test.timout` to 10s, but not sure if it helps with this particular case since the test on Jenkins just runs over 1m30s while the test it self is run with a 30s timeout. But the retry should hopefully get it eventually to pass.

Update: added a new commit to build test binaries first before running all tests in parallel