### PR TITLE
Be consistent with official docs in systemd service file

### DIFF
--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -9,7 +9,7 @@ Type=notify
 # means that error codes from this command are ignored. Without this line,
 # `systemctl --user restart kbfs.service` will hit mount failures if there
 # are any running shells cd'd into a Keybase folder.
-ExecStartPre=-/bin/sh -c 'fusermount -uz "$(keybase config get mountdir|sed s/\x5c"//g)"'
+ExecStartPre=-/bin/sh -c 'fusermount -uz "$(keybase config get mountpoint|sed s/\x5c"//g)"'
 ExecStart=/usr/bin/kbfsfuse -debug -log-to-file
 Restart=on-failure
 


### PR DESCRIPTION
Service file `kbfs.service` uses the keyword `mountdir` to get configured mount point from user configuration and mount keybase FS. However, the official documentation say that users should set the entry for keyword `mountpoint` instead. Thus users are left with bad configuration until they manually dig this up and fix it themselves.