### PR TITLE
keybase_service_base: fetch the merkle root following a reset

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -36,6 +36,8 @@ type revokedKeyInfo struct {
 
 	// These fields never need copying.
 	sigChainLocation keybase1.SigChainLocation
+	resetSeqno       keybase1.Seqno
+	isReset          bool
 	filledInMerkle   bool
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/notify_ctl.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/notify_ctl.go
@@ -9,42 +9,44 @@ import (
 )
 
 type NotificationChannels struct {
-	Session      bool `codec:"session" json:"session"`
-	Users        bool `codec:"users" json:"users"`
-	Kbfs         bool `codec:"kbfs" json:"kbfs"`
-	Tracking     bool `codec:"tracking" json:"tracking"`
-	Favorites    bool `codec:"favorites" json:"favorites"`
-	Paperkeys    bool `codec:"paperkeys" json:"paperkeys"`
-	Keyfamily    bool `codec:"keyfamily" json:"keyfamily"`
-	Service      bool `codec:"service" json:"service"`
-	App          bool `codec:"app" json:"app"`
-	Chat         bool `codec:"chat" json:"chat"`
-	PGP          bool `codec:"pgp" json:"pgp"`
-	Kbfsrequest  bool `codec:"kbfsrequest" json:"kbfsrequest"`
-	Badges       bool `codec:"badges" json:"badges"`
-	Reachability bool `codec:"reachability" json:"reachability"`
-	Team         bool `codec:"team" json:"team"`
-	Ephemeral    bool `codec:"ephemeral" json:"ephemeral"`
+	Session       bool `codec:"session" json:"session"`
+	Users         bool `codec:"users" json:"users"`
+	Kbfs          bool `codec:"kbfs" json:"kbfs"`
+	Tracking      bool `codec:"tracking" json:"tracking"`
+	Favorites     bool `codec:"favorites" json:"favorites"`
+	Paperkeys     bool `codec:"paperkeys" json:"paperkeys"`
+	Keyfamily     bool `codec:"keyfamily" json:"keyfamily"`
+	Service       bool `codec:"service" json:"service"`
+	App           bool `codec:"app" json:"app"`
+	Chat          bool `codec:"chat" json:"chat"`
+	PGP           bool `codec:"pgp" json:"pgp"`
+	Kbfsrequest   bool `codec:"kbfsrequest" json:"kbfsrequest"`
+	Badges        bool `codec:"badges" json:"badges"`
+	Reachability  bool `codec:"reachability" json:"reachability"`
+	Team          bool `codec:"team" json:"team"`
+	Ephemeral     bool `codec:"ephemeral" json:"ephemeral"`
+	Chatkbfsedits bool `codec:"chatkbfsedits" json:"chatkbfsedits"`
 }
 
 func (o NotificationChannels) DeepCopy() NotificationChannels {
 	return NotificationChannels{
-		Session:      o.Session,
-		Users:        o.Users,
-		Kbfs:         o.Kbfs,
-		Tracking:     o.Tracking,
-		Favorites:    o.Favorites,
-		Paperkeys:    o.Paperkeys,
-		Keyfamily:    o.Keyfamily,
-		Service:      o.Service,
-		App:          o.App,
-		Chat:         o.Chat,
-		PGP:          o.PGP,
-		Kbfsrequest:  o.Kbfsrequest,
-		Badges:       o.Badges,
-		Reachability: o.Reachability,
-		Team:         o.Team,
-		Ephemeral:    o.Ephemeral,
+		Session:       o.Session,
+		Users:         o.Users,
+		Kbfs:          o.Kbfs,
+		Tracking:      o.Tracking,
+		Favorites:     o.Favorites,
+		Paperkeys:     o.Paperkeys,
+		Keyfamily:     o.Keyfamily,
+		Service:       o.Service,
+		App:           o.App,
+		Chat:          o.Chat,
+		PGP:           o.PGP,
+		Kbfsrequest:   o.Kbfsrequest,
+		Badges:        o.Badges,
+		Reachability:  o.Reachability,
+		Team:          o.Team,
+		Ephemeral:     o.Ephemeral,
+		Chatkbfsedits: o.Chatkbfsedits,
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,10 +250,10 @@
 			"revisionTime": "2018-05-19T05:29:12Z"
 		},
 		{
-			"checksumSHA1": "OMroGLoVRHto6eo+i3oLdHUeBI4=",
+			"checksumSHA1": "iNzTGQRQfuwQCid6UpWVhXIstGc=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "4c1e533ca2720c973bebd9b42bf169d1fbc343c2",
-			"revisionTime": "2018-06-01T21:16:37Z"
+			"revision": "1b4e66fb0be75febd24774b080c73511033566fa",
+			"revisionTime": "2018-06-07T22:01:22Z"
 		},
 		{
 			"checksumSHA1": "X5Xf9+Z7OkhIQiaPB+ILw4xzkag=",


### PR DESCRIPTION
Just like we did for revokes, we also need to get the next Merkle root following an account reset (which effectively revokes all the old devices).

Tested it manually with a TLF containing a write by a pre-reset device.

Issue: KBFS-3029