### PR TITLE
modes: increase block archival period to 2 weeks

### DIFF
--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -28,6 +28,11 @@ func NewInitModeFromType(t InitModeType) InitMode {
 	}
 }
 
+const (
+	defaultQRPeriod      = 1 * time.Hour
+	defaultQRMinUnrefAge = 2 * 7 * 24 * time.Hour // 2 weeks
+)
+
 // Default mode:
 
 type modeDefault struct {
@@ -82,18 +87,18 @@ func (md modeDefault) QuotaReclamationEnabled() bool {
 }
 
 func (md modeDefault) QuotaReclamationPeriod() time.Duration {
-	return 1 * time.Minute
+	return defaultQRPeriod
 }
 
 func (md modeDefault) QuotaReclamationMinUnrefAge() time.Duration {
-	return 1 * time.Minute
+	return defaultQRMinUnrefAge
 }
 
 func (md modeDefault) QuotaReclamationMinHeadAge() time.Duration {
 	// How old must the most recent TLF revision be before another
 	// device can run QR on that TLF?  This is large, to avoid
 	// unnecessary conflicts on the TLF between devices.
-	return 24 * time.Hour
+	return defaultQRMinUnrefAge + 24*time.Hour
 }
 
 func (md modeDefault) NodeCacheEnabled() bool {
@@ -366,11 +371,11 @@ func (mc modeConstrained) QuotaReclamationEnabled() bool {
 }
 
 func (mc modeConstrained) QuotaReclamationPeriod() time.Duration {
-	return 1 * time.Minute
+	return defaultQRPeriod
 }
 
 func (mc modeConstrained) QuotaReclamationMinUnrefAge() time.Duration {
-	return 1 * time.Minute
+	return defaultQRMinUnrefAge
 }
 
 func (mc modeConstrained) QuotaReclamationMinHeadAge() time.Duration {
@@ -420,6 +425,12 @@ func (mt modeTest) IsTestMode() bool {
 func (mt modeTest) QuotaReclamationPeriod() time.Duration {
 	// No auto-reclamation during testing.
 	return 0
+}
+
+func (mt modeTest) QuotaReclamationMinUnrefAge() time.Duration {
+	// Smaller archival window by default during testing, for
+	// backwards compatibility with old tests.
+	return 1 * time.Minute
 }
 
 func (mt modeTest) QuotaReclamationMinHeadAge() time.Duration {


### PR DESCRIPTION
This also increases the QR period to a full hour instead of one minute, since it seems unreasonable to check every minute if blocks are sticking around for a full 2 weeks.  But it tempers that by a) running QR immediately on startup rather than waiting for one period, and b) shortening the period to one minute if it knows there is more QR left to do.

(I won't merge this until the bserver quota changes are deployed.)

Issue: KBFS-3186