### PR TITLE
md_ops: check historic team writership

### DIFF
--- a/kbfsmd/root_metadata_v3.go
+++ b/kbfsmd/root_metadata_v3.go
@@ -979,8 +979,6 @@ func (md *RootMetadataV3) IsValidAndSigned(
 			return err
 		}
 
-		// TODO: Eventually this will have to use a Merkle sequence
-		// number to check historic versions.
 		isWriter, err = teamMemChecker.IsTeamWriter(
 			ctx, tid, writer, writerVerifyingKey)
 		if err != nil {

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -72,8 +72,9 @@ type TeamInfo struct {
 	Writers map[keybase1.UID]bool
 	Readers map[keybase1.UID]bool
 
-	// TODO: Should we add a historic membership log to easily check
-	// whether a user was a member given some Merkle seqno?
+	// Last writers map a KID to the last time the writer associated
+	// with that KID trasitioned from writer to non-writer.
+	LastWriters map[kbfscrypto.VerifyingKey]keybase1.MerkleRootV2
 }
 
 // ImplicitTeamInfo contains information needed after

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1187,7 +1187,7 @@ type MDWrittenAfterRevokeError struct {
 
 // Error implements the Error interface for MDWrittenAfterRevokeError.
 func (e MDWrittenAfterRevokeError) Error() string {
-	return fmt.Sprintf("Faled to verify revision %d of folder %s by key %s; "+
+	return fmt.Sprintf("Failed to verify revision %d of folder %s by key %s; "+
 		"last valid revision would have been %d",
 		e.revBad, e.tlfID, e.verifyingKey, e.revLimit)
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -522,7 +522,8 @@ type KeybaseService interface {
 	// isn't a member of the team yet according to local caches; it
 	// may be set to "" if no server check is required.
 	LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID,
-		desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
+		tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen,
+		desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey,
 		desiredRole keybase1.TeamRole) (TeamInfo, error)
 
 	// CurrentSession returns a SessionInfo struct with all the
@@ -647,6 +648,15 @@ type teamMembershipChecker interface {
 	// kbfsmd.TeamMembershipChecker.IsTeamWriter.
 	IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID,
 		verifyingKey kbfscrypto.VerifyingKey) (bool, error)
+	// NoLongerTeamWriter returns the global Merkle root of the
+	// most-recent time the given user (with the given device key,
+	// which implies an eldest seqno) transitioned from being a writer
+	// to not being a writer on the given team.  If the user was never
+	// a writer of the team, it returns an error.
+	NoLongerTeamWriter(
+		ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type,
+		uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (
+		keybase1.MerkleRootV2, error)
 	// IsTeamReader is a copy of
 	// kbfsmd.TeamMembershipChecker.IsTeamWriter.
 	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -751,10 +751,15 @@ func (k *KeybaseDaemonLocal) removeTeamWriterForTest(
 		if err != nil {
 			return err
 		}
+		if t.LastWriters == nil {
+			t.LastWriters = make(
+				map[kbfscrypto.VerifyingKey]keybase1.MerkleRootV2)
+		}
 		for _, key := range u.VerifyingKeys {
 			t.LastWriters[key] = k.merkleRoot
 		}
 	}
+	k.merkleRoot.Seqno++
 
 	delete(t.Writers, uid)
 	delete(t.Readers, uid)

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -431,7 +431,8 @@ func (k *KeybaseDaemonLocal) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) LoadTeamPlusKeys(
-	ctx context.Context, tid keybase1.TeamID, _ kbfsmd.KeyGen, _ keybase1.UserVersion,
+	ctx context.Context, tid keybase1.TeamID, _ tlf.Type, _ kbfsmd.KeyGen,
+	_ keybase1.UserVersion, _ kbfscrypto.VerifyingKey,
 	_ keybase1.TeamRole) (TeamInfo, error) {
 	if err := checkContext(ctx); err != nil {
 		return TeamInfo{}, err

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	metrics "github.com/rcrowley/go-metrics"
@@ -131,11 +132,13 @@ func (k KeybaseServiceMeasured) LoadUserPlusKeys(ctx context.Context,
 
 // LoadTeamPlusKeys implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) LoadTeamPlusKeys(ctx context.Context,
-	tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion,
+	tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen,
+	desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey,
 	desiredRole keybase1.TeamRole) (teamInfo TeamInfo, err error) {
 	k.loadTeamPlusKeysTimer.Time(func() {
 		teamInfo, err = k.delegate.LoadTeamPlusKeys(
-			ctx, tid, desiredKeyGen, desiredUser, desiredRole)
+			ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey,
+			desiredRole)
 	})
 	return teamInfo, err
 }

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -514,6 +514,10 @@ func (mbtc merkleBasedTeamChecker) IsTeamWriter(
 func (mbtc merkleBasedTeamChecker) IsTeamReader(
 	ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
 	bool, error) {
+	if mbtc.irmd.TlfID().Type() == tlf.Public {
+		return true, nil
+	}
+
 	isCurrentReader, err := mbtc.teamMembershipChecker.IsTeamReader(
 		ctx, tid, uid)
 	if err != nil {

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -521,8 +521,7 @@ func (mbtc merkleBasedTeamChecker) IsTeamReader(
 	// above function).  TODO: fix this once historic team readership
 	// is available in the service.
 	mbtc.md.log.CDebugf(ctx,
-		"Faking old writership in IsTeamReader for user %s in team %s",
-		uid, tid)
+		"Faking old readership for user %s in team %s", uid, tid)
 	return true, nil
 }
 

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -520,7 +520,7 @@ func testMDOpsGetBlankSigFailure(t *testing.T, ver kbfsmd.MetadataVer) {
 	rmds, extra := newRMDS(t, config, h)
 	rmds.SigInfo = kbfscrypto.SignatureInfo{}
 
-	// only the get happens, no verify needed with a blank sig
+	verifyMDForPrivate(config, rmds)
 	config.mockMdserv.EXPECT().GetForTLF(ctx, rmds.MD.TlfID(), kbfsmd.NullBranchID,
 		kbfsmd.Merged, nil).Return(rmds, nil)
 	expectGetKeyBundles(ctx, config, extra)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1661,16 +1661,16 @@ func (mr *MockKeybaseServiceMockRecorder) LoadUserPlusKeys(ctx, uid, pollForKID 
 }
 
 // LoadTeamPlusKeys mocks base method
-func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredRole keybase1.TeamRole) (TeamInfo, error) {
-	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, desiredKeyGen, desiredUser, desiredRole)
+func (m *MockKeybaseService) LoadTeamPlusKeys(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, desiredKeyGen kbfsmd.KeyGen, desiredUser keybase1.UserVersion, desiredKey kbfscrypto.VerifyingKey, desiredRole keybase1.TeamRole) (TeamInfo, error) {
+	ret := m.ctrl.Call(m, "LoadTeamPlusKeys", ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole)
 	ret0, _ := ret[0].(TeamInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadTeamPlusKeys indicates an expected call of LoadTeamPlusKeys
-func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, desiredKeyGen, desiredUser, desiredRole interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), ctx, tid, desiredKeyGen, desiredUser, desiredRole)
+func (mr *MockKeybaseServiceMockRecorder) LoadTeamPlusKeys(ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTeamPlusKeys", reflect.TypeOf((*MockKeybaseService)(nil).LoadTeamPlusKeys), ctx, tid, tlfType, desiredKeyGen, desiredUser, desiredKey, desiredRole)
 }
 
 // CurrentSession mocks base method
@@ -2076,6 +2076,19 @@ func (mr *MockteamMembershipCheckerMockRecorder) IsTeamWriter(ctx, tid, uid, ver
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey)
 }
 
+// NoLongerTeamWriter mocks base method
+func (m *MockteamMembershipChecker) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (keybase1.MerkleRootV2, error) {
+	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey)
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter
+func (mr *MockteamMembershipCheckerMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockteamMembershipChecker)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey)
+}
+
 // IsTeamReader mocks base method
 func (m *MockteamMembershipChecker) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (bool, error) {
 	ret := m.ctrl.Call(m, "IsTeamReader", ctx, tid, uid)
@@ -2341,6 +2354,19 @@ func (m *MockKBPKI) IsTeamWriter(ctx context.Context, tid keybase1.TeamID, uid k
 // IsTeamWriter indicates an expected call of IsTeamWriter
 func (mr *MockKBPKIMockRecorder) IsTeamWriter(ctx, tid, uid, verifyingKey interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).IsTeamWriter), ctx, tid, uid, verifyingKey)
+}
+
+// NoLongerTeamWriter mocks base method
+func (m *MockKBPKI) NoLongerTeamWriter(ctx context.Context, tid keybase1.TeamID, tlfType tlf.Type, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (keybase1.MerkleRootV2, error) {
+	ret := m.ctrl.Call(m, "NoLongerTeamWriter", ctx, tid, tlfType, uid, verifyingKey)
+	ret0, _ := ret[0].(keybase1.MerkleRootV2)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NoLongerTeamWriter indicates an expected call of NoLongerTeamWriter
+func (mr *MockKBPKIMockRecorder) NoLongerTeamWriter(ctx, tid, tlfType, uid, verifyingKey interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NoLongerTeamWriter", reflect.TypeOf((*MockKBPKI)(nil).NoLongerTeamWriter), ctx, tid, tlfType, uid, verifyingKey)
 }
 
 // IsTeamReader mocks base method

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -518,7 +518,8 @@ func AddTeamKeyForTest(config Config, tid keybase1.TeamID) error {
 	}
 
 	ti, err := kbd.LoadTeamPlusKeys(
-		context.Background(), tid, kbfsmd.UnspecifiedKeyGen, keybase1.UserVersion{},
+		context.Background(), tid, tlf.Unknown, kbfsmd.UnspecifiedKeyGen,
+		keybase1.UserVersion{}, kbfscrypto.VerifyingKey{},
 		keybase1.TeamRole_NONE)
 	if err != nil {
 		return err

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -489,6 +489,27 @@ func AddTeamWriterForTestOrBust(t logger.TestLogBackend, config Config,
 	}
 }
 
+// RemoveTeamWriterForTest removes the given user from a team.
+func RemoveTeamWriterForTest(
+	config Config, tid keybase1.TeamID, uid keybase1.UID) error {
+	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
+	if !ok {
+		return errors.New("Bad keybase daemon")
+	}
+
+	return kbd.removeTeamWriterForTest(tid, uid)
+}
+
+// RemoveTeamWriterForTestOrBust is like RemoveTeamWriterForTest, but
+// dies if there's an error.
+func RemoveTeamWriterForTestOrBust(t logger.TestLogBackend, config Config,
+	tid keybase1.TeamID, uid keybase1.UID) {
+	err := RemoveTeamWriterForTest(config, tid, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 // AddTeamReaderForTest makes the given user a team reader.
 func AddTeamReaderForTest(
 	config Config, tid keybase1.TeamID, uid keybase1.UID) error {


### PR DESCRIPTION
This PR checks, if the writer of an MD is not currently a writer of the team, that the user _was_ a writer at the "time" the revision was made.  Here "time" is defined by the merkle trees, just as it is with checking revoked devices.  We ask the service for the merkle root following when the user was last downgraded from being a writer, and then we use that to call `FindNextMD`.  This required some refactoring to share that code with the device-revocation-checking code.

Two notes:
1. Currently, the service can only tell us about writership downgrades, not readership downgrades.  Our MD validators call `IsTeamReader` for the last modifying user, since a reader is allowed to copy a writer's MD to make a rekey request.  So the best we can do now is just fake it, which should be fine since a) we do the full verification on the real writer of the MD, and b) readers can only make rekey requests, and it seems ok to be slack about the verification of those, as long as the writer stuff is fully verified.
2. The service has a small bug right now where it won't return an error if the user was NEVER a writer of the team.  Max is fixing this soon as CORE-8199.

Issue: KBFS-2955