### PR TITLE
libkbfs: stop QR early when an unverifiable TLF

### DIFF
--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -657,7 +657,12 @@ func (k *KeybaseDaemonLocal) revokeDeviceForTesting(clock Clock,
 	}
 
 	kbtime := keybase1.ToTime(clock.Now())
-	info := revokedKeyInfo{Time: kbtime}
+	info := revokedKeyInfo{
+		Time: kbtime,
+		MerkleRoot: keybase1.MerkleRootV2{
+			Seqno: 1,
+		},
+	}
 	user.RevokedVerifyingKeys[user.VerifyingKeys[index]] = info
 	user.RevokedCryptPublicKeys[user.CryptPublicKeys[index]] = info
 

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -221,6 +221,13 @@ func (md *MDOpsStandard) verifyKey(
 				"Skipping revoked key verification due to recursion")
 			return false, nil
 		}
+		if e.info.MerkleRoot.Seqno <= 0 {
+			md.log.CDebugf(ctx, "Can't verify an MD written by a revoked "+
+				"device if there's no valid root seqno to check: %d",
+				e.info.MerkleRoot.Seqno)
+			return false, err
+		}
+
 		info = e.info
 		// Fall through to check via the merkle tree.
 	default:


### PR DESCRIPTION
Apparently some users have sigchains with revocations that are missing the root sequence number of when the revocation happened.  In this case, the service tells us they were revoked at seqno 0.  The API server rejects this as an invalid seqno, and gives back an opaque error type, which the mdserver sends back to the client.  A background process like QR treats this as a transient error and tries the TLF again, over and over.

This issue will go away once the service lands CORE-7806, but for now we can prevent this from happening forever by catching the problem early and returning a specific error type that will stop QR early.