### PR TITLE
use MinCost for bcrypt in test

### DIFF
--- a/libpages/config/config_v1_test.go
+++ b/libpages/config/config_v1_test.go
@@ -88,7 +88,7 @@ func TestConfigV1Invalid(t *testing.T) {
 
 func generatePasswordHashForTestOrBust(t *testing.T, password string) []byte {
 	passwordHash, err := bcrypt.GenerateFromPassword(
-		[]byte(password), bcrypt.DefaultCost)
+		[]byte(password), bcrypt.MinCost)
 	require.NoError(t, err)
 	return passwordHash
 }


### PR DESCRIPTION
Not sure if this is really gonna help with CI flake which I still don't understand, but there's no harm in using `MinCost` in test which should make bcrypt faster in tests.