### PR TITLE
kbfs_ops: use inbox to initialize FBOs needed to construct the edit history

### DIFF
--- a/kbfsedits/user_history.go
+++ b/kbfsedits/user_history.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// The max number of TLF writer clusters to return in a user history.
-	maxClusters = 10
+	// MaxClusters is the max number of TLF writer clusters to return
+	// in a user history.
+	MaxClusters = 10
 )
 
 type tlfKey struct {
@@ -146,10 +147,10 @@ func (uh *UserHistory) Get() (history []keybase1.FSFolderEditHistory) {
 	// We need to sort these by clusters, not by the full TLF time.
 	sort.Sort(clusters)
 	// TODO: consolidate neighboring clusters that share the same folder?
-	if len(clusters) > maxClusters {
+	if len(clusters) > MaxClusters {
 		// TODO: add the user's public folder to the list even if it
 		// doesn't make the cut.
-		return clusters[:maxClusters]
+		return clusters[:MaxClusters]
 	}
 	return clusters
 }

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -351,6 +351,9 @@ func (f *FS) open(ctx context.Context, oc *openContext, ps []string) (dokan.File
 			enable: false,
 		})
 
+	case libfs.EditHistoryName == ps[0]:
+		return oc.returnFileNoCleanup(NewUserEditHistoryFile(&Folder{fs: f}))
+
 	case ".kbfs_unmount" == ps[0]:
 		os.Exit(0)
 	case ".kbfs_number_of_handles" == ps[0]:

--- a/libdokan/user_edit_history.go
+++ b/libdokan/user_edit_history.go
@@ -1,0 +1,23 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libdokan
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"golang.org/x/net/context"
+)
+
+// NewUserEditHistoryFile returns a special read file that contains a text
+// representation of the file edit history for the logged-in user.
+func NewUserEditHistoryFile(folder *Folder) *SpecialReadFile {
+	return &SpecialReadFile{
+		read: func(_ context.Context) ([]byte, time.Time, error) {
+			return libfs.GetEncodedUserEditHistory(folder.fs.config)
+		},
+		fs: folder.fs,
+	}
+}

--- a/libfs/user_edit_history.go
+++ b/libfs/user_edit_history.go
@@ -1,0 +1,20 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libkbfs"
+)
+
+// GetEncodedUserEditHistory returns serialized JSON containing the
+// file edit history for the user.
+func GetEncodedUserEditHistory(config libkbfs.Config) (
+	data []byte, t time.Time, err error) {
+	edits := config.UserHistory().Get()
+	data, err = PrettyJSON(edits)
+	return data, time.Time{}, err
+}

--- a/libfuse/special_files.go
+++ b/libfuse/special_files.go
@@ -64,6 +64,9 @@ func handleNonTLFSpecialFile(
 		return &DebugServerFile{fs: fs, enable: true}
 	case libfs.DisableDebugServerFileName:
 		return &DebugServerFile{fs: fs, enable: false}
+
+	case libfs.EditHistoryName:
+		return NewUserEditHistoryFile(&Folder{fs: fs}, entryValid)
 	}
 
 	return nil

--- a/libfuse/user_edit_history_file.go
+++ b/libfuse/user_edit_history_file.go
@@ -1,0 +1,25 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/keybase/kbfs/libfs"
+)
+
+// NewUserEditHistoryFile returns a special read file that contains a text
+// representation of the file edit history for the logged-in user.
+func NewUserEditHistoryFile(
+	folder *Folder, entryValid *time.Duration) *SpecialReadFile {
+	*entryValid = 0
+	return &SpecialReadFile{
+		read: func(_ context.Context) ([]byte, time.Time, error) {
+			return libfs.GetEncodedUserEditHistory(folder.fs.config)
+		},
+	}
+}

--- a/libkbfs/chat_local.go
+++ b/libkbfs/chat_local.go
@@ -138,6 +138,9 @@ func (c *chatLocal) SendTextMessage(
 	}
 	conv.messages = append(conv.messages, body)
 	conv.mtime = c.config.Clock().Now()
+	// TODO: if there are some users who can read this folder but who
+	// haven't yet subscribed to the conversation, we should send them
+	// a new channel notification.
 	for _, cb := range conv.cbs {
 		cb(convID, body)
 	}

--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -54,7 +54,9 @@ func (c *ChatRPC) HandlerName() string {
 // OnConnect implements the ConnectionHandler interface.
 func (c *ChatRPC) OnConnect(ctx context.Context, conn *rpc.Connection,
 	_ rpc.GenericClient, server *rpc.Server) error {
-	c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, nil)
+	if c.config.KBFSOps() != nil {
+		c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, nil)
+	}
 
 	err := server.Register(chat1.NotifyChatProtocol(c))
 	switch err.(type) {
@@ -70,14 +72,18 @@ func (c *ChatRPC) OnConnect(ctx context.Context, conn *rpc.Connection,
 func (c *ChatRPC) OnConnectError(err error, wait time.Duration) {
 	c.log.Warning("Chat: connection error: %q; retrying in %s",
 		err, wait)
-	c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, err)
+	if c.config.KBFSOps() != nil {
+		c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, err)
+	}
 }
 
 // OnDoCommandError implements the ConnectionHandler interface.
 func (c *ChatRPC) OnDoCommandError(err error, wait time.Duration) {
 	c.log.Warning("Chat: docommand error: %q; retrying in %s",
 		err, wait)
-	c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, err)
+	if c.config.KBFSOps() != nil {
+		c.config.KBFSOps().PushConnectionStatusChange(KeybaseServiceName, err)
+	}
 }
 
 // OnDisconnected implements the ConnectionHandler interface.
@@ -85,8 +91,10 @@ func (c *ChatRPC) OnDisconnected(_ context.Context,
 	status rpc.DisconnectStatus) {
 	if status == rpc.StartingNonFirstConnection {
 		c.log.Warning("Chat is disconnected")
-		c.config.KBFSOps().PushConnectionStatusChange(
-			KeybaseServiceName, errDisconnected{})
+		if c.config.KBFSOps() != nil {
+			c.config.KBFSOps().PushConnectionStatusChange(
+				KeybaseServiceName, errDisconnected{})
+		}
 	}
 }
 
@@ -368,8 +376,10 @@ func (c *ChatRPC) newNotificationChannel(
 	if err != nil {
 		return err
 	}
-	c.config.KBFSOps().NewNotificationChannel(
-		ctx, tlfHandle, convID, conv.Channel)
+	if c.config.KBFSOps() != nil {
+		c.config.KBFSOps().NewNotificationChannel(
+			ctx, tlfHandle, convID, conv.Channel)
+	}
 	return nil
 }
 

--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -231,6 +231,9 @@ func (c *ChatRPC) GetGroupedInbox(
 			continue
 		}
 		seen[tlfID] = true
+
+		// TODO: ignore TLFs that aren't in your favorites list.
+
 		tlfType := tlf.Private
 		if info.Visibility == keybase1.TLFVisibility_PUBLIC {
 			tlfType = tlf.Public
@@ -343,8 +346,32 @@ func (c *ChatRPC) RegisterForMessages(
 
 // We only register for the kbfs-edits type of notification in
 // keybase_daemon_rpc, so all the other methods below besides
-// `NewChatKBFSFileEditActivity` should never be called.
+// `NewChatActivity` should never be called.
 var _ chat1.NotifyChatInterface = (*ChatRPC)(nil)
+
+func (c *ChatRPC) newNotificationChannel(
+	ctx context.Context, convID chat1.ConversationID,
+	conv *chat1.InboxUIItem) error {
+	if conv == nil {
+		c.log.CDebugf(ctx,
+			"No conv for new notification channel %s; ignoring", convID)
+		return nil
+	}
+	tlfType := tlf.Private
+	if conv.Visibility == keybase1.TLFVisibility_PUBLIC {
+		tlfType = tlf.Public
+	} else if conv.MembersType == chat1.ConversationMembersType_TEAM {
+		tlfType = tlf.SingleTeam
+	}
+	tlfHandle, err := GetHandleFromFolderNameAndType(
+		ctx, c.config.KBPKI(), c.config.MDOps(), conv.Name, tlfType)
+	if err != nil {
+		return err
+	}
+	c.config.KBFSOps().NewNotificationChannel(
+		ctx, tlfHandle, convID, conv.Channel)
+	return nil
+}
 
 // NewChatActivity implements the chat1.NotifyChatInterface for
 // ChatRPC.
@@ -359,19 +386,10 @@ func (c *ChatRPC) NewChatActivity(
 		// If we learn about a new conversation for a given TLF,
 		// attempt to route it to the TLF.
 		info := arg.Activity.NewConversation()
-		tlfType := tlf.Private
-		if info.Conv.Visibility == keybase1.TLFVisibility_PUBLIC {
-			tlfType = tlf.Public
-		} else if info.Conv.MembersType == chat1.ConversationMembersType_TEAM {
-			tlfType = tlf.SingleTeam
-		}
-		tlfHandle, err := GetHandleFromFolderNameAndType(
-			ctx, c.config.KBPKI(), c.config.MDOps(), info.Conv.Name, tlfType)
+		err := c.newNotificationChannel(ctx, info.ConvID, info.Conv)
 		if err != nil {
 			return err
 		}
-		c.config.KBFSOps().NewNotificationChannel(
-			ctx, tlfHandle, info.ConvID, info.Conv.Channel)
 	case chat1.ChatActivityType_INCOMING_MESSAGE:
 		// If we learn about a new message for a given conversation ID,
 		// let any registered callbacks for that conversation ID know.
@@ -398,8 +416,17 @@ func (c *ChatRPC) NewChatActivity(
 		cbs := c.convCBs[msg.ConvID.String()]
 		c.convLock.RUnlock()
 
-		for _, cb := range cbs {
-			cb(msg.ConvID, body)
+		if len(cbs) == 0 {
+			// No one is listening for this channel yet, so consider
+			// it a new channel.
+			err := c.newNotificationChannel(ctx, msg.ConvID, msg.Conv)
+			if err != nil {
+				return err
+			}
+		} else {
+			for _, cb := range cbs {
+				cb(msg.ConvID, body)
+			}
 		}
 	}
 	return nil

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -242,6 +242,44 @@ func (lu *LocalUser) GetPublicKeys() []keybase1.PublicKey {
 	return append(sibkeys, subkeys...)
 }
 
+func (lu LocalUser) deepCopy() LocalUser {
+	luCopy := lu
+
+	luCopy.VerifyingKeys = make(
+		[]kbfscrypto.VerifyingKey, len(lu.VerifyingKeys))
+	copy(luCopy.VerifyingKeys, lu.VerifyingKeys)
+
+	luCopy.CryptPublicKeys = make(
+		[]kbfscrypto.CryptPublicKey, len(lu.CryptPublicKeys))
+	copy(luCopy.CryptPublicKeys, lu.CryptPublicKeys)
+
+	luCopy.KIDNames = make(map[keybase1.KID]string, len(lu.KIDNames))
+	for k, v := range lu.KIDNames {
+		luCopy.KIDNames[k] = v
+	}
+
+	luCopy.RevokedVerifyingKeys = make(
+		map[kbfscrypto.VerifyingKey]revokedKeyInfo,
+		len(lu.RevokedVerifyingKeys))
+	for k, v := range lu.RevokedVerifyingKeys {
+		luCopy.RevokedVerifyingKeys[k] = v
+	}
+
+	luCopy.RevokedCryptPublicKeys = make(
+		map[kbfscrypto.CryptPublicKey]revokedKeyInfo,
+		len(lu.RevokedCryptPublicKeys))
+	for k, v := range lu.RevokedCryptPublicKeys {
+		luCopy.RevokedCryptPublicKeys[k] = v
+	}
+
+	luCopy.Asserts = make([]string, len(lu.Asserts))
+	copy(luCopy.Asserts, lu.Asserts)
+	luCopy.UnverifiedKeys = make([]keybase1.PublicKey, len(lu.UnverifiedKeys))
+	copy(luCopy.UnverifiedKeys, lu.UnverifiedKeys)
+
+	return luCopy
+}
+
 // Helper functions to get a various keys for a local user suitable
 // for use with CryptoLocal. Each function will return the same key
 // will always be returned for a given user.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2314,11 +2314,15 @@ func (fbo *folderBranchOps) makeEditNotifications(
 		return nil, nil
 	}
 
-	// If journaling is enabled, this MD is coming from the journal,
-	// and the final paths will not be set on the ops.  Use crChains
-	// to set them.
+	// If this MD is coming from the journal or from the conflict
+	// resolver, the final paths will not be set on the ops.  Use
+	// crChains to set them.
 	ops := rmd.data.Changes.Ops
-	if TLFJournalEnabled(fbo.config, fbo.id()) {
+	isResolution := false
+	if len(ops) > 0 {
+		_, isResolution = ops[0].(*resolutionOp)
+	}
+	if isResolution || TLFJournalEnabled(fbo.config, fbo.id()) {
 		chains, err := newCRChainsForIRMDs(
 			ctx, fbo.config.Codec(), []ImmutableRootMetadata{rmd},
 			&fbo.blocks, true)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -157,6 +157,9 @@ func (fs *KBFSOpsStandard) PushConnectionStatusChange(
 // PushStatusChange forces a new status be fetched by status listeners.
 func (fs *KBFSOpsStandard) PushStatusChange() {
 	fs.currentStatus.PushStatusChange()
+
+	fs.log.CDebugf(nil, "Asking for an edit re-init after status change")
+	go fs.initTlfsForEditHistories()
 }
 
 // ClearPrivateFolderMD implements the KBFSOps interface for

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1155,6 +1155,7 @@ func (fs *KBFSOpsStandard) onMDFlush(tlfID tlf.ID, bid kbfsmd.BranchID,
 }
 
 func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
+	defer fs.editActivity.Done()
 	shutdown := func() bool {
 		fs.editLock.Lock()
 		defer fs.editLock.Unlock()
@@ -1164,7 +1165,6 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 		return
 	}
 
-	defer fs.editActivity.Done()
 	if !fs.config.Mode().TLFEditHistoryEnabled() {
 		return
 	}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1064,6 +1064,10 @@ func (fs *KBFSOpsStandard) KickoffAllOutstandingRekeys() error {
 func (fs *KBFSOpsStandard) NewNotificationChannel(
 	ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
 	channelName string) {
+	if !fs.config.Mode().TLFEditHistoryEnabled() {
+		return
+	}
+
 	fs.log.CDebugf(ctx, "New notification channel for %s",
 		handle.GetCanonicalPath())
 

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -460,12 +460,27 @@ func TestKBFSOpsConcurDeferredDoubleWritesDuringSync(t *testing.T) {
 	}
 }
 
+type modeNoHistory struct {
+	InitMode
+}
+
+func (mnh modeNoHistory) TLFEditHistoryEnabled() bool {
+	return false
+}
+
+func (mnh modeNoHistory) SendEditNotificationsEnabled() bool {
+	return false
+}
+
 // Test that a block write can happen concurrently with a block
 // read. This is a regression test for KBFS-536.
 func TestKBFSOpsConcurBlockReadWrite(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	// TODO: Use kbfsConcurTestShutdown.
 	defer kbfsConcurTestShutdownNoCheck(t, config, ctx, cancel)
+	// Turn off tlf edit history because it messes with the FBO state
+	// asynchronously.
+	config.mode = modeNoHistory{config.Mode()}
 
 	// Turn off transient block caching.
 	config.SetBlockCache(NewBlockCacheStandard(0, 1<<30))
@@ -591,6 +606,9 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	// TODO: Use kbfsConcurTestShutdown.
 	defer kbfsConcurTestShutdownNoCheck(t, config, ctx, cancel)
+	// Turn off tlf edit history because it messes with the FBO state
+	// asynchronously.
+	config.mode = modeNoHistory{config.Mode()}
 
 	<-config.BlockOps().TogglePrefetcher(false)
 
@@ -681,6 +699,9 @@ func TestKBFSOpsConcurBlockSyncWrite(t *testing.T) {
 func TestKBFSOpsConcurBlockSyncTruncate(t *testing.T) {
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, "test_user")
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
+	// Turn off tlf edit history because it messes with the FBO state
+	// asynchronously.
+	config.mode = modeNoHistory{config.Mode()}
 
 	<-config.BlockOps().TogglePrefetcher(false)
 

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -1165,6 +1165,10 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.Metada
 	if err != nil {
 		t.Fatalf("Couldn't sync file: %+v", err)
 	}
+	err = kbfsOps1.SyncFromServer(ctx, rootNode1.GetFolderBranch(), nil)
+	if err != nil {
+		t.Fatalf("Couldn't sync from server: %+v", err)
+	}
 
 	config2Dev2 := ConfigAsUser(config1, u2)
 	defer CheckConfigAndShutdown(ctx, t, config2Dev2)

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -628,6 +628,7 @@ func (k *KeybaseDaemonLocal) addDeviceForTesting(uid keybase1.UID,
 	if err != nil {
 		return 0, fmt.Errorf("No such user %s: %v", uid, err)
 	}
+	user = user.deepCopy()
 
 	index := len(user.VerifyingKeys)
 	newCryptPublicKey, newVerifyingKey := makeKeys(user.Name, index)
@@ -647,6 +648,7 @@ func (k *KeybaseDaemonLocal) revokeDeviceForTesting(clock Clock,
 	if err != nil {
 		return fmt.Errorf("No such user %s: %v", uid, err)
 	}
+	user = user.deepCopy()
 
 	if index >= len(user.VerifyingKeys) ||
 		(k.currentUID == uid && index == user.CurrentCryptPublicKeyIndex) {

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -355,8 +355,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	require.NoError(t, err)
 
 	kbfsOps2 := config2.KBFSOps()
-	err = kbfsOps2.SyncFromServer(ctx,
-		rootNode2.GetFolderBranch(), nil)
+	err = kbfsOps2.SyncFromServer(ctx, rootNode2.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	clock.Add(1 * time.Minute)
@@ -367,8 +366,9 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
 
-	err = kbfsOps1.SyncFromServer(ctx,
-		rootNode1.GetFolderBranch(), nil)
+	err = kbfsOps2.SyncFromServer(ctx, rootNode2.GetFolderBranch(), nil)
+	require.NoError(t, err)
+	err = kbfsOps1.SyncFromServer(ctx, rootNode1.GetFolderBranch(), nil)
 	require.NoError(t, err)
 
 	session1, err := config1.KBPKI().GetCurrentSession(context.Background())
@@ -381,7 +381,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 	// We should see 1 create edit for each user.
 	expectedHistory := keybase1.FSFolderEditHistory{
 		Folder: keybase1.Folder{
-			Name:       "u1,u2",
+			Name:       name,
 			FolderType: keybase1.FolderType_PRIVATE,
 			Private:    true,
 		},
@@ -390,7 +390,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 			{
 				WriterName: "u2",
 				Edits: []keybase1.FSFolderWriterEdit{{
-					Filename:         name + "/b",
+					Filename:         "/keybase/private/u1,u2/b",
 					NotificationType: keybase1.FSNotificationType_FILE_MODIFIED,
 					ServerTime:       keybase1.ToTime(second),
 				}},
@@ -398,7 +398,7 @@ func TestKeybaseDaemonRPCEditList(t *testing.T) {
 			{
 				WriterName: "u1",
 				Edits: []keybase1.FSFolderWriterEdit{{
-					Filename:         name + "/a",
+					Filename:         "/keybase/private/u1,u2/a",
 					NotificationType: keybase1.FSNotificationType_FILE_MODIFIED,
 					ServerTime:       keybase1.ToTime(first),
 				}},

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -521,7 +521,8 @@ func (co *createOp) ToEditNotification(
 	rev kbfsmd.Revision, revTime time.Time, device kbfscrypto.VerifyingKey,
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(rev, revTime, device, uid, tlfID, co.Type)
-	n.Filename = co.getFinalPath().ChildPathNoPtr(co.NewName).String()
+	n.Filename = co.getFinalPath().ChildPathNoPtr(co.NewName).
+		CanonicalPathString()
 	n.Type = kbfsedits.NotificationCreate
 	return &n
 }
@@ -636,7 +637,8 @@ func (ro *rmOp) ToEditNotification(
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(
 		rev, revTime, device, uid, tlfID, ro.RemovedType)
-	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.OldName).String()
+	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.OldName).
+		CanonicalPathString()
 	n.Type = kbfsedits.NotificationDelete
 	return &n
 }
@@ -779,10 +781,12 @@ func (ro *renameOp) ToEditNotification(
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(
 		rev, revTime, device, uid, tlfID, ro.RenamedType)
-	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.NewName).String()
+	n.Filename = ro.getFinalPath().ChildPathNoPtr(ro.NewName).
+		CanonicalPathString()
 	n.Type = kbfsedits.NotificationRename
 	n.Params = &kbfsedits.NotificationParams{
-		OldFilename: ro.oldFinalPath.ChildPathNoPtr(ro.OldName).String(),
+		OldFilename: ro.oldFinalPath.ChildPathNoPtr(ro.OldName).
+			CanonicalPathString(),
 	}
 	return &n
 }
@@ -979,7 +983,7 @@ func (so *syncOp) ToEditNotification(
 	rev kbfsmd.Revision, revTime time.Time, device kbfscrypto.VerifyingKey,
 	uid keybase1.UID, tlfID tlf.ID) *kbfsedits.NotificationMessage {
 	n := makeBaseEditNotification(rev, revTime, device, uid, tlfID, File)
-	n.Filename = so.getFinalPath().String()
+	n.Filename = so.getFinalPath().CanonicalPathString()
 	n.Type = kbfsedits.NotificationModify
 	var mods []kbfsedits.ModifyRange
 	for _, w := range so.Writes {

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -1542,6 +1542,8 @@ func RegisterOps(codec kbfscodec.Codec) {
 		opPointerizer)
 }
 
+// pathSortedOps sorts the ops in increasing order by path length, so
+// e.g. file creates come before file modifies.
 type pathSortedOps []op
 
 func (pso pathSortedOps) Len() int {

--- a/libkbfs/ops.go
+++ b/libkbfs/ops.go
@@ -1541,3 +1541,17 @@ func RegisterOps(codec kbfscodec.Codec) {
 	codec.RegisterIfaceSliceType(reflect.TypeOf(opsList{}), opsListCode,
 		opPointerizer)
 }
+
+type pathSortedOps []op
+
+func (pso pathSortedOps) Len() int {
+	return len(pso)
+}
+
+func (pso pathSortedOps) Less(i, j int) bool {
+	return len(pso[i].getFinalPath().path) < len(pso[j].getFinalPath().path)
+}
+
+func (pso pathSortedOps) Swap(i, j int) {
+	pso[i], pso[j] = pso[j], pso[i]
+}

--- a/redirector/main.go
+++ b/redirector/main.go
@@ -261,7 +261,7 @@ func (r *root) Lookup(
 		"kbfs.error.txt", "kbfs.nologin.txt", ".kbfs_enable_auto_journals",
 		".kbfs_disable_auto_journals", ".kbfs_enable_block_prefetching",
 		".kbfs_disable_block_prefetching", ".kbfs_enable_debug_server",
-		".kbfs_disable_debug_server":
+		".kbfs_disable_debug_server", ".kbfs_edit_history":
 		return symlink{filepath.Join(mountpoint, req.Name)}, nil
 	}
 	return nil, fuse.ENOENT

--- a/test/edit_history_test.go
+++ b/test/edit_history_test.go
@@ -1,0 +1,144 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+)
+
+func TestEditHistorySimple(t *testing.T) {
+	// Bob writes one file.
+	expectedEdits1 := []expectedEdit{
+		{
+			"alice,bob",
+			keybase1.FolderType_PRIVATE,
+			"bob",
+			[]string{"/keybase/private/alice,bob/a/b"},
+		},
+	}
+	// Alice writes one file.
+	expectedEdits2 := []expectedEdit{
+		{
+			"alice,bob",
+			keybase1.FolderType_PRIVATE,
+			"alice",
+			[]string{"/keybase/private/alice,bob/a/c"},
+		},
+		expectedEdits1[0],
+	}
+	// Bob overwrites his first file.
+	expectedEdits3 := []expectedEdit{
+		expectedEdits1[0],
+		expectedEdits2[0],
+	}
+
+	test(t,
+		users("alice", "bob"),
+		as(alice,
+			mkdir("a"),
+		),
+		as(bob,
+			mkfile("a/b", "hello"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits1),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits1),
+		),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a/c", "hello2"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits2),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits2),
+		),
+		as(bob,
+			addTime(1*time.Minute),
+			write("a/b", "hello again"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits3),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits3),
+		),
+	)
+}
+
+func TestEditHistoryMultiTlf(t *testing.T) {
+	// Bob writes one file to private.
+	expectedEdits1 := []expectedEdit{
+		{
+			"alice,bob",
+			keybase1.FolderType_PRIVATE,
+			"bob",
+			[]string{"/keybase/private/alice,bob/a"},
+		},
+	}
+	// Alice writes one file to public.
+	expectedEdits2 := []expectedEdit{
+		{
+			"alice,bob",
+			keybase1.FolderType_PUBLIC,
+			"alice",
+			[]string{"/keybase/public/alice,bob/b"},
+		},
+		expectedEdits1[0],
+	}
+	// Bob writes one file to team TLF.
+	expectedEdits3 := []expectedEdit{
+		{
+			"ab",
+			keybase1.FolderType_TEAM,
+			"bob",
+			[]string{"/keybase/team/ab/c"},
+		},
+		expectedEdits2[0],
+		expectedEdits1[0],
+	}
+
+	test(t,
+		users("alice", "bob"),
+		team("ab", "alice,bob", ""),
+		as(bob,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits1),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits1),
+		),
+		inPublicTlf("alice,bob"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("b", "hello"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits2),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits2),
+		),
+		inSingleTeamTlf("ab"),
+		as(bob,
+			addTime(1*time.Minute),
+			write("c", "hello again"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits3),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits3),
+		),
+	)
+}

--- a/test/engine.go
+++ b/test/engine.go
@@ -146,6 +146,9 @@ type Engine interface {
 	// paths haven't yet been flushed from the journal.
 	UnflushedPaths(u User, tlfName string, t tlf.Type) (
 		paths []string, err error)
+	// UserEditHistory called by the test harness to get the edit
+	// history for the given user.
+	UserEditHistory(u User) (history []keybase1.FSFolderEditHistory, err error)
 	// DirtyPaths called by the test harness to find out which
 	// paths haven't yet been flushed out of memory.
 	DirtyPaths(u User, tlfName string, t tlf.Type) (paths []string, err error)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -405,6 +405,24 @@ func (*fsEngine) UnflushedPaths(user User, tlfName string, t tlf.Type) (
 	return bufStatus.Journal.UnflushedPaths, nil
 }
 
+// UserEditHistory implements the Engine interface.
+func (*fsEngine) UserEditHistory(user User) (
+	history []keybase1.FSFolderEditHistory, err error) {
+	u := user.(*fsUser)
+	buf, err := ioutil.ReadFile(
+		filepath.Join(u.mntDir, libfs.EditHistoryName))
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(buf, &history)
+	if err != nil {
+		return nil, err
+	}
+
+	return history, nil
+}
+
 // DirtyPaths implements the Engine interface.
 func (*fsEngine) DirtyPaths(user User, tlfName string, t tlf.Type) (
 	[]string, error) {

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -738,6 +738,15 @@ func (k *LibKBFS) UnflushedPaths(u User, tlfName string, t tlf.Type) (
 	return status.Journal.UnflushedPaths, nil
 }
 
+// UserEditHistory implements the Engine interface.
+func (k *LibKBFS) UserEditHistory(u User) (
+	[]keybase1.FSFolderEditHistory, error) {
+	config := u.(*libkbfs.ConfigLocal)
+
+	history := config.UserHistory().Get()
+	return history, nil
+}
+
 // DirtyPaths implements the Engine interface.
 func (k *LibKBFS) DirtyPaths(u User, tlfName string, t tlf.Type) (
 	[]string, error) {


### PR DESCRIPTION
(Depends on #1628.)

Also, causes a notification about a new channel to fire if we get a new message on a conversation we haven't yet subscribed to.  That way we can launch a new `folderBranchOps` for a TLF that was written to but didn't previously appear high enough in our inbox.

Re-initialize the FBOs after each re-connect and re-login as well.

Issue: KBFS-2996