### PR TITLE
don't error on InputCanceledError

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5386,7 +5386,8 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 		stillNeedsRekey = true
 
 	default:
-		if err == context.DeadlineExceeded {
+		_, isInputCanceled := err.(libkb.InputCanceledError)
+		if isInputCanceled || err == context.DeadlineExceeded {
 			fbo.log.CDebugf(ctx, "Paper key prompt timed out")
 			// Reschedule the prompt in the timeout case.
 			stillNeedsRekey = true


### PR DESCRIPTION
Otherwise we'd fall into this case here: https://github.com/keybase/kbfs/blob/2cc8f8832ed876f51044ddefe7edb5e57bef5432/libkbfs/rekey_fsm.go#L386-L395 and schedule another rekey in `rekeyRecheckInterval` which is 30s. With the added error check in this PR, we'd continue with a rekey scheduled in `r.fsm.fbo.config.RekeyWithPromptWaitTime()` which is 10min for now.
