### PR TITLE
Avoid rare overflow in file offsets on 32-bit builds.

### DIFF
--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -1096,9 +1096,9 @@ func (fd *fileData) write(ctx context.Context, data []byte, off int64,
 
 		// Take care not to write past the beginning of the next block
 		// by using max.
-		max := len(data)
+		max := int64(len(data))
 		if nextBlockOff > 0 {
-			if room := int(nextBlockOff - off); room < max {
+			if room := nextBlockOff - off; room < max {
 				max = room
 			}
 		}


### PR DESCRIPTION
This occured on 32 bit builds.
If `nextBlockOff - off` overflowed a 32 bit signed integer, then room ended up being negative. Which was smaller than max, and thus max got an invalid value.