### PR TITLE
fix redirect with some HTTP clients

### DIFF
--- a/libhttpserver/server.go
+++ b/libhttpserver/server.go
@@ -92,7 +92,7 @@ func (e obsoleteTrackingFS) isObsolete() bool {
 func (s *Server) getHTTPFileSystem(ctx context.Context, requestPath string) (
 	toStrip string, fs http.FileSystem, err error) {
 	fields := strings.Split(requestPath, "/")
-	if len(fields) < 3 {
+	if len(fields) < 2 {
 		return "", nil, errors.New("bad path")
 	}
 


### PR DESCRIPTION
With curl, when it makes a reqeust

```
GET public/songgao/index.html?token=blah
```

and get a 301 to "./?tokan=blah", it'd make a follow-up request

```
GET public/songgao?token=blah
```

instead of

```
GET public/songgao/?token=blah
```

This commit is for fixing this particular scenario.

Note that this isn't required for fixing KBFS-3028 on desktop (which is handled in https://github.com/keybase/client/pull/12399), since Electron does redirect with the trailing backslash. I haven't tried RN yet, so not sure if RN needs this. But either way it's good to make it compatible with other clients too.