### PR TITLE
libfs: create parent dirs when needed (disovered by strib)

### DIFF
--- a/libfs/fs_test.go
+++ b/libfs/fs_test.go
@@ -424,7 +424,14 @@ func TestSymlink(t *testing.T) {
 	err = fs.Symlink("foo", "a/b/c/bar")
 	require.NoError(t, err)
 
-	bar, err := fs.Open("a/b/c/bar")
+	_, err = fs.Open("a/b/c/bar")
+	require.NoError(t, err)
+
+	t.Log("Make sure Symlink creates parent directories as needed")
+	err = fs.Symlink("../../foo", "a/b/c/d/e/bar")
+	require.NoError(t, err)
+
+	bar, err := fs.Open("a/b/c/d/e/bar")
 	require.NoError(t, err)
 
 	checkData := func(f billy.File) {


### PR DESCRIPTION
This fixes a bug where `autogit` fails to checkout if there's symlink inside a directory by itself. The parent directory doesn't get created, and `go-git` fails on the `Symlink()` call trying to grab its parent directory.

Thanks @strib for spotting the root cause!