### PR TITLE
redirector: fix volume and favorite names in macOS

### DIFF
--- a/libfuse/mounter.go
+++ b/libfuse/mounter.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"strings"
 
 	"bazil.org/fuse"
 	"github.com/keybase/client/go/libkb"
@@ -97,12 +98,16 @@ func (m *mounter) Unmount() (err error) {
 	return
 }
 
-// volumeName returns the directory (base) name
+// volumeName returns the first word of the directory (base) name
 func volumeName(dir string) (string, error) {
 	volName := path.Base(dir)
 	if volName == "." || volName == "/" {
 		err := fmt.Errorf("Bad volume name: %v", volName)
 		return "", err
 	}
-	return volName, nil
+	s := strings.Split(volName, " ")
+	if len(s) == 0 {
+		return "", fmt.Errorf("Bad volume name: %v", volName)
+	}
+	return s[0], nil
 }

--- a/redirector/main.go
+++ b/redirector/main.go
@@ -296,7 +296,7 @@ func main() {
 	options = append(options, fuse.ReadOnly())
 	if runtime.GOOS == "darwin" {
 		options = append(options, fuse.OSXFUSELocations(kbfusePath))
-		options = append(options, fuse.VolumeName("keybase-redirector"))
+		options = append(options, fuse.VolumeName("keybase"))
 		options = append(options, fuse.NoBrowse())
 		// Without NoLocalCaches(), OSX will cache symlinks for a long time.
 		options = append(options, fuse.NoLocalCaches())


### PR DESCRIPTION
This shows up when browsing the root disk of the local computer in Finder, and it's confusing if it says "keybase-redirector". "keybase-redirector" will still show up in `mount` though.

Also, the favorite was showing up as "Keybase (strib)" instead of just "Keybase".  This fixes that as well.

cc: @mlsteele 

Issue: KBFS-2866