### PR TITLE
simplefs: add a way to get quota usage for the logged-in user

### DIFF
--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -1539,3 +1539,20 @@ func (k *SimpleFS) SimpleFSSuppressNotifications(ctx context.Context, suppressDu
 	k.config.Reporter().SuppressNotifications(ctx, time.Duration(suppressDurationSec)*time.Second)
 	return nil
 }
+
+// SimpleFSGetUserQuotaUsage returns the quota usage information for
+// the logged-in user.
+func (k *SimpleFS) SimpleFSGetUserQuotaUsage(ctx context.Context) (
+	res keybase1.SimpleFSQuotaUsage, err error) {
+	status, _, err := k.config.KBFSOps().Status(ctx)
+	if err != nil {
+		return keybase1.SimpleFSQuotaUsage{}, err
+	}
+	res.UsageBytes = status.UsageBytes
+	res.ArchiveBytes = status.ArchiveBytes
+	res.LimitBytes = status.LimitBytes
+	res.GitUsageBytes = status.GitUsageBytes
+	res.GitArchiveBytes = status.GitArchiveBytes
+	res.GitLimitBytes = status.GitLimitBytes
+	return res, nil
+}

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -1773,10 +1773,10 @@ func (o AnnotatedTeamList) DeepCopy() AnnotatedTeamList {
 }
 
 type TeamAddMemberResult struct {
-	Invited   bool  `codec:"invited" json:"invited"`
-	User      *User `codec:"user,omitempty" json:"user,omitempty"`
-	EmailSent bool  `codec:"emailSent" json:"emailSent"`
-	ChatSent  bool  `codec:"chatSent" json:"chatSent"`
+	Invited     bool  `codec:"invited" json:"invited"`
+	User        *User `codec:"user,omitempty" json:"user,omitempty"`
+	EmailSent   bool  `codec:"emailSent" json:"emailSent"`
+	ChatSending bool  `codec:"chatSending" json:"chatSending"`
 }
 
 func (o TeamAddMemberResult) DeepCopy() TeamAddMemberResult {
@@ -1789,8 +1789,8 @@ func (o TeamAddMemberResult) DeepCopy() TeamAddMemberResult {
 			tmp := (*x).DeepCopy()
 			return &tmp
 		})(o.User),
-		EmailSent: o.EmailSent,
-		ChatSent:  o.ChatSent,
+		EmailSent:   o.EmailSent,
+		ChatSending: o.ChatSending,
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,10 +250,10 @@
 			"revisionTime": "2018-05-19T05:29:12Z"
 		},
 		{
-			"checksumSHA1": "LcLQq5l2p2ZHlgpiEhN5nyzzwT0=",
+			"checksumSHA1": "LwZrHiQvlqa/ijbrmb8PlyLnu1Y=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "8cf8aa08202d3957d1825331eff7a8fe6232cbaa",
-			"revisionTime": "2018-07-10T22:34:20Z"
+			"revision": "c92a88b2bc73276539c8d87975e333155bea4072",
+			"revisionTime": "2018-07-17T16:33:21Z"
 		},
 		{
 			"checksumSHA1": "X5Xf9+Z7OkhIQiaPB+ILw4xzkag=",


### PR DESCRIPTION
Also vendors in the protocol change from keybase/client#12831.  (I'll merge the correct commit hash in as soon as that client PR is merged.)

Note that to get the quota, we make an explicit RPC to the server.  Unlike with the Finder integration, I don't think we'll be getting constant GUI requests for this, so this should be ok, plus it allows us to easily reuse the code that adds journal usage into the quota usage.

Issue: KBFS-3188