### PR TITLE
libkbfs: implement migrating TLFs to implicit team TLFs

### DIFF
--- a/kbfsmd/root_metadata.go
+++ b/kbfsmd/root_metadata.go
@@ -229,6 +229,10 @@ type MutableRootMetadata interface {
 	SetFinalizedInfo(fi *tlf.HandleExtension)
 	// SetWriters sets the list of writers associated with this folder.
 	SetWriters(writers []keybase1.UserOrTeamID)
+	// ClearForV4Migration clears out data not needed for an upgrade
+	// to an implicit-team-backed TLF.  Note that `SetWriters` should
+	// also be called separately to set the new team ID as a writer.
+	ClearForV4Migration()
 	// SetTlfID sets the ID of the underlying folder in the metadata structure.
 	SetTlfID(tlf tlf.ID)
 

--- a/kbfsmd/root_metadata_v2.go
+++ b/kbfsmd/root_metadata_v2.go
@@ -413,7 +413,7 @@ func (md *RootMetadataV2) makeSuccessorCopyV3(
 	// Have this as ExtraMetadata so we return an untyped nil
 	// instead of a typed nil.
 	var extraCopy ExtraMetadata
-	if md.LatestKeyGeneration() != PublicKeyGen {
+	if md.LatestKeyGeneration() != PublicKeyGen && md.WKeys != nil {
 		// Fill out the writer key bundle.
 		wkbV2, wkbV3, err := md.WKeys.ToTLFWriterKeyBundleV3(
 			codec, tlfCryptKeyGetter)
@@ -1110,6 +1110,15 @@ func (md *RootMetadataV2) SetFinalizedInfo(fi *tlf.HandleExtension) {
 // SetWriters implements the MutableRootMetadata interface for RootMetadataV2.
 func (md *RootMetadataV2) SetWriters(writers []keybase1.UserOrTeamID) {
 	md.Writers = writers
+}
+
+// ClearForV4Migration implements the MutableRootMetadata interface
+// for RootMetadataV2.
+func (md *RootMetadataV2) ClearForV4Migration() {
+	md.WKeys = nil
+	md.RKeys = nil
+	md.Extra.UnresolvedWriters = nil
+	md.UnresolvedReaders = nil
 }
 
 // SetTlfID implements the MutableRootMetadata interface for RootMetadataV2.

--- a/kbfsmd/root_metadata_v3.go
+++ b/kbfsmd/root_metadata_v3.go
@@ -1426,6 +1426,13 @@ func (md *RootMetadataV3) SetWriters(writers []keybase1.UserOrTeamID) {
 	md.WriterMetadata.Writers = writers
 }
 
+// ClearForV4Migration implements the MutableRootMetadata interface
+// for RootMetadataV3.
+func (md *RootMetadataV3) ClearForV4Migration() {
+	md.WriterMetadata.WKeyBundleID = TLFWriterKeyBundleID{}
+	md.RKeyBundleID = TLFReaderKeyBundleID{}
+}
+
 // SetTlfID implements the MutableRootMetadata interface for RootMetadataV3.
 func (md *RootMetadataV3) SetTlfID(tlf tlf.ID) {
 	md.WriterMetadata.ID = tlf

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -892,7 +892,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	resolvesTo, partialResolvedOldHandle, err :=
 		oldHandle.ResolvesTo(
 			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
-			constIDGetter{fbo.id()}, *newHandle)
+			constIDGetter{fbo.id()}, fbo.config.KBPKI(), *newHandle)
 	if err != nil {
 		fbo.log.CDebugf(ctx, "oldHandle=%+v, newHandle=%+v: err=%+v", oldHandle, newHandle, err)
 		return err
@@ -6467,9 +6467,10 @@ func (fbo *folderBranchOps) MigrateToImplicitTeam(
 		return nil
 	}
 
+	name := string(md.GetTlfHandle().GetCanonicalName())
+	fbo.log.CDebugf(ctx, "Looking up implicit team for %s", name)
 	newHandle, err := ParseTlfHandle(
-		ctx, fbo.config.KBPKI(), fbo.config.MDOps(),
-		string(md.GetTlfHandle().GetCanonicalName()), id.Type())
+		ctx, fbo.config.KBPKI(), fbo.config.MDOps(), name, id.Type())
 	if err != nil {
 		return err
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -903,8 +903,8 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 
 	if !resolvesTo {
 		fbo.log.CDebugf(ctx, "Incompatible handle error, "+
-			"oldHandle: %#v, partialResolvedOldHandle: %#v",
-			oldHandle, partialResolvedOldHandle)
+			"oldHandle: %#v, partialResolvedOldHandle: %#v, newHandle: %#v",
+			oldHandle, partialResolvedOldHandle, newHandle)
 		return IncompatibleHandleError{
 			oldName,
 			partialResolvedOldHandle.GetCanonicalName(),
@@ -6492,6 +6492,10 @@ func (fbo *folderBranchOps) MigrateToImplicitTeam(
 		md.mdID, isWriter)
 	if err != nil {
 		return err
+	}
+
+	if newMD.TypeForKeying() != tlf.TeamKeying {
+		return errors.New("Migration failed")
 	}
 
 	// Add an empty operation to satisfy assumptions elsewhere.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -418,6 +418,10 @@ type KBFSOps interface {
 	// TeamAbandoned indicates that a team has been abandoned, and
 	// shouldn't be referred to by its previous name anymore.
 	TeamAbandoned(ctx context.Context, tid keybase1.TeamID)
+	// MigrateToImplicitTeam migrates the given folder from a private-
+	// or public-keyed folder, to a team-keyed folder.  If it's
+	// already a private/public team-keyed folder, nil is returned.
+	MigrateToImplicitTeam(ctx context.Context, id tlf.ID) error
 	// KickoffAllOutstandingRekeys kicks off all outstanding rekeys. It does
 	// nothing to folders that have not scheduled a rekey. This should be
 	// called when we receive an event of "paper key cached" from service.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -640,6 +640,10 @@ type teamMembershipChecker interface {
 	// kbfsmd.TeamMembershipChecker.IsTeamWriter.
 	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
 		bool, error)
+	// ListResolvedTeamMembers returns the lists of resolved writers
+	// and readers.
+	ListResolvedTeamMembers(ctx context.Context, tid keybase1.TeamID) (
+		writers, readers []keybase1.UID, err error)
 }
 
 type teamKeysGetter interface {

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1014,6 +1014,18 @@ func (fs *KBFSOpsStandard) TeamAbandoned(
 	}
 }
 
+// MigrateToImplicitTeam implements the KBFSOps interface for KBFSOpsStandard.
+func (fs *KBFSOpsStandard) MigrateToImplicitTeam(
+	ctx context.Context, id tlf.ID) error {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	// We currently only migrate on the master branch of a TLF.
+	ops := fs.getOps(ctx,
+		FolderBranch{Tlf: id, Branch: MasterBranch}, FavoritesOpNoChange)
+	return ops.MigrateToImplicitTeam(ctx, id)
+}
+
 // KickoffAllOutstandingRekeys implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) KickoffAllOutstandingRekeys() error {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -340,6 +340,26 @@ func (k *KBPKIClient) IsTeamReader(
 	return tid.IsPublic() || teamInfo.Writers[uid] || teamInfo.Readers[uid], nil
 }
 
+// ListResolvedTeamMembers implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) ListResolvedTeamMembers(
+	ctx context.Context, tid keybase1.TeamID) (
+	writers, readers []keybase1.UID, err error) {
+	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
+		ctx, tid, kbfsmd.UnspecifiedKeyGen, keybase1.UserVersion{},
+		keybase1.TeamRole_NONE)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for w := range teamInfo.Writers {
+		writers = append(writers, w)
+	}
+	for r := range teamInfo.Readers {
+		readers = append(readers, r)
+	}
+	return writers, readers, nil
+}
+
 // GetTeamRootID implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
 	keybase1.TeamID, error) {

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -272,6 +272,7 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 		keybase1.NotifyTeamProtocol(k),
 		keybase1.TlfKeysProtocol(k),
 		keybase1.ReachabilityProtocol(k),
+		keybase1.ImplicitTeamMigrationProtocol(k),
 	}
 
 	// Add simplefs if set

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -1122,7 +1122,13 @@ func (k *KeybaseServiceBase) StartMigration(ctx context.Context,
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) FinalizeMigration(ctx context.Context,
 	folder keybase1.Folder) (err error) {
-	return nil
+	fav := NewFavoriteFromFolder(folder)
+	handle, err := GetHandleFromFolderNameAndType(
+		ctx, k.config.KBPKI(), k.config.MDOps(), fav.Name, fav.Type)
+	if err != nil {
+		return err
+	}
+	return k.config.KBFSOps().MigrateToImplicitTeam(ctx, handle.TlfID())
 }
 
 // GetTLFCryptKeys implements the TlfKeysInterface interface for

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -1118,6 +1118,13 @@ func (k *KeybaseServiceBase) StartMigration(ctx context.Context,
 	return k.config.MDServer().StartImplicitTeamMigration(ctx, handle.TlfID())
 }
 
+// FinalizeMigration implements keybase1.ImplicitTeamMigrationInterface for
+// KeybaseServiceBase.
+func (k *KeybaseServiceBase) FinalizeMigration(ctx context.Context,
+	folder keybase1.Folder) (err error) {
+	return nil
+}
+
 // GetTLFCryptKeys implements the TlfKeysInterface interface for
 // KeybaseServiceBase.
 func (k *KeybaseServiceBase) GetTLFCryptKeys(ctx context.Context,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1354,6 +1354,18 @@ func (mr *MockKBFSOpsMockRecorder) TeamAbandoned(ctx, tid interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TeamAbandoned", reflect.TypeOf((*MockKBFSOps)(nil).TeamAbandoned), ctx, tid)
 }
 
+// MigrateToImplicitTeam mocks base method
+func (m *MockKBFSOps) MigrateToImplicitTeam(ctx context.Context, id tlf.ID) error {
+	ret := m.ctrl.Call(m, "MigrateToImplicitTeam", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MigrateToImplicitTeam indicates an expected call of MigrateToImplicitTeam
+func (mr *MockKBFSOpsMockRecorder) MigrateToImplicitTeam(ctx, id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MigrateToImplicitTeam", reflect.TypeOf((*MockKBFSOps)(nil).MigrateToImplicitTeam), ctx, id)
+}
+
 // KickoffAllOutstandingRekeys mocks base method
 func (m *MockKBFSOps) KickoffAllOutstandingRekeys() error {
 	ret := m.ctrl.Call(m, "KickoffAllOutstandingRekeys")

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2028,6 +2028,20 @@ func (mr *MockteamMembershipCheckerMockRecorder) IsTeamReader(ctx, tid, uid inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamReader), ctx, tid, uid)
 }
 
+// ListResolvedTeamMembers mocks base method
+func (m *MockteamMembershipChecker) ListResolvedTeamMembers(ctx context.Context, tid keybase1.TeamID) ([]keybase1.UID, []keybase1.UID, error) {
+	ret := m.ctrl.Call(m, "ListResolvedTeamMembers", ctx, tid)
+	ret0, _ := ret[0].([]keybase1.UID)
+	ret1, _ := ret[1].([]keybase1.UID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListResolvedTeamMembers indicates an expected call of ListResolvedTeamMembers
+func (mr *MockteamMembershipCheckerMockRecorder) ListResolvedTeamMembers(ctx, tid interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResolvedTeamMembers", reflect.TypeOf((*MockteamMembershipChecker)(nil).ListResolvedTeamMembers), ctx, tid)
+}
+
 // MockteamKeysGetter is a mock of teamKeysGetter interface
 type MockteamKeysGetter struct {
 	ctrl     *gomock.Controller
@@ -2267,6 +2281,20 @@ func (m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid k
 // IsTeamReader indicates an expected call of IsTeamReader
 func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), ctx, tid, uid)
+}
+
+// ListResolvedTeamMembers mocks base method
+func (m *MockKBPKI) ListResolvedTeamMembers(ctx context.Context, tid keybase1.TeamID) ([]keybase1.UID, []keybase1.UID, error) {
+	ret := m.ctrl.Call(m, "ListResolvedTeamMembers", ctx, tid)
+	ret0, _ := ret[0].([]keybase1.UID)
+	ret1, _ := ret[1].([]keybase1.UID)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListResolvedTeamMembers indicates an expected call of ListResolvedTeamMembers
+func (mr *MockKBPKIMockRecorder) ListResolvedTeamMembers(ctx, tid interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResolvedTeamMembers", reflect.TypeOf((*MockKBPKI)(nil).ListResolvedTeamMembers), ctx, tid)
 }
 
 // GetTeamTLFCryptKeys mocks base method

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -285,6 +285,25 @@ func (md *RootMetadata) MakeSuccessor(
 	return newMd, nil
 }
 
+// MakeSuccessorWithNewHandle does the same thing as MakeSuccessor,
+// plus it changes the handle.  (The caller is responsible for
+// ensuring that the handle change is valid.)
+func (md *RootMetadata) MakeSuccessorWithNewHandle(
+	ctx context.Context, newHandle *TlfHandle, latestMDVer kbfsmd.MetadataVer,
+	codec kbfscodec.Codec, keyManager KeyManager, merkleGetter merkleRootGetter,
+	teamKeyer teamKeysGetter, mdID kbfsmd.ID, isWriter bool) (
+	*RootMetadata, error) {
+	mdCopy, err := md.deepCopy(codec)
+	if err != nil {
+		return nil, err
+	}
+
+	mdCopy.tlfHandle = newHandle.deepCopy()
+	return mdCopy.MakeSuccessor(
+		ctx, latestMDVer, codec, keyManager, merkleGetter, teamKeyer, mdID,
+		isWriter)
+}
+
 // GetTlfHandle returns the TlfHandle for this RootMetadata.
 func (md *RootMetadata) GetTlfHandle() *TlfHandle {
 	if md.tlfHandle == nil {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -298,7 +298,11 @@ func (md *RootMetadata) MakeSuccessorWithNewHandle(
 		return nil, err
 	}
 
+	mdCopy.extra = nil
 	mdCopy.tlfHandle = newHandle.deepCopy()
+	mdCopy.SetWriters(newHandle.ResolvedWriters())
+	mdCopy.bareMd.ClearForV4Migration()
+
 	return mdCopy.MakeSuccessor(
 		ctx, latestMDVer, codec, keyManager, merkleGetter, teamKeyer, mdID,
 		isWriter)

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -331,8 +331,7 @@ func (h TlfHandle) Equals(
 	}
 
 	if eq && h.name != other.name {
-		panic(fmt.Errorf(
-			"%+v equals %+v in everything but name", h, other))
+		return false, nil
 	}
 
 	return eq, nil

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -589,14 +589,13 @@ func TestTlfHandlEqual(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, eq)
 
-	// Test panic on name difference.
+	// Test failure on name difference.
 	h2, err = ParseTlfHandle(ctx, kbpki, nil, name1, tlf.Private)
 	require.NoError(t, err)
 	h2.name += "x"
-
-	require.Panics(t, func() {
-		h1.Equals(codec, *h2)
-	}, "in everything but name")
+	eq, err = h1.Equals(codec, *h2)
+	require.NoError(t, err)
+	require.False(t, eq)
 }
 
 func TestParseTlfHandleSocialAssertion(t *testing.T) {
@@ -870,7 +869,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err :=
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h1)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h1)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -883,7 +882,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -902,7 +901,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -918,7 +917,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h2.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -944,7 +943,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -968,7 +967,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h1.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -985,7 +984,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
 	require.Error(t, err)
 
 	// Test positive resolution cases.
@@ -1015,7 +1014,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
 		require.NoError(t, err)
 		assert.True(t, resolvesTo, tc.name2)
 		require.Equal(t, h2, partialResolvedH1, tc.name2)
@@ -1039,12 +1038,139 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
 		require.NoError(t, err)
 		assert.False(t, resolvesTo, tc.name2)
 
 		daemon.removeAssertionForTest("u2@twitter")
 	}
+}
+
+func TestTlfHandleMigrationResolvesTo(t *testing.T) {
+	ctx := context.Background()
+
+	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{
+		"u1", "u2", "u3",
+	})
+	currentUID := localUsers[0].UID
+	codec := kbfscodec.NewMsgpack()
+	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
+
+	kbpki := &daemonKBPKI{
+		KBPKI:  NewKBPKIClient(keybaseServiceSelfOwner{daemon}, nil),
+		daemon: daemon,
+	}
+
+	t.Log("Simple private team migration")
+	id := tlf.FakeID(1, tlf.Private)
+	// Handle without iteam.
+	name1 := "u1,u2"
+	h1, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name1, tlf.Private)
+	require.NoError(t, err)
+
+	makeImplicitHandle := func(
+		name string, ty tlf.Type, id tlf.ID) *TlfHandle {
+		wrName, suffix, err := tlf.SplitExtension(name)
+		require.NoError(t, err)
+		iteamInfo, err := daemon.ResolveIdentifyImplicitTeam(
+			ctx, wrName, suffix, ty, true, "")
+		require.NoError(t, err)
+		err = daemon.CreateTeamTLF(ctx, iteamInfo.TID, id)
+		require.NoError(t, err)
+		h, err := ParseTlfHandle(
+			ctx, kbpki, constIDGetter{id}, name, ty)
+		require.NoError(t, err)
+		require.Equal(t, tlf.TeamKeying, h.TypeForKeying())
+		return h
+	}
+	h2 := makeImplicitHandle(name1, tlf.Private, id)
+
+	resolvesTo, partialResolvedH1, err :=
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h2)
+	require.NoError(t, err)
+	require.True(t, resolvesTo)
+	require.Equal(t, h1, partialResolvedH1)
+
+	t.Log("Simple public team migration")
+	idPub := tlf.FakeID(1, tlf.Public)
+	// Handle without iteam.
+	h1Pub, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{idPub}, name1, tlf.Public)
+	require.NoError(t, err)
+	h2Pub := makeImplicitHandle(name1, tlf.Public, idPub)
+
+	resolvesTo, partialResolvedH1, err =
+		h1Pub.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, kbpki, *h2Pub)
+	require.NoError(t, err)
+	require.True(t, resolvesTo)
+	require.Equal(t, h1Pub, partialResolvedH1)
+
+	t.Log("Bad migration to team with extra user")
+	name2 := "u1,u2,u3"
+	h3 := makeImplicitHandle(name2, tlf.Private, id)
+	resolvesTo, _, err =
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h3)
+	require.NoError(t, err)
+	require.False(t, resolvesTo)
+
+	t.Log("Bad migration to team with fewer users")
+	name3 := "u1"
+	h4 := makeImplicitHandle(name3, tlf.Private, id)
+	resolvesTo, _, err =
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h4)
+	require.NoError(t, err)
+	require.False(t, resolvesTo)
+
+	t.Log("Bad migration to team with new readers")
+	name4 := "u1,u2#u3"
+	h5 := makeImplicitHandle(name4, tlf.Private, id)
+	resolvesTo, _, err =
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h5)
+	require.NoError(t, err)
+	require.False(t, resolvesTo)
+
+	t.Log("Private team migration with unresolved users")
+	// Handle without iteam.
+	name5 := "u1,u2,u3@twitter"
+	h6, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name5, tlf.Private)
+	require.NoError(t, err)
+	h7 := makeImplicitHandle(name5, tlf.Private, id)
+	resolvesTo, partialResolvedH6, err :=
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h7)
+	require.NoError(t, err)
+	require.True(t, resolvesTo)
+	require.Equal(t, h6, partialResolvedH6)
+
+	t.Log("Bad private team migration with extra unresolved user")
+	// Handle without iteam.
+	name6 := "u1,u2,u3@twitter,u4@twitter"
+	h8 := makeImplicitHandle(name6, tlf.Private, id)
+	resolvesTo, _, err =
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h8)
+	require.NoError(t, err)
+	require.False(t, resolvesTo)
+
+	t.Log("Private team migration with newly-resolved user")
+	daemon.addNewAssertionForTestOrBust("u3", "u3@twitter")
+	resolvesTo, partialResolvedH6, err =
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h3)
+	require.NoError(t, err)
+	require.True(t, resolvesTo)
+	require.Len(t, partialResolvedH6.UnresolvedWriters(), 0)
+
+	t.Log("Private team migration with conflict info")
+	name7 := "u1,u2 (conflicted copy 2016-03-14 #3)"
+	h9, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{id}, name7, tlf.Private)
+	require.NoError(t, err)
+	h10 := makeImplicitHandle(name7, tlf.Private, id)
+	resolvesTo, partialResolvedH9, err :=
+		h9.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h10)
+	require.NoError(t, err)
+	require.True(t, resolvesTo)
+	require.Equal(t, h9, partialResolvedH9)
 }
 
 func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {

--- a/tlf/handle.go
+++ b/tlf/handle.go
@@ -414,3 +414,27 @@ func (h *Handle) DeepEqual(other Handle) bool {
 
 	return true
 }
+
+func checkUIDEquality(a, b []keybase1.UserOrTeamID) bool {
+	// Assume `a` doesn't contain any duplicates (or that we don't
+	// care if `b` matches the exact number of duplicates).
+	aMap := make(map[keybase1.UserOrTeamID]bool)
+	for _, u := range a {
+		aMap[u] = true
+	}
+	for _, u := range b {
+		if !aMap[u] {
+			return false
+		}
+		delete(aMap, u)
+	}
+	return len(aMap) == 0
+}
+
+// ResolvedUsersEqual checks whether the resolved users of this TLF
+// matches the provided lists of writers and readers.
+func (h *Handle) ResolvedUsersEqual(
+	writers []keybase1.UserOrTeamID, readers []keybase1.UserOrTeamID) bool {
+	return checkUIDEquality(h.Writers, writers) &&
+		checkUIDEquality(h.Readers, readers)
+}

--- a/tlf/handle.go
+++ b/tlf/handle.go
@@ -415,9 +415,10 @@ func (h *Handle) DeepEqual(other Handle) bool {
 	return true
 }
 
+// checkUIDEquality returns true if `a` and `b` contain the same IDs,
+// regardless of order.  However, if `a` contains duplicates, this
+// function may return an incorrect value.
 func checkUIDEquality(a, b []keybase1.UserOrTeamID) bool {
-	// Assume `a` doesn't contain any duplicates (or that we don't
-	// care if `b` matches the exact number of duplicates).
 	aMap := make(map[keybase1.UserOrTeamID]bool)
 	for _, u := range a {
 		aMap[u] = true

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/common.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/common.go
@@ -146,6 +146,18 @@ func (o HashMeta) DeepCopy() HashMeta {
 	})(o)
 }
 
+type UserVersion struct {
+	Uid         UID   `codec:"uid" json:"uid"`
+	EldestSeqno Seqno `codec:"eldestSeqno" json:"eldestSeqno"`
+}
+
+func (o UserVersion) DeepCopy() UserVersion {
+	return UserVersion{
+		Uid:         o.Uid.DeepCopy(),
+		EldestSeqno: o.EldestSeqno.DeepCopy(),
+	}
+}
+
 type TeamType int
 
 const (

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -1674,6 +1674,13 @@ func (u UserVersionPercentForm) String() string {
 	return string(u)
 }
 
+func NewUserVersion(uid UID, eldestSeqno Seqno) UserVersion {
+	return UserVersion{
+		Uid:         uid,
+		EldestSeqno: eldestSeqno,
+	}
+}
+
 func (u UserVersion) PercentForm() UserVersionPercentForm {
 	return UserVersionPercentForm(u.String())
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/implicit_team_migration.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/implicit_team_migration.go
@@ -12,8 +12,13 @@ type StartMigrationArg struct {
 	Folder Folder `codec:"folder" json:"folder"`
 }
 
+type FinalizeMigrationArg struct {
+	Folder Folder `codec:"folder" json:"folder"`
+}
+
 type ImplicitTeamMigrationInterface interface {
 	StartMigration(context.Context, Folder) error
+	FinalizeMigration(context.Context, Folder) error
 }
 
 func ImplicitTeamMigrationProtocol(i ImplicitTeamMigrationInterface) rpc.Protocol {
@@ -36,6 +41,22 @@ func ImplicitTeamMigrationProtocol(i ImplicitTeamMigrationInterface) rpc.Protoco
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"finalizeMigration": {
+				MakeArg: func() interface{} {
+					ret := make([]FinalizeMigrationArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]FinalizeMigrationArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]FinalizeMigrationArg)(nil), args)
+						return
+					}
+					err = i.FinalizeMigration(ctx, (*typedArgs)[0].Folder)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -47,5 +68,11 @@ type ImplicitTeamMigrationClient struct {
 func (c ImplicitTeamMigrationClient) StartMigration(ctx context.Context, folder Folder) (err error) {
 	__arg := StartMigrationArg{Folder: folder}
 	err = c.Cli.Call(ctx, "keybase.1.implicitTeamMigration.startMigration", []interface{}{__arg}, nil)
+	return
+}
+
+func (c ImplicitTeamMigrationClient) FinalizeMigration(ctx context.Context, folder Folder) (err error) {
+	__arg := FinalizeMigrationArg{Folder: folder}
+	err = c.Cli.Call(ctx, "keybase.1.implicitTeamMigration.finalizeMigration", []interface{}{__arg}, nil)
 	return
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/metadata.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/metadata.go
@@ -271,6 +271,10 @@ type GetMerkleNodeArg struct {
 	Hash string `codec:"hash" json:"hash"`
 }
 
+type SetImplicitTeamModeForTestArg struct {
+	ImplicitTeamMode string `codec:"implicitTeamMode" json:"implicitTeamMode"`
+}
+
 type MetadataInterface interface {
 	GetChallenge(context.Context) (ChallengeInfo, error)
 	Authenticate(context.Context, string) (int, error)
@@ -296,6 +300,7 @@ type MetadataInterface interface {
 	GetMerkleRootLatest(context.Context, MerkleTreeID) (MerkleRoot, error)
 	GetMerkleRootSince(context.Context, GetMerkleRootSinceArg) (MerkleRoot, error)
 	GetMerkleNode(context.Context, string) ([]byte, error)
+	SetImplicitTeamModeForTest(context.Context, string) error
 }
 
 func MetadataProtocol(i MetadataInterface) rpc.Protocol {
@@ -671,6 +676,22 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"setImplicitTeamModeForTest": {
+				MakeArg: func() interface{} {
+					ret := make([]SetImplicitTeamModeForTestArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]SetImplicitTeamModeForTestArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]SetImplicitTeamModeForTestArg)(nil), args)
+						return
+					}
+					err = i.SetImplicitTeamModeForTest(ctx, (*typedArgs)[0].ImplicitTeamMode)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -804,5 +825,11 @@ func (c MetadataClient) GetMerkleRootSince(ctx context.Context, __arg GetMerkleR
 func (c MetadataClient) GetMerkleNode(ctx context.Context, hash string) (res []byte, err error) {
 	__arg := GetMerkleNodeArg{Hash: hash}
 	err = c.Cli.Call(ctx, "keybase.1.metadata.getMerkleNode", []interface{}{__arg}, &res)
+	return
+}
+
+func (c MetadataClient) SetImplicitTeamModeForTest(ctx context.Context, implicitTeamMode string) (err error) {
+	__arg := SetImplicitTeamModeForTestArg{ImplicitTeamMode: implicitTeamMode}
+	err = c.Cli.Call(ctx, "keybase.1.metadata.setImplicitTeamModeForTest", []interface{}{__arg}, nil)
 	return
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -343,18 +343,6 @@ func (o TeamDetails) DeepCopy() TeamDetails {
 	}
 }
 
-type UserVersion struct {
-	Uid         UID   `codec:"uid" json:"uid"`
-	EldestSeqno Seqno `codec:"eldestSeqno" json:"eldestSeqno"`
-}
-
-func (o UserVersion) DeepCopy() UserVersion {
-	return UserVersion{
-		Uid:         o.Uid.DeepCopy(),
-		EldestSeqno: o.EldestSeqno.DeepCopy(),
-	}
-}
-
 type UserVersionPercentForm string
 
 func (o UserVersionPercentForm) DeepCopy() UserVersionPercentForm {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -238,10 +238,10 @@
 			"revisionTime": "2018-01-25T22:56:34Z"
 		},
 		{
-			"checksumSHA1": "JLJ129zugp7D2BbBFrk4Yiqj780=",
+			"checksumSHA1": "mfp9yZagtFRClK00xDuLTGoo+6U=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "fe0e6560c9962d151bb1a8725cdda1879aeec244",
-			"revisionTime": "2018-04-07T04:11:38Z"
+			"revision": "8eb4d528169d5fa64114e2614772c6b4cc50280a",
+			"revisionTime": "2018-04-10T22:55:50Z"
 		},
 		{
 			"checksumSHA1": "o26ztx0R+4h9il8gTztHccctK+4=",


### PR DESCRIPTION
When the service is ready to migrate a TLF to an implicit team, it can call `FinalizeMigration`.  This re-resolves the handle of a TLF using the implicit team, and then generates a new MD for the TLF using team-keying.

When setting the MD successor, we check that the migration is valid: that is, the new implicit team has the same writers, readers, and canonical name as the original MD.

Issue: KBFS-2606