### PR TITLE
rekey_queue: put queue size into mode, and drop reqs when full

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1837,6 +1837,8 @@ type InitMode interface {
 	PrefetchWorkers() int
 	// RekeyWorkers returns the number of rekey workers to run.
 	RekeyWorkers() int
+	// RekeyQueueSize returns the size of the rekey queue.
+	RekeyQueueSize() int
 	// DirtyBlockCacheEnabled indicates if we should run a dirty block
 	// cache.
 	DirtyBlockCacheEnabled() bool

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5986,6 +5986,18 @@ func (mr *MockInitModeMockRecorder) RekeyWorkers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RekeyWorkers", reflect.TypeOf((*MockInitMode)(nil).RekeyWorkers))
 }
 
+// RekeyQueueSize mocks base method
+func (m *MockInitMode) RekeyQueueSize() int {
+	ret := m.ctrl.Call(m, "RekeyQueueSize")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// RekeyQueueSize indicates an expected call of RekeyQueueSize
+func (mr *MockInitModeMockRecorder) RekeyQueueSize() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RekeyQueueSize", reflect.TypeOf((*MockInitMode)(nil).RekeyQueueSize))
+}
+
 // DirtyBlockCacheEnabled mocks base method
 func (m *MockInitMode) DirtyBlockCacheEnabled() bool {
 	ret := m.ctrl.Call(m, "DirtyBlockCacheEnabled")

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -48,6 +48,10 @@ func (md modeDefault) RekeyWorkers() int {
 	return 16
 }
 
+func (md modeDefault) RekeyQueueSize() int {
+	return 2048 // 48 KB
+}
+
 func (md modeDefault) IsTestMode() bool {
 	return false
 }
@@ -137,6 +141,10 @@ func (mm modeMinimal) PrefetchWorkers() int {
 
 func (mm modeMinimal) RekeyWorkers() int {
 	return 4
+}
+
+func (mm modeMinimal) RekeyQueueSize() int {
+	return 512 // 12 KB
 }
 
 func (mm modeMinimal) IsTestMode() bool {
@@ -239,6 +247,10 @@ func (mso modeSingleOp) RekeyWorkers() int {
 	return 0
 }
 
+func (mso modeSingleOp) RekeyQueueSize() int {
+	return 0
+}
+
 func (mso modeSingleOp) QuotaReclamationEnabled() bool {
 	return false
 }
@@ -295,6 +307,10 @@ func (mc modeConstrained) PrefetchWorkers() int {
 
 func (mc modeConstrained) RekeyWorkers() int {
 	return 4
+}
+
+func (mc modeConstrained) RekeyQueueSize() int {
+	return 1024 // 24 KB
 }
 
 func (mc modeConstrained) BackgroundFlushesEnabled() bool {

--- a/libkbfs/rekey_fsm.go
+++ b/libkbfs/rekey_fsm.go
@@ -454,7 +454,7 @@ type rekeyFSM struct {
 // NewRekeyFSM creates a new rekey FSM.
 func NewRekeyFSM(fbo *folderBranchOps) RekeyFSM {
 	fsm := &rekeyFSM{
-		reqs:       make(chan RekeyEvent, rekeyQueueSize),
+		reqs:       make(chan RekeyEvent, fbo.config.Mode().RekeyQueueSize()),
 		shutdownCh: make(chan struct{}),
 		fbo:        fbo,
 		log:        fbo.config.MakeLogger("RekeyFSM"),


### PR DESCRIPTION
Launching a goroutine for rekey requests when the queue is full doesn't make a lot of sense if we're trying to conserve memory (like on a phone), since it probably uses a lot more memory than just expanding the queue.  So this PR just drops requests when the queue is full, and increases the queue size on desktop to handle more requests at a time.  Any dropped requests will get processed again at the next rekey interval.

This only changes behavior for people with more than 2K TLFs, which is probably only two users.

Issue: KBFS-3072