### PR TITLE
libkbfs: introduce a new InitMode interface, and a new "constrained" mode for mobile KBFS

### DIFF
--- a/libfs/file.go
+++ b/libfs/file.go
@@ -219,7 +219,7 @@ func (f *File) Unlock() (err error) {
 			f.fs.root.GetFolderBranch().Tlf, f.getLockID())
 	}
 
-	if f.fs.config.Mode() == libkbfs.InitSingleOp {
+	if f.fs.config.Mode().Type() == libkbfs.InitSingleOp {
 		err = jServer.FinishSingleOp(f.fs.ctx,
 			f.fs.root.GetFolderBranch().Tlf, &keybase1.LockContext{
 				RequireLockID:       f.getLockID(),

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -80,7 +80,7 @@ func (nc *newConfigger) shutdown(t *testing.T, ctx context.Context) {
 }
 
 func (nc *newConfigger) getNewConfigForTestWithMode(
-	ctx context.Context, mode libkbfs.InitMode) (
+	ctx context.Context, mode libkbfs.InitModeType) (
 	newCtx context.Context, gitConfig libkbfs.Config,
 	tempDir string, err error) {
 	ctx, err = libkbfs.NewContextWithCancellationDelayer(ctx)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -369,14 +369,14 @@ func getDefaultCleanBlockCacheCapacity() uint64 {
 //
 // TODO: Now that NewConfigLocal takes loggerFn, add more default
 // components.
-func NewConfigLocal(modeType InitModeType,
+func NewConfigLocal(mode InitMode,
 	loggerFn func(module string) logger.Logger,
 	storageRoot string, diskCacheMode DiskCacheMode,
 	kbCtx Context) *ConfigLocal {
 	config := &ConfigLocal{
 		loggerFn:      loggerFn,
 		storageRoot:   storageRoot,
-		mode:          NewInitModeFromType(modeType),
+		mode:          mode,
 		diskCacheMode: diskCacheMode,
 		kbCtx:         kbCtx,
 	}

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -418,7 +418,7 @@ func NewConfigLocal(mode InitMode, loggerFn func(module string) logger.Logger,
 	case InitDefault:
 		// In normal desktop app, we limit to 16 routines.
 		config.rekeyFSMLimiter = NewOngoingWorkLimiter(16)
-	case InitMinimal:
+	case InitMinimal, InitConstrained:
 		// This is likely mobile. Limit it to 4.
 		config.rekeyFSMLimiter = NewOngoingWorkLimiter(4)
 	case InitSingleOp:

--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -133,6 +133,7 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.qrPeriod = 0 * time.Second // no auto reclamation
 	config.qrUnrefAge = qrUnrefAgeDefault
 	config.SetMetadataVersion(defaultClientMetadataVer)
+	config.mode = NewInitModeFromType(InitDefault | InitTest)
 
 	return config
 }

--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -133,7 +133,7 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.qrPeriod = 0 * time.Second // no auto reclamation
 	config.qrUnrefAge = qrUnrefAgeDefault
 	config.SetMetadataVersion(defaultClientMetadataVer)
-	config.mode = NewInitModeFromType(InitDefault | InitTest)
+	config.mode = modeTest{NewInitModeFromType(InitDefault)}
 
 	return config
 }

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -103,12 +103,8 @@ func NewConflictResolver(
 		},
 	}
 
-	if config.Mode() != InitMinimal {
+	if config.Mode().ConflictResolutionEnabled() {
 		cr.startProcessing(BackgroundContextWithCancellationDelayer())
-	} else {
-		// No need to run CR if there won't be any data writes on this
-		// device.  (There may still be rekey writes, but we don't
-		// allow conflicts to happen in that case.)
 	}
 	return cr
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -664,11 +664,6 @@ type RekeyResult struct {
 type InitModeType int
 
 const (
-	// InitModeMask masks out mode flags.
-	InitModeMask InitModeType = 0xffff
-	// InitTest is a mode flag that represents whether we're running in a test.
-	InitTest InitModeType = 1 << 16
-
 	// InitDefault is the normal mode for when KBFS data will be read
 	// and written.
 	InitDefault InitModeType = iota
@@ -685,18 +680,8 @@ const (
 	InitConstrained
 )
 
-// Mode returns the mode absent any mode flags.
-func (im InitModeType) Mode() InitModeType {
-	return im & InitModeMask
-}
-
-// HasFlags returns whether all the specified flags are set.
-func (im InitModeType) HasFlags(flags InitModeType) bool {
-	return im&flags > 0
-}
-
 func (im InitModeType) String() string {
-	switch im.Mode() {
+	switch im {
 	case InitDefault:
 		return InitDefaultString
 	case InitMinimal:

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -680,6 +680,9 @@ const (
 	// needed, and some naming restrictions are lifted (e.g., `.kbfs_`
 	// filenames are allowed).
 	InitSingleOp
+	// InitConstrained is a mode where KBFS reads and writes data, but
+	// constrains itself to using fewer resources (e.g. on mobile).
+	InitConstrained
 )
 
 // Mode returns the mode absent any mode flags.
@@ -700,6 +703,8 @@ func (im InitMode) String() string {
 		return InitMinimalString
 	case InitSingleOp:
 		return InitSingleOpString
+	case InitConstrained:
+		return InitConstrainedString
 	default:
 		return "unknown"
 	}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -660,18 +660,18 @@ type RekeyResult struct {
 	NeedsPaperKey bool
 }
 
-// InitMode indicates how KBFS should configure itself at runtime.
-type InitMode int
+// InitModeType indicates how KBFS should configure itself at runtime.
+type InitModeType int
 
 const (
 	// InitModeMask masks out mode flags.
-	InitModeMask InitMode = 0xffff
+	InitModeMask InitModeType = 0xffff
 	// InitTest is a mode flag that represents whether we're running in a test.
-	InitTest InitMode = 1 << 16
+	InitTest InitModeType = 1 << 16
 
 	// InitDefault is the normal mode for when KBFS data will be read
 	// and written.
-	InitDefault InitMode = iota
+	InitDefault InitModeType = iota
 	// InitMinimal is for when KBFS will only be used as a MD lookup
 	// layer (e.g., for chat on mobile).
 	InitMinimal
@@ -686,16 +686,16 @@ const (
 )
 
 // Mode returns the mode absent any mode flags.
-func (im InitMode) Mode() InitMode {
+func (im InitModeType) Mode() InitModeType {
 	return im & InitModeMask
 }
 
 // HasFlags returns whether all the specified flags are set.
-func (im InitMode) HasFlags(flags InitMode) bool {
+func (im InitModeType) HasFlags(flags InitModeType) bool {
 	return im&flags > 0
 }
 
-func (im InitMode) String() string {
+func (im InitModeType) String() string {
 	switch im.Mode() {
 	case InitDefault:
 		return InitDefaultString

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -138,17 +138,13 @@ func newFolderBlockManager(config Config, fb FolderBranch,
 	// doesn't do possibly-racy-in-tests access to
 	// fbm.config.BlockOps().
 
-	if config.Mode() == InitMinimal {
-		// If this device is in minimal mode and won't be doing any
-		// data writes, no need deal with block-level cleanup
-		// operations.  TODO: in the future it might still be useful
-		// to have e.g. mobile devices doing QR.
+	if !config.Mode().BlockManagementEnabled() {
 		return fbm
 	}
 
 	go fbm.archiveBlocksInBackground()
 	go fbm.deleteBlocksInBackground()
-	if fb.Branch == MasterBranch && config.Mode() != InitSingleOp {
+	if fb.Branch == MasterBranch && config.Mode().QuotaReclamationEnabled() {
 		go fbm.reclaimQuotaInBackground()
 	}
 	return fbm

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1627,7 +1627,8 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 			md.Revision(), md.MergedStatus(), err)
 	}()
 
-	if md.IsReadable() && fbo.config.Mode() != InitMinimal {
+	if md.IsReadable() && fbo.config.Mode() != InitMinimal &&
+		fbo.config.Mode() != InitConstrained {
 		// We `Get` the root block to ensure downstream prefetches occur.
 		_ = fbo.config.BlockOps().BlockRetriever().Request(ctx,
 			defaultOnDemandRequestPriority, md, md.data.Dir.BlockPointer,

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -572,19 +572,20 @@ func doInit(
 		return nil, fmt.Errorf("Unexpected mode: %s", params.Mode)
 	}
 
-	config := NewConfigLocal(mode, func(module string) logger.Logger {
-		mname := logPrefix
-		if module != "" {
-			mname += fmt.Sprintf("(%s)", module)
-		}
-		lg := logger.New(mname)
-		if params.Debug {
-			// Turn on debugging.  TODO: allow a proper log file and
-			// style to be specified.
-			lg.Configure("", true, "")
-		}
-		return lg
-	}, params.StorageRoot, params.DiskCacheMode, kbCtx)
+	config := NewConfigLocal(NewInitModeFromType(mode),
+		func(module string) logger.Logger {
+			mname := logPrefix
+			if module != "" {
+				mname += fmt.Sprintf("(%s)", module)
+			}
+			lg := logger.New(mname)
+			if params.Debug {
+				// Turn on debugging.  TODO: allow a proper log file and
+				// style to be specified.
+				lg.Configure("", true, "")
+			}
+			return lg
+		}, params.StorageRoot, params.DiskCacheMode, kbCtx)
 
 	if params.CleanBlockCacheCapacity > 0 {
 		log.CDebugf(

--- a/libkbfs/interface_test.go
+++ b/libkbfs/interface_test.go
@@ -77,10 +77,14 @@ func (t *testSyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID,
 }
 
 type testInitModeGetter struct {
-	InitMode
+	mode InitModeType
 }
 
 var _ initModeGetter = (*testInitModeGetter)(nil)
+
+func (t testInitModeGetter) Mode() InitMode {
+	return NewInitModeFromType(t.mode)
+}
 
 func (t testInitModeGetter) IsTestMode() bool {
 	return true

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1767,6 +1767,60 @@ type Tracer interface {
 	MaybeFinishTrace(ctx context.Context, err error)
 }
 
+// InitMode encapsulates mode differences.
+type InitMode interface {
+	// Type returns the InitModeType of this mode.
+	Type() InitModeType
+	// IsTestMode returns whether we are running a test.
+	IsTestMode() bool
+	// BlockWorkers returns the number of block workers to run.
+	BlockWorkers() int
+	// PrefetchWorkers returns the number of prefetch workers to run.
+	PrefetchWorkers() int
+	// RekeyWorkers returns the number of rekey workers to run.
+	RekeyWorkers() int
+	// DirtyBlockCacheEnabled indicates if we should run a dirty block
+	// cache.
+	DirtyBlockCacheEnabled() bool
+	// BackgroundFlushesEnabled indicates if we should periodically be
+	// flushing unsynced dirty writes to the server or journal.
+	BackgroundFlushesEnabled() bool
+	// MetricsEnabled indicates if we should be collecting metrics.
+	MetricsEnabled() bool
+	// ConflictResolutionEnabled indicated if we should be running
+	// the conflict resolution background process.
+	ConflictResolutionEnabled() bool
+	// BlockManagementEnabled indicates whether we should be running
+	// the block archive/delete background process, and whether we
+	// should be re-embedding block change blocks in MDs.
+	BlockManagementEnabled() bool
+	// QuotaReclamationEnabled indicates whether we should be running
+	// the quota reclamation background process.
+	QuotaReclamationEnabled() bool
+	// NodeCacheEnabled indicates whether we should be caching data nodes.
+	NodeCacheEnabled() bool
+	// TLFUpdatesEnabled indicates whether we should be registering
+	// ourselves with the mdserver for TLF updates.
+	TLFUpdatesEnabled() bool
+	// KBFSServiceEnabled indicates whether we should launch a local
+	// service for answering incoming KBFS-related RPCs.
+	KBFSServiceEnabled() bool
+	// JournalEnabled indicates whether this mode supports a journal.
+	JournalEnabled() bool
+	// UnmergedTLFsEnabled indicates whether it's possible for a
+	// device in this mode to have unmerged TLFs.
+	UnmergedTLFsEnabled() bool
+	// ServiceKeepaliveEnabled indicates whether we need to send
+	// keepalive probes to the Keybase service daemon.
+	ServiceKeepaliveEnabled() bool
+	// TLFEditHistoryEnabled indicates whether we should be running
+	// the background TLF edit history process.
+	TLFEditHistoryEnabled() bool
+	// ClientType indicates the type we should advertise to the
+	// Keybase service.
+	ClientType() keybase1.ClientType
+}
+
 type initModeGetter interface {
 	// Mode indicates how KBFS is configured to run.
 	Mode() InitMode

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -259,7 +259,7 @@ func (j *JournalServer) getTLFJournal(
 		j.log.CDebugf(ctx, "Enabling a new journal for %s (enableAuto=%t, set by user=%t)",
 			tlfID, enableAuto, enableAutoSetByUser)
 		bws := TLFJournalBackgroundWorkEnabled
-		if j.config.Mode() == InitSingleOp {
+		if j.config.Mode().Type() == InitSingleOp {
 			bws = TLFJournalSingleOpBackgroundWorkEnabled
 		}
 		err = j.Enable(ctx, tlfID, h, bws)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -440,11 +440,8 @@ func (fs *KBFSOpsStandard) getMDByHandle(ctx context.Context,
 		return ImmutableRootMetadata{}, err
 	}
 
-	// Check for an unmerged MD first, unless we're in single-op
-	// mode.  If this is a single-op, we can skip this check because
-	// there's basically no way for a TLF to start off as unmerged
-	// since single-ops should be using a fresh journal.
-	if fs.config.Mode() != InitSingleOp {
+	// Check for an unmerged MD first if necessary.
+	if fs.config.Mode().UnmergedTLFsEnabled() {
 		rmd, err = fs.config.MDOps().GetUnmergedForTLF(
 			ctx, tlfHandle.tlfID, kbfsmd.NullBranchID)
 		if err != nil {
@@ -561,11 +558,8 @@ func (fs *KBFSOpsStandard) getMaybeCreateRootNode(
 
 	mdops := fs.config.MDOps()
 	var md ImmutableRootMetadata
-	// Check for an unmerged MD first, unless we're in single-op
-	// mode.  If this is a single-op, we can skip this check because
-	// there's basically no way for a TLF to start off as unmerged
-	// since single-ops should be using a fresh journal.
-	if fs.config.Mode() != InitSingleOp {
+	// Check for an unmerged MD first if necessary.
+	if fs.config.Mode().UnmergedTLFsEnabled() {
 		md, err = mdops.GetUnmergedForTLF(ctx, h.tlfID, kbfsmd.NullBranchID)
 		if err != nil {
 			return nil, EntryInfo{}, err

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -78,7 +78,7 @@ func NewKeybaseDaemonRPC(config Config, kbCtx Context, log logger.Logger,
 	k.fillClients(conn.GetClient())
 	k.shutdownFn = conn.Shutdown
 
-	if config.Mode() != InitMinimal {
+	if config.Mode() != InitMinimal && config.Mode() != InitConstrained {
 		ctx, cancel := context.WithCancel(context.Background())
 		k.keepAliveCancel = cancel
 		go k.keepAliveLoop(ctx)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -436,12 +436,13 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 		return nil
 	}
 
-	if mode == InitMinimal {
+	if !mode.BlockManagementEnabled() {
 		// Leave the block changes unembedded -- they aren't needed in
 		// minimal mode since there's no node cache, and thus there
 		// are no Nodes that needs to be updated due to BlockChange
 		// pointers in those blocks.
-		log.CDebugf(ctx, "Skipping block change reembedding in mode: %s", mode)
+		log.CDebugf(ctx, "Skipping block change reembedding in mode: %s",
+			mode.Type())
 		return nil
 	}
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5753,28 +5753,28 @@ func (mr *MockInitModeMockRecorder) DirtyBlockCacheEnabled() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DirtyBlockCacheEnabled", reflect.TypeOf((*MockInitMode)(nil).DirtyBlockCacheEnabled))
 }
 
-// DoBackgroundFlushes mocks base method
-func (m *MockInitMode) DoBackgroundFlushes() bool {
-	ret := m.ctrl.Call(m, "DoBackgroundFlushes")
+// BackgroundFlushesEnabled mocks base method
+func (m *MockInitMode) BackgroundFlushesEnabled() bool {
+	ret := m.ctrl.Call(m, "BackgroundFlushesEnabled")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// DoBackgroundFlushes indicates an expected call of DoBackgroundFlushes
-func (mr *MockInitModeMockRecorder) DoBackgroundFlushes() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoBackgroundFlushes", reflect.TypeOf((*MockInitMode)(nil).DoBackgroundFlushes))
+// BackgroundFlushesEnabled indicates an expected call of BackgroundFlushesEnabled
+func (mr *MockInitModeMockRecorder) BackgroundFlushesEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackgroundFlushesEnabled", reflect.TypeOf((*MockInitMode)(nil).BackgroundFlushesEnabled))
 }
 
-// UseMetrics mocks base method
-func (m *MockInitMode) UseMetrics() bool {
-	ret := m.ctrl.Call(m, "UseMetrics")
+// MetricsEnabled mocks base method
+func (m *MockInitMode) MetricsEnabled() bool {
+	ret := m.ctrl.Call(m, "MetricsEnabled")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// UseMetrics indicates an expected call of UseMetrics
-func (mr *MockInitModeMockRecorder) UseMetrics() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseMetrics", reflect.TypeOf((*MockInitMode)(nil).UseMetrics))
+// MetricsEnabled indicates an expected call of MetricsEnabled
+func (mr *MockInitModeMockRecorder) MetricsEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MetricsEnabled", reflect.TypeOf((*MockInitMode)(nil).MetricsEnabled))
 }
 
 // ConflictResolutionEnabled mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5658,6 +5658,257 @@ func (mr *MockTracerMockRecorder) MaybeFinishTrace(ctx, err interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaybeFinishTrace", reflect.TypeOf((*MockTracer)(nil).MaybeFinishTrace), ctx, err)
 }
 
+// MockInitMode is a mock of InitMode interface
+type MockInitMode struct {
+	ctrl     *gomock.Controller
+	recorder *MockInitModeMockRecorder
+}
+
+// MockInitModeMockRecorder is the mock recorder for MockInitMode
+type MockInitModeMockRecorder struct {
+	mock *MockInitMode
+}
+
+// NewMockInitMode creates a new mock instance
+func NewMockInitMode(ctrl *gomock.Controller) *MockInitMode {
+	mock := &MockInitMode{ctrl: ctrl}
+	mock.recorder = &MockInitModeMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockInitMode) EXPECT() *MockInitModeMockRecorder {
+	return m.recorder
+}
+
+// Type mocks base method
+func (m *MockInitMode) Type() InitModeType {
+	ret := m.ctrl.Call(m, "Type")
+	ret0, _ := ret[0].(InitModeType)
+	return ret0
+}
+
+// Type indicates an expected call of Type
+func (mr *MockInitModeMockRecorder) Type() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Type", reflect.TypeOf((*MockInitMode)(nil).Type))
+}
+
+// IsTestMode mocks base method
+func (m *MockInitMode) IsTestMode() bool {
+	ret := m.ctrl.Call(m, "IsTestMode")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTestMode indicates an expected call of IsTestMode
+func (mr *MockInitModeMockRecorder) IsTestMode() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTestMode", reflect.TypeOf((*MockInitMode)(nil).IsTestMode))
+}
+
+// BlockWorkers mocks base method
+func (m *MockInitMode) BlockWorkers() int {
+	ret := m.ctrl.Call(m, "BlockWorkers")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// BlockWorkers indicates an expected call of BlockWorkers
+func (mr *MockInitModeMockRecorder) BlockWorkers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockWorkers", reflect.TypeOf((*MockInitMode)(nil).BlockWorkers))
+}
+
+// PrefetchWorkers mocks base method
+func (m *MockInitMode) PrefetchWorkers() int {
+	ret := m.ctrl.Call(m, "PrefetchWorkers")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// PrefetchWorkers indicates an expected call of PrefetchWorkers
+func (mr *MockInitModeMockRecorder) PrefetchWorkers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchWorkers", reflect.TypeOf((*MockInitMode)(nil).PrefetchWorkers))
+}
+
+// RekeyWorkers mocks base method
+func (m *MockInitMode) RekeyWorkers() int {
+	ret := m.ctrl.Call(m, "RekeyWorkers")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// RekeyWorkers indicates an expected call of RekeyWorkers
+func (mr *MockInitModeMockRecorder) RekeyWorkers() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RekeyWorkers", reflect.TypeOf((*MockInitMode)(nil).RekeyWorkers))
+}
+
+// DirtyBlockCacheEnabled mocks base method
+func (m *MockInitMode) DirtyBlockCacheEnabled() bool {
+	ret := m.ctrl.Call(m, "DirtyBlockCacheEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DirtyBlockCacheEnabled indicates an expected call of DirtyBlockCacheEnabled
+func (mr *MockInitModeMockRecorder) DirtyBlockCacheEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DirtyBlockCacheEnabled", reflect.TypeOf((*MockInitMode)(nil).DirtyBlockCacheEnabled))
+}
+
+// DoBackgroundFlushes mocks base method
+func (m *MockInitMode) DoBackgroundFlushes() bool {
+	ret := m.ctrl.Call(m, "DoBackgroundFlushes")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DoBackgroundFlushes indicates an expected call of DoBackgroundFlushes
+func (mr *MockInitModeMockRecorder) DoBackgroundFlushes() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoBackgroundFlushes", reflect.TypeOf((*MockInitMode)(nil).DoBackgroundFlushes))
+}
+
+// UseMetrics mocks base method
+func (m *MockInitMode) UseMetrics() bool {
+	ret := m.ctrl.Call(m, "UseMetrics")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UseMetrics indicates an expected call of UseMetrics
+func (mr *MockInitModeMockRecorder) UseMetrics() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseMetrics", reflect.TypeOf((*MockInitMode)(nil).UseMetrics))
+}
+
+// ConflictResolutionEnabled mocks base method
+func (m *MockInitMode) ConflictResolutionEnabled() bool {
+	ret := m.ctrl.Call(m, "ConflictResolutionEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ConflictResolutionEnabled indicates an expected call of ConflictResolutionEnabled
+func (mr *MockInitModeMockRecorder) ConflictResolutionEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictResolutionEnabled", reflect.TypeOf((*MockInitMode)(nil).ConflictResolutionEnabled))
+}
+
+// BlockManagementEnabled mocks base method
+func (m *MockInitMode) BlockManagementEnabled() bool {
+	ret := m.ctrl.Call(m, "BlockManagementEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BlockManagementEnabled indicates an expected call of BlockManagementEnabled
+func (mr *MockInitModeMockRecorder) BlockManagementEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockManagementEnabled", reflect.TypeOf((*MockInitMode)(nil).BlockManagementEnabled))
+}
+
+// QuotaReclamationEnabled mocks base method
+func (m *MockInitMode) QuotaReclamationEnabled() bool {
+	ret := m.ctrl.Call(m, "QuotaReclamationEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// QuotaReclamationEnabled indicates an expected call of QuotaReclamationEnabled
+func (mr *MockInitModeMockRecorder) QuotaReclamationEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationEnabled", reflect.TypeOf((*MockInitMode)(nil).QuotaReclamationEnabled))
+}
+
+// NodeCacheEnabled mocks base method
+func (m *MockInitMode) NodeCacheEnabled() bool {
+	ret := m.ctrl.Call(m, "NodeCacheEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NodeCacheEnabled indicates an expected call of NodeCacheEnabled
+func (mr *MockInitModeMockRecorder) NodeCacheEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeCacheEnabled", reflect.TypeOf((*MockInitMode)(nil).NodeCacheEnabled))
+}
+
+// TLFUpdatesEnabled mocks base method
+func (m *MockInitMode) TLFUpdatesEnabled() bool {
+	ret := m.ctrl.Call(m, "TLFUpdatesEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// TLFUpdatesEnabled indicates an expected call of TLFUpdatesEnabled
+func (mr *MockInitModeMockRecorder) TLFUpdatesEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLFUpdatesEnabled", reflect.TypeOf((*MockInitMode)(nil).TLFUpdatesEnabled))
+}
+
+// KBFSServiceEnabled mocks base method
+func (m *MockInitMode) KBFSServiceEnabled() bool {
+	ret := m.ctrl.Call(m, "KBFSServiceEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// KBFSServiceEnabled indicates an expected call of KBFSServiceEnabled
+func (mr *MockInitModeMockRecorder) KBFSServiceEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KBFSServiceEnabled", reflect.TypeOf((*MockInitMode)(nil).KBFSServiceEnabled))
+}
+
+// JournalEnabled mocks base method
+func (m *MockInitMode) JournalEnabled() bool {
+	ret := m.ctrl.Call(m, "JournalEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// JournalEnabled indicates an expected call of JournalEnabled
+func (mr *MockInitModeMockRecorder) JournalEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JournalEnabled", reflect.TypeOf((*MockInitMode)(nil).JournalEnabled))
+}
+
+// UnmergedTLFsEnabled mocks base method
+func (m *MockInitMode) UnmergedTLFsEnabled() bool {
+	ret := m.ctrl.Call(m, "UnmergedTLFsEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UnmergedTLFsEnabled indicates an expected call of UnmergedTLFsEnabled
+func (mr *MockInitModeMockRecorder) UnmergedTLFsEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmergedTLFsEnabled", reflect.TypeOf((*MockInitMode)(nil).UnmergedTLFsEnabled))
+}
+
+// ServiceKeepaliveEnabled mocks base method
+func (m *MockInitMode) ServiceKeepaliveEnabled() bool {
+	ret := m.ctrl.Call(m, "ServiceKeepaliveEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ServiceKeepaliveEnabled indicates an expected call of ServiceKeepaliveEnabled
+func (mr *MockInitModeMockRecorder) ServiceKeepaliveEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceKeepaliveEnabled", reflect.TypeOf((*MockInitMode)(nil).ServiceKeepaliveEnabled))
+}
+
+// TLFEditHistoryEnabled mocks base method
+func (m *MockInitMode) TLFEditHistoryEnabled() bool {
+	ret := m.ctrl.Call(m, "TLFEditHistoryEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// TLFEditHistoryEnabled indicates an expected call of TLFEditHistoryEnabled
+func (mr *MockInitModeMockRecorder) TLFEditHistoryEnabled() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TLFEditHistoryEnabled", reflect.TypeOf((*MockInitMode)(nil).TLFEditHistoryEnabled))
+}
+
+// ClientType mocks base method
+func (m *MockInitMode) ClientType() keybase1.ClientType {
+	ret := m.ctrl.Call(m, "ClientType")
+	ret0, _ := ret[0].(keybase1.ClientType)
+	return ret0
+}
+
+// ClientType indicates an expected call of ClientType
+func (mr *MockInitModeMockRecorder) ClientType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClientType", reflect.TypeOf((*MockInitMode)(nil).ClientType))
+}
+
 // MockinitModeGetter is a mock of initModeGetter interface
 type MockinitModeGetter struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -1,0 +1,310 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"fmt"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+// NewInitModeFromType returns an InitMode object corresponding to the
+// given type.
+func NewInitModeFromType(t InitModeType) InitMode {
+	switch t.Mode() {
+	case InitDefault:
+		return modeDefault{t}
+	case InitMinimal:
+		return modeMinimal{t}
+	case InitSingleOp:
+		return modeSingleOp{modeDefault{t}}
+	case InitConstrained:
+		return modeConstrained{modeDefault{t}}
+	default:
+		panic(fmt.Sprintf("Unknown mode: %s", t))
+	}
+}
+
+// Default mode:
+
+type modeDefault struct {
+	originalMode InitModeType
+}
+
+func (md modeDefault) Type() InitModeType {
+	return InitDefault
+}
+
+func (md modeDefault) BlockWorkers() int {
+	return defaultBlockRetrievalWorkerQueueSize
+}
+
+func (md modeDefault) PrefetchWorkers() int {
+	return defaultPrefetchWorkerQueueSize
+}
+
+func (md modeDefault) RekeyWorkers() int {
+	return 16
+}
+
+func (md modeDefault) IsTestMode() bool {
+	return md.originalMode.HasFlags(InitTest)
+}
+
+func (md modeDefault) DirtyBlockCacheEnabled() bool {
+	return true
+}
+
+func (md modeDefault) BackgroundFlushesEnabled() bool {
+	return true
+}
+
+func (md modeDefault) MetricsEnabled() bool {
+	return true
+}
+
+func (md modeDefault) ConflictResolutionEnabled() bool {
+	return true
+}
+
+func (md modeDefault) BlockManagementEnabled() bool {
+	return true
+}
+
+func (md modeDefault) QuotaReclamationEnabled() bool {
+	return true
+}
+
+func (md modeDefault) NodeCacheEnabled() bool {
+	return true
+}
+
+func (md modeDefault) TLFUpdatesEnabled() bool {
+	return true
+}
+
+func (md modeDefault) KBFSServiceEnabled() bool {
+	return true
+}
+
+func (md modeDefault) JournalEnabled() bool {
+	return true
+}
+
+func (md modeDefault) UnmergedTLFsEnabled() bool {
+	return true
+}
+
+func (md modeDefault) ServiceKeepaliveEnabled() bool {
+	return true
+}
+
+func (md modeDefault) TLFEditHistoryEnabled() bool {
+	return true
+}
+
+func (md modeDefault) ClientType() keybase1.ClientType {
+	return keybase1.ClientType_KBFS
+}
+
+// Minimal mode:
+
+type modeMinimal struct {
+	originalMode InitModeType
+}
+
+func (mm modeMinimal) Type() InitModeType {
+	return InitMinimal
+}
+
+func (mm modeMinimal) BlockWorkers() int {
+	// In minimal mode, block re-embedding is not required, so we
+	// don't fetch the unembedded blocks..
+	return 0
+}
+
+func (mm modeMinimal) PrefetchWorkers() int {
+	return 0
+}
+
+func (mm modeMinimal) RekeyWorkers() int {
+	return 4
+}
+
+func (mm modeMinimal) IsTestMode() bool {
+	return mm.originalMode.HasFlags(InitTest)
+}
+
+func (mm modeMinimal) DirtyBlockCacheEnabled() bool {
+	// No blocks will be dirtied in minimal mode, so don't bother with
+	// the dirty block cache.
+	return false
+}
+
+func (mm modeMinimal) BackgroundFlushesEnabled() bool {
+	// Don't do background flushes when in minimal mode, since there
+	// shouldn't be any data writes.
+	return false
+}
+
+func (mm modeMinimal) MetricsEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) ConflictResolutionEnabled() bool {
+	// No need to run CR if there won't be any data writes on this
+	// device.  (There may still be rekey writes, but we don't allow
+	// conflicts to happen in that case.)
+	return false
+}
+
+func (mm modeMinimal) BlockManagementEnabled() bool {
+	// If this device is in minimal mode and won't be doing any data
+	// writes, no need deal with block-level cleanup operations.
+	// TODO: in the future it might still be useful to have
+	// e.g. mobile devices doing QR.
+	return false
+}
+
+func (mm modeMinimal) QuotaReclamationEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) NodeCacheEnabled() bool {
+	// If we're in minimal mode, let the node cache remain nil to
+	// ensure that the user doesn't try any data reads or writes.
+	return false
+}
+
+func (mm modeMinimal) TLFUpdatesEnabled() bool {
+	return true
+}
+
+func (mm modeMinimal) KBFSServiceEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) JournalEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) UnmergedTLFsEnabled() bool {
+	// Writes aren't allowed, so unmerged TLFs on this device
+	// shouldn't be possible.
+	return false
+}
+
+func (mm modeMinimal) ServiceKeepaliveEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) TLFEditHistoryEnabled() bool {
+	return false
+}
+
+func (mm modeMinimal) ClientType() keybase1.ClientType {
+	return keybase1.ClientType_KBFS
+}
+
+// Single op mode:
+
+type modeSingleOp struct {
+	InitMode
+}
+
+func (mso modeSingleOp) Type() InitModeType {
+	return InitSingleOp
+}
+
+func (mso modeSingleOp) RekeyWorkers() int {
+	// Just block all rekeys and don't bother cleaning up requests
+	// since the process is short lived anyway.
+	return 0
+}
+
+func (mso modeSingleOp) QuotaReclamationEnabled() bool {
+	return false
+}
+
+func (mso modeSingleOp) TLFUpdatesEnabled() bool {
+	return false
+}
+
+func (mso modeSingleOp) KBFSServiceEnabled() bool {
+	return false
+}
+
+func (mso modeSingleOp) UnmergedTLFsEnabled() bool {
+	// There's basically no way for a TLF to start off as unmerged
+	// since single-ops should be using a fresh journal.
+	return false
+}
+
+func (mso modeSingleOp) TLFEditHistoryEnabled() bool {
+	return false
+}
+
+func (mso modeSingleOp) ClientType() keybase1.ClientType {
+	return keybase1.ClientType_NONE
+}
+
+// Constrained mode:
+
+type modeConstrained struct {
+	InitMode
+}
+
+func (mc modeConstrained) Type() InitModeType {
+	return InitConstrained
+}
+
+func (mc modeConstrained) BlockWorkers() int {
+	return 1
+}
+
+func (mc modeConstrained) PrefetchWorkers() int {
+	return 0
+}
+
+func (mc modeConstrained) RekeyWorkers() int {
+	return 4
+}
+
+func (mc modeConstrained) BackgroundFlushesEnabled() bool {
+	// TODO: turn this on once we allow mobile writes.
+	return false
+}
+
+func (mc modeConstrained) ConflictResolutionEnabled() bool {
+	// TODO: turn this on once we allow mobile writes.
+	return false
+}
+
+func (mc modeConstrained) QuotaReclamationEnabled() bool {
+	// TODO: turn this on once we allow mobile writes.
+	return false
+}
+
+func (mc modeConstrained) KBFSServiceEnabled() bool {
+	return false
+}
+
+func (mc modeConstrained) JournalEnabled() bool {
+	// TODO: turn this on once we allow mobile writes.
+	return false
+}
+
+func (mc modeConstrained) UnmergedTLFsEnabled() bool {
+	// TODO: turn this on once we allow mobile writes.
+	return false
+}
+
+func (mc modeConstrained) ServiceKeepaliveEnabled() bool {
+	return false
+}
+
+func (mc modeConstrained) TLFEditHistoryEnabled() bool {
+	return false
+}

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -13,15 +13,15 @@ import (
 // NewInitModeFromType returns an InitMode object corresponding to the
 // given type.
 func NewInitModeFromType(t InitModeType) InitMode {
-	switch t.Mode() {
+	switch t {
 	case InitDefault:
-		return modeDefault{t}
+		return modeDefault{}
 	case InitMinimal:
-		return modeMinimal{t}
+		return modeMinimal{}
 	case InitSingleOp:
-		return modeSingleOp{modeDefault{t}}
+		return modeSingleOp{modeDefault{}}
 	case InitConstrained:
-		return modeConstrained{modeDefault{t}}
+		return modeConstrained{modeDefault{}}
 	default:
 		panic(fmt.Sprintf("Unknown mode: %s", t))
 	}
@@ -30,7 +30,6 @@ func NewInitModeFromType(t InitModeType) InitMode {
 // Default mode:
 
 type modeDefault struct {
-	originalMode InitModeType
 }
 
 func (md modeDefault) Type() InitModeType {
@@ -50,7 +49,7 @@ func (md modeDefault) RekeyWorkers() int {
 }
 
 func (md modeDefault) IsTestMode() bool {
-	return md.originalMode.HasFlags(InitTest)
+	return false
 }
 
 func (md modeDefault) DirtyBlockCacheEnabled() bool {
@@ -112,7 +111,6 @@ func (md modeDefault) ClientType() keybase1.ClientType {
 // Minimal mode:
 
 type modeMinimal struct {
-	originalMode InitModeType
 }
 
 func (mm modeMinimal) Type() InitModeType {
@@ -134,7 +132,7 @@ func (mm modeMinimal) RekeyWorkers() int {
 }
 
 func (mm modeMinimal) IsTestMode() bool {
-	return mm.originalMode.HasFlags(InitTest)
+	return false
 }
 
 func (mm modeMinimal) DirtyBlockCacheEnabled() bool {
@@ -307,4 +305,14 @@ func (mc modeConstrained) ServiceKeepaliveEnabled() bool {
 
 func (mc modeConstrained) TLFEditHistoryEnabled() bool {
 	return false
+}
+
+// Wrapper for tests.
+
+type modeTest struct {
+	InitMode
+}
+
+func (mt modeTest) IsTestMode() bool {
+	return true
 }

--- a/libkbfs/rekey_queue.go
+++ b/libkbfs/rekey_queue.go
@@ -66,7 +66,7 @@ func NewRekeyQueueStandard(config Config) (rkq *RekeyQueueStandard) {
 		pendings: make(map[tlf.ID]bool),
 		cancel:   cancel,
 	}
-	if config.Mode() != InitSingleOp {
+	if config.Mode().RekeyWorkers() > 0 {
 		rkq.start(ctx)
 	}
 	return rkq

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -43,8 +43,7 @@ const (
 // MakeTestConfigOrBust or ConfigAsUser.
 //
 // TODO: Move more common code here.
-func newConfigForTest(mode InitMode,
-	loggerFn func(module string) logger.Logger) *ConfigLocal {
+func newConfigForTest(mode InitModeType, loggerFn func(module string) logger.Logger) *ConfigLocal {
 	config := NewConfigLocal(mode|InitTest, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
 
 	bops := NewBlockOpsStandard(config,
@@ -117,7 +116,7 @@ func newTestRPCLogFactory(t testLogger) rpc.LogFactory {
 // being logged in.
 func MakeTestConfigOrBustLoggedInWithMode(
 	t logger.TestLogBackend, loggedInIndex int,
-	mode InitMode, users ...libkb.NormalizedUsername) *ConfigLocal {
+	mode InitModeType, users ...libkb.NormalizedUsername) *ConfigLocal {
 	log := logger.NewTestLogger(t)
 	config := newConfigForTest(mode, func(m string) logger.Logger {
 		return log
@@ -231,7 +230,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 // enabled in the returned Config, regardless of the journal status in
 // `config`.
 func ConfigAsUserWithMode(config *ConfigLocal,
-	loggedInUser libkb.NormalizedUsername, mode InitMode) *ConfigLocal {
+	loggedInUser libkb.NormalizedUsername, mode InitModeType) *ConfigLocal {
 	c := newConfigForTest(mode, config.loggerFn)
 	c.SetMetadataVersion(config.MetadataVersion())
 	c.SetRekeyWithPromptWaitTime(config.RekeyWithPromptWaitTime())
@@ -320,7 +319,7 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 // `config`.
 func ConfigAsUser(config *ConfigLocal,
 	loggedInUser libkb.NormalizedUsername) *ConfigLocal {
-	return ConfigAsUserWithMode(config, loggedInUser, config.Mode())
+	return ConfigAsUserWithMode(config, loggedInUser, config.Mode().Type())
 }
 
 // NewEmptyTLFWriterKeyBundle creates a new empty kbfsmd.TLFWriterKeyBundleV2

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -43,8 +43,9 @@ const (
 // MakeTestConfigOrBust or ConfigAsUser.
 //
 // TODO: Move more common code here.
-func newConfigForTest(mode InitModeType, loggerFn func(module string) logger.Logger) *ConfigLocal {
-	config := NewConfigLocal(mode|InitTest, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
+func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger.Logger) *ConfigLocal {
+	mode := modeTest{NewInitModeFromType(modeType)}
+	config := NewConfigLocal(mode, loggerFn, "", DiskCacheModeOff, &env.KBFSContext{})
 
 	bops := NewBlockOpsStandard(config,
 		testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize)

--- a/libkbfs/tlf_edit_history.go
+++ b/libkbfs/tlf_edit_history.go
@@ -176,11 +176,11 @@ func NewTlfEditHistory(config Config, fbo *folderBranchOps,
 		rmdsChan: make(chan []ImmutableRootMetadata, 100),
 		cancel:   cancel,
 	}
-	if config.Mode() == InitDefault {
+	if config.Mode().TLFEditHistoryEnabled() {
 		go teh.process(processCtx)
 	} else {
-		// No need to process updates in non-default mode. TODO: avoid
-		// rmdsChan memory overhead?
+		// No need to process updates. TODO: avoid rmdsChan memory
+		// overhead?
 	}
 	return teh
 }
@@ -635,7 +635,7 @@ func (teh *TlfEditHistory) process(ctx context.Context) {
 // ImmutableRootMetadata in rmds is the current head.
 func (teh *TlfEditHistory) UpdateHistory(ctx context.Context,
 	rmds []ImmutableRootMetadata) error {
-	if teh.config.Mode() != InitDefault {
+	if !teh.config.Mode().TLFEditHistoryEnabled() {
 		// Non-default mode doesn't have a processor.
 		return nil
 	}

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1667,7 +1667,7 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		rmd := makeRootMetadata(brmd, ibrmd.extra, handle)
 
 		// Assume, since journal is running, that we're in default mode.
-		mode := InitDefault
+		mode := NewInitModeFromType(InitDefault)
 		pmd, err := decryptMDPrivateData(
 			ctx, j.config.Codec(), j.config.Crypto(),
 			j.config.BlockCache(), j.config.BlockOps(),


### PR DESCRIPTION
This cleans up all the scattered mode cruft into an interface, and puts all the behaviors of each mode into a single struct for easier reference and maintenance.

It also adds a new "constrained" mode, with behavior matching what jzila wrote in #1486.

Issue: KBFS-2744