### PR TITLE
libfuse: assign constant inodes to each node

### DIFF
--- a/libfuse/alias.go
+++ b/libfuse/alias.go
@@ -18,6 +18,7 @@ type Alias struct {
 	// The real path this alias points to. In case of TLF alias, this is the
 	// canonical name for the folder.
 	realPath string
+	inode    uint64
 }
 
 var _ fs.Node = (*Alias)(nil)
@@ -25,6 +26,7 @@ var _ fs.Node = (*Alias)(nil)
 // Attr implements the fs.Node interface for Alias.
 func (*Alias) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Mode = os.ModeSymlink | 0777
+	// Aliases can't be moved, so let bazil generate an inode.
 	return nil
 }
 

--- a/libfuse/file.go
+++ b/libfuse/file.go
@@ -57,6 +57,7 @@ func (c *eiCacheHolder) set(reqID string, ei libkbfs.EntryInfo) {
 type File struct {
 	folder *Folder
 	node   libkbfs.Node
+	inode  uint64
 
 	eiCache eiCacheHolder
 }
@@ -73,6 +74,8 @@ func (f *File) fillAttrWithMode(
 	if ei.Type == libkbfs.Exec {
 		a.Mode |= 0100
 	}
+
+	a.Inode = f.inode
 	return nil
 }
 

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -28,6 +28,7 @@ type FolderList struct {
 	fs *FS
 	// only accept public folders
 	tlfType tlf.Type
+	inode   uint64
 
 	mu      sync.Mutex
 	folders map[string]*TLF
@@ -60,9 +61,10 @@ func (*FolderList) Access(ctx context.Context, r *fuse.AccessRequest) error {
 var _ fs.Node = (*FolderList)(nil)
 
 // Attr implements the fs.Node interface.
-func (*FolderList) Attr(ctx context.Context, a *fuse.Attr) error {
+func (fl *FolderList) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Mode = os.ModeDir | 0500
 	a.Uid = uint32(os.Getuid())
+	a.Inode = fl.inode
 	return nil
 }
 
@@ -199,6 +201,7 @@ func (fl *FolderList) Lookup(ctx context.Context, req *fuse.LookupRequest, resp 
 		// Non-canonical name.
 		n := &Alias{
 			realPath: e.NameToTry,
+			inode:    0,
 		}
 		return n, nil
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -146,11 +146,11 @@ func NewFS(config libkbfs.Config, conn *fuse.Conn, debug bool, platformParams Pl
 	return fs
 }
 
-func (fs *FS) assignInode() uint64 {
-	fs.inodeLock.Lock()
-	defer fs.inodeLock.Unlock()
-	next := fs.nextInode
-	fs.nextInode++
+func (f *FS) assignInode() uint64 {
+	f.inodeLock.Lock()
+	defer f.inodeLock.Unlock()
+	next := f.nextInode
+	f.nextInode++
 	return next
 }
 

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -57,6 +57,9 @@ type FS struct {
 	platformParams PlatformParams
 
 	quotaUsage *libkbfs.EventuallyConsistentQuotaUsage
+
+	inodeLock sync.Mutex
+	nextInode uint64
 }
 
 func makeTraceHandler(renderFn func(http.ResponseWriter, *http.Request, bool)) func(http.ResponseWriter, *http.Request) {
@@ -117,26 +120,38 @@ func NewFS(config libkbfs.Config, conn *fuse.Conn, debug bool, platformParams Pl
 		notifications:  libfs.NewFSNotifications(log),
 		platformParams: platformParams,
 		quotaUsage:     libkbfs.NewEventuallyConsistentQuotaUsage(config, "FS"),
+		nextInode:      2, // root is 1
 	}
 	fs.root.private = &FolderList{
 		fs:      fs,
 		tlfType: tlf.Private,
 		folders: make(map[string]*TLF),
+		inode:   fs.assignInode(),
 	}
 	fs.root.public = &FolderList{
 		fs:      fs,
 		tlfType: tlf.Public,
 		folders: make(map[string]*TLF),
+		inode:   fs.assignInode(),
 	}
 	fs.root.team = &FolderList{
 		fs:      fs,
 		tlfType: tlf.SingleTeam,
 		folders: make(map[string]*TLF),
+		inode:   fs.assignInode(),
 	}
 	fs.execAfterDelay = func(d time.Duration, f func()) {
 		time.AfterFunc(d, f)
 	}
 	return fs
+}
+
+func (fs *FS) assignInode() uint64 {
+	fs.inodeLock.Lock()
+	defer fs.inodeLock.Unlock()
+	next := fs.nextInode
+	fs.nextInode++
+	return next
 }
 
 // tcpKeepAliveListener is copied from net/http/server.go, since it is
@@ -427,6 +442,7 @@ var _ fs.Node = (*Root)(nil)
 // Attr implements the fs.Node interface for Root.
 func (*Root) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Mode = os.ModeDir | 0500
+	a.Inode = 1
 	return nil
 }
 

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -3932,7 +3932,7 @@ func TestInodes(t *testing.T) {
 
 	inode2 := getInode(p2)
 	if inode != inode2 {
-		t.Fatal("Inode changed after rename: %d vs %d", inode, inode2)
+		t.Fatalf("Inode changed after rename: %d vs %d", inode, inode2)
 	}
 
 	t.Log("A new file with the previous name should get a new inode")

--- a/libfuse/symlink.go
+++ b/libfuse/symlink.go
@@ -24,6 +24,7 @@ type Symlink struct {
 	// single Symlink value.
 	parent *Dir
 	name   string
+	inode  uint64
 }
 
 var _ fs.Node = (*Symlink)(nil)
@@ -43,6 +44,7 @@ func (s *Symlink) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 
 	s.parent.folder.fillAttrWithUIDAndWritePerm(ctx, s.parent.node, &de, a)
 	a.Mode = os.ModeSymlink | a.Mode | 0500
+	a.Inode = s.inode
 	return nil
 }
 


### PR DESCRIPTION
Otherwise, bazil.org/fuse assigns inodes based on hash(parentInode, name), and if a file gets moved it can end up having the same inode as a new node that took its old name.

This instead has the *FS object keep a monotonically-increasing uint64 and assigns a new inode to every new node, excepting those special files and aliases that can't actually be renamed and cause problems.

Issue: KBFS-2853