### PR TITLE
libfuse/libdokan: expose `.kbfs_archived_rev` at the root of a TLF

### DIFF
--- a/libdokan/dir.go
+++ b/libdokan/dir.go
@@ -585,7 +585,13 @@ func asDir(ctx context.Context, f dokan.File) *Dir {
 	case *Dir:
 		return x
 	case *TLF:
-		d, _, _ := x.loadDirHelper(ctx, "asDir", libkbfs.WriteMode, false)
+		branch := x.folder.getFolderBranch().Branch
+		filterErr := false
+		if branch != libkbfs.MasterBranch {
+			filterErr = true
+		}
+		d, _, _ := x.loadDirHelper(
+			ctx, "asDir", libkbfs.WriteMode, branch, filterErr)
 		return d
 	}
 	return nil

--- a/libdokan/tlf.go
+++ b/libdokan/tlf.go
@@ -45,7 +45,7 @@ func (tlf *TLF) getStoredDir() *Dir {
 }
 
 func (tlf *TLF) loadDirHelper(ctx context.Context, info string,
-	mode libkbfs.ErrorModeType, filterErr bool) (
+	mode libkbfs.ErrorModeType, branch libkbfs.BranchName, filterErr bool) (
 	dir *Dir, exitEarly bool, err error) {
 	dir = tlf.getStoredDir()
 	if dir != nil {
@@ -81,7 +81,7 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, info string,
 	var rootNode libkbfs.Node
 	if filterErr {
 		rootNode, _, err = tlf.folder.fs.config.KBFSOps().GetRootNode(
-			ctx, handle, libkbfs.MasterBranch)
+			ctx, handle, branch)
 		if err != nil {
 			return nil, false, err
 		}
@@ -91,7 +91,7 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, info string,
 		}
 	} else {
 		rootNode, _, err = tlf.folder.fs.config.KBFSOps().GetOrCreateRootNode(
-			ctx, handle, libkbfs.MasterBranch)
+			ctx, handle, branch)
 		if err != nil {
 			return nil, false, err
 		}
@@ -112,7 +112,8 @@ func (tlf *TLF) loadDirHelper(ctx context.Context, info string,
 }
 
 func (tlf *TLF) loadDir(ctx context.Context, info string) (*Dir, error) {
-	dir, _, err := tlf.loadDirHelper(ctx, info, libkbfs.WriteMode, false)
+	dir, _, err := tlf.loadDirHelper(
+		ctx, info, libkbfs.WriteMode, libkbfs.MasterBranch, false)
 	return dir, err
 }
 
@@ -122,7 +123,16 @@ func (tlf *TLF) loadDir(ctx context.Context, info string) (*Dir, error) {
 // folder.
 func (tlf *TLF) loadDirAllowNonexistent(ctx context.Context, info string) (
 	*Dir, bool, error) {
-	return tlf.loadDirHelper(ctx, info, libkbfs.ReadMode, true)
+	return tlf.loadDirHelper(
+		ctx, info, libkbfs.ReadMode, libkbfs.MasterBranch, true)
+}
+
+func (tlf *TLF) loadArchivedDir(
+	ctx context.Context, info string, branch libkbfs.BranchName) (
+	*Dir, bool, error) {
+	// Always filter errors for archive TLF directories, so that we
+	// don't try to initialize them.
+	return tlf.loadDirHelper(ctx, info, libkbfs.ReadMode, branch, true)
 }
 
 // SetFileTime sets mtime for FSOs (File and Dir).
@@ -173,7 +183,8 @@ func (tlf *TLF) open(ctx context.Context, oc *openContext, path []string) (
 	}
 	// If it is a creation then we need the dir for real.
 	dir, exitEarly, err :=
-		tlf.loadDirHelper(ctx, "open", mode, !oc.isCreation())
+		tlf.loadDirHelper(
+			ctx, "open", mode, libkbfs.MasterBranch, !oc.isCreation())
 	if err != nil {
 		return nil, 0, err
 	}
@@ -185,6 +196,18 @@ func (tlf *TLF) open(ctx context.Context, oc *openContext, path []string) (
 
 		return nil, 0, dokan.ErrObjectNameNotFound
 	}
+
+	branch, isArchivedBranch := libfs.BranchNameFromArchiveRefDir(path[0])
+	if isArchivedBranch {
+		archivedTLF := newTLF(
+			tlf.folder.list, tlf.folder.h, tlf.folder.hPreferredName)
+		_, _, err := archivedTLF.loadArchivedDir(ctx, "open", branch)
+		if err != nil {
+			return nil, 0, err
+		}
+		return archivedTLF.open(ctx, oc, path[1:])
+	}
+
 	return dir.open(ctx, oc, path)
 }
 

--- a/libfs/archive_util.go
+++ b/libfs/archive_util.go
@@ -1,0 +1,29 @@
+// Copyright 2016 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfs
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/libkbfs"
+)
+
+// BranchNameFromArchiveRefDir returns a branch name and true if the
+// given directory name is specifying an archived revision with a
+// revision number.
+func BranchNameFromArchiveRefDir(dir string) (libkbfs.BranchName, bool) {
+	if !strings.HasPrefix(dir, ArchivedRevDirPrefix) {
+		return "", false
+	}
+
+	rev, err := strconv.ParseInt(dir[len(ArchivedRevDirPrefix):], 10, 64)
+	if err != nil {
+		return "", false
+	}
+
+	return libkbfs.MakeRevBranchName(kbfsmd.Revision(rev)), true
+}

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -104,3 +104,7 @@ const EnableSyncFileName = ".kbfs_enable_sync"
 // DisableSyncFileName is the name of the file to disable the sync cache for a
 // TLF. It can be reached anywhere within a TLF.
 const DisableSyncFileName = ".kbfs_disable_sync"
+
+// ArchivedRevDirPrefix is the prefix to the directory at the root of a
+// TLF that exposes a version of that TLF at the specified revision.
+const ArchivedRevDirPrefix = ".kbfs_archived_rev="

--- a/libfuse/errors.go
+++ b/libfuse/errors.go
@@ -74,6 +74,8 @@ func filterError(err error) error {
 		return errorWithErrno{err, syscall.EXDEV}
 	case *libkbfs.ErrDiskLimitTimeout:
 		return errorWithErrno{err, syscall.ENOSPC}
+	case libkbfs.RevGarbageCollectedError:
+		return errorWithErrno{err, syscall.ENOENT}
 	}
 	return err
 }

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1191,3 +1191,16 @@ func (e MDWrittenAfterRevokeError) Error() string {
 		"last valid revision would have been %d",
 		e.revBad, e.tlfID, e.verifyingKey, e.revLimit)
 }
+
+// RevGarbageCollectedError indicates that the user is trying to
+// access a revision that's already been garbage-collected.
+type RevGarbageCollectedError struct {
+	rev       kbfsmd.Revision
+	lastGCRev kbfsmd.Revision
+}
+
+// Error implements the Error interface for RevGarbageCollectedError.
+func (e RevGarbageCollectedError) Error() string {
+	return fmt.Sprintf("Requested revision %d has already been garbage "+
+		"collected (last GC'd rev=%d)", e.rev, e.lastGCRev)
+}

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -27,6 +27,7 @@ type FolderBranchStatus struct {
 	LatestKeyGeneration kbfsmd.KeyGen
 	FolderID            string
 	Revision            kbfsmd.Revision
+	LastGCRevision      kbfsmd.Revision
 	MDVersion           kbfsmd.MetadataVer
 	RootBlockID         string
 	SyncEnabled         bool
@@ -211,6 +212,7 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 		fbs.LatestKeyGeneration = fbsk.md.LatestKeyGeneration()
 		fbs.FolderID = fbsk.md.TlfID().String()
 		fbs.Revision = fbsk.md.Revision()
+		fbs.LastGCRevision = fbsk.md.data.LastGCRevision
 		fbs.MDVersion = fbsk.md.Version()
 		fbs.SyncEnabled = fbsk.config.IsSyncedTlf(fbsk.md.TlfID())
 		prefetchStatus := fbsk.config.PrefetchStatus(ctx, fbsk.md.TlfID(),

--- a/test/archive_test.go
+++ b/test/archive_test.go
@@ -1,0 +1,36 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package test
+
+import (
+	"testing"
+)
+
+func TestArchiveByRevision(t *testing.T) {
+	test(t,
+		users("alice", "bob"),
+
+		inPrivateTlf("alice,bob"),
+		as(alice,
+			mkdir("a"),
+		),
+		as(alice,
+			lsdir("", m{"a$": "DIR"}),
+			lsdir("a", m{}),
+		),
+		as(bob,
+			lsdir("", m{"a$": "DIR"}),
+			lsdir("a", m{}),
+		),
+
+		inPrivateTlfAtRevision("alice,bob", 1),
+		as(alice,
+			lsdir("", m{}),
+		),
+		as(bob,
+			lsdir("", m{}),
+		),
+	)
+}

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -41,6 +41,7 @@ type opt struct {
 	tlfName                  string
 	expectedCanonicalTlfName string
 	tlfType                  tlf.Type
+	tlfRevision              kbfsmd.Revision
 	users                    map[libkb.NormalizedUsername]User
 	stallers                 map[libkb.NormalizedUsername]*libkbfs.NaïveStaller
 	tb                       testing.TB
@@ -320,6 +321,15 @@ func inPrivateTlf(name string) optionOp {
 	}
 }
 
+func inPrivateTlfAtRevision(name string, rev kbfsmd.Revision) optionOp {
+	return func(o *opt) {
+		o.tlfName = name
+		o.expectedCanonicalTlfName = name
+		o.tlfType = tlf.Private
+		o.tlfRevision = rev
+	}
+}
+
 func inPrivateTlfNonCanonical(name, expectedCanonicalName string) optionOp {
 	return func(o *opt) {
 		o.tlfName = name
@@ -507,7 +517,16 @@ func initRoot() fileOp {
 				return err
 			}
 		}
-		root, err := c.engine.GetRootDir(c.user, c.tlfName, c.tlfType, c.expectedCanonicalTlfName)
+		var root Node
+		var err error
+		if c.tlfRevision == kbfsmd.RevisionUninitialized {
+			root, err = c.engine.GetRootDir(
+				c.user, c.tlfName, c.tlfType, c.expectedCanonicalTlfName)
+		} else {
+			root, err = c.engine.GetRootDirAtRevision(
+				c.user, c.tlfName, c.tlfType, c.tlfRevision,
+				c.expectedCanonicalTlfName)
+		}
 		if err != nil {
 			return err
 		}

--- a/test/engine.go
+++ b/test/engine.go
@@ -58,6 +58,12 @@ type Engine interface {
 	// GetRootDir is called by the test harness to get a handle to a TLF from the given user's
 	// perspective
 	GetRootDir(u User, tlfName string, t tlf.Type, expectedCanonicalTlfName string) (dir Node, err error)
+	// GetRootDirAtRevision is called by the test harness to get a
+	// handle to an archived TLF from the given user's perspective, at
+	// a given revision.
+	GetRootDirAtRevision(
+		u User, tlfName string, t tlf.Type, rev kbfsmd.Revision,
+		expectedCanonicalTlfName string) (dir Node, err error)
 	// CreateDir is called by the test harness to create a directory relative to the passed
 	// parent directory for the given user.
 	CreateDir(u User, parentDir Node, name string) (dir Node, err error)

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -149,6 +149,19 @@ func (e *fsEngine) GetRootDir(user User, tlfName string, t tlf.Type, expectedCan
 	return fsNode{realPath}, nil
 }
 
+// GetRootDirAtRevision implements the Engine interface.
+func (e *fsEngine) GetRootDirAtRevision(
+	u User, tlfName string, t tlf.Type, rev kbfsmd.Revision,
+	expectedCanonicalTlfName string) (dir Node, err error) {
+	d, err := e.GetRootDir(u, tlfName, t, expectedCanonicalTlfName)
+	if err != nil {
+		return nil, err
+	}
+	p := d.(fsNode)
+	revDir := libfs.ArchivedRevDirPrefix + rev.String()
+	return fsNode{filepath.Join(p.path, revDir)}, nil
+}
+
 // CreateDir is called by the test harness to create a directory relative to the passed
 // parent directory for the given user.
 func (*fsEngine) CreateDir(u User, parentDir Node, name string) (dir Node, err error) {


### PR DESCRIPTION
[This is a dup of #1687, which was acidentally merged then overwritten.  It was approved there.]

If the revision has already been GC'd, libkbfs returns a nice error (which libfuse interprets as ENOENT).

Also prints the last gc'd revision to a TLF's .kbfs_status, for easier debugging.

Also also, adds a simple DSL test to check that archived revisions work on all platforms.

Depends on #1686.

Issue: KBFS-3205