### PR TITLE
Use omitemptyrecursive with omitemptycheckstruct

### DIFF
--- a/kbfsmd/root_metadata_v2.go
+++ b/kbfsmd/root_metadata_v2.go
@@ -57,8 +57,8 @@ type WriterMetadataV2 struct {
 	MDRefBytes uint64 `codec:",omitempty"`
 
 	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitempty for structs.
-	Extra WriterMetadataExtraV2 `codec:"x,omitempty,omitemptycheckstruct"`
+	// go-codec that supports omitemptyrecursive.
+	Extra WriterMetadataExtraV2 `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
 }
 
 // ToWriterMetadataV3 converts the WriterMetadataV2 to a

--- a/kbfsmd/root_metadata_v2.go
+++ b/kbfsmd/root_metadata_v2.go
@@ -56,9 +56,9 @@ type WriterMetadataV2 struct {
 	// real v2 MDs in the wild won't ever have this set).
 	MDRefBytes uint64 `codec:",omitempty"`
 
-	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitemptyrecursive.
-	Extra WriterMetadataExtraV2 `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
+	// TODO: Remove omitempty and omitemptycheckstruct once we use
+	// a version of go-codec that supports omitemptyrecursive.
+	Extra WriterMetadataExtraV2 `codec:"x,omitemptyrecursive,omitempty,omitemptycheckstruct"`
 }
 
 // ToWriterMetadataV3 converts the WriterMetadataV2 to a

--- a/kbfsmd/root_metadata_v2_test.go
+++ b/kbfsmd/root_metadata_v2_test.go
@@ -192,9 +192,9 @@ type writerMetadataV2Future struct {
 	WKeys tlfWriterKeyGenerationsV2Future
 	// Override WriterMetadata.Extra.
 	//
-	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitemptyrecursive.
-	Extra writerMetadataExtraV2Future `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
+	// TODO: Remove omitempty and omitemptycheckstruct once we use
+	// a version of go-codec that supports omitemptyrecursive.
+	Extra writerMetadataExtraV2Future `codec:"x,omitemptyrecursive,omitempty,omitemptycheckstruct"`
 }
 
 func (wmf writerMetadataV2Future) toCurrent() WriterMetadataV2 {

--- a/kbfsmd/root_metadata_v2_test.go
+++ b/kbfsmd/root_metadata_v2_test.go
@@ -193,8 +193,8 @@ type writerMetadataV2Future struct {
 	// Override WriterMetadata.Extra.
 	//
 	// TODO: Remove omitemptycheckstruct once we use a version of
-	// go-codec that supports omitempty for structs.
-	Extra writerMetadataExtraV2Future `codec:"x,omitempty,omitemptycheckstruct"`
+	// go-codec that supports omitemptyrecursive.
+	Extra writerMetadataExtraV2Future `codec:"x,omitemptyrecursive,omitemptycheckstruct"`
 }
 
 func (wmf writerMetadataV2Future) toCurrent() WriterMetadataV2 {


### PR DESCRIPTION
This is a fixed version of a previous PR, which erroneously removed omitempty
(which omitemptycheckstruct still needs).