### PR TITLE
tlf_journal: re-create info.json file when journal gets more data

### DIFF
--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -2068,15 +2068,6 @@ func (j *tlfJournal) putBlockData(
 		return err
 	}
 
-	if j.needInfoFile {
-		err := writeTLFJournalInfoFile(
-			j.dir, j.uid, j.key, j.tlfID, j.chargedTo)
-		if err != nil {
-			return err
-		}
-		j.needInfoFile = false
-	}
-
 	storedBytesBefore := j.blockJournal.getStoredBytes()
 
 	putData, err = j.blockJournal.putData(


### PR DESCRIPTION
`TlfJournal` creates an `info.json` file when it is first constructed. But whenever it finishes completely flushing, it removes ALL files in its directory, including `info.json`.  If more data comes into the journal after that, the `info.json` file was not re-created.  If KBFS then restarts, it won't be able to re-enable that journal since `info.json` is missing, and the data won't be flushed (and the user will see the server's view of the folder, instead of the journal view) until the user actually visits the folder.

This bug must have been present forever, but we never noticed it!

cc: @akalin-keybase 