### PR TITLE
libkbfs: turn on QR for mobile, but limit it to self-QR

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -42,14 +42,6 @@ const (
 	rekeyWithPromptWaitTimeDefault = 10 * time.Minute
 	// see Config doc for the purpose of DelayedCancellationGracePeriod
 	delayedCancellationGracePeriodDefault = 2 * time.Second
-	// How often do we check for stuff to reclaim?
-	qrPeriodDefault = 1 * time.Minute
-	// How long must something be unreferenced before we reclaim it?
-	qrUnrefAgeDefault = 1 * time.Minute
-	// How old must the most recent TLF revision be before another
-	// device can run QR on that TLF?  This is large, to avoid
-	// unnecessary conflicts on the TLF between devices.
-	qrMinHeadAgeDefault = 24 * time.Hour
 	// tlfValidDurationDefault is the default for tlf validity before redoing identify.
 	tlfValidDurationDefault = 6 * time.Hour
 	// bgFlushDirOpThresholdDefault is the default for how many
@@ -117,9 +109,6 @@ type ConfigLocal struct {
 	traceLock    sync.RWMutex
 	traceEnabled bool
 
-	qrPeriod                       time.Duration
-	qrUnrefAge                     time.Duration
-	qrMinHeadAge                   time.Duration
 	delayedCancellationGracePeriod time.Duration
 
 	// allKnownConfigsForTesting is used for testing, and contains all created
@@ -437,10 +426,6 @@ func NewConfigLocal(mode InitMode,
 	config.rwpWaitTime = rekeyWithPromptWaitTimeDefault
 
 	config.delayedCancellationGracePeriod = delayedCancellationGracePeriodDefault
-	config.qrPeriod = qrPeriodDefault
-	config.qrUnrefAge = qrUnrefAgeDefault
-	config.qrMinHeadAge = qrMinHeadAgeDefault
-
 	// Don't bother creating the registry if UseNilMetrics is set, or
 	// if we're in minimal mode.
 	if !metrics.UseNilMetrics && config.Mode().MetricsEnabled() {
@@ -924,21 +909,6 @@ func (c *ConfigLocal) DelayedCancellationGracePeriod() time.Duration {
 // SetDelayedCancellationGracePeriod implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) SetDelayedCancellationGracePeriod(d time.Duration) {
 	c.delayedCancellationGracePeriod = d
-}
-
-// QuotaReclamationPeriod implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) QuotaReclamationPeriod() time.Duration {
-	return c.qrPeriod
-}
-
-// QuotaReclamationMinUnrefAge implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) QuotaReclamationMinUnrefAge() time.Duration {
-	return c.qrUnrefAge
-}
-
-// QuotaReclamationMinHeadAge implements the Config interface for ConfigLocal.
-func (c *ConfigLocal) QuotaReclamationMinHeadAge() time.Duration {
-	return c.qrMinHeadAge
 }
 
 // ReqsBufSize implements the Config interface for ConfigLocal.

--- a/libkbfs/config_mock_test.go
+++ b/libkbfs/config_mock_test.go
@@ -5,8 +5,6 @@
 package libkbfs
 
 import (
-	"time"
-
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -135,8 +133,6 @@ func NewConfigMock(c *gomock.Controller, ctr *SafeTestReporter) *ConfigMock {
 	config.maxDirBytes = maxDirBytesDefault
 	config.rwpWaitTime = rekeyWithPromptWaitTimeDefault
 
-	config.qrPeriod = 0 * time.Second // no auto reclamation
-	config.qrUnrefAge = qrUnrefAgeDefault
 	config.SetMetadataVersion(defaultClientMetadataVer)
 	config.mode = modeTest{NewInitModeFromType(InitDefault)}
 

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -30,7 +30,8 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	config.SetClock(wallClock{})
 	id := tlf.FakeID(1, tlf.Private)
 	fbo := newFolderBranchOps(
-		ctx, config, FolderBranch{id, MasterBranch}, standard)
+		ctx, libkb.NewGlobalContext().Init(), config,
+		FolderBranch{id, MasterBranch}, standard)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(gomock.Any(), gomock.Any()).
 		AnyTimes().Return(libkb.NormalizedUsername("mockUser"), nil)

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -66,6 +67,7 @@ type blocksToDelete struct {
 // particular TLF.  It archives historical blocks and reclaims quota
 // usage, all in the background.
 type folderBlockManager struct {
+	g            *libkb.GlobalContext
 	config       Config
 	log          logger.Logger
 	shutdownChan chan struct{}
@@ -117,11 +119,13 @@ type folderBlockManager struct {
 	lastReclamationTime time.Time
 }
 
-func newFolderBlockManager(config Config, fb FolderBranch,
+func newFolderBlockManager(
+	g *libkb.GlobalContext, config Config, fb FolderBranch,
 	helper fbmHelper) *folderBlockManager {
 	tlfStringFull := fb.Tlf.String()
 	log := config.MakeLogger(fmt.Sprintf("FBM %s", tlfStringFull[:8]))
 	fbm := &folderBlockManager{
+		g:            g,
 		config:       config,
 		log:          log,
 		shutdownChan: make(chan struct{}),

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -368,7 +368,8 @@ var _ KBFSOps = (*folderBranchOps)(nil)
 var _ fbmHelper = (*folderBranchOps)(nil)
 
 // newFolderBranchOps constructs a new folderBranchOps object.
-func newFolderBranchOps(ctx context.Context, config Config, fb FolderBranch,
+func newFolderBranchOps(
+	ctx context.Context, g *libkb.GlobalContext, config Config, fb FolderBranch,
 	bType branchType) *folderBranchOps {
 	var nodeCache NodeCache
 	if config.Mode().NodeCacheEnabled() {
@@ -440,7 +441,7 @@ func newFolderBranchOps(ctx context.Context, config Config, fb FolderBranch,
 		log:          log,
 	}
 	fbo.cr = NewConflictResolver(config, fbo)
-	fbo.fbm = newFolderBlockManager(config, fb, fbo)
+	fbo.fbm = newFolderBlockManager(g, config, fb, fbo)
 	fbo.rekeyFSM = NewRekeyFSM(fbo)
 	if config.DoBackgroundFlushes() {
 		go fbo.backgroundFlusher()

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -645,7 +645,7 @@ func doInit(
 	k := NewKBPKIClient(config, kbfsLog)
 	config.SetKBPKI(k)
 
-	kbfsOps := NewKBFSOpsStandard(config)
+	kbfsOps := NewKBFSOpsStandard(kbCtx.GetGlobalContext(), config)
 	config.SetKBFSOps(kbfsOps)
 	config.SetNotifier(kbfsOps)
 	config.SetKeyManager(NewKeyManagerStandard(config))

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1857,6 +1857,17 @@ type InitMode interface {
 	// QuotaReclamationEnabled indicates whether we should be running
 	// the quota reclamation background process.
 	QuotaReclamationEnabled() bool
+	// QuotaReclamationPeriod indicates how often should each TLF
+	// should check for quota to reclaim.  If the Duration.Seconds()
+	// == 0, quota reclamation should not run automatically.
+	QuotaReclamationPeriod() time.Duration
+	// QuotaReclamationMinUnrefAge indicates the minimum time a block
+	// must have been unreferenced before it can be reclaimed.
+	QuotaReclamationMinUnrefAge() time.Duration
+	// QuotaReclamationMinHeadAge indicates the minimum age of the
+	// most recently merged MD update before we can run reclamation,
+	// to avoid conflicting with a currently active writer.
+	QuotaReclamationMinHeadAge() time.Duration
 	// NodeCacheEnabled indicates whether we should be caching data nodes.
 	NodeCacheEnabled() bool
 	// TLFUpdatesEnabled indicates whether we should be registering
@@ -1999,17 +2010,6 @@ type Config interface {
 	// conditions.
 	DelayedCancellationGracePeriod() time.Duration
 	SetDelayedCancellationGracePeriod(time.Duration)
-	// QuotaReclamationPeriod indicates how often should each TLF
-	// should check for quota to reclaim.  If the Duration.Seconds()
-	// == 0, quota reclamation should not run automatically.
-	QuotaReclamationPeriod() time.Duration
-	// QuotaReclamationMinUnrefAge indicates the minimum time a block
-	// must have been unreferenced before it can be reclaimed.
-	QuotaReclamationMinUnrefAge() time.Duration
-	// QuotaReclamationMinHeadAge indicates the minimum age of the
-	// most recently merged MD update before we can run reclamation,
-	// to avoid conflicting with a currently active writer.
-	QuotaReclamationMinHeadAge() time.Duration
 
 	// ResetCaches clears and re-initializes all data and key caches.
 	ResetCaches()

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -25,6 +26,7 @@ import (
 // safe by forwarding requests to individual per-folder-branch
 // handlers that are go-routine-safe.
 type KBFSOpsStandard struct {
+	g        *libkb.GlobalContext
 	config   Config
 	log      logger.Logger
 	deferLog logger.Logger
@@ -54,9 +56,11 @@ var _ KBFSOps = (*KBFSOpsStandard)(nil)
 const longOperationDebugDumpDuration = time.Minute
 
 // NewKBFSOpsStandard constructs a new KBFSOpsStandard object.
-func NewKBFSOpsStandard(config Config) *KBFSOpsStandard {
+func NewKBFSOpsStandard(
+	g *libkb.GlobalContext, config Config) *KBFSOpsStandard {
 	log := config.MakeLogger("")
 	kops := &KBFSOpsStandard{
+		g:                     g,
 		config:                config,
 		log:                   log,
 		deferLog:              log.CloneWithAddedDepth(1),
@@ -330,7 +334,7 @@ func (fs *KBFSOpsStandard) getOpsNoAdd(
 	if !ok {
 		// TODO: add some interface for specifying the type of the
 		// branch; for now assume online and read-write.
-		ops = newFolderBranchOps(ctx, fs.config, fb, standard)
+		ops = newFolderBranchOps(ctx, fs.g, fs.config, fb, standard)
 		fs.ops[fb] = ops
 	}
 	return ops

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -63,7 +63,7 @@ func kbfsOpsInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config.SetCodec(kbfscodec.NewMsgpack())
 	blockops := &CheckBlockOps{config.mockBops, ctr}
 	config.SetBlockOps(blockops)
-	kbfsops := NewKBFSOpsStandard(config)
+	kbfsops := NewKBFSOpsStandard(libkb.NewGlobalContext().Init(), config)
 	config.SetKBFSOps(kbfsops)
 	config.SetNotifier(kbfsops)
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -6070,6 +6070,42 @@ func (mr *MockInitModeMockRecorder) QuotaReclamationEnabled() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationEnabled", reflect.TypeOf((*MockInitMode)(nil).QuotaReclamationEnabled))
 }
 
+// QuotaReclamationPeriod mocks base method
+func (m *MockInitMode) QuotaReclamationPeriod() time.Duration {
+	ret := m.ctrl.Call(m, "QuotaReclamationPeriod")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// QuotaReclamationPeriod indicates an expected call of QuotaReclamationPeriod
+func (mr *MockInitModeMockRecorder) QuotaReclamationPeriod() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationPeriod", reflect.TypeOf((*MockInitMode)(nil).QuotaReclamationPeriod))
+}
+
+// QuotaReclamationMinUnrefAge mocks base method
+func (m *MockInitMode) QuotaReclamationMinUnrefAge() time.Duration {
+	ret := m.ctrl.Call(m, "QuotaReclamationMinUnrefAge")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// QuotaReclamationMinUnrefAge indicates an expected call of QuotaReclamationMinUnrefAge
+func (mr *MockInitModeMockRecorder) QuotaReclamationMinUnrefAge() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationMinUnrefAge", reflect.TypeOf((*MockInitMode)(nil).QuotaReclamationMinUnrefAge))
+}
+
+// QuotaReclamationMinHeadAge mocks base method
+func (m *MockInitMode) QuotaReclamationMinHeadAge() time.Duration {
+	ret := m.ctrl.Call(m, "QuotaReclamationMinHeadAge")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// QuotaReclamationMinHeadAge indicates an expected call of QuotaReclamationMinHeadAge
+func (mr *MockInitModeMockRecorder) QuotaReclamationMinHeadAge() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationMinHeadAge", reflect.TypeOf((*MockInitMode)(nil).QuotaReclamationMinHeadAge))
+}
+
 // NodeCacheEnabled mocks base method
 func (m *MockInitMode) NodeCacheEnabled() bool {
 	ret := m.ctrl.Call(m, "NodeCacheEnabled")
@@ -7132,42 +7168,6 @@ func (m *MockConfig) SetDelayedCancellationGracePeriod(arg0 time.Duration) {
 // SetDelayedCancellationGracePeriod indicates an expected call of SetDelayedCancellationGracePeriod
 func (mr *MockConfigMockRecorder) SetDelayedCancellationGracePeriod(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDelayedCancellationGracePeriod", reflect.TypeOf((*MockConfig)(nil).SetDelayedCancellationGracePeriod), arg0)
-}
-
-// QuotaReclamationPeriod mocks base method
-func (m *MockConfig) QuotaReclamationPeriod() time.Duration {
-	ret := m.ctrl.Call(m, "QuotaReclamationPeriod")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// QuotaReclamationPeriod indicates an expected call of QuotaReclamationPeriod
-func (mr *MockConfigMockRecorder) QuotaReclamationPeriod() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationPeriod", reflect.TypeOf((*MockConfig)(nil).QuotaReclamationPeriod))
-}
-
-// QuotaReclamationMinUnrefAge mocks base method
-func (m *MockConfig) QuotaReclamationMinUnrefAge() time.Duration {
-	ret := m.ctrl.Call(m, "QuotaReclamationMinUnrefAge")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// QuotaReclamationMinUnrefAge indicates an expected call of QuotaReclamationMinUnrefAge
-func (mr *MockConfigMockRecorder) QuotaReclamationMinUnrefAge() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationMinUnrefAge", reflect.TypeOf((*MockConfig)(nil).QuotaReclamationMinUnrefAge))
-}
-
-// QuotaReclamationMinHeadAge mocks base method
-func (m *MockConfig) QuotaReclamationMinHeadAge() time.Duration {
-	ret := m.ctrl.Call(m, "QuotaReclamationMinHeadAge")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// QuotaReclamationMinHeadAge indicates an expected call of QuotaReclamationMinHeadAge
-func (mr *MockConfigMockRecorder) QuotaReclamationMinHeadAge() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QuotaReclamationMinHeadAge", reflect.TypeOf((*MockConfig)(nil).QuotaReclamationMinHeadAge))
 }
 
 // ResetCaches mocks base method

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 )
@@ -78,6 +79,21 @@ func (md modeDefault) BlockManagementEnabled() bool {
 
 func (md modeDefault) QuotaReclamationEnabled() bool {
 	return true
+}
+
+func (md modeDefault) QuotaReclamationPeriod() time.Duration {
+	return 1 * time.Minute
+}
+
+func (md modeDefault) QuotaReclamationMinUnrefAge() time.Duration {
+	return 1 * time.Minute
+}
+
+func (md modeDefault) QuotaReclamationMinHeadAge() time.Duration {
+	// How old must the most recent TLF revision be before another
+	// device can run QR on that TLF?  This is large, to avoid
+	// unnecessary conflicts on the TLF between devices.
+	return 24 * time.Hour
 }
 
 func (md modeDefault) NodeCacheEnabled() bool {
@@ -186,6 +202,18 @@ func (mm modeMinimal) QuotaReclamationEnabled() bool {
 	return false
 }
 
+func (mm modeMinimal) QuotaReclamationPeriod() time.Duration {
+	return 0
+}
+
+func (mm modeMinimal) QuotaReclamationMinUnrefAge() time.Duration {
+	return 0
+}
+
+func (mm modeMinimal) QuotaReclamationMinHeadAge() time.Duration {
+	return 0
+}
+
 func (mm modeMinimal) NodeCacheEnabled() bool {
 	// If we're in minimal mode, let the node cache remain nil to
 	// ensure that the user doesn't try any data reads or writes.
@@ -255,6 +283,18 @@ func (mso modeSingleOp) QuotaReclamationEnabled() bool {
 	return false
 }
 
+func (mso modeSingleOp) QuotaReclamationPeriod() time.Duration {
+	return 0
+}
+
+func (mso modeSingleOp) QuotaReclamationMinUnrefAge() time.Duration {
+	return 0
+}
+
+func (mso modeSingleOp) QuotaReclamationMinHeadAge() time.Duration {
+	return 0
+}
+
 func (mso modeSingleOp) TLFUpdatesEnabled() bool {
 	return false
 }
@@ -322,11 +362,21 @@ func (mc modeConstrained) ConflictResolutionEnabled() bool {
 }
 
 func (mc modeConstrained) QuotaReclamationEnabled() bool {
-	// Disable QR for mobile for now, until we add a new mode mothod to
-	// indicate that this device should only self-QR. Also need to verify that
-	// the QR timer doesn't cause app wakeups.
-	// See https://github.com/keybase/kbfs/pull/1616#discussion_r195269845
-	return false
+	return true
+}
+
+func (mc modeConstrained) QuotaReclamationPeriod() time.Duration {
+	return 1 * time.Minute
+}
+
+func (mc modeConstrained) QuotaReclamationMinUnrefAge() time.Duration {
+	return 1 * time.Minute
+}
+
+func (mc modeConstrained) QuotaReclamationMinHeadAge() time.Duration {
+	// Don't ever run QR in constrained mode unless this device was
+	// the most recent writer.
+	return 0
 }
 
 func (mc modeConstrained) KBFSServiceEnabled() bool {
@@ -365,4 +415,14 @@ type modeTest struct {
 
 func (mt modeTest) IsTestMode() bool {
 	return true
+}
+
+func (mt modeTest) QuotaReclamationPeriod() time.Duration {
+	// No auto-reclamation during testing.
+	return 0
+}
+
+func (mt modeTest) QuotaReclamationMinHeadAge() time.Duration {
+	// No min head age during testing.
+	return 0
 }

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -108,7 +108,8 @@ func (sc *StateChecker) getLastGCData(ctx context.Context,
 
 	sc.log.CDebugf(ctx, "Last qr data for TLF %s: revTime=%s, rev=%d",
 		tlfID, latestTime, latestRev)
-	return latestTime.Add(-sc.config.QuotaReclamationMinUnrefAge()), latestRev
+	return latestTime.Add(
+		-sc.config.Mode().QuotaReclamationMinUnrefAge()), latestRev
 }
 
 // CheckMergedState verifies that the state for the given tlf is

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -199,12 +199,6 @@ func MakeTestConfigOrBustLoggedInWithMode(
 	// turn off background flushing by default during tests
 	config.noBGFlush = true
 
-	// no auto reclamation
-	config.qrPeriod = 0 * time.Second
-
-	// no min head age
-	config.qrMinHeadAge = 0 * time.Second
-
 	configs := []Config{config}
 	config.allKnownConfigsForTesting = &configs
 

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -123,7 +123,7 @@ func MakeTestConfigOrBustLoggedInWithMode(
 		return log
 	})
 
-	kbfsOps := NewKBFSOpsStandard(config)
+	kbfsOps := NewKBFSOpsStandard(libkb.NewGlobalContext().Init(), config)
 	config.SetKBFSOps(kbfsOps)
 	config.SetNotifier(kbfsOps)
 
@@ -231,7 +231,7 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 	c.SetMetadataVersion(config.MetadataVersion())
 	c.SetRekeyWithPromptWaitTime(config.RekeyWithPromptWaitTime())
 
-	kbfsOps := NewKBFSOpsStandard(c)
+	kbfsOps := NewKBFSOpsStandard(libkb.NewGlobalContext().Init(), c)
 	c.SetKBFSOps(kbfsOps)
 	c.SetNotifier(kbfsOps)
 


### PR DESCRIPTION
Once mobile devices can write, we don't want them wasting cycles cleaning up after other device writes (which would have happened after 24 hours if the other device didn't do it first).

Instead, move all the QR stuff into the mode, and make sure mobile devices (running in constrained mode) only run QR when the latest writer was the local device.

Issue: KBFS-3121