### PR TITLE
keybase_service_base: use `FindNextMerkleRootAfterRevoke`

### DIFF
--- a/vendor/github.com/keybase/client/go/protocol/keybase1/account.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/account.go
@@ -40,7 +40,8 @@ type HasServerKeysArg struct {
 }
 
 type ResetAccountArg struct {
-	SessionID int `codec:"sessionID" json:"sessionID"`
+	SessionID  int    `codec:"sessionID" json:"sessionID"`
+	Passphrase string `codec:"passphrase" json:"passphrase"`
 }
 
 type AccountInterface interface {
@@ -54,7 +55,9 @@ type AccountInterface interface {
 	// * Whether the logged-in user has uploaded private keys
 	// * Will error if not logged in.
 	HasServerKeys(context.Context, int) (HasServerKeysRes, error)
-	ResetAccount(context.Context, int) error
+	// resetAccount resets the user's account; it's meant only for devel and tests.
+	// passphrase is optional and will be prompted for if not supplied.
+	ResetAccount(context.Context, ResetAccountArg) error
 }
 
 func AccountProtocol(i AccountInterface) rpc.Protocol {
@@ -136,7 +139,7 @@ func AccountProtocol(i AccountInterface) rpc.Protocol {
 						err = rpc.NewTypeError((*[]ResetAccountArg)(nil), args)
 						return
 					}
-					err = i.ResetAccount(ctx, (*typedArgs)[0].SessionID)
+					err = i.ResetAccount(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodCall,
@@ -176,8 +179,9 @@ func (c AccountClient) HasServerKeys(ctx context.Context, sessionID int) (res Ha
 	return
 }
 
-func (c AccountClient) ResetAccount(ctx context.Context, sessionID int) (err error) {
-	__arg := ResetAccountArg{SessionID: sessionID}
+// resetAccount resets the user's account; it's meant only for devel and tests.
+// passphrase is optional and will be prompted for if not supplied.
+func (c AccountClient) ResetAccount(ctx context.Context, __arg ResetAccountArg) (err error) {
 	err = c.Cli.Call(ctx, "keybase.1.account.resetAccount", []interface{}{__arg}, nil)
 	return
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/ephemeral.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/ephemeral.go
@@ -14,18 +14,20 @@ func (o EkGeneration) DeepCopy() EkGeneration {
 }
 
 type DeviceEkMetadata struct {
-	Kid        KID          `codec:"kid" json:"device_ephemeral_dh_public"`
-	HashMeta   HashMeta     `codec:"hashMeta" json:"hash_meta"`
-	Generation EkGeneration `codec:"generation" json:"generation"`
-	Ctime      Time         `codec:"ctime" json:"ctime"`
+	Kid         KID          `codec:"kid" json:"device_ephemeral_dh_public"`
+	HashMeta    HashMeta     `codec:"hashMeta" json:"hash_meta"`
+	Generation  EkGeneration `codec:"generation" json:"generation"`
+	Ctime       Time         `codec:"ctime" json:"ctime"`
+	DeviceCtime Time         `codec:"deviceCtime" json:"deviceCtime"`
 }
 
 func (o DeviceEkMetadata) DeepCopy() DeviceEkMetadata {
 	return DeviceEkMetadata{
-		Kid:        o.Kid.DeepCopy(),
-		HashMeta:   o.HashMeta.DeepCopy(),
-		Generation: o.Generation.DeepCopy(),
-		Ctime:      o.Ctime.DeepCopy(),
+		Kid:         o.Kid.DeepCopy(),
+		HashMeta:    o.HashMeta.DeepCopy(),
+		Generation:  o.Generation.DeepCopy(),
+		Ctime:       o.Ctime.DeepCopy(),
+		DeviceCtime: o.DeviceCtime.DeepCopy(),
 	}
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -574,6 +574,8 @@ func (s SigID) Exists() bool {
 	return !s.IsNil()
 }
 
+func (s SigID) String() string { return string(s) }
+
 func (s SigID) Equal(t SigID) bool {
 	return s == t
 }
@@ -1830,6 +1832,15 @@ func (t TeamMembersDetails) ActiveUsernames() map[string]bool {
 		m[u.Username] = m[u.Username] || u.Active
 	}
 	return m
+}
+
+func FilterInactiveMembers(arg []TeamMemberDetails) (ret []TeamMemberDetails) {
+	for _, v := range arg {
+		if v.Active {
+			ret = append(ret, v)
+		}
+	}
+	return ret
 }
 
 func (t TeamName) IsNil() bool {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,10 +250,10 @@
 			"revisionTime": "2018-05-19T05:29:12Z"
 		},
 		{
-			"checksumSHA1": "rqJLcuNegL0aONPh05kMeu1tQFA=",
+			"checksumSHA1": "MjgDDXy50RMjl9kMDs6FrO6N9xI=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "94012483abbcf11dd835c21e3fcfda3ede2ad754",
-			"revisionTime": "2018-05-19T05:29:12Z"
+			"revision": "70fb7c9f72ccc200265e5c361bdeaa28a25e63d3",
+			"revisionTime": "2018-05-29T19:39:57Z"
 		},
 		{
 			"checksumSHA1": "X5Xf9+Z7OkhIQiaPB+ILw4xzkag=",


### PR DESCRIPTION
Instead of relying on the `PrevMerkleRootSigned` field in the revocation (which is the seqno that the client performing the revocation saw before pushing it), use the service to look up the exact merkle root that first contains the revocation.

This is more accurate and gets around the issue where some old revocations have a 0 root seqno.

Issue: keybase/client#12101