### PR TITLE
Pages: add a cleartext cache for password and a rate limiter for bcrypt

### DIFF
--- a/libpages/config/config.go
+++ b/libpages/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 )
@@ -63,7 +64,7 @@ func parseVersion(s string) (Version, error) {
 // parameters.
 type Config interface {
 	Version() Version
-	Authenticate(username, password string) bool
+	Authenticate(ctx context.Context, username, password string) bool
 	// GetPermissions returns permission info. If username is nil, anonymous
 	// permissions are returned. Otherwise, permissions for *username is
 	// returned. Additionally, "maximum possible permissions" are returned,

--- a/libpages/config/config_v1_test.go
+++ b/libpages/config/config_v1_test.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -135,7 +136,9 @@ func TestConfigV1Full(t *testing.T) {
 		},
 	}
 
-	authenticated := config.Authenticate("alice", "12345")
+	ctx := context.Background()
+
+	authenticated := config.Authenticate(ctx, "alice", "12345")
 	require.True(t, authenticated)
 
 	read, list, possibleRead, possibleList,

--- a/libpages/server.go
+++ b/libpages/server.go
@@ -458,7 +458,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var username *string
 	user, pass, ok := r.BasicAuth()
-	if ok && cfg.Authenticate(user, pass) {
+	if ok && cfg.Authenticate(r.Context(), user, pass) {
 		sri.Authenticated = true
 		username = &user
 	}


### PR DESCRIPTION
As suggested by @maxtaco a month ago, this adds a cleartext cache for passwords for the HTTP Basic Auth. Also added a per-site rate limiter for bcrypt.