### PR TITLE
cr: fix bug with recreated file and subdirectory

### DIFF
--- a/test/cr_complex_test.go
+++ b/test/cr_complex_test.go
@@ -1042,3 +1042,37 @@ func TestCrJournalCreateDirRenameFileRemoveUnmerged(t *testing.T) {
 		),
 	)
 }
+
+// Regression test for KBFS-2915.
+func TestCrDoubleMergedDeleteAndRecreate(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			mkdir("a/b/c/d"),
+			write("a/b/c/d/e1/f1", "f1"),
+			write("a/b/c/d/e2/f2", "f2"),
+		),
+		as(bob,
+			disableUpdates(),
+		),
+		as(alice,
+			rm("a/b/c/d/e1/f1"),
+			rm("a/b/c/d/e2/f2"),
+			rmdir("a/b/c/d/e1"),
+			rmdir("a/b/c/d/e2"),
+			rmdir("a/b/c/d"),
+			rmdir("a/b/c"),
+		),
+		as(bob, noSync(),
+			write("a/b/c/d/e1/f1", "f1.2"),
+			write("a/b/c/d/e2/f2", "f2.2"),
+			reenableUpdates(),
+			read("a/b/c/d/e1/f1", "f1.2"),
+			read("a/b/c/d/e2/f2", "f2.2"),
+		),
+		as(alice,
+			read("a/b/c/d/e1/f1", "f1.2"),
+			read("a/b/c/d/e2/f2", "f2.2"),
+		),
+	)
+}


### PR DESCRIPTION
A user hit an issue where they deleted a file and several of its parent subdirectories in the merged branch, but re-created that file and the parent subdirectories in the unmerged branch.  They did this for several files, across multiple subdirs.

This triggered a bug related to the fact that action updates to files actually affect their parent directories, and so parent directories can be processed twice during the action loop.  If the parent directory is being recreated, we could end up making two new blocks for it, and the second one would overwrite any changes that we already made to the first one, leading to the error.

Instead, make sure we only make new blocks once, while still preserving the previous correct behavior that a recreated directory block should always start out empty, regardless of what was still left in the unmerged branch.

Issue: KBFS-2915