### PR TITLE
libkbfs: verify the merkle root and KBFS merkle nodes returned by FindNextMD

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -432,6 +432,11 @@ type merkleRootGetter interface {
 	// GetCurrentMerkleRoot returns the current root of the global
 	// Keybase Merkle tree.
 	GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRootV2, error)
+	// VerifyMerkleRoot checks that the specified merkle root
+	// contains the given KBFS root; if not, it returns an error.
+	VerifyMerkleRoot(
+		ctx context.Context, root keybase1.MerkleRootV2,
+		kbfsRoot keybase1.KBFSRoot) error
 }
 
 type gitMetadataPutter interface {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1541,11 +1541,11 @@ type MDServer interface {
 	// tree to be produced after a given Keybase global merkle tree
 	// sequence number `rootSeqno` (and all merkle nodes between it
 	// and the root, and the root itself).  It also returns the global
-	// merkle tree sequence number and hash of the root that first
-	// included the returned metadata object.
+	// merkle tree sequence number of the root that first included the
+	// returned metadata object.
 	FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
 		nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
-		nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error)
+		nextRootSeqno keybase1.Seqno, err error)
 }
 
 type mdServerLocal interface {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -227,6 +227,14 @@ func (k *KBPKIClient) GetCurrentMerkleRoot(ctx context.Context) (
 	return k.serviceOwner.KeybaseService().GetCurrentMerkleRoot(ctx)
 }
 
+// VerifyMerkleRoot implements the KBPKI interface for KBPKIClient.
+func (k *KBPKIClient) VerifyMerkleRoot(
+	ctx context.Context, root keybase1.MerkleRootV2,
+	kbfsRoot keybase1.KBFSRoot) error {
+	return k.serviceOwner.KeybaseService().VerifyMerkleRoot(
+		ctx, root, kbfsRoot)
+}
+
 // IsTeamWriter implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) IsTeamWriter(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -505,6 +505,12 @@ func (k *KeybaseDaemonLocal) GetCurrentMerkleRoot(ctx context.Context) (
 	return k.merkleRoot, nil
 }
 
+// VerifyMerkleRoot implements the KBPKI interface for KeybaseDaemonLocal.
+func (k *KeybaseDaemonLocal) VerifyMerkleRoot(
+	_ context.Context, _ keybase1.MerkleRootV2, _ keybase1.KBFSRoot) error {
+	return nil
+}
+
 // CurrentSession implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) CurrentSession(ctx context.Context, sessionID int) (
 	SessionInfo, error) {

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -70,6 +70,11 @@ func (k *keybaseServiceMerkleGetter) GetCurrentMerkleRoot(
 	return k.k.getCurrentMerkleRoot(ctx)
 }
 
+func (k *keybaseServiceMerkleGetter) VerifyMerkleRoot(
+	_ context.Context, _ keybase1.MerkleRootV2, _ keybase1.KBFSRoot) error {
+	panic("constMerkleRootGetter doesn't verify merkle roots")
+}
+
 // NewKeybaseServiceBase makes a new KeybaseService.
 func NewKeybaseServiceBase(config Config, kbCtx Context, log logger.Logger) *KeybaseServiceBase {
 	k := KeybaseServiceBase{
@@ -803,6 +808,17 @@ func (k *KeybaseServiceBase) GetCurrentMerkleRoot(ctx context.Context) (
 	// block.
 	_, root, err := k.merkleRoot.Get(ctx, 30*time.Second, 60*time.Second)
 	return root, err
+}
+
+// VerifyMerkleRoot implements the KBPKI interface for KeybaseServiceBase.
+func (k *KeybaseServiceBase) VerifyMerkleRoot(
+	ctx context.Context, root keybase1.MerkleRootV2,
+	kbfsRoot keybase1.KBFSRoot) error {
+	return k.merkleClient.VerifyMerkleRootAndKBFS(ctx,
+		keybase1.VerifyMerkleRootAndKBFSArg{
+			Root:             root,
+			ExpectedKBFSRoot: kbfsRoot,
+		})
 }
 
 func (k *KeybaseServiceBase) processUserPlusKeys(

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -26,6 +26,7 @@ type KeybaseServiceMeasured struct {
 	createTeamTLFTimer               metrics.Timer
 	getTeamSettingsTimer             metrics.Timer
 	getCurrentMerkleRootTimer        metrics.Timer
+	verifyMerkleRootTimer            metrics.Timer
 	currentSessionTimer              metrics.Timer
 	favoriteAddTimer                 metrics.Timer
 	favoriteDeleteTimer              metrics.Timer
@@ -50,6 +51,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 	createTeamTLFTimer := metrics.GetOrRegisterTimer("KeybaseService.CreateTeamTLF", r)
 	getTeamSettingsTimer := metrics.GetOrRegisterTimer("KeybaseService.GetTeamSettings", r)
 	getCurrentMerkleRootTimer := metrics.GetOrRegisterTimer("KeybaseService.GetCurrentMerkleRoot", r)
+	verifyMerkleRootTimer := metrics.GetOrRegisterTimer("KeybaseService.VerifyMerkleRoot", r)
 	currentSessionTimer := metrics.GetOrRegisterTimer("KeybaseService.CurrentSession", r)
 	favoriteAddTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteAdd", r)
 	favoriteDeleteTimer := metrics.GetOrRegisterTimer("KeybaseService.FavoriteDelete", r)
@@ -68,6 +70,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 		createTeamTLFTimer:               createTeamTLFTimer,
 		getTeamSettingsTimer:             getTeamSettingsTimer,
 		getCurrentMerkleRootTimer:        getCurrentMerkleRootTimer,
+		verifyMerkleRootTimer:            verifyMerkleRootTimer,
 		currentSessionTimer:              currentSessionTimer,
 		favoriteAddTimer:                 favoriteAddTimer,
 		favoriteDeleteTimer:              favoriteDeleteTimer,
@@ -166,6 +169,17 @@ func (k KeybaseServiceMeasured) GetCurrentMerkleRoot(ctx context.Context) (
 		root, err = k.delegate.GetCurrentMerkleRoot(ctx)
 	})
 	return root, err
+}
+
+// VerifyMerkleRoot implements the KBPKI interface for
+// KeybaseServiceMeasured.
+func (k KeybaseServiceMeasured) VerifyMerkleRoot(
+	ctx context.Context, root keybase1.MerkleRootV2,
+	kbfsRoot keybase1.KBFSRoot) (err error) {
+	k.verifyMerkleRootTimer.Time(func() {
+		err = k.delegate.VerifyMerkleRoot(ctx, root, kbfsRoot)
+	})
+	return err
 }
 
 // CurrentSession implements the KeybaseService interface for

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -115,6 +115,11 @@ func (cmrg constMerkleRootGetter) GetCurrentMerkleRoot(
 	return keybase1.MerkleRootV2{}, nil
 }
 
+func (cmrg constMerkleRootGetter) VerifyMerkleRoot(
+	_ context.Context, _ keybase1.MerkleRootV2, _ keybase1.KBFSRoot) error {
+	return nil
+}
+
 func putMDRangeHelper(t testing.TB, ver kbfsmd.MetadataVer, tlfID tlf.ID,
 	signer kbfscrypto.Signer, firstRevision kbfsmd.Revision,
 	firstPrevRoot kbfsmd.ID, mdCount int, uid keybase1.UID,

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -238,7 +238,7 @@ func (md *MDOpsStandard) verifyKey(
 		irmd.Revision(), irmd.TlfID(), info.Time, info.MerkleRoot.Seqno)
 	ctx = context.WithValue(ctx, ctxMDOpsSkipKeyVerification, struct{}{})
 
-	kbfsRoot, merkleNodes, rootSeqno, _, err :=
+	kbfsRoot, merkleNodes, rootSeqno, err :=
 		md.config.MDServer().FindNextMD(ctx, rmds.MD.TlfID(),
 			info.MerkleRoot.Seqno)
 	if err != nil {
@@ -321,11 +321,6 @@ func (md *MDOpsStandard) verifyKey(
 	if err != nil {
 		return false, err
 	}
-
-	// TODO(KBFS-2954): check with the service to verify the global
-	// root info, to make sure it fits into our view of the global
-	// merkle tree and that it indeed points to the leaf we're using
-	// via `kbfsRoot` and all the `merkleNodes`.
 
 	return true, nil
 }

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -281,6 +281,15 @@ func (md *MDOpsStandard) verifyKey(
 		"Next KBFS merkle root is %d, included in global merkle root seqno=%d",
 		kbfsRoot.SeqNo, rootSeqno)
 
+	// The FindNextMD call already validated the global root, and the
+	// fact that the root contained the given KBFS root.  Now we need
+	// to validate the hashes of the nodes all the way down to the
+	// leaf.
+	err = verifyMerkleNodes(ctx, kbfsRoot, merkleNodes, irmd.TlfID())
+	if err != nil {
+		return false, err
+	}
+
 	// Decode (and possibly decrypt) the leaf node, so we can see what
 	// the given MD revision number was for the MD that followed the
 	// revoke.

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -671,7 +671,7 @@ func (mds *keyBundleMDServer) GetKeyBundles(ctx context.Context, tlfID tlf.ID,
 func (mds *keyBundleMDServer) FindNextMD(
 	ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
 	nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
-	nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error) {
+	nextRootSeqno keybase1.Seqno, err error) {
 	nextKbfsRoot = mds.nextMerkleRoot
 	nextMerkleNodes = mds.nextMerkleNodes
 	nextRootSeqno = mds.nextMerkleRootSeqno
@@ -679,8 +679,7 @@ func (mds *keyBundleMDServer) FindNextMD(
 	mds.nextMerkleRoot = nil
 	mds.nextMerkleNodes = nil
 	mds.nextMerkleRootSeqno = 0
-	return nextKbfsRoot, nextMerkleNodes, nextRootSeqno,
-		keybase1.HashMeta{}, nil
+	return nextKbfsRoot, nextMerkleNodes, nextRootSeqno, nil
 }
 
 func testMDOpsGetRangeSuccessHelper(

--- a/libkbfs/mdserver_disk.go
+++ b/libkbfs/mdserver_disk.go
@@ -745,6 +745,6 @@ func (md *MDServerDisk) FastForwardBackoff() {}
 func (md *MDServerDisk) FindNextMD(
 	ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
 	nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
-	nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error) {
-	return nil, nil, 0, keybase1.HashMeta{}, nil
+	nextRootSeqno keybase1.Seqno, err error) {
+	return nil, nil, 0, nil
 }

--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -1096,6 +1096,6 @@ func (md *MDServerMemory) FastForwardBackoff() {}
 func (md *MDServerMemory) FindNextMD(
 	ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (
 	nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
-	nextRootSeqno keybase1.Seqno, nextRootHash keybase1.HashMeta, err error) {
-	return nil, nil, 0, keybase1.HashMeta{}, nil
+	nextRootSeqno keybase1.Seqno, err error) {
+	return nil, nil, 0, nil
 }

--- a/libkbfs/merkle_checker.go
+++ b/libkbfs/merkle_checker.go
@@ -64,6 +64,8 @@ func verifyMerkleNodes(
 	config := merkle.NewConfig(
 		merkle.SHA512Hasher{}, 256, 512, kbfsmd.MerkleLeaf{})
 	tree := merkle.NewTree(mc, config)
+	// If any of the nodes returned by the server fail to match their
+	// expected hashes, `Find` will return an error.
 	foundLeaf, rootHash, err := tree.Find(ctx, merkle.Hash(tlfID.Bytes()))
 	if err != nil {
 		return err
@@ -73,8 +75,9 @@ func verifyMerkleNodes(
 			rootHash, kbfsRoot.Hash)
 	}
 	// If the checker returned all the nodes except the last one
-	// (which is the encoded leaf), we know they all verified and we
-	// reached the expected leaf.
+	// (which is the encoded leaf, and not directly walked by the
+	// `Find` call above), we know they all verified and we reached
+	// the expected leaf.
 	if mc.nextNode != len(nodes)-1 {
 		return errors.Errorf("We checked %d nodes instead of %d",
 			mc.nextNode, len(nodes))

--- a/libkbfs/merkle_checker.go
+++ b/libkbfs/merkle_checker.go
@@ -1,0 +1,94 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"bytes"
+	"context"
+
+	merkle "github.com/keybase/go-merkle-tree"
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+)
+
+// merkleChecker implements a storage engine that can be used to
+// verify a chain of merkle nodes returned from the server, to
+// validate a given MD leaf.
+type merkleChecker struct {
+	root     *kbfsmd.MerkleRoot
+	nodes    [][]byte
+	nextNode int
+}
+
+var _ merkle.StorageEngine = (*merkleChecker)(nil)
+
+func (mc *merkleChecker) StoreNode(
+	_ context.Context, _ merkle.Hash, _ []byte) error {
+	return errors.New("merkleChecker can't store nodes")
+}
+
+func (mc *merkleChecker) CommitRoot(
+	_ context.Context, _ merkle.Hash, _ merkle.Hash, _ merkle.TxInfo) error {
+	return errors.New("merkleChecker can't commit roots")
+}
+
+func (mc *merkleChecker) LookupNode(
+	_ context.Context, h merkle.Hash) ([]byte, error) {
+	// Assume the hash refers to the next node in the list; if not,
+	// the tree will fail when verifying.
+	if mc.nextNode >= len(mc.nodes) {
+		return nil, errors.Errorf(
+			"Can't lookup node %d when there are only %d nodes",
+			mc.nextNode, len(mc.nodes))
+	}
+	n := mc.nodes[mc.nextNode]
+	mc.nextNode++
+	return n, nil
+}
+
+func (mc *merkleChecker) LookupRoot(_ context.Context) (
+	h merkle.Hash, err error) {
+	return mc.root.Hash, nil
+}
+
+func verifyMerkleNodes(
+	ctx context.Context, kbfsRoot *kbfsmd.MerkleRoot, nodes [][]byte,
+	tlfID tlf.ID) error {
+	// Verify the merkle nodes by pretending to look up the nodes
+	// using a merkle.Tree, which verifies all the nodes along the
+	// path of the lookup.
+	mc := &merkleChecker{kbfsRoot, nodes, 0}
+	config := merkle.NewConfig(
+		merkle.SHA512Hasher{}, 256, 512, kbfsmd.MerkleLeaf{})
+	tree := merkle.NewTree(mc, config)
+	foundLeaf, rootHash, err := tree.Find(ctx, merkle.Hash(tlfID.Bytes()))
+	if err != nil {
+		return err
+	}
+	if !rootHash.Eq(kbfsRoot.Hash) {
+		return errors.Errorf("Root hashes don't match: found=%v, rootHash=%v",
+			rootHash, kbfsRoot.Hash)
+	}
+	// If the checker returned all the nodes except the last one
+	// (which is the encoded leaf), we know they all verified and we
+	// reached the expected leaf.
+	if mc.nextNode != len(nodes)-1 {
+		return errors.Errorf("We checked %d nodes instead of %d",
+			mc.nextNode, len(nodes))
+	}
+
+	leafBytes, ok := foundLeaf.([]byte)
+	if !ok {
+		return errors.Errorf(
+			"Found merkle leaf isn't a byte slice: %T", foundLeaf)
+	}
+
+	if !bytes.Equal(leafBytes, nodes[len(nodes)-1]) {
+		return errors.New("Expected leaf didn't match found leaf")
+	}
+
+	return nil
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1414,6 +1414,18 @@ func (mr *MockmerkleRootGetterMockRecorder) GetCurrentMerkleRoot(ctx interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentMerkleRoot", reflect.TypeOf((*MockmerkleRootGetter)(nil).GetCurrentMerkleRoot), ctx)
 }
 
+// VerifyMerkleRoot mocks base method
+func (m *MockmerkleRootGetter) VerifyMerkleRoot(ctx context.Context, root keybase1.MerkleRootV2, kbfsRoot keybase1.KBFSRoot) error {
+	ret := m.ctrl.Call(m, "VerifyMerkleRoot", ctx, root, kbfsRoot)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMerkleRoot indicates an expected call of VerifyMerkleRoot
+func (mr *MockmerkleRootGetterMockRecorder) VerifyMerkleRoot(ctx, root, kbfsRoot interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMerkleRoot", reflect.TypeOf((*MockmerkleRootGetter)(nil).VerifyMerkleRoot), ctx, root, kbfsRoot)
+}
+
 // MockgitMetadataPutter is a mock of gitMetadataPutter interface
 type MockgitMetadataPutter struct {
 	ctrl     *gomock.Controller
@@ -1483,6 +1495,18 @@ func (m *MockKeybaseService) GetCurrentMerkleRoot(ctx context.Context) (keybase1
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot
 func (mr *MockKeybaseServiceMockRecorder) GetCurrentMerkleRoot(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentMerkleRoot", reflect.TypeOf((*MockKeybaseService)(nil).GetCurrentMerkleRoot), ctx)
+}
+
+// VerifyMerkleRoot mocks base method
+func (m *MockKeybaseService) VerifyMerkleRoot(ctx context.Context, root keybase1.MerkleRootV2, kbfsRoot keybase1.KBFSRoot) error {
+	ret := m.ctrl.Call(m, "VerifyMerkleRoot", ctx, root, kbfsRoot)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMerkleRoot indicates an expected call of VerifyMerkleRoot
+func (mr *MockKeybaseServiceMockRecorder) VerifyMerkleRoot(ctx, root, kbfsRoot interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMerkleRoot", reflect.TypeOf((*MockKeybaseService)(nil).VerifyMerkleRoot), ctx, root, kbfsRoot)
 }
 
 // PutGitMetadata mocks base method
@@ -2232,6 +2256,18 @@ func (m *MockKBPKI) GetCurrentMerkleRoot(ctx context.Context) (keybase1.MerkleRo
 // GetCurrentMerkleRoot indicates an expected call of GetCurrentMerkleRoot
 func (mr *MockKBPKIMockRecorder) GetCurrentMerkleRoot(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentMerkleRoot", reflect.TypeOf((*MockKBPKI)(nil).GetCurrentMerkleRoot), ctx)
+}
+
+// VerifyMerkleRoot mocks base method
+func (m *MockKBPKI) VerifyMerkleRoot(ctx context.Context, root keybase1.MerkleRootV2, kbfsRoot keybase1.KBFSRoot) error {
+	ret := m.ctrl.Call(m, "VerifyMerkleRoot", ctx, root, kbfsRoot)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// VerifyMerkleRoot indicates an expected call of VerifyMerkleRoot
+func (mr *MockKBPKIMockRecorder) VerifyMerkleRoot(ctx, root, kbfsRoot interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyMerkleRoot", reflect.TypeOf((*MockKBPKI)(nil).VerifyMerkleRoot), ctx, root, kbfsRoot)
 }
 
 // IsTeamWriter mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4694,14 +4694,13 @@ func (mr *MockMDServerMockRecorder) FastForwardBackoff() *gomock.Call {
 }
 
 // FindNextMD mocks base method
-func (m *MockMDServer) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, keybase1.HashMeta, error) {
+func (m *MockMDServer) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, error) {
 	ret := m.ctrl.Call(m, "FindNextMD", ctx, tlfID, rootSeqno)
 	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
 	ret1, _ := ret[1].([][]byte)
 	ret2, _ := ret[2].(keybase1.Seqno)
-	ret3, _ := ret[3].(keybase1.HashMeta)
-	ret4, _ := ret[4].(error)
-	return ret0, ret1, ret2, ret3, ret4
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // FindNextMD indicates an expected call of FindNextMD
@@ -4996,14 +4995,13 @@ func (mr *MockmdServerLocalMockRecorder) FastForwardBackoff() *gomock.Call {
 }
 
 // FindNextMD mocks base method
-func (m *MockmdServerLocal) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, keybase1.HashMeta, error) {
+func (m *MockmdServerLocal) FindNextMD(ctx context.Context, tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, error) {
 	ret := m.ctrl.Call(m, "FindNextMD", ctx, tlfID, rootSeqno)
 	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
 	ret1, _ := ret[1].([][]byte)
 	ret2, _ := ret[2].(keybase1.Seqno)
-	ret3, _ := ret[3].(keybase1.HashMeta)
-	ret4, _ := ret[4].(error)
-	return ret0, ret1, ret2, ret3, ret4
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // FindNextMD indicates an expected call of FindNextMD

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -202,3 +202,16 @@ func isWriterFromHandle(
 	}
 	return checker.IsTeamWriter(ctx, tid, uid, verifyingKey)
 }
+
+func tlfToMerkleTreeID(id tlf.ID) keybase1.MerkleTreeID {
+	switch id.Type() {
+	case tlf.Private:
+		return keybase1.MerkleTreeID_KBFS_PRIVATE
+	case tlf.Public:
+		return keybase1.MerkleTreeID_KBFS_PUBLIC
+	case tlf.SingleTeam:
+		return keybase1.MerkleTreeID_KBFS_PRIVATETEAM
+	default:
+		panic(fmt.Sprintf("Unexpected TLF type: %d", id.Type()))
+	}
+}

--- a/vendor/github.com/keybase/go-merkle-tree/README.md
+++ b/vendor/github.com/keybase/go-merkle-tree/README.md
@@ -2,3 +2,5 @@ go-merkle-tree
 ==============
 
 Go language to build and check keybase's sitewide merkle tree.
+
+[![GoDoc](https://godoc.org/github.com/keybase/go-merkle-tree?status.svg)](https://godoc.org/github.com/keybase/go-merkle-tree)

--- a/vendor/github.com/keybase/go-merkle-tree/interfaces.go
+++ b/vendor/github.com/keybase/go-merkle-tree/interfaces.go
@@ -1,10 +1,12 @@
 package merkleTree
 
+import "golang.org/x/net/context"
+
 // StorageEngine specifies how to store and lookup merkle tree nodes
 // and roots.  You can use a DB like Dynamo or SQL to do this.
 type StorageEngine interface {
-	StoreNode(Hash, []byte) error
-	CommitRoot(prev Hash, curr Hash, txinfo TxInfo) error
-	LookupNode(Hash) ([]byte, error)
-	LookupRoot() (Hash, error)
+	StoreNode(context.Context, Hash, []byte) error
+	CommitRoot(ctx context.Context, prev Hash, curr Hash, txinfo TxInfo) error
+	LookupNode(context.Context, Hash) ([]byte, error)
+	LookupRoot(context.Context) (Hash, error)
 }

--- a/vendor/github.com/keybase/go-merkle-tree/mem.go
+++ b/vendor/github.com/keybase/go-merkle-tree/mem.go
@@ -3,6 +3,8 @@ package merkleTree
 import (
 	"crypto/sha512"
 	"encoding/hex"
+
+	"golang.org/x/net/context"
 )
 
 // MemEngine is an in-memory MerkleTree engine, used now mainly for testing
@@ -21,29 +23,29 @@ func NewMemEngine() *MemEngine {
 var _ StorageEngine = (*MemEngine)(nil)
 
 // CommitRoot "commits" the root ot the blessed memory slot
-func (m *MemEngine) CommitRoot(prev Hash, curr Hash, txinfo TxInfo) error {
+func (m *MemEngine) CommitRoot(_ context.Context, prev Hash, curr Hash, txinfo TxInfo) error {
 	m.root = curr
 	return nil
 }
 
 // Hash runs SHA512
-func (m *MemEngine) Hash(d []byte) Hash {
+func (m *MemEngine) Hash(_ context.Context, d []byte) Hash {
 	sum := sha512.Sum512(d)
 	return Hash(sum[:])
 }
 
 // LookupNode looks up a MerkleTree node by hash
-func (m *MemEngine) LookupNode(h Hash) (b []byte, err error) {
+func (m *MemEngine) LookupNode(_ context.Context, h Hash) (b []byte, err error) {
 	return m.nodes[hex.EncodeToString(h)], nil
 }
 
 // LookupRoot fetches the root of the in-memory tree back out
-func (m *MemEngine) LookupRoot() (Hash, error) {
+func (m *MemEngine) LookupRoot(_ context.Context) (Hash, error) {
 	return m.root, nil
 }
 
 // StoreNode stores the given node under the given key.
-func (m *MemEngine) StoreNode(key Hash, b []byte) error {
+func (m *MemEngine) StoreNode(_ context.Context, key Hash, b []byte) error {
 	m.nodes[hex.EncodeToString(key)] = b
 	return nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -414,9 +414,10 @@
 			"revisionTime": "2016-03-16T16:25:20-04:00"
 		},
 		{
+			"checksumSHA1": "OgoahEm1klTnBu8VUttmyqhsi6M=",
 			"path": "github.com/keybase/go-merkle-tree",
-			"revision": "94090372642a4b6fcac21e6f1e71f4050c19d908",
-			"revisionTime": "2016-02-04T22:18:14Z"
+			"revision": "90288bcf8366442e1d29ad22356fae3f2e8254a5",
+			"revisionTime": "2018-02-26T14:35:15Z"
 		},
 		{
 			"path": "github.com/keybase/go-triplesec",


### PR DESCRIPTION
So far, we've been trusting the merkle data returned from the mdserver in `FindNextMD`.  In this PR, we start verifying it.  We call into the service to verify that the global root we have is legitimate and contains the KBFS root we expect it to.  And then we check the nodes of the KBFS merkle tree to make sure they contain the merkle leaf it is supposed to have.

Issue: KBFS-2954