### PR TITLE
tlf_handle_resolve: use the team suffix when checking canonicals

### DIFF
--- a/fsrpc/path.go
+++ b/fsrpc/path.go
@@ -5,14 +5,13 @@
 package fsrpc
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
-
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -255,7 +254,7 @@ outer:
 	for {
 		var parseErr error
 		tlfHandle, parseErr = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, name, t)
-		switch parseErr := parseErr.(type) {
+		switch parseErr := errors.Cause(parseErr).(type) {
 		case nil:
 			// No error.
 			break outer

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -130,13 +131,13 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 		h, err := libfs.ParseTlfHandlePreferredQuick(
 			ctx, fl.fs.config.KBPKI(), name, fl.tlfType)
 		fl.fs.log.CDebugf(ctx, "FL Lookup continuing -> %v,%v", h, err)
-		switch err := err.(type) {
+		switch e := errors.Cause(err).(type) {
 		case nil:
 			// no error
 
 		case libkbfs.TlfNameNotCanonical:
 			// Only permit Aliases to targets that contain no errors.
-			aliasTarget = err.NameToTry
+			aliasTarget = e.NameToTry
 			fl.fs.log.CDebugf(ctx, "FL Lookup set alias: %q -> %q", name, aliasTarget)
 			if !fl.isValidAliasTarget(ctx, aliasTarget) {
 				fl.fs.log.CDebugf(ctx, "FL Refusing alias to non-valid target %q", aliasTarget)

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -7,7 +7,6 @@ package libkbfs
 // This file has the type for TlfHandles and offline functionality.
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -18,6 +17,7 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -463,7 +463,7 @@ func splitAndNormalizeTLFName(name string, t tlf.Type) (
 	}
 	// Check for changes - not just ordering differences here.
 	if changes {
-		return nil, nil, "", TlfNameNotCanonical{name, normalizedName}
+		return nil, nil, "", errors.WithStack(TlfNameNotCanonical{name, normalizedName})
 	}
 
 	return writerNames, readerNames, strings.ToLower(extensionSuffix), nil

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/net/context"
 )
 
@@ -49,7 +49,8 @@ func TestParseTlfHandleEarlyFailure(t *testing.T) {
 
 	nonCanonicalName := "W1,w2#r1"
 	_, err = ParseTlfHandle(ctx, nil, nil, nonCanonicalName, tlf.Private)
-	assert.Equal(t, TlfNameNotCanonical{nonCanonicalName, name}, err)
+	assert.Equal(
+		t, TlfNameNotCanonical{nonCanonicalName, name}, errors.Cause(err))
 }
 
 func TestParseTlfHandleNoUserFailure(t *testing.T) {
@@ -184,7 +185,8 @@ func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 	// Names with assertions should be identified before the error
 	// is returned.
 	assert.Equal(t, 3, kbpki.getIdentifyCalls())
-	assert.Equal(t, TlfNameNotCanonical{nonCanonicalName, name}, err)
+	assert.Equal(
+		t, TlfNameNotCanonical{nonCanonicalName, name}, errors.Cause(err))
 }
 
 func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
@@ -646,7 +648,7 @@ func TestParseTlfHandleUIDAssertion(t *testing.T) {
 	_, err := ParseTlfHandle(
 		ctx, kbpki, constIDGetter{tlf.FakeID(1, tlf.Private)}, a, tlf.Private)
 	assert.Equal(t, 1, kbpki.getIdentifyCalls())
-	assert.Equal(t, TlfNameNotCanonical{a, "u1"}, err)
+	assert.Equal(t, TlfNameNotCanonical{a, "u1"}, errors.Cause(err))
 }
 
 func TestParseTlfHandleAndAssertion(t *testing.T) {
@@ -670,7 +672,7 @@ func TestParseTlfHandleAndAssertion(t *testing.T) {
 	// We expect 1 extra identify for compound assertions until
 	// KBFS-2022 is completed.
 	assert.Equal(t, 1+1, kbpki.getIdentifyCalls())
-	assert.Equal(t, TlfNameNotCanonical{a, "u1"}, err)
+	assert.Equal(t, TlfNameNotCanonical{a, "u1"}, errors.Cause(err))
 }
 
 func TestParseTlfHandleConflictSuffix(t *testing.T) {
@@ -1077,7 +1079,8 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	nonCanonicalName := "u1,u2#u3 (files before u2 account reset 2016-03-14 #2) (conflicted copy 2016-03-14 #3)"
 	_, err = ParseTlfHandle(
 		ctx, kbpki, constIDGetter{id}, nonCanonicalName, tlf.Private)
-	assert.Equal(t, TlfNameNotCanonical{nonCanonicalName, name}, err)
+	assert.Equal(
+		t, TlfNameNotCanonical{nonCanonicalName, name}, errors.Cause(err))
 }
 
 func TestParseTlfHandleImplicitTeams(t *testing.T) {

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -160,7 +160,7 @@ func GetHandleFromFolderNameAndType(
 	t tlf.Type) (*TlfHandle, error) {
 	for {
 		tlfHandle, err := ParseTlfHandle(ctx, kbpki, idGetter, tlfName, t)
-		switch e := err.(type) {
+		switch e := errors.Cause(err).(type) {
 		case TlfNameNotCanonical:
 			tlfName = e.NameToTry
 		case nil:

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -205,7 +206,7 @@ func parseTlfHandle(
 outer:
 	for i := 0; i < 2; i++ {
 		h, err = libkbfs.ParseTlfHandle(ctx, kbpki, mdOps, tlfName, t)
-		switch err := err.(type) {
+		switch err := errors.Cause(err).(type) {
 		case nil:
 			break outer
 		case libkbfs.TlfNameNotCanonical:

--- a/tlf/name.go
+++ b/tlf/name.go
@@ -69,12 +69,11 @@ func getSortedNames(
 	return names
 }
 
-// MakeCanonicalName makes a CanonicalName from components.
-func MakeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
+func makeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
 	resolvedReaders []libkb.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
-	extensions []HandleExtension) CanonicalName {
+	extensions []HandleExtension, isBackedByTeam bool) CanonicalName {
 	writerNames := getSortedNames(resolvedWriters, unresolvedWriters)
 	canonicalName := strings.Join(writerNames, ",")
 	if len(resolvedReaders)+len(unresolvedReaders) > 0 {
@@ -85,8 +84,34 @@ func MakeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
 	extensionList := make(HandleExtensionList, len(extensions))
 	copy(extensionList, extensions)
 	sort.Sort(extensionList)
-	canonicalName += extensionList.Suffix()
+	if isBackedByTeam {
+		canonicalName += extensionList.SuffixForTeamHandle()
+	} else {
+		canonicalName += extensionList.Suffix()
+	}
 	return CanonicalName(canonicalName)
+}
+
+// MakeCanonicalName makes a CanonicalName from components.
+func MakeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
+	unresolvedWriters []keybase1.SocialAssertion,
+	resolvedReaders []libkb.NormalizedUsername,
+	unresolvedReaders []keybase1.SocialAssertion,
+	extensions []HandleExtension) CanonicalName {
+	return makeCanonicalName(
+		resolvedWriters, unresolvedWriters, resolvedReaders, unresolvedReaders,
+		extensions, false)
+}
+
+// MakeCanonicalNameForTeam makes a CanonicalName from components for a team.
+func MakeCanonicalNameForTeam(resolvedWriters []libkb.NormalizedUsername,
+	unresolvedWriters []keybase1.SocialAssertion,
+	resolvedReaders []libkb.NormalizedUsername,
+	unresolvedReaders []keybase1.SocialAssertion,
+	extensions []HandleExtension) CanonicalName {
+	return makeCanonicalName(
+		resolvedWriters, unresolvedWriters, resolvedReaders, unresolvedReaders,
+		extensions, true)
 }
 
 // PreferredName is a preferred TLF name.


### PR DESCRIPTION
When someone passes a TLF name like "a,b,c (conflicted copy 2018-03-22 #1)" to FUSE, we need to figure out if it's canonical, but it's hard, because the "#1" is needed for implicit teams, but during the initial parsing we don't know yet whether the folder is team-backed or not without making expensive service calls.

So this PR does makes the right suffix when it knows for sure about the team-backed-status of the TLF; otherwise, if the user passed in a "#1", it assumes the user (likely a KBFS server test) already knows that it should be an implicit team TLF.

Also it wrap the TLFNameNotCanonical error with a stack, because this was really hard to debug without that.

Issue: KBFS-2652
