### PR TITLE
simplefs: support by-rel-time archive paths

### DIFF
--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -227,6 +227,14 @@ func (k *SimpleFS) branchNameFromPath(
 				return "", err
 			}
 			return libkbfs.MakeRevBranchName(rev), nil
+		case keybase1.KBFSArchivedType_REL_TIME_STRING:
+			t := archivedParam.RelTimeString()
+			rev, err := libfs.RevFromRelativeTimeString(
+				ctx, k.config, tlfHandle, t)
+			if err != nil {
+				return "", err
+			}
+			return libkbfs.MakeRevBranchName(rev), nil
 		default:
 			return "", simpleFSError{"Invalid archived type for branch name"}
 		}

--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -324,6 +324,23 @@ func TestList(t *testing.T) {
 				rev1Time.String()),
 		})
 	checkArchived(pathArchivedTimeString, 0)
+
+	pathArchivedRelTimeString := keybase1.NewPathWithKbfsArchived(
+		keybase1.KBFSArchivedPath{
+			Path: `/private/jdoe`,
+			ArchivedParam: keybase1.NewKBFSArchivedParamWithRelTimeString(
+				"45s"),
+		})
+	checkArchived(pathArchivedRelTimeString, 0)
+
+	clock.Add(1 * time.Minute)
+	pathArchivedRelTimeString = keybase1.NewPathWithKbfsArchived(
+		keybase1.KBFSArchivedPath{
+			Path: `/private/jdoe`,
+			ArchivedParam: keybase1.NewKBFSArchivedParamWithRelTimeString(
+				"45s"),
+		})
+	checkArchived(pathArchivedRelTimeString, 1)
 }
 
 func TestListRecursive(t *testing.T) {


### PR DESCRIPTION
Depends on keybase/client#13025 and #1709.

Issue: KBFS-3212