### PR TITLE
simplefs: support new debug-dumping RPC

### DIFF
--- a/libkbfs/impatient_debug_dumper.go
+++ b/libkbfs/impatient_debug_dumper.go
@@ -119,7 +119,20 @@ func NewImpatientDebugDumper(config Config, dumpIn time.Duration) *ImpatientDebu
 	return d
 }
 
-func (d *ImpatientDebugDumper) dump(tracker *ctxTimeTracker) {
+// NewImpatientDebugDumperForForcedDumps creates a new
+// *ImpatientDebugDumper, just as above, though without launching any
+// background goroutines or allowing the user to begin any
+// time-tracked tasks
+func NewImpatientDebugDumperForForcedDumps(config Config) *ImpatientDebugDumper {
+	return &ImpatientDebugDumper{
+		config: config,
+		log:    config.MakeLogger("IGD"),
+		limiter: rate.NewLimiter(
+			rate.Every(impatientDebugDumperDumpMinInterval), 1),
+	}
+}
+
+func (d *ImpatientDebugDumper) dump(ctx context.Context) {
 	if !d.limiter.Allow() {
 		// Use a limiter to avoid dumping too much into log accidently.
 		return
@@ -136,10 +149,14 @@ func (d *ImpatientDebugDumper) dump(tracker *ctxTimeTracker) {
 	}
 	gzipper.Close()
 	base64er.Close()
-	d.log.CDebugf(tracker.ctx,
+	d.log.CDebugf(ctx,
 		"Operation exceeded max wait time. dump>gzip>base64: %q "+
 			"Pipe the quoted content into ` | base64 -d | gzip -d ` "+
 			"to read as a Homosapien.", buf.String())
+}
+
+func (d *ImpatientDebugDumper) ForceDump(ctx context.Context) {
+	d.dump(ctx)
 }
 
 func (d *ImpatientDebugDumper) dumpTick() {
@@ -170,7 +187,7 @@ func (d *ImpatientDebugDumper) dumpTick() {
 		if t.isExpired(d.config.Clock()) {
 			// This operation isn't done, and it has expired. So dump debug
 			// information and move on.
-			d.dump(t)
+			d.dump(t.ctx)
 			d.chronologicalTimeTrackerList.popFront()
 			continue
 		}
@@ -197,6 +214,9 @@ func (d *ImpatientDebugDumper) dumpLoop(shutdownCh <-chan struct{}) {
 // be called once the associated operation is done, likely in a defer
 // statement.
 func (d *ImpatientDebugDumper) Begin(ctx context.Context) (done func()) {
+	if d.chronologicalTimeTrackerList == nil {
+		return nil
+	}
 	tracker := &ctxTimeTracker{
 		ctx:       ctx,
 		expiresAt: d.config.Clock().Now().Add(d.dumpIn),
@@ -209,5 +229,7 @@ func (d *ImpatientDebugDumper) Begin(ctx context.Context) (done func()) {
 
 // Shutdown shuts down d idempotently.
 func (d *ImpatientDebugDumper) Shutdown() {
-	d.shutdownFunc()
+	if d.shutdownFunc != nil {
+		d.shutdownFunc()
+	}
 }

--- a/libkbfs/impatient_debug_dumper.go
+++ b/libkbfs/impatient_debug_dumper.go
@@ -155,6 +155,8 @@ func (d *ImpatientDebugDumper) dump(ctx context.Context) {
 			"to read as a Homosapien.", buf.String())
 }
 
+// ForceDump dumps all debug info to the log, if it hasn't done so
+// recently according to the rate-limiter.
 func (d *ImpatientDebugDumper) ForceDump(ctx context.Context) {
 	d.dump(ctx)
 }

--- a/libkbfs/impatient_debug_dumper.go
+++ b/libkbfs/impatient_debug_dumper.go
@@ -122,7 +122,8 @@ func NewImpatientDebugDumper(config Config, dumpIn time.Duration) *ImpatientDebu
 // NewImpatientDebugDumperForForcedDumps creates a new
 // *ImpatientDebugDumper, just as above, though without launching any
 // background goroutines or allowing the user to begin any
-// time-tracked tasks
+// time-tracked tasks.  `ForceDump` is the only way to obtain a dump
+// from a dumper constructed with this function.
 func NewImpatientDebugDumperForForcedDumps(config Config) *ImpatientDebugDumper {
 	return &ImpatientDebugDumper{
 		config: config,

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -80,6 +80,9 @@ type SimpleFS struct {
 	// The function to call for constructing a new KBFS file system.
 	// Overrideable for testing purposes.
 	newFS newFSFunc
+	// For dumping debug info to the logs.
+	idd *libkbfs.ImpatientDebugDumper
+
 	// lock protects handles and inProgress
 	lock sync.RWMutex
 	// handles contains handles opened by SimpleFSOpen,
@@ -121,6 +124,7 @@ func newSimpleFS(config libkbfs.Config) *SimpleFS {
 		inProgress: map[keybase1.OpID]*inprogress{},
 		log:        log,
 		newFS:      defaultNewFS,
+		idd:        libkbfs.NewImpatientDebugDumperForForcedDumps(config),
 	}
 }
 
@@ -1261,4 +1265,12 @@ func (k *SimpleFS) SimpleFSWait(ctx context.Context, opid keybase1.OpID) error {
 		return errNoResult
 	}
 	return err
+}
+
+// SimpleFSDumpDebuggingInfo - Instructs KBFS to dump debugging info
+// into its logs.
+func (k *SimpleFS) SimpleFSDumpDebuggingInfo(ctx context.Context) error {
+	ctx = k.makeContext(ctx)
+	k.idd.ForceDump(ctx)
+	return nil
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -2275,6 +2275,13 @@ func (req *TeamChangeReq) AddUVWithRole(uv UserVersion, role TeamRole) error {
 	return nil
 }
 
+func (req *TeamChangeReq) CompleteInviteID(inviteID TeamInviteID, uv UserVersionPercentForm) {
+	if req.CompletedInvites == nil {
+		req.CompletedInvites = make(map[TeamInviteID]UserVersionPercentForm)
+	}
+	req.CompletedInvites[inviteID] = uv
+}
+
 func (req *TeamChangeReq) GetAllAdds() (ret []UserVersion) {
 	ret = append(ret, req.Readers...)
 	ret = append(ret, req.Writers...)

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
@@ -724,6 +724,9 @@ type SimpleFSWaitArg struct {
 	OpID OpID `codec:"opID" json:"opID"`
 }
 
+type SimpleFSDumpDebuggingInfoArg struct {
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path
 	// Retrieve results with readList()
@@ -773,6 +776,8 @@ type SimpleFSInterface interface {
 	SimpleFSGetOps(context.Context) ([]OpDescription, error)
 	// Blocking wait for the pending operation to finish
 	SimpleFSWait(context.Context, OpID) error
+	// Instructs KBFS to dump debugging info into its logs.
+	SimpleFSDumpDebuggingInfo(context.Context) error
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -1073,6 +1078,17 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"simpleFSDumpDebuggingInfo": {
+				MakeArg: func() interface{} {
+					ret := make([]SimpleFSDumpDebuggingInfoArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.SimpleFSDumpDebuggingInfo(ctx)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -1208,5 +1224,11 @@ func (c SimpleFSClient) SimpleFSGetOps(ctx context.Context) (res []OpDescription
 func (c SimpleFSClient) SimpleFSWait(ctx context.Context, opID OpID) (err error) {
 	__arg := SimpleFSWaitArg{OpID: opID}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSWait", []interface{}{__arg}, nil)
+	return
+}
+
+// Instructs KBFS to dump debugging info into its logs.
+func (c SimpleFSClient) SimpleFSDumpDebuggingInfo(ctx context.Context) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSDumpDebuggingInfo", []interface{}{SimpleFSDumpDebuggingInfoArg{}}, nil)
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -238,10 +238,10 @@
 			"revisionTime": "2018-01-25T22:56:34Z"
 		},
 		{
-			"checksumSHA1": "kbjmOI+orxLwYE48U7L/bHgXJUk=",
+			"checksumSHA1": "/QzszLbNDF8O7mIl3plHX4rWhTQ=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "d71ab674f3df1923745677aad850dafb639ed0e1",
-			"revisionTime": "2018-03-19T18:00:33Z"
+			"revision": "57d96047f8a75cf991b22bd42b901d91c3c07cdf",
+			"revisionTime": "2018-03-19T19:58:19Z"
 		},
 		{
 			"checksumSHA1": "o26ztx0R+4h9il8gTztHccctK+4=",


### PR DESCRIPTION
Uses a new instance of the impatient debug dumper, without any background goroutines, to make this happen.

Issue: KBFS-2746
