### PR TITLE
md_ops: check revoked keys using the merkle tree

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -1170,8 +1171,8 @@ type RevokedDeviceVerificationError struct {
 
 // Error implements the Error interface for RevokedDeviceVerificationError.
 func (e RevokedDeviceVerificationError) Error() string {
-	return fmt.Sprintf("Device was revoked at time %d, root seqno %d",
-		e.info.Time, e.info.MerkleRoot.Seqno)
+	return fmt.Sprintf("Device was revoked at time %s, root seqno %d",
+		e.info.Time.Time().Format(time.RFC3339Nano), e.info.MerkleRoot.Seqno)
 }
 
 // MDWrittenAfterRevokeError indicates that we failed to verify an MD

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1159,3 +1159,17 @@ func (e DiskBlockCacheError) ToStatus() (s keybase1.Status) {
 func (e DiskBlockCacheError) Error() string {
 	return "DiskBlockCacheError{" + e.Msg + "}"
 }
+
+// RevokedDeviceVerificationError indicates that the user is trying to
+// verify a key that has been revoked.  It includes useful information
+// about the revocation, so the code receiving the error can check if
+// the device was valid at the time of the data being checked.
+type RevokedDeviceVerificationError struct {
+	info revokedKeyInfo
+}
+
+// Error implements the Error interface for RevokedDeviceVerificationError.
+func (e RevokedDeviceVerificationError) Error() string {
+	return fmt.Sprintf("Device was revoked at time %d, root seqno %d",
+		e.info.Time, e.info.MerkleRoot.Seqno)
+}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1173,3 +1173,20 @@ func (e RevokedDeviceVerificationError) Error() string {
 	return fmt.Sprintf("Device was revoked at time %d, root seqno %d",
 		e.info.Time, e.info.MerkleRoot.Seqno)
 }
+
+// MDWrittenAfterRevokeError indicates that we failed to verify an MD
+// revision because it was written after the last valid revision that
+// the corresponding device could have written.
+type MDWrittenAfterRevokeError struct {
+	tlfID        tlf.ID
+	revBad       kbfsmd.Revision
+	revLimit     kbfsmd.Revision
+	verifyingKey kbfscrypto.VerifyingKey
+}
+
+// Error implements the Error interface for MDWrittenAfterRevokeError.
+func (e MDWrittenAfterRevokeError) Error() string {
+	return fmt.Sprintf("Faled to verify revision %d of folder %s by key %s; "+
+		"last valid revision would have been %d",
+		e.revBad, e.tlfID, e.verifyingKey, e.revLimit)
+}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -667,7 +667,11 @@ type KBPKI interface {
 	gitMetadataPutter
 
 	// HasVerifyingKey returns nil if the given user has the given
-	// VerifyingKey, and an error otherwise.
+	// VerifyingKey, and an error otherwise.  If the revoked key was
+	// valid according to the untrusted server timestamps, a special
+	// error type `RevokedDeviceVerificationError` is returned, which
+	// includes information the caller can use to verify the key using
+	// the merkle tree.
 	HasVerifyingKey(ctx context.Context, uid keybase1.UID,
 		verifyingKey kbfscrypto.VerifyingKey,
 		atServerTime time.Time) error

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -153,14 +153,14 @@ func (k *KBPKIClient) hasVerifyingKey(ctx context.Context, uid keybase1.UID,
 	// period of time until it learns about the revoke.
 	const revokeSlack = 1 * time.Minute
 	revokedTime := keybase1.FromTime(info.Time)
-	// Trust the server times -- if the key was valid at the given
-	// time, we are good to go.  TODO: use Merkle data to check
-	// the server timestamps, to prove the server isn't lying.
+	// Check the server times -- if the key was valid at the given
+	// time, the caller can proceed with their merkle checking if
+	// desired.
 	if atServerTime.Before(revokedTime.Add(revokeSlack)) {
-		k.log.CDebugf(ctx, "Trusting revoked verifying key %s for user %s "+
-			"(revoked time: %v vs. server time %v, slack=%s)",
+		k.log.CDebugf(ctx, "Revoked verifying key %s for user %s passes time "+
+			"check (revoked time: %v vs. server time %v, slack=%s)",
 			verifyingKey.KID(), uid, revokedTime, atServerTime, revokeSlack)
-		return true, nil
+		return false, RevokedDeviceVerificationError{info}
 	}
 	k.log.CDebugf(ctx, "Not trusting revoked verifying key %s for "+
 		"user %s (revoked time: %v vs. server time %v, slack=%s)",

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -116,7 +117,7 @@ func TestKBPKIClientHasRevokedVerifyingKey(t *testing.T) {
 	// Something verified before the key was revoked
 	err := c.HasVerifyingKey(context.Background(), keybase1.MakeTestUID(1),
 		revokedKey, revokeTime.Add(-10*time.Second))
-	if err != nil {
+	if _, ok := errors.Cause(err).(RevokedDeviceVerificationError); !ok {
 		t.Error(err)
 	}
 

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -818,7 +818,7 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 			}
 			for key, serverHalfIDs := range userRemovalInfo.DeviceServerHalfIDs {
 				km.log.CInfof(ctx, "Rekey %s: removing %d server key halves "+
-					" for device %s of user %s", md.TlfID(),
+					"for device %s of user %s", md.TlfID(),
 					len(serverHalfIDs), key, uid)
 				for _, serverHalfID := range serverHalfIDs {
 					err := kops.DeleteTLFCryptKeyServerHalf(

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -241,12 +241,12 @@ func (md *MDOpsStandard) verifyKey(
 			}
 		}
 
-		// TODO: check the most recent global merkle root and KBFS
-		// merkle root ctimes and make sure they fall within the
-		// expected error window with respect to the revocation.  Also
-		// eventually check the blockchain-published merkles to make
-		// sure the server isn't lying (though that will have a much
-		// larger error window).
+		// TODO(KBFS-2956): check the most recent global merkle root
+		// and KBFS merkle root ctimes and make sure they fall within
+		// the expected error window with respect to the revocation.
+		// Also eventually check the blockchain-published merkles to
+		// make sure the server isn't lying (though that will have a
+		// much larger error window).
 		return true, nil
 	}
 
@@ -295,10 +295,10 @@ func (md *MDOpsStandard) verifyKey(
 		return false, err
 	}
 
-	// TODO: check with the service to verify the global root info, to
-	// make sure it fits into our view of the global merkle tree and
-	// that it indeed points to the leaf we're using via `kbfsRoot`
-	// and all the `merkleNodes`.
+	// TODO(KBFS-2954): check with the service to verify the global
+	// root info, to make sure it fits into our view of the global
+	// merkle tree and that it indeed points to the leaf we're using
+	// via `kbfsRoot` and all the `merkleNodes`.
 
 	return true, nil
 }
@@ -435,7 +435,7 @@ func (e everyoneOnEveryTeamChecker) IsTeamReader(
 func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	handle *TlfHandle, rmds *RootMetadataSigned, extra kbfsmd.ExtraMetadata,
 	getRangeLock *sync.Mutex) (ImmutableRootMetadata, error) {
-	// First, verify validity and signatures. Until KBFS-2904 is
+	// First, verify validity and signatures. Until KBFS-2955 is
 	// complete, KBFS doesn't check for team membership on MDs that
 	// have been fetched from the server, because if the writer has
 	// been removed from the team since the MD was written, we have no
@@ -444,7 +444,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	// secret key as a way to prove that only an authorized team
 	// member wrote the update, along with trusting that the server
 	// would have rejected an update from a former team member that is
-	// still using an old key.  TODO(KBFS-2904): remove this.
+	// still using an old key.  TODO(KBFS-2955): remove this.
 	err := rmds.IsValidAndSigned(
 		ctx, md.config.Codec(),
 		everyoneOnEveryTeamChecker{}, extra)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -195,6 +195,11 @@ func (md *MDOpsStandard) verifyKey(
 	case nil:
 		return true, nil
 	case RevokedDeviceVerificationError:
+		// TODO(KBFS-2963): Support team-keyed TLFs.
+		if irmd.TypeForKeying() == tlf.TeamKeying {
+			md.log.CDebugf(ctx, "Skipping team folder verification for now")
+			return false, nil
+		}
 		if ctx.Value(ctxMDOpsSkipKeyVerification) != nil {
 			md.log.CDebugf(ctx,
 				"Skipping revoked key verification due to recursion")

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -100,7 +100,6 @@ func (md *MDOpsStandard) decryptMerkleLeaf(
 	}
 
 	currRmd := rmd
-	//var fetched []*RootMetadataSigned
 	for {
 		// If currRmd isn't readable, keep fetching MDs until it can
 		// be read.  Then try currRmd.data.TLFPrivateKey to decrypt
@@ -504,7 +503,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	irmd := MakeImmutableRootMetadata(rmd, key, mdID, localTimestamp, true)
 
 	// Then, verify the verifying keys.  We do this after decrypting
-	// the MD and making the ImmutableRootMetadata, since we way need
+	// the MD and making the ImmutableRootMetadata, since we may need
 	// access to the private metadata when checking the merkle roots,
 	// and we also need access to the `mdID`.
 	if err := md.verifyWriterKey(


### PR DESCRIPTION
[This shouldn't be merged until we deploy the FindNextMD RPC.]

The algorithm is:

* Make a preliminary check against the untrusted server timestamps, as before.  If that fails, fail the verification.
* Fetch the merkle info from the mdserver, using the key revocation merkle root.
* If the server doesn't return anything, verify that the revision has a valid chain of updates up to the current head of the TLF.  If everything checks out, consider it valid. TODO in a future PR: make sure there's not a big merkle time gap between the revision and the head, or else the server might be lying.
* Otherwise, for private and team folders, we need to decrypt the merkle leaf, but we don't know what key generation was used for it. So, starting at the revision we care about, iterate forwards and try each new key generation we find.
* If the leaf revision corresponding to the revocation is smaller than the MD we're verifying, fail the verification because the MD was written too late.
* Otherwise, verify the chain of MDs between the revision we're verifying and the leaf revision.  If everything checks out, consider it valid.

Still TODO in a future PR: cross-check the global merkle root info with the service, to make sure it all fits together with our view of the global merkle tree.

Issue: KBFS-2904
