### PR TITLE
redirector: turn off local caches on osx

### DIFF
--- a/redirector/go/main.go
+++ b/redirector/go/main.go
@@ -276,6 +276,8 @@ func main() {
 		options = append(options, fuse.OSXFUSELocations(kbfusePath))
 		options = append(options, fuse.VolumeName("keybase-redirector"))
 		options = append(options, fuse.NoBrowse())
+		// Without NoLocalCaches(), OSX will cache symlinks for a long time.
+		options = append(options, fuse.NoLocalCaches())
 	}
 
 	c, err := fuse.Mount(os.Args[1], options...)

--- a/vendor/bazil.org/fuse/options.go
+++ b/vendor/bazil.org/fuse/options.go
@@ -114,6 +114,13 @@ func NoBrowse() MountOption {
 	return noBrowse
 }
 
+// NoLocalCaches makes disables all kernel caching.
+//
+// OS X only.  Others ignore this option.
+func NoLocalCaches() MountOption {
+	return noLocalCaches
+}
+
 // ExclCreate causes O_EXCL flag to be set for only "truly" exclusive creates,
 // i.e. create calls for which the initiator explicitly set the O_EXCL flag.
 //

--- a/vendor/bazil.org/fuse/options_darwin.go
+++ b/vendor/bazil.org/fuse/options_darwin.go
@@ -38,3 +38,8 @@ func noBrowse(conf *mountConfig) error {
 	conf.options["nobrowse"] = ""
 	return nil
 }
+
+func noLocalCaches(conf *mountConfig) error {
+	conf.options["nolocalcaches"] = ""
+	return nil
+}

--- a/vendor/bazil.org/fuse/options_freebsd.go
+++ b/vendor/bazil.org/fuse/options_freebsd.go
@@ -30,3 +30,7 @@ func exclCreate(conf *mountConfig) error {
 func noBrowse(conf *mountConfig) error {
 	return nil
 }
+
+func noLocalCaches(conf *mountConfig) error {
+	return nil
+}

--- a/vendor/bazil.org/fuse/options_linux.go
+++ b/vendor/bazil.org/fuse/options_linux.go
@@ -27,3 +27,7 @@ func exclCreate(conf *mountConfig) error {
 func noBrowse(conf *mountConfig) error {
 	return nil
 }
+
+func noLocalCaches(conf *mountConfig) error {
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,11 +3,11 @@
 	"ignore": "test appenginevm",
 	"package": [
 		{
-			"checksumSHA1": "NgV1fBpGcstO5Xc9ikwaDzvRzBQ=",
+			"checksumSHA1": "FCasIexhOSYqzSMSYL0LLHvAztM=",
 			"origin": "github.com/keybase/fuse",
 			"path": "bazil.org/fuse",
-			"revision": "3afe336dd3e3da7877742a660034c46753cf868e",
-			"revisionTime": "2018-02-28T18:57:49Z"
+			"revision": "7906bf0143593669930f29dea20667526aaa5000",
+			"revisionTime": "2018-03-06T00:43:11Z"
 		},
 		{
 			"checksumSHA1": "389JFJTJADMtZkTIfdSnsmHVOUs=",


### PR DESCRIPTION
Otherwise, the kernel will cache symlinks for a long time.