### PR TITLE
kbfsedits: add a class that can construct per-TLF edit histories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,6 +308,12 @@ def runNixTest(prefix) {
             sh './kbfscrypto.test -test.timeout 30s'
         }
     }
+    tests[prefix+'kbfsedits'] = {
+        dir('kbfsedits') {
+            sh 'go test -race -c'
+            sh './kbfsedits.test -test.timeout 30s'
+        }
+    }
     tests[prefix+'kbfsgit'] = {
         dir('kbfsgit') {
             sh 'go test -race -c'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,6 +73,7 @@ build_script:
   - echo github.com/keybase/kbfs/kbfsblock >> testlist.txt
   - echo github.com/keybase/kbfs/kbfscodec >> testlist.txt
   - echo github.com/keybase/kbfs/kbfscrypto >> testlist.txt
+  - echo github.com/keybase/kbfs/kbfsedits >> testlist.txt
   - echo github.com/keybase/kbfs/kbfsgit >> testlist.txt
   - echo github.com/keybase/kbfs/kbfshash >> testlist.txt
   - echo github.com/keybase/kbfs/kbfsmd >> testlist.txt

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -22,7 +22,7 @@ type writerNotifications struct {
 	notifications notificationsByRevision
 }
 
-// writersByRevision sort sets of per-writer notifications in reverse
+// writersByRevision sorts sets of per-writer notifications in reverse
 // order by the revision of the latest notification for each writer.
 type writersByRevision []*writerNotifications
 
@@ -122,8 +122,6 @@ func (th *TlfHistory) AddNotifications(
 			newEdits = append(newEdits, revMsg)
 		}
 	}
-	sort.Sort(newEdits)
-	newEdits = newEdits.uniquify()
 
 	th.lock.Lock()
 	defer th.lock.Unlock()
@@ -160,8 +158,8 @@ type recomputer struct {
 	numProcessed  map[string]int             // writer name -> num
 }
 
-func newRecomputer() recomputer {
-	return recomputer{
+func newRecomputer() *recomputer {
+	return &recomputer{
 		byWriter:      make(map[string]*writerNotifications),
 		modifiedFiles: make(map[string]map[string]bool),
 		fileEvents:    make(map[string]fileEvent),
@@ -169,7 +167,7 @@ func newRecomputer() recomputer {
 	}
 }
 
-// processNotification add the notification to the recomputer's
+// processNotification adds the notification to the recomputer's
 // history if it is a create/modify for a file that hasn't yet been
 // deleted.  If the file is renamed in a future revision, the added
 // notification has the new name of the file.  processNotification
@@ -178,7 +176,7 @@ func newRecomputer() recomputer {
 //
 // It returns true if it has added enough notifications for the given
 // writer, and the caller should not send any more for that writer.
-func (r recomputer) processNotification(
+func (r *recomputer) processNotification(
 	writer string, notification NotificationMessage) (doTrim bool) {
 	filename := notification.Filename
 	r.numProcessed[writer]++

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -1,0 +1,343 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsedits
+
+import (
+	"container/heap"
+	"encoding/json"
+	"sort"
+	"sync"
+)
+
+const (
+	// The max number of edits needed for each writer.
+	maxEditsPerWriter    = 10
+	maxWritersPerHistory = 10
+)
+
+type writerNotifications struct {
+	writerName    string
+	notifications notificationsByRevision
+}
+
+// writersByRevision sort sets of per-writer notifications in reverse
+// order by the revision of the latest notification for each writer.
+type writersByRevision []*writerNotifications
+
+func (wbr writersByRevision) Len() int {
+	return len(wbr)
+}
+
+func (wbr writersByRevision) Less(i, j int) bool {
+	// Some revisions come before no revisions.
+	iHasZero := len(wbr[i].notifications) == 0
+	jHasZero := len(wbr[j].notifications) == 0
+	if jHasZero {
+		return iHasZero
+	} else if iHasZero {
+		return false
+	}
+
+	// Reverse sort, so latest revisions come first.
+	return wbr[i].notifications[0].Revision > wbr[j].notifications[0].Revision
+}
+
+func (wbr writersByRevision) Swap(i, j int) {
+	wbr[i], wbr[j] = wbr[j], wbr[i]
+}
+
+func (wbr *writersByRevision) Push(x interface{}) {
+	wn := x.(*writerNotifications)
+	*wbr = append(*wbr, wn)
+}
+
+func (wbr *writersByRevision) Pop() interface{} {
+	// The item to remove is the last item; heap has already swapped
+	// it to the end.
+	old := *wbr
+	n := len(old)
+	item := old[n-1]
+	*wbr = old[0 : n-1]
+	return item
+}
+
+// TlfHistory maintains a history of the last N file edits from each
+// writer in the TLF.
+//
+// There will be two users of a TlfHistory instance:
+//
+//   * One user (likely something outside of the kbfsedits package,
+//     e.g. libkbfs.folderBranchOps) will read notifications from the
+//     corresponding TLF and add them to this history.  After adding a
+//     batch or several batches of messages, it should call
+//     `Recompute()`, and if some writers need more, earlier revisions,
+//     it should fetch more notifications for the indicated writer and
+//     repeat.
+//
+//   * The other user (within the kbfsedits package) will collate the
+//     histories from multiple TlfHistory instances together using
+//     `getHistory()` from each one.  It may also construct pretty
+//     versions of individual edit histories for a particular TLF.
+type TlfHistory struct {
+	lock          sync.RWMutex
+	byWriter      map[string]*writerNotifications
+	computed      bool
+	cachedHistory writersByRevision
+}
+
+// NewTlfHistory constructs a new TlfHistory instance.
+func NewTlfHistory() *TlfHistory {
+	return &TlfHistory{
+		byWriter: make(map[string]*writerNotifications),
+	}
+}
+
+// AddNotifications takes in a set of messages in this TLF by
+// `writer`, and adds them to the history.  Once done adding messages,
+// the caller should call `Recompute` to find out if more messages
+// should be added for any particular writer.
+func (th *TlfHistory) AddNotifications(
+	writerName string, messages []string) (err error) {
+	newEdits := make(notificationsByRevision, len(messages))
+
+	// Unmarshal and sort the new messages.
+	for i, msg := range messages {
+		err := json.Unmarshal([]byte(msg), &newEdits[i])
+		if err != nil {
+			return err
+		}
+	}
+	sort.Sort(newEdits)
+	newEdits = newEdits.uniquify()
+
+	th.lock.Lock()
+	defer th.lock.Unlock()
+	wn, existed := th.byWriter[writerName]
+	if !existed {
+		wn = &writerNotifications{writerName, nil}
+	}
+	oldLen := len(wn.notifications)
+	newEdits = append(newEdits, wn.notifications...)
+	sort.Sort(newEdits)
+	wn.notifications = newEdits.uniquify()
+	if len(wn.notifications) == oldLen {
+		// No new messages.
+		return nil
+	}
+	if !existed {
+		wn.writerName = writerName
+		th.byWriter[writerName] = wn
+	}
+	// Invalidate the cached results.
+	th.computed = false
+	return nil
+}
+
+type fileEvent struct {
+	delete  bool
+	newName string
+}
+
+type recomputer struct {
+	byWriter      map[string]*writerNotifications
+	modifiedFiles map[string]map[string]bool // writer -> file -> bool
+	fileEvents    map[string]fileEvent       // currentName -> ultimate fate
+	numProcessed  map[string]int             // writer name -> num
+}
+
+func newRecomputer() recomputer {
+	return recomputer{
+		byWriter:      make(map[string]*writerNotifications),
+		modifiedFiles: make(map[string]map[string]bool),
+		fileEvents:    make(map[string]fileEvent),
+		numProcessed:  make(map[string]int),
+	}
+}
+
+// processNotification add the notification to the recomputer's
+// history if it is a create/modify for a file that hasn't yet been
+// deleted.  If the file is renamed in a future revision, the added
+// notification has the new name of the file.  processNotification
+// should be called with notifications in reverse order of their
+// revision number.
+//
+// It returns true if it has added enough notifications for the given
+// writer, and the caller should not send any more for that writer.
+func (r recomputer) processNotification(
+	writer string, notification NotificationMessage) (doTrim bool) {
+	filename := notification.Filename
+	r.numProcessed[writer]++
+
+	// If the file is renamed in a future revision, rename it in the
+	// notification.
+	eventFilename := filename
+	event, hasEvent := r.fileEvents[filename]
+	if hasEvent && event.newName != "" {
+		notification.Filename = event.newName
+		filename = event.newName
+	}
+
+	// Keep only the creates and modifies for non-deleted files,
+	// but remember the renames and deletes.
+	switch notification.Type {
+	case NotificationCreate, NotificationModify:
+		// Disregard any file that's already been deleted.
+		if hasEvent && event.delete {
+			return false
+		}
+
+		// We only care about files, so skip dir and sym creates.
+		if notification.FileType != EntryTypeFile {
+			return false
+		}
+
+		// We only need one modify message per writer per file.
+		if r.modifiedFiles[writer][filename] {
+			return false
+		}
+
+		wn, ok := r.byWriter[writer]
+		if !ok {
+			wn = &writerNotifications{writer, nil}
+			r.byWriter[writer] = wn
+		}
+		wn.writerName = writer
+		wn.notifications = append(wn.notifications, notification)
+
+		modified, ok := r.modifiedFiles[writer]
+		if !ok {
+			modified = make(map[string]bool)
+			r.modifiedFiles[writer] = modified
+		}
+		modified[filename] = true
+
+		if len(wn.notifications) == maxEditsPerWriter {
+			// We have enough edits for this user.
+			return true
+		}
+	case NotificationRename:
+		// If the file already has a final event, move that to the old
+		// filename.  Otherwise, this is the final event.
+		if hasEvent {
+			r.fileEvents[notification.Params.OldFilename] = event
+			delete(r.fileEvents, eventFilename)
+		} else {
+			r.fileEvents[notification.Params.OldFilename] =
+				fileEvent{newName: eventFilename}
+		}
+
+		// The renamed file overwrote any existing file with the new
+		// name.
+		r.fileEvents[eventFilename] = fileEvent{delete: true}
+	case NotificationDelete:
+		r.fileEvents[eventFilename] = fileEvent{delete: true}
+	}
+	return false
+}
+
+func (th *TlfHistory) recomputeLocked() (
+	history writersByRevision, writersWhoNeedMore map[string]bool) {
+	writersWhoNeedMore = make(map[string]bool)
+
+	// Copy the writer notifications into a heap.
+	var writersHeap writersByRevision
+	for _, wn := range th.byWriter {
+		wnCopy := writerNotifications{
+			writerName:    wn.writerName,
+			notifications: make(notificationsByRevision, len(wn.notifications)),
+		}
+		copy(wnCopy.notifications, wn.notifications)
+		writersHeap = append(writersHeap, &wnCopy)
+	}
+	heap.Init(&writersHeap)
+
+	r := newRecomputer()
+
+	// Iterate through the heap.  The writer with the next highest
+	// revision will always be at index 0.  Process that writer's
+	// first notification, then remove it and fix the heap so that the
+	// next highest revision is at index 0.  That way events that
+	// happen more recently (like deletes and renames) can be taken
+	// into account when looking at older events.
+	for writersHeap.Len() > 0 {
+		nextWriter := writersHeap[0].writerName
+		nextNotification := writersHeap[0].notifications[0]
+		doTrim := r.processNotification(nextWriter, nextNotification)
+
+		// Remove that notification, and fix the heap because this
+		// writer has a different newest revision.
+		if doTrim {
+			// Trim all earlier revisions because they won't be needed
+			// for the cached history.
+			numProcessed := r.numProcessed[nextWriter]
+			th.byWriter[nextWriter].notifications =
+				th.byWriter[nextWriter].notifications[numProcessed:]
+		} else {
+			writersHeap[0].notifications = writersHeap[0].notifications[1:]
+		}
+		if len(writersHeap[0].notifications) == 0 || doTrim {
+			heap.Pop(&writersHeap)
+		} else {
+			heap.Fix(&writersHeap, 0)
+		}
+	}
+
+	history = make(writersByRevision, 0, len(r.byWriter))
+	for writerName := range th.byWriter {
+		wn := r.byWriter[writerName]
+		if wn != nil && len(wn.notifications) > 0 {
+			history = append(history, wn)
+		}
+		if wn == nil || len(wn.notifications) < maxEditsPerWriter {
+			writersWhoNeedMore[writerName] = true
+		}
+	}
+	sort.Sort(history)
+	// Garbage-collect any writers that don't appear in the history.
+	for i := maxWritersPerHistory; i < len(history); i++ {
+		delete(th.byWriter, history[i].writerName)
+		delete(writersWhoNeedMore, history[i].writerName)
+	}
+	if len(history) > maxWritersPerHistory {
+		history = history[:maxWritersPerHistory]
+	}
+	th.computed = true
+	th.cachedHistory = history
+	return history, writersWhoNeedMore
+}
+
+func (th *TlfHistory) getHistoryIfCached() (
+	cached bool, history writersByRevision) {
+	th.lock.RLock()
+	defer th.lock.RUnlock()
+	return th.computed, th.cachedHistory
+}
+
+func (th *TlfHistory) getHistory() writersByRevision {
+	cached, history := th.getHistoryIfCached()
+	if cached {
+		return history
+	}
+
+	th.lock.Lock()
+	defer th.lock.Unlock()
+	if th.computed {
+		// Maybe another goroutine got the lock and recomuted the
+		// history since we checked above.
+		return th.cachedHistory
+	}
+	history, _ = th.recomputeLocked()
+	return history
+}
+
+// Recompute processes (and caches) the history so that it reflects
+// all recently-added notifications, and returns the names of writers
+// which don't yet have the maximum number of edits in the history.
+func (th *TlfHistory) Recompute() (writersWhoNeedMore map[string]bool) {
+	th.lock.Lock()
+	defer th.lock.Unlock()
+	_, writersWhoNeedMore = th.recomputeLocked()
+	return writersWhoNeedMore
+}

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -107,11 +107,17 @@ func (th *TlfHistory) AddNotifications(
 		var revList []NotificationMessage
 		err := json.Unmarshal([]byte(msg), &revList)
 		if err != nil {
-			return err
+			// The messages might be from a new version we don't
+			// understand, so swallow the error.
+			continue
 		}
 
 		for j := len(revList) - 1; j >= 0; j-- {
 			revMsg := revList[j]
+			if revMsg.Version != NotificationV2 {
+				// Ignore messages that are too new for us to understand.
+				continue
+			}
 			revMsg.numWithinRevision = j
 			newEdits = append(newEdits, revMsg)
 		}

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -311,12 +311,12 @@ func (th *TlfHistory) recomputeLocked() (
 		}
 	}
 	sort.Sort(history)
-	// Garbage-collect any writers that don't appear in the history.
-	for i := maxWritersPerHistory; i < len(history); i++ {
-		delete(th.byWriter, history[i].writerName)
-		delete(writersWhoNeedMore, history[i].writerName)
-	}
 	if len(history) > maxWritersPerHistory {
+		// Garbage-collect any writers that don't appear in the history.
+		for i := maxWritersPerHistory; i < len(history); i++ {
+			delete(th.byWriter, history[i].writerName)
+			delete(writersWhoNeedMore, history[i].writerName)
+		}
 		history = history[:maxWritersPerHistory]
 	}
 	th.computed = true
@@ -328,7 +328,10 @@ func (th *TlfHistory) getHistoryIfCached() (
 	cached bool, history writersByRevision) {
 	th.lock.RLock()
 	defer th.lock.RUnlock()
-	return th.computed, th.cachedHistory
+	if th.computed {
+		return true, th.cachedHistory
+	}
+	return false, nil
 }
 
 func (th *TlfHistory) getHistory() writersByRevision {

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -100,13 +100,20 @@ func NewTlfHistory() *TlfHistory {
 // should be added for any particular writer.
 func (th *TlfHistory) AddNotifications(
 	writerName string, messages []string) (err error) {
-	newEdits := make(notificationsByRevision, len(messages))
+	newEdits := make(notificationsByRevision, 0, len(messages))
 
 	// Unmarshal and sort the new messages.
-	for i, msg := range messages {
-		err := json.Unmarshal([]byte(msg), &newEdits[i])
+	for _, msg := range messages {
+		var revList []NotificationMessage
+		err := json.Unmarshal([]byte(msg), &revList)
 		if err != nil {
 			return err
+		}
+
+		for j := len(revList) - 1; j >= 0; j-- {
+			revMsg := revList[j]
+			revMsg.numWithinRevision = j
+			newEdits = append(newEdits, revMsg)
 		}
 	}
 	sort.Sort(newEdits)

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -183,6 +183,11 @@ func (r *recomputer) processNotification(
 
 	// If the file is renamed in a future revision, rename it in the
 	// notification.
+	//
+	// TODO(KBFS-3073): maybe we should check all the parent
+	// directories for renames as well, so we can give a full, updated
+	// path for older edits.  That would also help avoid showing edits
+	// for files that were later deleted, but in a renamed directory.
 	eventFilename := filename
 	event, hasEvent := r.fileEvents[filename]
 	if hasEvent && event.newName != "" {

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -289,7 +289,7 @@ func (th *TlfHistory) recomputeLocked() (
 			// for the cached history.
 			numProcessed := r.numProcessed[nextWriter]
 			th.byWriter[nextWriter].notifications =
-				th.byWriter[nextWriter].notifications[numProcessed:]
+				th.byWriter[nextWriter].notifications[:numProcessed]
 		} else {
 			writersHeap[0].notifications = writersHeap[0].notifications[1:]
 		}

--- a/kbfsedits/tlf_history_test.go
+++ b/kbfsedits/tlf_history_test.go
@@ -1,0 +1,251 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsedits
+
+import (
+	"encoding/json"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+)
+
+func checkTlfHistory(t *testing.T, th *TlfHistory, expected writersByRevision) {
+	writersWhoNeedMore := th.Recompute()
+	history := th.getHistory() // should use cached history.
+	require.Len(t, history, len(expected))
+
+	for i, e := range expected {
+		require.Equal(t, e.writerName, history[i].writerName)
+		require.Len(t, history[i].notifications, len(e.notifications))
+		for j, n := range e.notifications {
+			require.Equal(t, n, history[i].notifications[j])
+		}
+		if len(e.notifications) < maxEditsPerWriter {
+			require.Contains(t, writersWhoNeedMore, e.writerName)
+		}
+	}
+}
+
+type nextNotification struct {
+	nextRevision kbfsmd.Revision
+	tlfID        tlf.ID
+}
+
+func (nn *nextNotification) make(
+	t *testing.T, filename string, nt NotificationOpType, uid keybase1.UID,
+	params *NotificationParams) (
+	NotificationMessage, string) {
+	next := NotificationMessage{
+		Revision: nn.nextRevision,
+		Filename: filename,
+		Type:     nt,
+		FolderID: nn.tlfID,
+		UID:      uid,
+		Params:   params,
+		FileType: EntryTypeFile,
+	}
+	nn.nextRevision++
+	msg, err := json.Marshal(next)
+	require.NoError(t, err)
+	return next, string(msg)
+}
+
+func TestTlfHistorySimple(t *testing.T) {
+	aliceName, bobName := "alice", "bob"
+	aliceUID, bobUID := keybase1.MakeTestUID(1), keybase1.MakeTestUID(2)
+	tlfID, err := tlf.MakeRandomID(tlf.Private)
+	require.NoError(t, err)
+
+	nn := nextNotification{1, tlfID}
+	aliceWrite, aliceMessage := nn.make(
+		t, "a", NotificationCreate, aliceUID, nil)
+	bobWrite, bobMessage := nn.make(t, "b", NotificationCreate, bobUID, nil)
+
+	expected := writersByRevision{
+		{bobName, []NotificationMessage{bobWrite}},
+		{aliceName, []NotificationMessage{aliceWrite}},
+	}
+
+	// Alice, then Bob.
+	th := NewTlfHistory()
+	err = th.AddNotifications(aliceName, []string{string(aliceMessage)})
+	require.NoError(t, err)
+	err = th.AddNotifications(bobName, []string{string(bobMessage)})
+	require.NoError(t, err)
+	checkTlfHistory(t, th, expected)
+
+	// Bob, then Alice.
+	th = NewTlfHistory()
+	err = th.AddNotifications(bobName, []string{string(bobMessage)})
+	require.NoError(t, err)
+	err = th.AddNotifications(aliceName, []string{string(aliceMessage)})
+	require.NoError(t, err)
+	checkTlfHistory(t, th, expected)
+
+	// Add a duplicate notification.
+	err = th.AddNotifications(bobName, []string{string(bobMessage)})
+	require.NoError(t, err)
+	checkTlfHistory(t, th, expected)
+}
+
+func TestTlfHistoryMultipleWrites(t *testing.T) {
+	aliceName, bobName := "alice", "bob"
+	aliceUID, bobUID := keybase1.MakeTestUID(1), keybase1.MakeTestUID(2)
+	tlfID, err := tlf.MakeRandomID(tlf.Private)
+	require.NoError(t, err)
+
+	var aliceMessages, bobMessages []string
+	nn := nextNotification{1, tlfID}
+
+	// Alice creates and writes to "a".
+	_, msg := nn.make(t, "a", NotificationCreate, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+	aliceModA, msg := nn.make(t, "a", NotificationModify, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+
+	// Bob creates "b", writes to existing file "c", and writes to "a".
+	bobCreateB, msg := nn.make(t, "b", NotificationCreate, bobUID, nil)
+	bobMessages = append(bobMessages, msg)
+	bobModC, msg := nn.make(t, "c", NotificationModify, bobUID, nil)
+	bobMessages = append(bobMessages, msg)
+	bobModA, msg := nn.make(t, "a", NotificationModify, bobUID, nil)
+	bobMessages = append(bobMessages, msg)
+
+	// Alice writes to "c".
+	aliceModC, msg := nn.make(t, "c", NotificationModify, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+
+	expected := writersByRevision{
+		{aliceName, []NotificationMessage{aliceModC, aliceModA}},
+		{bobName, []NotificationMessage{bobModA, bobModC, bobCreateB}},
+	}
+
+	// Alice, then Bob.
+	th := NewTlfHistory()
+	err = th.AddNotifications(aliceName, aliceMessages)
+	require.NoError(t, err)
+	err = th.AddNotifications(bobName, bobMessages)
+	require.NoError(t, err)
+	checkTlfHistory(t, th, expected)
+
+	// Add each message one at a time, alternating users.
+	th = NewTlfHistory()
+	for i := 0; i < len(aliceMessages); i++ {
+		err = th.AddNotifications(aliceName, []string{aliceMessages[i]})
+		require.NoError(t, err)
+		err = th.AddNotifications(bobName, []string{bobMessages[i]})
+		require.NoError(t, err)
+	}
+	checkTlfHistory(t, th, expected)
+}
+
+func TestTlfHistoryRenamesAndDeletes(t *testing.T) {
+	aliceName, bobName := "alice", "bob"
+	aliceUID, bobUID := keybase1.MakeTestUID(1), keybase1.MakeTestUID(2)
+	tlfID, err := tlf.MakeRandomID(tlf.Private)
+	require.NoError(t, err)
+
+	var aliceMessages, bobMessages []string
+	nn := nextNotification{1, tlfID}
+
+	// Alice creates modifies "c" (later overwritten).
+	_, msg := nn.make(t, "c", NotificationCreate, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+
+	// Bob modifies "c" (later overwritten).
+	_, msg = nn.make(t, "c", NotificationModify, bobUID, nil)
+	bobMessages = append(bobMessages, msg)
+
+	// Alice creates "b".
+	aliceCreateB, msg := nn.make(t, "b", NotificationCreate, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+
+	// Bob moves "b" to "c".
+	_, msg = nn.make(t, "c", NotificationRename, bobUID, &NotificationParams{
+		OldFilename: "b",
+	})
+	bobMessages = append(bobMessages, msg)
+	aliceCreateB.Filename = "c"
+
+	// Alice creates "a".
+	_, msg = nn.make(t, "a", NotificationCreate, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+
+	// Bob modifies "a".
+	_, msg = nn.make(t, "a", NotificationModify, aliceUID, nil)
+	bobMessages = append(bobMessages, msg)
+
+	// Alice moves "a" to "b".
+	_, msg = nn.make(t, "b", NotificationRename, aliceUID, &NotificationParams{
+		OldFilename: "a",
+	})
+	bobMessages = append(bobMessages, msg)
+
+	// Bob creates "a".
+	_, msg = nn.make(t, "a", NotificationCreate, bobUID, nil)
+	bobMessages = append(bobMessages, msg)
+
+	// Alice deletes "b".
+	_, msg = nn.make(t, "b", NotificationDelete, aliceUID, nil)
+	aliceMessages = append(aliceMessages, msg)
+
+	// Bob modifies "a".
+	bobModA, msg := nn.make(t, "a", NotificationModify, bobUID, nil)
+	bobMessages = append(bobMessages, msg)
+
+	expected := writersByRevision{
+		{bobName, []NotificationMessage{bobModA}},
+		{aliceName, []NotificationMessage{aliceCreateB}},
+	}
+
+	// Alice, then Bob.
+	th := NewTlfHistory()
+	err = th.AddNotifications(aliceName, aliceMessages)
+	require.NoError(t, err)
+	err = th.AddNotifications(bobName, bobMessages)
+	require.NoError(t, err)
+	checkTlfHistory(t, th, expected)
+}
+
+func TestTlfHistoryNeedsMoreThenComplete(t *testing.T) {
+	aliceName := "alice"
+	aliceUID := keybase1.MakeTestUID(1)
+	tlfID, err := tlf.MakeRandomID(tlf.Private)
+	require.NoError(t, err)
+
+	var allExpected notificationsByRevision
+
+	var aliceMessages []string
+	nn := nextNotification{1, tlfID}
+	for i := 0; i < maxEditsPerWriter; i++ {
+		event, msg := nn.make(
+			t, strconv.Itoa(i), NotificationCreate, aliceUID, nil)
+		allExpected = append(allExpected, event)
+		aliceMessages = append(aliceMessages, msg)
+	}
+	sort.Sort(allExpected)
+
+	// Input most recent half of messages first.
+	expected := writersByRevision{
+		{aliceName, allExpected[:maxEditsPerWriter/2]},
+	}
+	th := NewTlfHistory()
+	err = th.AddNotifications(aliceName, aliceMessages[maxEditsPerWriter/2:])
+	require.NoError(t, err)
+	checkTlfHistory(t, th, expected)
+
+	// Then input the rest, and we'll have a complete set.
+	err = th.AddNotifications(aliceName, aliceMessages[:maxEditsPerWriter/2])
+	require.NoError(t, err)
+	expected = writersByRevision{
+		{aliceName, allExpected},
+	}
+	checkTlfHistory(t, th, expected)
+}

--- a/kbfsedits/tlf_history_test.go
+++ b/kbfsedits/tlf_history_test.go
@@ -44,6 +44,7 @@ func (nn *nextNotification) make(
 	filename string, nt NotificationOpType, uid keybase1.UID,
 	params *NotificationParams) NotificationMessage {
 	n := NotificationMessage{
+		Version:           NotificationV2,
 		Revision:          nn.nextRevision,
 		Filename:          filename,
 		Type:              nt,


### PR DESCRIPTION
This introduces `kbfsedits.TlfHistory`, which receives raw notification strings from a caller for each writer in a TLF, and constructs the edit history from each writer (up to `maxEditsPerWriter` edits each), up to `maxWritersPerHistory` writers per TLF.

The collected sets of per-writer edits in the history are sorted in reverse order, by the most recent revision from each writer.  Within each set, a writer's edits are sorted in reverse order by revision.

The constructed history only includes creates and modifies of files (no directories or symlinks).  If a file was modified and later renamed, the notification for the modify shows the new file name.  If a file was modified but later deleted, it doesn't appear in the history.  Each writer only has the most recent modification or create for each file.

For performance reasons, it's possible that not all deletes or renames will be processed, because they might have been done by a writer prior to their `maxEditsPerWriter` edits, and so those won't be reflected in the modifications of any of the other writers.

The idea is that each `libkbfs.FolderBranchOps`, subscribe to the kbfs-edits chat channels for the TLF's notifications, and fill in these histories with notifications as needed.  Then a new, yet-to-be-written object in `kbfsedits` will collate together a complete history for the logged-in user, using the individual `TlfHistory` instances corresponding to the most-recently-written TLFs.

NOTE: This doesn't yet take journal revisions into account.  That support will come in a future commit so it's easier to review.

Issue: KBFS-2996