### PR TITLE
[KBFS-3240] Fix windows uploads

### DIFF
--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -869,6 +869,7 @@ func (k *SimpleFS) doCopyFromSource(
 
 	src, err := srcFS.Open(srcFI.Name())
 	if err != nil {
+		k.log.CDebugf(ctx, "Failed to open file: %s, root: %s", srcFI.Name(), srcFS.Root())
 		return err
 	}
 	defer src.Close()

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -893,10 +893,12 @@ func (k *SimpleFS) doCopy(
 	srcPath, destPath keybase1.Path) (err error) {
 	// Note this is also used by move, so if this changes update SimpleFSMove
 	// code also.
+	k.log.CDebugf(ctx, "Opening file: %s", srcPath)
 	srcFS, finalSrcElem, err := k.getFS(ctx, srcPath)
 	if err != nil {
 		return err
 	}
+	k.log.CDebugf(ctx, "Opened file: %s, root: %s", finalSrcElem, srcFS.Root())
 	srcFI, err := srcFS.Stat(finalSrcElem)
 	if err != nil {
 		return err

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -251,8 +251,6 @@ func (k *SimpleFS) getFS(ctx context.Context, path keybase1.Path) (
 		}
 		return fs, finalElem, nil
 	case keybase1.PathType_LOCAL:
-		dir := filepath.Dir(path.Local())
-		k.log.CDebugf(ctx, "getting FS for local path in directory: %s", dir)
 		fs = osfs.New(filepath.Dir(path.Local()))
 		return fs, filepath.Base(path.Local()), nil
 	default:
@@ -900,12 +898,10 @@ func (k *SimpleFS) doCopy(
 	if err != nil {
 		return err
 	}
-	k.log.CDebugf(ctx, "Opened file: %s, root: %s", finalSrcElem, srcFS.Root())
 	srcFI, err := srcFS.Stat(finalSrcElem)
 	if err != nil {
 		return err
 	}
-	k.log.CDebugf(ctx, "srcFI: %s", srcFI.Name())
 	if srcFI.IsDir() {
 		// The byte count for making a single directory is meaningless.
 		k.setProgressTotals(opID, 0, 1)

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -250,6 +250,8 @@ func (k *SimpleFS) getFS(ctx context.Context, path keybase1.Path) (
 		}
 		return fs, finalElem, nil
 	case keybase1.PathType_LOCAL:
+		dir := stdpath.Dir(path.Local())
+		k.log.CDebugf(ctx, "getting FS for local path in directory: %s", dir)
 		fs = osfs.New(stdpath.Dir(path.Local()))
 		return fs, stdpath.Base(path.Local()), nil
 	default:
@@ -893,7 +895,7 @@ func (k *SimpleFS) doCopy(
 	srcPath, destPath keybase1.Path) (err error) {
 	// Note this is also used by move, so if this changes update SimpleFSMove
 	// code also.
-	k.log.CDebugf(ctx, "Opening file: %s", srcPath)
+	k.log.CDebugf(ctx, "Opening file: %s", srcPath.Local())
 	srcFS, finalSrcElem, err := k.getFS(ctx, srcPath)
 	if err != nil {
 		return err
@@ -903,6 +905,7 @@ func (k *SimpleFS) doCopy(
 	if err != nil {
 		return err
 	}
+	k.log.CDebugf(ctx, "srcFI: %s", srcFI.Name())
 	if srcFI.IsDir() {
 		// The byte count for making a single directory is meaningless.
 		k.setProgressTotals(opID, 0, 1)

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -9,7 +9,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	stdpath "path/filepath"
+	stdpath "path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -250,10 +251,10 @@ func (k *SimpleFS) getFS(ctx context.Context, path keybase1.Path) (
 		}
 		return fs, finalElem, nil
 	case keybase1.PathType_LOCAL:
-		dir := stdpath.Dir(path.Local())
+		dir := filepath.Dir(path.Local())
 		k.log.CDebugf(ctx, "getting FS for local path in directory: %s", dir)
-		fs = osfs.New(stdpath.Dir(path.Local()))
-		return fs, stdpath.Base(path.Local()), nil
+		fs = osfs.New(filepath.Dir(path.Local()))
+		return fs, filepath.Base(path.Local()), nil
 	default:
 		return nil, "", simpleFSError{"Invalid path type"}
 	}
@@ -895,7 +896,6 @@ func (k *SimpleFS) doCopy(
 	srcPath, destPath keybase1.Path) (err error) {
 	// Note this is also used by move, so if this changes update SimpleFSMove
 	// code also.
-	k.log.CDebugf(ctx, "Opening file: %s", srcPath.Local())
 	srcFS, finalSrcElem, err := k.getFS(ctx, srcPath)
 	if err != nil {
 		return err
@@ -931,7 +931,7 @@ type pathPair struct {
 
 func pathAppend(p keybase1.Path, leaf string) keybase1.Path {
 	if p.Local__ != nil {
-		var s = stdpath.Join(*p.Local__, leaf)
+		var s = filepath.Join(*p.Local__, leaf)
 		p.Local__ = &s
 	} else if p.Kbfs__ != nil {
 		var s = stdpath.Join(*p.Kbfs__, leaf)

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	stdpath "path"
+	stdpath "path/filepath"
 	"strings"
 	"sync"
 	"time"


### PR DESCRIPTION
Local paths need to be manipulated using the `path/filepath` package, not the `path` package.