### PR TITLE
folder_branch_ops: support "archive" FBOs

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -103,7 +103,7 @@ func NewConflictResolver(
 		},
 	}
 
-	if config.Mode().ConflictResolutionEnabled() {
+	if fbo.bType == standard && config.Mode().ConflictResolutionEnabled() {
 		cr.startProcessing(BackgroundContextWithCancellationDelayer())
 	}
 	return cr

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -120,7 +120,7 @@ type folderBlockManager struct {
 }
 
 func newFolderBlockManager(
-	g *libkb.GlobalContext, config Config, fb FolderBranch,
+	g *libkb.GlobalContext, config Config, fb FolderBranch, bType branchType,
 	helper fbmHelper) *folderBlockManager {
 	tlfStringFull := fb.Tlf.String()
 	log := config.MakeLogger(fmt.Sprintf("FBM %s", tlfStringFull[:8]))
@@ -142,7 +142,7 @@ func newFolderBlockManager(
 	// doesn't do possibly-racy-in-tests access to
 	// fbm.config.BlockOps().
 
-	if !config.Mode().BlockManagementEnabled() {
+	if bType != standard || !config.Mode().BlockManagementEnabled() {
 		return fbm
 	}
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -378,6 +378,9 @@ func newFolderBranchOps(
 		for _, f := range config.RootNodeWrappers() {
 			nodeCache.AddRootWrapper(f)
 		}
+		if bType == archive {
+			nodeCache.AddRootWrapper(readonlyWrapper)
+		}
 	}
 
 	if bType == standard && fb.Branch != MasterBranch {
@@ -448,7 +451,7 @@ func newFolderBranchOps(
 		log:          log,
 	}
 	fbo.cr = NewConflictResolver(config, fbo)
-	fbo.fbm = newFolderBlockManager(g, config, fb, fbo)
+	fbo.fbm = newFolderBlockManager(g, config, fb, bType, fbo)
 	fbo.rekeyFSM = NewRekeyFSM(fbo)
 	if config.DoBackgroundFlushes() && bType == standard {
 		go fbo.backgroundFlusher()

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -380,6 +380,12 @@ func newFolderBranchOps(
 		}
 	}
 
+	if bType == standard && fb.Branch != MasterBranch {
+		panic("standard FBOs must use the master branch")
+	} else if bType != standard && fb.Branch == MasterBranch {
+		panic("non-standard FBOs must not use the master branch")
+	}
+
 	// make logger
 	branchSuffix := ""
 	if fb.Branch != MasterBranch {
@@ -444,7 +450,7 @@ func newFolderBranchOps(
 	fbo.cr = NewConflictResolver(config, fbo)
 	fbo.fbm = newFolderBlockManager(g, config, fb, fbo)
 	fbo.rekeyFSM = NewRekeyFSM(fbo)
-	if config.DoBackgroundFlushes() {
+	if config.DoBackgroundFlushes() && bType == standard {
 		go fbo.backgroundFlusher()
 	}
 
@@ -714,7 +720,7 @@ func (fbo *folderBranchOps) validateHeadLocked(
 }
 
 func (fbo *folderBranchOps) startMonitorChat(tlfName tlf.CanonicalName) {
-	if !fbo.config.Mode().TLFEditHistoryEnabled() {
+	if fbo.bType != standard || !fbo.config.Mode().TLFEditHistoryEnabled() {
 		return
 	}
 
@@ -869,9 +875,8 @@ func (fbo *folderBranchOps) setHeadLocked(
 	fbo.status.setRootMetadata(md)
 	if isFirstHead {
 		// Start registering for updates right away, using this MD
-		// as a starting point. For now only the master branch can
-		// get updates
-		if fbo.branch() == MasterBranch {
+		// as a starting point. Only standard FBOs get updates.
+		if fbo.bType == standard {
 			if fbo.config.Mode().TLFUpdatesEnabled() {
 				fbo.updateDoneChan = make(chan struct{})
 				go fbo.registerAndWaitForUpdates()
@@ -1716,9 +1721,9 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	}
 
 	return runUnlessCanceled(ctx, func() error {
-		fb := FolderBranch{md.TlfID(), MasterBranch}
-		if fb != fbo.folderBranch {
-			return WrongOpsError{fbo.folderBranch, fb}
+		if md.TlfID() != fbo.id() {
+			return WrongOpsError{
+				fbo.folderBranch, FolderBranch{md.TlfID(), MasterBranch}}
 		}
 
 		// Always identify first when trying to initialize the folder,
@@ -1791,6 +1796,7 @@ func (fbo *folderBranchOps) SetInitialHeadToNew(
 	}
 
 	return runUnlessCanceled(ctx, func() error {
+		// New heads can only be set for the MasterBranch.
 		fb := FolderBranch{rmd.TlfID(), MasterBranch}
 		if fb != fbo.folderBranch {
 			return WrongOpsError{fbo.folderBranch, fb}
@@ -2918,6 +2924,9 @@ func (fbo *folderBranchOps) signalWrite() {
 
 func (fbo *folderBranchOps) syncDirUpdateOrSignal(
 	ctx context.Context, lState *lockState) error {
+	if fbo.bType != standard {
+		panic("Cannot write to a non-standard FBO")
+	}
 	if fbo.config.BGFlushDirOpBatchSize() == 1 {
 		return fbo.syncAllLocked(ctx, lState, NoExcl)
 	}
@@ -5711,6 +5720,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 }
 
 func (fbo *folderBranchOps) RequestRekey(_ context.Context, tlf tlf.ID) {
+	// Only the MasterBranch can be rekeyed.
 	fb := FolderBranch{tlf, MasterBranch}
 	if fb != fbo.folderBranch {
 		// TODO: log instead of panic?
@@ -6703,6 +6713,7 @@ func (fbo *folderBranchOps) TeamAbandoned(
 // MigrateToImplicitTeam implements the KBFSOps interface for folderBranchOps.
 func (fbo *folderBranchOps) MigrateToImplicitTeam(
 	ctx context.Context, id tlf.ID) (err error) {
+	// Only MasterBranch FBOs may be migrated.
 	fb := FolderBranch{id, MasterBranch}
 	if fb != fbo.folderBranch {
 		// TODO: log instead of panic?

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -1632,36 +1632,6 @@ func TestRenameFailAcrossTopLevelFolders(t *testing.T) {
 	}
 }
 
-func TestRenameFailAcrossBranches(t *testing.T) {
-	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
-	defer kbfsTestShutdown(mockCtrl, config, ctx, cancel)
-
-	id1 := tlf.FakeID(1, tlf.Private)
-	h1 := parseTlfHandleOrBust(t, config, "alice,bob", tlf.Private, id1)
-	rmd1, err := makeInitialRootMetadata(config.MetadataVersion(), id1, h1)
-	require.NoError(t, err)
-
-	uid1 := h1.FirstResolvedWriter()
-	rootID1 := kbfsblock.FakeID(41)
-	aID1 := kbfsblock.FakeID(42)
-	node1 := pathNode{makeBP(rootID1, rmd1, config, uid1), "p"}
-	aNode1 := pathNode{makeBP(aID1, rmd1, config, uid1), "a"}
-	p1 := path{FolderBranch{Tlf: id1}, []pathNode{node1, aNode1}}
-	p2 := path{FolderBranch{id1, "test"}, []pathNode{node1, aNode1}}
-	ops1 := getOps(config, id1)
-	n1 := nodeFromPath(t, ops1, p1)
-	ops2 := config.KBFSOps().(*KBFSOpsStandard).getOpsNoAdd(
-		ctx, FolderBranch{id1, "test"})
-	n2 := nodeFromPath(t, ops2, p2)
-
-	expectedErr := RenameAcrossDirsError{}
-	if err := config.KBFSOps().Rename(ctx, n1, "b", n2, "c"); err == nil {
-		t.Errorf("Got no expected error on rename")
-	} else if err.Error() != expectedErr.Error() {
-		t.Errorf("Got unexpected error on rename: %+v", err)
-	}
-}
-
 func TestKBFSOpsCacheReadFullSuccess(t *testing.T) {
 	mockCtrl, config, ctx, cancel := kbfsOpsInit(t)
 	defer kbfsTestShutdown(mockCtrl, config, ctx, cancel)

--- a/libkbfs/readonly_node.go
+++ b/libkbfs/readonly_node.go
@@ -35,3 +35,7 @@ func (rn ReadonlyNode) Readonly(ctx context.Context) bool {
 func (rn ReadonlyNode) WrapChild(child Node) Node {
 	return &ReadonlyNode{rn.Node.WrapChild(child)}
 }
+
+func readonlyWrapper(node Node) Node {
+	return &ReadonlyNode{Node: node}
+}

--- a/libkbfs/rekey_fsm.go
+++ b/libkbfs/rekey_fsm.go
@@ -462,7 +462,9 @@ func NewRekeyFSM(fbo *folderBranchOps) RekeyFSM {
 		listeners: make(map[rekeyEventType][]rekeyFSMListener),
 	}
 	fsm.current = newRekeyStateIdle(fsm)
-	go fsm.loop()
+	if fbo.bType == standard {
+		go fsm.loop()
+	}
 	return fsm
 }
 


### PR DESCRIPTION
Archive FBOs turn off all background work, and make the whole TLF read-only. 

In a future PR, `KBFSOpsStandard` will create these according to a revision number encoded in the branch name, and set the "head" of the FBO to that exact revision.

Issue: KBFS-3203
