### PR TITLE
kbfs_ops: avoid tracker popups on new writes post-startup

### DIFF
--- a/libkbfs/mdserver_memory.go
+++ b/libkbfs/mdserver_memory.go
@@ -189,10 +189,12 @@ func (md *MDServerMemory) getHandleID(ctx context.Context, handle tlf.Handle,
 			return tlf.NullID, false, kbfsmd.ServerError{Err: err}
 		}
 		if !isReader {
-			return tlf.NullID, false, kbfsmd.ServerErrorUnauthorized{}
+			return tlf.NullID, false, errors.WithStack(
+				kbfsmd.ServerErrorUnauthorized{})
 		}
 	} else if !handle.IsReader(session.UID.AsUserOrTeam()) {
-		return tlf.NullID, false, kbfsmd.ServerErrorUnauthorized{}
+		return tlf.NullID, false, errors.WithStack(
+			kbfsmd.ServerErrorUnauthorized{})
 	}
 
 	if md.implicitTeamsEnabled {
@@ -267,7 +269,8 @@ func (md *MDServerMemory) checkGetParamsRLocked(
 			return kbfsmd.NullBranchID, kbfsmd.ServerError{Err: err}
 		}
 		if !ok {
-			return kbfsmd.NullBranchID, kbfsmd.ServerErrorUnauthorized{}
+			return kbfsmd.NullBranchID, errors.WithStack(
+				kbfsmd.ServerErrorUnauthorized{})
 		}
 	}
 
@@ -543,7 +546,7 @@ func (md *MDServerMemory) Put(ctx context.Context, rmds *RootMetadataSigned,
 			return kbfsmd.ServerError{Err: err}
 		}
 		if !ok {
-			return kbfsmd.ServerErrorUnauthorized{}
+			return errors.WithStack(kbfsmd.ServerErrorUnauthorized{})
 		}
 	}
 


### PR DESCRIPTION
Previously, I fixed the case where kbfs edit channels were causing tracker popups on startup for no reason.  Unfortunately, this can also happen after startup, if some other device writes to the folder and causes your local device to make an FBO for it.  Fix it by just monitoring the chats, not creating the FBO.