### PR TITLE
kbfs_ops: support revision branch names

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -373,7 +373,7 @@ const (
 // MakeRevBranchName returns a branch name specifying an archive
 // branch pinned to the given revision number.
 func MakeRevBranchName(rev kbfsmd.Revision) BranchName {
-	return BranchName(fmt.Sprintf("%s%d", branchRevPrefix, rev))
+	return BranchName(branchRevPrefix + strconv.FormatInt(int64(rev), 10))
 }
 
 // RevisionIfSpecified returns a valid revision number and true if

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -7,6 +7,7 @@ package libkbfs
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -365,7 +366,34 @@ const (
 	// folder.  Set to the empty string so that the default will be
 	// the master branch.
 	MasterBranch BranchName = ""
+
+	branchRevPrefix = "rev="
 )
+
+// MakeRevBranchName returns a branch name specifying an archive
+// branch pinned to the given revision number.
+func MakeRevBranchName(rev kbfsmd.Revision) BranchName {
+	return BranchName(fmt.Sprintf("%s%d", branchRevPrefix, rev))
+}
+
+// HasRevision returns a valid revision number and true if `bn` is a
+// revision branch.
+func (bn BranchName) HasRevision() (kbfsmd.Revision, bool) {
+	if len(bn) <= len(branchRevPrefix) {
+		return kbfsmd.RevisionUninitialized, false
+	}
+
+	if bn[:len(branchRevPrefix)] != branchRevPrefix {
+		return kbfsmd.RevisionUninitialized, false
+	}
+
+	i, err := strconv.ParseInt(string(bn[len(branchRevPrefix):]), 10, 64)
+	if err != nil {
+		return kbfsmd.RevisionUninitialized, false
+	}
+
+	return kbfsmd.Revision(i), true
+}
 
 // FolderBranch represents a unique pair of top-level folder and a
 // branch of that folder.

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -379,7 +379,7 @@ func MakeRevBranchName(rev kbfsmd.Revision) BranchName {
 // HasRevision returns a valid revision number and true if `bn` is a
 // revision branch.
 func (bn BranchName) HasRevision() (kbfsmd.Revision, bool) {
-	if len(bn) <= len(branchRevPrefix) {
+	if !strings.HasPrefix(string(bn), branchRevPrefix) {
 		return kbfsmd.RevisionUninitialized, false
 	}
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -383,10 +383,6 @@ func (bn BranchName) RevisionIfSpecified() (kbfsmd.Revision, bool) {
 		return kbfsmd.RevisionUninitialized, false
 	}
 
-	if bn[:len(branchRevPrefix)] != branchRevPrefix {
-		return kbfsmd.RevisionUninitialized, false
-	}
-
 	i, err := strconv.ParseInt(string(bn[len(branchRevPrefix):]), 10, 64)
 	if err != nil {
 		return kbfsmd.RevisionUninitialized, false

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -376,9 +376,9 @@ func MakeRevBranchName(rev kbfsmd.Revision) BranchName {
 	return BranchName(fmt.Sprintf("%s%d", branchRevPrefix, rev))
 }
 
-// HasRevision returns a valid revision number and true if `bn` is a
-// revision branch.
-func (bn BranchName) HasRevision() (kbfsmd.Revision, bool) {
+// RevisionIfSpecified returns a valid revision number and true if
+// `bn` is a revision branch.
+func (bn BranchName) RevisionIfSpecified() (kbfsmd.Revision, bool) {
 	if !strings.HasPrefix(string(bn), branchRevPrefix) {
 		return kbfsmd.RevisionUninitialized, false
 	}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -461,7 +461,9 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		md, err = getSingleMD(
 			ctx, fs.config, h.tlfID, kbfsmd.NullBranchID, rev,
 			kbfsmd.Merged, nil)
-		// This will error if there's no corresponding MD.
+		// This will error if there's no corresponding MD, which is
+		// what we want since that means the user input an incorrect
+		// MD revision.
 		if err != nil {
 			return false, ImmutableRootMetadata{}, tlf.NullID, err
 		}

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -333,7 +333,7 @@ func (fs *KBFSOpsStandard) getOpsNoAdd(
 	ops, ok := fs.ops[fb]
 	if !ok {
 		bType := standard
-		if _, isRevBranch := fb.Branch.HasRevision(); isRevBranch {
+		if _, isRevBranch := fb.Branch.RevisionIfSpecified(); isRevBranch {
 			bType = archive
 		}
 		ops = newFolderBranchOps(ctx, fs.g, fs.config, fb, bType)
@@ -455,7 +455,7 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		return false, ImmutableRootMetadata{}, tlf.NullID, err
 	}
 
-	if rev, isRevBranch := fb.Branch.HasRevision(); isRevBranch {
+	if rev, isRevBranch := fb.Branch.RevisionIfSpecified(); isRevBranch {
 		fs.log.CDebugf(ctx, "Getting archived revision %d for branch %s",
 			rev, fb.Branch)
 		md, err = getSingleMD(

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1148,11 +1148,13 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 		fs.editActivity.Add(1)
 		go func() {
 			defer fs.editActivity.Done()
-			fs.log.CDebugf(ctx, "Initializing TLF %s for the edit history",
-				handle.GetCanonicalPath())
+			fs.log.CDebugf(ctx, "%p: Initializing TLF %s for the edit history",
+				fs, handle.GetCanonicalPath())
 			ctx := CtxWithRandomIDReplayable(
 				context.Background(), CtxFBOIDKey, CtxFBOOpID, fs.log)
-			ops := fs.getOpsNoAdd(ctx, FolderBranch{handle.tlfID, MasterBranch})
+			ops := fs.getOpsByHandle(
+				ctx, handle, FolderBranch{handle.tlfID, MasterBranch},
+				FavoritesOpNoChange)
 			// Don't initialize the entire TLF, because we don't want
 			// to run identifies on it.  Instead, just start the
 			// chat-monitoring part.
@@ -1249,7 +1251,9 @@ func (fs *KBFSOpsStandard) initTlfsForEditHistories() {
 		if h.tlfID != tlf.NullID {
 			fs.log.CDebugf(ctx, "Initializing TLF %s (%s) for the edit history",
 				h.GetCanonicalPath(), h.tlfID)
-			ops := fs.getOpsNoAdd(ctx, FolderBranch{h.tlfID, MasterBranch})
+			ops := fs.getOpsByHandle(
+				ctx, h, FolderBranch{h.tlfID, MasterBranch},
+				FavoritesOpNoChange)
 			// Don't initialize the entire TLF, because we don't want
 			// to run identifies on it.  Instead, just start the
 			// chat-monitoring part.

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -467,11 +467,12 @@ func (fs *KBFSOpsStandard) getOrInitializeNewMDMaster(ctx context.Context,
 		if err != nil {
 			return false, ImmutableRootMetadata{}, tlf.NullID, err
 		}
-	} else {
-		md, err = mdops.GetForTLF(ctx, h.tlfID, nil)
-		if err != nil {
-			return false, ImmutableRootMetadata{}, tlf.NullID, err
-		}
+		return false, md, h.tlfID, nil
+	}
+
+	md, err = mdops.GetForTLF(ctx, h.tlfID, nil)
+	if err != nil {
+		return false, ImmutableRootMetadata{}, tlf.NullID, err
 	}
 	if md != (ImmutableRootMetadata{}) {
 		return false, md, h.tlfID, nil
@@ -1150,8 +1151,8 @@ func (fs *KBFSOpsStandard) NewNotificationChannel(
 		fs.editActivity.Add(1)
 		go func() {
 			defer fs.editActivity.Done()
-			fs.log.CDebugf(ctx, "%p: Initializing TLF %s for the edit history",
-				fs, handle.GetCanonicalPath())
+			fs.log.CDebugf(ctx, "Initializing TLF %s for the edit history",
+				handle.GetCanonicalPath())
 			ctx := CtxWithRandomIDReplayable(
 				context.Background(), CtxFBOIDKey, CtxFBOOpID, fs.log)
 			ops := fs.getOpsByHandle(

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -610,12 +610,6 @@ func TestKBFSOpsGetRootMDForHandleExisting(t *testing.T) {
 		},
 	}
 
-	config.mockMdops.EXPECT().GetUnmergedForTLF(
-		gomock.Any(), id, kbfsmd.NullBranchID).Return(
-		ImmutableRootMetadata{}, nil)
-	config.mockMdops.EXPECT().GetForTLF(
-		gomock.Any(), id, nil).Return(
-		makeImmutableRMDForTest(t, config, rmd, kbfsmd.FakeID(1)), nil)
 	ops := getOps(config, id)
 	assert.False(t, fboIdentityDone(ops))
 


### PR DESCRIPTION
This PR introduces branch names that can refer to a specific revision, and `KBFSOpsStandard` respects that when creating FBOs.  It includes the first successful test of a time-travelling TLF!

It depends on #1685, which should be merged first.

Issue: KBFS-3204
