### PR TITLE
cr: fix crash when modified file was removed on the merged branch

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -867,6 +867,11 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 			if err != nil {
 				return path{}, BlockPointer{}, nil, err
 			}
+
+			// Delete any sync/setattr ops on the removed, merged file.
+			if mergedChain, ok := mergedChains.byOriginal[currOriginal]; ok {
+				mergedChains.removeChain(mergedChain.mostRecent)
+			}
 		}
 
 		// If this happens to have been renamed on the unmerged

--- a/test/cr_basic_conflicts_test.go
+++ b/test/cr_basic_conflicts_test.go
@@ -231,6 +231,35 @@ func TestCrConflictCreateFile(t *testing.T) {
 	)
 }
 
+// alice writes and removes a file, while bob writes it. Regression
+// test for KBFS-2507.
+func TestCrConflictWriteVsModifiedRemovedFile(t *testing.T) {
+	test(t,
+		skip("dokan", "SetEx is a no-op on Dokan, thus no conflict"),
+		users("alice", "bob"),
+		as(alice,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			write("a", "goodbye"),
+			rm("a"),
+		),
+		as(bob, noSync(),
+			write("a", "hello world"),
+			reenableUpdates(),
+			lsdir("", m{"a$": "FILE"}),
+			read("a", "hello world"),
+		),
+		as(alice,
+			lsdir("", m{"a$": "FILE"}),
+			read("a", "hello world"),
+		),
+	)
+}
+
 // alice setattr's a file, while bob removes, recreates and writes to
 // a file of the same name. Regression test for KBFS-668.
 func TestCrConflictSetattrVsRecreatedFileInRoot(t *testing.T) {


### PR DESCRIPTION
If a file was modified then removed in the merged branch, those syncOps shouldn't be counted as conflicts against modifications of the same file in the unmerged branch.  Doing so leads to a crash, because the final path won't be set in the merged syncOp.

Without the fix, the new test fails in exactly the same way as the client in keybase/client#11318.

Issue: keybase/client#11318