### PR TITLE
cr_chains: don't revert rename op if it was just created

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -1223,6 +1223,13 @@ func (ccs *crChains) revertRenames(oldOps []op) {
 				}
 			}
 
+			if !rop.oldFinalPath.isValid() {
+				// We don't need to revert any renames without an
+				// rmOp, because it was probably just created and
+				// renamed within a single journal update.
+				continue
+			}
+
 			newChain := oldChain
 			if rop.NewDir != (blockUpdate{}) {
 				newChain = ccs.byMostRecent[rop.NewDir.Ref]


### PR DESCRIPTION
If an entry is created and then renamed within a single journal update, `crChains` ends up collapsing the [`createOp`,`renameOp`] into a single `createOp`, but with `createOp.renamed = true`.

This confused the `revertRenames` function, because it couldn't find a matching `rmOp` for the given `renameOp`.  But that's valid, so we can just leave that `createOp` un-reverted.  Otherwise, we'll have a `renameOp` without a valid `oldFinalPath`, and we'll crash.

Issue: keybase/client#12817