### PR TITLE
kbfsgit: update go-git to avoid failing on conflict files

### DIFF
--- a/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
+++ b/vendor/gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit/dotgit.go
@@ -160,8 +160,11 @@ func (d *DotGit) ObjectPacks() ([]plumbing.Hash, error) {
 
 		n := f.Name()
 		h := plumbing.NewHash(n[5 : len(n)-5]) //pack-(hash).pack
+		if h.IsZero() {
+			// Ignore files with badly-formatted names.
+			continue
+		}
 		packs = append(packs, h)
-
 	}
 
 	return packs, nil
@@ -257,7 +260,12 @@ func (d *DotGit) ForEachObjectHash(fun func(plumbing.Hash) error) error {
 			}
 
 			for _, o := range d {
-				err = fun(plumbing.NewHash(base + o.Name()))
+				h := plumbing.NewHash(base + o.Name())
+				if h.IsZero() {
+					// Ignore files with badly-formatted names.
+					continue
+				}
+				err = fun(h)
 				if err != nil {
 					return err
 				}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1148,11 +1148,11 @@
 			"revisionTime": "2017-12-01T00:24:35Z"
 		},
 		{
-			"checksumSHA1": "rZYExDgnlRGQip6eHLzV+ptdKFI=",
+			"checksumSHA1": "62+vHe8Tw5C0/6hrCYK55vS8C8A=",
 			"origin": "github.com/keybase/go-git/storage/filesystem/internal/dotgit",
 			"path": "gopkg.in/src-d/go-git.v4/storage/filesystem/internal/dotgit",
-			"revision": "d2b6d67be5cb04d1640faf47995ace874dc3cb05",
-			"revisionTime": "2017-12-01T00:24:35Z"
+			"revision": "58898ae21bb8fb3cdde546f12872767683a2239a",
+			"revisionTime": "2018-04-13T23:39:03Z"
 		},
 		{
 			"checksumSHA1": "4xP9AhC2OWXL3oUsZ/k6n7oMs8s=",


### PR DESCRIPTION
If conflict files ended up in `objects` or `objects/pack`, go-git would still try to treat their full names as hashes, and end up trying to access a file named by the 0 hash, which would fail.  Instead, just skip files like that.

Issue: keybase/client#11366