### PR TITLE
keybase_service_base: fill in revoked merkle info on demand

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -33,6 +33,10 @@ type revokedKeyInfo struct {
 	// Fields are exported so they can be copied by the codec.
 	Time       keybase1.Time
 	MerkleRoot keybase1.MerkleRootV2
+
+	// These fields never need copying.
+	sigChainLocation keybase1.SigChainLocation
+	filledInMerkle   bool
 }
 
 // UserInfo contains all the info about a keybase user that kbfs cares

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -563,9 +563,6 @@ func (k *KeybaseServiceBase) ResolveImplicitTeamByID(
 func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 	ctx context.Context, currUserInfo UserInfo, kid keybase1.KID) (
 	newUserInfo UserInfo, exists bool, err error) {
-	k.log.CDebugf(ctx, "Checking merkle info for user %s, revoked key %s",
-		currUserInfo.UID, kid)
-
 	for key, info := range currUserInfo.RevokedVerifyingKeys {
 		if !key.KID().Equal(kid) {
 			continue


### PR DESCRIPTION
The `FindNextMerkleRootAfterRevoke` is expensive, so this commit only calls it for a key that's being explicitly asked for by the user (say, to read an MD update written by that key).

cc: @maxtaco 

Issue: KBFS-3009