### PR TITLE
md_ops: decrypt team Merkle leafs

### DIFF
--- a/kbfscrypto/encrypted_data.go
+++ b/kbfscrypto/encrypted_data.go
@@ -251,13 +251,13 @@ func MakeEncryptedMerkleLeaf(
 func PrepareMerkleLeaf(encryptedMerkleLeaf EncryptedMerkleLeaf) (
 	nonce [24]byte, err error) {
 	if encryptedMerkleLeaf.Version != EncryptionSecretbox {
-		return [24]byte{},
+		return nonce,
 			errors.WithStack(UnknownEncryptionVer{
 				Ver: encryptedMerkleLeaf.Version})
 	}
 
 	if len(encryptedMerkleLeaf.Nonce) != len(nonce) {
-		return [24]byte{},
+		return nonce,
 			errors.WithStack(InvalidNonceError{
 				Nonce: encryptedMerkleLeaf.Nonce})
 	}
@@ -265,8 +265,8 @@ func PrepareMerkleLeaf(encryptedMerkleLeaf EncryptedMerkleLeaf) (
 	return nonce, nil
 }
 
-// DecryptMerkleLeaf decrypts an EncryptedMerkleLeaf
-// using the given device private key and ephemeral public key.
+// DecryptMerkleLeaf decrypts an EncryptedMerkleLeaf using the given
+// private TLF key and ephemeral public key.
 func DecryptMerkleLeaf(
 	privateKey TLFPrivateKey, publicKey TLFEphemeralPublicKey,
 	encryptedMerkleLeaf EncryptedMerkleLeaf) ([]byte, error) {

--- a/libkbfs/crypto_client_rpc.go
+++ b/libkbfs/crypto_client_rpc.go
@@ -37,6 +37,7 @@ func NewCryptoClientRPC(config Config, kbCtx Context) *CryptoClientRPC {
 	}
 	conn := NewSharedKeybaseConnection(kbCtx, config, c)
 	c.CryptoClient.client = keybase1.CryptoClient{Cli: conn.GetClient()}
+	c.CryptoClient.teamsClient = keybase1.TeamsClient{Cli: conn.GetClient()}
 	c.CryptoClient.shutdownFn = conn.Shutdown
 	return c
 }
@@ -50,6 +51,7 @@ func newCryptoClientWithClient(codec kbfscodec.Codec, log logger.Logger, client 
 			log:          log,
 			deferLog:     deferLog,
 			client:       keybase1.CryptoClient{Cli: client},
+			teamsClient:  keybase1.TeamsClient{Cli: client},
 		},
 	}
 }

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 type FakeCryptoClient struct {
-	Local     CryptoLocal
+	Local     *CryptoLocal
 	readyChan chan<- struct{}
 	goChan    <-chan struct{}
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1162,6 +1162,14 @@ type Crypto interface {
 		promptPaper bool) (
 		kbfscrypto.TLFCryptKeyClientHalf, int, error)
 
+	// DecryptTeamMerkleLeaf decrypts a team-encrypted Merkle leaf
+	// using some team key generation greater than `minKeyGen`, and
+	// the provided ephemeral public key.
+	DecryptTeamMerkleLeaf(ctx context.Context, teamID keybase1.TeamID,
+		publicKey kbfscrypto.TLFEphemeralPublicKey,
+		encryptedMerkleLeaf kbfscrypto.EncryptedMerkleLeaf,
+		minKeyGen keybase1.PerTeamKeyGeneration) ([]byte, error)
+
 	// Shutdown frees any resources associated with this instance.
 	Shutdown()
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3878,6 +3878,19 @@ func (mr *MockCryptoMockRecorder) DecryptTLFCryptKeyClientHalfAny(ctx, keys, pro
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptTLFCryptKeyClientHalfAny", reflect.TypeOf((*MockCrypto)(nil).DecryptTLFCryptKeyClientHalfAny), ctx, keys, promptPaper)
 }
 
+// DecryptTeamMerkleLeaf mocks base method
+func (m *MockCrypto) DecryptTeamMerkleLeaf(ctx context.Context, teamID keybase1.TeamID, publicKey kbfscrypto.TLFEphemeralPublicKey, encryptedMerkleLeaf kbfscrypto.EncryptedMerkleLeaf, minKeyGen keybase1.PerTeamKeyGeneration) ([]byte, error) {
+	ret := m.ctrl.Call(m, "DecryptTeamMerkleLeaf", ctx, teamID, publicKey, encryptedMerkleLeaf, minKeyGen)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DecryptTeamMerkleLeaf indicates an expected call of DecryptTeamMerkleLeaf
+func (mr *MockCryptoMockRecorder) DecryptTeamMerkleLeaf(ctx, teamID, publicKey, encryptedMerkleLeaf, minKeyGen interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptTeamMerkleLeaf", reflect.TypeOf((*MockCrypto)(nil).DecryptTeamMerkleLeaf), ctx, teamID, publicKey, encryptedMerkleLeaf, minKeyGen)
+}
+
 // Shutdown mocks base method
 func (m *MockCrypto) Shutdown() {
 	m.ctrl.Call(m, "Shutdown")

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -402,7 +402,7 @@ func SwitchDeviceForLocalUserOrBust(t logger.TestLogBackend, config Config, inde
 		t.Fatal(err.Error())
 	}
 
-	if _, ok := config.Crypto().(CryptoLocal); !ok {
+	if _, ok := config.Crypto().(*CryptoLocal); !ok {
 		t.Fatal("Bad crypto")
 	}
 

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -77,7 +77,7 @@ type testTLFJournalConfig struct {
 	t            *testing.T
 	tlfID        tlf.ID
 	splitter     BlockSplitter
-	crypto       CryptoLocal
+	crypto       *CryptoLocal
 	bcache       BlockCache
 	bops         BlockOps
 	mdcache      MDCache


### PR DESCRIPTION
(Note: this depends on #1569, which is blocking on a server deploy.)

If a team MD was written by a revoked device and we need to decrypt the Merkle leaf, this PR calls out to the service to get it done (since only the service has access to the team's per-key-generation private key).

If refactors the `kbfsmd.EncryptedMerkleLeaf` class a little to move the actual decryption into `kbfscrypto`, to match some of our other encrypted data types.

Issue: KBFS-2963