### PR TITLE
identify_util: don't require that i-team names match

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -213,7 +213,10 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 			return err
 		}
 	}
-	if resultName != name {
+	// The names of implicit teams can change out from under us,
+	// unlike for regular users, so don't require that they remain the
+	// same.
+	if resultName != name && !isImplicit {
 		return fmt.Errorf("Identify returned name=%s, expected %s",
 			resultName, name)
 	}


### PR DESCRIPTION
An implicit team name can change (due to SBS resolution) between when we start an identify and when we get the result back.  I guess something changed in the timing of our tests recently to make this likely.

(This should fix the `TestSBSMultipleResolutions` flake.)