### PR TITLE
keybase_service_base: don't refine revoked merkle root when prev=0

### DIFF
--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -200,7 +200,7 @@ func (k *KeybaseServiceBase) filterRevokedKeys(
 		if key.Base.Revocation != nil {
 			info.Time = key.Base.Revocation.Time
 			info.MerkleRoot = key.Base.Revocation.PrevMerkleRootSigned
-			// if possible, ask the service to give us the first
+			// If possible, ask the service to give us the first
 			// merkle root that covers this revoke. Some older device
 			// revokes didn't yet include a prev field, so we can't
 			// refine the merkle root in those cases, and will be

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -223,9 +223,8 @@ func (md *MDOpsStandard) verifyKey(
 		}
 		if e.info.MerkleRoot.Seqno <= 0 {
 			md.log.CDebugf(ctx, "Can't verify an MD written by a revoked "+
-				"device if there's no valid root seqno to check: %d",
-				e.info.MerkleRoot.Seqno)
-			return false, err
+				"device if there's no valid root seqno to check: %+e", e)
+			return true, nil
 		}
 
 		info = e.info

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -223,7 +223,7 @@ func (md *MDOpsStandard) verifyKey(
 		}
 		if e.info.MerkleRoot.Seqno <= 0 {
 			md.log.CDebugf(ctx, "Can't verify an MD written by a revoked "+
-				"device if there's no valid root seqno to check: %+e", e)
+				"device if there's no valid root seqno to check: %+v", e)
 			return true, nil
 		}
 


### PR DESCRIPTION
Also don't try to FindNextMD in that case either.  Old revoke sigchain entries just don't have enough information for us to check the merkle info when verifying writes by revoked devices, so we have to rely on server trust.