### PR TITLE
data_types: add a PrevRevisions skiplist to EntryInfo

### DIFF
--- a/libdokan/file_info_file.go
+++ b/libdokan/file_info_file.go
@@ -1,0 +1,25 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libdokan
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// NewFileInfoFile returns a special file that contains a text
+// representation of a file's KBFS metadata.
+func NewFileInfoFile(
+	fs *FS, dir libkbfs.Node, name string) *SpecialReadFile {
+	return &SpecialReadFile{
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			return libfs.GetFileInfo(ctx, fs.config, dir, name)
+		},
+		fs: fs,
+	}
+}

--- a/libfs/file_info_file.go
+++ b/libfs/file_info_file.go
@@ -1,0 +1,37 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+type fileInfoFile struct {
+	libkbfs.NodeMetadata
+	libkbfs.PrevRevisions
+}
+
+// GetFileInfo returns serialized JSON containing status information
+// for a file or directory entry.
+func GetFileInfo(
+	ctx context.Context, config libkbfs.Config, dir libkbfs.Node, name string) (
+	data []byte, t time.Time, err error) {
+	node, ei, err := config.KBFSOps().Lookup(ctx, dir, name)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	nmd, err := config.KBFSOps().GetNodeMetadata(ctx, node)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	data, err = PrettyJSON(fileInfoFile{nmd, ei.PrevRevisions})
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	return data, time.Unix(0, ei.Mtime), nil
+}

--- a/libfuse/file_info_file.go
+++ b/libfuse/file_info_file.go
@@ -1,0 +1,26 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// NewFileInfoFile returns a special file that contains a text
+// representation of a file's KBFS metadata.
+func NewFileInfoFile(
+	fs *FS, dir libkbfs.Node, name string,
+	entryValid *time.Duration) *SpecialReadFile {
+	*entryValid = 0
+	return &SpecialReadFile{
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			return libfs.GetFileInfo(ctx, fs.config, dir, name)
+		},
+	}
+}

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -34,9 +34,13 @@ import (
 const (
 	// Max supported size of a directory entry name.
 	maxNameBytesDefault = 255
-	// Maximum supported plaintext size of a directory in KBFS. TODO:
-	// increase this once we support levels of indirection for directories.
-	maxDirBytesDefault = MaxBlockSizeBytesDefault
+	// Maximum supported plaintext size of a directory in KBFS.  Make
+	// it bigger than the default block size because we added the
+	// revision skiplist to the directory entries and we didn't want
+	// to break legacy directories in the case that all of their
+	// entries got updated EntryInfos.  TODO: increase this once we
+	// support levels of indirection for directories.
+	maxDirBytesDefault = MaxBlockSizeBytesDefault * 1.5
 	// Default time after setting the rekey bit before prompting for a
 	// paper key.
 	rekeyWithPromptWaitTimeDefault = 10 * time.Minute

--- a/libkbfs/dir_entry_test.go
+++ b/libkbfs/dir_entry_test.go
@@ -34,6 +34,7 @@ func makeFakeDirEntry(t *testing.T, typ EntryType, size uint64) DirEntry {
 			101,
 			102,
 			"",
+			nil,
 		},
 		codec.UnknownFieldSetHandler{},
 	}

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -293,7 +293,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			refPath = *refPath.parentPath()
 		}
 		de.BlockInfo = info
-		de.PrevRevisions = de.PrevRevisions.addRevision(md.Revision())
+		de.PrevRevisions = de.PrevRevisions.addRevision(
+			md.Revision(), md.data.LastGCRevision)
 
 		if doSetTime {
 			if mtime {

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -293,6 +293,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			refPath = *refPath.parentPath()
 		}
 		de.BlockInfo = info
+		de.PrevRevisions = de.PrevRevisions.addRevision(md.Revision())
 
 		if doSetTime {
 			if mtime {

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -746,7 +746,7 @@ func TestKBFSOpsGetBaseDirChildrenHidesFiles(t *testing.T) {
 	for c, ei := range children {
 		if de, ok := dirBlock.Children[c]; !ok {
 			t.Errorf("No such child: %s", c)
-		} else if de.EntryInfo != ei {
+		} else if !de.EntryInfo.Eq(ei) {
 			t.Errorf("Wrong EntryInfo for child %s: %v", c, ei)
 		}
 	}
@@ -779,7 +779,7 @@ func TestKBFSOpsGetBaseDirChildrenCacheSuccess(t *testing.T) {
 	for c, ei := range children {
 		if de, ok := dirBlock.Children[c]; !ok {
 			t.Errorf("No such child: %s", c)
-		} else if de.EntryInfo != ei {
+		} else if !de.EntryInfo.Eq(ei) {
 			t.Errorf("Wrong EntryInfo for child %s: %v", c, ei)
 		}
 	}
@@ -912,7 +912,7 @@ func TestKBFSOpsGetNestedDirChildrenCacheSuccess(t *testing.T) {
 	for c, ei := range children {
 		if de, ok := dirBlock.Children[c]; !ok {
 			t.Errorf("No such child: %s", c)
-		} else if de.EntryInfo != ei {
+		} else if !de.EntryInfo.Eq(ei) {
 			t.Errorf("Wrong EntryInfo for child %s: %v", c, ei)
 		}
 	}
@@ -954,7 +954,7 @@ func TestKBFSOpsLookupSuccess(t *testing.T) {
 	bPath := ops.nodeCache.PathFromNode(bn)
 	expectedBNode := pathNode{makeBP(bID, rmd, config, u), "b"}
 	expectedBNode.KeyGen = kbfsmd.FirstValidKeyGen
-	if ei != dirBlock.Children["b"].EntryInfo {
+	if !ei.Eq(dirBlock.Children["b"].EntryInfo) {
 		t.Errorf("Lookup returned a bad entry info: %v vs %v",
 			ei, dirBlock.Children["b"].EntryInfo)
 	} else if bPath.path[2] != expectedBNode {
@@ -995,7 +995,7 @@ func TestKBFSOpsLookupSymlinkSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error on Lookup: %+v", err)
 	}
-	if ei != dirBlock.Children["b"].EntryInfo {
+	if !ei.Eq(dirBlock.Children["b"].EntryInfo) {
 		t.Errorf("Lookup returned a bad directory entry: %v vs %v",
 			ei, dirBlock.Children["b"].EntryInfo)
 	} else if bn != nil {
@@ -1122,7 +1122,7 @@ func TestKBFSOpsStatSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error on Stat: %+v", err)
 	}
-	if ei != dirBlock.Children["b"].EntryInfo {
+	if !ei.Eq(dirBlock.Children["b"].EntryInfo) {
 		t.Errorf("Stat returned a bad entry info: %v vs %v",
 			ei, dirBlock.Children["b"].EntryInfo)
 	}

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -32,6 +32,7 @@ func makeRandomDirEntry(
 			101,
 			102,
 			"",
+			nil,
 		},
 		codec.UnknownFieldSetHandler{},
 	}

--- a/libkbfs/prev_revisions.go
+++ b/libkbfs/prev_revisions.go
@@ -43,6 +43,7 @@ func (pr PrevRevisions) addRevision(
 	}
 	ret = make(PrevRevisions, newLength)
 	copy(ret, pr)
+	numDropped := 0
 	for i, prc := range ret {
 		if prc.Count == 0 {
 			// A count of 0 indicates an empty slot.
@@ -58,9 +59,13 @@ func (pr PrevRevisions) addRevision(
 				Revision: kbfsmd.RevisionUninitialized,
 				Count:    0,
 			}
+			numDropped++
 			continue
 		}
 		ret[i].Count++
+	}
+	if numDropped > 1 {
+		ret = ret[:len(ret)-(numDropped-1)]
 	}
 	for i := len(ret) - 1; i >= 1; i-- {
 		toMove := ret[i-1]

--- a/libkbfs/prev_revisions.go
+++ b/libkbfs/prev_revisions.go
@@ -1,0 +1,66 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"github.com/keybase/go-codec/codec"
+	"github.com/keybase/kbfs/kbfsmd"
+)
+
+// PrevRevisionAndCount track the MD version of a previous revision of
+// a dir entry, and how many revisions ago that was from the current
+// revision.
+type PrevRevisionAndCount struct {
+	Revision kbfsmd.Revision `codec:"r"`
+	Count    uint8           `codec:"c"`
+
+	codec.UnknownFieldSetHandler
+}
+
+// minPrevRevisionSlotCounts defines the "min count" of each
+// corresponding entry in a `PrevRevisions` slice.  The length of
+// `minPrevRevisionSlotCounts` is the max length of a `PrevRevisions`
+// slice.
+var minPrevRevisionSlotCounts = [...]uint8{1, 5, 20, 50, 100}
+
+// PrevRevisions tracks several previous versions of a file in order
+// of descending revision number, starting with the most recent.
+type PrevRevisions []PrevRevisionAndCount
+
+// addRevision returns a copy of `pr` with a new immediately-previous
+// revision added, with the existing entries moved or overwritten to
+// accomodate the new entry, and with increased counts.
+func (pr PrevRevisions) addRevision(r kbfsmd.Revision) (ret PrevRevisions) {
+	newLength := len(pr)
+	if newLength < len(minPrevRevisionSlotCounts) {
+		newLength++
+	}
+	ret = make(PrevRevisions, newLength)
+	copy(ret, pr)
+	for i, prc := range ret {
+		if prc.Count == 0 {
+			// A count of 0 indicates an empty slot.
+			break
+		} else if prc.Count == 255 {
+			panic("Previous revision count is about to overflow")
+		}
+		ret[i].Count++
+	}
+	for i := len(ret) - 1; i >= 1; i-- {
+		toMove := ret[i-1]
+		if ret[i].Count == 0 || toMove.Count >= minPrevRevisionSlotCounts[i] {
+			ret[i] = toMove
+			ret[i-1] = PrevRevisionAndCount{
+				Revision: kbfsmd.RevisionUninitialized,
+				Count:    0,
+			}
+		}
+	}
+	ret[0] = PrevRevisionAndCount{
+		Revision: r,
+		Count:    1,
+	}
+	return ret
+}

--- a/libkbfs/prev_revisions.go
+++ b/libkbfs/prev_revisions.go
@@ -88,10 +88,9 @@ func (pr PrevRevisions) addRevision(
 	}
 
 	for i := len(ret) - 1; i >= 1; i-- {
-		toMove := ret[i-1]
-		if ret[i].Count == 0 || toMove.Count >= minPrevRevisionSlotCounts[i] {
-			ret[i] = toMove
-			ret[i-1] = PrevRevisionAndCount{
+		// Check if we can shift over the entry in slot i-1.
+		if ret[i].Count == 0 || ret[i-1].Count >= minPrevRevisionSlotCounts[i] {
+			ret[i], ret[i-1] = ret[i-1], PrevRevisionAndCount{
 				Revision: kbfsmd.RevisionUninitialized,
 				Count:    0,
 			}

--- a/libkbfs/prev_revisions_test.go
+++ b/libkbfs/prev_revisions_test.go
@@ -1,0 +1,82 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"testing"
+
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/stretchr/testify/require"
+)
+
+func checkRevRevisions(
+	t *testing.T, pr PrevRevisions, minRev kbfsmd.Revision,
+	maxRev kbfsmd.Revision, numRevisions int) {
+	// Make sure the revisions are in descending order, and the counts
+	// are in increasing order.
+	maxMin := kbfsmd.Revision(
+		minPrevRevisionSlotCounts[len(minPrevRevisionSlotCounts)-1])
+	shouldBeFull := maxRev-minRev >= maxMin
+	if shouldBeFull {
+		require.Len(t, pr, len(minPrevRevisionSlotCounts))
+	}
+	require.Equal(t, uint8(1), pr[0].Count)
+	for i, r := range pr {
+		require.True(t, r.Revision > minRev)
+		require.True(t, r.Revision <= maxRev)
+		if i > 0 {
+			require.True(t, r.Revision < pr[i-1].Revision)
+			require.True(t, r.Count > pr[i-1].Count)
+		}
+	}
+}
+
+func TestPrevRevisions(t *testing.T) {
+	var pr PrevRevisions
+	t.Log("Add the first set of revisions")
+	var i int
+	for ; i < len(minPrevRevisionSlotCounts); i++ {
+		rev := kbfsmd.Revision((i + 1) * 2)
+		pr = pr.addRevision(rev, 0)
+		require.Len(t, pr, i+1)
+		checkRevRevisions(t, pr, 0, rev, i+1)
+	}
+	t.Log("The next set will start replacing the prev ones")
+	for ; i < len(minPrevRevisionSlotCounts)*2; i++ {
+		rev := kbfsmd.Revision((i + 1) * 2)
+		pr = pr.addRevision(rev, 0)
+		require.Len(t, pr, len(minPrevRevisionSlotCounts))
+		checkRevRevisions(t, pr, 0, rev, i+1)
+	}
+	maxMin := int(minPrevRevisionSlotCounts[len(minPrevRevisionSlotCounts)-1])
+	t.Log("Exceed the maximum min count")
+	for ; i < maxMin+1; i++ {
+		rev := kbfsmd.Revision((i + 1) * 2)
+		pr = pr.addRevision(rev, 0)
+		require.Len(t, pr, len(minPrevRevisionSlotCounts))
+		checkRevRevisions(t, pr, 0, rev, i+1)
+	}
+	t.Log("Exceed the maximum min count by even more")
+	for ; i < maxMin*2+1; i++ {
+		rev := kbfsmd.Revision((i + 1) * 2)
+		pr = pr.addRevision(rev, 0)
+		require.Len(t, pr, len(minPrevRevisionSlotCounts))
+		checkRevRevisions(t, pr, 0, rev, i+1)
+	}
+	t.Log("Garbage collect past the oldest revision")
+	gcRev := pr[len(pr)-1].Revision + 1
+	i++
+	rev := kbfsmd.Revision((i + 1) * 2)
+	pr = pr.addRevision(rev, gcRev)
+	require.Len(t, pr, len(minPrevRevisionSlotCounts))
+	checkRevRevisions(t, pr, gcRev, rev, i+1)
+	t.Log("Garbage collect past the final two revisions")
+	gcRev = pr[len(pr)-2].Revision + 1
+	i++
+	rev = kbfsmd.Revision((i + 1) * 2)
+	pr = pr.addRevision(rev, gcRev)
+	require.Len(t, pr, len(minPrevRevisionSlotCounts)-1)
+	checkRevRevisions(t, pr, gcRev, rev, i+1)
+}

--- a/libkbfs/prev_revisions_test.go
+++ b/libkbfs/prev_revisions_test.go
@@ -79,4 +79,11 @@ func TestPrevRevisions(t *testing.T) {
 	pr = pr.addRevision(rev, gcRev)
 	require.Len(t, pr, len(minPrevRevisionSlotCounts)-1)
 	checkRevRevisions(t, pr, gcRev, rev, i+1)
+	t.Log("Garbage collect everything")
+	gcRev = pr[0].Revision
+	i++
+	rev = kbfsmd.Revision((i + 1) * 2)
+	pr = pr.addRevision(rev, gcRev)
+	require.Len(t, pr, 1)
+	checkRevRevisions(t, pr, gcRev, rev, i+1)
 }

--- a/test/cr_basic_conflicts_test.go
+++ b/test/cr_basic_conflicts_test.go
@@ -283,11 +283,15 @@ func TestCrConflictSetattrVsRecreatedFileInRoot(t *testing.T) {
 			lsdir("", m{"a$": "EXEC", crnameEsc("a", bob): "FILE"}),
 			read("a", "hello"),
 			read(crname("a", bob), "world"),
+			checkPrevRevisions("a", []uint8{1}),
+			checkPrevRevisions(crname("a", bob), []uint8{1}),
 		),
 		as(alice,
 			lsdir("", m{"a$": "EXEC", crnameEsc("a", bob): "FILE"}),
 			read("a", "hello"),
 			read(crname("a", bob), "world"),
+			checkPrevRevisions("a", []uint8{1}),
+			checkPrevRevisions(crname("a", bob), []uint8{1}),
 		),
 	)
 }
@@ -342,11 +346,13 @@ func TestCrConflictCauseRenameOfMergedRecreatedFile(t *testing.T) {
 			lsdir("a/", m{"b$": "DIR", crnameEsc("b", alice): "FILE"}),
 			read(crname("a/b", alice), "world"),
 			read("a/b/c", "uh oh"),
+			checkPrevRevisions("a", []uint8{1, 2, 3}),
 		),
 		as(alice,
 			lsdir("a/", m{"b$": "DIR", crnameEsc("b", alice): "FILE"}),
 			read(crname("a/b", alice), "world"),
 			read("a/b/c", "uh oh"),
+			checkPrevRevisions("a", []uint8{1, 2, 3}),
 		),
 	)
 }

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -945,6 +945,28 @@ func checkUnflushedPaths(expectedPaths []string) fileOp {
 	}, IsInit, fmt.Sprintf("checkUnflushedPaths(%s)", expectedPaths)}
 }
 
+func checkPrevRevisions(filepath string, counts []uint8) fileOp {
+	return fileOp{func(c *ctx) error {
+		file, _, err := c.getNode(filepath, noCreate, resolveAllSyms)
+		if err != nil {
+			return err
+		}
+		pr, err := c.engine.GetPrevRevisions(c.user, file)
+		if err != nil {
+			return err
+		}
+		if len(pr) != len(counts) {
+			return fmt.Errorf("Wrong number of prev revisions: %v", pr)
+		}
+		for i, c := range counts {
+			if c != pr[i].Count {
+				return fmt.Errorf("Unexpected prev revision counts: %v", pr)
+			}
+		}
+		return nil
+	}, Defaults, fmt.Sprintf("prevRevisions(%s, %v)", filepath, counts)}
+}
+
 type expectedEdit struct {
 	tlfName string
 	tlfType keybase1.FolderType

--- a/test/engine.go
+++ b/test/engine.go
@@ -97,6 +97,9 @@ type Engine interface {
 	// GetMtime is called by the test harness as the given user to get
 	// the mtime of the given file.
 	GetMtime(u User, file Node) (mtime time.Time, err error)
+	// GetPrevResions is called by the test harness as the given user
+	// to get the previous revisions of the given file.
+	GetPrevRevisions(u User, file Node) (revs libkbfs.PrevRevisions, err error)
 	// SyncAll is called by the test harness as the given user to
 	// flush all writes buffered in memory to disk.
 	SyncAll(u User, tlfName string, t tlf.Type) (err error)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -551,6 +551,28 @@ func (*fsEngine) GetMtime(u User, file Node) (mtime time.Time, err error) {
 	return fi.ModTime(), err
 }
 
+type prevRevisions struct {
+	PrevRevisions libkbfs.PrevRevisions
+}
+
+// GetPrevRevisions implements the Engine interface.
+func (*fsEngine) GetPrevRevisions(u User, file Node) (
+	revs libkbfs.PrevRevisions, err error) {
+	n := file.(fsNode)
+	d, f := filepath.Split(n.path)
+	fullPath := filepath.Join(d, libfs.FileInfoPrefix+f)
+	buf, err := ioutil.ReadFile(fullPath)
+	if err != nil {
+		return nil, err
+	}
+	var pr prevRevisions
+	err = json.Unmarshal(buf, &pr)
+	if err != nil {
+		return nil, err
+	}
+	return pr.PrevRevisions, nil
+}
+
 // SyncAll implements the Engine interface.
 func (e *fsEngine) SyncAll(
 	user User, tlfName string, t tlf.Type) (err error) {

--- a/test/simple_test.go
+++ b/test/simple_test.go
@@ -61,10 +61,12 @@ func TestCreateFileInRoot(t *testing.T) {
 		as(alice,
 			lsdir("", m{"a$": "FILE"}),
 			read("a", "hello"),
+			checkPrevRevisions("a", []uint8{1}),
 		),
 		as(bob,
 			lsdir("", m{"a$": "FILE"}),
 			read("a", "hello"),
+			checkPrevRevisions("a", []uint8{1}),
 		),
 	)
 }
@@ -210,10 +212,13 @@ func TestRenameInDir(t *testing.T) {
 		as(alice,
 			lsdir("a", m{"c$": "FILE"}),
 			read("a/c", "hello"),
+			// The directory underwent two revisions.
+			checkPrevRevisions("a", []uint8{1, 2}),
 		),
 		as(bob,
 			lsdir("a", m{"c$": "FILE"}),
 			read("a/c", "hello"),
+			checkPrevRevisions("a", []uint8{1, 2}),
 		),
 	)
 }


### PR DESCRIPTION
This tracks the MD revision numbers for revisions of a file (or directory) in a skiplist-like fashion, basically giving pointers into places in the file's history, which will allow for easier access to past versions of the file.

To account for the extra metadata in the fileinfo, this also increases the max directory size by 50%.

For testing, this exposes the PrevRevision list in the `.kbfs_fileinfo` file (along with some refactoring to clean that up a bit and avoid kernel caching issues), and adds a few very simple checks to some DSL tests to make sure it shows the right number of revisions in the basic cases.

(This isn't strictly needed for time travel M1, but the earlier we get it in, the more useful it will be for people later on.)

Issue: KBFS-3194