### PR TITLE
folder_branch_ops: rename branch-related stuff to avoid confusion

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3124,7 +3124,7 @@ outer:
 	}
 
 	cr.log.CDebugf(ctx, "Unstaging due to a failed resolution: %v", err)
-	reportedError := CRAbandonStagedBranchError{err, cr.fbo.bid}
+	reportedError := CRAbandonStagedBranchError{err, cr.fbo.unmergedBID}
 	unstageErr := cr.fbo.unstageAfterFailedResolution(ctx, lState)
 	if unstageErr != nil {
 		cr.log.CDebugf(ctx, "Couldn't unstage: %v", unstageErr)

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -123,7 +123,7 @@ func TestCRInput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Branch id err: %+v", bid)
 	}
-	cr.fbo.bid = bid
+	cr.fbo.unmergedBID = bid
 	cr.fbo.head = crMakeFakeRMD(unmergedHead, bid)
 	cr.fbo.headStatus = headTrusted
 	// serve all the MDs from the cache
@@ -185,7 +185,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Branch id err: %+v", bid)
 	}
-	cr.fbo.bid = bid
+	cr.fbo.unmergedBID = bid
 	cr.fbo.head = crMakeFakeRMD(unmergedHead, bid)
 	cr.fbo.headStatus = headTrusted
 	// serve all the MDs from the cache

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -750,7 +750,7 @@ func RestartCRForTesting(baseCtx context.Context, config Config,
 
 	// Start a resolution for anything we've missed.
 	lState := makeFBOLockState()
-	if !ops.isMasterBranch(lState) {
+	if ops.isUnmerged(lState) {
 		ops.cr.Resolve(baseCtx, ops.getCurrMDRevision(lState),
 			kbfsmd.RevisionUninitialized)
 	}


### PR DESCRIPTION
In several places in FBO, we were referring to "branch" and "master branch" in a limited way that referred only to the merged status of the TLF.  "Branch" is actually meant to be a broader term, also encompassing archived views of a TLF.  So make the current uses a bit more explicit.

Issue: KBFS-3203