### PR TITLE
move the mime type overrider into a ResponseWriter wrapper

### DIFF
--- a/libhttpserver/content_type_utils.go
+++ b/libhttpserver/content_type_utils.go
@@ -1,0 +1,80 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libhttpserver
+
+import (
+	"net/http"
+	"strings"
+)
+
+type contentTypeOverridingResponseWriter struct {
+	original http.ResponseWriter
+}
+
+var _ http.ResponseWriter = (*contentTypeOverridingResponseWriter)(nil)
+
+func newContentTypeOverridingResponseWriter(
+	original http.ResponseWriter) *contentTypeOverridingResponseWriter {
+	return &contentTypeOverridingResponseWriter{
+		original: original,
+	}
+}
+
+func (w *contentTypeOverridingResponseWriter) overrideMimeType(
+	mimeType string) (newMimeType string) {
+	// Send text/plain for all HTML and JS files to avoid them being executed
+	// by the frontend WebView.
+	lower := strings.ToLower(mimeType)
+	if strings.Contains(lower, "javascript") ||
+		strings.Contains(lower, "html") {
+		return "text/plain"
+	}
+	return mimeType
+}
+
+func (w *contentTypeOverridingResponseWriter) override() {
+	t := w.original.Header().Get("Content-Type")
+	if len(t) > 0 {
+		w.original.Header().Set("Content-Type", w.overrideMimeType(t))
+	}
+	w.original.Header().Set("X-Content-Type-Options", "nosniff")
+}
+
+func (w *contentTypeOverridingResponseWriter) Header() http.Header {
+	return w.original.Header()
+}
+
+func (w *contentTypeOverridingResponseWriter) WriteHeader(statusCode int) {
+	w.override()
+	w.original.WriteHeader(statusCode)
+}
+
+func (w *contentTypeOverridingResponseWriter) Write(data []byte) (int, error) {
+	w.override()
+	return w.original.Write(data)
+}
+
+var additionalMimeTypes = map[string]string{
+	".go":    "text/plain",
+	".py":    "text/plain",
+	".zsh":   "text/plain",
+	".fish":  "text/plain",
+	".cs":    "text/plain",
+	".rb":    "text/plain",
+	".m":     "text/plain",
+	".mm":    "text/plain",
+	".swift": "text/plain",
+	".flow":  "text/plain",
+	".php":   "text/plain",
+	".pl":    "text/plain",
+	".sh":    "text/plain",
+	".js":    "text/plain",
+	".json":  "text/plain",
+	".sql":   "text/plain",
+	".rs":    "text/plain",
+	".xml":   "text/plain",
+	".tex":   "text/plain",
+	".pub":   "text/plain",
+}

--- a/libmime/patch.go
+++ b/libmime/patch.go
@@ -18,7 +18,7 @@ import "mime"
 //
 // Note that due to unpredictibility of what's on the device's file system,
 // merely using this function may not be enough if you want to override a
-// particularly mime type (e.g. text/javascript). To do so you should check the
+// particular mime type (e.g. text/javascript). To do so you should check the
 // determined mime type at a later time, e.g. before writing the HTTP response.
 func Patch(additional map[string]string) {
 	for ext, mimeType := range mimeTypes {

--- a/libmime/patch.go
+++ b/libmime/patch.go
@@ -6,36 +6,25 @@ package libmime
 
 import "mime"
 
-// Overrider defines a type that overrides a <ext, mimeType> mapping.
-type Overrider func(ext string, mimeType string) (newExt string, newMimeType string)
-
-func dontOverride(ext string, mimeType string) (newExt string, newMimeType string) {
-	return ext, mimeType
-}
-
 // Patch patches the mime types Go uses by calling mime.AddExtensionType on
-// each from a private list in this package.  Both parameters are optional.
-// Provide a non-nil additional map (ext->mimeType) to add additional mime
-// types. Provide a non-nil Overrider to override any mime type defined in the
-// list. Note that the Overrider can override what's in the additional too.
+// each from a builtin list in this package.  Optionally, provide a non-nil
+// additional map (ext->mimeType) to add additional mime types. The additional
+// mime types are added after the builtin ones, and both builtin ones and the
+// additional ones are added after the `mime` package loads from a few
+// filesystem locations such as /etc/apache2/mime.types. In other words, the
+// overriding precedence is:
+//     filesystem -> builtin in this package -> optional additional parameter
+// where the ones on right side can override what's from ones on the left side.
 //
-// Overrider is different from additional in the way that, additional provides
-// exact ext-mimeType pairs, while overrider allows the user of this function
-// to examine ext-mimeTypes flexibly. For example, this allows overrider to
-// replace mimeTypes without an exaustive list of all extensions that resolve
-// to it. So why is additional useful? Go's mime package loads mime types from
-// a few filesystem locations such as /etc/apache2/mime.types. This happens
-// inside the mime package and is beyond our control. So having additional here
-// allows user to guard against unwanted mime types that may exist in one of
-// mime type files.
-func Patch(additional map[string]string, override Overrider) {
-	if override == nil {
-		override = dontOverride
-	}
+// Note that due to unpredictibility of what's on the device's file system,
+// merely using this function may not be enough if you want to override a
+// particularly mime type (e.g. text/javascript). To do so you should check the
+// determined mime type at a later time, e.g. before writing the HTTP response.
+func Patch(additional map[string]string) {
 	for ext, mimeType := range mimeTypes {
-		mime.AddExtensionType(override(ext, mimeType))
+		mime.AddExtensionType(ext, mimeType)
 	}
 	for ext, mimeType := range additional {
-		mime.AddExtensionType(override(ext, mimeType))
+		mime.AddExtensionType(ext, mimeType)
 	}
 }

--- a/libpages/server.go
+++ b/libpages/server.go
@@ -564,7 +564,7 @@ func ListenAndServe(ctx context.Context,
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	libmime.Patch(nil, nil)
+	libmime.Patch(nil)
 
 	server := &Server{
 		config:     config,


### PR DESCRIPTION
This should entirely eliminate the possibilities of returning `text/javascript` or `test/html` to front end. We can add other sensitive mime types later if we want.

I'll have a follow-up PR in client to make GUI always use this interface to determine the mime type, either through HEAD or GET.