### PR TITLE
Migrate to CircleCI 2.0

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -36,7 +36,7 @@ jobs:
         name: Update PATH and Define Environment Variable at Runtime
         command: |
           echo 'export GOPATH=$HOME/go-path' >> $BASH_ENV
-          echo 'export PATH=$HOME/.yarn/bin:$GOROOT/bin:$PATH' >> $BASH_ENV
+          echo 'export PATH=$GOROOT/bin:$PATH' >> $BASH_ENV
 
           # Some node dependencies break without this.
           echo 'export ANDROID_NDK=$ANDROID_HOME/ndk-bundle' >> $BASH_ENV
@@ -45,6 +45,7 @@ jobs:
           source $BASH_ENV
 
     # Install node and java.
+    # - run: nvm ls-remote
     - run: nvm install 10 && nvm alias default 10
     - run: sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/jdk1.8.0/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/jdk1.8.0" >> $BASH_ENV
 
@@ -58,12 +59,6 @@ jobs:
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
 
-    # - run: nvm ls-remote
-    - run: sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-    - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-    - run: sudo apt-get update -qq
-    # - run: sudo apt-cache show yarn
-    - run: sudo apt-get install -y -qq yarn=1.7.0-1
     - run: sudo rm -rf /usr/local/go*
     - run: mkdir -p ~/downloads ~/go-path
     - run: ls "$HOME/downloads"
@@ -110,7 +105,6 @@ jobs:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
         paths:
         - ~/downloads
-        - ~/.cache/yarn
         - /tmp/go-android/bin
         - /tmp/go-android/pkg
         - /usr/local/android-sdk-linux/tools

--- a/circle.yml
+++ b/circle.yml
@@ -100,6 +100,8 @@ jobs:
           LOCAL_KBFS: 1
         command: yarn run rn-gobuild-android
 
+    - run: ls -la $GOPATH/src/github.com/keybase/client/shared/react-native/android/keybaselib/keybaselib.aar
+
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}

--- a/circle.yml
+++ b/circle.yml
@@ -90,14 +90,6 @@ jobs:
     - run: git clone https://github.com/keybase/client.git $HOME/client
     - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
 
-    # Install JS dependencies.
-    - run:
-        working_directory: ../client/shared
-        command: yarn install --pure-lockfile --ignore-engines --prefer-offline
-    - run:
-        working_directory: ../client/shared
-        command: yarn global add react-native-cli
-
     ##
     ## Build.
     ##
@@ -109,7 +101,7 @@ jobs:
         working_directory: ../client/shared
         environment:
           LOCAL_KBFS: 1
-        command: yarn run rn-gobuild-android
+        command: ./react-native/gobuild.sh android
 
     - run: ls -la $GOPATH/src/github.com/keybase/client/shared/react-native/android/keybaselib/keybaselib.aar
 

--- a/circle.yml
+++ b/circle.yml
@@ -60,7 +60,7 @@ jobs:
     - run: sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
     - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     - run: sudo apt-get update -qq
-    - run: sudo apt-cache show yarn
+    # - run: sudo apt-cache show yarn
     - run: sudo apt-get install -y -qq yarn=1.7.0-1
     - run: sudo rm -rf /usr/local/go*
     - run: mkdir -p ~/downloads ~/go-path

--- a/circle.yml
+++ b/circle.yml
@@ -43,9 +43,7 @@ jobs:
     - checkout
 
     # Install node and java.
-    #
-    # TODO: Upgrade node?
-    - run: nvm install 8 && nvm alias default 8
+    - run: nvm install 10 && nvm alias default 10
     - run: sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/jdk1.8.0/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/jdk1.8.0" >> $BASH_ENV
 
     # Restore the dependency cache
@@ -88,7 +86,7 @@ jobs:
     # Clone client and install Yarn
     - run: mkdir -p $GOPATH/src/github.com/keybase
     - run: git clone https://github.com/keybase/client.git $HOME/client
-    - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
+    - run: ln -s $HOME/client $GOPwATH/src/github.com/keybase/client
     - run:
         working_directory: ../client/shared
         command: yarn install --pure-lockfile --ignore-engines --prefer-offline

--- a/circle.yml
+++ b/circle.yml
@@ -60,8 +60,8 @@ jobs:
     - run: sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
     - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     - run: sudo apt-get update -qq
-    # - run: sudo apt-cache show yarn
-    - run: sudo apt-get install -y -qq yarn=1.0.2-1
+    - run: sudo apt-cache show yarn
+    - run: sudo apt-get install -y -qq yarn=1.7.0-1
     - run: sudo rm -rf /usr/local/go*
     - run: mkdir -p ~/downloads ~/go-path
     - run: ls "$HOME/downloads"
@@ -86,7 +86,7 @@ jobs:
     # Clone client and install Yarn
     - run: mkdir -p $GOPATH/src/github.com/keybase
     - run: git clone https://github.com/keybase/client.git $HOME/client
-    - run: ln -s $HOME/client $GOPwATH/src/github.com/keybase/client
+    - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
     - run:
         working_directory: ../client/shared
         command: yarn install --pure-lockfile --ignore-engines --prefer-offline

--- a/circle.yml
+++ b/circle.yml
@@ -106,7 +106,6 @@ jobs:
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
         paths:
-        - ~/.gradle
         - ~/downloads
         - ~/.cache/yarn
         - /tmp/go-android/bin

--- a/circle.yml
+++ b/circle.yml
@@ -85,10 +85,12 @@ jobs:
     - run: echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
     - run: echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> /usr/local/android-sdk-linux/licenses/android-sdk-license
 
-    # Clone client and install Yarn
+    # Clone client.
     - run: mkdir -p $GOPATH/src/github.com/keybase
     - run: git clone https://github.com/keybase/client.git $HOME/client
     - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
+
+    # Install JS dependencies.
     - run:
         working_directory: ../client/shared
         command: yarn install --pure-lockfile --ignore-engines --prefer-offline

--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,10 @@ jobs:
       command: /sbin/init
 
     steps:
+    ##
+    ## Install prereqs.
+    ##
+
     - run:
         name: Update PATH and Define Environment Variable at Runtime
         command: |
@@ -39,8 +43,6 @@ jobs:
           echo 'export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle' >> $BASH_ENV
 
           source $BASH_ENV
-
-    - checkout
 
     # Install node and java.
     - run: nvm install 10 && nvm alias default 10
@@ -93,6 +95,12 @@ jobs:
     - run:
         working_directory: ../client/shared
         command: yarn global add react-native-cli
+
+    ##
+    ## Build.
+    ##
+
+    - checkout
 
     - run: ln -s $HOME/kbfs $GOPATH/src/github.com/keybase/kbfs
     - run:

--- a/circle.yml
+++ b/circle.yml
@@ -85,17 +85,20 @@ jobs:
     - run: echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
     - run: echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> /usr/local/android-sdk-linux/licenses/android-sdk-license
 
-    # Install Yarn
+    # Clone client and install Yarn
+    - run: mkdir -p $GOPATH/src/github.com/keybase
+    - run: git clone https://github.com/keybase/client.git $HOME/client
+    - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
     - run:
-        working_directory: shared
+        working_directory: ../client/shared
         command: yarn install --pure-lockfile --ignore-engines --prefer-offline
     - run:
-        working_directory: shared
+        working_directory: ../client/shared
         command: yarn global add react-native-cli
-    - run: mkdir -p $GOPATH/src/github.com/keybase
+
     - run: ln -s $HOME/kbfs $GOPATH/src/github.com/keybase/kbfs
     - run:
-        working_directory: shared
+        working_directory: ../client/shared
         environment:
           LOCAL_KBFS: 1
         command: yarn run rn-gobuild-android

--- a/circle.yml
+++ b/circle.yml
@@ -1,56 +1,53 @@
-# This configuration was automatically generated from a CircleCI 1.0 config.
-# It should include any build commands you had along with commands that CircleCI
-# inferred from your project structure. We strongly recommend you read all the
-# comments in this file to understand the structure of CircleCI 2.0, as the idiom
-# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
-# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
-# configuration as a reference rather than using it in production, though in most
-# cases it should duplicate the execution of your original 1.0 config.
+# -----------------------------------------------------------------------------
+#
+#   REMINDER: If you edit this file, you'll most likely also want to edit
+#   circle.yml in the client repository!
+#
+# -----------------------------------------------------------------------------
 version: 2
 jobs:
   build:
-    working_directory: ~/keybase/kbfs/.
+    working_directory: ~/kbfs
     parallelism: 1
     shell: /bin/bash --login
-    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
-    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
     environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-      GOPATH: $HOME/go-path
-      PATH: $GOROOT/bin:$PATH
-      _JAVA_OPTIONS: -Xms512m -Xmx2048m
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"
-      REACT_NATIVE_MAX_WORKERS: 1
+      GOVERSION: 1.10.3
+
+      # Some node dependencies break without this.
       CXX: g++-4.8
-      ANDROID_NDK_HOME: ${ANDROID_NDK}
-    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
-    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
-    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
-    # We have selected a pre-built image that mirrors the build environment we use on
-    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
-    # of each job. For more information on choosing an image (or alternatively using a
-    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
-    # To see the list of pre-built images that CircleCI provides for most common languages see
-    # https://circleci.com/docs/2.0/circleci-images/
+
+    # TODO: Consider picking a better docker image.
+    #
+    # For more information on choosing an image (or alternatively
+    # using a VM instead of a container) see
+    # https://circleci.com/docs/2.0/executor-types/ To see the list of
+    # pre-built images that CircleCI provides for most common
+    # languages see https://circleci.com/docs/2.0/circleci-images/
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
       command: /sbin/init
+
     steps:
-    # Machine Setup
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
-    - checkout
-    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
-    # In many cases you can simplify this from what is generated here.
-    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
-    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-    # This is based on your 1.0 configuration file or project settings
     - run:
-        working_directory: ~/keybase/kbfs/.
-        command: nvm install 5.7.0 && nvm alias default 5.7.0
-    # Dependencies
-    #   This would typically go in either a build or a build-and-test job when using workflows
+        name: Update PATH and Define Environment Variable at Runtime
+        command: |
+          echo 'export GOPATH=$HOME/go-path' >> $BASH_ENV
+          echo 'export PATH=$HOME/.yarn/bin:$GOROOT/bin:$PATH' >> $BASH_ENV
+
+          # Some node dependencies break without this.
+          echo 'export ANDROID_NDK=$ANDROID_HOME/ndk-bundle' >> $BASH_ENV
+          echo 'export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle' >> $BASH_ENV
+
+          source $BASH_ENV
+
+    - checkout
+
+    # Install node and java.
+    #
+    # TODO: Upgrade node?
+    - run: nvm install 8 && nvm alias default 8
+    - run: sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/jdk1.8.0/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/jdk1.8.0" >> $BASH_ENV
+
     # Restore the dependency cache
     - restore_cache:
         keys:
@@ -60,60 +57,59 @@ jobs:
         - v1-dep-master-
         # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
         - v1-dep-
-    # This is based on your 1.0 configuration file or project settings
-    - run: sudo rm -rf $HOME/go*
-    - run: sudo rm -rf /usr/local/go*
-    - run: wget -nv https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -O $HOME/go.tar.gz
-    - run: mkdir $HOME/go-path
-    - run: (cd $HOME; tar -xzvf go.tar.gz)
-    - run: sudo mv $HOME/go /usr/local
-    - run: (cd $HOME; git clone https://github.com/keybase/client.git)
-    - run: mkdir -p $GOPATH/src/github.com/keybase
-    - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
-    - run: if ! $(grep -q "Revision=24.4.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk -u -a -t "tools"; fi
-    - run: if [ ! -e $ANDROID_HOME/build-tools/23.0.2 ]; then echo y | android update sdk -u -a -t "build-tools-23.0.2"; fi
-    - run: if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository/com/android/support/design/24.1.0" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-    - run: mkdir /usr/local/android-sdk-linux/licenses
-    - run: if [[ ! -e "$ANDROID_HOME/ndk_bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O android-ndk-r11c-linux-x86_64.zip && unzip -o android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
-    - run: echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
+
+    # - run: nvm ls-remote
     - run: sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
     - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
     - run: sudo apt-get update -qq
+    # - run: sudo apt-cache show yarn
     - run: sudo apt-get install -y -qq yarn=1.0.2-1
-    # This is based on your 1.0 configuration file or project settings
-    - run: yarn install --pure-lockfile
-    - run: yarn global add react-native-cli
+    - run: sudo rm -rf /usr/local/go*
+    - run: mkdir -p ~/downloads ~/go-path
+    - run: ls "$HOME/downloads"
+    - run: ls "$ANDROID_HOME"
+
+    - run: if [[ ! -e "$HOME/downloads/go.$GOVERSION.tar.gz" ]]; then wget -nv https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz -O $HOME/downloads/go.$GOVERSION.tar.gz ; fi
+    - run: cd $HOME && tar -xzvf downloads/go.$GOVERSION.tar.gz
+    - run: sudo mv $HOME/go /usr/local
+
+    - run: if ! $(grep -q "Revision=24.4.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk -u -a -t "tools"; fi
+    - run: if [ ! -e $ANDROID_HOME/build-tools/23.0.2 ]; then echo y | android update sdk -u -a -t "build-tools-23.0.2"; fi
+
+    # Android Support Repository, revision 35 / Local Maven repository for Support Libraries
+    - run: if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository/com/android/support/design/24.1.0" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+
+    # Accept android licenses
+    - run: mkdir -p /usr/local/android-sdk-linux/licenses
+    - run: if [[ ! -e "$ANDROID_HOME/ndk-bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O android-ndk-r11c-linux-x86_64.zip && unzip -o android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
+    - run: echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
+    - run: echo "d56f5187479451eabf01fb78af6dfcb131a6481e" >> /usr/local/android-sdk-linux/licenses/android-sdk-license
+
+    # Install Yarn
+    - run:
+        working_directory: shared
+        command: yarn install --pure-lockfile --ignore-engines --prefer-offline
+    - run:
+        working_directory: shared
+        command: yarn global add react-native-cli
+    - run: mkdir -p $GOPATH/src/github.com/keybase
     - run: ln -s $HOME/kbfs $GOPATH/src/github.com/keybase/kbfs
-    - run: (cd $GOPATH/src/github.com/keybase/client/shared; LOCAL_KBFS=1 yarn run rn-gobuild-android)
-    - run: ls -la $GOPATH/src/github.com/keybase/client/shared/react-native/android/keybaselib/keybaselib.aar
+    - run:
+        working_directory: shared
+        environment:
+          LOCAL_KBFS: 1
+        command: yarn run rn-gobuild-android
+
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}
         paths:
-        # This is a broad list of cache paths to include many possible development environments
-        # You can probably delete some of these entries
-        - vendor/bundle
-        - ~/virtualenvs
-        - ~/.m2
-        - ~/.ivy2
-        - ~/.bundle
-        - ~/.go_workspace
         - ~/.gradle
-        - ~/.cache/bower
-        # These cache paths were specified in the 1.0 config
+        - ~/downloads
+        - ~/.cache/yarn
+        - /tmp/go-android/bin
+        - /tmp/go-android/pkg
         - /usr/local/android-sdk-linux/tools
+        - /usr/local/android-sdk-linux/ndk-bundle
         - /usr/local/android-sdk-linux/build-tools/23.0.2
-    # Test
-    #   This would typically be a build job when using workflows, possibly combined with build
-    # This is based on your 1.0 configuration file or project settings
-    - run: echo "Only testing builds"
-    # Teardown
-    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
-    # Save test results
-    - store_test_results:
-        path: /tmp/circleci-test-results
-    # Save artifacts
-    - store_artifacts:
-        path: /tmp/circleci-artifacts
-    - store_artifacts:
-        path: /tmp/circleci-test-results
+        - /usr/local/android-sdk-linux/extras/android/m2repository

--- a/circle.yml
+++ b/circle.yml
@@ -1,61 +1,119 @@
-# -----------------------------------------------------------------------------
-#
-#   REMINDER: If you edit this file, you'll most likely also want to edit
-#   circle.yml in the client repository!
-#
-# -----------------------------------------------------------------------------
-machine:
-  xcode:
-    version: 7.2
-  node:
-    version: 5.7.0
-  environment:
-    GOPATH: $HOME/go-path
-    PATH: $GOROOT/bin:$PATH
-    # Limit memory usage of gradle
-    _JAVA_OPTIONS: "-Xms512m -Xmx2048m"
-    GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-    REACT_NATIVE_MAX_WORKERS: 1
-    # Some node dependencies break without this
-    CXX: g++-4.8
-    ANDROID_NDK_HOME: ${ANDROID_NDK}
-general:
-  build_dir: .
-dependencies:
-  pre:
-    - sudo rm -rf $HOME/go* # Remove old go installation
-    - sudo rm -rf /usr/local/go* # Remove old go installation
-    - wget -nv https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -O $HOME/go.tar.gz
-    - mkdir $HOME/go-path
-    - (cd $HOME; tar -xzvf go.tar.gz)
-    - sudo mv $HOME/go /usr/local
-    - (cd $HOME; git clone https://github.com/keybase/client.git)
-    - mkdir -p $GOPATH/src/github.com/keybase
-    - ln -s $HOME/client $GOPATH/src/github.com/keybase/client
-    - if ! $(grep -q "Revision=24.4.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk -u -a -t "tools"; fi
-    - if [ ! -e $ANDROID_HOME/build-tools/23.0.2 ]; then echo y | android update sdk -u -a -t "build-tools-23.0.2"; fi
-     # Android Support Repository, revision 35 / Local Maven repository for Support Libraries
-    - if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository/com/android/support/design/24.1.0" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
-    # Accept android licenses
-    - mkdir /usr/local/android-sdk-linux/licenses
-    - if [[ ! -e "$ANDROID_HOME/ndk_bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O android-ndk-r11c-linux-x86_64.zip && unzip -o android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
-    - echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
-    # Install Yarn
-    - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-    - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-    - sudo apt-get update -qq
-    - sudo apt-get install -y -qq yarn=1.0.2-1
-  cache_directories:
-    - /usr/local/android-sdk-linux/tools
-    - /usr/local/android-sdk-linux/build-tools/23.0.2
-    # - android-ndk-r11c
-  override:
-    - yarn install --pure-lockfile
-    - yarn global add react-native-cli
-    - ln -s $HOME/kbfs $GOPATH/src/github.com/keybase/kbfs
-    - (cd $GOPATH/src/github.com/keybase/client/shared; LOCAL_KBFS=1 yarn run rn-gobuild-android)
-    - ls -la $GOPATH/src/github.com/keybase/client/shared/react-native/android/keybaselib/keybaselib.aar
-test:
-  override:
-    # Just testing builds
-    - echo "Only testing builds"
+# This configuration was automatically generated from a CircleCI 1.0 config.
+# It should include any build commands you had along with commands that CircleCI
+# inferred from your project structure. We strongly recommend you read all the
+# comments in this file to understand the structure of CircleCI 2.0, as the idiom
+# for configuration has changed substantially in 2.0 to allow arbitrary jobs rather
+# than the prescribed lifecycle of 1.0. In general, we recommend using this generated
+# configuration as a reference rather than using it in production, though in most
+# cases it should duplicate the execution of your original 1.0 config.
+version: 2
+jobs:
+  build:
+    working_directory: ~/keybase/kbfs/.
+    parallelism: 1
+    shell: /bin/bash --login
+    # CircleCI 2.0 does not support environment variables that refer to each other the same way as 1.0 did.
+    # If any of these refer to each other, rewrite them so that they don't or see https://circleci.com/docs/2.0/env-vars/#interpolating-environment-variables-to-set-other-environment-variables .
+    environment:
+      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
+      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
+      GOPATH: $HOME/go-path
+      PATH: $GOROOT/bin:$PATH
+      _JAVA_OPTIONS: -Xms512m -Xmx2048m
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"
+      REACT_NATIVE_MAX_WORKERS: 1
+      CXX: g++-4.8
+      ANDROID_NDK_HOME: ${ANDROID_NDK}
+    # In CircleCI 1.0 we used a pre-configured image with a large number of languages and other packages.
+    # In CircleCI 2.0 you can now specify your own image, or use one of our pre-configured images.
+    # The following configuration line tells CircleCI to use the specified docker image as the runtime environment for you job.
+    # We have selected a pre-built image that mirrors the build environment we use on
+    # the 1.0 platform, but we recommend you choose an image more tailored to the needs
+    # of each job. For more information on choosing an image (or alternatively using a
+    # VM instead of a container) see https://circleci.com/docs/2.0/executor-types/
+    # To see the list of pre-built images that CircleCI provides for most common languages see
+    # https://circleci.com/docs/2.0/circleci-images/
+    docker:
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
+      command: /sbin/init
+    steps:
+    # Machine Setup
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # The following `checkout` command checks out your code to your working directory. In 1.0 we did this implicitly. In 2.0 you can choose where in the course of a job your code should be checked out.
+    - checkout
+    # Prepare for artifact and test results  collection equivalent to how it was done on 1.0.
+    # In many cases you can simplify this from what is generated here.
+    # 'See docs on artifact collection here https://circleci.com/docs/2.0/artifacts/'
+    - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+    # This is based on your 1.0 configuration file or project settings
+    - run:
+        working_directory: ~/keybase/kbfs/.
+        command: nvm install 5.7.0 && nvm alias default 5.7.0
+    # Dependencies
+    #   This would typically go in either a build or a build-and-test job when using workflows
+    # Restore the dependency cache
+    - restore_cache:
+        keys:
+        # This branch if available
+        - v1-dep-{{ .Branch }}-
+        # Default branch if not
+        - v1-dep-master-
+        # Any branch if there are none on the default branch - this should be unnecessary if you have your default branch configured correctly
+        - v1-dep-
+    # This is based on your 1.0 configuration file or project settings
+    - run: sudo rm -rf $HOME/go*
+    - run: sudo rm -rf /usr/local/go*
+    - run: wget -nv https://storage.googleapis.com/golang/go1.9.linux-amd64.tar.gz -O $HOME/go.tar.gz
+    - run: mkdir $HOME/go-path
+    - run: (cd $HOME; tar -xzvf go.tar.gz)
+    - run: sudo mv $HOME/go /usr/local
+    - run: (cd $HOME; git clone https://github.com/keybase/client.git)
+    - run: mkdir -p $GOPATH/src/github.com/keybase
+    - run: ln -s $HOME/client $GOPATH/src/github.com/keybase/client
+    - run: if ! $(grep -q "Revision=24.4.1" $ANDROID_HOME/tools/source.properties); then echo y | android update sdk -u -a -t "tools"; fi
+    - run: if [ ! -e $ANDROID_HOME/build-tools/23.0.2 ]; then echo y | android update sdk -u -a -t "build-tools-23.0.2"; fi
+    - run: if [ ! -d "/usr/local/android-sdk-linux/extras/android/m2repository/com/android/support/design/24.1.0" ]; then echo y | android update sdk --no-ui --all --filter "extra-android-m2repository"; fi
+    - run: mkdir /usr/local/android-sdk-linux/licenses
+    - run: if [[ ! -e "$ANDROID_HOME/ndk_bundle" ]]; then wget -nv http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip -O android-ndk-r11c-linux-x86_64.zip && unzip -o android-ndk-r11c-linux-x86_64.zip -d "$ANDROID_HOME" && mv "$ANDROID_HOME/android-ndk-r11c" "$ANDROID_HOME/ndk-bundle"; fi
+    - run: echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > /usr/local/android-sdk-linux/licenses/android-sdk-license
+    - run: sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+    - run: echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+    - run: sudo apt-get update -qq
+    - run: sudo apt-get install -y -qq yarn=1.0.2-1
+    # This is based on your 1.0 configuration file or project settings
+    - run: yarn install --pure-lockfile
+    - run: yarn global add react-native-cli
+    - run: ln -s $HOME/kbfs $GOPATH/src/github.com/keybase/kbfs
+    - run: (cd $GOPATH/src/github.com/keybase/client/shared; LOCAL_KBFS=1 yarn run rn-gobuild-android)
+    - run: ls -la $GOPATH/src/github.com/keybase/client/shared/react-native/android/keybaselib/keybaselib.aar
+    # Save dependency cache
+    - save_cache:
+        key: v1-dep-{{ .Branch }}-{{ epoch }}
+        paths:
+        # This is a broad list of cache paths to include many possible development environments
+        # You can probably delete some of these entries
+        - vendor/bundle
+        - ~/virtualenvs
+        - ~/.m2
+        - ~/.ivy2
+        - ~/.bundle
+        - ~/.go_workspace
+        - ~/.gradle
+        - ~/.cache/bower
+        # These cache paths were specified in the 1.0 config
+        - /usr/local/android-sdk-linux/tools
+        - /usr/local/android-sdk-linux/build-tools/23.0.2
+    # Test
+    #   This would typically be a build job when using workflows, possibly combined with build
+    # This is based on your 1.0 configuration file or project settings
+    - run: echo "Only testing builds"
+    # Teardown
+    #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each
+    # Save test results
+    - store_test_results:
+        path: /tmp/circleci-test-results
+    # Save artifacts
+    - store_artifacts:
+        path: /tmp/circleci-artifacts
+    - store_artifacts:
+        path: /tmp/circleci-test-results

--- a/circle.yml
+++ b/circle.yml
@@ -13,9 +13,6 @@ jobs:
     environment:
       GOVERSION: 1.10.3
 
-      # Some node dependencies break without this.
-      CXX: g++-4.8
-
     # TODO: Consider picking a better docker image.
     #
     # For more information on choosing an image (or alternatively
@@ -38,15 +35,9 @@ jobs:
           echo 'export GOPATH=$HOME/go-path' >> $BASH_ENV
           echo 'export PATH=$GOROOT/bin:$PATH' >> $BASH_ENV
 
-          # Some node dependencies break without this.
-          echo 'export ANDROID_NDK=$ANDROID_HOME/ndk-bundle' >> $BASH_ENV
-          echo 'export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle' >> $BASH_ENV
-
           source $BASH_ENV
 
-    # Install node and java.
-    # - run: nvm ls-remote
-    - run: nvm install 10 && nvm alias default 10
+    # Configure java.
     - run: sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java; sudo update-alternatives --set javac /usr/lib/jvm/jdk1.8.0/bin/javac; echo -e "export JAVA_HOME=/usr/lib/jvm/jdk1.8.0" >> $BASH_ENV
 
     # Restore the dependency cache


### PR DESCRIPTION
Also use go 1.10.3.

Sync with circle.yml from client, but remove node and yarn.