### PR TITLE
libfuse/libdokan: file for by-relative-time archives

### DIFF
--- a/libdokan/archive_reltime_file.go
+++ b/libdokan/archive_reltime_file.go
@@ -1,0 +1,34 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libdokan
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// NewArchiveRelTimeFile returns a special read file that contains a
+// text representation of the global KBFS status.
+func NewArchiveRelTimeFile(
+	fs *FS, handle *libkbfs.TlfHandle, filename string) *SpecialReadFile {
+	return &SpecialReadFile{
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			data, isRel, err := libfs.FileDataFromRelativeTimeString(
+				ctx, fs.config, handle, filename)
+			if err != nil {
+				return nil, time.Time{}, err
+			}
+			if !isRel {
+				panic("ArchiveRelTimeFile should only be used with " +
+					"reltime file names")
+			}
+			return data, time.Time{}, nil
+		},
+		fs: fs,
+	}
+}

--- a/libdokan/archive_reltime_file.go
+++ b/libdokan/archive_reltime_file.go
@@ -13,7 +13,8 @@ import (
 )
 
 // NewArchiveRelTimeFile returns a special read file that contains a
-// text representation of the global KBFS status.
+// by-revision directory name that corresponds to the given relative
+// time string for the given folder.
 func NewArchiveRelTimeFile(
 	fs *FS, handle *libkbfs.TlfHandle, filename string) *SpecialReadFile {
 	return &SpecialReadFile{

--- a/libdokan/tlf.go
+++ b/libdokan/tlf.go
@@ -222,6 +222,16 @@ func (tlf *TLF) open(ctx context.Context, oc *openContext, path []string) (
 		return tlf.open(ctx, oc, path)
 	}
 
+	_, isRelTimeLink, err := libfs.FileDataFromRelativeTimeString(
+		ctx, tlf.folder.fs.config, tlf.folder.h, path[0])
+	if err != nil {
+		return nil, 0, err
+	}
+	if isRelTimeLink {
+		return NewArchiveRelTimeFile(tlf.folder.fs, tlf.folder.h, path[0]),
+			dokan.ExistingFile, nil
+	}
+
 	return dir.open(ctx, oc, path)
 }
 

--- a/libfs/constants.go
+++ b/libfs/constants.go
@@ -112,3 +112,8 @@ const ArchivedRevDirPrefix = ".kbfs_archived_rev="
 // ArchivedTimeLinkPrefix is the prefix to the symlink at the root of a
 // TLF that links to a version of that TLF at the specified time.
 const ArchivedTimeLinkPrefix = ".kbfs_archived_time="
+
+// ArchivedRelTimeFilePrefix is the prefix to the file at the root of
+// a TLF that contains the directory name of an archived revision
+// described by the given relative time.
+const ArchivedRelTimeFilePrefix = ".kbfs_archived_reltime="

--- a/libfuse/archive_reltime_file.go
+++ b/libfuse/archive_reltime_file.go
@@ -13,7 +13,8 @@ import (
 )
 
 // NewArchiveRelTimeFile returns a special read file that contains a
-// text representation of the global KBFS status.
+// by-revision directory name that corresponds to the given relative
+// time string for the given folder.
 func NewArchiveRelTimeFile(
 	fs *FS, handle *libkbfs.TlfHandle, filename string,
 	entryValid *time.Duration) *SpecialReadFile {

--- a/libfuse/archive_reltime_file.go
+++ b/libfuse/archive_reltime_file.go
@@ -1,0 +1,35 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libfuse
+
+import (
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"golang.org/x/net/context"
+)
+
+// NewArchiveRelTimeFile returns a special read file that contains a
+// text representation of the global KBFS status.
+func NewArchiveRelTimeFile(
+	fs *FS, handle *libkbfs.TlfHandle, filename string,
+	entryValid *time.Duration) *SpecialReadFile {
+	*entryValid = 0
+	return &SpecialReadFile{
+		read: func(ctx context.Context) ([]byte, time.Time, error) {
+			data, isRel, err := libfs.FileDataFromRelativeTimeString(
+				ctx, fs.config, handle, filename)
+			if err != nil {
+				return nil, time.Time{}, err
+			}
+			if !isRel {
+				panic("ArchiveRelTimeFile should only be used with " +
+					"reltime file names")
+			}
+			return data, time.Time{}, nil
+		},
+	}
+}

--- a/libfuse/tlf.go
+++ b/libfuse/tlf.go
@@ -224,6 +224,16 @@ func (tlf *TLF) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.
 		}, nil
 	}
 
+	_, isRelTimeLink, err := libfs.FileDataFromRelativeTimeString(
+		ctx, tlf.folder.fs.config, tlf.folder.h, req.Name)
+	if err != nil {
+		return nil, err
+	}
+	if isRelTimeLink {
+		return NewArchiveRelTimeFile(
+			tlf.folder.fs, tlf.folder.h, req.Name, &resp.EntryValid), nil
+	}
+
 	return dir.Lookup(ctx, req, resp)
 }
 

--- a/test/archive_test.go
+++ b/test/archive_test.go
@@ -37,7 +37,7 @@ func TestArchiveByRevision(t *testing.T) {
 }
 
 func TestArchiveByTime(t *testing.T) {
-	// The start time of the test is 1970-01-01 00:00:00 +0000 UTC.
+	// The start time of the test is 1970-01-01 00:00:01 +0000 UTC.
 	rev1checks := []optionOp{
 		as(alice,
 			lsdir("", m{}),
@@ -92,7 +92,7 @@ func TestArchiveByTime(t *testing.T) {
 }
 
 func TestArchiveByTimeWithColons(t *testing.T) {
-	// The start time of the test is 1970-01-01 00:00:00 +0000 UTC.
+	// The start time of the test is 1970-01-01 00:00:01 +0000 UTC.
 	rev1checks := []optionOp{
 		as(alice,
 			lsdir("", m{}),
@@ -137,6 +137,69 @@ func TestArchiveByTimeWithColons(t *testing.T) {
 		rev2checks[0], rev2checks[1],
 
 		inPrivateTlfAtTime("alice,bob", "Tue Jan  2 15:04:05 2018"),
+		rev2checks[0], rev2checks[1],
+	)
+}
+
+func TestArchiveByRelativeTime(t *testing.T) {
+	// The start time of the test is 1970-01-01 00:00:01 +0000 UTC.
+	rev1checks := []optionOp{
+		as(alice,
+			lsdir("", m{}),
+		),
+		as(bob,
+			lsdir("", m{}),
+		),
+	}
+
+	rev2checks := []optionOp{
+		as(alice,
+			lsdir("", m{"a$": "DIR"}),
+			lsdir("a", m{}),
+		),
+		as(bob,
+			lsdir("", m{"a$": "DIR"}),
+			lsdir("a", m{}),
+		),
+	}
+
+	test(t,
+		users("alice", "bob"),
+
+		inPrivateTlf("alice,bob"),
+		rev1checks[0], rev1checks[1],
+		as(alice,
+			addTime(365*24*time.Hour),
+			mkdir("a"),
+		),
+		rev2checks[0], rev2checks[1],
+
+		as(alice,
+			addTime(30*time.Second),
+		),
+
+		// Try various formats for the first revision.
+		inPrivateTlfAtRelativeTime("alice,bob", "1h"),
+		rev1checks[0], rev1checks[1],
+
+		inPrivateTlfAtRelativeTime("alice,bob", "3600s"),
+		rev1checks[0], rev1checks[1],
+
+		inPrivateTlfAtRelativeTime("alice,bob", "5h55m"),
+		rev1checks[0], rev1checks[1],
+
+		// Now the second revision.
+		inPrivateTlfAtRelativeTime("alice,bob", "1s"),
+		rev2checks[0], rev2checks[1],
+
+		inPrivateTlfAtRelativeTime("alice,bob", "15s"),
+		rev2checks[0], rev2checks[1],
+
+		// Make sure the relative time adjusts with the clock.
+		as(alice,
+			addTime(1*time.Hour),
+		),
+		inPrivateTlfAtRelativeTime("alice,bob", "1h"),
 		rev2checks[0], rev2checks[1],
 	)
 }

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -43,6 +43,7 @@ type opt struct {
 	tlfType                  tlf.Type
 	tlfRevision              kbfsmd.Revision
 	tlfTime                  string
+	tlfRelTime               string
 	users                    map[libkb.NormalizedUsername]User
 	stallers                 map[libkb.NormalizedUsername]*libkbfs.NaïveStaller
 	tb                       testing.TB
@@ -340,6 +341,15 @@ func inPrivateTlfAtTime(name string, timeString string) optionOp {
 	}
 }
 
+func inPrivateTlfAtRelativeTime(name string, relTimeString string) optionOp {
+	return func(o *opt) {
+		o.tlfName = name
+		o.expectedCanonicalTlfName = name
+		o.tlfType = tlf.Private
+		o.tlfRelTime = relTimeString
+	}
+}
+
 func inPrivateTlfNonCanonical(name, expectedCanonicalName string) optionOp {
 	return func(o *opt) {
 		o.tlfName = name
@@ -536,6 +546,10 @@ func initRoot() fileOp {
 		} else if c.tlfTime != "" {
 			root, err = c.engine.GetRootDirAtTimeString(
 				c.user, c.tlfName, c.tlfType, c.tlfTime,
+				c.expectedCanonicalTlfName)
+		} else if c.tlfRelTime != "" {
+			root, err = c.engine.GetRootDirAtRelTimeString(
+				c.user, c.tlfName, c.tlfType, c.tlfRelTime,
 				c.expectedCanonicalTlfName)
 		} else {
 			root, err = c.engine.GetRootDir(

--- a/test/engine.go
+++ b/test/engine.go
@@ -64,11 +64,17 @@ type Engine interface {
 	GetRootDirAtRevision(
 		u User, tlfName string, t tlf.Type, rev kbfsmd.Revision,
 		expectedCanonicalTlfName string) (dir Node, err error)
-	// GetRootDirAtTime is called by the test harness to get a
+	// GetRootDirAtTimeString is called by the test harness to get a
 	// handle to an archived TLF from the given user's perspective, at
 	// a given time.
 	GetRootDirAtTimeString(
 		u User, tlfName string, t tlf.Type, timeString string,
+		expectedCanonicalTlfName string) (dir Node, err error)
+	// GetRootDirAtRelTimeString is called by the test harness to get
+	// a handle to an archived TLF from the given user's perspective,
+	// at a given relative time from now.
+	GetRootDirAtRelTimeString(
+		u User, tlfName string, t tlf.Type, relTimeString string,
 		expectedCanonicalTlfName string) (dir Node, err error)
 	// CreateDir is called by the test harness to create a directory relative to the passed
 	// parent directory for the given user.

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -175,6 +175,24 @@ func (e *fsEngine) GetRootDirAtTimeString(
 	return fsNode{filepath.Join(p.path, timeLink)}, nil
 }
 
+// GetRootDirAtRelTimeString implements the Engine interface.
+func (e *fsEngine) GetRootDirAtRelTimeString(
+	u User, tlfName string, t tlf.Type, relTimeString string,
+	expectedCanonicalTlfName string) (dir Node, err error) {
+	d, err := e.GetRootDir(u, tlfName, t, expectedCanonicalTlfName)
+	if err != nil {
+		return nil, err
+	}
+	p := d.(fsNode)
+	fileName := libfs.ArchivedRelTimeFilePrefix + relTimeString
+	revDir, err := ioutil.ReadFile(filepath.Join(p.path, fileName))
+	if err != nil {
+		return nil, err
+	}
+
+	return fsNode{filepath.Join(p.path, string(revDir))}, nil
+}
+
 // CreateDir is called by the test harness to create a directory relative to the passed
 // parent directory for the given user.
 func (*fsEngine) CreateDir(u User, parentDir Node, name string) (dir Node, err error) {

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -308,6 +308,27 @@ func (k *LibKBFS) GetRootDirAtTimeString(
 		u, tlfName, t, libkbfs.MakeRevBranchName(rev), expectedCanonicalTlfName)
 }
 
+// GetRootDirAtRelTimeString implements the Engine interface.
+func (k *LibKBFS) GetRootDirAtRelTimeString(
+	u User, tlfName string, t tlf.Type, relTimeString string,
+	expectedCanonicalTlfName string) (dir Node, err error) {
+	config := u.(*libkbfs.ConfigLocal)
+	ctx, cancel := k.newContext(u)
+	defer cancel()
+	h, err := parseTlfHandle(ctx, config.KBPKI(), config.MDOps(), tlfName, t)
+	if err != nil {
+		return nil, err
+	}
+
+	rev, err := libfs.RevFromRelativeTimeString(ctx, config, h, relTimeString)
+	if err != nil {
+		return nil, err
+	}
+
+	return k.getRootDir(
+		u, tlfName, t, libkbfs.MakeRevBranchName(rev), expectedCanonicalTlfName)
+}
+
 // CreateDir implements the Engine interface.
 func (k *LibKBFS) CreateDir(u User, parentDir Node, name string) (dir Node, err error) {
 	config := u.(*libkbfs.ConfigLocal)


### PR DESCRIPTION
This depends on #1707, and won't pass circle until keybase/client#12850 is merged.

This adds support for a file like `.kbfs_archived_reltime=5m` at the root of a TLF, that will contain the name of the by-revision archive directory name, corresponding to a revision of the TLF that was live at the given relative time (e.g., 5 minutes ago, in the example).

It's a file, rather than a symlink, because if it were a symlink it would form a non-universal path that you wouldn't be able to send to other users or save for later use, without risking changing the revision you are pointing to.

The relative time is any string that can be parsed by `time.ParseDuration`.

Issue: KBFS-3211
