### PR TITLE
keybase_service_util: don't block on initializing FBOs on login

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1346,7 +1346,8 @@ func (c *ConfigLocal) EnableJournaling(
 			return err
 		}
 
-		jServer.MakeFBOsForExistingJournals(ctx)
+		wg := jServer.MakeFBOsForExistingJournals(ctx)
+		wg.Wait()
 		return nil
 	}()
 	switch {

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -314,11 +314,14 @@ func (j *JournalServer) makeFBOForJournal(
 
 // MakeFBOsForExistingJournals creates folderBranchOps objects for all
 // existing, non-empty journals.  This is useful to initialize the
-// unflushed edit history, for example.
-func (j *JournalServer) MakeFBOsForExistingJournals(ctx context.Context) {
+// unflushed edit history, for example.  It returns a wait group that
+// the caller can use to determine when all the FBOs have been
+// initialized.  If the caller is not going to wait on the group, it
+// should provoide a context that won't be canceled before the wait
+// group is finished.
+func (j *JournalServer) MakeFBOsForExistingJournals(
+	ctx context.Context) *sync.WaitGroup {
 	var wg sync.WaitGroup
-	// Wait for all the FBOs to be initialized, after releasing the lock.
-	defer wg.Wait()
 
 	j.lock.Lock()
 	defer j.lock.Unlock()
@@ -339,6 +342,7 @@ func (j *JournalServer) MakeFBOsForExistingJournals(ctx context.Context) {
 			}
 		}()
 	}
+	return &wg
 }
 
 // EnableExistingJournals turns on the write journal for all TLFs for

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -488,8 +488,9 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, ImmutableRootMetadata{}, head)
 
-	serviceLoggedIn(
+	wg := serviceLoggedIn(
 		ctx, config, session, TLFJournalBackgroundWorkPaused)
+	wg.Wait()
 
 	// Get the block.
 
@@ -593,8 +594,9 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	session, err = config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
-	serviceLoggedIn(
+	wg := serviceLoggedIn(
 		ctx, config, session, TLFJournalBackgroundWorkPaused)
+	wg.Wait()
 
 	err = jServer.Enable(ctx, tlfID, nil, TLFJournalBackgroundWorkPaused)
 	require.NoError(t, err)
@@ -655,8 +657,9 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	session, err = config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
-	serviceLoggedIn(
+	wg = serviceLoggedIn(
 		ctx, config, session, TLFJournalBackgroundWorkPaused)
+	wg.Wait()
 
 	// Only user 1's block and MD should be visible.
 
@@ -681,8 +684,9 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	session, err = config.KBPKI().GetCurrentSession(ctx)
 	require.NoError(t, err)
-	serviceLoggedIn(
+	wg = serviceLoggedIn(
 		ctx, config, session, TLFJournalBackgroundWorkPaused)
+	wg.Wait()
 
 	// Only user 2's block and MD should be visible.
 

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -1046,7 +1046,7 @@ func (k *KeybaseServiceBase) CurrentSession(ctx context.Context, sessionID int) 
 
 	if newSession && k.config != nil {
 		// Don't hold the lock while calling `serviceLoggedIn`.
-		serviceLoggedIn(ctx, k.config, s, TLFJournalBackgroundWorkEnabled)
+		_ = serviceLoggedIn(ctx, k.config, s, TLFJournalBackgroundWorkEnabled)
 	}
 
 	return s, nil

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -30,6 +30,7 @@ func EnableAdminFeature(ctx context.Context, runMode libkb.RunMode, config Confi
 // shouldn't be called again until after serviceLoggedOut is called.
 func serviceLoggedIn(ctx context.Context, config Config, session SessionInfo,
 	bws TLFJournalBackgroundWorkStatus) (wg *sync.WaitGroup) {
+	wg = &sync.WaitGroup{} // To avoid returning a nil pointer.
 	log := config.MakeLogger("")
 	if jServer, err := GetJournalServer(config); err == nil {
 		err := jServer.EnableExistingJournals(


### PR DESCRIPTION
`serviceLoggedIn` can be called as a side-effect of the mdserver `OnConnect` call, if that is the first time the current session is discovered.  Initializing FBOs depends on the mdserver, and so that can lead to a deadlock.

Instead, initialize them in the background in that case, while the other cases can still wait for the initialization to complete.

Issue: KBFS-3155