### PR TITLE
libfs: don't error on fileinfo when last writer is a team

### DIFF
--- a/libfs/file_info.go
+++ b/libfs/file_info.go
@@ -91,6 +91,12 @@ func (fis fileInfoSys) LastWriter() (keybase1.User, error) {
 		return keybase1.User{}, err
 	}
 	lastWriterName := md.LastWriterUnverified
+	if lastWriterName == "" {
+		// This can happen in old, buggy team folders where the writer
+		// isn't properly set.  See KBFS-2939.
+		return keybase1.User{}, nil
+	}
+
 	_, id, err := fis.fi.fs.config.KBPKI().Resolve(
 		fis.fi.fs.ctx, lastWriterName.String())
 	if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2090,10 +2090,15 @@ func (fbo *folderBranchOps) GetNodeMetadata(ctx context.Context, node Node) (
 	if id.IsNil() {
 		id = de.Creator
 	}
-	res.LastWriterUnverified, err =
-		fbo.config.KBPKI().GetNormalizedUsername(ctx, id)
-	if err != nil {
-		return res, err
+	// Only set the last resolved writer if it's really a user ID.
+	// This works around an old teams bug where the TeamWriter isn't
+	// set.  See KBFS-2939.
+	if id.IsUser() {
+		res.LastWriterUnverified, err =
+			fbo.config.KBPKI().GetNormalizedUsername(ctx, id)
+		if err != nil {
+			return res, err
+		}
 	}
 	prefetchStatus := fbo.config.PrefetchStatus(ctx, fbo.id(),
 		res.BlockInfo.BlockPointer)


### PR DESCRIPTION
There was a bug in some very old team folders where the last writer of a file might be unset.  Previously it ended up defaulting back to the team ID, which caused an error to surface in the GUI.  Instead, just use a blank string/ID.

Issue: KBFS-2939