### PR TITLE
Return a *[]byte from {,Encrypted}MerkleLeaf.Construct()

### DIFF
--- a/kbfsmd/merkle_leaf.go
+++ b/kbfsmd/merkle_leaf.go
@@ -24,7 +24,7 @@ var _ merkle.ValueConstructor = (*MerkleLeaf)(nil)
 // Construct implements the go-merkle-tree.ValueConstructor interface.
 func (l MerkleLeaf) Construct() interface{} {
 	// In the Merkle tree leaves are simply byte slices.
-	return []byte{}
+	return &[]byte{}
 }
 
 // EncryptedMerkleLeaf is an encrypted Merkle leaf.
@@ -37,7 +37,7 @@ type EncryptedMerkleLeaf struct {
 // Construct implements the go-merkle-tree.ValueConstructor interface.
 func (el EncryptedMerkleLeaf) Construct() interface{} {
 	// In the Merkle tree leaves are simply byte slices.
-	return []byte{}
+	return &[]byte{}
 }
 
 // Encrypt encrypts a Merkle leaf node with the given key pair.

--- a/kbfsmd/merkle_leaf_test.go
+++ b/kbfsmd/merkle_leaf_test.go
@@ -1,0 +1,36 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsmd
+
+import (
+	"testing"
+
+	merkle "github.com/keybase/go-merkle-tree"
+	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/stretchr/testify/require"
+)
+
+func testValueConstructor(t *testing.T, vc merkle.ValueConstructor) {
+	c := kbfscodec.NewMsgpack()
+
+	// Mimic the logic in merkle.Tree.findTyped.
+	data := []byte("hello world")
+	buf, err := c.Encode(data)
+	require.NoError(t, err)
+
+	obj := vc.Construct()
+	err = c.Decode(buf, &obj)
+	require.NoError(t, err)
+
+	require.Equal(t, &data, obj)
+}
+
+func TestConstructMerkleLeaf(t *testing.T) {
+	testValueConstructor(t, MerkleLeaf{})
+}
+
+func TestConstructEncryptedMerkleLeaf(t *testing.T) {
+	testValueConstructor(t, EncryptedMerkleLeaf{})
+}

--- a/libkbfs/merkle_checker.go
+++ b/libkbfs/merkle_checker.go
@@ -90,7 +90,7 @@ func verifyMerkleNodes(
 	}
 
 	if !bytes.Equal(leafBytes, nodes[len(nodes)-1]) {
-		return errors.New("Expected leaf didn't match found leaf")
+		return errors.Errorf("Expected leaf didn't match found leaf: expected=%x, found=%x", nodes[len(nodes)-1], leafBytes)
 	}
 
 	return nil

--- a/libkbfs/merkle_checker.go
+++ b/libkbfs/merkle_checker.go
@@ -83,14 +83,14 @@ func verifyMerkleNodes(
 			mc.nextNode, len(nodes))
 	}
 
-	leafBytes, ok := foundLeaf.([]byte)
+	leafBytes, ok := foundLeaf.(*[]byte)
 	if !ok {
 		return errors.Errorf(
-			"Found merkle leaf isn't a byte slice: %T", foundLeaf)
+			"Found merkle leaf isn't a byte slice pointer: %T", foundLeaf)
 	}
 
-	if !bytes.Equal(leafBytes, nodes[len(nodes)-1]) {
-		return errors.Errorf("Expected leaf didn't match found leaf: expected=%x, found=%x", nodes[len(nodes)-1], leafBytes)
+	if !bytes.Equal(*leafBytes, nodes[len(nodes)-1]) {
+		return errors.Errorf("Expected leaf didn't match found leaf: expected=%x, found=%x", nodes[len(nodes)-1], *leafBytes)
 	}
 
 	return nil


### PR DESCRIPTION
Upstream codec decodes into a []byte only up to its existing length; see
https://github.com/ugorji/go/issues/249 .