### PR TITLE
lock better and log better

### DIFF
--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -315,8 +315,6 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 		}
 	}
 
-	return nil
-
 	// Using conn.GetClient() here would cause problematic
 	// recursion.
 	c := keybase1.NotifyCtlClient{Cli: rawClient}

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -267,9 +267,9 @@ func (*KeybaseDaemonRPC) HandlerName() string {
 	return "KeybaseDaemonRPC"
 }
 
-func (k *KeybaseDaemonRPC) registerProtocolLocked(p rpc.Protocol) error {
+func (k *KeybaseDaemonRPC) registerProtocol(server *rpc.Server, p rpc.Protocol) error {
 	k.log.Debug("registering protocol %q", p.Name)
-	err := k.server.Register(p)
+	err := server.Register(p)
 	switch err.(type) {
 	case nil, rpc.AlreadyRegisteredError:
 		return nil
@@ -297,7 +297,7 @@ func (k *KeybaseDaemonRPC) AddProtocols(protocols []rpc.Protocol) {
 	// If we are already connected, register these protocols.
 	if k.server != nil {
 		for _, p := range protocols {
-			k.registerProtocolLocked(p)
+			k.registerProtocol(k.server, p)
 		}
 	}
 }
@@ -310,7 +310,7 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 	defer k.lock.Unlock()
 
 	for _, p := range k.protocols {
-		if err = k.registerProtocolLocked(p); err != nil {
+		if err = k.registerProtocol(server, p); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
It's possible that `AddProtocol` is called after we iterate protocols in
`OnConnect`, but before it manages to finish everything and assign
the `(*KeybaseDaemonRPC).server`, so `AddProtocol` would find `server`
to be nil, and skips registering additional protocols. So just do a full
lock at the beginning of `OnConnect` to avoid this race.

Also add logging for each registered protocol to help with debugging.