### PR TITLE
kbfs_ops: fix log message, all team types get TLF IDs

### DIFF
--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -424,7 +424,7 @@ func (fs *KBFSOpsStandard) createAndStoreTlfIDIfNeeded(
 		return err
 	}
 
-	fs.log.CDebugf(ctx, "Creating new TLF ID %s for implicit team %s, %s",
+	fs.log.CDebugf(ctx, "Creating new TLF ID %s for team %s, %s",
 		tlfID, teamID, h.GetCanonicalName())
 
 	err = fs.config.KBPKI().CreateTeamTLF(ctx, teamID, tlfID)


### PR DESCRIPTION
Suggested by jzila.

Issue: KBFS-3307