### PR TITLE
journal_server_test: pause work so journal doesn't become empty

### DIFF
--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -718,6 +718,8 @@ func TestJournalServerEnableAuto(t *testing.T) {
 	id := h.ResolvedWriters()[0]
 	tlfID := h.tlfID
 
+	jServer.PauseBackgroundWork(ctx, tlfID)
+
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
 	bID, err := kbfsblock.MakePermanentID(data)


### PR DESCRIPTION
If the journal is empty, then after a restart it gets automatically cleaned up, leading to a test failure.

Issue: KBFS-2794