### PR TITLE
md_ops: check merkle time gaps when verifying a revoked key

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2840,7 +2840,7 @@ func (fbo *folderBranchOps) signalWrite() {
 		go func() {
 			defer fbo.merkleFetches.Done()
 			newCtx := fbo.ctxWithFBOID(context.Background())
-			_, err := fbo.config.KBPKI().GetCurrentMerkleRoot(newCtx)
+			_, _, err := fbo.config.KBPKI().GetCurrentMerkleRoot(newCtx)
 			if err != nil {
 				fbo.log.CDebugf(newCtx, "Couldn't fetch merkle root: %+v", err)
 			}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -440,7 +440,8 @@ type KBFSOps interface {
 type merkleRootGetter interface {
 	// GetCurrentMerkleRoot returns the current root of the global
 	// Keybase Merkle tree.
-	GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error)
+	GetCurrentMerkleRoot(ctx context.Context) (
+		keybase1.MerkleRootV2, time.Time, error)
 	// VerifyMerkleRoot checks that the specified merkle root
 	// contains the given KBFS root; if not, it returns an error.
 	VerifyMerkleRoot(

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1594,6 +1594,7 @@ type mdServerLocal interface {
 	isShutdown() bool
 	copy(config mdServerLocalConfig) mdServerLocal
 	enableImplicitTeams()
+	setKbfsMerkleRoot(treeID keybase1.MerkleTreeID, root *kbfsmd.MerkleRoot)
 }
 
 // BlockServer gets and puts opaque data blocks.  The instantiation

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1577,7 +1577,7 @@ type MDServer interface {
 	// returned metadata object.
 	FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
 		nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
-		nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error)
+		nextRootSeqno keybase1.Seqno, err error)
 
 	// GetMerkleRootLatest returns the latest KBFS merkle root for the
 	// given tree ID.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1577,7 +1577,12 @@ type MDServer interface {
 	// returned metadata object.
 	FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
 		nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
-		nextRootSeqno keybase1.Seqno, err error)
+		nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error)
+
+	// GetMerkleRootLatest returns the latest KBFS merkle root for the
+	// given tree ID.
+	GetMerkleRootLatest(ctx context.Context, treeID keybase1.MerkleTreeID) (
+		root *kbfsmd.MerkleRoot, err error)
 }
 
 type mdServerLocal interface {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -101,7 +101,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 
 	// Ignore MerkleRoot calls for now.
 	config.mockKbpki.EXPECT().GetCurrentMerkleRoot(gomock.Any()).
-		Return(keybase1.MerkleRootV2{}, nil).AnyTimes()
+		Return(keybase1.MerkleRootV2{}, time.Time{}, nil).AnyTimes()
 
 	// Max out MaxPtrsPerBlock
 	config.mockBsplit.EXPECT().MaxPtrsPerBlock().

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -224,7 +224,7 @@ func (k *KBPKIClient) GetTeamTLFCryptKeys(
 
 // GetCurrentMerkleRoot implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) GetCurrentMerkleRoot(ctx context.Context) (
-	keybase1.MerkleRootV2, error) {
+	keybase1.MerkleRootV2, time.Time, error) {
 	return k.serviceOwner.KeybaseService().GetCurrentMerkleRoot(ctx)
 }
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1004,11 +1004,16 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev2, uid2, 0)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev3, uid2, 0)
 
-	SetGlobalMerkleRootOrBust(t, config1, keybase1.MerkleRootV2{}, clock.Now())
-	SetGlobalMerkleRootOrBust(
+	SetGlobalMerkleRootForTestOrBust(
+		t, config1, keybase1.MerkleRootV2{}, clock.Now())
+	SetGlobalMerkleRootForTestOrBust(
 		t, config2Dev2, keybase1.MerkleRootV2{}, clock.Now())
-	SetGlobalMerkleRootOrBust(
+	SetGlobalMerkleRootForTestOrBust(
 		t, config2Dev3, keybase1.MerkleRootV2{}, clock.Now())
+	SetKbfsMerkleRootForTestOrBust(
+		t, config1, keybase1.MerkleTreeID_KBFS_PRIVATE, &kbfsmd.MerkleRoot{
+			Timestamp: clock.Now().Unix(),
+		})
 
 	// First request a rekey from the new device, which will only be
 	// able to set the rekey bit (copying the root MD).
@@ -2060,8 +2065,12 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 	clock.Add(1 * time.Minute)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev2, uid1, 0)
 
-	SetGlobalMerkleRootOrBust(
+	SetGlobalMerkleRootForTestOrBust(
 		t, config2Dev2, keybase1.MerkleRootV2{}, clock.Now())
+	SetKbfsMerkleRootForTestOrBust(
+		t, config2Dev2, keybase1.MerkleTreeID_KBFS_PRIVATE, &kbfsmd.MerkleRoot{
+			Timestamp: clock.Now().Unix(),
+		})
 
 	t.Log("Doing first rekey")
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1004,6 +1004,12 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev2, uid2, 0)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev3, uid2, 0)
 
+	SetGlobalMerkleRootOrBust(t, config1, keybase1.MerkleRootV2{}, clock.Now())
+	SetGlobalMerkleRootOrBust(
+		t, config2Dev2, keybase1.MerkleRootV2{}, clock.Now())
+	SetGlobalMerkleRootOrBust(
+		t, config2Dev3, keybase1.MerkleRootV2{}, clock.Now())
+
 	// First request a rekey from the new device, which will only be
 	// able to set the rekey bit (copying the root MD).
 	_, err = RequestRekeyAndWaitForOneFinishEvent(ctx,
@@ -2053,6 +2059,9 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 	// Revoke some previous device
 	clock.Add(1 * time.Minute)
 	RevokeDeviceForLocalUserOrBust(t, config2Dev2, uid1, 0)
+
+	SetGlobalMerkleRootOrBust(
+		t, config2Dev2, keybase1.MerkleRootV2{}, clock.Now())
 
 	t.Log("Doing first rekey")
 

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -514,6 +514,14 @@ func (k *KeybaseDaemonLocal) VerifyMerkleRoot(
 	return nil
 }
 
+func (k *KeybaseDaemonLocal) setCurrentMerkleRoot(
+	root keybase1.MerkleRootV2, rootTime time.Time) {
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	k.merkleRoot = root
+	k.merkleTime = rootTime
+}
+
 // CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) CurrentSession(ctx context.Context, sessionID int) (
 	SessionInfo, error) {

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -165,6 +166,7 @@ type KeybaseDaemonLocal struct {
 	implicitAsserts    map[string]keybase1.TeamID
 	favoriteStore      favoriteStore
 	merkleRoot         keybase1.MerkleRootV2
+	merkleTime         time.Time
 }
 
 var _ KeybaseService = &KeybaseDaemonLocal{}
@@ -496,14 +498,14 @@ func (k *KeybaseDaemonLocal) GetTeamSettings(
 // GetCurrentMerkleRoot implements the KeybaseService interface for
 // KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) GetCurrentMerkleRoot(ctx context.Context) (
-	keybase1.MerkleRootV2, error) {
+	keybase1.MerkleRootV2, time.Time, error) {
 	if err := checkContext(ctx); err != nil {
-		return keybase1.MerkleRootV2{}, err
+		return keybase1.MerkleRootV2{}, time.Time{}, err
 	}
 
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	return k.merkleRoot, nil
+	return k.merkleRoot, k.merkleTime, nil
 }
 
 // VerifyMerkleRoot implements the KBPKI interface for KeybaseDaemonLocal.

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -211,8 +211,6 @@ func (k *KeybaseServiceBase) filterRevokedKeys(
 			info.sigChainLocation = key.Base.Revocation.SigChainLocation
 		} else if reset != nil {
 			info.Time = keybase1.ToTime(keybase1.FromUnixTime(reset.Ctime))
-			// TODO(CORE-7933): get a verified sequence number from
-			// the service.
 			info.MerkleRoot.Seqno = reset.MerkleRoot.Seqno
 			info.MerkleRoot.HashMeta = reset.MerkleRoot.HashMeta
 			// If we don't have a prev seqno, then we already have the

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -211,6 +211,8 @@ func (k *KeybaseServiceBase) filterRevokedKeys(
 			info.sigChainLocation = key.Base.Revocation.SigChainLocation
 		} else if reset != nil {
 			info.Time = keybase1.ToTime(keybase1.FromUnixTime(reset.Ctime))
+			// TODO(CORE-7933): get a verified sequence number from
+			// the service.
 			info.MerkleRoot.Seqno = reset.MerkleRoot.Seqno
 			info.MerkleRoot.HashMeta = reset.MerkleRoot.HashMeta
 			// If we don't have a prev seqno, then we already have the

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -5,6 +5,8 @@
 package libkbfs
 
 import (
+	"time"
+
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -167,11 +169,11 @@ func (k KeybaseServiceMeasured) GetTeamSettings(
 // GetCurrentMerkleRoot implements the KeybaseService interface for
 // KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) GetCurrentMerkleRoot(ctx context.Context) (
-	root keybase1.MerkleRootV2, err error) {
+	root keybase1.MerkleRootV2, updateTime time.Time, err error) {
 	k.getCurrentMerkleRootTimer.Time(func() {
-		root, err = k.delegate.GetCurrentMerkleRoot(ctx)
+		root, updateTime, err = k.delegate.GetCurrentMerkleRoot(ctx)
 	})
-	return root, err
+	return root, updateTime, err
 }
 
 // VerifyMerkleRoot implements the KBPKI interface for

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -111,8 +111,8 @@ type constMerkleRootGetter struct{}
 var _ merkleRootGetter = constMerkleRootGetter{}
 
 func (cmrg constMerkleRootGetter) GetCurrentMerkleRoot(
-	ctx context.Context) (keybase1.MerkleRootV2, error) {
-	return keybase1.MerkleRootV2{}, nil
+	ctx context.Context) (keybase1.MerkleRootV2, time.Time, error) {
+	return keybase1.MerkleRootV2{}, time.Time{}, nil
 }
 
 func (cmrg constMerkleRootGetter) VerifyMerkleRoot(

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -219,12 +219,12 @@ func (md *MDOpsStandard) makeMerkleLeaf(
 }
 
 func mdToMerkleTreeID(irmd ImmutableRootMetadata) keybase1.MerkleTreeID {
-	switch irmd.TypeForKeying() {
-	case tlf.PrivateKeying:
+	switch irmd.TlfID().Type() {
+	case tlf.Private:
 		return keybase1.MerkleTreeID_KBFS_PRIVATE
-	case tlf.PublicKeying:
+	case tlf.Public:
 		return keybase1.MerkleTreeID_KBFS_PUBLIC
-	case tlf.TeamKeying:
+	case tlf.SingleTeam:
 		return keybase1.MerkleTreeID_KBFS_PRIVATETEAM
 	default:
 		panic(fmt.Sprintf("Unexpected TLF keying type: %d",

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -369,10 +369,8 @@ func (md *MDOpsStandard) checkRevisionCameBeforeMerkle(
 	// Check the gap between the revocation and the global/KBFS roots
 	// that include the revocation, to make sure they fall within the
 	// expected error window.  The server didn't begin enforcing this
-	// until some time into KBFS's existence though.  TODO(CORE-7924):
-	// remove the one minute slack once we have a more exact seqno
-	// that includes the revocation.
-	revokeTime := keybase1.FromTime(info.Time).Add(-1 * time.Minute)
+	// until some time into KBFS's existence though.
+	revokeTime := keybase1.FromTime(info.Time)
 	if revokeTime.After(merkleGapEnforcementStart) {
 		// TODO(KBFS-2954): get the right root time for the
 		// corresponding global root.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -26,13 +26,14 @@ const (
 	// writes if more than 3 hours have passed since the last Merkle
 	// roots (both global and KBFS) were published.  Add some padding
 	// to that, and if we see any gaps larger than this, we will know
-	// we shouldn't be trusting the server.
-	maxAllowedMerkleGap = 3*time.Hour + 15*time.Minute
+	// we shouldn't be trusting the server.  TODO: reduce this once
+	// merkle computation is faster.
+	maxAllowedMerkleGap = 8*time.Hour + 15*time.Minute
 
 	// merkleGapEnforcementStartString indicates when the mdserver
 	// started rejecting new writes based on the lack of recent merkle
 	// updates (according to `maxAllowedMerkleGap` above).
-	merkleGapEnforcementStartString = "2018-05-17T00:00:00+07:00"
+	merkleGapEnforcementStartString = "2018-05-22T13:19:00-07:00"
 )
 
 var merkleGapEnforcementStart time.Time
@@ -40,7 +41,7 @@ var merkleGapEnforcementStart time.Time
 func init() {
 	var err error
 	merkleGapEnforcementStart, err = time.Parse(
-		"2006-01-02T15:04:05+07:00", merkleGapEnforcementStartString)
+		"2006-01-02T15:04:05-07:00", merkleGapEnforcementStartString)
 	if err != nil {
 		// Can never happen without a bad global const string.
 		panic(err)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -369,8 +369,10 @@ func (md *MDOpsStandard) checkRevisionCameBeforeMerkle(
 	// Check the gap between the revocation and the global/KBFS roots
 	// that include the revocation, to make sure they fall within the
 	// expected error window.  The server didn't begin enforcing this
-	// until some time into KBFS's existence though.
-	revokeTime := keybase1.FromTime(info.Time)
+	// until some time into KBFS's existence though.  TODO(CORE-7924):
+	// remove the one minute slack once we have a more exact seqno
+	// that includes the revocation.
+	revokeTime := keybase1.FromTime(info.Time).Add(-1 * time.Minute)
 	if revokeTime.After(merkleGapEnforcementStart) {
 		// TODO(KBFS-2954): get the right root time for the
 		// corresponding global root.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -33,7 +33,7 @@ const (
 	// merkleGapEnforcementStartString indicates when the mdserver
 	// started rejecting new writes based on the lack of recent merkle
 	// updates (according to `maxAllowedMerkleGap` above).
-	merkleGapEnforcementStartString = "2018-05-22T13:19:00-07:00"
+	merkleGapEnforcementStartString = "2018-06-14T16:21:30-07:00"
 )
 
 var merkleGapEnforcementStart time.Time

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -1053,15 +1053,16 @@ func makeEncryptedMerkleLeafForTesting(
 	var nonce [24]byte
 	_, err = rand.Read(nonce[:])
 	require.NoError(t, err)
+	now := config.Clock().Now().Unix()
 	root = &kbfsmd.MerkleRoot{
-		EPubKey: &ePubKey,
-		Nonce:   &nonce,
+		EPubKey:   &ePubKey,
+		Nonce:     &nonce,
+		Timestamp: now,
 	}
 
-	now := config.Clock().Now()
 	mLeaf = kbfsmd.MerkleLeaf{
 		Revision:  1,
-		Timestamp: now.Unix(),
+		Timestamp: now,
 	}
 	var pubKey kbfscrypto.TLFPublicKey
 	if rmd.TypeForKeying() == tlf.TeamKeying {

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -748,3 +748,10 @@ func (md *MDServerDisk) FindNextMD(
 	nextRootSeqno keybase1.Seqno, err error) {
 	return nil, nil, 0, nil
 }
+
+// GetMerkleRootLatest implements the MDServer interface for MDServerDisk.
+func (md *MDServerDisk) GetMerkleRootLatest(
+	ctx context.Context, treeID keybase1.MerkleTreeID) (
+	root *kbfsmd.MerkleRoot, err error) {
+	return nil, nil
+}

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -1099,3 +1099,10 @@ func (md *MDServerMemory) FindNextMD(
 	nextRootSeqno keybase1.Seqno, err error) {
 	return nil, nil, 0, nil
 }
+
+// GetMerkleRootLatest implements the MDServer interface for MDServerMemory.
+func (md *MDServerMemory) GetMerkleRootLatest(
+	ctx context.Context, treeID keybase1.MerkleTreeID) (
+	root *kbfsmd.MerkleRoot, err error) {
+	return nil, nil
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1449,11 +1449,12 @@ func (m *MockmerkleRootGetter) EXPECT() *MockmerkleRootGetterMockRecorder {
 }
 
 // GetCurrentMerkleRoot mocks base method
-func (m *MockmerkleRootGetter) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error) {
+func (m *MockmerkleRootGetter) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, time.Time, error) {
 	ret := m.ctrl.Call(m, "GetCurrentMerkleRoot", ctx)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(time.Time)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot
@@ -1532,11 +1533,12 @@ func (m *MockKeybaseService) EXPECT() *MockKeybaseServiceMockRecorder {
 }
 
 // GetCurrentMerkleRoot mocks base method
-func (m *MockKeybaseService) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error) {
+func (m *MockKeybaseService) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, time.Time, error) {
 	ret := m.ctrl.Call(m, "GetCurrentMerkleRoot", ctx)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(time.Time)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot
@@ -2319,11 +2321,12 @@ func (mr *MockKBPKIMockRecorder) GetNormalizedUsername(ctx, id interface{}) *gom
 }
 
 // GetCurrentMerkleRoot mocks base method
-func (m *MockKBPKI) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error) {
+func (m *MockKBPKI) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, time.Time, error) {
 	ret := m.ctrl.Call(m, "GetCurrentMerkleRoot", ctx)
 	ret0, _ := ret[0].(keybase1.MerkleRootV2)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(time.Time)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4823,6 +4823,19 @@ func (mr *MockMDServerMockRecorder) FindNextMD(ctx, tlfID, rootSeqno interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNextMD", reflect.TypeOf((*MockMDServer)(nil).FindNextMD), ctx, tlfID, rootSeqno)
 }
 
+// GetMerkleRootLatest mocks base method
+func (m *MockMDServer) GetMerkleRootLatest(ctx context.Context, treeID keybase1.MerkleTreeID) (*kbfsmd.MerkleRoot, error) {
+	ret := m.ctrl.Call(m, "GetMerkleRootLatest", ctx, treeID)
+	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMerkleRootLatest indicates an expected call of GetMerkleRootLatest
+func (mr *MockMDServerMockRecorder) GetMerkleRootLatest(ctx, treeID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleRootLatest", reflect.TypeOf((*MockMDServer)(nil).GetMerkleRootLatest), ctx, treeID)
+}
+
 // MockmdServerLocal is a mock of mdServerLocal interface
 type MockmdServerLocal struct {
 	ctrl     *gomock.Controller
@@ -5122,6 +5135,19 @@ func (m *MockmdServerLocal) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSe
 // FindNextMD indicates an expected call of FindNextMD
 func (mr *MockmdServerLocalMockRecorder) FindNextMD(ctx, tlfID, rootSeqno interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindNextMD", reflect.TypeOf((*MockmdServerLocal)(nil).FindNextMD), ctx, tlfID, rootSeqno)
+}
+
+// GetMerkleRootLatest mocks base method
+func (m *MockmdServerLocal) GetMerkleRootLatest(ctx context.Context, treeID keybase1.MerkleTreeID) (*kbfsmd.MerkleRoot, error) {
+	ret := m.ctrl.Call(m, "GetMerkleRootLatest", ctx, treeID)
+	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMerkleRootLatest indicates an expected call of GetMerkleRootLatest
+func (mr *MockmdServerLocalMockRecorder) GetMerkleRootLatest(ctx, treeID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMerkleRootLatest", reflect.TypeOf((*MockmdServerLocal)(nil).GetMerkleRootLatest), ctx, treeID)
 }
 
 // addNewAssertionForTest mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5209,6 +5209,16 @@ func (mr *MockmdServerLocalMockRecorder) enableImplicitTeams() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "enableImplicitTeams", reflect.TypeOf((*MockmdServerLocal)(nil).enableImplicitTeams))
 }
 
+// setKbfsMerkleRoot mocks base method
+func (m *MockmdServerLocal) setKbfsMerkleRoot(treeID keybase1.MerkleTreeID, root *kbfsmd.MerkleRoot) {
+	m.ctrl.Call(m, "setKbfsMerkleRoot", treeID, root)
+}
+
+// setKbfsMerkleRoot indicates an expected call of setKbfsMerkleRoot
+func (mr *MockmdServerLocalMockRecorder) setKbfsMerkleRoot(treeID, root interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setKbfsMerkleRoot", reflect.TypeOf((*MockmdServerLocal)(nil).setKbfsMerkleRoot), treeID, root)
+}
+
 // MockBlockServer is a mock of BlockServer interface
 type MockBlockServer struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -276,7 +276,7 @@ func (md *RootMetadata) MakeSuccessor(
 	}
 	newMd.SetRevision(md.Revision() + 1)
 
-	merkleRoot, err := merkleGetter.GetCurrentMerkleRoot(ctx)
+	merkleRoot, _, err := merkleGetter.GetCurrentMerkleRoot(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -639,8 +639,8 @@ func ChangeTeamNameForTestOrBust(t logger.TestLogBackend, config Config,
 	}
 }
 
-// SetGlobalMerkleRoot sets the global Merkle root and time.
-func SetGlobalMerkleRoot(
+// SetGlobalMerkleRootForTest sets the global Merkle root and time.
+func SetGlobalMerkleRootForTest(
 	config Config, root keybase1.MerkleRootV2, rootTime time.Time) error {
 	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
 	if !ok {
@@ -651,12 +651,35 @@ func SetGlobalMerkleRoot(
 	return nil
 }
 
-// SetGlobalMerkleRootOrBust is like SetGlobalMerkleRoot, but dies
-// if there's an error.
-func SetGlobalMerkleRootOrBust(
+// SetGlobalMerkleRootForTestOrBust is like
+// SetGlobalMerkleRootForTest, but dies if there's an error.
+func SetGlobalMerkleRootForTestOrBust(
 	t logger.TestLogBackend, config Config, root keybase1.MerkleRootV2,
 	rootTime time.Time) {
-	err := SetGlobalMerkleRoot(config, root, rootTime)
+	err := SetGlobalMerkleRootForTest(config, root, rootTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// SetKbfsMerkleRootForTest sets a Merkle root for the given KBFS tree ID.
+func SetKbfsMerkleRootForTest(
+	config Config, treeID keybase1.MerkleTreeID,
+	root *kbfsmd.MerkleRoot) error {
+	md, ok := config.MDServer().(mdServerLocal)
+	if !ok {
+		return errors.New("Bad md server")
+	}
+	md.setKbfsMerkleRoot(treeID, root)
+	return nil
+}
+
+// SetKbfsMerkleRootForTestOrBust is like SetKbfsMerkleRootForTest,
+// but dies if there's an error.
+func SetKbfsMerkleRootForTestOrBust(
+	t logger.TestLogBackend, config Config, treeID keybase1.MerkleTreeID,
+	root *kbfsmd.MerkleRoot) {
+	err := SetKbfsMerkleRootForTest(config, treeID, root)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -639,6 +639,29 @@ func ChangeTeamNameForTestOrBust(t logger.TestLogBackend, config Config,
 	}
 }
 
+// SetGlobalMerkleRoot sets the global Merkle root and time.
+func SetGlobalMerkleRoot(
+	config Config, root keybase1.MerkleRootV2, rootTime time.Time) error {
+	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
+	if !ok {
+		return errors.New("Bad keybase daemon")
+	}
+
+	kbd.setCurrentMerkleRoot(root, rootTime)
+	return nil
+}
+
+// SetGlobalMerkleRootOrBust is like SetGlobalMerkleRoot, but dies
+// if there's an error.
+func SetGlobalMerkleRootOrBust(
+	t logger.TestLogBackend, config Config, root keybase1.MerkleRootV2,
+	rootTime time.Time) {
+	err := SetGlobalMerkleRoot(config, root, rootTime)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // EnableImplicitTeamsForTest causes the mdserver to stop returning
 // random TLF IDs for new TLFs.
 func EnableImplicitTeamsForTest(config Config) error {


### PR DESCRIPTION
(Note: this depends on #1569, which is blocking on a server deploy.)

This adds interface methods fetch timestamps for both global and KBFS Merkle roots, and uses that to make sure that a) if the mdserver doesn't return any Merkle info after a revoke, that the gap since the last merkle root hasn't been too big; and b) if it does return a Merkle root, there wasn't too big a gap since the revoke happened.

Issue: KBFS-2956