### PR TITLE
prev_revisions: avoid panic when squashing all revisions in list

### DIFF
--- a/libkbfs/prev_revisions.go
+++ b/libkbfs/prev_revisions.go
@@ -103,6 +103,10 @@ func (pr PrevRevisions) addRevision(
 	//
 	// ret = [25, 15, 0, 0]
 	if earliestGoodSlot > 0 {
+		if earliestGoodSlot == len(ret) {
+			// Always leave at least one empty slot.
+			earliestGoodSlot--
+		}
 		ret = ret[earliestGoodSlot:]
 	}
 

--- a/libkbfs/prev_revisions_test.go
+++ b/libkbfs/prev_revisions_test.go
@@ -86,4 +86,14 @@ func TestPrevRevisions(t *testing.T) {
 	pr = pr.addRevision(rev, gcRev)
 	require.Len(t, pr, 1)
 	checkRevRevisions(t, pr, gcRev, rev, i+1)
+
+	t.Log("Fill it up again")
+	for j := kbfsmd.Revision(1); j < 5; j++ {
+		pr = pr.addRevision(rev+j, gcRev)
+	}
+
+	t.Log("A lower revision number wipes everything out")
+	rev = kbfsmd.Revision(rev - 1)
+	pr = pr.addRevision(rev, gcRev)
+	require.Len(t, pr, 1)
 }


### PR DESCRIPTION
If the prev revisions list is full of revision numbers that are less than the new number `r`, we were clearing out the entire list without leaving an extra slot.  I think this can happen when squashing many journal revisions together into one, where the squashed one has a equal or lower revision number than the others.

Issue: keybase/client#12174