### PR TITLE
unflushed_path_cache: check for nil channel before closing

### DIFF
--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -136,8 +136,10 @@ func (upc *unflushedPathCache) abortInitialization() {
 	defer upc.lock.Unlock()
 	upc.state = upcUninitialized
 	upc.queue = nil
-	close(upc.ready)
-	upc.ready = nil
+	if upc.ready != nil {
+		close(upc.ready)
+		upc.ready = nil
+	}
 }
 
 // unflushedPathMDInfo is the subset of metadata info needed by
@@ -329,8 +331,10 @@ func (upc *unflushedPathCache) setCacheIfPossible(cache unflushedPathsMap,
 
 	upc.unflushedPaths = cache
 	upc.chainsPopulator = cpp
-	close(upc.ready)
-	upc.ready = nil
+	if upc.ready != nil {
+		close(upc.ready)
+		upc.ready = nil
+	}
 	upc.state = upcInitialized
 	return nil
 }


### PR DESCRIPTION
I guess this got triggered by simple FS starting to call for the status all of the sudden?  Still investigating how it could get into this state, but this should stop the panics.

Issue: KBFS-3101