### PR TITLE
kbfsedits: includes at least 3 self-clusters in the overall user history

### DIFF
--- a/kbfsedits/data_types.go
+++ b/kbfsedits/data_types.go
@@ -7,6 +7,7 @@ package kbfsedits
 import (
 	"time"
 
+	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -136,4 +137,13 @@ func (nbr notificationsByRevision) uniquify() (ret notificationsByRevision) {
 		}
 	}
 	return ret
+}
+
+// SelfWriteMessage is written into a special, private channel when
+// the user writes to some TLF.
+type SelfWriteMessage struct {
+	Version    NotificationVersion
+	Folder     keybase1.Folder
+	ConvID     chat1.ConversationID
+	ServerTime time.Time
 }

--- a/kbfsedits/prepare.go
+++ b/kbfsedits/prepare.go
@@ -15,3 +15,13 @@ func Prepare(edits []NotificationMessage) (string, error) {
 	}
 	return string(buf), nil
 }
+
+// PrepareSelfWrite converts the given message into a string suitable
+// for sending/storing it.
+func PrepareSelfWrite(msg SelfWriteMessage) (string, error) {
+	buf, err := json.Marshal(msg)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}

--- a/kbfsedits/read.go
+++ b/kbfsedits/read.go
@@ -1,0 +1,17 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package kbfsedits
+
+import "encoding/json"
+
+// ReadSelfWrite converts the given message string into the
+// SelfWriteMessage type, if possible.
+func ReadSelfWrite(msg string) (ret SelfWriteMessage, err error) {
+	err = json.Unmarshal([]byte(msg), &err)
+	if err != nil {
+		return SelfWriteMessage{}, err
+	}
+	return ret, nil
+}

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -20,7 +20,6 @@ const (
 type writerNotifications struct {
 	writerName    string
 	notifications notificationsByRevision
-	isLoggedIn    bool
 }
 
 // writersByRevision sorts sets of per-writer notifications in reverse
@@ -82,10 +81,11 @@ func (wbr *writersByRevision) Pop() interface{} {
 //     `getHistory()` from each one.  It may also construct pretty
 //     versions of individual edit histories for a particular TLF.
 type TlfHistory struct {
-	lock          sync.RWMutex
-	byWriter      map[string]*writerNotifications
-	computed      bool
-	cachedHistory writersByRevision
+	lock               sync.RWMutex
+	byWriter           map[string]*writerNotifications
+	computed           bool
+	cachedHistory      writersByRevision
+	cachedLoggedInUser string
 }
 
 // NewTlfHistory constructs a new TlfHistory instance.
@@ -100,7 +100,7 @@ func NewTlfHistory() *TlfHistory {
 // the caller should call `Recompute` to find out if more messages
 // should be added for any particular writer.
 func (th *TlfHistory) AddNotifications(
-	writerName string, messages []string, isLoggedIn bool) (err error) {
+	writerName string, messages []string) (err error) {
 	newEdits := make(notificationsByRevision, 0, len(messages))
 
 	// Unmarshal and sort the new messages.
@@ -128,9 +128,8 @@ func (th *TlfHistory) AddNotifications(
 	defer th.lock.Unlock()
 	wn, existed := th.byWriter[writerName]
 	if !existed {
-		wn = &writerNotifications{writerName, nil, isLoggedIn}
+		wn = &writerNotifications{writerName, nil}
 	}
-	wn.isLoggedIn = isLoggedIn
 	oldLen := len(wn.notifications)
 	newEdits = append(newEdits, wn.notifications...)
 	sort.Sort(newEdits)
@@ -145,6 +144,7 @@ func (th *TlfHistory) AddNotifications(
 	}
 	// Invalidate the cached results.
 	th.computed = false
+	th.cachedLoggedInUser = ""
 	return nil
 }
 
@@ -218,7 +218,7 @@ func (r *recomputer) processNotification(
 
 		wn, ok := r.byWriter[writer]
 		if !ok {
-			wn = &writerNotifications{writer, nil, false /* fill in later */}
+			wn = &writerNotifications{writer, nil}
 			r.byWriter[writer] = wn
 		}
 		wn.writerName = writer
@@ -255,7 +255,7 @@ func (r *recomputer) processNotification(
 	return false
 }
 
-func (th *TlfHistory) recomputeLocked() (
+func (th *TlfHistory) recomputeLocked(loggedInUser string) (
 	history writersByRevision, writersWhoNeedMore map[string]bool) {
 	writersWhoNeedMore = make(map[string]bool)
 
@@ -303,10 +303,9 @@ func (th *TlfHistory) recomputeLocked() (
 	}
 
 	history = make(writersByRevision, 0, len(r.byWriter))
-	for writerName, oldWn := range th.byWriter {
+	for writerName := range th.byWriter {
 		wn := r.byWriter[writerName]
 		if wn != nil && len(wn.notifications) > 0 {
-			wn.isLoggedIn = oldWn.isLoggedIn
 			history = append(history, wn)
 		}
 		if wn == nil || len(wn.notifications) < maxEditsPerWriter {
@@ -318,7 +317,7 @@ func (th *TlfHistory) recomputeLocked() (
 		// Garbage-collect any writers that don't appear in the history.
 		loggedInIndex := -1
 		for i := maxWritersPerHistory; i < len(history); i++ {
-			if history[i].isLoggedIn {
+			if history[i].writerName == loggedInUser {
 				// Don't purge the logged-in user.
 				loggedInIndex = i
 				continue
@@ -340,22 +339,23 @@ func (th *TlfHistory) recomputeLocked() (
 	}
 	th.computed = true
 	th.cachedHistory = history
+	th.cachedLoggedInUser = loggedInUser
 	return history, writersWhoNeedMore
 }
 
 func (th *TlfHistory) getHistoryIfCached() (
-	cached bool, history writersByRevision) {
+	cached bool, history writersByRevision, loggedInUser string) {
 	th.lock.RLock()
 	defer th.lock.RUnlock()
 	if th.computed {
-		return true, th.cachedHistory
+		return true, th.cachedHistory, th.cachedLoggedInUser
 	}
-	return false, nil
+	return false, nil, ""
 }
 
-func (th *TlfHistory) getHistory() writersByRevision {
-	cached, history := th.getHistoryIfCached()
-	if cached {
+func (th *TlfHistory) getHistory(loggedInUser string) writersByRevision {
+	cached, history, cachedLoggedInUser := th.getHistoryIfCached()
+	if cached && loggedInUser == cachedLoggedInUser {
 		return history
 	}
 
@@ -366,16 +366,17 @@ func (th *TlfHistory) getHistory() writersByRevision {
 		// history since we checked above.
 		return th.cachedHistory
 	}
-	history, _ = th.recomputeLocked()
+	history, _ = th.recomputeLocked(loggedInUser)
 	return history
 }
 
 // Recompute processes (and caches) the history so that it reflects
 // all recently-added notifications, and returns the names of writers
 // which don't yet have the maximum number of edits in the history.
-func (th *TlfHistory) Recompute() (writersWhoNeedMore map[string]bool) {
+func (th *TlfHistory) Recompute(loggedInUser string) (
+	writersWhoNeedMore map[string]bool) {
 	th.lock.Lock()
 	defer th.lock.Unlock()
-	_, writersWhoNeedMore = th.recomputeLocked()
+	_, writersWhoNeedMore = th.recomputeLocked(loggedInUser)
 	return writersWhoNeedMore
 }

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -20,6 +20,7 @@ const (
 type writerNotifications struct {
 	writerName    string
 	notifications notificationsByRevision
+	isLoggedIn    bool
 }
 
 // writersByRevision sorts sets of per-writer notifications in reverse
@@ -99,7 +100,7 @@ func NewTlfHistory() *TlfHistory {
 // the caller should call `Recompute` to find out if more messages
 // should be added for any particular writer.
 func (th *TlfHistory) AddNotifications(
-	writerName string, messages []string) (err error) {
+	writerName string, messages []string, isLoggedIn bool) (err error) {
 	newEdits := make(notificationsByRevision, 0, len(messages))
 
 	// Unmarshal and sort the new messages.
@@ -127,8 +128,9 @@ func (th *TlfHistory) AddNotifications(
 	defer th.lock.Unlock()
 	wn, existed := th.byWriter[writerName]
 	if !existed {
-		wn = &writerNotifications{writerName, nil}
+		wn = &writerNotifications{writerName, nil, isLoggedIn}
 	}
+	wn.isLoggedIn = isLoggedIn
 	oldLen := len(wn.notifications)
 	newEdits = append(newEdits, wn.notifications...)
 	sort.Sort(newEdits)
@@ -216,7 +218,7 @@ func (r *recomputer) processNotification(
 
 		wn, ok := r.byWriter[writer]
 		if !ok {
-			wn = &writerNotifications{writer, nil}
+			wn = &writerNotifications{writer, nil, false /* fill in later */}
 			r.byWriter[writer] = wn
 		}
 		wn.writerName = writer
@@ -301,9 +303,10 @@ func (th *TlfHistory) recomputeLocked() (
 	}
 
 	history = make(writersByRevision, 0, len(r.byWriter))
-	for writerName := range th.byWriter {
+	for writerName, oldWn := range th.byWriter {
 		wn := r.byWriter[writerName]
 		if wn != nil && len(wn.notifications) > 0 {
+			wn.isLoggedIn = oldWn.isLoggedIn
 			history = append(history, wn)
 		}
 		if wn == nil || len(wn.notifications) < maxEditsPerWriter {
@@ -313,11 +316,24 @@ func (th *TlfHistory) recomputeLocked() (
 	sort.Sort(history)
 	if len(history) > maxWritersPerHistory {
 		// Garbage-collect any writers that don't appear in the history.
+		loggedInIndex := -1
 		for i := maxWritersPerHistory; i < len(history); i++ {
+			if history[i].isLoggedIn {
+				// Don't purge the logged-in user.
+				loggedInIndex = i
+				continue
+			}
 			delete(th.byWriter, history[i].writerName)
 			delete(writersWhoNeedMore, history[i].writerName)
 		}
-		history = history[:maxWritersPerHistory]
+		if loggedInIndex > 0 {
+			// Keep the logged-in user as the last entry.
+			loggedIn := history[loggedInIndex]
+			history = history[:maxWritersPerHistory]
+			history[maxWritersPerHistory-1] = loggedIn
+		} else {
+			history = history[:maxWritersPerHistory]
+		}
 	}
 	th.computed = true
 	th.cachedHistory = history

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -330,9 +330,8 @@ func (th *TlfHistory) recomputeLocked(loggedInUser string) (
 			// `loggedInIndex` is guaranteed to be greater or equal to
 			// `maxWritersPerHistory`, so this logic swaps in the
 			// loggedIn entry (and doesn't duplicate it).
-			loggedIn := history[loggedInIndex]
-			history = history[:maxWritersPerHistory]
-			history[maxWritersPerHistory-1] = loggedIn
+			history = append(
+				history[:maxWritersPerHistory-1], history[loggedInIndex])
 		} else {
 			history = history[:maxWritersPerHistory]
 		}

--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -327,7 +327,10 @@ func (th *TlfHistory) recomputeLocked() (
 			delete(writersWhoNeedMore, history[i].writerName)
 		}
 		if loggedInIndex > 0 {
-			// Keep the logged-in user as the last entry.
+			// Keep the logged-in user as the last entry.  Note that
+			// `loggedInIndex` is guaranteed to be greater or equal to
+			// `maxWritersPerHistory`, so this logic swaps in the
+			// loggedIn entry (and doesn't duplicate it).
 			loggedIn := history[loggedInIndex]
 			history = history[:maxWritersPerHistory]
 			history[maxWritersPerHistory-1] = loggedIn

--- a/kbfsedits/user_history.go
+++ b/kbfsedits/user_history.go
@@ -48,8 +48,9 @@ func NewUserHistory() *UserHistory {
 // UpdateHistory should be called whenever the edit history for a
 // given TLF gets new information.
 func (uh *UserHistory) UpdateHistory(
-	tlfName tlf.CanonicalName, tlfType tlf.Type, tlfHistory *TlfHistory) {
-	history := tlfHistory.getHistory()
+	tlfName tlf.CanonicalName, tlfType tlf.Type, tlfHistory *TlfHistory,
+	loggedInUser string) {
+	history := tlfHistory.getHistory(loggedInUser)
 	key := tlfKey{tlfName, tlfType}
 
 	uh.lock.Lock()

--- a/kbfsedits/user_history_test.go
+++ b/kbfsedits/user_history_test.go
@@ -77,15 +77,15 @@ func TestUserHistorySimple(t *testing.T) {
 	}
 	privHomeTime := keybase1.ToTime(now)
 
-	err = privSharedTH.AddNotifications(bobName, privSharedBob)
+	err = privSharedTH.AddNotifications(bobName, privSharedBob, false)
 	require.NoError(t, err)
-	err = privSharedTH.AddNotifications(aliceName, privSharedAlice)
-	require.NoError(t, err)
-
-	err = privHomeTH.AddNotifications(aliceName, privHomeAlice)
+	err = privSharedTH.AddNotifications(aliceName, privSharedAlice, false)
 	require.NoError(t, err)
 
-	err = publicTH.AddNotifications(aliceName, publicAlice)
+	err = privHomeTH.AddNotifications(aliceName, privHomeAlice, false)
+	require.NoError(t, err)
+
+	err = publicTH.AddNotifications(aliceName, publicAlice, false)
 	require.NoError(t, err)
 
 	uh := NewUserHistory()
@@ -124,7 +124,7 @@ func TestUserHistorySimple(t *testing.T) {
 	}
 
 	check := func(expected []expectInfo) {
-		history := uh.Get()
+		history := uh.Get(aliceName)
 		require.Len(t, history, len(expected))
 		for i, wh := range history {
 			require.Len(t, wh.History, 1)
@@ -141,7 +141,7 @@ func TestUserHistorySimple(t *testing.T) {
 	now = now.Add(1 * time.Minute)
 	_ = privSharedNN.make("7", NotificationCreate, aliceUID, nil, now)
 	err = privSharedTH.AddNotifications(
-		aliceName, []string{privSharedNN.encode(t)})
+		aliceName, []string{privSharedNN.encode(t)}, false)
 	require.NoError(t, err)
 	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH)
 	expected[3].serverTime = keybase1.ToTime(now)

--- a/kbfsedits/user_history_test.go
+++ b/kbfsedits/user_history_test.go
@@ -77,21 +77,21 @@ func TestUserHistorySimple(t *testing.T) {
 	}
 	privHomeTime := keybase1.ToTime(now)
 
-	err = privSharedTH.AddNotifications(bobName, privSharedBob, false)
+	err = privSharedTH.AddNotifications(bobName, privSharedBob)
 	require.NoError(t, err)
-	err = privSharedTH.AddNotifications(aliceName, privSharedAlice, false)
-	require.NoError(t, err)
-
-	err = privHomeTH.AddNotifications(aliceName, privHomeAlice, false)
+	err = privSharedTH.AddNotifications(aliceName, privSharedAlice)
 	require.NoError(t, err)
 
-	err = publicTH.AddNotifications(aliceName, publicAlice, false)
+	err = privHomeTH.AddNotifications(aliceName, privHomeAlice)
+	require.NoError(t, err)
+
+	err = publicTH.AddNotifications(aliceName, publicAlice)
 	require.NoError(t, err)
 
 	uh := NewUserHistory()
-	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH)
-	uh.UpdateHistory(privHomeName, tlf.Private, privHomeTH)
-	uh.UpdateHistory(publicName, tlf.Public, publicTH)
+	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH, aliceName)
+	uh.UpdateHistory(privHomeName, tlf.Private, privHomeTH, aliceName)
+	uh.UpdateHistory(publicName, tlf.Public, publicTH, aliceName)
 
 	type expectInfo struct {
 		tlfName    string
@@ -141,9 +141,9 @@ func TestUserHistorySimple(t *testing.T) {
 	now = now.Add(1 * time.Minute)
 	_ = privSharedNN.make("7", NotificationCreate, aliceUID, nil, now)
 	err = privSharedTH.AddNotifications(
-		aliceName, []string{privSharedNN.encode(t)}, false)
+		aliceName, []string{privSharedNN.encode(t)})
 	require.NoError(t, err)
-	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH)
+	uh.UpdateHistory(privSharedName, tlf.Private, privSharedTH, aliceName)
 	expected[3].serverTime = keybase1.ToTime(now)
 	expected[3].num++
 	expected = append([]expectInfo{expected[3]}, expected[0:3]...)

--- a/libdokan/user_edit_history.go
+++ b/libdokan/user_edit_history.go
@@ -15,8 +15,8 @@ import (
 // representation of the file edit history for the logged-in user.
 func NewUserEditHistoryFile(folder *Folder) *SpecialReadFile {
 	return &SpecialReadFile{
-		read: func(_ context.Context) ([]byte, time.Time, error) {
-			return libfs.GetEncodedUserEditHistory(folder.fs.config)
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			return libfs.GetEncodedUserEditHistory(ctx, folder.fs.config)
 		},
 		fs: folder.fs,
 	}

--- a/libfs/user_edit_history.go
+++ b/libfs/user_edit_history.go
@@ -5,6 +5,7 @@
 package libfs
 
 import (
+	"context"
 	"time"
 
 	"github.com/keybase/kbfs/libkbfs"
@@ -12,9 +13,15 @@ import (
 
 // GetEncodedUserEditHistory returns serialized JSON containing the
 // file edit history for the user.
-func GetEncodedUserEditHistory(config libkbfs.Config) (
+func GetEncodedUserEditHistory(ctx context.Context, config libkbfs.Config) (
 	data []byte, t time.Time, err error) {
-	edits := config.UserHistory().Get()
+	session, err := libkbfs.GetCurrentSessionIfPossible(
+		ctx, config.KBPKI(), true)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	edits := config.UserHistory().Get(string(session.Name))
 	data, err = PrettyJSON(edits)
 	return data, time.Time{}, err
 }

--- a/libfuse/user_edit_history_file.go
+++ b/libfuse/user_edit_history_file.go
@@ -18,8 +18,8 @@ func NewUserEditHistoryFile(
 	folder *Folder, entryValid *time.Duration) *SpecialReadFile {
 	*entryValid = 0
 	return &SpecialReadFile{
-		read: func(_ context.Context) ([]byte, time.Time, error) {
-			return libfs.GetEncodedUserEditHistory(folder.fs.config)
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			return libfs.GetEncodedUserEditHistory(ctx, folder.fs.config)
 		},
 	}
 }

--- a/libkbfs/chat_local.go
+++ b/libkbfs/chat_local.go
@@ -328,3 +328,10 @@ func (c *chatLocal) copy(config Config) *chatLocal {
 		c.data.newChannelCBs, config.KBFSOps().NewNotificationChannel)
 	return copy
 }
+
+// ClearCache implements the Chat interface.
+func (c *chatLocal) ClearCache() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.selfConvInfos = nil
+}

--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -534,6 +534,14 @@ func (c *ChatRPC) RegisterForMessages(
 	c.convCBs[str] = append(c.convCBs[str], cb)
 }
 
+// ClearCache implements the Chat interface.
+func (c *ChatRPC) ClearCache() {
+	c.convLock.Lock()
+	defer c.convLock.Unlock()
+	c.selfConvID = nil
+	c.lastWrittenConvID = nil
+}
+
 // We only register for the kbfs-edits type of notification in
 // keybase_daemon_rpc, so all the other methods below besides
 // `NewChatActivity` should never be called.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2249,4 +2249,8 @@ type Chat interface {
 	// RegisterForMessages registers a callback that will be called
 	// for each new messages that reaches convID.
 	RegisterForMessages(convID chat1.ConversationID, cb ChatChannelNewMessageCB)
+
+	// ClearCache is called to force this instance to forget
+	// everything it might have cached, e.g. when a user logs out.
+	ClearCache()
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1199,27 +1199,6 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 				h.GetCanonicalName(), err)
 		}
 	}
-
-	session, err := fs.config.KBPKI().GetCurrentSession(ctx)
-	if err != nil {
-		// No current session.
-		return
-	}
-
-	pubHandle, err := GetHandleFromFolderNameAndType(
-		ctx, fs.config.KBPKI(), fs.config.MDOps(), string(session.Name),
-		tlf.Public)
-	if err != nil {
-		fs.log.CWarningf(ctx, "Couldn't get handle for public folder: %+v", err)
-		return
-	}
-	fs.log.CDebugf(ctx, "Initializing TLF %s for the edit history",
-		pubHandle.GetCanonicalPath())
-	_, _, err = fs.GetRootNode(ctx, pubHandle, MasterBranch)
-	if err != nil {
-		fs.log.CWarningf(ctx, "Couldn't get root node for public folder: %+v",
-			err)
-	}
 }
 
 // kbfsOpsFavoriteObserver deals with a handle change for a particular

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -62,6 +62,7 @@ func serviceLoggedOut(ctx context.Context, config Config) {
 	}
 	config.ResetCaches()
 	config.UserHistory().Clear()
+	config.Chat().ClearCache()
 	mdServer := config.MDServer()
 	if mdServer != nil {
 		mdServer.RefreshAuthToken(ctx)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -7764,3 +7764,13 @@ func (m *MockChat) RegisterForMessages(convID chat1.ConversationID, cb ChatChann
 func (mr *MockChatMockRecorder) RegisterForMessages(convID, cb interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterForMessages", reflect.TypeOf((*MockChat)(nil).RegisterForMessages), convID, cb)
 }
+
+// ClearCache mocks base method
+func (m *MockChat) ClearCache() {
+	m.ctrl.Call(m, "ClearCache")
+}
+
+// ClearCache indicates an expected call of ClearCache
+func (mr *MockChatMockRecorder) ClearCache() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCache", reflect.TypeOf((*MockChat)(nil).ClearCache))
+}

--- a/test/edit_history_test.go
+++ b/test/edit_history_test.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -139,6 +140,113 @@ func TestEditHistoryMultiTlf(t *testing.T) {
 		),
 		as(alice,
 			checkUserEditHistory(expectedEdits3),
+		),
+	)
+}
+
+func TestEditHistorySelfClusters(t *testing.T) {
+	// Bob writes one file to private.
+	expectedEdits1 := []expectedEdit{
+		{
+			"alice,bob",
+			keybase1.FolderType_PRIVATE,
+			"bob",
+			[]string{"/keybase/private/alice,bob/a"},
+		},
+	}
+	// Alice writes to ten team TLFs, but bob should still see his own
+	// write from above.
+	expectedEdits2Alice := make([]expectedEdit, 0, 10)
+	expectedEdits2Bob := make([]expectedEdit, 0, 10)
+	for i := 9; i >= 0; i-- {
+		team := fmt.Sprintf("ab%d", i)
+		e := expectedEdit{
+			team,
+			keybase1.FolderType_TEAM,
+			"alice",
+			[]string{fmt.Sprintf("/keybase/team/%s/a", team)},
+		}
+		expectedEdits2Alice = append(expectedEdits2Alice, e)
+		expectedEdits2Bob = append(expectedEdits2Bob, e)
+	}
+	expectedEdits2Bob[9] = expectedEdits1[0]
+
+	test(t,
+		users("alice", "bob"),
+		team("ab0", "alice,bob", ""),
+		team("ab1", "alice,bob", ""),
+		team("ab2", "alice,bob", ""),
+		team("ab3", "alice,bob", ""),
+		team("ab4", "alice,bob", ""),
+		team("ab5", "alice,bob", ""),
+		team("ab6", "alice,bob", ""),
+		team("ab7", "alice,bob", ""),
+		team("ab8", "alice,bob", ""),
+		team("ab9", "alice,bob", ""),
+		as(bob,
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits1),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits1),
+		),
+		inSingleTeamTlf("ab0"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab1"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab2"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab3"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab4"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab5"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab6"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab7"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab8"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		inSingleTeamTlf("ab9"),
+		as(alice,
+			addTime(1*time.Minute),
+			mkfile("a", "hello"),
+		),
+		as(bob,
+			checkUserEditHistory(expectedEdits2Bob),
+		),
+		as(alice,
+			checkUserEditHistory(expectedEdits2Alice),
 		),
 	)
 }

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -743,7 +743,15 @@ func (k *LibKBFS) UserEditHistory(u User) (
 	[]keybase1.FSFolderEditHistory, error) {
 	config := u.(*libkbfs.ConfigLocal)
 
-	history := config.UserHistory().Get()
+	ctx, cancel := k.newContext(u)
+	defer cancel()
+	session, err := libkbfs.GetCurrentSessionIfPossible(
+		ctx, config.KBPKI(), true)
+	if err != nil {
+		return nil, err
+	}
+
+	history := config.UserHistory().Get(string(session.Name))
 	return history, nil
 }
 


### PR DESCRIPTION
(Depends on #1631.)

This is the first attempt at making sure your own recent write history appears in the overall edit history, even if they were a long time ago.  The desired behavior, for now:

* Make sure there are always 3 TLF-writer clusters for yourself in the list.
* Sort them into the list according to the regular algorithm -- i.e., if they happened a long time ago, they will still appear at the bottom.
* Don't do anything special for the public folder -- if it happens to be one of the top-3 self-clusters, it will make the list; if not, it won't.

To make this happen, this PR:
* Creates a special "#self" kbfs-edits notification channel in the logged-in user's private conversation.
* On every "normal" notification, it writes the name and type of the TLF into this "#self" channel.
   * But as a best-effort optimization, it tries to make sure that whatever it writes is _different_ from the last write to the "#self" channel, so we don't build up a bunch of useless duplicate entries.
* When loading the inbox, it makes sure the last 3 unique TLFs from the "#self" channel are included.
* `TlfHistory` never trims the logged-in user's writes from the history.
* `UserHistory` always includes at least 3 clusters by the logged-in user in the overall history.

Issue: KBFS-3080