### PR TITLE
chat: register for new channels and messages

### DIFF
--- a/libkbfs/chat_local.go
+++ b/libkbfs/chat_local.go
@@ -72,3 +72,8 @@ func (c *ChatLocal) ReadChannel(
 	messages []string, nextPage []byte, err error) {
 	return nil, nil, nil
 }
+
+// RegisterForMessages implements the Chat interface.
+func (c *ChatLocal) RegisterForMessages(
+	convID chat1.ConversationID, cb ChatChannelNewMessageCB) {
+}

--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -50,6 +50,14 @@ func (ChatRPC) HandlerName() string {
 func (c *ChatRPC) OnConnect(ctx context.Context, conn *rpc.Connection,
 	_ rpc.GenericClient, server *rpc.Server) error {
 	c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, nil)
+
+	err := server.Register(chat1.NotifyChatProtocol(c))
+	switch err.(type) {
+	case nil, rpc.AlreadyRegisteredError:
+	default:
+		return err
+	}
+
 	return nil
 }
 
@@ -295,4 +303,120 @@ func (c *ChatRPC) ReadChannel(
 		nextPage = res.Thread.Pagination.Next
 	}
 	return messages, nextPage, nil
+}
+
+// We only register for the kbfs-edits type of notification in
+// keybase_daemon_rpc, so all the other methods below besides
+// `NewChatKBFSFileEditActivity` should never be called.
+var _ chat1.NotifyChatInterface = (*ChatRPC)(nil)
+
+// NewChatActivity implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) NewChatActivity(
+	_ context.Context, _ chat1.NewChatActivityArg) error {
+	return nil
+}
+
+// NewChatKBFSFileEditActivity implements the
+// chat1.NotifyChatInterface for ChatRPC.
+func (c *ChatRPC) NewChatKBFSFileEditActivity(
+	context.Context, chat1.NewChatKBFSFileEditActivityArg) error {
+	return nil
+}
+
+// ChatIdentifyUpdate implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatIdentifyUpdate(
+	_ context.Context, _ keybase1.CanonicalTLFNameAndIDWithBreaks) error {
+	return nil
+}
+
+// ChatTLFFinalize implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatTLFFinalize(
+	_ context.Context, _ chat1.ChatTLFFinalizeArg) error {
+	return nil
+}
+
+// ChatTLFResolve implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatTLFResolve(
+	_ context.Context, _ chat1.ChatTLFResolveArg) error {
+	return nil
+}
+
+// ChatInboxStale implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatInboxStale(_ context.Context, _ keybase1.UID) error {
+	return nil
+}
+
+// ChatThreadsStale implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatThreadsStale(
+	_ context.Context, _ chat1.ChatThreadsStaleArg) error {
+	return nil
+}
+
+// ChatTypingUpdate implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatTypingUpdate(
+	_ context.Context, _ []chat1.ConvTypingUpdate) error {
+	return nil
+}
+
+// ChatJoinedConversation implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatJoinedConversation(
+	_ context.Context, _ chat1.ChatJoinedConversationArg) error {
+	return nil
+}
+
+// ChatLeftConversation implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatLeftConversation(
+	_ context.Context, _ chat1.ChatLeftConversationArg) error {
+	return nil
+}
+
+// ChatResetConversation implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatResetConversation(
+	_ context.Context, _ chat1.ChatResetConversationArg) error {
+	return nil
+}
+
+// ChatInboxSyncStarted implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatInboxSyncStarted(
+	_ context.Context, _ keybase1.UID) error {
+	return nil
+}
+
+// ChatInboxSynced implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatInboxSynced(
+	_ context.Context, _ chat1.ChatInboxSyncedArg) error {
+	return nil
+}
+
+// ChatSetConvRetention implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatSetConvRetention(
+	_ context.Context, _ chat1.ChatSetConvRetentionArg) error {
+	return nil
+}
+
+// ChatSetTeamRetention implements the chat1.NotifyChatInterface for
+// ChatRPC.
+func (c *ChatRPC) ChatSetTeamRetention(
+	_ context.Context, _ chat1.ChatSetTeamRetentionArg) error {
+	return nil
+}
+
+// ChatKBFSToImpteamUpgrade implements the chat1.NotifyChatInterface
+// for ChatRPC.
+func (c *ChatRPC) ChatKBFSToImpteamUpgrade(
+	_ context.Context, _ chat1.ChatKBFSToImpteamUpgradeArg) error {
+	return nil
 }

--- a/libkbfs/connection_status.go
+++ b/libkbfs/connection_status.go
@@ -12,6 +12,7 @@ import (
 const (
 	KeybaseServiceName     = "keybase-service"
 	MDServiceName          = "md-server"
+	GregorServiceName      = "gregor"
 	LoginStatusUpdateName  = "login"
 	LogoutStatusUpdateName = "logout"
 )

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6841,10 +6841,20 @@ func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
 }
 
 // KickoffAllOutstandingRekeys (does not) implement the KBFSOps interface for
-// KBFSOpsStandard.
+// folderBranchOps.
 func (fbo *folderBranchOps) KickoffAllOutstandingRekeys() error {
 	return errors.New(
 		"KickoffAllOutstandingRekeys is not supported on *folderBranchOps")
+}
+
+// NewNotificationChannel implements the KBFSOps interface for
+// folderBranchOps.
+func (fbo *folderBranchOps) NewNotificationChannel(
+	ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
+	channelName string) {
+	// TODO(KBFS-2996): invalidate the local edit notification
+	// tracker, and register for notifications of new messages on the
+	// channel.
 }
 
 // PushConnectionStatusChange pushes human readable connection status changes.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -431,6 +431,11 @@ type KBFSOps interface {
 	// nothing to folders that have not scheduled a rekey. This should be
 	// called when we receive an event of "paper key cached" from service.
 	KickoffAllOutstandingRekeys() error
+	// NewNotificationChannel is called to notify any existing TLF
+	// matching `handle` that a new kbfs-edits channel is available.
+	NewNotificationChannel(
+		ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
+		channelName string)
 }
 
 type merkleRootGetter interface {
@@ -2191,6 +2196,10 @@ type BlockRetriever interface {
 	TogglePrefetcher(enable bool, syncCh <-chan struct{}) <-chan struct{}
 }
 
+// ChatChannelNewMessageCB is a callback function that can be called
+// when there's a new message on a given conversation.
+type ChatChannelNewMessageCB func(convID chat1.ConversationID, body string)
+
 // Chat specifies a minimal interface for Keybase chatting.
 type Chat interface {
 	// GetConversationID returns the chat conversation ID associated
@@ -2227,4 +2236,8 @@ type Chat interface {
 	ReadChannel(
 		ctx context.Context, convID chat1.ConversationID, startPage []byte) (
 		messages []string, nextPage []byte, err error)
+
+	// RegisterForMessages registers a callback that will be called
+	// for each new messages that reaches convID.
+	RegisterForMessages(convID chat1.ConversationID, cb ChatChannelNewMessageCB)
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -1033,6 +1034,16 @@ func (fs *KBFSOpsStandard) KickoffAllOutstandingRekeys() error {
 		op.rekeyFSM.Event(newRekeyKickoffEvent())
 	}
 	return nil
+}
+
+// NewNotificationChannel implements the KBFSOps interface for
+// KBFSOpsStandard.
+func (fs *KBFSOpsStandard) NewNotificationChannel(
+	ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
+	channelName string) {
+	// TODO(KBFS-2996): find the right TLF using the handle, and let
+	// it know of the new channel.  Also, invalidate the overall edit
+	// activity tracker.
 }
 
 func (fs *KBFSOpsStandard) changeHandle(ctx context.Context,

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -320,13 +320,14 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 	// recursion.
 	c := keybase1.NotifyCtlClient{Cli: rawClient}
 	err = c.SetNotifications(ctx, keybase1.NotificationChannels{
-		Session:      true,
-		Paperkeys:    true,
-		Keyfamily:    true,
-		Kbfsrequest:  true,
-		Reachability: true,
-		Service:      true,
-		Team:         true,
+		Session:       true,
+		Paperkeys:     true,
+		Keyfamily:     true,
+		Kbfsrequest:   true,
+		Reachability:  true,
+		Service:       true,
+		Team:          true,
+		Chatkbfsedits: true,
 	})
 	if err != nil {
 		return err

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -375,6 +375,12 @@ func (k *KeybaseServiceBase) KeyfamilyChanged(ctx context.Context,
 func (k *KeybaseServiceBase) ReachabilityChanged(ctx context.Context,
 	reachability keybase1.Reachability) error {
 	k.log.CDebugf(ctx, "CheckReachability invoked: %v", reachability)
+	if reachability.Reachable == keybase1.Reachable_YES {
+		k.config.KBFSOps().PushConnectionStatusChange(GregorServiceName, nil)
+	} else {
+		k.config.KBFSOps().PushConnectionStatusChange(
+			GregorServiceName, errDisconnected{})
+	}
 	mdServer := k.config.MDServer()
 	if mdServer != nil {
 		mdServer.CheckReachability(ctx)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1414,6 +1414,16 @@ func (mr *MockKBFSOpsMockRecorder) KickoffAllOutstandingRekeys() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KickoffAllOutstandingRekeys", reflect.TypeOf((*MockKBFSOps)(nil).KickoffAllOutstandingRekeys))
 }
 
+// NewNotificationChannel mocks base method
+func (m *MockKBFSOps) NewNotificationChannel(ctx context.Context, handle *TlfHandle, convID chat1.ConversationID, channelName string) {
+	m.ctrl.Call(m, "NewNotificationChannel", ctx, handle, convID, channelName)
+}
+
+// NewNotificationChannel indicates an expected call of NewNotificationChannel
+func (mr *MockKBFSOpsMockRecorder) NewNotificationChannel(ctx, handle, convID, channelName interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewNotificationChannel", reflect.TypeOf((*MockKBFSOps)(nil).NewNotificationChannel), ctx, handle, convID, channelName)
+}
+
 // MockmerkleRootGetter is a mock of merkleRootGetter interface
 type MockmerkleRootGetter struct {
 	ctrl     *gomock.Controller
@@ -7682,4 +7692,14 @@ func (m *MockChat) ReadChannel(ctx context.Context, convID chat1.ConversationID,
 // ReadChannel indicates an expected call of ReadChannel
 func (mr *MockChatMockRecorder) ReadChannel(ctx, convID, startPage interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChannel", reflect.TypeOf((*MockChat)(nil).ReadChannel), ctx, convID, startPage)
+}
+
+// RegisterForMessages mocks base method
+func (m *MockChat) RegisterForMessages(convID chat1.ConversationID, cb ChatChannelNewMessageCB) {
+	m.ctrl.Call(m, "RegisterForMessages", convID, cb)
+}
+
+// RegisterForMessages indicates an expected call of RegisterForMessages
+func (mr *MockChatMockRecorder) RegisterForMessages(convID, cb interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForMessages", reflect.TypeOf((*MockChat)(nil).RegisterForMessages), convID, cb)
 }


### PR DESCRIPTION
(Based on #1610, which needs to be merged first.)

This registers KBFS for kbfs-edits notifications, and adds the interface methods needed to invalid local edit notification state (including gregor reconnects).

Issue: KBFS-2995