### PR TITLE
keybase_service_base: call new service RPC to get ALL revoked keys

### DIFF
--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -28,7 +28,7 @@ func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libk
 
 	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Unix.Time(), k), true
+			deviceName, revokedTime.Time(), k), true
 	}
 
 	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
@@ -43,7 +43,7 @@ func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.
 
 	if revokedTime, ok := ui.RevokedVerifyingKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Unix.Time(), k), true
+			deviceName, revokedTime.Time(), k), true
 	}
 
 	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -40,8 +40,8 @@ type UserInfo struct {
 	EldestSeqno     keybase1.Seqno
 
 	// Revoked keys, and the time at which they were revoked.
-	RevokedVerifyingKeys   map[kbfscrypto.VerifyingKey]keybase1.KeybaseTime
-	RevokedCryptPublicKeys map[kbfscrypto.CryptPublicKey]keybase1.KeybaseTime
+	RevokedVerifyingKeys   map[kbfscrypto.VerifyingKey]keybase1.Time
+	RevokedCryptPublicKeys map[kbfscrypto.CryptPublicKey]keybase1.Time
 }
 
 // TeamInfo contains all the info about a keybase team that kbfs cares
@@ -579,33 +579,6 @@ const (
 	// WriteMode indicates that an error happened while trying to write.
 	WriteMode
 )
-
-// UserInfoFromProtocol returns UserInfo from UserPlusKeys
-func UserInfoFromProtocol(upk keybase1.UserPlusKeys) (UserInfo, error) {
-	verifyingKeys, cryptPublicKeys, kidNames, err := filterKeys(upk.DeviceKeys)
-	if err != nil {
-		return UserInfo{}, err
-	}
-
-	revokedVerifyingKeys, revokedCryptPublicKeys, revokedKidNames, err := filterRevokedKeys(upk.RevokedDeviceKeys)
-	if err != nil {
-		return UserInfo{}, err
-	}
-
-	for k, v := range revokedKidNames {
-		kidNames[k] = v
-	}
-
-	return UserInfo{
-		Name:                   libkb.NewNormalizedUsername(upk.Username),
-		UID:                    upk.Uid,
-		VerifyingKeys:          verifyingKeys,
-		CryptPublicKeys:        cryptPublicKeys,
-		KIDNames:               kidNames,
-		RevokedVerifyingKeys:   revokedVerifyingKeys,
-		RevokedCryptPublicKeys: revokedCryptPublicKeys,
-	}, nil
-}
 
 // SessionInfoFromProtocol returns SessionInfo from Session
 func SessionInfoFromProtocol(session keybase1.Session) (SessionInfo, error) {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -152,7 +152,7 @@ func (k *KBPKIClient) hasVerifyingKey(ctx context.Context, uid keybase1.UID,
 	// keep accepting writes from the revoked device for a short
 	// period of time until it learns about the revoke.
 	const revokeSlack = 1 * time.Minute
-	revokedTime := keybase1.FromTime(t.Unix)
+	revokedTime := keybase1.FromTime(t)
 	// Trust the server times -- if the key was valid at the given
 	// time, we are good to go.  TODO: use Merkle data to check
 	// the server timestamps, to prove the server isn't lying.

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -51,8 +51,8 @@ func makeTestKBPKIClientWithRevokedKey(t *testing.T, revokeTime time.Time) (
 		index := 99
 		keySalt := keySaltForUserDevice(user.Name, index)
 		newVerifyingKey := MakeLocalUserVerifyingKeyOrBust(keySalt)
-		user.RevokedVerifyingKeys = map[kbfscrypto.VerifyingKey]keybase1.KeybaseTime{
-			newVerifyingKey: {Unix: keybase1.ToTime(revokeTime), Chain: 100},
+		user.RevokedVerifyingKeys = map[kbfscrypto.VerifyingKey]keybase1.Time{
+			newVerifyingKey: keybase1.ToTime(revokeTime),
 		}
 		users[i] = user
 	}

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -665,17 +665,14 @@ func (k *KeybaseDaemonLocal) revokeDeviceForTesting(clock Clock,
 
 	if user.RevokedVerifyingKeys == nil {
 		user.RevokedVerifyingKeys =
-			make(map[kbfscrypto.VerifyingKey]keybase1.KeybaseTime)
+			make(map[kbfscrypto.VerifyingKey]keybase1.Time)
 	}
 	if user.RevokedCryptPublicKeys == nil {
 		user.RevokedCryptPublicKeys =
-			make(map[kbfscrypto.CryptPublicKey]keybase1.KeybaseTime)
+			make(map[kbfscrypto.CryptPublicKey]keybase1.Time)
 	}
 
-	kbtime := keybase1.KeybaseTime{
-		Unix:  keybase1.ToTime(clock.Now()),
-		Chain: 100,
-	}
+	kbtime := keybase1.ToTime(clock.Now())
 	user.RevokedVerifyingKeys[user.VerifyingKeys[index]] = kbtime
 	user.RevokedCryptPublicKeys[user.CryptPublicKeys[index]] = kbtime
 

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -103,18 +103,21 @@ func (c *fakeKeybaseClient) Call(ctx context.Context, s string, args interface{}
 		c.identifyCalled = true
 		return nil
 
-	case "keybase.1.user.loadUserPlusKeys":
-		arg := args.([]interface{})[0].(keybase1.LoadUserPlusKeysArg)
+	case "keybase.1.user.loadUserPlusKeysV2":
+		arg := args.([]interface{})[0].(keybase1.LoadUserPlusKeysV2Arg)
 
 		userInfo, ok := c.users[arg.Uid]
 		if !ok {
 			return fmt.Errorf("Could not find user info for UID %s", arg.Uid)
 		}
 
-		*res.(*keybase1.UserPlusKeys) = keybase1.UserPlusKeys{
-			Uid:      arg.Uid,
-			Username: string(userInfo.Name),
-		}
+		*res.(*keybase1.UserPlusKeysV2AllIncarnations) =
+			keybase1.UserPlusKeysV2AllIncarnations{
+				Current: keybase1.UserPlusKeysV2{
+					Uid:      arg.Uid,
+					Username: string(userInfo.Name),
+				},
+			}
 
 		c.loadUserPlusKeysCalled = true
 		return nil


### PR DESCRIPTION
We previously had no way of getting all the pre-reset keys of a user, which led to situations where team folders are unreadable when they are last written by a user who then reset their account.

The service started exposing a V2 RPC that gives us all past incarnations of the user, so we can check all their keys, using the "reset" time as the revocation time.

Issue: KBFS-2842