### PR TITLE
md_ops: iterate correctly when decrypting merkle leaf

### DIFF
--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -185,6 +185,7 @@ func (md *MDOpsStandard) decryptMerkleLeaf(
 					"We tried all revisions and couldn't find a working keygen")
 				return nil, errors.Errorf("Can't decrypt merkle leaf")
 			}
+			currRmd = nextRMDs[len(nextRMDs)-1].ReadOnly()
 		}
 	}
 }


### PR DESCRIPTION
Forgot to set the next MD when iterating in a loop to try to decrypt a Merkle leaf.  This caused infinite loops whenever we were trying to verify an MD written by a revoked key, and the leaf we were using to verify it was encrypted for a key generation that was more than 10 MD updates away from the MD being verified.

Issue: KBFS-3019