### PR TITLE
kbfs_ops: on TLF history init, don't run TLF identifies

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -887,19 +887,6 @@ func (fbo *folderBranchOps) setHeadLocked(
 	return nil
 }
 
-// setInitialHeadUntrustedLocked is for when the given RootMetadata
-// was fetched not due to a user action, i.e. via a Rekey
-// notification, and we don't have a TLF name to check against.
-func (fbo *folderBranchOps) setInitialHeadUntrustedLocked(ctx context.Context,
-	lState *lockState, md ImmutableRootMetadata) error {
-	fbo.mdWriterLock.AssertLocked(lState)
-	fbo.headLock.AssertLocked(lState)
-	if fbo.head != (ImmutableRootMetadata{}) {
-		return errors.New("Unexpected non-nil head in setInitialHeadUntrustedLocked")
-	}
-	return fbo.setHeadLocked(ctx, lState, md, headUntrusted)
-}
-
 // setNewInitialHeadLocked is for when we're creating a brand-new TLF.
 // This is trusted.
 func (fbo *folderBranchOps) setNewInitialHeadLocked(ctx context.Context,
@@ -923,7 +910,7 @@ func (fbo *folderBranchOps) setInitialHeadTrustedLocked(ctx context.Context,
 	fbo.mdWriterLock.AssertLocked(lState)
 	fbo.headLock.AssertLocked(lState)
 	if fbo.head != (ImmutableRootMetadata{}) {
-		return errors.New("Unexpected non-nil head in setInitialHeadUntrustedLocked")
+		return errors.New("Unexpected non-nil head in setInitialHeadTrustedLocked")
 	}
 	return fbo.setHeadLocked(ctx, lState, md, headTrusted)
 }

--- a/libkbfs/journal_server.go
+++ b/libkbfs/journal_server.go
@@ -308,6 +308,11 @@ func (j *JournalServer) makeFBOForJournal(
 		return err
 	}
 
+	// TODO: since we're likely just initializing this TLF to get the
+	// unflushed edit history, it would be better to do it in a way
+	// that doesn't force an identify (which might lead to unexpected
+	// tracker popups).  But this situation is so rare, it's probably
+	// not worth all the plumbing that would take.
 	_, _, err = j.config.KBFSOps().GetRootNode(ctx, handle, MasterBranch)
 	return err
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1206,12 +1206,18 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 	// that doesn't have one yet.  Also make sure there's one for the
 	// logged-in user's public folder.
 	for _, h := range handles {
-		fs.log.CDebugf(ctx, "Initializing TLF %s for the edit history",
-			h.GetCanonicalPath())
-		_, _, err := fs.GetRootNode(ctx, h, MasterBranch)
-		if err != nil {
-			fs.log.CWarningf(ctx, "Couldn't get root node for %s: %+v",
-				h.GetCanonicalName(), err)
+		if h.tlfID != tlf.NullID {
+			fs.log.CDebugf(ctx, "Initializing TLF %s (%s) for the edit history",
+				h.GetCanonicalPath(), h.tlfID)
+			ops := fs.getOpsNoAdd(ctx, FolderBranch{h.tlfID, MasterBranch})
+			// Don't initialize the entire TLF, because we don't want
+			// to run identifies on it.  Instead, just start the
+			// chat-monitoring part.
+			ops.startMonitorChat(h.GetCanonicalName())
+		} else {
+			fs.log.CWarningf(ctx,
+				"Handle %s for existing folder unexpectedly has no TLF ID",
+				h.GetCanonicalName())
 		}
 	}
 }


### PR DESCRIPTION
Just start up the chat monitoring, so we don't trigger any unintended popups.

If there are unflushed journals for some TLFs, we could theoretically trigger popups for them since they are initialized differently, but in that case the user would probably have recently written to the TLF and so would have already gone through the identify flow.

Also, remove a `folderBranchOps` function that's been unused for a long time, and confused me.

Issue: CORE-8290