### PR TITLE
don't automatically add favorites in SimpleFS operations

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -705,6 +705,27 @@ const (
 	FavoritesOpNoChange
 )
 
+func (o FavoritesOp) String() string {
+	switch o {
+	case FavoritesOpAdd:
+		return "Add"
+	case FavoritesOpAddNewlyCreated:
+		return "AddNewlyCreated"
+	case FavoritesOpRemove:
+		return "Remove"
+	case FavoritesOpNoChange:
+		return "NoChange"
+	default:
+		return "Unknown"
+	}
+}
+
+// CtxKeyFavoritesOp is the context key which when present, controls whether an
+// operation should result in adding a TLF into favorites. Explicit favorites
+// related calls (e.g. AddFavorite and DeleteFavorite) are not affected by
+// this.
+type CtxKeyFavoritesOp struct{}
+
 // RekeyResult represents the result of an rekey operation.
 type RekeyResult struct {
 	DidRekey      bool

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -72,6 +72,9 @@ type newFSFunc func(
 func defaultNewFS(ctx context.Context, config libkbfs.Config,
 	tlfHandle *libkbfs.TlfHandle, branch libkbfs.BranchName, subdir string) (
 	billy.Filesystem, error) {
+	// Prevent from automatically adding favorites in all simpleFS operations.
+	ctx = context.WithValue(ctx,
+		libkbfs.CtxKeyFavoritesOp{}, libkbfs.FavoritesOpNoChange)
 	return libfs.NewFS(
 		ctx, config, tlfHandle, branch, subdir, "", keybase1.MDPriorityNormal)
 }


### PR DESCRIPTION
This would affect `keybase fs` too, but as John suggested we can just add `keybase fs favorites add/ignore`.