### PR TITLE
libkbfs: prepare chats for edit notifications on each MD flush

### DIFF
--- a/kbfsedits/data_types.go
+++ b/kbfsedits/data_types.go
@@ -58,6 +58,8 @@ const (
 	EntryTypeSym EntryType = "sym"
 )
 
+// ModifyRange represents a file modification.  Length is 0 for a
+// truncate.
 type ModifyRange struct {
 	Offset uint64
 	Length uint64

--- a/kbfsedits/data_types.go
+++ b/kbfsedits/data_types.go
@@ -58,11 +58,15 @@ const (
 	EntryTypeSym EntryType = "sym"
 )
 
+type ModifyRange struct {
+	Offset uint64
+	Length uint64
+}
+
 // NotificationParams is used for op-type-specific data.
 type NotificationParams struct {
-	OldFileName string `json:",omitempty"` // for renames
-	Offset      uint64 `json:",omitempty"` // for modifies
-	Length      uint64 `json:",omitempty"` // for modifies
+	OldFilename string        `json:",omitempty"` // for renames
+	Modifies    []ModifyRange `json:",omitempty"` // for modifies
 }
 
 // NotificationMessage is a summary of a single edit notification in

--- a/kbfsedits/prepare.go
+++ b/kbfsedits/prepare.go
@@ -6,7 +6,7 @@ package kbfsedits
 
 import "encoding/json"
 
-// Prepare convert the given slice of notifications into a string
+// Prepare converts the given slice of notifications into a string
 // suitable for sending/storing them.
 func Prepare(edits []NotificationMessage) (string, error) {
 	buf, err := json.Marshal(edits)

--- a/kbfsedits/prepare.go
+++ b/kbfsedits/prepare.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsedits
+
+import "encoding/json"
+
+// Prepare convert the given slice of notifications into a string
+// suitable for sending/storing them.
+func Prepare(edits []NotificationMessage) (string, error) {
+	buf, err := json.Marshal(edits)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}

--- a/libkbfs/chat_local.go
+++ b/libkbfs/chat_local.go
@@ -1,0 +1,73 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/chat1"
+	"github.com/keybase/kbfs/tlf"
+)
+
+// ChatLocal is a local implementation for chat.  TODO: fill in the
+// logic to allow for testing.
+type ChatLocal struct {
+	config   Config
+	log      logger.Logger
+	deferLog logger.Logger
+}
+
+// NewChatLocal constructs a new local chat implementation.
+func NewChatLocal(config Config) *ChatLocal {
+	log := config.MakeLogger("")
+	deferLog := log.CloneWithAddedDepth(1)
+	return &ChatLocal{
+		log:      log,
+		deferLog: deferLog,
+		config:   config,
+	}
+}
+
+var _ Chat = (*ChatLocal)(nil)
+
+// GetConversationID implements the Chat interface.
+func (c *ChatLocal) GetConversationID(
+	ctx context.Context, tlfName tlf.CanonicalName, tlfType tlf.Type,
+	channelName string, chatType chat1.TopicType) (
+	chat1.ConversationID, error) {
+	return chat1.ConversationID("TODO"), nil
+}
+
+// SendTextMessage implements the Chat interface.
+func (c *ChatLocal) SendTextMessage(
+	ctx context.Context, tlfName tlf.CanonicalName, tlfType tlf.Type,
+	convID chat1.ConversationID, body string) error {
+	c.log.CDebugf(ctx, "Asked to send text message for %s, %s, "+
+		"but ignoring: %s", tlfName, tlfType, body)
+	return nil
+}
+
+// GetGroupedInbox implements the Chat interface.
+func (c *ChatLocal) GetGroupedInbox(
+	ctx context.Context, chatType chat1.TopicType, maxChats int) (
+	results []tlf.CanonicalName, err error) {
+	return nil, nil
+}
+
+// GetChannels implements the Chat interface.
+func (c *ChatLocal) GetChannels(
+	ctx context.Context, tlfName tlf.CanonicalName, tlfType tlf.Type,
+	chatType chat1.TopicType) (
+	convIDs []chat1.ConversationID, channelNames []string, err error) {
+	return nil, nil, nil
+}
+
+// ReadChannel implements the Chat interface.
+func (c *ChatLocal) ReadChannel(
+	ctx context.Context, convID chat1.ConversationID, startPage []byte) (
+	messages []string, nextPage []byte, err error) {
+	return nil, nil, nil
+}

--- a/libkbfs/chat_local.go
+++ b/libkbfs/chat_local.go
@@ -12,8 +12,9 @@ import (
 	"github.com/keybase/kbfs/tlf"
 )
 
-// ChatLocal is a local implementation for chat.  TODO: fill in the
-// logic to allow for testing.
+// ChatLocal is a local implementation for chat.
+//
+// TODO: fill in the logic to allow for testing.
 type ChatLocal struct {
 	config   Config
 	log      logger.Logger

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1354,6 +1354,7 @@ outer:
 				continue
 			}
 
+			oldType := cop.Type
 			if cop.Type == Dir {
 				cop.Type = Sym
 				cop.crSymPath = symPath
@@ -1380,7 +1381,7 @@ outer:
 			} else {
 				// invert the op in the merged chains
 				invertCreate, err := newRmOp(info.newName,
-					info.originalNewParent)
+					info.originalNewParent, oldType)
 				if err != nil {
 					return err
 				}

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -999,7 +999,7 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 	mergedPathB := cr1.fbo.nodeCache.PathFromNode(dirB1)
 	mergedPaths[unmergedPathB.tailPointer()] = mergedPathB
 
-	ro, err := newRmOp("dirA", unmergedPathRoot.tailPointer())
+	ro, err := newRmOp("dirA", unmergedPathRoot.tailPointer(), Dir)
 	require.NoError(t, err)
 	err = ro.Dir.setRef(unmergedPathRoot.tailPointer())
 	require.NoError(t, err)

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -539,7 +539,8 @@ func (ccs *crChains) makeChainForOp(op op) error {
 	case *renameOp:
 		// split rename op into two separate operations, one for
 		// remove and one for create
-		ro, err := newRmOp(realOp.OldName, realOp.OldDir.Unref)
+		ro, err := newRmOp(
+			realOp.OldName, realOp.OldDir.Unref, realOp.RenamedType)
 		if err != nil {
 			return err
 		}
@@ -564,7 +565,10 @@ func (ccs *crChains) makeChainForOp(op op) error {
 		if len(realOp.Unrefs()) > 0 {
 			// Something was overwritten; make an explicit rm for it
 			// so we can check for conflicts.
-			roOverwrite, err := newRmOp(realOp.NewName, ndu)
+			roOverwrite, err := newRmOp(realOp.NewName, ndu,
+				// We don't know the real type, but this op is only
+				// used locally so it doesn't matter.
+				File)
 			if err != nil {
 				return err
 			}

--- a/libkbfs/cr_chains_test.go
+++ b/libkbfs/cr_chains_test.go
@@ -241,7 +241,7 @@ func TestCRChainsRenameOp(t *testing.T) {
 	require.NoError(t, err)
 	co.renamed = true
 	testCRCheckOps(t, cc, dir2Unref, []op{co})
-	rmo, err := newRmOp(oldName, dir1Unref)
+	rmo, err := newRmOp(oldName, dir1Unref, Dir)
 	require.NoError(t, err)
 	testCRCheckOps(t, cc, dir1Unref, []op{rmo})
 }
@@ -324,7 +324,7 @@ func testCRChainsMultiOps(t *testing.T) ([]chainMetadata, BlockPointer) {
 	multiChainMDs = append(multiChainMDs, newChainMD)
 
 	// rm root/dir1/dir2/file1
-	op5, err := newRmOp(f1, dir2Unref)
+	op5, err := newRmOp(f1, dir2Unref, File)
 	require.NoError(t, err)
 	_ = testCRFillOpPtrs(currPtr, expected, revPtrs,
 		[]BlockPointer{expected[rootPtrUnref], expected[dir1Unref], dir2Unref},
@@ -357,7 +357,7 @@ func testCRChainsMultiOps(t *testing.T) ([]chainMetadata, BlockPointer) {
 	testCRCheckOps(t, cc, dir2Unref, []op{op5})
 
 	// dir3 should have the rm part of a rename
-	ro3, err := newRmOp(f2, op3.OldDir.Unref)
+	ro3, err := newRmOp(f2, op3.OldDir.Unref, File)
 	require.NoError(t, err)
 	testCRCheckOps(t, cc, dir3Unref, []op{ro3})
 
@@ -456,7 +456,7 @@ func TestCRChainsCollapse(t *testing.T) {
 	chainMD.AddOp(op4)
 
 	// rm root/dir1/file2
-	op5, err := newRmOp(f2, expected[dir1Unref])
+	op5, err := newRmOp(f2, expected[dir1Unref], File)
 	require.NoError(t, err)
 	currPtr = testCRFillOpPtrs(currPtr, expected, revPtrs,
 		[]BlockPointer{expected[rootPtrUnref], expected[dir1Unref]}, op5)
@@ -473,7 +473,7 @@ func TestCRChainsCollapse(t *testing.T) {
 	chainMD.AddOp(op6)
 
 	// rm root/dir1/file3
-	op7, err := newRmOp(f3, expected[dir1Unref])
+	op7, err := newRmOp(f3, expected[dir1Unref], File)
 	require.NoError(t, err)
 	currPtr = testCRFillOpPtrs(currPtr, expected, revPtrs,
 		[]BlockPointer{expected[rootPtrUnref], expected[dir1Unref]}, op7)
@@ -517,7 +517,7 @@ func TestCRChainsCollapse(t *testing.T) {
 	testCRCheckOps(t, cc, dir1Unref, []op{co1})
 
 	// dir2 should have the rm part of a rename
-	ro2, err := newRmOp(f1, op6.OldDir.Unref)
+	ro2, err := newRmOp(f1, op6.OldDir.Unref, File)
 	require.NoError(t, err)
 	testCRCheckOps(t, cc, dir2Unref, []op{ro2})
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1734,12 +1734,8 @@ func (fbo *folderBlockOps) PrepRename(
 		return nil, nil, DirEntry{}, nil, err
 	}
 	ro.AddUpdate(oldParentPtr, oldParentPtr)
-
-	// A renameOp doesn't have a single path to represent it, so we
-	// can't call setFinalPath here unfortunately.  That means any
-	// rename may force a manual paths population at other layers
-	// (e.g., for journal statuses).  TODO: allow a way to set more
-	// than one final path for renameOps?
+	ro.setFinalPath(newParent)
+	ro.oldFinalPath = oldParent
 
 	// TODO: Write a SameBlock() function that can deal properly with
 	// dedup'd blocks that share an ID but can be updated separately.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6351,10 +6351,10 @@ func (fbo *folderBranchOps) sendEditNotifications(
 	if err != nil {
 		return err
 	}
-	// For now only write out the notifications if we're an admin,
-	// just in case we decide to change the notification format before
-	// we launch.
-	if !libkb.IsKeybaseAdmin(session.UID) {
+	// For now only write out the notifications if we're an admin or
+	// if we're in test mode, just in case we decide to change the
+	// notification format before we launch.
+	if !fbo.config.Mode().IsTestMode() && !libkb.IsKeybaseAdmin(session.UID) {
 		return nil
 	}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2267,14 +2267,11 @@ func (fbo *folderBranchOps) getConvID(
 
 func (fbo *folderBranchOps) sendEditNotifications(
 	ctx context.Context, rmd ImmutableRootMetadata, body string) error {
-	session, err := fbo.config.KBPKI().GetCurrentSession(ctx)
-	if err != nil {
-		return err
-	}
-	// For now only write out the notifications if we're an admin or
-	// if we're in test mode, just in case we decide to change the
-	// notification format before we launch.
-	if !fbo.config.Mode().IsTestMode() && !libkb.IsKeybaseAdmin(session.UID) {
+	// For now only write out the notifications if we're in test mode,
+	// just in case we decide to change the notification format before
+	// we launch.  TODO: turn this on for admins once we can test it
+	// on staging.
+	if !fbo.config.Mode().IsTestMode() {
 		return nil
 	}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3354,7 +3354,7 @@ func (fbo *folderBranchOps) removeEntryLocked(ctx context.Context,
 	}
 
 	parentPtr := dirPath.tailPointer()
-	ro, err := newRmOp(name, parentPtr)
+	ro, err := newRmOp(name, parentPtr, de.Type)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -136,7 +136,7 @@ func (k keybaseDaemon) NewChat(
 	if localUser == "" {
 		chat = NewChatRPC(config, ctx)
 	} else {
-		// TODO: implement a simple local chat service.
+		chat = NewChatLocal(config)
 	}
 	return chat, nil
 }

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -594,6 +594,10 @@ type renameOp struct {
 	NewDir      blockUpdate  `codec:"nd"`
 	Renamed     BlockPointer `codec:"re"`
 	RenamedType EntryType    `codec:"rt"`
+
+	// oldFinalPath is the final resolved path to the old directory
+	// containing the renamed node.  Not exported; only used locally.
+	oldFinalPath path
 }
 
 func newRenameOp(oldName string, oldOldDir BlockPointer,

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -478,17 +478,20 @@ func (co *createOp) getDefaultAction(mergedPath path) crAction {
 // rmOp is an op representing a file or subdirectory removal
 type rmOp struct {
 	OpCommon
-	OldName string      `codec:"n"`
-	Dir     blockUpdate `codec:"d"`
+	OldName     string      `codec:"n"`
+	Dir         blockUpdate `codec:"d"`
+	RemovedType EntryType   `codec:"rt"`
 
 	// Indicates that the resolution process should skip this rm op.
 	// Likely indicates the rm half of a cycle-creating rename.
 	dropThis bool
 }
 
-func newRmOp(name string, oldDir BlockPointer) (*rmOp, error) {
+func newRmOp(name string, oldDir BlockPointer, removedType EntryType) (
+	*rmOp, error) {
 	ro := &rmOp{
-		OldName: name,
+		OldName:     name,
+		RemovedType: removedType,
 	}
 	err := ro.Dir.setUnref(oldDir)
 	if err != nil {
@@ -1340,7 +1343,7 @@ func invertOpForLocalNotifications(oldOp op) (newOp op, err error) {
 	default:
 		panic(fmt.Sprintf("Unrecognized operation: %v", op))
 	case *createOp:
-		newOp, err = newRmOp(op.NewName, op.Dir.Ref)
+		newOp, err = newRmOp(op.NewName, op.Dir.Ref, op.Type)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -33,7 +33,7 @@ func TestCreateOpCustomUpdate(t *testing.T) {
 
 func TestRmOpCustomUpdate(t *testing.T) {
 	oldDir := makeRandomBlockPointer(t)
-	ro, err := newRmOp("name", oldDir)
+	ro, err := newRmOp("name", oldDir, File)
 	require.NoError(t, err)
 	require.Equal(t, blockUpdate{Unref: oldDir}, ro.Dir)
 
@@ -271,6 +271,7 @@ func makeFakeRmOpFuture(t *testing.T) rmOpFuture {
 			makeFakeOpCommon(t, true),
 			"old name",
 			makeFakeBlockUpdate(t),
+			File,
 			false,
 		},
 		kbfscodec.MakeExtraOrBust("rmOp", t),
@@ -483,7 +484,7 @@ func TestOpSerialization(t *testing.T) {
 	// add a couple ops of different types
 	co, err := newCreateOp("test1", BlockPointer{ID: kbfsblock.FakeID(42)}, File)
 	require.NoError(t, err)
-	ro, err := newRmOp("test2", BlockPointer{ID: kbfsblock.FakeID(43)})
+	ro, err := newRmOp("test2", BlockPointer{ID: kbfsblock.FakeID(43)}, File)
 	require.NoError(t, err)
 	ops.Ops = append(ops.Ops, co, ro)
 
@@ -524,7 +525,7 @@ func TestOpInversion(t *testing.T) {
 	require.NoError(t, err)
 	cop.AddUpdate(oldPtr1, newPtr1)
 	cop.AddUpdate(oldPtr2, newPtr2)
-	expectedIOp, err := newRmOp("test1", newPtr1)
+	expectedIOp, err := newRmOp("test1", newPtr1, File)
 	require.NoError(t, err)
 	expectedIOp.AddUpdate(newPtr1, oldPtr1)
 	expectedIOp.AddUpdate(newPtr2, oldPtr2)

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -306,6 +306,7 @@ func makeFakeRenameOpFuture(t *testing.T) renameOpFuture {
 			makeFakeBlockUpdate(t),
 			makeFakeBlockPointer(t),
 			Exec,
+			path{},
 		},
 		kbfscodec.MakeExtraOrBust("renameOp", t),
 	}

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -136,6 +136,7 @@ func MakeTestConfigOrBustLoggedInWithMode(
 	daemon := NewKeybaseDaemonMemory(loggedInUser.UID, localUsers, nil,
 		config.Codec())
 	config.SetKeybaseService(daemon)
+	config.SetChat(NewChatLocal(config))
 
 	kbpki := NewKBPKIClient(config, config.MakeLogger(""))
 	config.SetKBPKI(kbpki)
@@ -243,6 +244,11 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 	c.SetKeyManager(NewKeyManagerStandard(c))
 	c.SetMDOps(NewMDOpsStandard(c))
 	c.SetClock(config.Clock())
+
+	// TODO: construct a new chat specific to the new user, but with a
+	// shared storage layer so the users can send messages to
+	// another's inbox.
+	c.SetChat(config.Chat())
 
 	daemon := config.KeybaseService().(*KeybaseDaemonLocal)
 	loggedInUID, ok := daemon.asserts[string(loggedInUser)]

--- a/vendor/github.com/keybase/client/go/protocol/chat1/chat_ui.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/chat_ui.go
@@ -402,9 +402,10 @@ type UIMessageValid struct {
 	AtMentions            []string               `codec:"atMentions" json:"atMentions"`
 	ChannelMention        ChannelMention         `codec:"channelMention" json:"channelMention"`
 	ChannelNameMentions   []UIChannelNameMention `codec:"channelNameMentions" json:"channelNameMentions"`
-	IsEphemeral           bool                   `codec:"ie" json:"ie"`
-	IsEphemeralExpired    bool                   `codec:"iex" json:"iex"`
-	Etime                 gregor1.Time           `codec:"e" json:"e"`
+	IsEphemeral           bool                   `codec:"isEphemeral" json:"isEphemeral"`
+	IsEphemeralExpired    bool                   `codec:"isEphemeralExpired" json:"isEphemeralExpired"`
+	ExplodedBy            *string                `codec:"explodedBy,omitempty" json:"explodedBy,omitempty"`
+	Etime                 gregor1.Time           `codec:"etime" json:"etime"`
 }
 
 func (o UIMessageValid) DeepCopy() UIMessageValid {
@@ -462,7 +463,14 @@ func (o UIMessageValid) DeepCopy() UIMessageValid {
 		})(o.ChannelNameMentions),
 		IsEphemeral:        o.IsEphemeral,
 		IsEphemeralExpired: o.IsEphemeralExpired,
-		Etime:              o.Etime.DeepCopy(),
+		ExplodedBy: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.ExplodedBy),
+		Etime: o.Etime.DeepCopy(),
 	}
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/chat1/common.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/common.go
@@ -232,6 +232,7 @@ const (
 	MessageType_LEAVE              MessageType = 10
 	MessageType_SYSTEM             MessageType = 11
 	MessageType_DELETEHISTORY      MessageType = 12
+	MessageType_REACTION           MessageType = 13
 )
 
 func (o MessageType) DeepCopy() MessageType { return o }
@@ -250,6 +251,7 @@ var MessageTypeMap = map[string]MessageType{
 	"LEAVE":              10,
 	"SYSTEM":             11,
 	"DELETEHISTORY":      12,
+	"REACTION":           13,
 }
 
 var MessageTypeRevMap = map[MessageType]string{
@@ -266,28 +268,32 @@ var MessageTypeRevMap = map[MessageType]string{
 	10: "LEAVE",
 	11: "SYSTEM",
 	12: "DELETEHISTORY",
+	13: "REACTION",
 }
 
 type TopicType int
 
 const (
-	TopicType_NONE TopicType = 0
-	TopicType_CHAT TopicType = 1
-	TopicType_DEV  TopicType = 2
+	TopicType_NONE         TopicType = 0
+	TopicType_CHAT         TopicType = 1
+	TopicType_DEV          TopicType = 2
+	TopicType_KBFSFILEEDIT TopicType = 3
 )
 
 func (o TopicType) DeepCopy() TopicType { return o }
 
 var TopicTypeMap = map[string]TopicType{
-	"NONE": 0,
-	"CHAT": 1,
-	"DEV":  2,
+	"NONE":         0,
+	"CHAT":         1,
+	"DEV":          2,
+	"KBFSFILEEDIT": 3,
 }
 
 var TopicTypeRevMap = map[TopicType]string{
 	0: "NONE",
 	1: "CHAT",
 	2: "DEV",
+	3: "KBFSFILEEDIT",
 }
 
 type TeamType int
@@ -1006,6 +1012,7 @@ func (o MessageSummary) DeepCopy() MessageSummary {
 type MessageServerHeader struct {
 	MessageID    MessageID    `codec:"messageID" json:"messageID"`
 	SupersededBy MessageID    `codec:"supersededBy" json:"supersededBy"`
+	ReactionIDs  []MessageID  `codec:"r" json:"r"`
 	Ctime        gregor1.Time `codec:"ctime" json:"ctime"`
 	Now          gregor1.Time `codec:"n" json:"n"`
 }
@@ -1014,8 +1021,19 @@ func (o MessageServerHeader) DeepCopy() MessageServerHeader {
 	return MessageServerHeader{
 		MessageID:    o.MessageID.DeepCopy(),
 		SupersededBy: o.SupersededBy.DeepCopy(),
-		Ctime:        o.Ctime.DeepCopy(),
-		Now:          o.Now.DeepCopy(),
+		ReactionIDs: (func(x []MessageID) []MessageID {
+			if x == nil {
+				return nil
+			}
+			var ret []MessageID
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.ReactionIDs),
+		Ctime: o.Ctime.DeepCopy(),
+		Now:   o.Now.DeepCopy(),
 	}
 }
 
@@ -1046,23 +1064,33 @@ func (o OutboxInfo) DeepCopy() OutboxInfo {
 type MsgEphemeralMetadata struct {
 	Lifetime   gregor1.DurationSec   `codec:"l" json:"l"`
 	Generation keybase1.EkGeneration `codec:"g" json:"g"`
+	ExplodedBy *string               `codec:"u,omitempty" json:"u,omitempty"`
 }
 
 func (o MsgEphemeralMetadata) DeepCopy() MsgEphemeralMetadata {
 	return MsgEphemeralMetadata{
 		Lifetime:   o.Lifetime.DeepCopy(),
 		Generation: o.Generation.DeepCopy(),
+		ExplodedBy: (func(x *string) *string {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x)
+			return &tmp
+		})(o.ExplodedBy),
 	}
 }
 
 type EphemeralPurgeInfo struct {
-	IsActive        bool         `codec:"a" json:"a"`
-	NextPurgeTime   gregor1.Time `codec:"n" json:"n"`
-	MinUnexplodedID MessageID    `codec:"e" json:"e"`
+	ConvID          ConversationID `codec:"c" json:"c"`
+	IsActive        bool           `codec:"a" json:"a"`
+	NextPurgeTime   gregor1.Time   `codec:"n" json:"n"`
+	MinUnexplodedID MessageID      `codec:"e" json:"e"`
 }
 
 func (o EphemeralPurgeInfo) DeepCopy() EphemeralPurgeInfo {
 	return EphemeralPurgeInfo{
+		ConvID:          o.ConvID.DeepCopy(),
 		IsActive:        o.IsActive,
 		NextPurgeTime:   o.NextPurgeTime.DeepCopy(),
 		MinUnexplodedID: o.MinUnexplodedID.DeepCopy(),

--- a/vendor/github.com/keybase/client/go/protocol/chat1/gregor.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/gregor.go
@@ -13,6 +13,7 @@ type GenericPayload struct {
 	Action       string         `codec:"Action" json:"Action"`
 	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
 	ConvID       ConversationID `codec:"convID" json:"convID"`
+	TopicType    TopicType      `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -21,6 +22,7 @@ func (o GenericPayload) DeepCopy() GenericPayload {
 		Action:    o.Action,
 		InboxVers: o.InboxVers.DeepCopy(),
 		ConvID:    o.ConvID.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -35,6 +37,7 @@ type NewConversationPayload struct {
 	Action       string         `codec:"Action" json:"Action"`
 	ConvID       ConversationID `codec:"convID" json:"convID"`
 	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	TopicType    TopicType      `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -43,6 +46,7 @@ func (o NewConversationPayload) DeepCopy() NewConversationPayload {
 		Action:    o.Action,
 		ConvID:    o.ConvID.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -58,6 +62,7 @@ type NewMessagePayload struct {
 	ConvID       ConversationID   `codec:"convID" json:"convID"`
 	Message      MessageBoxed     `codec:"message" json:"message"`
 	InboxVers    InboxVers        `codec:"inboxVers" json:"inboxVers"`
+	TopicType    TopicType        `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate    `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 	MaxMsgs      []MessageSummary `codec:"maxMsgs" json:"maxMsgs"`
 }
@@ -68,6 +73,7 @@ func (o NewMessagePayload) DeepCopy() NewMessagePayload {
 		ConvID:    o.ConvID.DeepCopy(),
 		Message:   o.Message.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -94,6 +100,7 @@ type ReadMessagePayload struct {
 	ConvID       ConversationID `codec:"convID" json:"convID"`
 	MsgID        MessageID      `codec:"msgID" json:"msgID"`
 	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	TopicType    TopicType      `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -103,6 +110,7 @@ func (o ReadMessagePayload) DeepCopy() ReadMessagePayload {
 		ConvID:    o.ConvID.DeepCopy(),
 		MsgID:     o.MsgID.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -118,6 +126,7 @@ type SetStatusPayload struct {
 	ConvID       ConversationID     `codec:"convID" json:"convID"`
 	Status       ConversationStatus `codec:"status" json:"status"`
 	InboxVers    InboxVers          `codec:"inboxVers" json:"inboxVers"`
+	TopicType    TopicType          `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate      `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -127,6 +136,7 @@ func (o SetStatusPayload) DeepCopy() SetStatusPayload {
 		ConvID:    o.ConvID.DeepCopy(),
 		Status:    o.Status.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -142,6 +152,7 @@ type TeamTypePayload struct {
 	ConvID       ConversationID `codec:"convID" json:"convID"`
 	TeamType     TeamType       `codec:"teamType" json:"teamType"`
 	InboxVers    InboxVers      `codec:"inboxVers" json:"inboxVers"`
+	TopicType    TopicType      `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate  `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -151,6 +162,7 @@ func (o TeamTypePayload) DeepCopy() TeamTypePayload {
 		ConvID:    o.ConvID.DeepCopy(),
 		TeamType:  o.TeamType.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -166,6 +178,7 @@ type SetAppNotificationSettingsPayload struct {
 	ConvID       ConversationID               `codec:"convID" json:"convID"`
 	InboxVers    InboxVers                    `codec:"inboxVers" json:"inboxVers"`
 	Settings     ConversationNotificationInfo `codec:"settings" json:"settings"`
+	TopicType    TopicType                    `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate                `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -175,6 +188,7 @@ func (o SetAppNotificationSettingsPayload) DeepCopy() SetAppNotificationSettings
 		ConvID:    o.ConvID.DeepCopy(),
 		InboxVers: o.InboxVers.DeepCopy(),
 		Settings:  o.Settings.DeepCopy(),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil
@@ -191,6 +205,7 @@ type ExpungePayload struct {
 	InboxVers    InboxVers        `codec:"inboxVers" json:"inboxVers"`
 	Expunge      Expunge          `codec:"expunge" json:"expunge"`
 	MaxMsgs      []MessageSummary `codec:"maxMsgs" json:"maxMsgs"`
+	TopicType    TopicType        `codec:"topicType" json:"topicType"`
 	UnreadUpdate *UnreadUpdate    `codec:"unreadUpdate,omitempty" json:"unreadUpdate,omitempty"`
 }
 
@@ -211,6 +226,7 @@ func (o ExpungePayload) DeepCopy() ExpungePayload {
 			}
 			return ret
 		})(o.MaxMsgs),
+		TopicType: o.TopicType.DeepCopy(),
 		UnreadUpdate: (func(x *UnreadUpdate) *UnreadUpdate {
 			if x == nil {
 				return nil

--- a/vendor/github.com/keybase/client/go/protocol/chat1/notify.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/notify.go
@@ -67,6 +67,7 @@ type IncomingMessage struct {
 	Message                    UIMessage      `codec:"message" json:"message"`
 	ConvID                     ConversationID `codec:"convID" json:"convID"`
 	DisplayDesktopNotification bool           `codec:"displayDesktopNotification" json:"displayDesktopNotification"`
+	DesktopNotificationSnippet string         `codec:"desktopNotificationSnippet" json:"desktopNotificationSnippet"`
 	Conv                       *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`
 	Pagination                 *UIPagination  `codec:"pagination,omitempty" json:"pagination,omitempty"`
 }
@@ -76,6 +77,7 @@ func (o IncomingMessage) DeepCopy() IncomingMessage {
 		Message: o.Message.DeepCopy(),
 		ConvID:  o.ConvID.DeepCopy(),
 		DisplayDesktopNotification: o.DisplayDesktopNotification,
+		DesktopNotificationSnippet: o.DesktopNotificationSnippet,
 		Conv: (func(x *InboxUIItem) *InboxUIItem {
 			if x == nil {
 				return nil
@@ -185,17 +187,37 @@ func (o FailedMessageInfo) DeepCopy() FailedMessageInfo {
 	}
 }
 
-type MembersUpdateInfo struct {
-	ConvID ConversationID           `codec:"convID" json:"convID"`
+type MemberInfo struct {
 	Member string                   `codec:"member" json:"member"`
 	Status ConversationMemberStatus `codec:"status" json:"status"`
+}
+
+func (o MemberInfo) DeepCopy() MemberInfo {
+	return MemberInfo{
+		Member: o.Member,
+		Status: o.Status.DeepCopy(),
+	}
+}
+
+type MembersUpdateInfo struct {
+	ConvID  ConversationID `codec:"convID" json:"convID"`
+	Members []MemberInfo   `codec:"members" json:"members"`
 }
 
 func (o MembersUpdateInfo) DeepCopy() MembersUpdateInfo {
 	return MembersUpdateInfo{
 		ConvID: o.ConvID.DeepCopy(),
-		Member: o.Member,
-		Status: o.Status.DeepCopy(),
+		Members: (func(x []MemberInfo) []MemberInfo {
+			if x == nil {
+				return nil
+			}
+			var ret []MemberInfo
+			for _, v := range x {
+				vCopy := v.DeepCopy()
+				ret = append(ret, vCopy)
+			}
+			return ret
+		})(o.Members),
 	}
 }
 
@@ -222,12 +244,20 @@ func (o TeamTypeInfo) DeepCopy() TeamTypeInfo {
 type ExpungeInfo struct {
 	ConvID  ConversationID `codec:"convID" json:"convID"`
 	Expunge Expunge        `codec:"expunge" json:"expunge"`
+	Conv    *InboxUIItem   `codec:"conv,omitempty" json:"conv,omitempty"`
 }
 
 func (o ExpungeInfo) DeepCopy() ExpungeInfo {
 	return ExpungeInfo{
 		ConvID:  o.ConvID.DeepCopy(),
 		Expunge: o.Expunge.DeepCopy(),
+		Conv: (func(x *InboxUIItem) *InboxUIItem {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Conv),
 	}
 }
 
@@ -738,6 +768,11 @@ type NewChatActivityArg struct {
 	Activity ChatActivity `codec:"activity" json:"activity"`
 }
 
+type NewChatKBFSFileEditActivityArg struct {
+	Uid      keybase1.UID `codec:"uid" json:"uid"`
+	Activity ChatActivity `codec:"activity" json:"activity"`
+}
+
 type ChatIdentifyUpdateArg struct {
 	Update keybase1.CanonicalTLFNameAndIDWithBreaks `codec:"update" json:"update"`
 }
@@ -812,6 +847,7 @@ type ChatKBFSToImpteamUpgradeArg struct {
 
 type NotifyChatInterface interface {
 	NewChatActivity(context.Context, NewChatActivityArg) error
+	NewChatKBFSFileEditActivity(context.Context, NewChatKBFSFileEditActivityArg) error
 	ChatIdentifyUpdate(context.Context, keybase1.CanonicalTLFNameAndIDWithBreaks) error
 	ChatTLFFinalize(context.Context, ChatTLFFinalizeArg) error
 	ChatTLFResolve(context.Context, ChatTLFResolveArg) error
@@ -844,6 +880,22 @@ func NotifyChatProtocol(i NotifyChatInterface) rpc.Protocol {
 						return
 					}
 					err = i.NewChatActivity(ctx, (*typedArgs)[0])
+					return
+				},
+				MethodType: rpc.MethodNotify,
+			},
+			"NewChatKBFSFileEditActivity": {
+				MakeArg: func() interface{} {
+					ret := make([]NewChatKBFSFileEditActivityArg, 1)
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[]NewChatKBFSFileEditActivityArg)
+					if !ok {
+						err = rpc.NewTypeError((*[]NewChatKBFSFileEditActivityArg)(nil), args)
+						return
+					}
+					err = i.NewChatKBFSFileEditActivity(ctx, (*typedArgs)[0])
 					return
 				},
 				MethodType: rpc.MethodNotify,
@@ -1082,6 +1134,11 @@ type NotifyChatClient struct {
 
 func (c NotifyChatClient) NewChatActivity(ctx context.Context, __arg NewChatActivityArg) (err error) {
 	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.NewChatActivity", []interface{}{__arg})
+	return
+}
+
+func (c NotifyChatClient) NewChatKBFSFileEditActivity(ctx context.Context, __arg NewChatKBFSFileEditActivityArg) (err error) {
+	err = c.Cli.Notify(ctx, "chat.1.NotifyChat.NewChatKBFSFileEditActivity", []interface{}{__arg})
 	return
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -238,10 +238,10 @@
 			"revisionTime": "2018-05-19T05:29:12Z"
 		},
 		{
-			"checksumSHA1": "u/AVcWNT0zsav3B8uMDqMWHOE7M=",
+			"checksumSHA1": "hIzRyJuRLkOGRmxRxFFxlJZIDc4=",
 			"path": "github.com/keybase/client/go/protocol/chat1",
-			"revision": "94012483abbcf11dd835c21e3fcfda3ede2ad754",
-			"revisionTime": "2018-05-19T05:29:12Z"
+			"revision": "7f5e202465f1c9cb6b12a237da4c0d6b480352e0",
+			"revisionTime": "2018-06-08T22:09:00Z"
 		},
 		{
 			"checksumSHA1": "BreJRQUSA+Wma2Xr/mFDrsggICA=",


### PR DESCRIPTION
This PR prepares chat messages for all the ops in a flushed MD, to be sent on a writer-specific channel in the kbfs-edits chat corresponding to the TLF.  Right now, it only actually sends the chat messages if we're in test mode, because I haven't yet been able to test it in staging or production.  But I wanted to get the reviews started on it now, while I work on the testing issues.

Other small things added in this PR to support making these notifications:
* Add the entry type of removed files to `removeOp`s, so we can get more details in the notifications.
* Add a path for the "old" directory in a `renameOp`, so we can give the full path of the old file location in a rename notification.

Issue: KBFS-2994