### PR TITLE
simplefs: return the last writer of a directory entry

### DIFF
--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -182,6 +182,10 @@ func TestList(t *testing.T) {
 
 	listResult, err = sfs.SimpleFSReadList(ctx, opid)
 	require.NoError(t, err)
+	require.Equal(
+		t, "jdoe", listResult.Entries[0].LastWriterUnverified.Username)
+	require.Equal(
+		t, "jdoe", listResult.Entries[1].LastWriterUnverified.Username)
 
 	assert.Len(t, listResult.Entries, 2, "Expected 2 directory entries in listing")
 
@@ -209,6 +213,8 @@ func TestList(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Len(t, listResult.Entries, 1, "Expected 1 directory entries in listing")
+	require.Equal(
+		t, "jdoe", listResult.Entries[0].LastWriterUnverified.Username)
 
 	// Assume we've exhausted the list now, so expect error
 	_, err = sfs.SimpleFSReadList(ctx, opid)

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -2330,9 +2330,8 @@ func (r ResetLink) Summarize() ResetSummary {
 // CheckInvariants checks that the bundle satisfies
 // 1. No duplicate account IDs
 // 2. At most one primary account
-func (s StellarSecretBundle) CheckInvariants() error {
+func (s StellarBundle) CheckInvariants() error {
 	accountIDs := make(map[StellarAccountID]bool)
-	names := make(map[string]bool)
 	var foundPrimary bool
 	for _, entry := range s.Accounts {
 		_, found := accountIDs[entry.AccountID]
@@ -2340,16 +2339,14 @@ func (s StellarSecretBundle) CheckInvariants() error {
 			return fmt.Errorf("duplicate account ID: %v", entry.AccountID)
 		}
 		accountIDs[entry.AccountID] = true
-		_, found = names[entry.Name]
-		if found {
-			return fmt.Errorf("duplicate account name: %v", entry.Name)
-		}
-		names[entry.Name] = true
 		if entry.IsPrimary {
 			if foundPrimary {
 				return errors.New("multiple primary accounts")
 			}
 			foundPrimary = true
+		}
+		if entry.Mode == StellarAccountMode_NONE {
+			return errors.New("account missing mode")
 		}
 	}
 	if s.Revision < 1 {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
@@ -152,18 +152,20 @@ func (e DirentType) String() string {
 }
 
 type Dirent struct {
-	Time       Time       `codec:"time" json:"time"`
-	Size       int        `codec:"size" json:"size"`
-	Name       string     `codec:"name" json:"name"`
-	DirentType DirentType `codec:"direntType" json:"direntType"`
+	Time                 Time       `codec:"time" json:"time"`
+	Size                 int        `codec:"size" json:"size"`
+	Name                 string     `codec:"name" json:"name"`
+	DirentType           DirentType `codec:"direntType" json:"direntType"`
+	LastWriterUnverified User       `codec:"lastWriterUnverified" json:"lastWriterUnverified"`
 }
 
 func (o Dirent) DeepCopy() Dirent {
 	return Dirent{
-		Time:       o.Time.DeepCopy(),
-		Size:       o.Size,
-		Name:       o.Name,
-		DirentType: o.DirentType.DeepCopy(),
+		Time:                 o.Time.DeepCopy(),
+		Size:                 o.Size,
+		Name:                 o.Name,
+		DirentType:           o.DirentType.DeepCopy(),
+		LastWriterUnverified: o.LastWriterUnverified.DeepCopy(),
 	}
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/stellar.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/stellar.go
@@ -26,15 +26,26 @@ func (o StellarRevision) DeepCopy() StellarRevision {
 	return o
 }
 
-type EncryptedStellarSecretBundle struct {
+type Hash []byte
+
+func (o Hash) DeepCopy() Hash {
+	return (func(x []byte) []byte {
+		if x == nil {
+			return nil
+		}
+		return append([]byte{}, x...)
+	})(o)
+}
+
+type EncryptedStellarBundle struct {
 	V   int                  `codec:"v" json:"v"`
 	E   []byte               `codec:"e" json:"e"`
 	N   BoxNonce             `codec:"n" json:"n"`
 	Gen PerUserKeyGeneration `codec:"gen" json:"gen"`
 }
 
-func (o EncryptedStellarSecretBundle) DeepCopy() EncryptedStellarSecretBundle {
-	return EncryptedStellarSecretBundle{
+func (o EncryptedStellarBundle) DeepCopy() EncryptedStellarBundle {
+	return EncryptedStellarBundle{
 		V: o.V,
 		E: (func(x []byte) []byte {
 			if x == nil {
@@ -47,37 +58,37 @@ func (o EncryptedStellarSecretBundle) DeepCopy() EncryptedStellarSecretBundle {
 	}
 }
 
-type StellarSecretBundleVersion int
+type StellarBundleVersion int
 
 const (
-	StellarSecretBundleVersion_V1 StellarSecretBundleVersion = 1
+	StellarBundleVersion_V1 StellarBundleVersion = 1
 )
 
-func (o StellarSecretBundleVersion) DeepCopy() StellarSecretBundleVersion { return o }
+func (o StellarBundleVersion) DeepCopy() StellarBundleVersion { return o }
 
-var StellarSecretBundleVersionMap = map[string]StellarSecretBundleVersion{
+var StellarBundleVersionMap = map[string]StellarBundleVersion{
 	"V1": 1,
 }
 
-var StellarSecretBundleVersionRevMap = map[StellarSecretBundleVersion]string{
+var StellarBundleVersionRevMap = map[StellarBundleVersion]string{
 	1: "V1",
 }
 
-func (e StellarSecretBundleVersion) String() string {
-	if v, ok := StellarSecretBundleVersionRevMap[e]; ok {
+func (e StellarBundleVersion) String() string {
+	if v, ok := StellarBundleVersionRevMap[e]; ok {
 		return v
 	}
 	return ""
 }
 
-type StellarSecretBundleVersioned struct {
-	Version__ StellarSecretBundleVersion `codec:"version" json:"version"`
-	V1__      *StellarSecretBundleV1     `codec:"v1,omitempty" json:"v1,omitempty"`
+type StellarBundleSecretVersioned struct {
+	Version__ StellarBundleVersion   `codec:"version" json:"version"`
+	V1__      *StellarBundleSecretV1 `codec:"v1,omitempty" json:"v1,omitempty"`
 }
 
-func (o *StellarSecretBundleVersioned) Version() (ret StellarSecretBundleVersion, err error) {
+func (o *StellarBundleSecretVersioned) Version() (ret StellarBundleVersion, err error) {
 	switch o.Version__ {
-	case StellarSecretBundleVersion_V1:
+	case StellarBundleVersion_V1:
 		if o.V1__ == nil {
 			err = errors.New("unexpected nil value for V1__")
 			return ret, err
@@ -86,8 +97,8 @@ func (o *StellarSecretBundleVersioned) Version() (ret StellarSecretBundleVersion
 	return o.Version__, nil
 }
 
-func (o StellarSecretBundleVersioned) V1() (res StellarSecretBundleV1) {
-	if o.Version__ != StellarSecretBundleVersion_V1 {
+func (o StellarBundleSecretVersioned) V1() (res StellarBundleSecretV1) {
+	if o.Version__ != StellarBundleVersion_V1 {
 		panic("wrong case accessed")
 	}
 	if o.V1__ == nil {
@@ -96,17 +107,17 @@ func (o StellarSecretBundleVersioned) V1() (res StellarSecretBundleV1) {
 	return *o.V1__
 }
 
-func NewStellarSecretBundleVersionedWithV1(v StellarSecretBundleV1) StellarSecretBundleVersioned {
-	return StellarSecretBundleVersioned{
-		Version__: StellarSecretBundleVersion_V1,
+func NewStellarBundleSecretVersionedWithV1(v StellarBundleSecretV1) StellarBundleSecretVersioned {
+	return StellarBundleSecretVersioned{
+		Version__: StellarBundleVersion_V1,
 		V1__:      &v,
 	}
 }
 
-func (o StellarSecretBundleVersioned) DeepCopy() StellarSecretBundleVersioned {
-	return StellarSecretBundleVersioned{
+func (o StellarBundleSecretVersioned) DeepCopy() StellarBundleSecretVersioned {
+	return StellarBundleSecretVersioned{
 		Version__: o.Version__.DeepCopy(),
-		V1__: (func(x *StellarSecretBundleV1) *StellarSecretBundleV1 {
+		V1__: (func(x *StellarBundleSecretV1) *StellarBundleSecretV1 {
 			if x == nil {
 				return nil
 			}
@@ -116,19 +127,21 @@ func (o StellarSecretBundleVersioned) DeepCopy() StellarSecretBundleVersioned {
 	}
 }
 
-type StellarSecretBundleV1 struct {
-	Revision StellarRevision      `codec:"revision" json:"revision"`
-	Accounts []StellarSecretEntry `codec:"accounts" json:"accounts"`
+type StellarBundleVisibleV1 struct {
+	Revision StellarRevision       `codec:"revision" json:"revision"`
+	Prev     Hash                  `codec:"prev" json:"prev"`
+	Accounts []StellarVisibleEntry `codec:"accounts" json:"accounts"`
 }
 
-func (o StellarSecretBundleV1) DeepCopy() StellarSecretBundleV1 {
-	return StellarSecretBundleV1{
+func (o StellarBundleVisibleV1) DeepCopy() StellarBundleVisibleV1 {
+	return StellarBundleVisibleV1{
 		Revision: o.Revision.DeepCopy(),
-		Accounts: (func(x []StellarSecretEntry) []StellarSecretEntry {
+		Prev:     o.Prev.DeepCopy(),
+		Accounts: (func(x []StellarVisibleEntry) []StellarVisibleEntry {
 			if x == nil {
 				return nil
 			}
-			var ret []StellarSecretEntry
+			var ret []StellarVisibleEntry
 			for _, v := range x {
 				vCopy := v.DeepCopy()
 				ret = append(ret, vCopy)
@@ -138,14 +151,14 @@ func (o StellarSecretBundleV1) DeepCopy() StellarSecretBundleV1 {
 	}
 }
 
-type StellarSecretBundle struct {
-	Revision StellarRevision      `codec:"revision" json:"revision"`
-	Accounts []StellarSecretEntry `codec:"accounts" json:"accounts"`
+type StellarBundleSecretV1 struct {
+	VisibleHash Hash                 `codec:"visibleHash" json:"visibleHash"`
+	Accounts    []StellarSecretEntry `codec:"accounts" json:"accounts"`
 }
 
-func (o StellarSecretBundle) DeepCopy() StellarSecretBundle {
-	return StellarSecretBundle{
-		Revision: o.Revision.DeepCopy(),
+func (o StellarBundleSecretV1) DeepCopy() StellarBundleSecretV1 {
+	return StellarBundleSecretV1{
+		VisibleHash: o.VisibleHash.DeepCopy(),
 		Accounts: (func(x []StellarSecretEntry) []StellarSecretEntry {
 			if x == nil {
 				return nil
@@ -163,17 +176,20 @@ func (o StellarSecretBundle) DeepCopy() StellarSecretBundle {
 type StellarAccountMode int
 
 const (
-	StellarAccountMode_USER StellarAccountMode = 0
+	StellarAccountMode_NONE StellarAccountMode = 0
+	StellarAccountMode_USER StellarAccountMode = 1
 )
 
 func (o StellarAccountMode) DeepCopy() StellarAccountMode { return o }
 
 var StellarAccountModeMap = map[string]StellarAccountMode{
-	"USER": 0,
+	"NONE": 0,
+	"USER": 1,
 }
 
 var StellarAccountModeRevMap = map[StellarAccountMode]string{
-	0: "USER",
+	0: "NONE",
+	1: "USER",
 }
 
 func (e StellarAccountMode) String() string {
@@ -183,18 +199,29 @@ func (e StellarAccountMode) String() string {
 	return ""
 }
 
-type StellarSecretEntry struct {
+type StellarVisibleEntry struct {
 	AccountID StellarAccountID   `codec:"accountID" json:"accountID"`
 	Mode      StellarAccountMode `codec:"mode" json:"mode"`
-	Signers   []StellarSecretKey `codec:"signers" json:"signers"`
 	IsPrimary bool               `codec:"isPrimary" json:"isPrimary"`
+}
+
+func (o StellarVisibleEntry) DeepCopy() StellarVisibleEntry {
+	return StellarVisibleEntry{
+		AccountID: o.AccountID.DeepCopy(),
+		Mode:      o.Mode.DeepCopy(),
+		IsPrimary: o.IsPrimary,
+	}
+}
+
+type StellarSecretEntry struct {
+	AccountID StellarAccountID   `codec:"accountID" json:"accountID"`
+	Signers   []StellarSecretKey `codec:"signers" json:"signers"`
 	Name      string             `codec:"name" json:"name"`
 }
 
 func (o StellarSecretEntry) DeepCopy() StellarSecretEntry {
 	return StellarSecretEntry{
 		AccountID: o.AccountID.DeepCopy(),
-		Mode:      o.Mode.DeepCopy(),
 		Signers: (func(x []StellarSecretKey) []StellarSecretKey {
 			if x == nil {
 				return nil
@@ -206,8 +233,61 @@ func (o StellarSecretEntry) DeepCopy() StellarSecretEntry {
 			}
 			return ret
 		})(o.Signers),
+		Name: o.Name,
+	}
+}
+
+type StellarBundle struct {
+	Revision StellarRevision `codec:"revision" json:"revision"`
+	Prev     Hash            `codec:"prev" json:"prev"`
+	OwnHash  Hash            `codec:"ownHash" json:"ownHash"`
+	Accounts []StellarEntry  `codec:"accounts" json:"accounts"`
+}
+
+func (o StellarBundle) DeepCopy() StellarBundle {
+	return StellarBundle{
+		Revision: o.Revision.DeepCopy(),
+		Prev:     o.Prev.DeepCopy(),
+		OwnHash:  o.OwnHash.DeepCopy(),
+		Accounts: (func(x []StellarEntry) []StellarEntry {
+			if x == nil {
+				return nil
+			}
+			var ret []StellarEntry
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Accounts),
+	}
+}
+
+type StellarEntry struct {
+	AccountID StellarAccountID   `codec:"accountID" json:"accountID"`
+	Mode      StellarAccountMode `codec:"mode" json:"mode"`
+	IsPrimary bool               `codec:"isPrimary" json:"isPrimary"`
+	Signers   []StellarSecretKey `codec:"signers" json:"signers"`
+	Name      string             `codec:"name" json:"name"`
+}
+
+func (o StellarEntry) DeepCopy() StellarEntry {
+	return StellarEntry{
+		AccountID: o.AccountID.DeepCopy(),
+		Mode:      o.Mode.DeepCopy(),
 		IsPrimary: o.IsPrimary,
-		Name:      o.Name,
+		Signers: (func(x []StellarSecretKey) []StellarSecretKey {
+			if x == nil {
+				return nil
+			}
+			var ret []StellarSecretKey
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Signers),
+		Name: o.Name,
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -238,10 +238,10 @@
 			"revisionTime": "2018-01-25T22:56:34Z"
 		},
 		{
-			"checksumSHA1": "g3M/5hv8rI/ewVxVrje0+pD+dHc=",
+			"checksumSHA1": "kbjmOI+orxLwYE48U7L/bHgXJUk=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "4e80ab538e5f95c17397d7499f53248dcab50207",
-			"revisionTime": "2018-03-16T22:43:31Z"
+			"revision": "d71ab674f3df1923745677aad850dafb639ed0e1",
+			"revisionTime": "2018-03-19T18:00:33Z"
 		},
 		{
 			"checksumSHA1": "o26ztx0R+4h9il8gTztHccctK+4=",


### PR DESCRIPTION
Get this info by using the `os.FileInfo.Sys()` generic interface, and introducing a new type of interface that the `Sys()` return value can implement.  That way we don't try to get the last writer when using a local disk file system.

Note: this won't return the last writer for symlink directory entries. I assume that's ok, but if not we can figure out a different way of doing this.

This will break CircleCI until keybase/client#10948 is merged.

Issue: KBFS-2836