### PR TITLE
Remove more useless omitempty tags

### DIFF
--- a/kbfsmd/root_metadata_v3.go
+++ b/kbfsmd/root_metadata_v3.go
@@ -34,7 +34,7 @@ type WriterMetadataV3 struct {
 	// Writers identified by unresolved social assertions.
 	UnresolvedWriters []keybase1.SocialAssertion `codec:"uw,omitempty"`
 	// Pointer to the writer key bundle for private TLFs.
-	WKeyBundleID TLFWriterKeyBundleID `codec:"wkid,omitempty"`
+	WKeyBundleID TLFWriterKeyBundleID `codec:"wkid"`
 	// Latest key generation.
 	LatestKeyGen KeyGen `codec:"lkg"`
 
@@ -78,7 +78,7 @@ type RootMetadataV3 struct {
 	// For private TLFs. Any unresolved social assertions for readers.
 	UnresolvedReaders []keybase1.SocialAssertion `codec:"ur,omitempty"`
 	// Pointer to the reader key bundle for private TLFs.
-	RKeyBundleID TLFReaderKeyBundleID `codec:"rkid,omitempty"`
+	RKeyBundleID TLFReaderKeyBundleID `codec:"rkid"`
 
 	// ConflictInfo is set if there's a conflict for the given folder's
 	// handle after a social assertion resolution.


### PR DESCRIPTION
Older versions of go-codec didn't respect them for
TLF*KeyBundleID, so now we're stuck without them, lest
verification (which re-encodes the metadata) fail.