### PR TITLE
redirector: handle mountpoints like  `/Volumes/Keybase (user)`

### DIFF
--- a/redirector/main.go
+++ b/redirector/main.go
@@ -189,7 +189,8 @@ func (r *root) findKBFSMount(ctx context.Context) (
 		if i < 0 {
 			continue
 		}
-		if len(mp) > i+len(str) && mp[i+len(str)] != '/' {
+		if len(mp) > i+len(str) && mp[i+len(str)] != '/' &&
+			mp[i+len(str)] != ' ' {
 			continue
 		}
 

--- a/redirector/main.go
+++ b/redirector/main.go
@@ -189,12 +189,10 @@ func (r *root) findKBFSMount(ctx context.Context) (
 		if i < 0 {
 			continue
 		}
-		if len(mp) > i+len(str) && mp[i+len(str)] != '/' &&
-			mp[i+len(str)] != ' ' {
-			continue
+		if len(mp) == i+len(str) || mp[i+len(str)] == '/' ||
+			mp[i+len(str)] == ' ' {
+			return mp, nil
 		}
-
-		return mp, nil
 	}
 
 	// Give up.


### PR DESCRIPTION
So instead of checking that "Keybase" is necessarily the last thing in the path, maybe sure it's at least followed by a space.

Issue: KBFS-2820