### PR TITLE
simplefs: `GetRevisions` should try to include oldest revision

### DIFF
--- a/simplefs/simplefs_test.go
+++ b/simplefs/simplefs_test.go
@@ -984,7 +984,6 @@ func TestGetRevisions(t *testing.T) {
 		numExpected, newestRev int, spanType keybase1.RevisionSpanType) {
 		res := getRevisions(spanType)
 		require.Len(t, res.Revisions, numExpected)
-		t.Log(res.Revisions)
 
 		// Default should get the most recent one, and then the 4
 		// earliest ones, while LAST_FIVE should get the last five.


### PR DESCRIPTION
When a revision is garbage-collected, all of the blocks live at the time of the GC are, of course, still alive.  So any version of a file alive at the time of the last GC is still accesible.

However, the previous revisions list drops any revisions numbers that are less than or equal to the revision number that was last GC'd.  It does this for simplicity, because it is hard to figure out, because without a full TLF history/skiplist scan it's hard to figure out if the revision was deleted before or after that GC'd revision. Unfortunately, this meant the `GetRevisions` code might not return all the available revisions, since the oldest one might be missing from the previous revisions list.

Instead, have `GetRevisions` check the revision _before_ the oldest revision in the list, in case it survived the garbage collection and can still be accessed.

Issue: KBFS-3281