### PR TITLE
libkbfs: cache merkle roots for revoked and reset keys

### DIFF
--- a/kbfstool/md_dump_common.go
+++ b/kbfstool/md_dump_common.go
@@ -26,9 +26,9 @@ func mdDumpGetDeviceStringForCryptPublicKey(k kbfscrypto.CryptPublicKey, ui libk
 		return "", false
 	}
 
-	if revokedTime, ok := ui.RevokedCryptPublicKeys[k]; ok {
+	if revokedInfo, ok := ui.RevokedCryptPublicKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Time(), k), true
+			deviceName, revokedInfo.Time.Time(), k), true
 	}
 
 	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true
@@ -41,9 +41,9 @@ func mdDumpGetDeviceStringForVerifyingKey(k kbfscrypto.VerifyingKey, ui libkbfs.
 		return "", false
 	}
 
-	if revokedTime, ok := ui.RevokedVerifyingKeys[k]; ok {
+	if revokedInfo, ok := ui.RevokedVerifyingKeys[k]; ok {
 		return fmt.Sprintf("%s (revoked %s) (kid:%s)",
-			deviceName, revokedTime.Time(), k), true
+			deviceName, revokedInfo.Time.Time(), k), true
 	}
 
 	return fmt.Sprintf("%s (kid:%s)", deviceName, k), true

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -29,6 +29,12 @@ const (
 // user-created directory entry name.
 var disallowedPrefixes = [...]string{".kbfs"}
 
+type revokedKeyInfo struct {
+	// Fields are exported so they can be copied by the codec.
+	Time       keybase1.Time
+	MerkleRoot keybase1.MerkleRootV2
+}
+
 // UserInfo contains all the info about a keybase user that kbfs cares
 // about.
 type UserInfo struct {
@@ -40,8 +46,8 @@ type UserInfo struct {
 	EldestSeqno     keybase1.Seqno
 
 	// Revoked keys, and the time at which they were revoked.
-	RevokedVerifyingKeys   map[kbfscrypto.VerifyingKey]keybase1.Time
-	RevokedCryptPublicKeys map[kbfscrypto.CryptPublicKey]keybase1.Time
+	RevokedVerifyingKeys   map[kbfscrypto.VerifyingKey]revokedKeyInfo
+	RevokedCryptPublicKeys map[kbfscrypto.CryptPublicKey]revokedKeyInfo
 }
 
 // TeamInfo contains all the info about a keybase team that kbfs cares

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -142,7 +142,7 @@ func (k *KBPKIClient) hasVerifyingKey(ctx context.Context, uid keybase1.UID,
 		}
 	}
 
-	t, ok := userInfo.RevokedVerifyingKeys[verifyingKey]
+	info, ok := userInfo.RevokedVerifyingKeys[verifyingKey]
 	if !ok {
 		return false, nil
 	}
@@ -152,7 +152,7 @@ func (k *KBPKIClient) hasVerifyingKey(ctx context.Context, uid keybase1.UID,
 	// keep accepting writes from the revoked device for a short
 	// period of time until it learns about the revoke.
 	const revokeSlack = 1 * time.Minute
-	revokedTime := keybase1.FromTime(t)
+	revokedTime := keybase1.FromTime(info.Time)
 	// Trust the server times -- if the key was valid at the given
 	// time, we are good to go.  TODO: use Merkle data to check
 	// the server timestamps, to prove the server isn't lying.

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -51,8 +51,8 @@ func makeTestKBPKIClientWithRevokedKey(t *testing.T, revokeTime time.Time) (
 		index := 99
 		keySalt := keySaltForUserDevice(user.Name, index)
 		newVerifyingKey := MakeLocalUserVerifyingKeyOrBust(keySalt)
-		user.RevokedVerifyingKeys = map[kbfscrypto.VerifyingKey]keybase1.Time{
-			newVerifyingKey: keybase1.ToTime(revokeTime),
+		user.RevokedVerifyingKeys = map[kbfscrypto.VerifyingKey]revokedKeyInfo{
+			newVerifyingKey: {Time: keybase1.ToTime(revokeTime)},
 		}
 		users[i] = user
 	}

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -665,16 +665,17 @@ func (k *KeybaseDaemonLocal) revokeDeviceForTesting(clock Clock,
 
 	if user.RevokedVerifyingKeys == nil {
 		user.RevokedVerifyingKeys =
-			make(map[kbfscrypto.VerifyingKey]keybase1.Time)
+			make(map[kbfscrypto.VerifyingKey]revokedKeyInfo)
 	}
 	if user.RevokedCryptPublicKeys == nil {
 		user.RevokedCryptPublicKeys =
-			make(map[kbfscrypto.CryptPublicKey]keybase1.Time)
+			make(map[kbfscrypto.CryptPublicKey]revokedKeyInfo)
 	}
 
 	kbtime := keybase1.ToTime(clock.Now())
-	user.RevokedVerifyingKeys[user.VerifyingKeys[index]] = kbtime
-	user.RevokedCryptPublicKeys[user.CryptPublicKeys[index]] = kbtime
+	info := revokedKeyInfo{Time: kbtime}
+	user.RevokedVerifyingKeys[user.VerifyingKeys[index]] = info
+	user.RevokedCryptPublicKeys[user.CryptPublicKeys[index]] = info
 
 	user.VerifyingKeys = append(user.VerifyingKeys[:index],
 		user.VerifyingKeys[index+1:]...)


### PR DESCRIPTION
In the future this will let us order MD writes against key revokes/resets with less server trust.

Issue: KBFS-2890