### PR TITLE
simplefs: support by-revision archived paths

### DIFF
--- a/kbfsgit/runner_test.go
+++ b/kbfsgit/runner_test.go
@@ -112,7 +112,9 @@ func testRunnerInitRepo(t *testing.T, tlfType tlf.Type, typeString string) {
 
 	// Now there should be a valid git repo stored in KBFS.  Check the
 	// existence of the HEAD file to be sure.
-	fs, err := libfs.NewFS(ctx, config, h, ".kbfs_git/test", "", keybase1.MDPriorityGit)
+	fs, err := libfs.NewFS(
+		ctx, config, h, libkbfs.MasterBranch, ".kbfs_git/test", "",
+		keybase1.MDPriorityGit)
 	require.NoError(t, err)
 	head, err := fs.Open("HEAD")
 	require.NoError(t, err)
@@ -989,7 +991,7 @@ func TestRunnerWithKBFSReset(t *testing.T) {
 	// Reset using worktree.
 	repoFS, _, err := libgit.GetRepoAndID(ctx, config, h, "test", "")
 	require.NoError(t, err)
-	rootFS, err := libfs.NewFS(ctx, config, h, "", "", 0)
+	rootFS, err := libfs.NewFS(ctx, config, h, libkbfs.MasterBranch, "", "", 0)
 	require.NoError(t, err)
 	err = rootFS.MkdirAll("test-checkout", 0600)
 	require.NoError(t, err)

--- a/libfs/fs.go
+++ b/libfs/fs.go
@@ -104,10 +104,14 @@ func followSymlink(parentPath, link string) (newPath string, err error) {
 // globally; for example, a device ID combined with a local tempfile
 // name is recommended.
 func NewFS(ctx context.Context, config libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, subdir string, uniqID string,
-	priority keybase1.MDPriority) (*FS, error) {
-	rootNode, ei, err := config.KBFSOps().GetOrCreateRootNode(
-		ctx, tlfHandle, libkbfs.MasterBranch)
+	tlfHandle *libkbfs.TlfHandle, branch libkbfs.BranchName, subdir string,
+	uniqID string, priority keybase1.MDPriority) (*FS, error) {
+	rootNodeGetter := config.KBFSOps().GetOrCreateRootNode
+	if branch != libkbfs.MasterBranch {
+		rootNodeGetter = config.KBFSOps().GetRootNode
+	}
+
+	rootNode, ei, err := rootNodeGetter(ctx, tlfHandle, branch)
 	if err != nil {
 		return nil, err
 	}

--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -326,7 +326,7 @@ func (am *AutogitManager) doReset(ctx context.Context, req resetReq) (
 
 	// And a dst parent checkout FS, which better already exist.
 	dstFS, err := libfs.NewFS(
-		ctx, gitConfig, req.dstTLF, req.dstDir, uniqID,
+		ctx, gitConfig, req.dstTLF, libkbfs.MasterBranch, req.dstDir, uniqID,
 		keybase1.MDPriorityNormal)
 	if err != nil {
 		return err
@@ -507,7 +507,7 @@ func (am *AutogitManager) doDelete(req deleteReq) (err error) {
 	}
 
 	dstFS, err := libfs.NewFS(
-		ctx, gitConfig, req.dstTLF, req.dstDir, uniqID,
+		ctx, gitConfig, req.dstTLF, libkbfs.MasterBranch, req.dstDir, uniqID,
 		keybase1.MDPriorityNormal)
 	if err != nil {
 		return err
@@ -604,7 +604,8 @@ func (am *AutogitManager) Clone(
 	}()
 
 	dstFS, err := libfs.NewFS(
-		ctx, am.config, dstTLF, dstDir, "", keybase1.MDPriorityNormal)
+		ctx, am.config, dstTLF, libkbfs.MasterBranch, dstDir, "",
+		keybase1.MDPriorityNormal)
 	if err != nil {
 		return nil, err
 	}

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -185,7 +185,7 @@ func TestAutogitManager(t *testing.T) {
 		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
-		ctx, config, h, "", "", keybase1.MDPriorityNormal)
+		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
 
 	t.Log("Init a new repo directly into KBFS.")

--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -35,7 +35,7 @@ func TestAutogitNodeWrappers(t *testing.T) {
 		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
-		ctx, config, h, "", "", keybase1.MDPriorityNormal)
+		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
 
 	t.Log("Looking at user1's autogit directory should succeed, and " +
@@ -114,7 +114,7 @@ func TestAutogitRepoNode(t *testing.T) {
 		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
-		ctx, config, h, "", "", keybase1.MDPriorityNormal)
+		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
 
 	t.Log("Init a new repo directly into KBFS.")
@@ -191,7 +191,7 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Public)
 	require.NoError(t, err)
 	rootFS, err := libfs.NewFS(
-		ctx, config, h, "", "", keybase1.MDPriorityNormal)
+		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
 	require.NoError(t, err)
 
 	t.Log("Init a new repo directly into KBFS.")
@@ -229,7 +229,8 @@ func TestAutogitRepoNodeReadonly(t *testing.T) {
 		ctx2, config2.KBPKI(), config2.MDOps(), "user2", tlf.Private)
 	require.NoError(t, err)
 	rootFS2, err := libfs.NewFS(
-		ctx2, config2, h2, "", "", keybase1.MDPriorityNormal)
+		ctx2, config2, h2, libkbfs.MasterBranch, "", "",
+		keybase1.MDPriorityNormal)
 	require.NoError(t, err)
 	checkAutogitOneFile(t, rootFS2, "public")
 

--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -121,7 +121,8 @@ func CleanOldDeletedRepos(
 	ctx context.Context, config libkbfs.Config,
 	tlfHandle *libkbfs.TlfHandle) (err error) {
 	fs, err := libfs.NewFS(
-		ctx, config, tlfHandle, path.Join(kbfsRepoDir, kbfsDeletedReposDir),
+		ctx, config, tlfHandle, libkbfs.MasterBranch,
+		path.Join(kbfsRepoDir, kbfsDeletedReposDir),
 		"" /* uniq ID isn't used for removals */, keybase1.MDPriorityGit)
 	switch errors.Cause(err).(type) {
 	case libkbfs.NoSuchNameError:
@@ -492,7 +493,8 @@ func getOrCreateRepoAndID(
 	repoExists = true
 
 	fs, err = libfs.NewFS(
-		ctx, config, tlfHandle, path.Join(kbfsRepoDir, normalizedRepoName),
+		ctx, config, tlfHandle, libkbfs.MasterBranch,
+		path.Join(kbfsRepoDir, normalizedRepoName),
 		uniqID, keybase1.MDPriorityGit)
 	if err != nil {
 		return nil, NullID, err
@@ -724,7 +726,8 @@ func RenameRepo(
 		return nil
 	}
 
-	fs, err := libfs.NewFS(ctx, config, tlfHandle, path.Join(kbfsRepoDir),
+	fs, err := libfs.NewFS(
+		ctx, config, tlfHandle, libkbfs.MasterBranch, path.Join(kbfsRepoDir),
 		"", keybase1.MDPriorityGit)
 	if err != nil {
 		return err

--- a/libhttpserver/server.go
+++ b/libhttpserver/server.go
@@ -118,7 +118,8 @@ func (s *Server) getHTTPFileSystem(ctx context.Context, requestPath string) (
 	}
 
 	tlfFS, err := libfs.NewFS(ctx,
-		s.config, tlfHandle, "", "", keybase1.MDPriorityNormal)
+		s.config, tlfHandle, libkbfs.MasterBranch, "", "",
+		keybase1.MDPriorityNormal)
 	if err != nil {
 		return "", nil, err
 	}

--- a/libpages/root.go
+++ b/libpages/root.go
@@ -129,8 +129,9 @@ func (r *Root) MakeFS(
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
-		tlfFS, err := libfs.NewFS(fsCtx, kbfsConfig,
-			tlfHandle, "", "", keybase1.MDPriorityNormal)
+		tlfFS, err := libfs.NewFS(
+			fsCtx, kbfsConfig, tlfHandle, libkbfs.MasterBranch, "", "",
+			keybase1.MDPriorityNormal)
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
@@ -161,7 +162,8 @@ func (r *Root) MakeFS(
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
-		autogitTLFFS, err := libfs.NewFS(fsCtx, kbfsConfig, tlfHandle,
+		autogitTLFFS, err := libfs.NewFS(
+			fsCtx, kbfsConfig, tlfHandle, libkbfs.MasterBranch,
 			fmt.Sprintf("%s/%s", libgit.AutogitTLFListDir(r.TlfType),
 				r.TlfNameUnparsed), "",
 			keybase1.MDPriorityNormal)

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -64,13 +64,14 @@ var errNoSuchHandle = simpleFSError{"No such handle"}
 var errNoResult = simpleFSError{"Async result not found"}
 
 type newFSFunc func(
-	context.Context, libkbfs.Config, *libkbfs.TlfHandle, string) (
-	billy.Filesystem, error)
+	context.Context, libkbfs.Config, *libkbfs.TlfHandle, libkbfs.BranchName,
+	string) (billy.Filesystem, error)
 
 func defaultNewFS(ctx context.Context, config libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, subdir string) (billy.Filesystem, error) {
+	tlfHandle *libkbfs.TlfHandle, branch libkbfs.BranchName, subdir string) (
+	billy.Filesystem, error) {
 	return libfs.NewFS(
-		ctx, config, tlfHandle, subdir, "", keybase1.MDPriorityNormal)
+		ctx, config, tlfHandle, branch, subdir, "", keybase1.MDPriorityNormal)
 }
 
 // SimpleFS is the simple filesystem rpc layer implementation.
@@ -196,7 +197,8 @@ func (k *SimpleFS) getFS(ctx context.Context, path keybase1.Path) (
 		if err != nil {
 			return nil, "", err
 		}
-		fs, err := k.newFS(ctx, k.config, tlfHandle, restOfPath)
+		fs, err := k.newFS(
+			ctx, k.config, tlfHandle, libkbfs.MasterBranch, restOfPath)
 		if err != nil {
 			if exitEarly, _ := libfs.FilterTLFEarlyExitError(
 				ctx, err, k.log, tlfHandle.GetCanonicalName()); exitEarly {
@@ -1033,7 +1035,8 @@ func (k *SimpleFS) SimpleFSRename(ctx context.Context, arg keybase1.SimpleFSRena
 		return err
 	}
 	fs, err := libfs.NewFS(
-		ctx, k.config, tlfHandle, "", "", keybase1.MDPriorityNormal)
+		ctx, k.config, tlfHandle, libkbfs.MasterBranch, "", "",
+		keybase1.MDPriorityNormal)
 	if err != nil {
 		return err
 	}

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -930,6 +930,10 @@ func pathAppend(p keybase1.Path, leaf string) keybase1.Path {
 	} else if p.Kbfs__ != nil {
 		var s = stdpath.Join(*p.Kbfs__, leaf)
 		p.Kbfs__ = &s
+	} else if p.KbfsArchived__ != nil {
+		var s = stdpath.Join(p.KbfsArchived__.Path, leaf)
+		p = p.DeepCopy()
+		p.KbfsArchived__.Path = s
 	}
 	return p
 }

--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -616,9 +616,10 @@ type fsBlockerMaker struct {
 
 func (maker fsBlockerMaker) makeNewBlocker(
 	ctx context.Context, config libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, subdir string) (billy.Filesystem, error) {
+	tlfHandle *libkbfs.TlfHandle, branch libkbfs.BranchName, subdir string) (
+	billy.Filesystem, error) {
 	fs, err := libfs.NewFS(
-		ctx, config, tlfHandle, subdir, "", keybase1.MDPriorityNormal)
+		ctx, config, tlfHandle, branch, subdir, "", keybase1.MDPriorityNormal)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/appstate.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/appstate.go
@@ -15,7 +15,6 @@ const (
 	AppState_BACKGROUND       AppState = 1
 	AppState_INACTIVE         AppState = 2
 	AppState_BACKGROUNDACTIVE AppState = 3
-	AppState_BACKGROUNDFINAL  AppState = 4
 )
 
 func (o AppState) DeepCopy() AppState { return o }
@@ -25,7 +24,6 @@ var AppStateMap = map[string]AppState{
 	"BACKGROUND":       1,
 	"INACTIVE":         2,
 	"BACKGROUNDACTIVE": 3,
-	"BACKGROUNDFINAL":  4,
 }
 
 var AppStateRevMap = map[AppState]string{
@@ -33,7 +31,6 @@ var AppStateRevMap = map[AppState]string{
 	1: "BACKGROUND",
 	2: "INACTIVE",
 	3: "BACKGROUNDACTIVE",
-	4: "BACKGROUNDFINAL",
 }
 
 func (e AppState) String() string {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/extras.go
@@ -1206,7 +1206,8 @@ func (b TLFIdentifyBehavior) CanUseUntrackedFastPath() bool {
 	switch b {
 	case TLFIdentifyBehavior_CHAT_GUI,
 		TLFIdentifyBehavior_CHAT_GUI_STRICT,
-		TLFIdentifyBehavior_SALTPACK:
+		TLFIdentifyBehavior_SALTPACK,
+		TLFIdentifyBehavior_RESOLVE_AND_CHECK:
 		return true
 	default:
 		// TLFIdentifyBehavior_DEFAULT_KBFS, for filesystem activity that
@@ -1222,6 +1223,39 @@ func (b TLFIdentifyBehavior) WarningInsteadOfErrorOnBrokenTracks() bool {
 		// track errors, because people need to be able to use it to ask each other
 		// about the fact that proofs are broken.
 		return true
+	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// Tracks don't matter for ResolveAndCheck, since we act logged out.
+		return true
+	default:
+		return false
+	}
+}
+
+func (b TLFIdentifyBehavior) SkipUserCard() bool {
+	switch b {
+	case TLFIdentifyBehavior_CHAT_GUI, TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// We don't need to bother loading a user card in these cases.
+		return true
+	default:
+		return false
+	}
+}
+
+func (b TLFIdentifyBehavior) AllowCaching() bool {
+	switch b {
+	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// We Don't want to use any internal ID2 caching for ResolveAndCheck.
+		return false
+	default:
+		return true
+	}
+}
+
+func (b TLFIdentifyBehavior) AllowDeletedUsers() bool {
+	switch b {
+	case TLFIdentifyBehavior_RESOLVE_AND_CHECK:
+		// ResolveAndCheck is OK with deleted users
+		return true
 	default:
 		return false
 	}
@@ -1236,6 +1270,7 @@ func (b TLFIdentifyBehavior) ShouldSuppressTrackerPopups() bool {
 		TLFIdentifyBehavior_KBFS_REKEY,
 		TLFIdentifyBehavior_KBFS_QR,
 		TLFIdentifyBehavior_SALTPACK,
+		TLFIdentifyBehavior_RESOLVE_AND_CHECK,
 		TLFIdentifyBehavior_KBFS_CHAT:
 		// These are identifies that either happen without user interaction at
 		// all, or happen while you're staring at some Keybase UI that can
@@ -1870,10 +1905,6 @@ func (t TeamMembers) AllUserVersions() []UserVersion {
 		all = append(all, uv)
 	}
 	return all
-}
-
-func (t TeamMember) IsReset() bool {
-	return t.EldestSeqno != t.UserEldestSeqno
 }
 
 func (s TeamMemberStatus) IsActive() bool {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/identify.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/identify.go
@@ -148,6 +148,7 @@ type Identify2Arg struct {
 	CanSuppressUI         bool                `codec:"canSuppressUI" json:"canSuppressUI"`
 	IdentifyBehavior      TLFIdentifyBehavior `codec:"identifyBehavior" json:"identifyBehavior"`
 	ForceDisplay          bool                `codec:"forceDisplay" json:"forceDisplay"`
+	ActLoggedOut          bool                `codec:"actLoggedOut" json:"actLoggedOut"`
 }
 
 type IdentifyLiteArg struct {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
@@ -17,23 +17,113 @@ func (o OpID) DeepCopy() OpID {
 	return ret
 }
 
+type KBFSRevision int64
+
+func (o KBFSRevision) DeepCopy() KBFSRevision {
+	return o
+}
+
+type KBFSArchivedType int
+
+const (
+	KBFSArchivedType_REVISION KBFSArchivedType = 0
+)
+
+func (o KBFSArchivedType) DeepCopy() KBFSArchivedType { return o }
+
+var KBFSArchivedTypeMap = map[string]KBFSArchivedType{
+	"REVISION": 0,
+}
+
+var KBFSArchivedTypeRevMap = map[KBFSArchivedType]string{
+	0: "REVISION",
+}
+
+func (e KBFSArchivedType) String() string {
+	if v, ok := KBFSArchivedTypeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type KBFSArchivedParam struct {
+	KBFSArchivedType__ KBFSArchivedType `codec:"KBFSArchivedType" json:"KBFSArchivedType"`
+	Revision__         *KBFSRevision    `codec:"revision,omitempty" json:"revision,omitempty"`
+}
+
+func (o *KBFSArchivedParam) KBFSArchivedType() (ret KBFSArchivedType, err error) {
+	switch o.KBFSArchivedType__ {
+	case KBFSArchivedType_REVISION:
+		if o.Revision__ == nil {
+			err = errors.New("unexpected nil value for Revision__")
+			return ret, err
+		}
+	}
+	return o.KBFSArchivedType__, nil
+}
+
+func (o KBFSArchivedParam) Revision() (res KBFSRevision) {
+	if o.KBFSArchivedType__ != KBFSArchivedType_REVISION {
+		panic("wrong case accessed")
+	}
+	if o.Revision__ == nil {
+		return
+	}
+	return *o.Revision__
+}
+
+func NewKBFSArchivedParamWithRevision(v KBFSRevision) KBFSArchivedParam {
+	return KBFSArchivedParam{
+		KBFSArchivedType__: KBFSArchivedType_REVISION,
+		Revision__:         &v,
+	}
+}
+
+func (o KBFSArchivedParam) DeepCopy() KBFSArchivedParam {
+	return KBFSArchivedParam{
+		KBFSArchivedType__: o.KBFSArchivedType__.DeepCopy(),
+		Revision__: (func(x *KBFSRevision) *KBFSRevision {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.Revision__),
+	}
+}
+
+type KBFSArchivedPath struct {
+	Path          string            `codec:"path" json:"path"`
+	ArchivedParam KBFSArchivedParam `codec:"archivedParam" json:"archivedParam"`
+}
+
+func (o KBFSArchivedPath) DeepCopy() KBFSArchivedPath {
+	return KBFSArchivedPath{
+		Path:          o.Path,
+		ArchivedParam: o.ArchivedParam.DeepCopy(),
+	}
+}
+
 type PathType int
 
 const (
-	PathType_LOCAL PathType = 0
-	PathType_KBFS  PathType = 1
+	PathType_LOCAL         PathType = 0
+	PathType_KBFS          PathType = 1
+	PathType_KBFS_ARCHIVED PathType = 2
 )
 
 func (o PathType) DeepCopy() PathType { return o }
 
 var PathTypeMap = map[string]PathType{
-	"LOCAL": 0,
-	"KBFS":  1,
+	"LOCAL":         0,
+	"KBFS":          1,
+	"KBFS_ARCHIVED": 2,
 }
 
 var PathTypeRevMap = map[PathType]string{
 	0: "LOCAL",
 	1: "KBFS",
+	2: "KBFS_ARCHIVED",
 }
 
 func (e PathType) String() string {
@@ -44,9 +134,10 @@ func (e PathType) String() string {
 }
 
 type Path struct {
-	PathType__ PathType `codec:"PathType" json:"PathType"`
-	Local__    *string  `codec:"local,omitempty" json:"local,omitempty"`
-	Kbfs__     *string  `codec:"kbfs,omitempty" json:"kbfs,omitempty"`
+	PathType__     PathType          `codec:"PathType" json:"PathType"`
+	Local__        *string           `codec:"local,omitempty" json:"local,omitempty"`
+	Kbfs__         *string           `codec:"kbfs,omitempty" json:"kbfs,omitempty"`
+	KbfsArchived__ *KBFSArchivedPath `codec:"kbfsArchived,omitempty" json:"kbfsArchived,omitempty"`
 }
 
 func (o *Path) PathType() (ret PathType, err error) {
@@ -59,6 +150,11 @@ func (o *Path) PathType() (ret PathType, err error) {
 	case PathType_KBFS:
 		if o.Kbfs__ == nil {
 			err = errors.New("unexpected nil value for Kbfs__")
+			return ret, err
+		}
+	case PathType_KBFS_ARCHIVED:
+		if o.KbfsArchived__ == nil {
+			err = errors.New("unexpected nil value for KbfsArchived__")
 			return ret, err
 		}
 	}
@@ -85,6 +181,16 @@ func (o Path) Kbfs() (res string) {
 	return *o.Kbfs__
 }
 
+func (o Path) KbfsArchived() (res KBFSArchivedPath) {
+	if o.PathType__ != PathType_KBFS_ARCHIVED {
+		panic("wrong case accessed")
+	}
+	if o.KbfsArchived__ == nil {
+		return
+	}
+	return *o.KbfsArchived__
+}
+
 func NewPathWithLocal(v string) Path {
 	return Path{
 		PathType__: PathType_LOCAL,
@@ -96,6 +202,13 @@ func NewPathWithKbfs(v string) Path {
 	return Path{
 		PathType__: PathType_KBFS,
 		Kbfs__:     &v,
+	}
+}
+
+func NewPathWithKbfsArchived(v KBFSArchivedPath) Path {
+	return Path{
+		PathType__:     PathType_KBFS_ARCHIVED,
+		KbfsArchived__: &v,
 	}
 }
 
@@ -116,6 +229,13 @@ func (o Path) DeepCopy() Path {
 			tmp := (*x)
 			return &tmp
 		})(o.Kbfs__),
+		KbfsArchived__: (func(x *KBFSArchivedPath) *KBFSArchivedPath {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.KbfsArchived__),
 	}
 }
 

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/tlf_keys.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/tlf_keys.go
@@ -11,35 +11,37 @@ import (
 type TLFIdentifyBehavior int
 
 const (
-	TLFIdentifyBehavior_UNSET           TLFIdentifyBehavior = 0
-	TLFIdentifyBehavior_CHAT_CLI        TLFIdentifyBehavior = 1
-	TLFIdentifyBehavior_CHAT_GUI        TLFIdentifyBehavior = 2
-	TLFIdentifyBehavior_CHAT_GUI_STRICT TLFIdentifyBehavior = 3
-	TLFIdentifyBehavior_KBFS_REKEY      TLFIdentifyBehavior = 4
-	TLFIdentifyBehavior_KBFS_QR         TLFIdentifyBehavior = 5
-	TLFIdentifyBehavior_CHAT_SKIP       TLFIdentifyBehavior = 6
-	TLFIdentifyBehavior_SALTPACK        TLFIdentifyBehavior = 7
-	TLFIdentifyBehavior_CLI             TLFIdentifyBehavior = 8
-	TLFIdentifyBehavior_GUI             TLFIdentifyBehavior = 9
-	TLFIdentifyBehavior_DEFAULT_KBFS    TLFIdentifyBehavior = 10
-	TLFIdentifyBehavior_KBFS_CHAT       TLFIdentifyBehavior = 11
+	TLFIdentifyBehavior_UNSET             TLFIdentifyBehavior = 0
+	TLFIdentifyBehavior_CHAT_CLI          TLFIdentifyBehavior = 1
+	TLFIdentifyBehavior_CHAT_GUI          TLFIdentifyBehavior = 2
+	TLFIdentifyBehavior_CHAT_GUI_STRICT   TLFIdentifyBehavior = 3
+	TLFIdentifyBehavior_KBFS_REKEY        TLFIdentifyBehavior = 4
+	TLFIdentifyBehavior_KBFS_QR           TLFIdentifyBehavior = 5
+	TLFIdentifyBehavior_CHAT_SKIP         TLFIdentifyBehavior = 6
+	TLFIdentifyBehavior_SALTPACK          TLFIdentifyBehavior = 7
+	TLFIdentifyBehavior_CLI               TLFIdentifyBehavior = 8
+	TLFIdentifyBehavior_GUI               TLFIdentifyBehavior = 9
+	TLFIdentifyBehavior_DEFAULT_KBFS      TLFIdentifyBehavior = 10
+	TLFIdentifyBehavior_KBFS_CHAT         TLFIdentifyBehavior = 11
+	TLFIdentifyBehavior_RESOLVE_AND_CHECK TLFIdentifyBehavior = 12
 )
 
 func (o TLFIdentifyBehavior) DeepCopy() TLFIdentifyBehavior { return o }
 
 var TLFIdentifyBehaviorMap = map[string]TLFIdentifyBehavior{
-	"UNSET":           0,
-	"CHAT_CLI":        1,
-	"CHAT_GUI":        2,
-	"CHAT_GUI_STRICT": 3,
-	"KBFS_REKEY":      4,
-	"KBFS_QR":         5,
-	"CHAT_SKIP":       6,
-	"SALTPACK":        7,
-	"CLI":             8,
-	"GUI":             9,
-	"DEFAULT_KBFS":    10,
-	"KBFS_CHAT":       11,
+	"UNSET":             0,
+	"CHAT_CLI":          1,
+	"CHAT_GUI":          2,
+	"CHAT_GUI_STRICT":   3,
+	"KBFS_REKEY":        4,
+	"KBFS_QR":           5,
+	"CHAT_SKIP":         6,
+	"SALTPACK":          7,
+	"CLI":               8,
+	"GUI":               9,
+	"DEFAULT_KBFS":      10,
+	"KBFS_CHAT":         11,
+	"RESOLVE_AND_CHECK": 12,
 }
 
 var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
@@ -55,6 +57,7 @@ var TLFIdentifyBehaviorRevMap = map[TLFIdentifyBehavior]string{
 	9:  "GUI",
 	10: "DEFAULT_KBFS",
 	11: "KBFS_CHAT",
+	12: "RESOLVE_AND_CHECK",
 }
 
 func (e TLFIdentifyBehavior) String() string {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -250,10 +250,10 @@
 			"revisionTime": "2018-05-19T05:29:12Z"
 		},
 		{
-			"checksumSHA1": "FNhA8KkG0O/4ZT4HvoduUBZ1ltc=",
+			"checksumSHA1": "OQ0X0kfqwS5shixPFnsmS3dryUY=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "1ff71e786dfc6527cd3df697f2f8a6cce6cb6f79",
-			"revisionTime": "2018-07-20T00:46:05Z"
+			"revision": "3d50fa88dc57347a6e4c62ce67186619a29f16c3",
+			"revisionTime": "2018-07-25T01:58:34Z"
 		},
 		{
 			"checksumSHA1": "X5Xf9+Z7OkhIQiaPB+ILw4xzkag=",


### PR DESCRIPTION
This uses keybase/client#12957 -- it should be reviewed and merged first.  CircleCI will break until then.

This PR also adds support for custom branch names to `libfs.NewFS`.

Issue: KBFS-3206