### PR TITLE
systemd: use the new keybase config bare mode when retrieving mountpoint

### DIFF
--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -9,7 +9,7 @@ Type=notify
 # means that error codes from this command are ignored. Without this line,
 # `systemctl --user restart kbfs.service` will hit mount failures if there
 # are any running shells cd'd into a Keybase folder.
-ExecStartPre=-/bin/sh -c 'fusermount -uz "$(keybase config get mountdir|sed s/\x5c"//g)"'
+ExecStartPre=-/bin/sh -c 'fusermount -uz "$(keybase config get -d -b mountdir)"'
 ExecStart=/usr/bin/kbfsfuse -debug -log-to-file
 Restart=on-failure
 


### PR DESCRIPTION
This removes the quotes from the output, removing the need to sed them out after the fact.

This new option was added deep in the thousand-line diff of this commit: https://github.com/keybase/client/commit/5a892792b9297df620c223c3968860481ded728a