### PR TITLE
Fix a latent bug with reembedBlockChanges

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -811,7 +811,7 @@ func (ccs *crChains) addOps(codec kbfscodec.Codec,
 	var oldOps opsList
 	if privateMD.Changes.Info.BlockPointer.IsInitialized() {
 		// In some cases (e.g., journaling) we might not have been
-		// able to re-embed the block changes.  So used the cached
+		// able to re-embed the block changes.  So use the cached
 		// version directly.
 		oldOps = privateMD.cachedChanges.Ops
 	} else {

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -402,7 +402,8 @@ type BlockChanges struct {
 	// so that decoding into an existing BlockChanges object
 	// clobbers any existing Info, so we can't omit Info until all
 	// clients have upgraded to a version that explicitly clears
-	// Info on decode.
+	// Info on decode, and we've verified that there's nothing
+	// else that relies on Info always being filled.
 	Info BlockInfo `codec:"p"`
 	// An ordered list of operations completed in this update
 	Ops opsList `codec:"o,omitempty"`

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -402,7 +402,7 @@ type BlockChanges struct {
 	// so that decoding into an existing BlockChanges object
 	// clobbers any existing Info, so we can't omit Info until all
 	// clients have upgraded to a version that explicitly clears
-	// Info on decode. (See comments in reembedBlockChanges.)
+	// Info on decode.
 	Info BlockInfo `codec:"p"`
 	// An ordered list of operations completed in this update
 	Ops opsList `codec:"o,omitempty"`

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -401,7 +401,7 @@ type BlockChanges struct {
 	// bug such that omitempty,omitemptycheckstruct doesn't work
 	// on BlockInfo. Use omitemptyrecursive once we use a version
 	// of go-codec that supports it.
-	Info BlockInfo `codec:"p,omitempty"`
+	Info BlockInfo `codec:"p"`
 	// An ordered list of operations completed in this update
 	Ops opsList `codec:"o,omitempty"`
 	// Estimate the number of bytes that this set of changes will take to encode

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -396,6 +396,11 @@ func (fb FolderBranch) String() string {
 type BlockChanges struct {
 	// If this is set, the actual changes are stored in a block (where
 	// the block contains a serialized version of BlockChanges)
+	//
+	// TODO: The old version of go-codec we have vendored has a
+	// bug such that omitempty,omitemptycheckstruct doesn't work
+	// on BlockInfo. Use omitemptyrecursive once we use a version
+	// of go-codec that supports it.
 	Info BlockInfo `codec:"p,omitempty"`
 	// An ordered list of operations completed in this update
 	Ops opsList `codec:"o,omitempty"`

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -397,10 +397,12 @@ type BlockChanges struct {
 	// If this is set, the actual changes are stored in a block (where
 	// the block contains a serialized version of BlockChanges)
 	//
-	// TODO: The old version of go-codec we have vendored has a
-	// bug such that omitempty,omitemptycheckstruct doesn't work
-	// on BlockInfo. Use omitemptyrecursive once we use a version
-	// of go-codec that supports it.
+	// Ideally, we'd omit Info if it's empty. However, old clients
+	// rely on encoded BlockChanges always having an encoded Info,
+	// so that decoding into an existing BlockChanges object
+	// clobbers any existing Info, so we can't omit Info until all
+	// clients have upgraded to a version that explicitly clears
+	// Info on decode. (See comments in reembedBlockChanges.)
 	Info BlockInfo `codec:"p"`
 	// An ordered list of operations completed in this update
 	Ops opsList `codec:"o,omitempty"`

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -442,7 +442,7 @@ func encryptMDPrivateData(
 	return nil
 }
 
-func getFileBlockForMD(ctx context.Context, bcache BlockCache, bops BlockOps,
+func getFileBlockForMD(ctx context.Context, bcache BlockCacheSimple, bops BlockOps,
 	ptr BlockPointer, tlfID tlf.ID, rmdWithKeys KeyMetadata) (
 	*FileBlock, error) {
 	// We don't have a convenient way to fetch the block from here via
@@ -465,7 +465,7 @@ func getFileBlockForMD(ctx context.Context, bcache BlockCache, bops BlockOps,
 }
 
 func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
-	bcache BlockCache, bops BlockOps, mode InitMode, tlfID tlf.ID,
+	bcache BlockCacheSimple, bops BlockOps, mode InitMode, tlfID tlf.ID,
 	pmd *PrivateMetadata, rmdWithKeys KeyMetadata, log logger.Logger) error {
 	info := pmd.Changes.Info
 	if info.BlockPointer == zeroPtr {

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -510,6 +510,9 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 		return err
 	}
 
+	// This relies on encoded BlockChanges always having an
+	// encoded Info, which would then clobber the one in
+	// pmd.Changes.
 	err = codec.Decode(buf, &pmd.Changes)
 	if err != nil {
 		return err

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -58,6 +58,9 @@ func TestReembedBlockChanges(t *testing.T) {
 			},
 		},
 	}
+
+	// We make the cache always return a block, so we can pass in
+	// nil for bops and rmdWithKeys.
 	err = reembedBlockChanges(ctx, codec, bcache, nil, mode, tlfID, &pmd, nil, logger.NewTestLogger(t))
 	require.NoError(t, err)
 }

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"testing"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+type testBlockCache struct {
+	b Block
+}
+
+func (c testBlockCache) Get(ptr BlockPointer) (Block, error) {
+	return c.b, nil
+}
+
+func (testBlockCache) Put(ptr BlockPointer, tlf tlf.ID, block Block,
+	lifetime BlockCacheLifetime) error {
+	return errors.New("Shouldn't be called")
+}
+
+func TestReembedBlockChanges(t *testing.T) {
+	codec := kbfscodec.NewMsgpack()
+	RegisterOps(codec)
+
+	oldDir := BlockPointer{ID: kbfsblock.FakeID(1)}
+	co, err := newCreateOp("file", oldDir, File)
+	require.NoError(t, err)
+
+	changes := BlockChanges{
+		Ops: opsList{co},
+	}
+
+	encodedChanges, err := codec.Encode(changes)
+	require.NoError(t, err)
+	block := &FileBlock{Contents: encodedChanges}
+
+	ctx := context.Background()
+	bcache := testBlockCache{block}
+	tlfID := tlf.FakeID(1, tlf.Private)
+	mode := modeTest{NewInitModeFromType(InitDefault)}
+
+	ptr := BlockPointer{ID: kbfsblock.FakeID(2)}
+	pmd := PrivateMetadata{
+		Changes: BlockChanges{
+			Info: BlockInfo{
+				BlockPointer: ptr,
+			},
+		},
+	}
+	err = reembedBlockChanges(ctx, codec, bcache, nil, mode, tlfID, &pmd, nil, logger.NewTestLogger(t))
+	require.NoError(t, err)
+}

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -29,6 +29,13 @@ func (testBlockCache) Put(ptr BlockPointer, tlf tlf.ID, block Block,
 	return errors.New("Shouldn't be called")
 }
 
+type blockChangesNoInfo struct {
+	// An ordered list of operations completed in this update
+	Ops opsList `codec:"o,omitempty"`
+	// Estimate the number of bytes that this set of changes will take to encode
+	sizeEstimate uint64
+}
+
 func TestReembedBlockChanges(t *testing.T) {
 	codec := kbfscodec.NewMsgpack()
 	RegisterOps(codec)
@@ -37,7 +44,7 @@ func TestReembedBlockChanges(t *testing.T) {
 	co, err := newCreateOp("file", oldDir, File)
 	require.NoError(t, err)
 
-	changes := BlockChanges{
+	changes := blockChangesNoInfo{
 		Ops: opsList{co},
 	}
 
@@ -73,10 +80,7 @@ func TestReembedBlockChanges(t *testing.T) {
 		Ops: opsList{expectedCO},
 	}
 
-	// In particular, Info should be empty. Note that old clients
-	// rely on the fact that encoded BlockChanges always have an
-	// encoded Info, which then clobbers any existing one on
-	// decode. (See comments for BlockChanges.)
+	// In particular, Info should be empty.
 	expectedPmd := PrivateMetadata{
 		Changes: expectedChanges,
 

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -73,6 +73,10 @@ func TestReembedBlockChanges(t *testing.T) {
 		Ops: opsList{expectedCO},
 	}
 
+	// In particular, Info should be empty. Note that old clients
+	// rely on the fact that encoded BlockChanges always have an
+	// encoded Info, which then clobbers any existing one on
+	// decode. (See comments for BlockChanges.)
 	expectedPmd := PrivateMetadata{
 		Changes: expectedChanges,
 

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -63,4 +63,24 @@ func TestReembedBlockChanges(t *testing.T) {
 	// nil for bops and rmdWithKeys.
 	err = reembedBlockChanges(ctx, codec, bcache, nil, mode, tlfID, &pmd, nil, logger.NewTestLogger(t))
 	require.NoError(t, err)
+
+	// We expect to get changes back, except with the implicit ref
+	// block added.
+	expectedCO, err := newCreateOp("file", oldDir, File)
+	require.NoError(t, err)
+	expectedCO.AddRefBlock(ptr)
+	expectedChanges := BlockChanges{
+		Ops: opsList{expectedCO},
+	}
+
+	expectedPmd := PrivateMetadata{
+		Changes: expectedChanges,
+
+		cachedChanges: BlockChanges{
+			Info: BlockInfo{
+				BlockPointer: ptr,
+			},
+		},
+	}
+	require.Equal(t, expectedPmd, pmd)
 }

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -6,7 +6,6 @@ package libkbfs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/pkg/errors"
 )
 
 // op represents a single file-system remote-sync operation
@@ -108,7 +108,7 @@ func (u blockUpdate) checkValid() error {
 
 func (u *blockUpdate) setUnref(ptr BlockPointer) error {
 	if ptr == (BlockPointer{}) {
-		return fmt.Errorf("setUnref called with nil ptr")
+		return errors.Errorf("setUnref called with nil ptr")
 	}
 	u.Unref = ptr
 	return nil
@@ -116,7 +116,7 @@ func (u *blockUpdate) setUnref(ptr BlockPointer) error {
 
 func (u *blockUpdate) setRef(ptr BlockPointer) error {
 	if ptr == (BlockPointer{}) {
-		return fmt.Errorf("setRef called with nil ptr")
+		return errors.Errorf("setRef called with nil ptr")
 	}
 	u.Ref = ptr
 	return nil
@@ -263,7 +263,7 @@ func (oc *OpCommon) checkUpdatesValid() error {
 	for i, update := range oc.Updates {
 		err := update.checkValid()
 		if err != nil {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"update[%d]=%v got error: %v", i, update, err)
 		}
 	}
@@ -370,7 +370,7 @@ func (co *createOp) checkValid() error {
 
 	err := co.Dir.checkValid()
 	if err != nil {
-		return fmt.Errorf("createOp.Dir=%v got error: %v", co.Dir, err)
+		return errors.Errorf("createOp.Dir=%v got error: %v", co.Dir, err)
 	}
 	return co.checkUpdatesValid()
 }
@@ -528,7 +528,7 @@ func (ro *rmOp) allUpdates() []blockUpdate {
 func (ro *rmOp) checkValid() error {
 	err := ro.Dir.checkValid()
 	if err != nil {
-		return fmt.Errorf("rmOp.Dir=%v got error: %v", ro.Dir, err)
+		return errors.Errorf("rmOp.Dir=%v got error: %v", ro.Dir, err)
 	}
 	return ro.checkUpdatesValid()
 }
@@ -657,13 +657,13 @@ func (ro *renameOp) allUpdates() []blockUpdate {
 func (ro *renameOp) checkValid() error {
 	err := ro.OldDir.checkValid()
 	if err != nil {
-		return fmt.Errorf("renameOp.OldDir=%v got error: %v",
+		return errors.Errorf("renameOp.OldDir=%v got error: %v",
 			ro.OldDir, err)
 	}
 	if ro.NewDir != (blockUpdate{}) {
 		err = ro.NewDir.checkValid()
 		if err != nil {
-			return fmt.Errorf("renameOp.NewDir=%v got error: %v",
+			return errors.Errorf("renameOp.NewDir=%v got error: %v",
 				ro.NewDir, err)
 		}
 	}
@@ -694,7 +694,7 @@ func (ro *renameOp) StringWithRefs(indent string) string {
 func (ro *renameOp) checkConflict(
 	ctx context.Context, renamer ConflictRenamer, mergedOp op,
 	isFile bool) (crAction, error) {
-	return nil, fmt.Errorf("Unexpected conflict check on a rename op: %s", ro)
+	return nil, errors.Errorf("Unexpected conflict check on a rename op: %s", ro)
 }
 
 func (ro *renameOp) getDefaultAction(mergedPath path) crAction {
@@ -824,7 +824,7 @@ func (so *syncOp) allUpdates() []blockUpdate {
 func (so *syncOp) checkValid() error {
 	err := so.File.checkValid()
 	if err != nil {
-		return fmt.Errorf("syncOp.File=%v got error: %v", so.File, err)
+		return errors.Errorf("syncOp.File=%v got error: %v", so.File, err)
 	}
 	return so.checkUpdatesValid()
 }
@@ -1097,7 +1097,7 @@ func (sao *setAttrOp) allUpdates() []blockUpdate {
 func (sao *setAttrOp) checkValid() error {
 	err := sao.Dir.checkValid()
 	if err != nil {
-		return fmt.Errorf("setAttrOp.Dir=%v got error: %v", sao.Dir, err)
+		return errors.Errorf("setAttrOp.Dir=%v got error: %v", sao.Dir, err)
 	}
 	return sao.checkUpdatesValid()
 }


### PR DESCRIPTION
We relied on decoding a BlockChanges clobbering any existing Info,
which would not be true if the omitempty tag on Info were actually respected
(which the upstream version of our codec library (buggily!) does).

So add a test that catches this, and make it so that we decode into an empty
BlockChanges and then assign.

Also, remove omitempty from Info in BlockChanges. We can't turn it back on
until old clients with the buggy behavior all disappear.