### PR TITLE
node_cache_test: use `runtime.KeepAlive` for GC test

### DIFF
--- a/libkbfs/node_cache_test.go
+++ b/libkbfs/node_cache_test.go
@@ -466,10 +466,10 @@ func TestNodeCacheGCReal(t *testing.T) {
 	runtime.GC()
 	<-finalizerChan
 
-	require.Len(t, ncs.nodes, 1)
+	require.Len(t, ncs.nodes, 2)
 
 	// Make sure childNode2 isn't GCed until after this point.
-	func(interface{}) {}(childNode2)
+	runtime.KeepAlive(childNode2)
 }
 
 type wrappedTestNode struct {


### PR DESCRIPTION
Apparently go1.10 can optimize away the old `func` trick for keeping references around.

This way works for both go1.9 and go1.10.