### PR TITLE
mdserver: add FindNextMD RPC support for remote

### DIFF
--- a/kbfsmd/errors.go
+++ b/kbfsmd/errors.go
@@ -193,3 +193,15 @@ type InvalidIDError struct {
 func (e InvalidIDError) Error() string {
 	return fmt.Sprintf("Invalid metadata ID %q", e.id)
 }
+
+// NewMerkleVersionError indicates that the merkle tree on the server
+// is using a new metadata version that our client doesn't understand.
+type NewMerkleVersionError struct {
+	Version int
+}
+
+// Error implements the error interface for NewMerkleVersionError.
+func (e NewMerkleVersionError) Error() string {
+	return fmt.Sprintf(
+		"The merkle tree is of a version (%d) that we can't read", e.Version)
+}

--- a/kbfsmd/merkle_hash.go
+++ b/kbfsmd/merkle_hash.go
@@ -1,0 +1,57 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsmd
+
+import (
+	"encoding"
+
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfshash"
+)
+
+// MerkleHash is the hash of a RootMetadataSigned block.
+type MerkleHash struct {
+	h kbfshash.Hash
+}
+
+// MakeMerkleHash hashes the given signed RootMetadata object.
+func MakeMerkleHash(codec kbfscodec.Codec, md *RootMetadataSigned) (MerkleHash, error) {
+	buf, err := codec.Encode(md)
+	if err != nil {
+		return MerkleHash{}, err
+	}
+	h, err := kbfshash.DefaultHash(buf)
+	if err != nil {
+		return MerkleHash{}, err
+	}
+	return MerkleHash{h}, nil
+}
+
+var _ encoding.BinaryMarshaler = MerkleHash{}
+var _ encoding.BinaryUnmarshaler = (*MerkleHash)(nil)
+
+// Bytes returns the bytes of the MerkleHash.
+func (h MerkleHash) Bytes() []byte {
+	return h.h.Bytes()
+}
+
+// String returns the string form of the MerkleHash.
+func (h MerkleHash) String() string {
+	return h.h.String()
+}
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface for
+// MerkleHash. Returns an error if the MerkleHash is invalid and not the
+// zero MerkleHash.
+func (h MerkleHash) MarshalBinary() (data []byte, err error) {
+	return h.h.MarshalBinary()
+}
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface
+// for MerkleHash. Returns an error if the given byte array is non-empty and
+// the MerkleHash is invalid.
+func (h *MerkleHash) UnmarshalBinary(data []byte) error {
+	return h.h.UnmarshalBinary(data)
+}

--- a/kbfsmd/merkle_leaf.go
+++ b/kbfsmd/merkle_leaf.go
@@ -1,0 +1,86 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsmd
+
+import (
+	"github.com/keybase/client/go/libkb"
+	merkle "github.com/keybase/go-merkle-tree"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/nacl/box"
+)
+
+// MerkleLeaf is the value of a Merkle leaf node.
+type MerkleLeaf struct {
+	_struct   bool `codec:",toarray"`
+	Revision  Revision
+	Hash      MerkleHash // hash of the signed metadata object
+	Timestamp int64
+}
+
+var _ merkle.ValueConstructor = (*MerkleLeaf)(nil)
+
+// Construct implements the go-merkle-tree.ValueConstructor interface.
+func (l MerkleLeaf) Construct() interface{} {
+	// In the Merkle tree leaves are simply byte slices.
+	return []byte{}
+}
+
+// EncryptedMerkleLeaf is an encrypted Merkle leaf.
+type EncryptedMerkleLeaf struct {
+	_struct       bool `codec:",toarray"`
+	Version       kbfscrypto.EncryptionVer
+	EncryptedData []byte
+}
+
+// Construct implements the go-merkle-tree.ValueConstructor interface.
+func (el EncryptedMerkleLeaf) Construct() interface{} {
+	// In the Merkle tree leaves are simply byte slices.
+	return []byte{}
+}
+
+// Encrypt encrypts a Merkle leaf node with the given key pair.
+func (l MerkleLeaf) Encrypt(codec kbfscodec.Codec,
+	pubKey kbfscrypto.TLFPublicKey, nonce *[24]byte,
+	ePrivKey kbfscrypto.TLFEphemeralPrivateKey) (EncryptedMerkleLeaf, error) {
+	// encode the clear-text leaf
+	leafBytes, err := codec.Encode(l)
+	if err != nil {
+		return EncryptedMerkleLeaf{}, err
+	}
+	// encrypt the encoded leaf
+	pubKeyData := pubKey.Data()
+	privKeyData := ePrivKey.Data()
+	encryptedData := box.Seal(
+		nil, leafBytes[:], nonce, &pubKeyData, &privKeyData)
+	return EncryptedMerkleLeaf{
+		Version:       kbfscrypto.EncryptionSecretbox,
+		EncryptedData: encryptedData,
+	}, nil
+}
+
+// Decrypt decrypts a Merkle leaf node with the given key pair.
+func (el EncryptedMerkleLeaf) Decrypt(codec kbfscodec.Codec,
+	privKey kbfscrypto.TLFPrivateKey, nonce *[24]byte,
+	ePubKey kbfscrypto.TLFEphemeralPublicKey) (MerkleLeaf, error) {
+	if el.Version != kbfscrypto.EncryptionSecretbox {
+		return MerkleLeaf{}, errors.WithStack(
+			kbfscrypto.UnknownEncryptionVer{Ver: el.Version})
+	}
+	pubKeyData := ePubKey.Data()
+	privKeyData := privKey.Data()
+	leafBytes, ok := box.Open(
+		nil, el.EncryptedData[:], nonce, &pubKeyData, &privKeyData)
+	if !ok {
+		return MerkleLeaf{}, errors.WithStack(libkb.DecryptionError{})
+	}
+	// decode the leaf
+	var leaf MerkleLeaf
+	if err := codec.Decode(leafBytes, &leaf); err != nil {
+		return MerkleLeaf{}, err
+	}
+	return leaf, nil
+}

--- a/kbfsmd/merkle_root.go
+++ b/kbfsmd/merkle_root.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsmd
+
+import (
+	"github.com/keybase/client/go/protocol/keybase1"
+	merkle "github.com/keybase/go-merkle-tree"
+	"github.com/keybase/kbfs/kbfscrypto"
+)
+
+// MerkleRootVersion is the current Merkle root version.
+const MerkleRootVersion = 1
+
+// MerkleRoot represents a signed Merkle tree root.
+type MerkleRoot struct {
+	Version   int                               `codec:"v"`
+	TreeID    keybase1.MerkleTreeID             `codec:"t"`
+	SeqNo     int64                             `codec:"sn"`
+	Timestamp int64                             `codec:"ts"`
+	Hash      merkle.Hash                       `codec:"h"`
+	PrevRoot  merkle.Hash                       `codec:"pr"`
+	EPubKey   *kbfscrypto.TLFEphemeralPublicKey `codec:"epk,omitempty"` // these two are only necessary with encrypted leaves.
+	Nonce     *[24]byte                         `codec:"non,omitempty"` // the public tree leaves are in the clear.
+}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1518,6 +1518,17 @@ type MDServer interface {
 	// reconnects. If MD server is connected at the time this is called, it's
 	// essentially a no-op.
 	FastForwardBackoff()
+
+	// FindNextMD finds the serialized (and possibly encrypted) root
+	// metadata object from the leaf node of the second KBFS merkle
+	// tree to be produced after a given Keybase global merkle tree
+	// sequence number `rootSeqno` (and all merkle nodes between it
+	// and the root, and the root itself).  It also returns the global
+	// merkle tree sequence number and hash of the root that first
+	// included the returned metadata object.
+	FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
+		nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
+		nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error)
 }
 
 type mdServerLocal interface {

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -735,8 +735,16 @@ func (md *MDServerDisk) GetKeyBundles(ctx context.Context,
 	return tlfStorage.getKeyBundles(tlfID, wkbID, rkbID)
 }
 
-// CheckReachability implements the MDServer interface for MDServerMemory.
+// CheckReachability implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) CheckReachability(ctx context.Context) {}
 
-// FastForwardBackoff implements the MDServer interface for MDServerMemory.
+// FastForwardBackoff implements the MDServer interface for MDServerDisk.
 func (md *MDServerDisk) FastForwardBackoff() {}
+
+// FindNextMD implements the MDServer interface for MDServerDisk.
+func (md *MDServerDisk) FindNextMD(
+	ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
+	nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
+	nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error) {
+	return nil, nil, 0, keybase1.HashMeta{}, nil
+}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -1091,3 +1091,11 @@ func (md *MDServerMemory) CheckReachability(ctx context.Context) {}
 
 // FastForwardBackoff implements the MDServer interface for MDServerMemory.
 func (md *MDServerMemory) FastForwardBackoff() {}
+
+// FindNextMD implements the MDServer interface for MDServerMemory.
+func (md *MDServerMemory) FindNextMD(
+	ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
+	nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
+	nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error) {
+	return nil, nil, 0, keybase1.HashMeta{}, nil
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4644,6 +4644,22 @@ func (mr *MockMDServerMockRecorder) FastForwardBackoff() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FastForwardBackoff", reflect.TypeOf((*MockMDServer)(nil).FastForwardBackoff))
 }
 
+// FindNextMD mocks base method
+func (m *MockMDServer) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, keybase1.HashMeta, error) {
+	ret := m.ctrl.Call(m, "FindNextMD", ctx, tlfID, rootSeqno)
+	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
+	ret1, _ := ret[1].([][]byte)
+	ret2, _ := ret[2].(keybase1.Seqno)
+	ret3, _ := ret[3].(keybase1.HashMeta)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// FindNextMD indicates an expected call of FindNextMD
+func (mr *MockMDServerMockRecorder) FindNextMD(ctx, tlfID, rootSeqno interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNextMD", reflect.TypeOf((*MockMDServer)(nil).FindNextMD), ctx, tlfID, rootSeqno)
+}
+
 // MockmdServerLocal is a mock of mdServerLocal interface
 type MockmdServerLocal struct {
 	ctrl     *gomock.Controller
@@ -4928,6 +4944,22 @@ func (m *MockmdServerLocal) FastForwardBackoff() {
 // FastForwardBackoff indicates an expected call of FastForwardBackoff
 func (mr *MockmdServerLocalMockRecorder) FastForwardBackoff() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FastForwardBackoff", reflect.TypeOf((*MockmdServerLocal)(nil).FastForwardBackoff))
+}
+
+// FindNextMD mocks base method
+func (m *MockmdServerLocal) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, keybase1.HashMeta, error) {
+	ret := m.ctrl.Call(m, "FindNextMD", ctx, tlfID, rootSeqno)
+	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
+	ret1, _ := ret[1].([][]byte)
+	ret2, _ := ret[2].(keybase1.Seqno)
+	ret3, _ := ret[3].(keybase1.HashMeta)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// FindNextMD indicates an expected call of FindNextMD
+func (mr *MockmdServerLocalMockRecorder) FindNextMD(ctx, tlfID, rootSeqno interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNextMD", reflect.TypeOf((*MockmdServerLocal)(nil).FindNextMD), ctx, tlfID, rootSeqno)
 }
 
 // addNewAssertionForTest mocks base method

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -154,6 +154,9 @@ func (r *ReporterKBPKI) ReportErr(ctx context.Context,
 	case kbfsmd.NewMetadataVersionError:
 		code = keybase1.FSErrorType_OLD_VERSION
 		err = OutdatedVersionError{}
+	case kbfsmd.NewMerkleVersionError:
+		code = keybase1.FSErrorType_OLD_VERSION
+		err = OutdatedVersionError{}
 	case NewDataVersionError:
 		code = keybase1.FSErrorType_OLD_VERSION
 		err = OutdatedVersionError{}

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/constants.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/constants.go
@@ -10,319 +10,331 @@ import (
 type StatusCode int
 
 const (
-	StatusCode_SCOk                        StatusCode = 0
-	StatusCode_SCInputError                StatusCode = 100
-	StatusCode_SCLoginRequired             StatusCode = 201
-	StatusCode_SCBadSession                StatusCode = 202
-	StatusCode_SCBadLoginUserNotFound      StatusCode = 203
-	StatusCode_SCBadLoginPassword          StatusCode = 204
-	StatusCode_SCNotFound                  StatusCode = 205
-	StatusCode_SCThrottleControl           StatusCode = 210
-	StatusCode_SCDeleted                   StatusCode = 216
-	StatusCode_SCGeneric                   StatusCode = 218
-	StatusCode_SCAlreadyLoggedIn           StatusCode = 235
-	StatusCode_SCExists                    StatusCode = 230
-	StatusCode_SCCanceled                  StatusCode = 237
-	StatusCode_SCInputCanceled             StatusCode = 239
-	StatusCode_SCReloginRequired           StatusCode = 274
-	StatusCode_SCResolutionFailed          StatusCode = 275
-	StatusCode_SCProfileNotPublic          StatusCode = 276
-	StatusCode_SCIdentifyFailed            StatusCode = 277
-	StatusCode_SCTrackingBroke             StatusCode = 278
-	StatusCode_SCWrongCryptoFormat         StatusCode = 279
-	StatusCode_SCDecryptionError           StatusCode = 280
-	StatusCode_SCInvalidAddress            StatusCode = 281
-	StatusCode_SCNoSession                 StatusCode = 283
-	StatusCode_SCAccountReset              StatusCode = 290
-	StatusCode_SCIdentifiesFailed          StatusCode = 295
-	StatusCode_SCNoSpaceOnDevice           StatusCode = 297
-	StatusCode_SCBadEmail                  StatusCode = 472
-	StatusCode_SCBadSignupUsernameTaken    StatusCode = 701
-	StatusCode_SCBadInvitationCode         StatusCode = 707
-	StatusCode_SCMissingResult             StatusCode = 801
-	StatusCode_SCKeyNotFound               StatusCode = 901
-	StatusCode_SCKeyCorrupted              StatusCode = 905
-	StatusCode_SCKeyInUse                  StatusCode = 907
-	StatusCode_SCKeyBadGen                 StatusCode = 913
-	StatusCode_SCKeyNoSecret               StatusCode = 914
-	StatusCode_SCKeyBadUIDs                StatusCode = 915
-	StatusCode_SCKeyNoActive               StatusCode = 916
-	StatusCode_SCKeyNoSig                  StatusCode = 917
-	StatusCode_SCKeyBadSig                 StatusCode = 918
-	StatusCode_SCKeyBadEldest              StatusCode = 919
-	StatusCode_SCKeyNoEldest               StatusCode = 920
-	StatusCode_SCKeyDuplicateUpdate        StatusCode = 921
-	StatusCode_SCSibkeyAlreadyExists       StatusCode = 922
-	StatusCode_SCDecryptionKeyNotFound     StatusCode = 924
-	StatusCode_SCKeyNoPGPEncryption        StatusCode = 927
-	StatusCode_SCKeyNoNaClEncryption       StatusCode = 928
-	StatusCode_SCKeySyncedPGPNotFound      StatusCode = 929
-	StatusCode_SCKeyNoMatchingGPG          StatusCode = 930
-	StatusCode_SCKeyRevoked                StatusCode = 931
-	StatusCode_SCSigOldSeqno               StatusCode = 1010
-	StatusCode_SCBadTrackSession           StatusCode = 1301
-	StatusCode_SCDeviceBadName             StatusCode = 1404
-	StatusCode_SCDeviceNameInUse           StatusCode = 1408
-	StatusCode_SCDeviceNotFound            StatusCode = 1409
-	StatusCode_SCDeviceMismatch            StatusCode = 1410
-	StatusCode_SCDeviceRequired            StatusCode = 1411
-	StatusCode_SCDevicePrevProvisioned     StatusCode = 1413
-	StatusCode_SCDeviceNoProvision         StatusCode = 1414
-	StatusCode_SCDeviceProvisionViaDevice  StatusCode = 1415
-	StatusCode_SCRevokeCurrentDevice       StatusCode = 1416
-	StatusCode_SCRevokeLastDevice          StatusCode = 1417
-	StatusCode_SCDeviceProvisionOffline    StatusCode = 1418
-	StatusCode_SCRevokeLastDevicePGP       StatusCode = 1419
-	StatusCode_SCStreamExists              StatusCode = 1501
-	StatusCode_SCStreamNotFound            StatusCode = 1502
-	StatusCode_SCStreamWrongKind           StatusCode = 1503
-	StatusCode_SCStreamEOF                 StatusCode = 1504
-	StatusCode_SCGenericAPIError           StatusCode = 1600
-	StatusCode_SCAPINetworkError           StatusCode = 1601
-	StatusCode_SCTimeout                   StatusCode = 1602
-	StatusCode_SCProofError                StatusCode = 1701
-	StatusCode_SCIdentificationExpired     StatusCode = 1702
-	StatusCode_SCSelfNotFound              StatusCode = 1703
-	StatusCode_SCBadKexPhrase              StatusCode = 1704
-	StatusCode_SCNoUIDelegation            StatusCode = 1705
-	StatusCode_SCNoUI                      StatusCode = 1706
-	StatusCode_SCGPGUnavailable            StatusCode = 1707
-	StatusCode_SCInvalidVersionError       StatusCode = 1800
-	StatusCode_SCOldVersionError           StatusCode = 1801
-	StatusCode_SCInvalidLocationError      StatusCode = 1802
-	StatusCode_SCServiceStatusError        StatusCode = 1803
-	StatusCode_SCInstallError              StatusCode = 1804
-	StatusCode_SCLoadKextError             StatusCode = 1810
-	StatusCode_SCLoadKextPermError         StatusCode = 1811
-	StatusCode_SCGitInternal               StatusCode = 2300
-	StatusCode_SCGitRepoAlreadyExists      StatusCode = 2301
-	StatusCode_SCGitInvalidRepoName        StatusCode = 2302
-	StatusCode_SCGitCannotDelete           StatusCode = 2303
-	StatusCode_SCGitRepoDoesntExist        StatusCode = 2304
-	StatusCode_SCLoginStateTimeout         StatusCode = 2400
-	StatusCode_SCChatInternal              StatusCode = 2500
-	StatusCode_SCChatRateLimit             StatusCode = 2501
-	StatusCode_SCChatConvExists            StatusCode = 2502
-	StatusCode_SCChatUnknownTLFID          StatusCode = 2503
-	StatusCode_SCChatNotInConv             StatusCode = 2504
-	StatusCode_SCChatBadMsg                StatusCode = 2505
-	StatusCode_SCChatBroadcast             StatusCode = 2506
-	StatusCode_SCChatAlreadySuperseded     StatusCode = 2507
-	StatusCode_SCChatAlreadyDeleted        StatusCode = 2508
-	StatusCode_SCChatTLFFinalized          StatusCode = 2509
-	StatusCode_SCChatCollision             StatusCode = 2510
-	StatusCode_SCIdentifySummaryError      StatusCode = 2511
-	StatusCode_SCNeedSelfRekey             StatusCode = 2512
-	StatusCode_SCNeedOtherRekey            StatusCode = 2513
-	StatusCode_SCChatMessageCollision      StatusCode = 2514
-	StatusCode_SCChatDuplicateMessage      StatusCode = 2515
-	StatusCode_SCChatClientError           StatusCode = 2516
-	StatusCode_SCChatNotInTeam             StatusCode = 2517
-	StatusCode_SCChatStalePreviousState    StatusCode = 2518
-	StatusCode_SCTeamBadMembership         StatusCode = 2604
-	StatusCode_SCTeamSelfNotOwner          StatusCode = 2607
-	StatusCode_SCTeamNotFound              StatusCode = 2614
-	StatusCode_SCTeamExists                StatusCode = 2619
-	StatusCode_SCTeamReadError             StatusCode = 2623
-	StatusCode_SCNoOp                      StatusCode = 2638
-	StatusCode_SCTeamInviteBadToken        StatusCode = 2646
-	StatusCode_SCTeamTarDuplicate          StatusCode = 2663
-	StatusCode_SCTeamTarNotFound           StatusCode = 2664
-	StatusCode_SCTeamMemberExists          StatusCode = 2665
-	StatusCode_SCTeamNotReleased           StatusCode = 2666
-	StatusCode_SCTeamPermanentlyLeft       StatusCode = 2667
-	StatusCode_SCTeamNeedRootId            StatusCode = 2668
-	StatusCode_SCTeamHasLiveChildren       StatusCode = 2669
-	StatusCode_SCTeamDeleteError           StatusCode = 2670
-	StatusCode_SCTeamBadRootTeam           StatusCode = 2671
-	StatusCode_SCTeamNameConflictsWithUser StatusCode = 2672
-	StatusCode_SCTeamDeleteNoUpPointer     StatusCode = 2673
-	StatusCode_SCTeamNeedOwner             StatusCode = 2674
-	StatusCode_SCTeamNoOwnerAllowed        StatusCode = 2675
-	StatusCode_SCTeamImplicitNoNonSbs      StatusCode = 2676
-	StatusCode_SCTeamImplicitBadHash       StatusCode = 2677
-	StatusCode_SCTeamImplicitBadName       StatusCode = 2678
-	StatusCode_SCTeamImplicitClash         StatusCode = 2679
-	StatusCode_SCTeamImplicitDuplicate     StatusCode = 2680
-	StatusCode_SCTeamImplicitBadOp         StatusCode = 2681
-	StatusCode_SCTeamImplicitBadRole       StatusCode = 2682
-	StatusCode_SCTeamImplicitNotFound      StatusCode = 2683
-	StatusCode_SCTeamBadAdminSeqnoType     StatusCode = 2684
-	StatusCode_SCTeamImplicitBadAdd        StatusCode = 2685
-	StatusCode_SCTeamImplicitBadRemove     StatusCode = 2686
-	StatusCode_SCTeamInviteTokenReused     StatusCode = 2696
-	StatusCode_SCTeamKeyMaskNotFound       StatusCode = 2697
-	StatusCode_SCTeamBanned                StatusCode = 2702
-	StatusCode_SCTeamInvalidBan            StatusCode = 2703
-	StatusCode_SCTeamShowcasePermDenied    StatusCode = 2711
-	StatusCode_SCTeamProvisionalCanKey     StatusCode = 2721
-	StatusCode_SCTeamProvisionalCannotKey  StatusCode = 2722
-	StatusCode_SCStellarError              StatusCode = 3100
-	StatusCode_SCStellarBadInput           StatusCode = 3101
-	StatusCode_SCStellarWrongRevision      StatusCode = 3102
-	StatusCode_SCStellarMissingBundle      StatusCode = 3103
-	StatusCode_SCStellarBadPuk             StatusCode = 3104
-	StatusCode_SCStellarMissingAccount     StatusCode = 3105
-	StatusCode_SCStellarBadPrev            StatusCode = 3106
+	StatusCode_SCOk                            StatusCode = 0
+	StatusCode_SCInputError                    StatusCode = 100
+	StatusCode_SCLoginRequired                 StatusCode = 201
+	StatusCode_SCBadSession                    StatusCode = 202
+	StatusCode_SCBadLoginUserNotFound          StatusCode = 203
+	StatusCode_SCBadLoginPassword              StatusCode = 204
+	StatusCode_SCNotFound                      StatusCode = 205
+	StatusCode_SCThrottleControl               StatusCode = 210
+	StatusCode_SCDeleted                       StatusCode = 216
+	StatusCode_SCGeneric                       StatusCode = 218
+	StatusCode_SCAlreadyLoggedIn               StatusCode = 235
+	StatusCode_SCExists                        StatusCode = 230
+	StatusCode_SCCanceled                      StatusCode = 237
+	StatusCode_SCInputCanceled                 StatusCode = 239
+	StatusCode_SCReloginRequired               StatusCode = 274
+	StatusCode_SCResolutionFailed              StatusCode = 275
+	StatusCode_SCProfileNotPublic              StatusCode = 276
+	StatusCode_SCIdentifyFailed                StatusCode = 277
+	StatusCode_SCTrackingBroke                 StatusCode = 278
+	StatusCode_SCWrongCryptoFormat             StatusCode = 279
+	StatusCode_SCDecryptionError               StatusCode = 280
+	StatusCode_SCInvalidAddress                StatusCode = 281
+	StatusCode_SCNoSession                     StatusCode = 283
+	StatusCode_SCAccountReset                  StatusCode = 290
+	StatusCode_SCIdentifiesFailed              StatusCode = 295
+	StatusCode_SCNoSpaceOnDevice               StatusCode = 297
+	StatusCode_SCBadEmail                      StatusCode = 472
+	StatusCode_SCBadSignupUsernameTaken        StatusCode = 701
+	StatusCode_SCBadInvitationCode             StatusCode = 707
+	StatusCode_SCMissingResult                 StatusCode = 801
+	StatusCode_SCKeyNotFound                   StatusCode = 901
+	StatusCode_SCKeyCorrupted                  StatusCode = 905
+	StatusCode_SCKeyInUse                      StatusCode = 907
+	StatusCode_SCKeyBadGen                     StatusCode = 913
+	StatusCode_SCKeyNoSecret                   StatusCode = 914
+	StatusCode_SCKeyBadUIDs                    StatusCode = 915
+	StatusCode_SCKeyNoActive                   StatusCode = 916
+	StatusCode_SCKeyNoSig                      StatusCode = 917
+	StatusCode_SCKeyBadSig                     StatusCode = 918
+	StatusCode_SCKeyBadEldest                  StatusCode = 919
+	StatusCode_SCKeyNoEldest                   StatusCode = 920
+	StatusCode_SCKeyDuplicateUpdate            StatusCode = 921
+	StatusCode_SCSibkeyAlreadyExists           StatusCode = 922
+	StatusCode_SCDecryptionKeyNotFound         StatusCode = 924
+	StatusCode_SCKeyNoPGPEncryption            StatusCode = 927
+	StatusCode_SCKeyNoNaClEncryption           StatusCode = 928
+	StatusCode_SCKeySyncedPGPNotFound          StatusCode = 929
+	StatusCode_SCKeyNoMatchingGPG              StatusCode = 930
+	StatusCode_SCKeyRevoked                    StatusCode = 931
+	StatusCode_SCSigWrongKey                   StatusCode = 1008
+	StatusCode_SCSigOldSeqno                   StatusCode = 1010
+	StatusCode_SCBadTrackSession               StatusCode = 1301
+	StatusCode_SCDeviceBadName                 StatusCode = 1404
+	StatusCode_SCDeviceNameInUse               StatusCode = 1408
+	StatusCode_SCDeviceNotFound                StatusCode = 1409
+	StatusCode_SCDeviceMismatch                StatusCode = 1410
+	StatusCode_SCDeviceRequired                StatusCode = 1411
+	StatusCode_SCDevicePrevProvisioned         StatusCode = 1413
+	StatusCode_SCDeviceNoProvision             StatusCode = 1414
+	StatusCode_SCDeviceProvisionViaDevice      StatusCode = 1415
+	StatusCode_SCRevokeCurrentDevice           StatusCode = 1416
+	StatusCode_SCRevokeLastDevice              StatusCode = 1417
+	StatusCode_SCDeviceProvisionOffline        StatusCode = 1418
+	StatusCode_SCRevokeLastDevicePGP           StatusCode = 1419
+	StatusCode_SCStreamExists                  StatusCode = 1501
+	StatusCode_SCStreamNotFound                StatusCode = 1502
+	StatusCode_SCStreamWrongKind               StatusCode = 1503
+	StatusCode_SCStreamEOF                     StatusCode = 1504
+	StatusCode_SCGenericAPIError               StatusCode = 1600
+	StatusCode_SCAPINetworkError               StatusCode = 1601
+	StatusCode_SCTimeout                       StatusCode = 1602
+	StatusCode_SCProofError                    StatusCode = 1701
+	StatusCode_SCIdentificationExpired         StatusCode = 1702
+	StatusCode_SCSelfNotFound                  StatusCode = 1703
+	StatusCode_SCBadKexPhrase                  StatusCode = 1704
+	StatusCode_SCNoUIDelegation                StatusCode = 1705
+	StatusCode_SCNoUI                          StatusCode = 1706
+	StatusCode_SCGPGUnavailable                StatusCode = 1707
+	StatusCode_SCInvalidVersionError           StatusCode = 1800
+	StatusCode_SCOldVersionError               StatusCode = 1801
+	StatusCode_SCInvalidLocationError          StatusCode = 1802
+	StatusCode_SCServiceStatusError            StatusCode = 1803
+	StatusCode_SCInstallError                  StatusCode = 1804
+	StatusCode_SCLoadKextError                 StatusCode = 1810
+	StatusCode_SCLoadKextPermError             StatusCode = 1811
+	StatusCode_SCGitInternal                   StatusCode = 2300
+	StatusCode_SCGitRepoAlreadyExists          StatusCode = 2301
+	StatusCode_SCGitInvalidRepoName            StatusCode = 2302
+	StatusCode_SCGitCannotDelete               StatusCode = 2303
+	StatusCode_SCGitRepoDoesntExist            StatusCode = 2304
+	StatusCode_SCLoginStateTimeout             StatusCode = 2400
+	StatusCode_SCChatInternal                  StatusCode = 2500
+	StatusCode_SCChatRateLimit                 StatusCode = 2501
+	StatusCode_SCChatConvExists                StatusCode = 2502
+	StatusCode_SCChatUnknownTLFID              StatusCode = 2503
+	StatusCode_SCChatNotInConv                 StatusCode = 2504
+	StatusCode_SCChatBadMsg                    StatusCode = 2505
+	StatusCode_SCChatBroadcast                 StatusCode = 2506
+	StatusCode_SCChatAlreadySuperseded         StatusCode = 2507
+	StatusCode_SCChatAlreadyDeleted            StatusCode = 2508
+	StatusCode_SCChatTLFFinalized              StatusCode = 2509
+	StatusCode_SCChatCollision                 StatusCode = 2510
+	StatusCode_SCIdentifySummaryError          StatusCode = 2511
+	StatusCode_SCNeedSelfRekey                 StatusCode = 2512
+	StatusCode_SCNeedOtherRekey                StatusCode = 2513
+	StatusCode_SCChatMessageCollision          StatusCode = 2514
+	StatusCode_SCChatDuplicateMessage          StatusCode = 2515
+	StatusCode_SCChatClientError               StatusCode = 2516
+	StatusCode_SCChatNotInTeam                 StatusCode = 2517
+	StatusCode_SCChatStalePreviousState        StatusCode = 2518
+	StatusCode_SCTeamBadMembership             StatusCode = 2604
+	StatusCode_SCTeamSelfNotOwner              StatusCode = 2607
+	StatusCode_SCTeamNotFound                  StatusCode = 2614
+	StatusCode_SCTeamExists                    StatusCode = 2619
+	StatusCode_SCTeamReadError                 StatusCode = 2623
+	StatusCode_SCNoOp                          StatusCode = 2638
+	StatusCode_SCTeamInviteBadToken            StatusCode = 2646
+	StatusCode_SCTeamTarDuplicate              StatusCode = 2663
+	StatusCode_SCTeamTarNotFound               StatusCode = 2664
+	StatusCode_SCTeamMemberExists              StatusCode = 2665
+	StatusCode_SCTeamNotReleased               StatusCode = 2666
+	StatusCode_SCTeamPermanentlyLeft           StatusCode = 2667
+	StatusCode_SCTeamNeedRootId                StatusCode = 2668
+	StatusCode_SCTeamHasLiveChildren           StatusCode = 2669
+	StatusCode_SCTeamDeleteError               StatusCode = 2670
+	StatusCode_SCTeamBadRootTeam               StatusCode = 2671
+	StatusCode_SCTeamNameConflictsWithUser     StatusCode = 2672
+	StatusCode_SCTeamDeleteNoUpPointer         StatusCode = 2673
+	StatusCode_SCTeamNeedOwner                 StatusCode = 2674
+	StatusCode_SCTeamNoOwnerAllowed            StatusCode = 2675
+	StatusCode_SCTeamImplicitNoNonSbs          StatusCode = 2676
+	StatusCode_SCTeamImplicitBadHash           StatusCode = 2677
+	StatusCode_SCTeamImplicitBadName           StatusCode = 2678
+	StatusCode_SCTeamImplicitClash             StatusCode = 2679
+	StatusCode_SCTeamImplicitDuplicate         StatusCode = 2680
+	StatusCode_SCTeamImplicitBadOp             StatusCode = 2681
+	StatusCode_SCTeamImplicitBadRole           StatusCode = 2682
+	StatusCode_SCTeamImplicitNotFound          StatusCode = 2683
+	StatusCode_SCTeamBadAdminSeqnoType         StatusCode = 2684
+	StatusCode_SCTeamImplicitBadAdd            StatusCode = 2685
+	StatusCode_SCTeamImplicitBadRemove         StatusCode = 2686
+	StatusCode_SCTeamInviteTokenReused         StatusCode = 2696
+	StatusCode_SCTeamKeyMaskNotFound           StatusCode = 2697
+	StatusCode_SCTeamBanned                    StatusCode = 2702
+	StatusCode_SCTeamInvalidBan                StatusCode = 2703
+	StatusCode_SCTeamShowcasePermDenied        StatusCode = 2711
+	StatusCode_SCTeamProvisionalCanKey         StatusCode = 2721
+	StatusCode_SCTeamProvisionalCannotKey      StatusCode = 2722
+	StatusCode_SCEphemeralKeyBadGeneration     StatusCode = 2900
+	StatusCode_SCEphemeralKeyUnexpectedBox     StatusCode = 2901
+	StatusCode_SCEphemeralKeyMissingBox        StatusCode = 2902
+	StatusCode_SCEphemeralKeyWrongNumberOfKeys StatusCode = 2903
+	StatusCode_SCEphemeralKeyMismatchedKey     StatusCode = 2904
+	StatusCode_SCStellarError                  StatusCode = 3100
+	StatusCode_SCStellarBadInput               StatusCode = 3101
+	StatusCode_SCStellarWrongRevision          StatusCode = 3102
+	StatusCode_SCStellarMissingBundle          StatusCode = 3103
+	StatusCode_SCStellarBadPuk                 StatusCode = 3104
+	StatusCode_SCStellarMissingAccount         StatusCode = 3105
+	StatusCode_SCStellarBadPrev                StatusCode = 3106
 )
 
 func (o StatusCode) DeepCopy() StatusCode { return o }
 
 var StatusCodeMap = map[string]StatusCode{
-	"SCOk":                        0,
-	"SCInputError":                100,
-	"SCLoginRequired":             201,
-	"SCBadSession":                202,
-	"SCBadLoginUserNotFound":      203,
-	"SCBadLoginPassword":          204,
-	"SCNotFound":                  205,
-	"SCThrottleControl":           210,
-	"SCDeleted":                   216,
-	"SCGeneric":                   218,
-	"SCAlreadyLoggedIn":           235,
-	"SCExists":                    230,
-	"SCCanceled":                  237,
-	"SCInputCanceled":             239,
-	"SCReloginRequired":           274,
-	"SCResolutionFailed":          275,
-	"SCProfileNotPublic":          276,
-	"SCIdentifyFailed":            277,
-	"SCTrackingBroke":             278,
-	"SCWrongCryptoFormat":         279,
-	"SCDecryptionError":           280,
-	"SCInvalidAddress":            281,
-	"SCNoSession":                 283,
-	"SCAccountReset":              290,
-	"SCIdentifiesFailed":          295,
-	"SCNoSpaceOnDevice":           297,
-	"SCBadEmail":                  472,
-	"SCBadSignupUsernameTaken":    701,
-	"SCBadInvitationCode":         707,
-	"SCMissingResult":             801,
-	"SCKeyNotFound":               901,
-	"SCKeyCorrupted":              905,
-	"SCKeyInUse":                  907,
-	"SCKeyBadGen":                 913,
-	"SCKeyNoSecret":               914,
-	"SCKeyBadUIDs":                915,
-	"SCKeyNoActive":               916,
-	"SCKeyNoSig":                  917,
-	"SCKeyBadSig":                 918,
-	"SCKeyBadEldest":              919,
-	"SCKeyNoEldest":               920,
-	"SCKeyDuplicateUpdate":        921,
-	"SCSibkeyAlreadyExists":       922,
-	"SCDecryptionKeyNotFound":     924,
-	"SCKeyNoPGPEncryption":        927,
-	"SCKeyNoNaClEncryption":       928,
-	"SCKeySyncedPGPNotFound":      929,
-	"SCKeyNoMatchingGPG":          930,
-	"SCKeyRevoked":                931,
-	"SCSigOldSeqno":               1010,
-	"SCBadTrackSession":           1301,
-	"SCDeviceBadName":             1404,
-	"SCDeviceNameInUse":           1408,
-	"SCDeviceNotFound":            1409,
-	"SCDeviceMismatch":            1410,
-	"SCDeviceRequired":            1411,
-	"SCDevicePrevProvisioned":     1413,
-	"SCDeviceNoProvision":         1414,
-	"SCDeviceProvisionViaDevice":  1415,
-	"SCRevokeCurrentDevice":       1416,
-	"SCRevokeLastDevice":          1417,
-	"SCDeviceProvisionOffline":    1418,
-	"SCRevokeLastDevicePGP":       1419,
-	"SCStreamExists":              1501,
-	"SCStreamNotFound":            1502,
-	"SCStreamWrongKind":           1503,
-	"SCStreamEOF":                 1504,
-	"SCGenericAPIError":           1600,
-	"SCAPINetworkError":           1601,
-	"SCTimeout":                   1602,
-	"SCProofError":                1701,
-	"SCIdentificationExpired":     1702,
-	"SCSelfNotFound":              1703,
-	"SCBadKexPhrase":              1704,
-	"SCNoUIDelegation":            1705,
-	"SCNoUI":                      1706,
-	"SCGPGUnavailable":            1707,
-	"SCInvalidVersionError":       1800,
-	"SCOldVersionError":           1801,
-	"SCInvalidLocationError":      1802,
-	"SCServiceStatusError":        1803,
-	"SCInstallError":              1804,
-	"SCLoadKextError":             1810,
-	"SCLoadKextPermError":         1811,
-	"SCGitInternal":               2300,
-	"SCGitRepoAlreadyExists":      2301,
-	"SCGitInvalidRepoName":        2302,
-	"SCGitCannotDelete":           2303,
-	"SCGitRepoDoesntExist":        2304,
-	"SCLoginStateTimeout":         2400,
-	"SCChatInternal":              2500,
-	"SCChatRateLimit":             2501,
-	"SCChatConvExists":            2502,
-	"SCChatUnknownTLFID":          2503,
-	"SCChatNotInConv":             2504,
-	"SCChatBadMsg":                2505,
-	"SCChatBroadcast":             2506,
-	"SCChatAlreadySuperseded":     2507,
-	"SCChatAlreadyDeleted":        2508,
-	"SCChatTLFFinalized":          2509,
-	"SCChatCollision":             2510,
-	"SCIdentifySummaryError":      2511,
-	"SCNeedSelfRekey":             2512,
-	"SCNeedOtherRekey":            2513,
-	"SCChatMessageCollision":      2514,
-	"SCChatDuplicateMessage":      2515,
-	"SCChatClientError":           2516,
-	"SCChatNotInTeam":             2517,
-	"SCChatStalePreviousState":    2518,
-	"SCTeamBadMembership":         2604,
-	"SCTeamSelfNotOwner":          2607,
-	"SCTeamNotFound":              2614,
-	"SCTeamExists":                2619,
-	"SCTeamReadError":             2623,
-	"SCNoOp":                      2638,
-	"SCTeamInviteBadToken":        2646,
-	"SCTeamTarDuplicate":          2663,
-	"SCTeamTarNotFound":           2664,
-	"SCTeamMemberExists":          2665,
-	"SCTeamNotReleased":           2666,
-	"SCTeamPermanentlyLeft":       2667,
-	"SCTeamNeedRootId":            2668,
-	"SCTeamHasLiveChildren":       2669,
-	"SCTeamDeleteError":           2670,
-	"SCTeamBadRootTeam":           2671,
-	"SCTeamNameConflictsWithUser": 2672,
-	"SCTeamDeleteNoUpPointer":     2673,
-	"SCTeamNeedOwner":             2674,
-	"SCTeamNoOwnerAllowed":        2675,
-	"SCTeamImplicitNoNonSbs":      2676,
-	"SCTeamImplicitBadHash":       2677,
-	"SCTeamImplicitBadName":       2678,
-	"SCTeamImplicitClash":         2679,
-	"SCTeamImplicitDuplicate":     2680,
-	"SCTeamImplicitBadOp":         2681,
-	"SCTeamImplicitBadRole":       2682,
-	"SCTeamImplicitNotFound":      2683,
-	"SCTeamBadAdminSeqnoType":     2684,
-	"SCTeamImplicitBadAdd":        2685,
-	"SCTeamImplicitBadRemove":     2686,
-	"SCTeamInviteTokenReused":     2696,
-	"SCTeamKeyMaskNotFound":       2697,
-	"SCTeamBanned":                2702,
-	"SCTeamInvalidBan":            2703,
-	"SCTeamShowcasePermDenied":    2711,
-	"SCTeamProvisionalCanKey":     2721,
-	"SCTeamProvisionalCannotKey":  2722,
-	"SCStellarError":              3100,
-	"SCStellarBadInput":           3101,
-	"SCStellarWrongRevision":      3102,
-	"SCStellarMissingBundle":      3103,
-	"SCStellarBadPuk":             3104,
-	"SCStellarMissingAccount":     3105,
-	"SCStellarBadPrev":            3106,
+	"SCOk":                            0,
+	"SCInputError":                    100,
+	"SCLoginRequired":                 201,
+	"SCBadSession":                    202,
+	"SCBadLoginUserNotFound":          203,
+	"SCBadLoginPassword":              204,
+	"SCNotFound":                      205,
+	"SCThrottleControl":               210,
+	"SCDeleted":                       216,
+	"SCGeneric":                       218,
+	"SCAlreadyLoggedIn":               235,
+	"SCExists":                        230,
+	"SCCanceled":                      237,
+	"SCInputCanceled":                 239,
+	"SCReloginRequired":               274,
+	"SCResolutionFailed":              275,
+	"SCProfileNotPublic":              276,
+	"SCIdentifyFailed":                277,
+	"SCTrackingBroke":                 278,
+	"SCWrongCryptoFormat":             279,
+	"SCDecryptionError":               280,
+	"SCInvalidAddress":                281,
+	"SCNoSession":                     283,
+	"SCAccountReset":                  290,
+	"SCIdentifiesFailed":              295,
+	"SCNoSpaceOnDevice":               297,
+	"SCBadEmail":                      472,
+	"SCBadSignupUsernameTaken":        701,
+	"SCBadInvitationCode":             707,
+	"SCMissingResult":                 801,
+	"SCKeyNotFound":                   901,
+	"SCKeyCorrupted":                  905,
+	"SCKeyInUse":                      907,
+	"SCKeyBadGen":                     913,
+	"SCKeyNoSecret":                   914,
+	"SCKeyBadUIDs":                    915,
+	"SCKeyNoActive":                   916,
+	"SCKeyNoSig":                      917,
+	"SCKeyBadSig":                     918,
+	"SCKeyBadEldest":                  919,
+	"SCKeyNoEldest":                   920,
+	"SCKeyDuplicateUpdate":            921,
+	"SCSibkeyAlreadyExists":           922,
+	"SCDecryptionKeyNotFound":         924,
+	"SCKeyNoPGPEncryption":            927,
+	"SCKeyNoNaClEncryption":           928,
+	"SCKeySyncedPGPNotFound":          929,
+	"SCKeyNoMatchingGPG":              930,
+	"SCKeyRevoked":                    931,
+	"SCSigWrongKey":                   1008,
+	"SCSigOldSeqno":                   1010,
+	"SCBadTrackSession":               1301,
+	"SCDeviceBadName":                 1404,
+	"SCDeviceNameInUse":               1408,
+	"SCDeviceNotFound":                1409,
+	"SCDeviceMismatch":                1410,
+	"SCDeviceRequired":                1411,
+	"SCDevicePrevProvisioned":         1413,
+	"SCDeviceNoProvision":             1414,
+	"SCDeviceProvisionViaDevice":      1415,
+	"SCRevokeCurrentDevice":           1416,
+	"SCRevokeLastDevice":              1417,
+	"SCDeviceProvisionOffline":        1418,
+	"SCRevokeLastDevicePGP":           1419,
+	"SCStreamExists":                  1501,
+	"SCStreamNotFound":                1502,
+	"SCStreamWrongKind":               1503,
+	"SCStreamEOF":                     1504,
+	"SCGenericAPIError":               1600,
+	"SCAPINetworkError":               1601,
+	"SCTimeout":                       1602,
+	"SCProofError":                    1701,
+	"SCIdentificationExpired":         1702,
+	"SCSelfNotFound":                  1703,
+	"SCBadKexPhrase":                  1704,
+	"SCNoUIDelegation":                1705,
+	"SCNoUI":                          1706,
+	"SCGPGUnavailable":                1707,
+	"SCInvalidVersionError":           1800,
+	"SCOldVersionError":               1801,
+	"SCInvalidLocationError":          1802,
+	"SCServiceStatusError":            1803,
+	"SCInstallError":                  1804,
+	"SCLoadKextError":                 1810,
+	"SCLoadKextPermError":             1811,
+	"SCGitInternal":                   2300,
+	"SCGitRepoAlreadyExists":          2301,
+	"SCGitInvalidRepoName":            2302,
+	"SCGitCannotDelete":               2303,
+	"SCGitRepoDoesntExist":            2304,
+	"SCLoginStateTimeout":             2400,
+	"SCChatInternal":                  2500,
+	"SCChatRateLimit":                 2501,
+	"SCChatConvExists":                2502,
+	"SCChatUnknownTLFID":              2503,
+	"SCChatNotInConv":                 2504,
+	"SCChatBadMsg":                    2505,
+	"SCChatBroadcast":                 2506,
+	"SCChatAlreadySuperseded":         2507,
+	"SCChatAlreadyDeleted":            2508,
+	"SCChatTLFFinalized":              2509,
+	"SCChatCollision":                 2510,
+	"SCIdentifySummaryError":          2511,
+	"SCNeedSelfRekey":                 2512,
+	"SCNeedOtherRekey":                2513,
+	"SCChatMessageCollision":          2514,
+	"SCChatDuplicateMessage":          2515,
+	"SCChatClientError":               2516,
+	"SCChatNotInTeam":                 2517,
+	"SCChatStalePreviousState":        2518,
+	"SCTeamBadMembership":             2604,
+	"SCTeamSelfNotOwner":              2607,
+	"SCTeamNotFound":                  2614,
+	"SCTeamExists":                    2619,
+	"SCTeamReadError":                 2623,
+	"SCNoOp":                          2638,
+	"SCTeamInviteBadToken":            2646,
+	"SCTeamTarDuplicate":              2663,
+	"SCTeamTarNotFound":               2664,
+	"SCTeamMemberExists":              2665,
+	"SCTeamNotReleased":               2666,
+	"SCTeamPermanentlyLeft":           2667,
+	"SCTeamNeedRootId":                2668,
+	"SCTeamHasLiveChildren":           2669,
+	"SCTeamDeleteError":               2670,
+	"SCTeamBadRootTeam":               2671,
+	"SCTeamNameConflictsWithUser":     2672,
+	"SCTeamDeleteNoUpPointer":         2673,
+	"SCTeamNeedOwner":                 2674,
+	"SCTeamNoOwnerAllowed":            2675,
+	"SCTeamImplicitNoNonSbs":          2676,
+	"SCTeamImplicitBadHash":           2677,
+	"SCTeamImplicitBadName":           2678,
+	"SCTeamImplicitClash":             2679,
+	"SCTeamImplicitDuplicate":         2680,
+	"SCTeamImplicitBadOp":             2681,
+	"SCTeamImplicitBadRole":           2682,
+	"SCTeamImplicitNotFound":          2683,
+	"SCTeamBadAdminSeqnoType":         2684,
+	"SCTeamImplicitBadAdd":            2685,
+	"SCTeamImplicitBadRemove":         2686,
+	"SCTeamInviteTokenReused":         2696,
+	"SCTeamKeyMaskNotFound":           2697,
+	"SCTeamBanned":                    2702,
+	"SCTeamInvalidBan":                2703,
+	"SCTeamShowcasePermDenied":        2711,
+	"SCTeamProvisionalCanKey":         2721,
+	"SCTeamProvisionalCannotKey":      2722,
+	"SCEphemeralKeyBadGeneration":     2900,
+	"SCEphemeralKeyUnexpectedBox":     2901,
+	"SCEphemeralKeyMissingBox":        2902,
+	"SCEphemeralKeyWrongNumberOfKeys": 2903,
+	"SCEphemeralKeyMismatchedKey":     2904,
+	"SCStellarError":                  3100,
+	"SCStellarBadInput":               3101,
+	"SCStellarWrongRevision":          3102,
+	"SCStellarMissingBundle":          3103,
+	"SCStellarBadPuk":                 3104,
+	"SCStellarMissingAccount":         3105,
+	"SCStellarBadPrev":                3106,
 }
 
 var StatusCodeRevMap = map[StatusCode]string{
@@ -375,6 +387,7 @@ var StatusCodeRevMap = map[StatusCode]string{
 	929:  "SCKeySyncedPGPNotFound",
 	930:  "SCKeyNoMatchingGPG",
 	931:  "SCKeyRevoked",
+	1008: "SCSigWrongKey",
 	1010: "SCSigOldSeqno",
 	1301: "SCBadTrackSession",
 	1404: "SCDeviceBadName",
@@ -473,6 +486,11 @@ var StatusCodeRevMap = map[StatusCode]string{
 	2711: "SCTeamShowcasePermDenied",
 	2721: "SCTeamProvisionalCanKey",
 	2722: "SCTeamProvisionalCannotKey",
+	2900: "SCEphemeralKeyBadGeneration",
+	2901: "SCEphemeralKeyUnexpectedBox",
+	2902: "SCEphemeralKeyMissingBox",
+	2903: "SCEphemeralKeyWrongNumberOfKeys",
+	2904: "SCEphemeralKeyMismatchedKey",
 	3100: "SCStellarError",
 	3101: "SCStellarBadInput",
 	3102: "SCStellarWrongRevision",

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/metadata.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/metadata.go
@@ -148,6 +148,37 @@ func (o LockContext) DeepCopy() LockContext {
 	}
 }
 
+type FindNextMDResponse struct {
+	KbfsRoot    MerkleRoot `codec:"kbfsRoot" json:"kbfsRoot"`
+	MerkleNodes [][]byte   `codec:"merkleNodes" json:"merkleNodes"`
+	RootSeqno   Seqno      `codec:"rootSeqno" json:"rootSeqno"`
+	RootHash    HashMeta   `codec:"rootHash" json:"rootHash"`
+}
+
+func (o FindNextMDResponse) DeepCopy() FindNextMDResponse {
+	return FindNextMDResponse{
+		KbfsRoot: o.KbfsRoot.DeepCopy(),
+		MerkleNodes: (func(x [][]byte) [][]byte {
+			if x == nil {
+				return nil
+			}
+			var ret [][]byte
+			for _, v := range x {
+				vCopy := (func(x []byte) []byte {
+					if x == nil {
+						return nil
+					}
+					return append([]byte{}, x...)
+				})(v)
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.MerkleNodes),
+		RootSeqno: o.RootSeqno.DeepCopy(),
+		RootHash:  o.RootHash.DeepCopy(),
+	}
+}
+
 type GetChallengeArg struct {
 }
 
@@ -271,8 +302,16 @@ type GetMerkleNodeArg struct {
 	Hash string `codec:"hash" json:"hash"`
 }
 
+type FindNextMDArg struct {
+	Seqno    Seqno  `codec:"seqno" json:"seqno"`
+	FolderID string `codec:"folderID" json:"folderID"`
+}
+
 type SetImplicitTeamModeForTestArg struct {
 	ImplicitTeamMode string `codec:"implicitTeamMode" json:"implicitTeamMode"`
+}
+
+type ForceMerkleBuildForTestArg struct {
 }
 
 type MetadataInterface interface {
@@ -300,7 +339,9 @@ type MetadataInterface interface {
 	GetMerkleRootLatest(context.Context, MerkleTreeID) (MerkleRoot, error)
 	GetMerkleRootSince(context.Context, GetMerkleRootSinceArg) (MerkleRoot, error)
 	GetMerkleNode(context.Context, string) ([]byte, error)
+	FindNextMD(context.Context, FindNextMDArg) (FindNextMDResponse, error)
 	SetImplicitTeamModeForTest(context.Context, string) error
+	ForceMerkleBuildForTest(context.Context) error
 }
 
 func MetadataProtocol(i MetadataInterface) rpc.Protocol {
@@ -676,6 +717,22 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"findNextMD": {
+				MakeArg: func() interface{} {
+					ret := make([]FindNextMDArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]FindNextMDArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]FindNextMDArg)(nil), args)
+						return
+					}
+					ret, err = i.FindNextMD(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 			"setImplicitTeamModeForTest": {
 				MakeArg: func() interface{} {
 					ret := make([]SetImplicitTeamModeForTestArg, 1)
@@ -688,6 +745,17 @@ func MetadataProtocol(i MetadataInterface) rpc.Protocol {
 						return
 					}
 					err = i.SetImplicitTeamModeForTest(ctx, (*typedArgs)[0].ImplicitTeamMode)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"forceMerkleBuildForTest": {
+				MakeArg: func() interface{} {
+					ret := make([]ForceMerkleBuildForTestArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					err = i.ForceMerkleBuildForTest(ctx)
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -828,8 +896,18 @@ func (c MetadataClient) GetMerkleNode(ctx context.Context, hash string) (res []b
 	return
 }
 
+func (c MetadataClient) FindNextMD(ctx context.Context, __arg FindNextMDArg) (res FindNextMDResponse, err error) {
+	err = c.Cli.Call(ctx, "keybase.1.metadata.findNextMD", []interface{}{__arg}, &res)
+	return
+}
+
 func (c MetadataClient) SetImplicitTeamModeForTest(ctx context.Context, implicitTeamMode string) (err error) {
 	__arg := SetImplicitTeamModeForTestArg{ImplicitTeamMode: implicitTeamMode}
 	err = c.Cli.Call(ctx, "keybase.1.metadata.setImplicitTeamModeForTest", []interface{}{__arg}, nil)
+	return
+}
+
+func (c MetadataClient) ForceMerkleBuildForTest(ctx context.Context) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.metadata.forceMerkleBuildForTest", []interface{}{ForceMerkleBuildForTestArg{}}, nil)
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,10 +250,10 @@
 			"revisionTime": "2018-01-25T22:56:34Z"
 		},
 		{
-			"checksumSHA1": "BhgT6vw7d71sUMLjHdbJHXzAnfc=",
+			"checksumSHA1": "HuRMa/HPqmBqkdX9+sHvEhuqnGE=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "24bdbdf884a64ea0c21cefd1f9542d2e8cc5c4ae",
-			"revisionTime": "2018-04-30T23:04:41Z"
+			"revision": "9b584e3c99154967e6210a5ef61084a0ca98e881",
+			"revisionTime": "2018-05-02T17:14:53Z"
 		},
 		{
 			"checksumSHA1": "IyAzfN+HALS4a6dvPR3C7xryMbM=",


### PR DESCRIPTION
This PR adds the `FindNextMD` call, and the various merkle data structures needed to use it.  It will be used in a future PR.

Issue: KBFS-2904