### PR TITLE
Fix file truncation on Windows with bash

### DIFF
--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -106,11 +106,15 @@ func kbfsLibdokanCreateFile(
 	if status.IsDir() {
 		pfi.IsDirectory = 1
 	}
-	if err == nil && !status.IsNew() && cd.CreateDisposition == FileOpenIf {
+	if err == nil && !status.IsNew() && cd.CreateDisposition.isSignalExisting() {
 		debugf("CreateFile adding ErrObjectNameCollision")
 		err = ErrObjectNameCollision
 	}
 	return fiStore(pfi, fi, err)
+}
+
+func (cd CreateDisposition) isSignalExisting() bool {
+	return cd == FileOpenIf || cd == FileSupersede || cd == FileOverwriteIf
 }
 
 func globalContext() context.Context {

--- a/dokan/cgo.go
+++ b/dokan/cgo.go
@@ -102,6 +102,9 @@ func kbfsLibdokanCreateFile(
 	if isDebug {
 		checkFileDirectoryFile(err, status.IsDir(), uint32(CreateOptions))
 		debugf("CreateFile result: %v new-entry: %v raw %v", status.IsDir(), status.IsNew(), status)
+		if err == nil && status&isValid == 0 {
+			debugf("CreateFile invalid status for successful operation!")
+		}
 	}
 	if status.IsDir() {
 		pfi.IsDirectory = 1

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -37,7 +37,7 @@ type FileSystem interface {
 	WithContext(context.Context) (context.Context, context.CancelFunc)
 
 	// CreateFile is called to open and create files.
-	CreateFile(ctx context.Context, fi *FileInfo, data *CreateData) (file File, isDirectory bool, err error)
+	CreateFile(ctx context.Context, fi *FileInfo, data *CreateData) (file File, status CreateStatus, err error)
 
 	// GetDiskFreeSpace returns information about disk free space.
 	// Called quite often by Explorer.
@@ -52,6 +52,34 @@ type FileSystem interface {
 	// ErrorPrint is called when dokan needs notify the program of an error message.
 	// A sensible approach is to print the error.
 	ErrorPrint(error)
+}
+
+// CreateStatus marks status of successfull create/open operations.
+type CreateStatus uint32
+
+const (
+	// 1 Bit 0 == always set for valid values,
+	// 2 Bit 1 == directory or not
+	// 4 Bit 2 == new or not
+
+	// NewDir for newly created directories.
+	NewDir = CreateStatus(4 | 2 | 1)
+	// NewFile for newly created files.
+	NewFile = CreateStatus(4 | 0 | 1)
+	// ExistingDir for newly created directories.
+	ExistingDir = CreateStatus(0 | 2 | 1)
+	// ExistingFile for newly created files.
+	ExistingFile = CreateStatus(0 | 0 | 1)
+)
+
+// IsDir tells whether a CreateStatus is about a directory or a file.
+func (cst CreateStatus) IsDir() bool {
+	return (cst & 2) != 0
+}
+
+// IsNew tells whether a CreateStatus is about a new or existing object.
+func (cst CreateStatus) IsNew() bool {
+	return (cst & 4) != 0
 }
 
 // MountFlag is the type for Dokan mount flags.

--- a/dokan/filesystem.go
+++ b/dokan/filesystem.go
@@ -61,15 +61,18 @@ const (
 	// 1 Bit 0 == always set for valid values,
 	// 2 Bit 1 == directory or not
 	// 4 Bit 2 == new or not
+	isValid = 1
+	isDir   = 2
+	isNew   = 4
 
 	// NewDir for newly created directories.
-	NewDir = CreateStatus(4 | 2 | 1)
+	NewDir = CreateStatus(isNew | isDir | isValid)
 	// NewFile for newly created files.
-	NewFile = CreateStatus(4 | 0 | 1)
+	NewFile = CreateStatus(isNew | isValid)
 	// ExistingDir for newly created directories.
-	ExistingDir = CreateStatus(0 | 2 | 1)
+	ExistingDir = CreateStatus(isDir | isValid)
 	// ExistingFile for newly created files.
-	ExistingFile = CreateStatus(0 | 0 | 1)
+	ExistingFile = CreateStatus(isValid)
 )
 
 // IsDir tells whether a CreateStatus is about a directory or a file.

--- a/dokan/testfs_test.go
+++ b/dokan/testfs_test.go
@@ -259,9 +259,9 @@ func (t emptyFS) ErrorPrint(err error) {
 	debug(err)
 }
 
-func (t emptyFS) CreateFile(ctx context.Context, fi *FileInfo, cd *CreateData) (File, bool, error) {
+func (t emptyFS) CreateFile(ctx context.Context, fi *FileInfo, cd *CreateData) (File, CreateStatus, error) {
 	debug("emptyFS.CreateFile")
-	return emptyFile{}, true, nil
+	return emptyFile{}, ExistingDir, nil
 }
 func (t emptyFile) CanDeleteFile(ctx context.Context, fi *FileInfo) error {
 	return ErrAccessDenied
@@ -333,22 +333,22 @@ func newTestFS() *testFS {
 	return &t
 }
 
-func (t *testFS) CreateFile(ctx context.Context, fi *FileInfo, cd *CreateData) (File, bool, error) {
+func (t *testFS) CreateFile(ctx context.Context, fi *FileInfo, cd *CreateData) (File, CreateStatus, error) {
 	path := fi.Path()
 	debug("testFS.CreateFile", path)
 	switch path {
 	case `\hello.txt`:
-		return testFile{}, false, nil
+		return testFile{}, ExistingFile, nil
 	case `\ram.txt`:
-		return t.ramFile, false, nil
+		return t.ramFile, ExistingFile, nil
 	// SL_OPEN_TARGET_DIRECTORY may get empty paths...
 	case `\`, ``:
 		if cd.CreateOptions&FileNonDirectoryFile != 0 {
-			return nil, true, ErrFileIsADirectory
+			return nil, 0, ErrFileIsADirectory
 		}
-		return testDir{}, true, nil
+		return testDir{}, ExistingDir, nil
 	}
-	return nil, false, ErrObjectNameNotFound
+	return nil, 0, ErrObjectNameNotFound
 }
 func (t *testFS) GetDiskFreeSpace(ctx context.Context) (FreeSpace, error) {
 	debug("testFS.GetDiskFreeSpace")

--- a/libdokan/empty_folder.go
+++ b/libdokan/empty_folder.go
@@ -15,9 +15,9 @@ type EmptyFolder struct {
 	emptyFile
 }
 
-func (ef *EmptyFolder) open(ctx context.Context, oc *openContext, path []string) (f dokan.File, isDir bool, err error) {
+func (ef *EmptyFolder) open(ctx context.Context, oc *openContext, path []string) (f dokan.File, cst dokan.CreateStatus, err error) {
 	if len(path) != 0 {
-		return nil, false, dokan.ErrObjectNameNotFound
+		return nil, 0, dokan.ErrObjectNameNotFound
 	}
 	return oc.returnDirNoCleanup(ef)
 }

--- a/libdokan/fakeroot.go
+++ b/libdokan/fakeroot.go
@@ -13,16 +13,16 @@ type fakeRoot struct {
 	EmptyFolder
 }
 
-func openFakeRoot(ctx context.Context, fs *FS, fi *dokan.FileInfo) (dokan.File, bool, error) {
+func openFakeRoot(ctx context.Context, fs *FS, fi *dokan.FileInfo) (dokan.File, dokan.CreateStatus, error) {
 	path := fi.Path()
 	fs.log.CDebugf(ctx, "openFakeRoot %q", path)
 	switch path {
 	case `\` + WrongUserErrorFileName:
-		return stringReadFile(WrongUserErrorContents), false, nil
+		return stringReadFile(WrongUserErrorContents), dokan.ExistingFile, nil
 	case `\`:
-		return &fakeRoot{}, true, nil
+		return &fakeRoot{}, dokan.ExistingDir, nil
 	}
-	return nil, false, dokan.ErrAccessDenied
+	return nil, 0, dokan.ErrAccessDenied
 }
 
 // FindFiles for dokan.

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -18,7 +18,8 @@ import (
 )
 
 type fileOpener interface {
-	open(ctx context.Context, oc *openContext, path []string) (f dokan.File, isDir bool, err error)
+	open(ctx context.Context, oc *openContext, path []string) (
+		f dokan.File, cst dokan.CreateStatus, err error)
 	dokan.File
 }
 
@@ -68,7 +69,7 @@ func (fl *FolderList) addToFavorite(ctx context.Context, h *libkbfs.TlfHandle) (
 
 // open tries to open the correct thing. Following aliases and deferring to
 // Dir.open as necessary.
-func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) (f dokan.File, isDir bool, err error) {
+func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) (f dokan.File, cst dokan.CreateStatus, err error) {
 	fl.fs.log.CDebugf(ctx, "FL Lookup %#v type=%s upper=%v",
 		path, fl.tlfType, oc.isUppercasePath)
 	if len(path) == 0 {
@@ -92,7 +93,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 
 		if name == "desktop.ini" || name == "DESKTOP.INI" {
 			fl.fs.log.CDebugf(ctx, "FL Lookup ignoring desktop.ini")
-			return nil, false, dokan.ErrObjectNameNotFound
+			return nil, 0, dokan.ErrObjectNameNotFound
 		}
 
 		var aliasTarget string
@@ -110,19 +111,19 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 
 		if len(path) == 1 && isNewFolderName(name) {
 			if !oc.isCreateDirectory() {
-				return nil, false, dokan.ErrObjectNameNotFound
+				return nil, 0, dokan.ErrObjectNameNotFound
 			}
 			fl.fs.log.CDebugf(ctx, "FL Lookup creating EmptyFolder for Explorer")
 			e := &EmptyFolder{}
 			fl.lockedAddChild(name, e)
-			return e, true, nil
+			return e, dokan.NewDir, nil
 		}
 
 		if aliasTarget != "" {
 			fl.fs.log.CDebugf(ctx, "FL Lookup aliasCache hit: %q -> %q", name, aliasTarget)
 			if len(path) == 1 && oc.isOpenReparsePoint() {
 				// TODO handle dir/non-dir here, semantics?
-				return &Alias{canon: aliasTarget}, true, nil
+				return &Alias{canon: aliasTarget}, dokan.ExistingDir, nil
 			}
 			path[0] = aliasTarget
 			continue
@@ -141,7 +142,7 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			fl.fs.log.CDebugf(ctx, "FL Lookup set alias: %q -> %q", name, aliasTarget)
 			if !fl.isValidAliasTarget(ctx, aliasTarget) {
 				fl.fs.log.CDebugf(ctx, "FL Refusing alias to non-valid target %q", aliasTarget)
-				return nil, false, dokan.ErrObjectNameNotFound
+				return nil, 0, dokan.ErrObjectNameNotFound
 			}
 			fl.mu.Lock()
 			fl.aliasCache[name] = aliasTarget
@@ -150,29 +151,29 @@ func (fl *FolderList) open(ctx context.Context, oc *openContext, path []string) 
 			if len(path) == 1 && oc.isOpenReparsePoint() {
 				// TODO handle dir/non-dir here, semantics?
 				fl.fs.log.CDebugf(ctx, "FL Lookup ret alias, oc: %#v", oc.CreateData)
-				return &Alias{canon: aliasTarget}, true, nil
+				return &Alias{canon: aliasTarget}, dokan.ExistingDir, nil
 			}
 			path[0] = aliasTarget
 			continue
 
 		case libkbfs.NoSuchNameError, libkbfs.BadTLFNameError:
-			return nil, false, dokan.ErrObjectNameNotFound
+			return nil, 0, dokan.ErrObjectNameNotFound
 
 		default:
 			// Some other error.
-			return nil, false, err
+			return nil, 0, err
 		}
 
 		fl.fs.log.CDebugf(ctx, "FL Lookup adding new child")
 		session, err := libkbfs.GetCurrentSessionIfPossible(ctx, fl.fs.config.KBPKI(), h.Type() == tlf.Public)
 		if err != nil {
-			return nil, false, err
+			return nil, 0, err
 		}
 		child = newTLF(fl, h, h.GetPreferredFormat(session.Name))
 		fl.lockedAddChild(name, child)
 		return child.open(ctx, oc, path[1:])
 	}
-	return nil, false, dokan.ErrObjectNameNotFound
+	return nil, 0, dokan.ErrObjectNameNotFound
 }
 
 func (fl *FolderList) forgetFolder(folderName string) {

--- a/libdokan/profilelist.go
+++ b/libdokan/profilelist.go
@@ -26,16 +26,16 @@ func (ProfileList) GetFileInformation(ctx context.Context, fi *dokan.FileInfo) (
 }
 
 // open tries to open a file.
-func (pl ProfileList) open(ctx context.Context, oc *openContext, path []string) (dokan.File, bool, error) {
+func (pl ProfileList) open(ctx context.Context, oc *openContext, path []string) (dokan.File, dokan.CreateStatus, error) {
 	if len(path) == 0 {
 		return oc.returnDirNoCleanup(ProfileList{})
 	}
 	if len(path) > 1 || !libfs.IsSupportedProfileName(path[0]) {
-		return nil, false, dokan.ErrObjectNameNotFound
+		return nil, 0, dokan.ErrObjectNameNotFound
 	}
 	f := libfs.ProfileGet(path[0])
 	if f == nil {
-		return nil, false, dokan.ErrObjectNameNotFound
+		return nil, 0, dokan.ErrObjectNameNotFound
 	}
 	return oc.returnFileNoCleanup(&SpecialReadFile{read: f, fs: pl.fs})
 }

--- a/libfs/mount_interrupter.go
+++ b/libfs/mount_interrupter.go
@@ -66,7 +66,7 @@ func (mi *MountInterrupter) Done() {
 	if mi.fun != nil {
 		err := mi.fun()
 		if err != nil {
-			mi.log.Error("Mount interrupter callback failed: ", err)
+			mi.log.Errorf("Mount interrupter callback failed: %v", err)
 			return
 		}
 	}


### PR DESCRIPTION
When a file is opened with FILE_OPEN_IF with Dokan and the file
exists it should be returned, but additionally ErrObjectNameCollision
should be returned.

Fixes KBFS-2812 and Fixes #1494

This ended up requiring quite a lot of restructuring code since
we need to pass up whether a file was created or an existing
one is returned. Doing this on all the return sites would have
been even more messy.
