### PR TITLE
md_util: check readership correctly after a decryption error

### DIFF
--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -59,8 +59,8 @@ func (j journalMDOps) convertImmutableBareRMDToIRMD(ctx context.Context,
 	config := j.jServer.config
 	pmd, err := decryptMDPrivateData(ctx, config.Codec(), config.Crypto(),
 		config.BlockCache(), config.BlockOps(), config.KeyManager(),
-		config.Mode(), uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd,
-		j.jServer.log)
+		config.KBPKI(), config.Mode(), uid, rmd.GetSerializedPrivateMetadata(),
+		rmd, rmd, j.jServer.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err
 	}

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -733,8 +733,9 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 	if !md.IsReadable() && len(md.GetSerializedPrivateMetadata()) > 0 {
 		pmd, err := decryptMDPrivateData(
 			ctx, km.config.Codec(), km.config.Crypto(),
-			km.config.BlockCache(), km.config.BlockOps(), km, km.config.Mode(),
-			session.UID, md.GetSerializedPrivateMetadata(), md, md, km.log)
+			km.config.BlockCache(), km.config.BlockOps(), km, km.config.KBPKI(),
+			km.config.Mode(), session.UID, md.GetSerializedPrivateMetadata(),
+			md, md, km.log)
 		if err != nil {
 			return false, nil, err
 		}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -161,8 +161,8 @@ func (md *MDOpsStandard) decryptMerkleLeaf(
 			pmd, err := decryptMDPrivateData(
 				ctx, md.config.Codec(), md.config.Crypto(),
 				md.config.BlockCache(), md.config.BlockOps(),
-				md.config.KeyManager(), md.config.Mode(), uid,
-				currRmd.GetSerializedPrivateMetadata(), currRmd,
+				md.config.KeyManager(), md.config.KBPKI(), md.config.Mode(),
+				uid, currRmd.GetSerializedPrivateMetadata(), currRmd,
 				head.ReadOnlyRootMetadata, md.log)
 			if err != nil {
 				return nil, err
@@ -709,7 +709,7 @@ func (md *MDOpsStandard) processMetadata(ctx context.Context,
 	pmd, err := decryptMDPrivateData(
 		ctx, md.config.Codec(), md.config.Crypto(),
 		md.config.BlockCache(), md.config.BlockOps(),
-		md.config.KeyManager(), md.config.Mode(), uid,
+		md.config.KeyManager(), md.config.KBPKI(), md.config.Mode(), uid,
 		rmd.GetSerializedPrivateMetadata(), rmd, rmd, md.log)
 	if err != nil {
 		return ImmutableRootMetadata{}, err

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1745,8 +1745,8 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		pmd, err := decryptMDPrivateData(
 			ctx, j.config.Codec(), j.config.Crypto(),
 			j.config.BlockCache(), j.config.BlockOps(),
-			j.config.mdDecryptionKeyGetter(), mode, j.uid,
-			rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.log)
+			j.config.mdDecryptionKeyGetter(), j.config.teamMembershipChecker(),
+			mode, j.uid, rmd.GetSerializedPrivateMetadata(), rmd, rmd, j.log)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
`handle.IsReader` crashes if you try to call it on a team-based handle.

Issue: KBFS-3253