### PR TITLE
tlf_handle_resolve: don't use finalized TLF IDs from iteam info

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1203,6 +1203,11 @@ type tlfIDGetter interface {
 	// exist yet, and it may return `tlf.NullID` with a `nil` error if
 	// it doesn't create a missing folder.
 	GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error)
+	// GetLatestHandleForTLF returns the server's idea of the latest
+	// handle for the TLF, which may not yet be reflected in the MD if
+	// the TLF hasn't been rekeyed since it entered into a conflicting
+	// state.
+	GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error)
 }
 
 // MDOps gets and puts root metadata to an MDServer.  On a get, it
@@ -1289,11 +1294,6 @@ type MDOps interface {
 	ResolveBranch(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID,
 		blocksToDelete []kbfsblock.ID, rmd *RootMetadata,
 		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
-
-	// GetLatestHandleForTLF returns the server's idea of the latest handle for the TLF,
-	// which may not yet be reflected in the MD if the TLF hasn't been rekeyed since it
-	// entered into a conflicting state.
-	GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error)
 }
 
 // KeyOps fetches server-side key halves from the key server.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1203,11 +1203,10 @@ type tlfIDGetter interface {
 	// exist yet, and it may return `tlf.NullID` with a `nil` error if
 	// it doesn't create a missing folder.
 	GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.ID, error)
-	// GetLatestHandleForTLF returns the server's idea of the latest
-	// handle for the TLF, which may not yet be reflected in the MD if
-	// the TLF hasn't been rekeyed since it entered into a conflicting
-	// state.
-	GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error)
+	// ValidateLatestHandleForTLF returns true if the TLF ID contained
+	// in `h` does not currently map to a finalized TLF.
+	ValidateLatestHandleNotFinal(ctx context.Context, h *TlfHandle) (
+		bool, error)
 }
 
 // MDOps gets and puts root metadata to an MDServer.  On a get, it
@@ -1294,6 +1293,12 @@ type MDOps interface {
 	ResolveBranch(ctx context.Context, id tlf.ID, bid kbfsmd.BranchID,
 		blocksToDelete []kbfsblock.ID, rmd *RootMetadata,
 		verifyingKey kbfscrypto.VerifyingKey) (ImmutableRootMetadata, error)
+
+	// GetLatestHandleForTLF returns the server's idea of the latest
+	// handle for the TLF, which may not yet be reflected in the MD if
+	// the TLF hasn't been rekeyed since it entered into a conflicting
+	// state.
+	GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error)
 }
 
 // KeyOps fetches server-side key halves from the key server.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1043,31 +1043,11 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 
 	_, err = md.config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
-		md.log.CDebugf(ctx, "Not logged in when validating latest handle "+
-			"for %s; checking with server for ID (currently %s)",
-			h.GetCanonicalName(), h.tlfID)
 		// If we're not logged in, the server won't tell us the latest
-		// handle (even for public folders), so look up the handle
-		// from the server to see if it has the ID.
-		id, _, err = md.getForHandle(ctx, h, kbfsmd.Merged, nil)
-		switch errors.Cause(err).(type) {
-		case kbfsmd.ServerErrorClassicTLFDoesNotExist:
-			err = mdcache.PutIDForHandle(h, h.tlfID)
-			if err != nil {
-				return false, err
-			}
-			// The server thinks this is an implicit team TLF, so we
-			// should trust whatever's in the handle.
-			return true, nil
-		case nil:
-			err = mdcache.PutIDForHandle(h, id)
-			if err != nil {
-				return false, err
-			}
-			return id == h.tlfID, nil
-		default:
-			return false, err
-		}
+		// handle (even for public folders), so just consider it
+		// invalid to force the caller to request the latest ID (which
+		// does work for public folders).
+		return false, nil
 	}
 
 	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1041,7 +1041,16 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 		return false, err
 	}
 
-	md.log.CDebugf(ctx, "Checking the latest handle for %d; "+
+	_, err = md.config.KBPKI().GetCurrentSession(ctx)
+	if err != nil {
+		// If we're not logged in, the server won't tell us the latest
+		// handle (even for public folders), so just consider it
+		// invalid to force the caller to request the latest ID (which
+		// does work for public folders).
+		return false, nil
+	}
+
+	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+
 		"curr handle is %s", h.tlfID, h.GetCanonicalName())
 	latestHandle, err := md.GetLatestHandleForTLF(ctx, h.tlfID)
 	if err != nil {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1047,11 +1047,7 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 	// Look up the handle from the server to see if it has the ID --
 	// from its response we can tell if this is supposed to be an
 	// implicit team TLF or if the server has a new ID for it.
-	bh, err := h.ToBareHandle()
-	if err != nil {
-		return false, err
-	}
-	id, _, err = md.config.MDServer().GetForHandle(ctx, bh, kbfsmd.Merged, nil)
+	id, _, err = md.getForHandle(ctx, h, kbfsmd.Merged, nil)
 	switch errors.Cause(err).(type) {
 	case kbfsmd.ServerErrorClassicTLFDoesNotExist:
 		err = mdcache.PutIDForHandle(h, h.tlfID)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1043,11 +1043,31 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 
 	_, err = md.config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
+		md.log.CDebugf(ctx, "Not logged in when validating latest handle "+
+			"for %s; checking with server for ID (currently %s)",
+			h.GetCanonicalName(), h.tlfID)
 		// If we're not logged in, the server won't tell us the latest
-		// handle (even for public folders), so just consider it
-		// invalid to force the caller to request the latest ID (which
-		// does work for public folders).
-		return false, nil
+		// handle (even for public folders), so look up the handle
+		// from the server to see if it has the ID.
+		id, _, err = md.getForHandle(ctx, h, kbfsmd.Merged, nil)
+		switch errors.Cause(err).(type) {
+		case kbfsmd.ServerErrorClassicTLFDoesNotExist:
+			err = mdcache.PutIDForHandle(h, h.tlfID)
+			if err != nil {
+				return false, err
+			}
+			// The server thinks this is an implicit team TLF, so we
+			// should trust whatever's in the handle.
+			return true, nil
+		case nil:
+			err = mdcache.PutIDForHandle(h, id)
+			if err != nil {
+				return false, err
+			}
+			return id == h.tlfID, nil
+		default:
+			return false, err
+		}
 	}
 
 	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -718,6 +718,11 @@ func (c constIDGetter) GetIDForHandle(_ context.Context, _ *TlfHandle) (
 	return c.id, nil
 }
 
+func (c constIDGetter) GetLatestHandleForTLF(
+	_ context.Context, _ tlf.ID) (tlf.Handle, error) {
+	return tlf.Handle{}, nil
+}
+
 func (md *MDOpsStandard) getForTLF(ctx context.Context, id tlf.ID,
 	bid kbfsmd.BranchID, mStatus kbfsmd.MergeStatus, lockBeforeGet *keybase1.LockID) (
 	ImmutableRootMetadata, error) {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1047,7 +1047,11 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 	// Look up the handle from the server to see if it has the ID --
 	// from its response we can tell if this is supposed to be an
 	// implicit team TLF or if the server has a new ID for it.
-	id, _, err = md.getForHandle(ctx, h, kbfsmd.Merged, nil)
+	bh, err := h.ToBareHandle()
+	if err != nil {
+		return false, err
+	}
+	id, _, err = md.config.MDServer().GetForHandle(ctx, bh, kbfsmd.Merged, nil)
 	switch errors.Cause(err).(type) {
 	case kbfsmd.ServerErrorClassicTLFDoesNotExist:
 		err = mdcache.PutIDForHandle(h, h.tlfID)

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1041,31 +1041,49 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 		return false, err
 	}
 
-	md.log.CDebugf(ctx, "Validating latest handle for %s; "+
-		"checking with server for ID (currently %s)",
-		h.GetCanonicalName(), h.tlfID)
-	// Look up the handle from the server to see if it has the ID --
-	// from its response we can tell if this is supposed to be an
-	// implicit team TLF or if the server has a new ID for it.
-	id, _, err = md.getForHandle(ctx, h, kbfsmd.Merged, nil)
-	switch errors.Cause(err).(type) {
-	case kbfsmd.ServerErrorClassicTLFDoesNotExist:
-		err = mdcache.PutIDForHandle(h, h.tlfID)
-		if err != nil {
+	_, err = md.config.KBPKI().GetCurrentSession(ctx)
+	if err != nil {
+		md.log.CDebugf(ctx, "Not logged in when validating latest handle "+
+			"for %s; checking with server for ID (currently %s)",
+			h.GetCanonicalName(), h.tlfID)
+		// If we're not logged in, the server won't tell us the latest
+		// handle (even for public folders), so look up the handle
+		// from the server to see if it has the ID.
+		id, _, err = md.getForHandle(ctx, h, kbfsmd.Merged, nil)
+		switch errors.Cause(err).(type) {
+		case kbfsmd.ServerErrorClassicTLFDoesNotExist:
+			err = mdcache.PutIDForHandle(h, h.tlfID)
+			if err != nil {
+				return false, err
+			}
+			// The server thinks this is an implicit team TLF, so we
+			// should trust whatever's in the handle.
+			return true, nil
+		case nil:
+			err = mdcache.PutIDForHandle(h, id)
+			if err != nil {
+				return false, err
+			}
+			return id == h.tlfID, nil
+		default:
 			return false, err
 		}
-		// The server thinks this is an implicit team TLF, so we
-		// should trust whatever's in the handle.
-		return true, nil
-	case nil:
-		err = mdcache.PutIDForHandle(h, id)
-		if err != nil {
-			return false, err
-		}
-		return id == h.tlfID, nil
-	default:
+	}
+
+	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+
+		"curr handle is %s", h.tlfID, h.GetCanonicalName())
+	latestHandle, err := md.GetLatestHandleForTLF(ctx, h.tlfID)
+	if err != nil {
 		return false, err
 	}
+	if latestHandle.IsFinal() {
+		return false, nil
+	}
+	err = mdcache.PutIDForHandle(h, h.tlfID)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (md *MDOpsStandard) getExtraMD(ctx context.Context, brmd kbfsmd.RootMetadata) (

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1041,7 +1041,7 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 		return false, err
 	}
 
-	md.log.CDebugf(ctx, "Checking the latest handle for %d; "+
+	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+
 		"curr handle is %s", h.tlfID, h.GetCanonicalName())
 	latestHandle, err := md.GetLatestHandleForTLF(ctx, h.tlfID)
 	switch errors.Cause(err).(type) {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -1041,16 +1041,7 @@ func (md *MDOpsStandard) ValidateLatestHandleNotFinal(
 		return false, err
 	}
 
-	_, err = md.config.KBPKI().GetCurrentSession(ctx)
-	if err != nil {
-		// If we're not logged in, the server won't tell us the latest
-		// handle (even for public folders), so just consider it
-		// invalid to force the caller to request the latest ID (which
-		// does work for public folders).
-		return false, nil
-	}
-
-	md.log.CDebugf(ctx, "Checking the latest handle for %s; "+
+	md.log.CDebugf(ctx, "Checking the latest handle for %d; "+
 		"curr handle is %s", h.tlfID, h.GetCanonicalName())
 	latestHandle, err := md.GetLatestHandleForTLF(ctx, h.tlfID)
 	if err != nil {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4032,6 +4032,19 @@ func (mr *MocktlfIDGetterMockRecorder) GetIDForHandle(ctx, handle interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MocktlfIDGetter)(nil).GetIDForHandle), ctx, handle)
 }
 
+// GetLatestHandleForTLF mocks base method
+func (m *MocktlfIDGetter) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {
+	ret := m.ctrl.Call(m, "GetLatestHandleForTLF", ctx, id)
+	ret0, _ := ret[0].(tlf.Handle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF
+func (mr *MocktlfIDGetterMockRecorder) GetLatestHandleForTLF(ctx, id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MocktlfIDGetter)(nil).GetLatestHandleForTLF), ctx, id)
+}
+
 // MockMDOps is a mock of MDOps interface
 type MockMDOps struct {
 	ctrl     *gomock.Controller
@@ -4066,6 +4079,19 @@ func (m *MockMDOps) GetIDForHandle(ctx context.Context, handle *TlfHandle) (tlf.
 // GetIDForHandle indicates an expected call of GetIDForHandle
 func (mr *MockMDOpsMockRecorder) GetIDForHandle(ctx, handle interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MockMDOps)(nil).GetIDForHandle), ctx, handle)
+}
+
+// GetLatestHandleForTLF mocks base method
+func (m *MockMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {
+	ret := m.ctrl.Call(m, "GetLatestHandleForTLF", ctx, id)
+	ret0, _ := ret[0].(tlf.Handle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF
+func (mr *MockMDOpsMockRecorder) GetLatestHandleForTLF(ctx, id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MockMDOps)(nil).GetLatestHandleForTLF), ctx, id)
 }
 
 // GetForTLF mocks base method
@@ -4169,19 +4195,6 @@ func (m *MockMDOps) ResolveBranch(ctx context.Context, id tlf.ID, bid kbfsmd.Bra
 // ResolveBranch indicates an expected call of ResolveBranch
 func (mr *MockMDOpsMockRecorder) ResolveBranch(ctx, id, bid, blocksToDelete, rmd, verifyingKey interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBranch", reflect.TypeOf((*MockMDOps)(nil).ResolveBranch), ctx, id, bid, blocksToDelete, rmd, verifyingKey)
-}
-
-// GetLatestHandleForTLF mocks base method
-func (m *MockMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {
-	ret := m.ctrl.Call(m, "GetLatestHandleForTLF", ctx, id)
-	ret0, _ := ret[0].(tlf.Handle)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF
-func (mr *MockMDOpsMockRecorder) GetLatestHandleForTLF(ctx, id interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MockMDOps)(nil).GetLatestHandleForTLF), ctx, id)
 }
 
 // MockKeyOps is a mock of KeyOps interface

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4032,17 +4032,17 @@ func (mr *MocktlfIDGetterMockRecorder) GetIDForHandle(ctx, handle interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MocktlfIDGetter)(nil).GetIDForHandle), ctx, handle)
 }
 
-// GetLatestHandleForTLF mocks base method
-func (m *MocktlfIDGetter) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {
-	ret := m.ctrl.Call(m, "GetLatestHandleForTLF", ctx, id)
-	ret0, _ := ret[0].(tlf.Handle)
+// ValidateLatestHandleNotFinal mocks base method
+func (m *MocktlfIDGetter) ValidateLatestHandleNotFinal(ctx context.Context, h *TlfHandle) (bool, error) {
+	ret := m.ctrl.Call(m, "ValidateLatestHandleNotFinal", ctx, h)
+	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF
-func (mr *MocktlfIDGetterMockRecorder) GetLatestHandleForTLF(ctx, id interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MocktlfIDGetter)(nil).GetLatestHandleForTLF), ctx, id)
+// ValidateLatestHandleNotFinal indicates an expected call of ValidateLatestHandleNotFinal
+func (mr *MocktlfIDGetterMockRecorder) ValidateLatestHandleNotFinal(ctx, h interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateLatestHandleNotFinal", reflect.TypeOf((*MocktlfIDGetter)(nil).ValidateLatestHandleNotFinal), ctx, h)
 }
 
 // MockMDOps is a mock of MDOps interface
@@ -4081,17 +4081,17 @@ func (mr *MockMDOpsMockRecorder) GetIDForHandle(ctx, handle interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIDForHandle", reflect.TypeOf((*MockMDOps)(nil).GetIDForHandle), ctx, handle)
 }
 
-// GetLatestHandleForTLF mocks base method
-func (m *MockMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {
-	ret := m.ctrl.Call(m, "GetLatestHandleForTLF", ctx, id)
-	ret0, _ := ret[0].(tlf.Handle)
+// ValidateLatestHandleNotFinal mocks base method
+func (m *MockMDOps) ValidateLatestHandleNotFinal(ctx context.Context, h *TlfHandle) (bool, error) {
+	ret := m.ctrl.Call(m, "ValidateLatestHandleNotFinal", ctx, h)
+	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF
-func (mr *MockMDOpsMockRecorder) GetLatestHandleForTLF(ctx, id interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MockMDOps)(nil).GetLatestHandleForTLF), ctx, id)
+// ValidateLatestHandleNotFinal indicates an expected call of ValidateLatestHandleNotFinal
+func (mr *MockMDOpsMockRecorder) ValidateLatestHandleNotFinal(ctx, h interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateLatestHandleNotFinal", reflect.TypeOf((*MockMDOps)(nil).ValidateLatestHandleNotFinal), ctx, h)
 }
 
 // GetForTLF mocks base method
@@ -4195,6 +4195,19 @@ func (m *MockMDOps) ResolveBranch(ctx context.Context, id tlf.ID, bid kbfsmd.Bra
 // ResolveBranch indicates an expected call of ResolveBranch
 func (mr *MockMDOpsMockRecorder) ResolveBranch(ctx, id, bid, blocksToDelete, rmd, verifyingKey interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveBranch", reflect.TypeOf((*MockMDOps)(nil).ResolveBranch), ctx, id, bid, blocksToDelete, rmd, verifyingKey)
+}
+
+// GetLatestHandleForTLF mocks base method
+func (m *MockMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (tlf.Handle, error) {
+	ret := m.ctrl.Call(m, "GetLatestHandleForTLF", ctx, id)
+	ret0, _ := ret[0].(tlf.Handle)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestHandleForTLF indicates an expected call of GetLatestHandleForTLF
+func (mr *MockMDOpsMockRecorder) GetLatestHandleForTLF(ctx, id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestHandleForTLF", reflect.TypeOf((*MockMDOps)(nil).GetLatestHandleForTLF), ctx, id)
 }
 
 // MockKeyOps is a mock of KeyOps interface

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -30,18 +30,19 @@ const (
 	StallableBlockGet StallableBlockOp = "Get"
 	StallableBlockPut StallableBlockOp = "Put"
 
-	StallableMDGetForTLF             StallableMDOp = "GetForTLF"
-	StallableMDGetLatestHandleForTLF StallableMDOp = "GetLatestHandleForTLF"
-	StallableMDGetUnmergedForTLF     StallableMDOp = "GetUnmergedForTLF"
-	StallableMDGetRange              StallableMDOp = "GetRange"
-	StallableMDAfterGetRange         StallableMDOp = "AfterGetRange"
-	StallableMDGetUnmergedRange      StallableMDOp = "GetUnmergedRange"
-	StallableMDPut                   StallableMDOp = "Put"
-	StallableMDAfterPut              StallableMDOp = "AfterPut"
-	StallableMDPutUnmerged           StallableMDOp = "PutUnmerged"
-	StallableMDAfterPutUnmerged      StallableMDOp = "AfterPutUnmerged"
-	StallableMDPruneBranch           StallableMDOp = "PruneBranch"
-	StallableMDResolveBranch         StallableMDOp = "ResolveBranch"
+	StallableMDGetForTLF                    StallableMDOp = "GetForTLF"
+	StallableMDGetLatestHandleForTLF        StallableMDOp = "GetLatestHandleForTLF"
+	StallableMDValidateLatestHandleNotFinal StallableMDOp = "ValidateLatestHandleNotFinal"
+	StallableMDGetUnmergedForTLF            StallableMDOp = "GetUnmergedForTLF"
+	StallableMDGetRange                     StallableMDOp = "GetRange"
+	StallableMDAfterGetRange                StallableMDOp = "AfterGetRange"
+	StallableMDGetUnmergedRange             StallableMDOp = "GetUnmergedRange"
+	StallableMDPut                          StallableMDOp = "Put"
+	StallableMDAfterPut                     StallableMDOp = "AfterPut"
+	StallableMDPutUnmerged                  StallableMDOp = "PutUnmerged"
+	StallableMDAfterPutUnmerged             StallableMDOp = "AfterPutUnmerged"
+	StallableMDPruneBranch                  StallableMDOp = "PruneBranch"
+	StallableMDResolveBranch                StallableMDOp = "ResolveBranch"
 )
 
 type stallKeyType uint64
@@ -433,6 +434,18 @@ func (m *stallingMDOps) GetLatestHandleForTLF(ctx context.Context, id tlf.ID) (
 		return errGetLatestHandleForTLF
 	})
 	return h, err
+}
+
+func (m *stallingMDOps) ValidateLatestHandleNotFinal(
+	ctx context.Context, h *TlfHandle) (b bool, err error) {
+	m.maybeStall(ctx, StallableMDValidateLatestHandleNotFinal)
+	err = runWithContextCheck(ctx, func(ctx context.Context) error {
+		var errValidateLatestHandleNotFinal error
+		b, errValidateLatestHandleNotFinal =
+			m.delegate.ValidateLatestHandleNotFinal(ctx, h)
+		return errValidateLatestHandleNotFinal
+	})
+	return b, err
 }
 
 func (m *stallingMDOps) GetUnmergedForTLF(ctx context.Context, id tlf.ID,

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -776,12 +776,12 @@ func parseTlfHandleLoose(
 				// that ID.  When we migrate existing TLFs to iteams, we can
 				// probably override the sigchain link with a new one
 				// containing the correct TLF ID.
-				latestHandle, err := idGetter.GetLatestHandleForTLF(
-					ctx, iteamHandle.tlfID)
+				valid, err := idGetter.ValidateLatestHandleNotFinal(
+					ctx, iteamHandle)
 				if err != nil {
 					return nil, err
 				}
-				if latestHandle.IsFinal() {
+				if !valid {
 					iteamHandle.tlfID = tlf.NullID
 				}
 			}


### PR DESCRIPTION
When chats got migrated to implicit teams, the current TLF ID got written into the iteam sigchain.  KBFS uses that ID in the sigchain, if it's available, in preparation for when we turn on KBFS iteams. However, if the TLF gets finalized (because a user resets), the old ID remains in the sigchain and KBFS will use it even when looking up the non-finalized TLF ID.

We can fix this more permanently when we migrate existing KBFS TLFs to iteams; at that point we can override the TLF ID using a new sigchain link.

Issue: KBFS-3045