### PR TITLE
chat_rpc: ignore errors for inbox items that can't get handle

### DIFF
--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -366,7 +366,10 @@ func (c *ChatRPC) getLastSelfWrittenHandles(
 			h, err := GetHandleFromFolderNameAndType(
 				ctx, c.config.KBPKI(), c.config.MDOps(), tlfName, tlfType)
 			if err != nil {
-				return nil, err
+				c.log.CDebugf(ctx,
+					"Ignoring errors getting handle for %s/%s: %+v",
+					tlfName, tlfType, err)
+				continue
 			}
 
 			p := h.GetCanonicalPath()
@@ -429,7 +432,9 @@ func (c *ChatRPC) GetGroupedInbox(
 		h, err := GetHandleFromFolderNameAndType(
 			ctx, c.config.KBPKI(), c.config.MDOps(), info.TlfName, tlfType)
 		if err != nil {
-			return nil, err
+			c.log.CDebugf(ctx, "Ignoring errors getting handle for %s/%s: %+v",
+				info.TlfName, tlfType, err)
+			continue
 		}
 
 		p := h.GetCanonicalPath()


### PR DESCRIPTION
For example, you might have written to a team folder that you're no longer a member of (or for which the team got deleted).  When looking up the last self-written TLFs, don't treat errors like that as fatal.

cc: @mmaxim 