### PR TITLE
journal_server: track dirty ops per TLF, not globally

### DIFF
--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -529,7 +529,7 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 	dirtyOps := func() uint {
 		jServer.lock.RLock()
 		defer jServer.lock.RUnlock()
-		return jServer.dirtyOps
+		return jServer.dirtyOps[tlfID]
 	}
 	require.NotEqual(t, 0, dirtyOps)
 }


### PR DESCRIPTION
Otherwise one TLF can prevent new writes to a second TLF from enabling the journal for the second TLF.

Issue: KBFS-2809