### PR TITLE
Use omitemptyrecursive with omitemptycheckstruct

### DIFF
--- a/kbfsmd/root_metadata_v2.go
+++ b/kbfsmd/root_metadata_v2.go
@@ -57,8 +57,8 @@ type WriterMetadataV2 struct {
 	MDRefBytes uint64 `codec:",omitempty"`
 
 	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitempty for structs.
-	Extra WriterMetadataExtraV2 `codec:"x,omitempty,omitemptycheckstruct"`
+	// go-codec that supports omitemptyrecursive.
+	Extra WriterMetadataExtraV2 `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
 }
 
 // ToWriterMetadataV3 converts the WriterMetadataV2 to a

--- a/kbfsmd/root_metadata_v2_test.go
+++ b/kbfsmd/root_metadata_v2_test.go
@@ -193,8 +193,8 @@ type writerMetadataV2Future struct {
 	// Override WriterMetadata.Extra.
 	//
 	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitempty for structs.
-	Extra writerMetadataExtraV2Future `codec:"x,omitempty,omitemptycheckstruct"`
+	// go-codec that supports omitemptyrecursive.
+	Extra writerMetadataExtraV2Future `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
 }
 
 func (wmf writerMetadataV2Future) toCurrent() WriterMetadataV2 {


### PR DESCRIPTION
This is in preparation for a go-codec update.