### PR TITLE
Revert "Use omitemptyrecursive with omitemptycheckstruct (#1572)"

### DIFF
--- a/kbfsmd/root_metadata_v2.go
+++ b/kbfsmd/root_metadata_v2.go
@@ -57,8 +57,8 @@ type WriterMetadataV2 struct {
 	MDRefBytes uint64 `codec:",omitempty"`
 
 	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitemptyrecursive.
-	Extra WriterMetadataExtraV2 `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
+	// go-codec that supports omitempty for structs.
+	Extra WriterMetadataExtraV2 `codec:"x,omitempty,omitemptycheckstruct"`
 }
 
 // ToWriterMetadataV3 converts the WriterMetadataV2 to a

--- a/kbfsmd/root_metadata_v2_test.go
+++ b/kbfsmd/root_metadata_v2_test.go
@@ -193,8 +193,8 @@ type writerMetadataV2Future struct {
 	// Override WriterMetadata.Extra.
 	//
 	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitemptyrecursive.
-	Extra writerMetadataExtraV2Future `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
+	// go-codec that supports omitempty for structs.
+	Extra writerMetadataExtraV2Future `codec:"x,omitempty,omitemptycheckstruct"`
 }
 
 func (wmf writerMetadataV2Future) toCurrent() WriterMetadataV2 {


### PR DESCRIPTION
This reverts commit 5cae975949afcbcff4355b8ad89ac463e290b0da.  That commit broke writer MD verification for `/keybase/public/airthom` (at least).  See #1578.  Reverting the commit fixes it again.  I guess we needed those structs to be non-empty for verification to pass.