### PR TITLE
libkbfs: handle TeamAbandoned notifications

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6416,6 +6416,15 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	fbo.observers.tlfHandleChange(ctx, newHandle)
 }
 
+// TeamAbandoned implements the KBFSOps interface for folderBranchOps.
+func (fbo *folderBranchOps) TeamAbandoned(
+	ctx context.Context, tid keybase1.TeamID) {
+	ctx, cancelFunc := fbo.newCtxWithFBOID()
+	defer cancelFunc()
+	fbo.log.CDebugf(ctx, "Abandoning team %s", tid)
+	fbo.locallyFinalizeTLF(ctx)
+}
+
 // GetUpdateHistory implements the KBFSOps interface for folderBranchOps
 func (fbo *folderBranchOps) GetUpdateHistory(ctx context.Context,
 	folderBranch FolderBranch) (history TLFUpdateHistory, err error) {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -415,6 +415,9 @@ type KBFSOps interface {
 	// we should clean up any outstanding handle info associated with
 	// the team ID.
 	TeamNameChanged(ctx context.Context, tid keybase1.TeamID)
+	// TeamAbandoned indicates that a team has been abandoned, and
+	// shouldn't be referred to by its previous name anymore.
+	TeamAbandoned(ctx context.Context, tid keybase1.TeamID)
 	// KickoffAllOutstandingRekeys kicks off all outstanding rekeys. It does
 	// nothing to folders that have not scheduled a rekey. This should be
 	// called when we receive an event of "paper key cached" from service.

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -413,16 +413,6 @@ func (k *KeybaseDaemonRPC) Shutdown() {
 
 }
 
-// TeamExit (does not) implement keybase1.NotifyTeamInterface.
-func (k *KeybaseDaemonRPC) TeamExit(context.Context, keybase1.TeamID) error {
-	return nil
-}
-
-// TeamAbandoned is a placeholder for the abandoned team notification from the service.
-func (k *KeybaseDaemonRPC) TeamAbandoned(context.Context, keybase1.TeamID) error {
-	return nil
-}
-
 // notifyServiceHandler implements keybase1.NotifyServiceInterface
 type notifyServiceHandler struct {
 	config Config

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -1082,6 +1082,20 @@ func (k *KeybaseServiceBase) TeamDeleted(ctx context.Context,
 	return nil
 }
 
+// TeamExit implements keybase1.NotifyTeamInterface for KeybaseServiceBase.
+func (k *KeybaseDaemonRPC) TeamExit(context.Context, keybase1.TeamID) error {
+	return nil
+}
+
+// TeamAbandoned implements keybase1.NotifyTeamInterface for KeybaseServiceBase.
+func (k *KeybaseDaemonRPC) TeamAbandoned(
+	ctx context.Context, tid keybase1.TeamID) error {
+	k.log.CDebugf(ctx, "Implicit team %s abandoned", tid)
+	k.setCachedTeamInfo(tid, TeamInfo{})
+	k.config.KBFSOps().TeamAbandoned(ctx, tid)
+	return nil
+}
+
 // StartMigration implements keybase1.ImplicitTeamMigrationInterface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) StartMigration(ctx context.Context,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1344,6 +1344,16 @@ func (mr *MockKBFSOpsMockRecorder) TeamNameChanged(ctx, tid interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamNameChanged", reflect.TypeOf((*MockKBFSOps)(nil).TeamNameChanged), ctx, tid)
 }
 
+// TeamAbandoned mocks base method
+func (m *MockKBFSOps) TeamAbandoned(ctx context.Context, tid keybase1.TeamID) {
+	m.ctrl.Call(m, "TeamAbandoned", ctx, tid)
+}
+
+// TeamAbandoned indicates an expected call of TeamAbandoned
+func (mr *MockKBFSOpsMockRecorder) TeamAbandoned(ctx, tid interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamAbandoned", reflect.TypeOf((*MockKBFSOps)(nil).TeamAbandoned), ctx, tid)
+}
+
 // KickoffAllOutstandingRekeys mocks base method
 func (m *MockKBFSOps) KickoffAllOutstandingRekeys() error {
 	ret := m.ctrl.Call(m, "KickoffAllOutstandingRekeys")


### PR DESCRIPTION
When a user resets, their implicit teams will be abandoned, and we have to update all our caches.

I wasn't able to test this yet because the staging server isn't up-to-date enough, but it's simple enough.  I'll test it manually before we turn on implicit team TLFs.

Issue: KBFS-2601
