### PR TITLE
libfs: better time parsing

### DIFF
--- a/libfs/archive_util.go
+++ b/libfs/archive_util.go
@@ -38,13 +38,7 @@ func BranchNameFromArchiveRefDir(dir string) (libkbfs.BranchName, bool) {
 func RevFromTimeString(
 	ctx context.Context, config libkbfs.Config, h *libkbfs.TlfHandle,
 	timeString string) (kbfsmd.Revision, error) {
-	// BUG: it looks like `dateparse` has trouble understanding some
-	// time zones, it seems to ignore things like "PDT" and "EST".  I
-	// filed https://github.com/araddon/dateparse/issues/68 about it.
-	// TODO: revert this back to `ParseAny` once the above issue is
-	// fixed, so that links are universally-shareable again when they
-	// contain time zones.
-	t, err := dateparse.ParseLocal(timeString)
+	t, err := dateparse.ParseAny(timeString)
 	if err != nil {
 		return kbfsmd.RevisionUninitialized, err
 	}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -982,7 +982,17 @@ func (md *MDOpsStandard) GetForTLF(
 // GetForTLFByTime implements the MDOps interface for MDOpsStandard.
 func (md *MDOpsStandard) GetForTLFByTime(
 	ctx context.Context, id tlf.ID, serverTime time.Time) (
-	ImmutableRootMetadata, error) {
+	irmd ImmutableRootMetadata, err error) {
+	md.log.CDebugf(ctx, "GetForTLFByTime %s %s", id, serverTime)
+	defer func() {
+		if err == nil {
+			md.log.CDebugf(ctx, "GetForTLFByTime %s %s done: %d",
+				id, serverTime, irmd.Revision())
+		} else {
+			md.log.CDebugf(ctx, "GetForTLFByTime %s %s done: %+v",
+				id, serverTime, err)
+		}
+	}()
 	rmds, err := md.config.MDServer().GetForTLFByTime(ctx, id, serverTime)
 	if err != nil {
 		return ImmutableRootMetadata{}, err

--- a/vendor/github.com/araddon/dateparse/parseany.go
+++ b/vendor/github.com/araddon/dateparse/parseany.go
@@ -1072,6 +1072,12 @@ iterRunes:
 					p.offseti = i
 				case ' ':
 					// 17:57:51 MST 2009
+					p.tzlen = i - p.tzi
+					if p.tzlen == 4 {
+						p.set(p.tzi, " MST")
+					} else if p.tzlen == 3 {
+						p.set(p.tzi, "MST")
+					}
 					p.stateTime = timeWsAlphaWs
 					p.yeari = i + 1
 				}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -48,10 +48,10 @@
 			"revisionTime": "2016-03-16T16:25:20-04:00"
 		},
 		{
-			"checksumSHA1": "JjYwz7jPth9BbFVVgSl6s7RPs9o=",
+			"checksumSHA1": "bxtrVQB+698clLEGq7PppnWfXJk=",
 			"path": "github.com/araddon/dateparse",
-			"revision": "42dbd9f872ebcc2d9bb8a5bf541984c9e1e50f8e",
-			"revisionTime": "2018-07-22T19:56:01Z"
+			"revision": "cfd92a431d0efe36a1b81ca25d15b98aae4dbdb6",
+			"revisionTime": "2018-07-29T17:48:19Z"
 		},
 		{
 			"path": "github.com/bitly/go-simplejson",


### PR DESCRIPTION
Revendor dateparse now that araddon/dateparse#68 is fixed, and switch back to using `ParseAny` since it uses the provided timezone correctly now.

Also add some logging so we can easily see what time was used and what revision was returned.
