### PR TITLE
keybase_service_base: avoid errors when merkle tree is too old

### DIFF
--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -616,10 +616,13 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 						Prev: info.MerkleRoot,
 					})
 			}
-			if err != nil {
+			if m, ok := err.(libkb.MerkleClientError); ok && m.IsOldTree() {
+				k.log.CDebugf(ctx, "Merkle root is too old for checking "+
+					"the revoked key: %+v", err)
+				info.MerkleRoot.Seqno = 0
+			} else if err != nil {
 				return UserInfo{}, false, err
-			}
-			if res.Res != nil {
+			} else if res.Res != nil {
 				info.MerkleRoot = *res.Res
 			}
 		}

--- a/vendor/github.com/keybase/client/go/libkb/all_provisioned_usernames.go
+++ b/vendor/github.com/keybase/client/go/libkb/all_provisioned_usernames.go
@@ -18,6 +18,9 @@ func getUsernameIfProvisioned(m MetaContext, uc UserConfig) (ret NormalizedUsern
 	case KeyRevokedError:
 		m.CDebugf("- device was revoked (s)", err)
 		return ret, nil
+	case UserDeletedError:
+		m.CDebugf(" - user was deleted (%s)", err)
+		return ret, nil
 	default:
 		m.CDebugf("- unexpected error; propagating (%s)", err)
 		return ret, err

--- a/vendor/github.com/keybase/client/go/libkb/api.go
+++ b/vendor/github.com/keybase/client/go/libkb/api.go
@@ -244,12 +244,15 @@ func getNIST(m MetaContext, sessType APISessionType) *NIST {
 // needed. This finisher is always non-nil (and just a noop in some cases),
 // so therefore it's fine to call it without checking for nil-ness.
 func doRequestShared(m MetaContext, api Requester, arg APIArg, req *http.Request, wantJSONRes bool) (_ *http.Response, finisher func(), jw *jsonw.Wrapper, err error) {
+	m = m.EnsureCtx().WithLogTag("API")
+	defer m.CTraceTimed("api.doRequestShared", func() error { return err })()
+	m, tbs := m.WithTimeBuckets()
+	defer tbs.Record("API.request")() // note this doesn't include time reading body from GetResp
+
 	if !m.G().Env.GetTorMode().UseSession() && arg.SessionType == APISessionTypeREQUIRED {
 		err = TorSessionRequiredError{}
 		return
 	}
-
-	m = m.EnsureCtx().WithLogTag("API")
 
 	finisher = noopFinisher
 
@@ -699,6 +702,7 @@ func (a *InternalAPIEngine) GetResp(arg APIArg) (*http.Response, func(), error) 
 // JSON into the value pointed to by v.
 func (a *InternalAPIEngine) GetDecode(arg APIArg, v APIResponseWrapper) error {
 	m := arg.GetMetaContext(a.G())
+	m = m.EnsureCtx().WithLogTag("API")
 	return a.getDecode(m, arg, v)
 }
 
@@ -770,6 +774,7 @@ func (a *InternalAPIEngine) postResp(m MetaContext, arg APIArg) (*http.Response,
 
 func (a *InternalAPIEngine) PostDecode(arg APIArg, v APIResponseWrapper) error {
 	m := arg.GetMetaContext(a.G())
+	m = m.EnsureCtx().WithLogTag("API")
 	return a.postDecode(m, arg, v)
 }
 
@@ -816,7 +821,6 @@ func (a *InternalAPIEngine) DoRequest(arg APIArg, req *http.Request) (*APIRes, e
 
 func (a *InternalAPIEngine) doRequest(m MetaContext, arg APIArg, req *http.Request) (res *APIRes, err error) {
 	m = m.EnsureCtx().WithLogTag("API")
-	defer a.G().CTraceTimed(m.Ctx(), "InternalAPIEngine#doRequest", func() error { return err })()
 	resp, finisher, jw, err := doRequestShared(m, a, arg, req, true)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/keybase/client/go/libkb/connmgr.go
+++ b/vendor/github.com/keybase/client/go/libkb/connmgr.go
@@ -130,6 +130,7 @@ func (c *ConnectionManager) WaitForClientType(clientType keybase1.ClientType, ti
 		return true
 	}
 	ticker := time.NewTicker(time.Second)
+	deadline := time.After(timeout)
 	defer ticker.Stop()
 	for {
 		select {
@@ -137,7 +138,7 @@ func (c *ConnectionManager) WaitForClientType(clientType keybase1.ClientType, ti
 			if c.hasClientType(clientType) {
 				return true
 			}
-		case <-time.After(timeout):
+		case <-deadline:
 			return false
 		}
 	}

--- a/vendor/github.com/keybase/client/go/libkb/context.go
+++ b/vendor/github.com/keybase/client/go/libkb/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keybase/client/go/profiling"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
 )
@@ -72,6 +73,9 @@ func (m MetaContext) CTrace(msg string, f func() error) func() {
 
 func (m MetaContext) CVTrace(lev VDebugLevel, msg string, f func() error) func() {
 	return m.g.CVTrace(m.ctx, lev, msg, f)
+}
+func (m MetaContext) CVTraceOK(lev VDebugLevel, msg string, f func() bool) func() {
+	return m.g.CVTraceOK(m.ctx, lev, msg, f)
 }
 
 func (m MetaContext) VLogf(lev VDebugLevel, msg string, args ...interface{}) {
@@ -148,6 +152,12 @@ func (m MetaContext) WithLogTag(k string) MetaContext {
 	return m
 }
 
+func (m MetaContext) WithTimeBuckets() (MetaContext, *profiling.TimeBuckets) {
+	ctx, tbs := m.G().CTimeBuckets(m.ctx)
+	m.ctx = ctx
+	return m, tbs
+}
+
 func (m MetaContext) EnsureCtx() MetaContext {
 	if m.ctx == nil {
 		m.ctx = context.Background()
@@ -200,8 +210,8 @@ func (m MetaContext) WithActiveDevice(a *ActiveDevice) MetaContext {
 	return m
 }
 
-func (m MetaContext) WithPaperKeyActiveDevice(d *DeviceWithKeys, u keybase1.UID) MetaContext {
-	return m.WithActiveDevice(d.ToPaperKeyActiveDevice(m, u))
+func (m MetaContext) WithPaperKeyActiveDevice(d *DeviceWithKeys, uv keybase1.UserVersion) MetaContext {
+	return m.WithActiveDevice(d.ToPaperKeyActiveDevice(m, uv))
 }
 
 func (m MetaContext) WithGlobalActiveDevice() MetaContext {
@@ -222,12 +232,12 @@ func (m MetaContext) WithNewProvisionalLoginContext() MetaContext {
 }
 
 func (m MetaContext) WithNewProvisionalLoginContextForUser(u *User) MetaContext {
-	return m.WithNewProvisionalLoginContextForUIDAndUsername(u.GetUID(), u.GetNormalizedName())
+	return m.WithNewProvisionalLoginContextForUserVersionAndUsername(u.ToUserVersion(), u.GetNormalizedName())
 }
 
-func (m MetaContext) WithNewProvisionalLoginContextForUIDAndUsername(uid keybase1.UID, un NormalizedUsername) MetaContext {
-	plc := newProvisionalLoginContextWithUIDAndUsername(m, uid, un)
-	m.ActiveDevice().CopyCacheToLoginContextIfForUID(m, plc, uid)
+func (m MetaContext) WithNewProvisionalLoginContextForUserVersionAndUsername(uv keybase1.UserVersion, un NormalizedUsername) MetaContext {
+	plc := newProvisionalLoginContextWithUserVersionAndUsername(m, uv, un)
+	m.ActiveDevice().CopyCacheToLoginContextIfForUserVersion(m, plc, uv)
 	return m.WithLoginContext(plc)
 }
 
@@ -336,9 +346,9 @@ func (m MetaContext) switchUserNewConfig(u keybase1.UID, n NormalizedUsername, s
 
 // SwitchUserNewConfigActiveDevice creates a new config file stanza and an active device
 // for the given user, all while holding the switchUserMu lock.
-func (m MetaContext) SwitchUserNewConfigActiveDevice(u keybase1.UID, n NormalizedUsername, salt []byte, d keybase1.DeviceID, sigKey GenericKey, encKey GenericKey, deviceName string) error {
-	ad := NewProvisionalActiveDevice(m, u, d, sigKey, encKey, deviceName)
-	return m.switchUserNewConfig(u, n, salt, d, ad)
+func (m MetaContext) SwitchUserNewConfigActiveDevice(uv keybase1.UserVersion, n NormalizedUsername, salt []byte, d keybase1.DeviceID, sigKey GenericKey, encKey GenericKey, deviceName string) error {
+	ad := NewProvisionalActiveDevice(m, uv, d, sigKey, encKey, deviceName)
+	return m.switchUserNewConfig(uv.Uid, n, salt, d, ad)
 }
 
 // SwitchUserNukeConfig removes the given username from the config file, and then switches
@@ -362,7 +372,7 @@ func (m MetaContext) SwitchUserNukeConfig(n NormalizedUsername) error {
 		return err
 	}
 	if g.ActiveDevice.UID().Equal(uid) {
-		g.ActiveDevice.Clear(nil)
+		g.ActiveDevice.Clear()
 	}
 	return nil
 }
@@ -426,7 +436,7 @@ func (m MetaContext) SwitchUserDeprovisionNukeConfig(username NormalizedUsername
 // to one that corresponds to the given UID and DeviceWithKeys, and also sets the config
 // file to a temporary in-memory config (not writing to disk) to satisfy local requests for
 // g.Env.*
-func (m MetaContext) SwitchUserToActiveOneshotDevice(uid keybase1.UID, nun NormalizedUsername, d *DeviceWithKeys) (err error) {
+func (m MetaContext) SwitchUserToActiveOneshotDevice(uv keybase1.UserVersion, nun NormalizedUsername, d *DeviceWithKeys) (err error) {
 	defer m.CTrace("MetaContext#SwitchUserToActiveOneshotDevice", func() error { return err })()
 
 	g := m.G()
@@ -436,12 +446,12 @@ func (m MetaContext) SwitchUserToActiveOneshotDevice(uid keybase1.UID, nun Norma
 	if cw == nil {
 		return NoConfigWriterError{}
 	}
-	ad := d.ToPaperKeyActiveDevice(m, uid)
+	ad := d.ToPaperKeyActiveDevice(m, uv)
 	err = g.ActiveDevice.Copy(m, ad)
 	if err != nil {
 		return err
 	}
-	uc := NewOneshotUserConfig(uid, nun, nil, d.DeviceID())
+	uc := NewOneshotUserConfig(uv.Uid, nun, nil, d.DeviceID())
 	err = cw.SetUserConfig(uc, false)
 	if err != nil {
 		return err
@@ -460,7 +470,7 @@ func (m MetaContext) SwitchUserLoggedOut() (err error) {
 	if cw == nil {
 		return NoConfigWriterError{}
 	}
-	g.ActiveDevice.Clear(nil)
+	g.ActiveDevice.Clear()
 	err = cw.SetUserConfig(nil, false)
 	if err != nil {
 		return err
@@ -468,36 +478,36 @@ func (m MetaContext) SwitchUserLoggedOut() (err error) {
 	return nil
 }
 
-// SetActiveDevice sets the active device to have the UID, deviceID, sigKey, encKey and deviceName
+// SetActiveDevice sets the active device to have the UserVersion, deviceID, sigKey, encKey and deviceName
 // as specified, and does so while grabbing the global switchUser lock, since it should be sycnhronized
 // with attempts to switch the global logged in user. It does not, however, change the `current_user`
 // in the config file, or edit the global config file in any way.
-func (m MetaContext) SetActiveDevice(uid keybase1.UID, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
+func (m MetaContext) SetActiveDevice(uv keybase1.UserVersion, deviceID keybase1.DeviceID, sigKey, encKey GenericKey, deviceName string) error {
 	g := m.G()
 	g.switchUserMu.Lock()
 	defer g.switchUserMu.Unlock()
-	if !g.Env.GetUID().Equal(uid) {
+	if !g.Env.GetUID().Equal(uv.Uid) {
 		return NewUIDMismatchError("UID switched out from underneath provisioning process")
 	}
-	err := g.ActiveDevice.Set(m, uid, deviceID, sigKey, encKey, deviceName)
+	err := g.ActiveDevice.Set(m, uv, deviceID, sigKey, encKey, deviceName)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m MetaContext) SetSigningKey(uid keybase1.UID, deviceID keybase1.DeviceID, sigKey GenericKey, deviceName string) error {
+func (m MetaContext) SetSigningKey(uv keybase1.UserVersion, deviceID keybase1.DeviceID, sigKey GenericKey, deviceName string) error {
 	g := m.G()
 	g.switchUserMu.Lock()
 	defer g.switchUserMu.Unlock()
-	return g.ActiveDevice.setSigningKey(g, nil, uid, deviceID, sigKey, deviceName)
+	return g.ActiveDevice.setSigningKey(g, uv, deviceID, sigKey, deviceName)
 }
 
-func (m MetaContext) SetEncryptionKey(uid keybase1.UID, deviceID keybase1.DeviceID, encKey GenericKey) error {
+func (m MetaContext) SetEncryptionKey(uv keybase1.UserVersion, deviceID keybase1.DeviceID, encKey GenericKey) error {
 	g := m.G()
 	g.switchUserMu.Lock()
 	defer g.switchUserMu.Unlock()
-	return g.ActiveDevice.setEncryptionKey(nil, uid, deviceID, encKey)
+	return g.ActiveDevice.setEncryptionKey(uv, deviceID, encKey)
 }
 
 // LogoutAndDeprovisionIfRevoked loads the user and checks if the current
@@ -592,6 +602,13 @@ func (m MetaContext) CurrentUID() keybase1.UID {
 		return m.LoginContext().GetUID()
 	}
 	return m.ActiveDevice().UID()
+}
+
+func (m MetaContext) CurrentUserVersion() keybase1.UserVersion {
+	if m.LoginContext() != nil {
+		return m.LoginContext().GetUserVersion()
+	}
+	return m.ActiveDevice().UserVersion()
 }
 
 func (m MetaContext) HasAnySession() (ret bool) {

--- a/vendor/github.com/keybase/client/go/libkb/device_with_keys.go
+++ b/vendor/github.com/keybase/client/go/libkb/device_with_keys.go
@@ -108,6 +108,6 @@ func (d *DeviceWithKeys) Populate(m MetaContext) (uid keybase1.UID, err error) {
 	return res.UID, nil
 }
 
-func (d *DeviceWithKeys) ToPaperKeyActiveDevice(m MetaContext, u keybase1.UID) *ActiveDevice {
-	return NewPaperKeyActiveDevice(m, u, d)
+func (d *DeviceWithKeys) ToPaperKeyActiveDevice(m MetaContext, uv keybase1.UserVersion) *ActiveDevice {
+	return NewPaperKeyActiveDevice(m, uv, d)
 }

--- a/vendor/github.com/keybase/client/go/libkb/interfaces.go
+++ b/vendor/github.com/keybase/client/go/libkb/interfaces.go
@@ -791,12 +791,45 @@ type ChatHelper interface {
 // into UIDs. It is based on sever-trust. All results are unverified. So you should check
 // its answer if used in a security-sensitive setting. (See engine.ResolveAndCheck)
 type Resolver interface {
-	EnableCaching()
-	Shutdown()
-	ResolveFullExpression(ctx context.Context, input string) (res ResolveResult)
-	ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult)
-	ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult)
-	ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error)
-	ResolveWithBody(input string) ResolveResult
-	Resolve(input string) ResolveResult
+	EnableCaching(m MetaContext)
+	Shutdown(m MetaContext)
+	ResolveFullExpression(m MetaContext, input string) (res ResolveResult)
+	ResolveFullExpressionNeedUsername(m MetaContext, input string) (res ResolveResult)
+	ResolveFullExpressionWithBody(m MetaContext, input string) (res ResolveResult)
+	ResolveUser(m MetaContext, assertion string) (u keybase1.User, res ResolveResult, err error)
+	ResolveWithBody(m MetaContext, input string) ResolveResult
+	Resolve(m MetaContext, input string) ResolveResult
+	PurgeResolveCache(m MetaContext, input string) error
+}
+
+type EnginePrereqs struct {
+	TemporarySession bool
+	Device           bool
+}
+
+type Engine2 interface {
+	Run(MetaContext) error
+	Prereqs() EnginePrereqs
+	UIConsumer
+}
+
+type SaltpackRecipientKeyfinderEngineInterface interface {
+	Engine2
+	GetPublicKIDs() []keybase1.KID
+	GetSymmetricKeys() []SaltpackReceiverSymmetricKey
+}
+
+type SaltpackRecipientKeyfinderArg struct {
+	Recipients        []string // usernames or user assertions
+	TeamRecipients    []string // team names
+	NoSelfEncrypt     bool
+	UseEntityKeys     bool // Both per user and per team keys (and implicit teams for non existing users)
+	UsePaperKeys      bool
+	UseDeviceKeys     bool // Does not include Paper Keys
+	UseRepudiableAuth bool // This is needed as team keys (implicit or not) are not compatible with repudiable authentication, so we can error out.
+}
+
+type SaltpackReceiverSymmetricKey struct {
+	Key        [32]byte
+	Identifier []byte
 }

--- a/vendor/github.com/keybase/client/go/libkb/json.go
+++ b/vendor/github.com/keybase/client/go/libkb/json.go
@@ -81,16 +81,6 @@ func (f *JSONFile) Load(warnOnNotFound bool) error {
 	}
 	f.jw = jsonw.NewWrapper(obj)
 
-	if runtime.GOOS == "android" {
-		// marshal it into json without indents to make it one line
-		out, err := json.Marshal(obj)
-		if err != nil {
-			f.G().Log.Debug("JSONFile.Load: error marshaling decoded config obj: %s", err)
-		} else {
-			f.G().Log.Debug("JSONFile.Load: %s contents (marshaled): %s", f.filename, string(out))
-		}
-	}
-
 	f.G().Log.Debug("- successfully loaded %s file", f.which)
 	return nil
 }

--- a/vendor/github.com/keybase/client/go/libkb/kex2_router.go
+++ b/vendor/github.com/keybase/client/go/libkb/kex2_router.go
@@ -12,22 +12,25 @@ import (
 
 // KexRouter implements the kex2.MessageRouter interface.
 type KexRouter struct {
-	Contextified
+	MetaContextified
 }
 
 // NewKexRouter creates a contextified KexRouter.
-func NewKexRouter(g *GlobalContext) *KexRouter {
-	return &KexRouter{Contextified: NewContextified(g)}
+func NewKexRouter(m MetaContext) *KexRouter {
+	return &KexRouter{
+		MetaContextified: NewMetaContextified(m),
+	}
 }
 
 // Post implements Post in the kex2.MessageRouter interface.
 func (k *KexRouter) Post(sessID kex2.SessionID, sender kex2.DeviceID, seqno kex2.Seqno, msg []byte) (err error) {
-	k.G().Log.Debug("+ KexRouter.Post(%x, %x, %d, ...)", sessID, sender, seqno)
+	mctx := k.M().WithLogTag("KEXR")
+	mctx.CDebugf("+ KexRouter.Post(%x, %x, %d, ...)", sessID, sender, seqno)
 	defer func() {
-		k.G().Log.Debug("- KexRouter.Post(%x, %x, %d) -> %s", sessID, sender, seqno, ErrToOk(err))
+		mctx.CDebugf("- KexRouter.Post(%x, %x, %d) -> %s", sessID, sender, seqno, ErrToOk(err))
 	}()
 
-	_, err = k.G().API.Post(APIArg{
+	_, err = mctx.G().API.Post(APIArg{
 		Endpoint: "kex2/send",
 		Args: HTTPArgs{
 			"I":      HexArg(sessID[:]),
@@ -35,6 +38,7 @@ func (k *KexRouter) Post(sessID kex2.SessionID, sender kex2.DeviceID, seqno kex2
 			"seqno":  I{Val: int(seqno)},
 			"msg":    B64Arg(msg),
 		},
+		MetaContext: mctx.BackgroundWithLogTags(),
 	})
 
 	return err
@@ -53,9 +57,10 @@ func (k *kexResp) GetAppStatus() *AppStatus {
 
 // Get implements Get in the kex2.MessageRouter interface.
 func (k *KexRouter) Get(sessID kex2.SessionID, receiver kex2.DeviceID, low kex2.Seqno, poll time.Duration) (msgs [][]byte, err error) {
-	k.G().Log.Debug("+ KexRouter.Get(%x, %x, %d, %s)", sessID, receiver, low, poll)
+	mctx := k.M().WithLogTag("KEXR")
+	mctx.CDebugf("+ KexRouter.Get(%x, %x, %d, %s)", sessID, receiver, low, poll)
 	defer func() {
-		k.G().Log.Debug("- KexRouter.Get(%x, %x, %d, %s) -> %s (messages: %d)", sessID, receiver, low, poll, ErrToOk(err), len(msgs))
+		mctx.CDebugf("- KexRouter.Get(%x, %x, %d, %s) -> %s (messages: %d)", sessID, receiver, low, poll, ErrToOk(err), len(msgs))
 	}()
 
 	if poll > HTTPPollMaximum {
@@ -70,10 +75,11 @@ func (k *KexRouter) Get(sessID kex2.SessionID, receiver kex2.DeviceID, low kex2.
 			"low":      I{Val: int(low)},
 			"poll":     I{Val: int(poll / time.Millisecond)},
 		},
+		MetaContext: mctx.BackgroundWithLogTags(),
 	}
 	var j kexResp
 
-	if err = k.G().API.GetDecode(arg, &j); err != nil {
+	if err = mctx.G().API.GetDecode(arg, &j); err != nil {
 		return nil, err
 	}
 	if j.Status.Code != SCOk {

--- a/vendor/github.com/keybase/client/go/libkb/key_pseudonym.go
+++ b/vendor/github.com/keybase/client/go/libkb/key_pseudonym.go
@@ -1,0 +1,305 @@
+// Copyright 2017 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkb
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	keybase1 "github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
+)
+
+// KeyPseudonym is a "random looking" identifier which refers to a specific application key belonging to a user or team
+// (the key is referred to by the application id, the generation number and the user or team id).
+// Pseudonyms are only used for saltpack encryption at the moment, but more applications are possible. They are used
+// to avoid that, when decrypting a message encrypted with a team key, a user has to loop through all the keys of all the
+// teams he is part of to find the right one. To avoid this, when encrypting for a team, the sender generates such a pseudonym
+// (which refers to the key it used to encrypt), sends it to the server and includes it as a recipient identifier for the
+// appropriare recipient payload box in the header of the saltpack message. When decrypting a saltpack message, a recipient
+// can ask the server if any of the recipient identifiers in the message correspond to known pseudonyms (for teams the user is part of),
+// and use the response from the server to identify which key to use for decryption. This mechanism substitutes an older kbfs based one
+// (which is still supported to allow decryptions of old saltpack messages).
+//
+// A pseudonym is computed as an HMAC (with a random nonce as a key) of the information it refers to in order to
+// prevent the server from tampering with the mapping (we rely on collision resistance and not unforgeability,
+// as the server knows the nonce, so a simple SHA256 would have worked as well).
+type KeyPseudonym [32]byte
+
+func (p KeyPseudonym) String() string {
+	return hex.EncodeToString(p[:])
+}
+
+func (p *KeyPseudonym) MarshalJSON() ([]byte, error) {
+	return keybase1.Quote((*p).String()), nil
+}
+
+func (p *KeyPseudonym) UnmarshalJSON(b []byte) error {
+	n, err := hex.Decode((*p)[:], keybase1.UnquoteBytes(b))
+	if err != nil {
+		return err
+	}
+	if n != len(*p) {
+		return NewKeyPseudonymError("KeyPseudonym has wrong length")
+	}
+	return nil
+}
+
+func (p KeyPseudonym) Eq(r KeyPseudonym) bool {
+	return hmac.Equal(p[:], r[:])
+}
+
+type KeyPseudonymNonce [32]byte
+
+func (p KeyPseudonymNonce) String() string {
+	return hex.EncodeToString(p[:])
+}
+
+func (p *KeyPseudonymNonce) MarshalJSON() ([]byte, error) {
+	return keybase1.Quote((*p).String()), nil
+}
+
+func (p *KeyPseudonymNonce) UnmarshalJSON(b []byte) error {
+	n, err := hex.Decode((*p)[:], keybase1.UnquoteBytes(b))
+	if err != nil {
+		return err
+	}
+	if n != len(*p) {
+		return NewKeyPseudonymError("KeyPseudonymNonce has wrong length")
+	}
+	return nil
+}
+
+const KeyPseudonymVersion = 1
+
+// KeyPseudonymInfo contains the KeyPseudonym as well as information about the key it represents.
+type KeyPseudonymInfo struct {
+	KeyPseudonym KeyPseudonym
+	ID           keybase1.UserOrTeamID
+	Application  keybase1.TeamApplication
+	KeyGen       KeyGen
+	Nonce        KeyPseudonymNonce
+}
+
+// keyPseudonymReq is what the server needs to store a pseudonym
+type keyPseudonymReq struct {
+	Pseudonym   KeyPseudonym          `json:"key_pseudonym"`   // hex
+	ID          keybase1.UserOrTeamID `json:"user_or_team_id"` // hex
+	Application int                   `json:"app_id"`
+	KeyGen      int                   `json:"key_gen"`
+	Nonce       KeyPseudonymNonce     `json:"nonce"` // hex
+}
+
+// keyPseudonymContents is the data packed inside the HMAC
+type keyPseudonymContents struct {
+	_struct     bool `codec:",toarray"`
+	Version     int
+	ID          [16]byte                 // keybase1.UserOrTeamId as a byte array
+	Application keybase1.TeamApplication // int
+	KeyGen      KeyGen                   // int
+}
+
+type getKeyPseudonymsRes struct {
+	KeyPseudonyms []getKeyPseudonymRes `json:"key_pseudonyms"`
+	Status        AppStatus            `json:"status"`
+}
+
+func (r *getKeyPseudonymsRes) GetAppStatus() *AppStatus {
+	return &r.Status
+}
+
+type getKeyPseudonymRes struct {
+	Err  *PseudonymGetError `json:"err"`
+	Info *struct {
+		ID          keybase1.UserOrTeamID `json:"user_or_team_id"`
+		Application int                   `json:"app_id"`
+		KeyGen      int                   `json:"key_gen"`
+		Nonce       KeyPseudonymNonce     `json:"nonce"`
+	} `json:"info"`
+}
+
+type KeyPseudonymOrError struct {
+	// Exactly one of these 2 fields is nil.
+	Err  error
+	Info *KeyPseudonymInfo
+}
+
+// MakePseudonym makes a key pseudonym from the given input.
+func MakeKeyPseudonym(info KeyPseudonymInfo) (KeyPseudonym, error) {
+	var idBytes [16]byte
+	id := info.ID.ToBytes()
+
+	copy(idBytes[:], id)
+
+	input := keyPseudonymContents{
+		Version:     KeyPseudonymVersion,
+		ID:          idBytes,
+		Application: info.Application,
+		KeyGen:      info.KeyGen,
+	}
+	mh := codec.MsgpackHandle{WriteExt: true}
+	var buf []byte
+	enc := codec.NewEncoderBytes(&buf, &mh)
+	if err := enc.Encode(input); err != nil {
+		return [32]byte{}, err
+	}
+
+	mac := hmac.New(sha256.New, info.Nonce[:])
+	mac.Write(buf)
+	hmac := MakeByte32(mac.Sum(nil))
+	return hmac, nil
+}
+
+// MakeAndPostKeyPseudonyms fills the KeyPseudonym field of each of the pnymInfos with the appropriate KeyPseudonym.
+func MakeAndPostKeyPseudonyms(m MetaContext, pnymInfos *[]KeyPseudonymInfo) (err error) {
+	var pnymReqs []keyPseudonymReq
+
+	if len(*pnymInfos) == 0 {
+		return
+	}
+
+	for i, info := range *pnymInfos {
+		// Compute the pseudonym
+		var pnym KeyPseudonym
+		pnym, err = MakeKeyPseudonym(info)
+		if err != nil {
+			return
+		}
+		(*pnymInfos)[i].KeyPseudonym = pnym
+		pnymReqs = append(pnymReqs, keyPseudonymReq{
+			Pseudonym:   pnym,
+			ID:          info.ID,
+			Application: int(info.Application),
+			KeyGen:      int(info.KeyGen),
+			Nonce:       info.Nonce,
+		})
+	}
+
+	payload := make(JSONPayload)
+	payload["key_pseudonyms"] = pnymReqs
+
+	_, err = m.G().API.PostJSON(APIArg{
+		MetaContext: m,
+		Endpoint:    "team/key_pseudonym",
+		JSONPayload: payload,
+		SessionType: APISessionTypeREQUIRED,
+	})
+	if err != nil {
+		return
+	}
+	return nil
+}
+
+// GetKeyPseudonyms fetches info for a list of pseudonyms.
+// The output structs are returned in the order corresponding to the inputs.
+// The top-level error is filled if the entire request fails.
+// The error in each of the returned structs may be filled for per-pseudonym errors.
+func GetKeyPseudonyms(m MetaContext, pnyms []KeyPseudonym) ([]KeyPseudonymOrError, error) {
+	var pnymStrings []string
+	for _, x := range pnyms {
+		pnymStrings = append(pnymStrings, x.String())
+	}
+
+	var res getKeyPseudonymsRes
+	err := m.G().API.GetDecode(
+		APIArg{
+			MetaContext: m,
+			Endpoint:    "team/key_pseudonym",
+			SessionType: APISessionTypeREQUIRED,
+			Args: HTTPArgs{
+				"key_pseudonyms": S{Val: strings.Join(pnymStrings, ",")},
+			},
+		},
+		&res)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the response
+	if len(res.KeyPseudonyms) != len(pnyms) {
+		return nil, &KeyPseudonymGetError{fmt.Sprintf("invalid server response for pseudonym get: len %v != %v",
+			len(res.KeyPseudonyms), len(pnyms))}
+	}
+	var resList []KeyPseudonymOrError
+	for i, received := range res.KeyPseudonyms {
+		resList = append(resList, checkAndConvertKeyPseudonymFromServer(pnyms[i], received))
+	}
+
+	return resList, nil
+}
+
+func checkAndConvertKeyPseudonymFromServer(req KeyPseudonym, received getKeyPseudonymRes) KeyPseudonymOrError {
+	mkErr := func(err error) KeyPseudonymOrError {
+		return KeyPseudonymOrError{
+			Info: nil,
+			Err:  err,
+		}
+	}
+
+	x := KeyPseudonymOrError{}
+
+	// This check is necessary because of sneaky typed nil.
+	// received.Err's type is lower than x.Err
+	// So doing `x.Err = received.Err` is bad if received.Err is nil.
+	// https://golang.org/doc/faq#nil_error
+	// https://play.golang.org/p/BnjVTGh-gO
+	if received.Err != nil {
+		x.Err = received.Err
+	}
+
+	if received.Info != nil {
+		info := KeyPseudonymInfo{}
+
+		info.ID = received.Info.ID
+		info.KeyGen = KeyGen(received.Info.KeyGen)
+		info.Application = keybase1.TeamApplication(received.Info.Application)
+		info.Nonce = received.Info.Nonce
+
+		x.Info = &info
+	}
+
+	err := checkKeyPseudonymFromServer(req, x)
+	if err != nil {
+		return mkErr(err)
+	}
+	return x
+}
+
+func checkKeyPseudonymFromServer(req KeyPseudonym, received KeyPseudonymOrError) error {
+	// Exactly one of Info and Err should exist
+	if (received.Info == nil) == (received.Err == nil) {
+		return &KeyPseudonymGetError{fmt.Sprintf("invalid server response for key_pseudonym get: %s", req)}
+	}
+
+	// Errors don't need validation
+	if received.Info == nil {
+		return nil
+	}
+
+	// Check that the pseudonym info matches the query.
+	pn, err := MakeKeyPseudonym(*received.Info)
+	if err != nil {
+		// Error creating pseudonym locally
+		return &KeyPseudonymGetError{err.Error()}
+	}
+	if !req.Eq(pn) {
+		return &KeyPseudonymGetError{fmt.Sprintf("returned data does not match key_pseudonym: %s != %s",
+			req, pn)}
+	}
+
+	return nil
+}
+
+// RandomPseudonymNonce returns a random nonce, which is used as an HMAC key.
+func RandomPseudonymNonce() KeyPseudonymNonce {
+	slice, err := RandBytes(32)
+	if err != nil {
+		panic(err)
+	}
+	return KeyPseudonymNonce(MakeByte32(slice))
+}

--- a/vendor/github.com/keybase/client/go/libkb/keyring.go
+++ b/vendor/github.com/keybase/client/go/libkb/keyring.go
@@ -379,6 +379,7 @@ func setCachedSecretKey(m MetaContext, ska SecretKeyArg, key GenericKey, device 
 	}
 
 	uid := ska.Me.GetUID()
+	uv := ska.Me.ToUserVersion()
 	deviceID := deviceIDFromDevice(m, uid, device)
 	if deviceID.IsNil() {
 		m.CDebugf("SetCachedSecretKey with nil deviceID (%+v)", ska)
@@ -388,10 +389,10 @@ func setCachedSecretKey(m MetaContext, ska SecretKeyArg, key GenericKey, device 
 	case DeviceSigningKeyType:
 		deviceName := deviceNameLookup(m, device, ska.Me, key)
 		m.CDebugf("caching secret device signing key (%q/%d)", deviceName, deviceID)
-		return m.SetSigningKey(uid, deviceID, key, deviceName)
+		return m.SetSigningKey(uv, deviceID, key, deviceName)
 	case DeviceEncryptionKeyType:
 		m.CDebugf("caching secret device encryption key")
-		return m.SetEncryptionKey(uid, deviceID, key)
+		return m.SetEncryptionKey(uv, deviceID, key)
 	default:
 		return fmt.Errorf("attempt to cache invalid key type: %d", ska.KeyType)
 	}

--- a/vendor/github.com/keybase/client/go/libkb/loaduser.go
+++ b/vendor/github.com/keybase/client/go/libkb/loaduser.go
@@ -227,7 +227,7 @@ func (arg *LoadUserArg) resolveUID() (ResolveResult, error) {
 		return rres, fmt.Errorf("resolveUID: no uid or name")
 	}
 
-	if rres = arg.m.G().Resolver.ResolveWithBody(arg.name).FailOnDeleted(); rres.err != nil {
+	if rres = arg.m.G().Resolver.ResolveWithBody(arg.m, arg.name).FailOnDeleted(); rres.err != nil {
 		return rres, rres.err
 	}
 

--- a/vendor/github.com/keybase/client/go/libkb/login_state.go
+++ b/vendor/github.com/keybase/client/go/libkb/login_state.go
@@ -32,8 +32,9 @@ type LoginContext interface {
 	LocalSession() *Session
 	GetUID() keybase1.UID
 	GetUsername() NormalizedUsername
-	SaveState(sessionID, csrf string, username NormalizedUsername, uid keybase1.UID, deviceID keybase1.DeviceID) error
-	SetUsernameUID(username NormalizedUsername, uid keybase1.UID) error
+	GetUserVersion() keybase1.UserVersion
+	SaveState(sessionID, csrf string, username NormalizedUsername, uv keybase1.UserVersion, deviceID keybase1.DeviceID) error
+	SetUsernameUserVersion(username NormalizedUsername, uv keybase1.UserVersion) error
 
 	Keyring(m MetaContext) (*SKBKeyringFile, error)
 	ClearKeyring()
@@ -45,7 +46,7 @@ type LoginContext interface {
 type loginAPIResult struct {
 	sessionID string
 	csrfToken string
-	uid       keybase1.UID
+	uv        keybase1.UserVersion
 	username  string
 	ppGen     PassphraseGeneration
 }

--- a/vendor/github.com/keybase/client/go/libkb/merkle_client.go
+++ b/vendor/github.com/keybase/client/go/libkb/merkle_client.go
@@ -1027,6 +1027,15 @@ func (ss SkipSequence) verify(m MetaContext, thisRoot keybase1.Seqno, lastRoot k
 			m.VLogf(VLog0, "| Failure in hashes: %s != %s", hash.String(), ss[nextIndex].shortHash().String())
 			return MerkleClientError{fmt.Sprintf("Skip pointer mismatch at %d->%d", thisRoot, prevRoot), merkleErrorSkipHashMismatch}
 		}
+
+		// Check that ctimes in the sequence are also strictly ordered
+		thisCTime, prevCTime := ss[index].ctime(), ss[nextIndex].ctime()
+		if thisCTime < prevCTime {
+			return MerkleClientError{
+				fmt.Sprintf("Out of order ctimes: %d at %d should not have come before %d at %d", thisRoot, thisCTime, prevRoot, prevCTime),
+				merkleErrorOutOfOrderCtime,
+			}
+		}
 	}
 
 	// Enforce the invariant that the most recently published merkle root and the last gotten

--- a/vendor/github.com/keybase/client/go/libkb/naclwrap.go
+++ b/vendor/github.com/keybase/client/go/libkb/naclwrap.go
@@ -516,6 +516,16 @@ func KIDToNaclSigningKeyPublic(bk []byte) *NaclSigningKeyPublic {
 	return &ret
 }
 
+func EncryptionKIDToPublicKeyBytes(bk []byte) ([]byte, error) {
+	if len(bk) != 3+NaclDHKeysize {
+		return []byte{}, fmt.Errorf("invalid DH encryption key KID (wrong length)")
+	}
+	if bk[0] != byte(KeybaseKIDV1) || bk[1] != byte(KIDNaclDH) || bk[len(bk)-1] != byte(IDSuffixKID) {
+		return []byte{}, fmt.Errorf("invalid DH encryption key KID (wrong type)")
+	}
+	return bk[2 : len(bk)-1], nil
+}
+
 func (s NaclSigInfo) Verify() (*NaclSigningKeyPublic, error) {
 	key := KIDToNaclSigningKeyPublic(s.Kid)
 	if key == nil {

--- a/vendor/github.com/keybase/client/go/libkb/per_user_key.go
+++ b/vendor/github.com/keybase/client/go/libkb/per_user_key.go
@@ -436,8 +436,8 @@ func (s *PerUserKeyring) SyncWithExtras(m MetaContext, upak *keybase1.UserPlusAl
 
 // `m.LoginContext` and `upak` are optional
 func (s *PerUserKeyring) syncAsConfiguredDevice(m MetaContext, upak *keybase1.UserPlusAllKeys) (err error) {
-	uid, deviceID, _, _, activeDecryptionKey := m.ActiveDevice().AllFields()
-	if !s.uid.Equal(uid) {
+	uv, deviceID, _, _, activeDecryptionKey := m.ActiveDevice().AllFields()
+	if !s.uid.Equal(uv.Uid) {
 		return fmt.Errorf("UID changed on PerUserKeyring")
 	}
 	if deviceID.IsNil() {

--- a/vendor/github.com/keybase/client/go/libkb/pgp_gen.go
+++ b/vendor/github.com/keybase/client/go/libkb/pgp_gen.go
@@ -5,6 +5,7 @@ package libkb
 
 import (
 	"crypto"
+	"crypto/rsa"
 	"fmt"
 	"strings"
 
@@ -12,7 +13,6 @@ import (
 	"github.com/keybase/go-crypto/openpgp/errors"
 	"github.com/keybase/go-crypto/openpgp/packet"
 	"github.com/keybase/go-crypto/openpgp/s2k"
-	"github.com/keybase/go-crypto/rsa"
 )
 
 type PGPGenArg struct {

--- a/vendor/github.com/keybase/client/go/libkb/provisional_login_context.go
+++ b/vendor/github.com/keybase/client/go/libkb/provisional_login_context.go
@@ -9,7 +9,7 @@ import (
 type ProvisionalLoginContext struct {
 	MetaContextified
 	username     NormalizedUsername
-	uid          keybase1.UID
+	uv           keybase1.UserVersion
 	salt         []byte
 	streamCache  *PassphraseStreamCache
 	localSession *Session
@@ -28,16 +28,16 @@ func newProvisionalLoginContext(m MetaContext) *ProvisionalLoginContext {
 	}
 }
 
-func newProvisionalLoginContextWithUIDAndUsername(m MetaContext, uid keybase1.UID, un NormalizedUsername) *ProvisionalLoginContext {
+func newProvisionalLoginContextWithUserVersionAndUsername(m MetaContext, uv keybase1.UserVersion, un NormalizedUsername) *ProvisionalLoginContext {
 	ret := newProvisionalLoginContext(m)
-	ret.uid = uid
+	ret.uv = uv
 	ret.username = un
 	return ret
 }
 
 func (p *ProvisionalLoginContext) Dump(m MetaContext, prefix string) {
 	m.CDebugf("%sUsername: %s", prefix, p.username)
-	m.CDebugf("%sUID: %s", prefix, p.uid)
+	m.CDebugf("%sUserVersion: %v", prefix, p.uv)
 	if p.salt != nil {
 		m.CDebugf("%sSalt: %s", prefix, hex.EncodeToString(p.salt))
 	}
@@ -83,36 +83,39 @@ func (p *ProvisionalLoginContext) LocalSession() *Session {
 	return p.localSession.Clone()
 }
 func (p *ProvisionalLoginContext) GetUID() keybase1.UID {
-	return p.uid
+	return p.uv.Uid
+}
+func (p *ProvisionalLoginContext) GetUserVersion() keybase1.UserVersion {
+	return p.uv
 }
 func (p *ProvisionalLoginContext) GetUsername() NormalizedUsername {
 	return p.username
 }
 
-func (p *ProvisionalLoginContext) SetUsernameUID(username NormalizedUsername, uid keybase1.UID) error {
-	if err := p.assertNotReused(username, uid); err != nil {
+func (p *ProvisionalLoginContext) SetUsernameUserVersion(username NormalizedUsername, uv keybase1.UserVersion) error {
+	if err := p.assertNotReused(username, uv); err != nil {
 		return err
 	}
 	p.username = username
-	p.uid = uid
+	p.uv = uv
 	return nil
 }
 
-func (p *ProvisionalLoginContext) assertNotReused(un NormalizedUsername, uid keybase1.UID) error {
-	if !(p.uid.IsNil() || p.uid.Equal(uid)) || !(p.username.IsNil() || p.username.Eq(un)) {
+func (p *ProvisionalLoginContext) assertNotReused(un NormalizedUsername, uv keybase1.UserVersion) error {
+	if !(p.uv.IsNil() || p.uv.Eq(uv)) || !(p.username.IsNil() || p.username.Eq(un)) {
 		return errors.New("can't reuse a ProvisionalLoginContext!")
 	}
 	return nil
 }
 
-func (p *ProvisionalLoginContext) SaveState(sessionID, csrf string, username NormalizedUsername, uid keybase1.UID, deviceID keybase1.DeviceID) (err error) {
+func (p *ProvisionalLoginContext) SaveState(sessionID, csrf string, username NormalizedUsername, uv keybase1.UserVersion, deviceID keybase1.DeviceID) (err error) {
 	defer p.M().CTrace("ProvisionalLoginContext#SaveState", func() error { return err })()
-	if err := p.assertNotReused(username, uid); err != nil {
+	if err := p.assertNotReused(username, uv); err != nil {
 		return err
 	}
-	p.uid = uid
+	p.uv = uv
 	p.username = username
-	return p.localSession.SetLoggedIn(sessionID, csrf, username, uid, deviceID)
+	return p.localSession.SetLoggedIn(sessionID, csrf, username, uv.Uid, deviceID)
 }
 
 func (p *ProvisionalLoginContext) Keyring(m MetaContext) (ret *SKBKeyringFile, err error) {

--- a/vendor/github.com/keybase/client/go/libkb/resolve.go
+++ b/vendor/github.com/keybase/client/go/libkb/resolve.go
@@ -11,7 +11,6 @@ import (
 
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	jsonw "github.com/keybase/go-jsonw"
-	"golang.org/x/net/context"
 	"stathat.com/c/ramcache"
 )
 
@@ -115,39 +114,39 @@ func (res ResolveResult) FailOnDeleted() ResolveResult {
 	return res
 }
 
-func (r *ResolverImpl) ResolveWithBody(input string) ResolveResult {
-	return r.resolve(input, true)
+func (r *ResolverImpl) ResolveWithBody(m MetaContext, input string) ResolveResult {
+	return r.resolve(m, input, true)
 }
 
-func (r *ResolverImpl) Resolve(input string) ResolveResult {
-	return r.resolve(input, false)
+func (r *ResolverImpl) Resolve(m MetaContext, input string) ResolveResult {
+	return r.resolve(m, input, false)
 }
 
-func (r *ResolverImpl) resolve(input string, withBody bool) (res ResolveResult) {
-	defer r.G().Trace(fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
+func (r *ResolverImpl) resolve(m MetaContext, input string, withBody bool) (res ResolveResult) {
+	defer m.CTraceTimed(fmt.Sprintf("Resolving username %q", input), func() error { return res.err })()
 
 	var au AssertionURL
-	if au, res.err = ParseAssertionURL(r.G().MakeAssertionContext(), input, false); res.err != nil {
+	if au, res.err = ParseAssertionURL(m.G().MakeAssertionContext(), input, false); res.err != nil {
 		return res
 	}
-	res = r.resolveURL(context.TODO(), au, input, withBody, false)
+	res = r.resolveURL(m, au, input, withBody, false)
 	return res
 }
 
-func (r *ResolverImpl) ResolveFullExpression(ctx context.Context, input string) (res ResolveResult) {
-	return r.resolveFullExpression(ctx, input, false, false)
+func (r *ResolverImpl) ResolveFullExpression(m MetaContext, input string) (res ResolveResult) {
+	return r.resolveFullExpression(m, input, false, false)
 }
 
-func (r *ResolverImpl) ResolveFullExpressionNeedUsername(ctx context.Context, input string) (res ResolveResult) {
-	return r.resolveFullExpression(ctx, input, false, true)
+func (r *ResolverImpl) ResolveFullExpressionNeedUsername(m MetaContext, input string) (res ResolveResult) {
+	return r.resolveFullExpression(m, input, false, true)
 }
 
-func (r *ResolverImpl) ResolveFullExpressionWithBody(ctx context.Context, input string) (res ResolveResult) {
-	return r.resolveFullExpression(ctx, input, true, false)
+func (r *ResolverImpl) ResolveFullExpressionWithBody(m MetaContext, input string) (res ResolveResult) {
+	return r.resolveFullExpression(m, input, true, false)
 }
 
-func (r *ResolverImpl) ResolveUser(ctx context.Context, assertion string) (u keybase1.User, res ResolveResult, err error) {
-	res = r.ResolveFullExpressionNeedUsername(ctx, assertion)
+func (r *ResolverImpl) ResolveUser(m MetaContext, assertion string) (u keybase1.User, res ResolveResult, err error) {
+	res = r.ResolveFullExpressionNeedUsername(m, assertion)
 	err = res.GetError()
 	if err != nil {
 		return u, res, err
@@ -159,11 +158,11 @@ func (r *ResolverImpl) ResolveUser(ctx context.Context, assertion string) (u key
 	return u, res, nil
 }
 
-func (r *ResolverImpl) resolveFullExpression(ctx context.Context, input string, withBody bool, needUsername bool) (res ResolveResult) {
-	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
+func (r *ResolverImpl) resolveFullExpression(m MetaContext, input string, withBody bool, needUsername bool) (res ResolveResult) {
+	defer m.CVTrace(VLog1, fmt.Sprintf("Resolver#resolveFullExpression(%q)", input), func() error { return res.err })()
 
 	var expr AssertionExpression
-	expr, res.err = AssertionParseAndOnly(r.G().MakeAssertionContext(), input)
+	expr, res.err = AssertionParseAndOnly(m.G().MakeAssertionContext(), input)
 	if res.err != nil {
 		return res
 	}
@@ -172,7 +171,7 @@ func (r *ResolverImpl) resolveFullExpression(ctx context.Context, input string, 
 		res.err = ResolutionError{Input: input, Msg: "Cannot find a resolvable factor"}
 		return res
 	}
-	ret := r.resolveURL(ctx, u, input, withBody, needUsername)
+	ret := r.resolveURL(m, u, input, withBody, needUsername)
 	ret.isCompound = len(expr.CollectUrls(nil)) > 1
 	return ret
 }
@@ -183,13 +182,13 @@ func (res *ResolveResult) addKeybaseNameIfKnown(au AssertionURL) {
 	}
 }
 
-func (r *ResolverImpl) getFromDiskCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
-	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
+func (r *ResolverImpl) getFromDiskCache(m MetaContext, key string, au AssertionURL) (ret *ResolveResult) {
+	defer m.CVTraceOK(VLog1, fmt.Sprintf("Resolver#getFromDiskCache(%q)", key), func() bool { return ret != nil })()
 	var uid keybase1.UID
-	found, err := r.G().LocalDb.GetInto(&uid, resolveDbKey(key))
+	found, err := m.G().LocalDb.GetInto(&uid, resolveDbKey(key))
 	r.Stats.diskGets++
 	if err != nil {
-		r.G().Log.CWarningf(ctx, "Problem fetching resolve result from local DB: %s", err)
+		m.CWarningf("Problem fetching resolve result from local DB: %s", err)
 		return nil
 	}
 	if !found {
@@ -197,7 +196,7 @@ func (r *ResolverImpl) getFromDiskCache(ctx context.Context, key string, au Asse
 		return nil
 	}
 	if uid.IsNil() {
-		r.G().Log.CWarningf(ctx, "nil UID found in disk cache")
+		m.CWarningf("nil UID found in disk cache")
 		return nil
 	}
 	r.Stats.diskGetHits++
@@ -208,24 +207,24 @@ func isMutable(au AssertionURL) bool {
 	return !(au.IsUID() || au.IsKeybase())
 }
 
-func (r *ResolverImpl) getFromUPAKLoader(ctx context.Context, uid keybase1.UID) (ret *ResolveResult) {
-	nun, err := r.G().GetUPAKLoader().LookupUsername(ctx, uid)
+func (r *ResolverImpl) getFromUPAKLoader(m MetaContext, uid keybase1.UID) (ret *ResolveResult) {
+	nun, err := m.G().GetUPAKLoader().LookupUsername(m.Ctx(), uid)
 	if err != nil {
 		return nil
 	}
 	return &ResolveResult{uid: uid, queriedByUID: true, resolvedKbUsername: nun.String(), mutable: false}
 }
 
-func (r *ResolverImpl) resolveURL(ctx context.Context, au AssertionURL, input string, withBody bool, needUsername bool) (res ResolveResult) {
+func (r *ResolverImpl) resolveURL(m MetaContext, au AssertionURL, input string, withBody bool, needUsername bool) (res ResolveResult) {
 	ck := au.CacheKey()
 
-	lock := r.locktab.AcquireOnName(ctx, r.G(), ck)
-	defer lock.Release(ctx)
+	lock := r.locktab.AcquireOnName(m.Ctx(), m.G(), ck)
+	defer lock.Release(m.Ctx())
 
-	// Debug succintly what happened in the resolution
+	// Debug succinctly what happened in the resolution
 	var trace string
 	defer func() {
-		r.G().Log.CDebugf(ctx, "| Resolver#resolveURL(%s) -> %s [trace:%s]", ck, res, trace)
+		m.CDebugf("| Resolver#resolveURL(%s) -> %s [trace:%s]", ck, res, trace)
 	}()
 
 	// A standard keybase UID, so it's already resolved... unless we explicitly
@@ -237,49 +236,49 @@ func (r *ResolverImpl) resolveURL(ctx context.Context, au AssertionURL, input st
 		}
 	}
 
-	if p := r.getFromMemCache(ctx, ck, au); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
+	if p := r.getFromMemCache(m, ck, au); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
 		trace += "m"
 		return *p
 	}
 
-	if p := r.getFromDiskCache(ctx, ck, au); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
+	if p := r.getFromDiskCache(m, ck, au); p != nil && (!needUsername || len(p.resolvedKbUsername) > 0) {
 		p.mutable = isMutable(au)
-		r.putToMemCache(ck, *p)
+		r.putToMemCache(m, ck, *p)
 		trace += "d"
 		return *p
 	}
 
 	// We can check the UPAK loader for the username if we're just mapping a UID to a username.
 	if tmp := au.ToUID(); !withBody && tmp.Exists() {
-		if p := r.getFromUPAKLoader(ctx, tmp); p != nil {
+		if p := r.getFromUPAKLoader(m, tmp); p != nil {
 			trace += "l"
-			r.putToMemCache(ck, *p)
+			r.putToMemCache(m, ck, *p)
 			return *p
 		}
 	}
 
 	trace += "s"
-	res = r.resolveURLViaServerLookup(ctx, au, input, withBody)
+	res = r.resolveURLViaServerLookup(m, au, input, withBody)
 
 	// Cache for a shorter period of time if it's not a Keybase identity
 	res.mutable = isMutable(au)
-	r.putToMemCache(ck, res)
+	r.putToMemCache(m, ck, res)
 
-	// We only put to disk cache if it's a Keybase-type assertion. In particular, UIDs
-	// are **not** stored to disk.
+	// We only put to disk cache if it's a Keybase-type assertion. In
+	// particular, UIDs are **not** stored to disk.
 	if au.IsKeybase() {
 		trace += "p"
-		r.putToDiskCache(ctx, ck, res)
+		r.putToDiskCache(m, ck, res)
 	}
 
 	return res
 }
 
-func (r *ResolverImpl) resolveURLViaServerLookup(ctx context.Context, au AssertionURL, input string, withBody bool) (res ResolveResult) {
-	defer r.G().CVTrace(ctx, VLog1, fmt.Sprintf("Resolver#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
+func (r *ResolverImpl) resolveURLViaServerLookup(m MetaContext, au AssertionURL, input string, withBody bool) (res ResolveResult) {
+	defer m.CVTrace(VLog1, fmt.Sprintf("Resolver#resolveURLViaServerLookup(input = %q)", input), func() error { return res.err })()
 
 	if au.IsTeamID() || au.IsTeamName() {
-		return r.resolveTeamViaServerLookup(ctx, au)
+		return r.resolveTeamViaServerLookup(m, au)
 	}
 
 	var key, val string
@@ -304,24 +303,24 @@ func (r *ResolverImpl) resolveURLViaServerLookup(ctx context.Context, au Asserti
 		fields += ",public_keys,pictures"
 	}
 	ha.Add("fields", S{fields})
-	ares, res.err = r.G().API.Get(APIArg{
+	ares, res.err = m.G().API.Get(APIArg{
 		Endpoint:        "user/lookup",
 		SessionType:     APISessionTypeNONE,
 		Args:            ha,
 		AppStatusCodes:  []int{SCOk, SCNotFound, SCDeleted},
-		NetContext:      ctx,
+		MetaContext:     m,
 		RetryCount:      3,
 		InitialTimeout:  4 * time.Second,
 		RetryMultiplier: 1.5,
 	})
 
 	if res.err != nil {
-		r.G().Log.CDebugf(ctx, "API user/lookup %q error: %s", input, res.err)
+		m.CDebugf("API user/lookup %q error: %s", input, res.err)
 		return
 	}
 	switch ares.AppStatus.Code {
 	case SCNotFound:
-		r.G().Log.CDebugf(ctx, "API user/lookup %q not found", input)
+		m.CDebugf("API user/lookup %q not found", input)
 		res.err = NotFoundError{}
 		return
 	}
@@ -361,7 +360,7 @@ func (r *ResolverImpl) resolveURLViaServerLookup(ctx context.Context, au Asserti
 		res.deleted = true
 	}
 
-	return
+	return res
 }
 
 type teamLookup struct {
@@ -374,8 +373,8 @@ func (t *teamLookup) GetAppStatus() *AppStatus {
 	return &t.Status
 }
 
-func (r *ResolverImpl) resolveTeamViaServerLookup(ctx context.Context, au AssertionURL) (res ResolveResult) {
-	r.G().Log.CDebugf(ctx, "resolveTeamViaServerLookup")
+func (r *ResolverImpl) resolveTeamViaServerLookup(m MetaContext, au AssertionURL) (res ResolveResult) {
+	m.CDebugf("resolveTeamViaServerLookup")
 
 	res.queriedByTeamID = au.IsTeamID()
 	key, val, err := au.ToLookup()
@@ -384,7 +383,7 @@ func (r *ResolverImpl) resolveTeamViaServerLookup(ctx context.Context, au Assert
 		return res
 	}
 
-	arg := NewAPIArgWithNetContext(ctx, "team/get")
+	arg := NewAPIArgWithMetaContext(m, "team/get")
 	arg.SessionType = APISessionTypeREQUIRED
 	arg.Args = make(HTTPArgs)
 	arg.Args[key] = S{Val: val}
@@ -394,7 +393,7 @@ func (r *ResolverImpl) resolveTeamViaServerLookup(ctx context.Context, au Assert
 	}
 
 	var lookup teamLookup
-	if err := r.G().API.GetDecode(arg, &lookup); err != nil {
+	if err := m.G().API.GetDecode(arg, &lookup); err != nil {
 		res.err = err
 		return res
 	}
@@ -418,7 +417,6 @@ type ResolveCacheStats struct {
 }
 
 type ResolverImpl struct {
-	Contextified
 	cache   *ramcache.Ramcache
 	Stats   ResolveCacheStats
 	locktab LockTable
@@ -432,29 +430,28 @@ func (s ResolveCacheStats) EqWithDiskHits(m, t, mt, et, h, dh int) bool {
 	return (s.misses == m) && (s.timeouts == t) && (s.mutableTimeouts == mt) && (s.errorTimeouts == et) && (s.hits == h) && (s.diskGetHits == dh)
 }
 
-func NewResolverImpl(g *GlobalContext) *ResolverImpl {
+func NewResolverImpl() *ResolverImpl {
 	return &ResolverImpl{
-		Contextified: NewContextified(g),
-		cache:        nil,
+		cache: nil,
 	}
 }
 
-func (r *ResolverImpl) EnableCaching() {
+func (r *ResolverImpl) EnableCaching(m MetaContext) {
 	cache := ramcache.New()
 	cache.MaxAge = ResolveCacheMaxAge
 	cache.TTL = resolveCacheTTL
 	r.cache = cache
 }
 
-func (r *ResolverImpl) Shutdown() {
+func (r *ResolverImpl) Shutdown(m MetaContext) {
 	if r.cache == nil {
 		return
 	}
 	r.cache.Shutdown()
 }
 
-func (r *ResolverImpl) getFromMemCache(ctx context.Context, key string, au AssertionURL) (ret *ResolveResult) {
-	defer r.G().CVTraceOK(ctx, VLog1, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
+func (r *ResolverImpl) getFromMemCache(m MetaContext, key string, au AssertionURL) (ret *ResolveResult) {
+	defer m.CVTraceOK(VLog1, fmt.Sprintf("Resolver#getFromMemCache(%q)", key), func() bool { return ret != nil })()
 	if r.cache == nil {
 		return nil
 	}
@@ -470,10 +467,10 @@ func (r *ResolverImpl) getFromMemCache(ctx context.Context, key string, au Asser
 	}
 	// Should never happen, but don't corrupt application state if it does
 	if !rres.HasPrimaryKey() {
-		r.G().Log.CInfof(ctx, "Resolver#getFromMemCache: nil UID/teamID in cache")
+		m.CInfof("Resolver#getFromMemCache: nil UID/teamID in cache")
 		return nil
 	}
-	now := r.G().Clock().Now()
+	now := m.G().Clock().Now()
 	if now.Sub(rres.cachedAt) > ResolveCacheMaxAge {
 		r.Stats.timeouts++
 		return nil
@@ -498,8 +495,8 @@ func resolveDbKey(key string) DbKey {
 	}
 }
 
-func (r *ResolverImpl) putToDiskCache(ctx context.Context, key string, res ResolveResult) {
-	r.G().VDL.CLogf(ctx, VLog1, "| Resolver#putToDiskCache (attempt) %+v", res)
+func (r *ResolverImpl) putToDiskCache(m MetaContext, key string, res ResolveResult) {
+	m.VLogf(VLog1, "| Resolver#putToDiskCache (attempt) %+v", res)
 	// Only cache immutable resolutions to disk
 	if res.mutable {
 		return
@@ -509,24 +506,23 @@ func (r *ResolverImpl) putToDiskCache(ctx context.Context, key string, res Resol
 		return
 	}
 	if res.uid.IsNil() {
-		r.G().Log.CWarningf(ctx, "Mistaken UID put to disk cache")
-		if r.G().Env.GetDebug() {
+		m.CWarningf("Mistaken UID put to disk cache")
+		if m.G().Env.GetDebug() {
 			debug.PrintStack()
 		}
 		return
 	}
 	r.Stats.diskPuts++
-	err := r.G().LocalDb.PutObj(resolveDbKey(key), nil, res.uid)
-	if err != nil {
-		r.G().Log.CWarningf(ctx, "Cannot put resolve result to disk: %s", err)
+	if err := m.G().LocalDb.PutObj(resolveDbKey(key), nil, res.uid); err != nil {
+		m.CWarningf("Cannot put resolve result to disk: %s", err)
 		return
 	}
-	r.G().Log.CDebugf(ctx, "| Resolver#putToDiskCache(%s) -> %v", key, res)
+	m.CDebugf("| Resolver#putToDiskCache(%s) -> %v", key, res)
 }
 
 // Put receives a copy of a ResolveResult, clears out the body
 // to avoid caching data that can go stale, and stores the result.
-func (r *ResolverImpl) putToMemCache(key string, res ResolveResult) {
+func (r *ResolverImpl) putToMemCache(m MetaContext, key string, res ResolveResult) {
 	if r.cache == nil {
 		return
 	}
@@ -535,15 +531,39 @@ func (r *ResolverImpl) putToMemCache(key string, res ResolveResult) {
 		return
 	}
 	if !res.HasPrimaryKey() {
-		r.G().Log.Warning("Mistaken UID put to mem cache")
-		if r.G().Env.GetDebug() {
+		m.CWarningf("Mistaken UID put to mem cache")
+		if m.G().Env.GetDebug() {
 			debug.PrintStack()
 		}
 		return
 	}
-	res.cachedAt = r.G().Clock().Now()
+	res.cachedAt = m.G().Clock().Now()
 	res.body = nil // Don't cache body
 	r.cache.Set(key, &res)
+}
+
+func (r *ResolverImpl) PurgeResolveCache(m MetaContext, input string) (err error) {
+	defer m.CTrace(fmt.Sprintf("Resolver#PurgeResolveCache(input = %q)", input), func() error { return err })()
+	expr, err := AssertionParseAndOnly(m.G().MakeAssertionContext(), input)
+	if err != nil {
+		return err
+	}
+	u := FindBestIdentifyComponentURL(expr)
+	if u == nil {
+		return ResolutionError{Input: input, Msg: "Cannot find a resolvable factor"}
+	}
+
+	key := u.CacheKey()
+	r.cache.Delete(key)
+	// Since we only put to disk cache if it's a Keybase-type assertion, we
+	// only remove it in this case as well.
+	if u.IsKeybase() {
+		if err := m.G().LocalDb.Delete(resolveDbKey(key)); err != nil {
+			m.CWarningf("Cannot remove resolve result from disk: %s", err)
+			return err
+		}
+	}
+	return nil
 }
 
 var _ Resolver = (*ResolverImpl)(nil)

--- a/vendor/github.com/keybase/client/go/libkb/rpc_exim.go
+++ b/vendor/github.com/keybase/client/go/libkb/rpc_exim.go
@@ -354,17 +354,25 @@ func ImportStatusAsError(g *GlobalContext, s *keybase1.Status) error {
 		ret := NoPGPEncryptionKeyError{User: s.Desc}
 		for _, field := range s.Fields {
 			switch field.Key {
-			case "device":
-				ret.HasDeviceKey = true
+			case "HasKeybaseEncryptionKey":
+				ret.HasKeybaseEncryptionKey = true
 			}
 		}
 		return ret
 	case SCKeyNoNaClEncryption:
-		ret := NoNaClEncryptionKeyError{User: s.Desc}
+		ret := NoNaClEncryptionKeyError{}
 		for _, field := range s.Fields {
 			switch field.Key {
-			case "pgp":
+			case "Username":
+				ret.Username = field.Value
+			case "HasPGPKey":
 				ret.HasPGPKey = true
+			case "HasPUK":
+				ret.HasPUK = true
+			case "HasPaperKey":
+				ret.HasPaperKey = true
+			case "HasDeviceKey":
+				ret.HasDeviceKey = true
 			}
 		}
 		return ret
@@ -1757,9 +1765,9 @@ func (e NoPGPEncryptionKeyError) ToStatus() keybase1.Status {
 		Name: "SC_KEY_NO_PGP_ENCRYPTION",
 		Desc: e.User,
 	}
-	if e.HasDeviceKey {
+	if e.HasKeybaseEncryptionKey {
 		ret.Fields = []keybase1.StringKVPair{
-			{Key: "device", Value: "1"},
+			{Key: "HasKeybaseEncryptionKey", Value: "1"},
 		}
 	}
 	return ret
@@ -1769,12 +1777,22 @@ func (e NoNaClEncryptionKeyError) ToStatus() keybase1.Status {
 	ret := keybase1.Status{
 		Code: SCKeyNoNaClEncryption,
 		Name: "SC_KEY_NO_NACL_ENCRYPTION",
-		Desc: e.User,
+		Desc: e.Error(),
 	}
+
+	ret.Fields = []keybase1.StringKVPair{{Key: "Username", Value: e.Username}}
+
 	if e.HasPGPKey {
-		ret.Fields = []keybase1.StringKVPair{
-			{Key: "pgp", Value: "1"},
-		}
+		ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "HasPGPKey", Value: "1"})
+	}
+	if e.HasPUK {
+		ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "HasPUK", Value: "1"})
+	}
+	if e.HasDeviceKey {
+		ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "HasDeviceKey", Value: "1"})
+	}
+	if e.HasPaperKey {
+		ret.Fields = append(ret.Fields, keybase1.StringKVPair{Key: "HasPaperKey", Value: "1"})
 	}
 	return ret
 }

--- a/vendor/github.com/keybase/client/go/libkb/saltpack_dec.go
+++ b/vendor/github.com/keybase/client/go/libkb/saltpack_dec.go
@@ -4,23 +4,16 @@
 package libkb
 
 import (
-	"bufio"
-	"bytes"
-	"context"
-	"fmt"
 	"io"
-	"strings"
 
-	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/saltpack"
 )
 
-func SaltpackDecrypt(
-	ctx context.Context, g *GlobalContext, source io.Reader, sink io.WriteCloser,
-	deviceEncryptionKey NaclDHKeyPair,
+func SaltpackDecrypt(m MetaContext, source io.Reader, sink io.WriteCloser,
+	decryptionKeyring saltpack.SigncryptKeyring,
 	checkSenderMki func(*saltpack.MessageKeyInfo) error,
-	checkSenderSigningKey func(saltpack.SigningPublicKey) error) (*saltpack.MessageKeyInfo, error) {
+	checkSenderSigningKey func(saltpack.SigningPublicKey) error,
+	keyResolver saltpack.SymmetricKeyResolver) (*saltpack.MessageKeyInfo, error) {
 
 	sc, newSource, err := ClassifyStream(source)
 	if err != nil {
@@ -37,20 +30,8 @@ func SaltpackDecrypt(
 
 	source = newSource
 
-	var dearmored io.Reader
-	var frame saltpack.Frame
-	if sc.Armored {
-		dearmored, frame, err = saltpack.NewArmor62DecoderStream(source)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		dearmored = source
-	}
-
 	// mki will be set for DH mode, senderSigningKey will be set for signcryption mode
-	plainsource, mki, senderSigningKey, typ, err := peekTypeAndMakeDecoder(ctx, g, dearmored, naclKeyring(deviceEncryptionKey))
-
+	plainsource, typ, mki, senderSigningKey, isArmored, brand, _, err := saltpack.ClassifyEncryptedStreamAndMakeDecoder(source, decryptionKeyring, keyResolver)
 	if err != nil {
 		return mki, err
 	}
@@ -71,177 +52,17 @@ func SaltpackDecrypt(
 		return mki, err
 	}
 
-	// TODO: Check header inline, and only warn if the footer
-	// doesn't match.
-	if sc.Armored {
-		var brand string
-		brand, err = saltpack.CheckArmor62Frame(frame, saltpack.MessageTypeEncryption)
-		if err != nil {
-			return mki, err
-		}
+	if isArmored {
+		// Note: the following check always passes!
 		if err = checkSaltpackBrand(brand); err != nil {
 			return mki, err
 		}
 	}
 
-	g.Log.CDebugf(ctx, "Decrypt: read %d bytes", n)
+	m.CDebugf("Decrypt: read %d bytes", n)
 
 	if err := sink.Close(); err != nil {
 		return mki, err
 	}
 	return mki, nil
-}
-
-func peekTypeAndMakeDecoder(ctx context.Context, g *GlobalContext, dearmored io.Reader, keyring naclKeyring) (io.Reader, *saltpack.MessageKeyInfo, saltpack.SigningPublicKey, saltpack.MessageType, error) {
-	// How much do we need to peek to get at the mode number?
-	// - bin tag (2, 3, or 5 bytes)
-	// - array tag (1 byte)
-	// - format name (9 bytes, including tag)
-	// - version (3 bytes, including tag)
-	// - and finally, the mode (1 byte)
-	// sums to 16-19 bytes.
-	peekable := bufio.NewReader(dearmored)
-	peekedBytes, err := peekable.Peek(19)
-	if err != nil {
-		return nil, nil, nil, -1, err
-	}
-
-	// Figure out the bin tag size.
-	var binTagSize int
-	switch peekedBytes[0] {
-	case 0xc4:
-		binTagSize = 2
-	case 0xc5:
-		binTagSize = 3
-	case 0xc6:
-		binTagSize = 5
-	default:
-		return nil, nil, nil, -1, fmt.Errorf("invalid bin tag value when peeking: %x", peekedBytes[0])
-	}
-	arrayTagOffset := binTagSize
-	formatNameOffset := arrayTagOffset + 1
-	versionOffset := formatNameOffset + 9
-	modeOffset := versionOffset + 3
-
-	// Sanity check all the values we've peeked, to avoid kicking errors down
-	// the road if we're reading garbage.
-
-	arrayTag := peekedBytes[arrayTagOffset]
-	if arrayTag&0x90 != 0x90 {
-		return nil, nil, nil, -1, fmt.Errorf("invalid array tag value when peeking: %x", arrayTag)
-	}
-
-	formatName := peekedBytes[formatNameOffset : formatNameOffset+9]
-	if !bytes.Equal([]byte("\xa8saltpack"), formatName) {
-		return nil, nil, nil, -1, fmt.Errorf("invalid format name when peeking: %q", string(formatName))
-	}
-
-	versionTag := peekedBytes[versionOffset]
-	if versionTag != 0x92 {
-		return nil, nil, nil, -1, fmt.Errorf("invalid version tag value when peeking: %x", versionTag)
-	}
-
-	// fixints are encoded as their literal byte value
-	typ := saltpack.MessageType(peekedBytes[modeOffset])
-	switch typ {
-	case saltpack.MessageTypeEncryption:
-		mki, plainsource, err := saltpack.NewDecryptStream(saltpack.CheckKnownMajorVersion, peekable, keyring)
-		return plainsource, mki, nil, typ, err
-	case saltpack.MessageTypeSigncryption:
-		senderPublic, plainsource, err := saltpack.NewSigncryptOpenStream(peekable, keyring, NewTlfKeyResolver(ctx, g))
-		return plainsource, nil, senderPublic, typ, err
-	default:
-		return nil, nil, nil, -1, fmt.Errorf("unexpected message mode when peeking: %d", typ)
-	}
-}
-
-type TlfKeyResolver struct {
-	Contextified
-	ctx context.Context
-}
-
-var _ saltpack.SymmetricKeyResolver = (*TlfKeyResolver)(nil)
-
-func NewTlfKeyResolver(ctx context.Context, g *GlobalContext) *TlfKeyResolver {
-	return &TlfKeyResolver{NewContextified(g), ctx}
-}
-
-func (r *TlfKeyResolver) ResolveKeys(identifiers [][]byte) ([]*saltpack.SymmetricKey, error) {
-	tlfPseudonyms := []TlfPseudonym{}
-	for _, identifier := range identifiers {
-		pseudonym := TlfPseudonym{}
-		if len(pseudonym) != len(identifier) {
-			return nil, fmt.Errorf("identifier is the wrong length for a TLF pseudonym (%d != %d)", len(pseudonym), len(identifier))
-		}
-		copy(pseudonym[:], identifier)
-		tlfPseudonyms = append(tlfPseudonyms, pseudonym)
-	}
-
-	results, err := GetTlfPseudonyms(r.ctx, r.G(), tlfPseudonyms)
-	if err != nil {
-		return nil, err
-	}
-
-	symmetricKeys := []*saltpack.SymmetricKey{}
-	for _, result := range results {
-		if result.Err != nil {
-			r.G().Log.CDebugf(r.ctx, "skipping unresolved pseudonym: %s", result.Err)
-			symmetricKeys = append(symmetricKeys, nil)
-			continue
-		}
-		r.G().Log.CDebugf(r.ctx, "resolved pseudonym for %s, fetching key", result.Info.Name)
-		symmetricKey, err := r.getSymmetricKey(*result.Info)
-		if err != nil {
-			return nil, err
-		}
-		symmetricKeys = append(symmetricKeys, symmetricKey)
-	}
-	return symmetricKeys, nil
-}
-
-func (r *TlfKeyResolver) getCryptKeys(ctx context.Context, name string) (keybase1.GetTLFCryptKeysRes, error) {
-	xp := r.G().ConnectionManager.LookupByClientType(keybase1.ClientType_KBFS)
-	if xp == nil {
-		return keybase1.GetTLFCryptKeysRes{}, KBFSNotRunningError{}
-	}
-	cli := &keybase1.TlfKeysClient{
-		Cli: rpc.NewClient(xp, NewContextifiedErrorUnwrapper(r.G()), LogTagsFromContext),
-	}
-	return cli.GetTLFCryptKeys(ctx, keybase1.TLFQuery{
-		TlfName:          name,
-		IdentifyBehavior: keybase1.TLFIdentifyBehavior_CHAT_CLI,
-	})
-}
-
-func (r *TlfKeyResolver) getSymmetricKey(info TlfPseudonymServerInfo) (*saltpack.SymmetricKey, error) {
-	// NOTE: In order to handle finalized TLFs (which is one of the main
-	// benefits of using TLF keys to begin with, for forward readability), we
-	// need the server to tell us what the current, potentially-finalized name
-	// of the TLF is. If that's not the same as what the name was when the
-	// message was sent, we can't necessarily check that the server is being
-	// honest. That's ok insofar as we're not relying on these keys for
-	// authenticity, but it's a drag to not be able to use the pseudonym
-	// machinery.
-
-	// TODO: Check as much as we can, if the original TLF was fully resolved.
-	// This is a little tricky, because the current TLF name parsing code lives
-	// in chat and depends on externals, and it would create a circular
-	// dependency if we pulled it directly into libkb.
-
-	// Strip "/keybase/private/" from the name.
-	basename := strings.TrimPrefix(info.UntrustedCurrentName, "/keybase/private/")
-	if len(basename) >= len(info.UntrustedCurrentName) {
-		return nil, fmt.Errorf("unexpected prefix, expected '/keybase/private', found %q", info.UntrustedCurrentName)
-	}
-	res, err := r.getCryptKeys(r.ctx, basename)
-	if err != nil {
-		return nil, err
-	}
-	for _, key := range res.CryptKeys {
-		if KeyGen(key.KeyGeneration) == info.KeyGen {
-			// Success!
-			return (*saltpack.SymmetricKey)(&key.Key), nil
-		}
-	}
-	return nil, fmt.Errorf("no keys in TLF %q matched generation %d", basename, info.KeyGen)
 }

--- a/vendor/github.com/keybase/client/go/libkb/saltpack_enc.go
+++ b/vendor/github.com/keybase/client/go/libkb/saltpack_enc.go
@@ -27,7 +27,7 @@ type SaltpackEncryptArg struct {
 // SaltpackEncrypt reads from the given source, encrypts it for the given
 // receivers from the given sender, and writes it to sink.  If
 // Binary is false, the data written to sink will be armored.
-func SaltpackEncrypt(g *GlobalContext, arg *SaltpackEncryptArg) error {
+func SaltpackEncrypt(m MetaContext, arg *SaltpackEncryptArg) error {
 	var receiverBoxKeys []saltpack.BoxPublicKey
 	for _, k := range arg.Receivers {
 		// Since signcryption became the default, we never use visible
@@ -54,7 +54,7 @@ func SaltpackEncrypt(g *GlobalContext, arg *SaltpackEncryptArg) error {
 	var err error
 	if !arg.EncryptionOnlyMode {
 		if arg.SaltpackVersion.Major == 1 {
-			return errors.New("specifying the saltpack version 1 requires --current-devices-only")
+			return errors.New("specifying saltpack version 1 requires repudiable authentication")
 		}
 		var signer saltpack.SigningSecretKey
 		if !arg.SenderSigning.IsNil() {
@@ -81,7 +81,7 @@ func SaltpackEncrypt(g *GlobalContext, arg *SaltpackEncryptArg) error {
 		return err
 	}
 
-	g.Log.Debug("Encrypt: wrote %d bytes", n)
+	m.CDebugf("Encrypt: wrote %d bytes", n)
 
 	if err := plainsink.Close(); err != nil {
 		return err

--- a/vendor/github.com/keybase/client/go/libkb/saltpack_verify.go
+++ b/vendor/github.com/keybase/client/go/libkb/saltpack_verify.go
@@ -35,9 +35,9 @@ func SaltpackVerify(g SaltpackVerifyContext, source io.Reader, sink io.WriteClos
 
 	var skey saltpack.SigningPublicKey
 	var vs io.Reader
-	var frame saltpack.Frame
+	var brand string
 	if sc.Armored {
-		skey, vs, frame, err = saltpack.NewDearmor62VerifyStream(saltpack.CheckKnownMajorVersion, source, kr)
+		skey, vs, brand, err = saltpack.NewDearmor62VerifyStream(saltpack.CheckKnownMajorVersion, source, kr)
 	} else {
 		skey, vs, err = saltpack.NewVerifyStream(saltpack.CheckKnownMajorVersion, source, kr)
 	}
@@ -58,9 +58,7 @@ func SaltpackVerify(g SaltpackVerifyContext, source io.Reader, sink io.WriteClos
 	}
 
 	if sc.Armored {
-		if brand, err := saltpack.CheckArmor62Frame(frame, saltpack.MessageTypeAttachedSignature); err != nil {
-			return err
-		} else if err = checkSaltpackBrand(brand); err != nil {
+		if err = checkSaltpackBrand(brand); err != nil {
 			return err
 		}
 	}

--- a/vendor/github.com/keybase/client/go/libkb/sig_chain.go
+++ b/vendor/github.com/keybase/client/go/libkb/sig_chain.go
@@ -219,6 +219,7 @@ func (sc *SigChain) Bump(mt MerkleTriple) {
 }
 
 func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keybase1.UID) (dirtyTail *MerkleTriple, err error) {
+	m, tbs := m.WithTimeBuckets()
 	low := sc.GetLastLoadedSeqno()
 	sc.loadedFromLinkOne = (low == keybase1.Seqno(0) || low == keybase1.Seqno(-1))
 
@@ -245,10 +246,13 @@ func (sc *SigChain) LoadFromServer(m MetaContext, t *MerkleTriple, selfUID keyba
 		defer finisher()
 	}
 
+	recordFin := tbs.Record("SigChain.LoadFromServer.ReadAll")
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		recordFin()
 		return nil, err
 	}
+	recordFin()
 	return sc.LoadServerBody(m, body, low, t, selfUID)
 }
 

--- a/vendor/github.com/keybase/client/go/libkb/version.go
+++ b/vendor/github.com/keybase/client/go/libkb/version.go
@@ -4,4 +4,4 @@
 package libkb
 
 // Version is the current version (should be MAJOR.MINOR.PATCH)
-const Version = "2.4.0"
+const Version = "2.6.0"

--- a/vendor/github.com/keybase/go-crypto/openpgp/armor/armor.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/armor/armor.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"io"
 	"strings"
+	"unicode"
 
 	"github.com/keybase/go-crypto/openpgp/errors"
 )
@@ -67,7 +68,14 @@ type lineReader struct {
 	in  *bufio.Reader
 	buf []byte
 	eof bool
-	crc uint32
+	crc *uint32
+}
+
+// ourIsSpace checks if a rune is either space according to unicode
+// package, or ZeroWidthSpace (which is not a space according to
+// unicode module). Used to trim lines during header reading.
+func ourIsSpace(r rune) bool {
+	return r == '\u200b' || unicode.IsSpace(r)
 }
 
 func (l *lineReader) Read(p []byte) (n int, err error) {
@@ -81,13 +89,13 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 		return
 	}
 
-	line, isPrefix, err := l.in.ReadLine()
+	line, _, err := l.in.ReadLine()
 	if err != nil {
 		return
 	}
-	if isPrefix {
-		return 0, ArmorCorrupt
-	}
+
+	// Entry-level cleanup, just trim spaces.
+	line = bytes.TrimFunc(line, ourIsSpace)
 
 	if len(line) == 5 && line[0] == '=' {
 		// This is the checksum line
@@ -97,13 +105,17 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 		if m != 3 || err != nil {
 			return
 		}
-		l.crc = uint32(expectedBytes[0])<<16 |
+		crc := uint32(expectedBytes[0])<<16 |
 			uint32(expectedBytes[1])<<8 |
 			uint32(expectedBytes[2])
+		l.crc = &crc
 
 		for {
 			line, _, err = l.in.ReadLine()
-			if err != nil && err != io.EOF {
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
 				return
 			}
 			if len(strings.TrimSpace(string(line))) > 0 {
@@ -118,9 +130,24 @@ func (l *lineReader) Read(p []byte) (n int, err error) {
 		return 0, io.EOF
 	}
 
-	if len(line) > 96 {
-		return 0, ArmorCorrupt
+	if bytes.HasPrefix(line, armorEnd) {
+		// Unexpected ending, there was no checksum.
+		l.eof = true
+		l.crc = nil
+		return 0, io.EOF
 	}
+
+	// Clean-up line from whitespace to pass it further (to base64
+	// decoder). This is done after test for CRC and test for
+	// armorEnd. Keys that have whitespace in CRC will have CRC
+	// treated as part of the payload and probably fail in base64
+	// reading.
+	line = bytes.Map(func(r rune) rune {
+		if ourIsSpace(r) {
+			return -1
+		}
+		return r
+	}, line)
 
 	n = copy(p, line)
 	bytesToSave := len(line) - n
@@ -149,7 +176,7 @@ func (r *openpgpReader) Read(p []byte) (n int, err error) {
 	r.currentCRC = crc24(r.currentCRC, p[:n])
 
 	if err == io.EOF {
-		if r.lReader.crc != uint32(r.currentCRC&crc24Mask) {
+		if r.lReader.crc != nil && *r.lReader.crc != uint32(r.currentCRC&crc24Mask) {
 			return 0, ArmorCorrupt
 		}
 	}
@@ -203,7 +230,7 @@ TryNextBlock:
 			p.Header[lastKey] += string(line)
 			continue
 		}
-		line = bytes.TrimSpace(line)
+		line = bytes.TrimFunc(line, ourIsSpace)
 		if len(line) == 0 {
 			break
 		}

--- a/vendor/github.com/keybase/go-crypto/openpgp/errors/errors.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/errors/errors.go
@@ -70,3 +70,11 @@ type UnknownPacketTypeError uint8
 func (upte UnknownPacketTypeError) Error() string {
 	return "openpgp: unknown packet type: " + strconv.Itoa(int(upte))
 }
+
+// DeprecatedKeyError indicates that the key was read and verified
+// properly, but uses a deprecated algorithm and can't be used.
+type DeprecatedKeyError string
+
+func (d DeprecatedKeyError) Error() string {
+	return "openpgp: key is deprecated: " + string(d)
+}

--- a/vendor/github.com/keybase/go-crypto/openpgp/keys.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/keys.go
@@ -6,6 +6,7 @@ package openpgp
 
 import (
 	"crypto/hmac"
+	"crypto/rsa"
 	"encoding/binary"
 	"io"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/keybase/go-crypto/openpgp/armor"
 	"github.com/keybase/go-crypto/openpgp/errors"
 	"github.com/keybase/go-crypto/openpgp/packet"
-	"github.com/keybase/go-crypto/rsa"
 )
 
 // PublicKeyType is the armor type for a PGP public key.
@@ -72,6 +72,7 @@ type Key struct {
 	PublicKey     *packet.PublicKey
 	PrivateKey    *packet.PrivateKey
 	SelfSignature *packet.Signature
+	KeyFlags      packet.KeyFlagBits
 }
 
 // A KeyRing provides access to public and private keys.
@@ -117,7 +118,8 @@ func (e *Entity) primaryIdentity() *Identity {
 func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 	candidateSubkey := -1
 
-	// Iterate the keys to find the newest key
+	// Iterate the keys to find the newest, non-revoked key that can
+	// encrypt.
 	var maxTime time.Time
 	for i, subkey := range e.Subkeys {
 
@@ -145,7 +147,7 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 
 	if candidateSubkey != -1 {
 		subkey := e.Subkeys[candidateSubkey]
-		return Key{e, subkey.PublicKey, subkey.PrivateKey, subkey.Sig}, true
+		return Key{e, subkey.PublicKey, subkey.PrivateKey, subkey.Sig, subkey.Sig.GetKeyFlags()}, true
 	}
 
 	// If we don't have any candidate subkeys for encryption and
@@ -159,7 +161,7 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 	if (!i.SelfSignature.FlagsValid || i.SelfSignature.FlagEncryptCommunications) &&
 		e.PrimaryKey.PubKeyAlgo.CanEncrypt() &&
 		!i.SelfSignature.KeyExpired(now) {
-		return Key{e, e.PrimaryKey, e.PrivateKey, i.SelfSignature}, true
+		return Key{e, e.PrimaryKey, e.PrivateKey, i.SelfSignature, i.SelfSignature.GetKeyFlags()}, true
 	}
 
 	// This Entity appears to be signing only.
@@ -171,20 +173,25 @@ func (e *Entity) encryptionKey(now time.Time) (Key, bool) {
 func (e *Entity) signingKey(now time.Time) (Key, bool) {
 	candidateSubkey := -1
 
+	// Iterate the keys to find the newest, non-revoked key that can
+	// sign.
+	var maxTime time.Time
 	for i, subkey := range e.Subkeys {
 		if (!subkey.Sig.FlagsValid || subkey.Sig.FlagSign) &&
 			subkey.PrivateKey.PrivateKey != nil &&
 			subkey.PublicKey.PubKeyAlgo.CanSign() &&
+			!subkey.Sig.KeyExpired(now) &&
 			subkey.Revocation == nil &&
-			!subkey.Sig.KeyExpired(now) {
+			(maxTime.IsZero() || subkey.Sig.CreationTime.After(maxTime)) {
 			candidateSubkey = i
+			maxTime = subkey.Sig.CreationTime
 			break
 		}
 	}
 
 	if candidateSubkey != -1 {
 		subkey := e.Subkeys[candidateSubkey]
-		return Key{e, subkey.PublicKey, subkey.PrivateKey, subkey.Sig}, true
+		return Key{e, subkey.PublicKey, subkey.PrivateKey, subkey.Sig, subkey.Sig.GetKeyFlags()}, true
 	}
 
 	// If we have no candidate subkey then we assume that it's ok to sign
@@ -194,7 +201,7 @@ func (e *Entity) signingKey(now time.Time) (Key, bool) {
 		e.PrimaryKey.PubKeyAlgo.CanSign() &&
 		!i.SelfSignature.KeyExpired(now) &&
 		e.PrivateKey.PrivateKey != nil {
-		return Key{e, e.PrimaryKey, e.PrivateKey, i.SelfSignature}, true
+		return Key{e, e.PrimaryKey, e.PrivateKey, i.SelfSignature, i.SelfSignature.GetKeyFlags()}, true
 	}
 
 	return Key{}, false
@@ -229,7 +236,13 @@ func (el EntityList) KeysById(id uint64, fp []byte) (keys []Key) {
 					break
 				}
 			}
-			keys = append(keys, Key{e, e.PrimaryKey, e.PrivateKey, selfSig})
+
+			var keyFlags packet.KeyFlagBits
+			for _, ident := range e.Identities {
+				keyFlags.Merge(ident.SelfSignature.GetKeyFlags())
+			}
+
+			keys = append(keys, Key{e, e.PrimaryKey, e.PrivateKey, selfSig, keyFlags})
 		}
 
 		for _, subKey := range e.Subkeys {
@@ -242,7 +255,7 @@ func (el EntityList) KeysById(id uint64, fp []byte) (keys []Key) {
 					sig = subKey.Sig
 				}
 
-				keys = append(keys, Key{e, subKey.PublicKey, subKey.PrivateKey, sig})
+				keys = append(keys, Key{e, subKey.PublicKey, subKey.PrivateKey, sig, sig.GetKeyFlags()})
 			}
 		}
 	}
@@ -269,19 +282,8 @@ func (el EntityList) KeysByIdUsage(id uint64, fp []byte, requiredUsage byte) (ke
 			var usage byte
 
 			switch {
-			case key.SelfSignature.FlagsValid:
-				if key.SelfSignature.FlagCertify {
-					usage |= packet.KeyFlagCertify
-				}
-				if key.SelfSignature.FlagSign {
-					usage |= packet.KeyFlagSign
-				}
-				if key.SelfSignature.FlagEncryptCommunications {
-					usage |= packet.KeyFlagEncryptCommunications
-				}
-				if key.SelfSignature.FlagEncryptStorage {
-					usage |= packet.KeyFlagEncryptStorage
-				}
+			case key.KeyFlags.Valid:
+				usage = key.KeyFlags.BitField
 
 			case key.PublicKey.PubKeyAlgo == packet.PubKeyAlgoElGamal:
 				// We also need to handle the case where, although the sig's
@@ -319,7 +321,7 @@ func (el EntityList) DecryptionKeys() (keys []Key) {
 	for _, e := range el {
 		for _, subKey := range e.Subkeys {
 			if subKey.PrivateKey != nil && subKey.PrivateKey.PrivateKey != nil && (!subKey.Sig.FlagsValid || subKey.Sig.FlagEncryptStorage || subKey.Sig.FlagEncryptCommunications) {
-				keys = append(keys, Key{e, subKey.PublicKey, subKey.PrivateKey, subKey.Sig})
+				keys = append(keys, Key{e, subKey.PublicKey, subKey.PrivateKey, subKey.Sig, subKey.Sig.GetKeyFlags()})
 			}
 		}
 	}
@@ -649,6 +651,15 @@ func addSubkey(e *Entity, packets *packet.Reader, pub *packet.PublicKey, priv *p
 			}
 		}
 	}
+
+	if subKey.Sig != nil {
+		if err := subKey.PublicKey.ErrorIfDeprecated(); err != nil {
+			// Key passed signature check but is deprecated.
+			subKey.Sig = nil
+			lastErr = err
+		}
+	}
+
 	if subKey.Sig != nil {
 		e.Subkeys = append(e.Subkeys, subKey)
 	} else {

--- a/vendor/github.com/keybase/go-crypto/openpgp/packet/encrypted_key.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/packet/encrypted_key.go
@@ -5,6 +5,7 @@
 package packet
 
 import (
+	"crypto/rsa"
 	"encoding/binary"
 	"io"
 	"math/big"
@@ -13,7 +14,6 @@ import (
 	"github.com/keybase/go-crypto/openpgp/ecdh"
 	"github.com/keybase/go-crypto/openpgp/elgamal"
 	"github.com/keybase/go-crypto/openpgp/errors"
-	"github.com/keybase/go-crypto/rsa"
 )
 
 const encryptedKeyVersion = 3
@@ -90,7 +90,8 @@ func (e *EncryptedKey) Decrypt(priv *PrivateKey, config *Config) error {
 	// padding oracle attacks.
 	switch priv.PubKeyAlgo {
 	case PubKeyAlgoRSA, PubKeyAlgoRSAEncryptOnly:
-		b, err = rsa.DecryptPKCS1v15(config.Random(), priv.PrivateKey.(*rsa.PrivateKey), e.encryptedMPI1.bytes)
+		k := priv.PrivateKey.(*rsa.PrivateKey)
+		b, err = rsa.DecryptPKCS1v15(config.Random(), k, padToKeySize(&k.PublicKey, e.encryptedMPI1.bytes))
 	case PubKeyAlgoElGamal:
 		c1 := new(big.Int).SetBytes(e.encryptedMPI1.bytes)
 		c2 := new(big.Int).SetBytes(e.encryptedMPI2.bytes)

--- a/vendor/github.com/keybase/go-crypto/openpgp/packet/packet.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/packet/packet.go
@@ -12,6 +12,7 @@ import (
 	"crypto/cipher"
 	"crypto/des"
 	"crypto/elliptic"
+	"crypto/rsa"
 	"io"
 	"math/big"
 
@@ -413,10 +414,12 @@ const (
 	PubKeyAlgoElGamal        PublicKeyAlgorithm = 16
 	PubKeyAlgoDSA            PublicKeyAlgorithm = 17
 	// RFC 6637, Section 5.
-	PubKeyAlgoECDH  PublicKeyAlgorithm = 18
-	PubKeyAlgoECDSA PublicKeyAlgorithm = 19
+	PubKeyAlgoECDH           PublicKeyAlgorithm = 18
+	PubKeyAlgoECDSA          PublicKeyAlgorithm = 19
+
+	PubKeyAlgoBadElGamal     PublicKeyAlgorithm = 20 // Reserved (deprecated, formerly ElGamal Encrypt or Sign)
 	// RFC -1
-	PubKeyAlgoEdDSA PublicKeyAlgorithm = 22
+	PubKeyAlgoEdDSA          PublicKeyAlgorithm = 22
 )
 
 // CanEncrypt returns true if it's possible to encrypt a message to a public
@@ -507,19 +510,17 @@ func readMPI(r io.Reader) (mpi []byte, bitLength uint16, err error) {
 	numBytes := (int(bitLength) + 7) / 8
 	mpi = make([]byte, numBytes)
 	_, err = readFull(r, mpi)
-	return
-}
-
-// mpiLength returns the length of the given *big.Int when serialized as an
-// MPI.
-func mpiLength(n *big.Int) (mpiLengthInBytes int) {
-	mpiLengthInBytes = 2 /* MPI length */
-	mpiLengthInBytes += (n.BitLen() + 7) / 8
+	// According to RFC 4880 3.2. we should check that the MPI has no leading
+	// zeroes (at least when not an encrypted MPI?), but this implementation
+	// does generate leading zeroes, so we keep accepting them.
 	return
 }
 
 // writeMPI serializes a big integer to w.
 func writeMPI(w io.Writer, bitLength uint16, mpiBytes []byte) (err error) {
+	// Note that we can produce leading zeroes, in violation of RFC 4880 3.2.
+	// Implementations seem to be tolerant of them, and stripping them would
+	// make it complex to guarantee matching re-serialization.
 	_, err = w.Write([]byte{byte(bitLength >> 8), byte(bitLength)})
 	if err == nil {
 		_, err = w.Write(mpiBytes)
@@ -549,6 +550,18 @@ func mpiPointByteLength(curve elliptic.Curve) int {
 // writeBig serializes a *big.Int to w.
 func writeBig(w io.Writer, i *big.Int) error {
 	return writeMPI(w, uint16(i.BitLen()), i.Bytes())
+}
+
+// padToKeySize left-pads a MPI with zeroes to match the length of the
+// specified RSA public.
+func padToKeySize(pub *rsa.PublicKey, b []byte) []byte {
+	k := (pub.N.BitLen() + 7) / 8
+	if len(b) >= k {
+		return b
+	}
+	bb := make([]byte, k)
+	copy(bb[len(bb)-len(b):], b)
+	return bb
 }
 
 // CompressionAlgo Represents the different compression algorithms

--- a/vendor/github.com/keybase/go-crypto/openpgp/packet/private_key.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/packet/private_key.go
@@ -9,6 +9,7 @@ import (
 	"crypto/cipher"
 	"crypto/dsa"
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/sha1"
 	"fmt"
 	"io"
@@ -22,7 +23,6 @@ import (
 	"github.com/keybase/go-crypto/openpgp/elgamal"
 	"github.com/keybase/go-crypto/openpgp/errors"
 	"github.com/keybase/go-crypto/openpgp/s2k"
-	"github.com/keybase/go-crypto/rsa"
 )
 
 // PrivateKey represents a possibly encrypted private key. See RFC 4880,
@@ -85,6 +85,13 @@ func NewElGamalPrivateKey(currentTime time.Time, priv *elgamal.PrivateKey) *Priv
 func NewECDSAPrivateKey(currentTime time.Time, priv *ecdsa.PrivateKey) *PrivateKey {
 	pk := new(PrivateKey)
 	pk.PublicKey = *NewECDSAPublicKey(currentTime, &priv.PublicKey)
+	pk.PrivateKey = priv
+	return pk
+}
+
+func NewECDHPrivateKey(currentTime time.Time, priv *ecdh.PrivateKey) *PrivateKey {
+	pk := new(PrivateKey)
+	pk.PublicKey = *NewECDHPublicKey(currentTime, &priv.PublicKey)
 	pk.PrivateKey = priv
 	return pk
 }

--- a/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key_v3.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/packet/public_key_v3.go
@@ -7,6 +7,7 @@ package packet
 import (
 	"crypto"
 	"crypto/md5"
+	"crypto/rsa"
 	"encoding/binary"
 	"fmt"
 	"hash"
@@ -16,7 +17,6 @@ import (
 	"time"
 
 	"github.com/keybase/go-crypto/openpgp/errors"
-	"github.com/keybase/go-crypto/rsa"
 )
 
 // PublicKeyV3 represents older, version 3 public keys. These keys are less secure and
@@ -107,7 +107,7 @@ func (pk *PublicKeyV3) parseRSA(r io.Reader) (err error) {
 	rsa := &rsa.PublicKey{N: new(big.Int).SetBytes(pk.n.bytes)}
 	for i := 0; i < len(pk.e.bytes); i++ {
 		rsa.E <<= 8
-		rsa.E |= int64(pk.e.bytes[i])
+		rsa.E |= int(pk.e.bytes[i])
 	}
 	pk.PublicKey = rsa
 	return

--- a/vendor/github.com/keybase/go-crypto/openpgp/packet/symmetric_key_encrypted.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/packet/symmetric_key_encrypted.go
@@ -91,10 +91,10 @@ func (ske *SymmetricKeyEncrypted) Decrypt(passphrase []byte) ([]byte, CipherFunc
 		return nil, ske.CipherFunc, errors.UnsupportedError("unknown cipher: " + strconv.Itoa(int(cipherFunc)))
 	}
 	plaintextKey = plaintextKey[1:]
-	if l := len(plaintextKey); l == 0 || l%cipherFunc.blockSize() != 0 {
-		return nil, cipherFunc, errors.StructuralError("length of decrypted key not a multiple of block size")
+	if l, cipherKeySize := len(plaintextKey), cipherFunc.KeySize(); l != cipherFunc.KeySize() {
+		return nil, cipherFunc, errors.StructuralError("length of decrypted key (" + strconv.Itoa(l) + ") " +
+			"not equal to cipher keysize (" + strconv.Itoa(cipherKeySize) + ")")
 	}
-
 	return plaintextKey, cipherFunc, nil
 }
 

--- a/vendor/github.com/keybase/go-crypto/openpgp/read.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/read.go
@@ -61,6 +61,9 @@ type MessageDetails struct {
 	Signature      *packet.Signature   // the signature packet itself, if v4 (default)
 	SignatureV3    *packet.SignatureV3 // the signature packet if it is a v2 or v3 signature
 
+	// Does the Message include multiple signatures? Also called "nested signatures".
+	MultiSig bool
+
 	decrypted io.ReadCloser
 }
 
@@ -244,8 +247,17 @@ FindLiteralData:
 				return nil, err
 			}
 		case *packet.OnePassSignature:
-			if !p.IsLast {
-				return nil, errors.UnsupportedError("nested signatures")
+			if md.IsSigned {
+				// If IsSigned is set, it means we have multiple
+				// OnePassSignature packets.
+				md.MultiSig = true
+				if md.SignedBy != nil {
+					// We've already found the signature we were looking
+					// for, made by key that we had in keyring and can
+					// check signature against. Continue with that instead
+					// of trying to find another.
+					continue FindLiteralData
+				}
 			}
 
 			h, wrappedHash, err = hashForSignature(p.Hash, p.SigType)
@@ -329,29 +341,54 @@ func (scr *signatureCheckReader) Read(buf []byte) (n int, err error) {
 	n, err = scr.md.LiteralData.Body.Read(buf)
 	scr.wrappedHash.Write(buf[:n])
 	if err == io.EOF {
-		var p packet.Packet
-		p, scr.md.SignatureError = scr.packets.Next()
-		if scr.md.SignatureError != nil {
-			return
-		}
-
-		var ok bool
-		if scr.md.Signature, ok = p.(*packet.Signature); ok {
-			var err error
-			if fingerprint := scr.md.Signature.IssuerFingerprint; fingerprint != nil {
-				if !hmac.Equal(fingerprint, scr.md.SignedBy.PublicKey.Fingerprint[:]) {
-					err = errors.StructuralError("bad key fingerprint")
+		for {
+			var p packet.Packet
+			p, scr.md.SignatureError = scr.packets.Next()
+			if scr.md.SignatureError != nil {
+				if scr.md.MultiSig {
+					// If we are in MultiSig, we might have found other
+					// signature that cannot be verified using our key.
+					// Clear Signature field so it's clear for consumers
+					// that this message failed to verify.
+					scr.md.Signature = nil
 				}
+				return
 			}
-			if err == nil {
-				err = scr.md.SignedBy.PublicKey.VerifySignature(scr.h, scr.md.Signature)
+
+			var ok bool
+			if scr.md.Signature, ok = p.(*packet.Signature); ok {
+				var err error
+				if keyID := scr.md.Signature.IssuerKeyId; keyID != nil {
+					if *keyID != scr.md.SignedBy.PublicKey.KeyId {
+						if scr.md.MultiSig {
+							continue // try again to find a sig we can verify
+						}
+						err = errors.StructuralError("bad key id")
+					}
+				}
+				if fingerprint := scr.md.Signature.IssuerFingerprint; fingerprint != nil {
+					if !hmac.Equal(fingerprint, scr.md.SignedBy.PublicKey.Fingerprint[:]) {
+						if scr.md.MultiSig {
+							continue // try again to find a sig we can verify
+						}
+						err = errors.StructuralError("bad key fingerprint")
+					}
+				}
+				if err == nil {
+					err = scr.md.SignedBy.PublicKey.VerifySignature(scr.h, scr.md.Signature)
+				}
+				scr.md.SignatureError = err
+			} else if scr.md.SignatureV3, ok = p.(*packet.SignatureV3); ok {
+				scr.md.SignatureError = scr.md.SignedBy.PublicKey.VerifySignatureV3(scr.h, scr.md.SignatureV3)
+			} else {
+				scr.md.SignatureError = errors.StructuralError("LiteralData not followed by Signature")
+				return
 			}
-			scr.md.SignatureError = err
-		} else if scr.md.SignatureV3, ok = p.(*packet.SignatureV3); ok {
-			scr.md.SignatureError = scr.md.SignedBy.PublicKey.VerifySignatureV3(scr.h, scr.md.SignatureV3)
-		} else {
-			scr.md.SignatureError = errors.StructuralError("LiteralData not followed by Signature")
-			return
+
+			// Parse only one packet by default, unless message is MultiSig. Then
+			// we ask for more packets after discovering non-matching signature,
+			// until we find one that we can verify.
+			break
 		}
 
 		// The SymmetricallyEncrypted packet, if any, might have an

--- a/vendor/github.com/keybase/go-crypto/openpgp/write.go
+++ b/vendor/github.com/keybase/go-crypto/openpgp/write.go
@@ -458,6 +458,17 @@ func AttachedSign(out io.WriteCloser, signed Entity, hints *FileHints,
 		return
 	}
 
+	if algo := config.Compression(); algo != packet.CompressionNone {
+		var compConfig *packet.CompressionConfig
+		if config != nil {
+			compConfig = config.CompressionConfig
+		}
+		out, err = packet.SerializeCompressed(out, algo, compConfig)
+		if err != nil {
+			return
+		}
+	}
+
 	hasher := crypto.SHA512
 
 	ops := &packet.OnePassSignature{

--- a/vendor/github.com/keybase/saltpack/armor62.go
+++ b/vendor/github.com/keybase/saltpack/armor62.go
@@ -44,15 +44,23 @@ func Armor62Seal(plaintext []byte, typ MessageType, brand string) (string, error
 
 // NewArmor62DecoderStream is used to decode input base62-armoring format. It returns
 // a stream you can read from, and also a Frame you can query to see what the open/close
-// frame markers were.
-func NewArmor62DecoderStream(r io.Reader) (io.Reader, Frame, error) {
-	return newArmorDecoderStream(r, Armor62Params)
+// frame markers were. hc and fc are optional and can be nil.
+func NewArmor62DecoderStream(r io.Reader, hc HeaderChecker, fc FrameChecker) (io.Reader, Frame, error) {
+	return newArmorDecoderStream(r, Armor62Params, hc, fc)
 }
 
 // Armor62Open runs armor stream decoding, but on a string, and it outputs
-// a string.
+// a string. It does not do any validation on the header and footer.
+// Deprecated: user Armor62OpenWithValidation instead.
 func Armor62Open(msg string) (body []byte, header string, footer string, err error) {
-	return armorOpen(msg, Armor62Params)
+	body, _, header, footer, err = Armor62OpenWithValidation(msg, nil, nil)
+	return body, header, footer, err
+}
+
+// Armor62OpenWithValidation runs armor stream decoding, but on a string, and it outputs
+// a string. It validates header and footer with the provided checkers (which are optional and can be nil).
+func Armor62OpenWithValidation(msg string, hc HeaderChecker, fc FrameChecker) (body []byte, brand string, header string, footer string, err error) {
+	return armorOpen(msg, Armor62Params, hc, fc)
 }
 
 // CheckArmor62Frame checks that the frame matches our standard

--- a/vendor/github.com/keybase/saltpack/armor62_verify.go
+++ b/vendor/github.com/keybase/saltpack/armor62_verify.go
@@ -9,38 +9,52 @@ import (
 	"io/ioutil"
 )
 
+var (
+	armor62SignatureHeaderChecker HeaderChecker = func(header string) (string, error) {
+		return parseFrame(header, MessageTypeAttachedSignature, headerMarker)
+	}
+	armor62SignatureFrameChecker FrameChecker = func(header, footer string) (string, error) {
+		return CheckArmor62(header, footer, MessageTypeAttachedSignature)
+	}
+	armor62DetachedSignatureHeaderChecker HeaderChecker = func(header string) (string, error) {
+		return parseFrame(header, MessageTypeDetachedSignature, headerMarker)
+	}
+	armor62DetachedSignatureFrameChecker FrameChecker = func(header, footer string) (string, error) {
+		return CheckArmor62(header, footer, MessageTypeDetachedSignature)
+	}
+)
+
 // NewDearmor62VerifyStream creates a stream that consumes data from reader
 // r.  It returns the signer's public key and a reader that only
 // contains verified data.  If the signer's key is not in keyring,
 // it will return an error. It expects the data it reads from r to
 // be armor62-encoded.
-func NewDearmor62VerifyStream(versionValidator VersionValidator, r io.Reader, keyring SigKeyring) (skey SigningPublicKey, vs io.Reader, frame Frame, err error) {
-	dearmored, frame, err := NewArmor62DecoderStream(r)
+func NewDearmor62VerifyStream(versionValidator VersionValidator, r io.Reader, keyring SigKeyring) (skey SigningPublicKey, vs io.Reader, brand string, err error) {
+	dearmored, frame, err := NewArmor62DecoderStream(r, armor62SignatureHeaderChecker, armor62SignatureFrameChecker)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, "", err
 	}
 	skey, vs, err = NewVerifyStream(versionValidator, dearmored, keyring)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, "", err
 	}
-	return skey, vs, frame, nil
+	if brand, err = frame.GetBrand(); err != nil {
+		return nil, nil, "", err
+	}
+	return skey, vs, brand, nil
 }
 
 // Dearmor62Verify checks the signature in signedMsg.  It returns the
 // signer's public key and a verified message.  It expects
 // signedMsg to be armor62-encoded.
 func Dearmor62Verify(versionValidator VersionValidator, signedMsg string, keyring SigKeyring) (skey SigningPublicKey, verifiedMsg []byte, brand string, err error) {
-	skey, stream, frame, err := NewDearmor62VerifyStream(versionValidator, bytes.NewBufferString(signedMsg), keyring)
+	skey, stream, brand, err := NewDearmor62VerifyStream(versionValidator, bytes.NewBufferString(signedMsg), keyring)
 	if err != nil {
 		return nil, nil, "", err
 	}
 
 	verifiedMsg, err = ioutil.ReadAll(stream)
 	if err != nil {
-		return nil, nil, "", err
-	}
-
-	if brand, err = CheckArmor62Frame(frame, MessageTypeAttachedSignature); err != nil {
 		return nil, nil, "", err
 	}
 
@@ -52,11 +66,8 @@ func Dearmor62Verify(versionValidator VersionValidator, signedMsg string, keyrin
 // and that the public key for the signer is in keyring. It returns
 // the signer's public key.
 func Dearmor62VerifyDetachedReader(versionValidator VersionValidator, r io.Reader, signature string, keyring SigKeyring) (skey SigningPublicKey, brand string, err error) {
-	dearmored, header, footer, err := Armor62Open(signature)
+	dearmored, brand, _, _, err := Armor62OpenWithValidation(signature, armor62DetachedSignatureHeaderChecker, armor62DetachedSignatureFrameChecker)
 	if err != nil {
-		return nil, "", err
-	}
-	if brand, err = CheckArmor62(header, footer, MessageTypeDetachedSignature); err != nil {
 		return nil, "", err
 	}
 	skey, err = VerifyDetachedReader(versionValidator, r, dearmored, keyring)

--- a/vendor/github.com/keybase/saltpack/classify_and_decrypt.go
+++ b/vendor/github.com/keybase/saltpack/classify_and_decrypt.go
@@ -1,0 +1,279 @@
+// Copyright 2017 Keybase, Inc. All rights reserved. Use of
+// this source code is governed by the included BSD license.
+
+package saltpack
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/keybase/saltpack/encoding/basex"
+
+	"github.com/keybase/go-codec/codec"
+)
+
+const (
+	// To decide if a byte slice might contain a valild header of a saltpack message, and identify its type, we need to consider at most:
+	// - 1 byte for bin tag at the beginning
+	// - at most 4 bytes for the bin length (i.e. the length of the binary encoded header)
+	// - at most 5 bytes to determine how many parts the header consists of (we expect 6 parts, but newer versions of saltpack might add more, which we would ignore as per the spec)
+	// - 9 bytes for the format name
+	// - 3 bytes for the version number
+	// - 1 byte for the message type
+	// In the common case less might be enough, but this makes the code simpler, and 23 bytes is not that much anyways.
+	minLengthToIdentifyBinarySaltpack int = 23
+)
+
+// IsSaltpackBinary peeks into the provided bufio.Reader to determine whether it encodes a binary saltpack message.
+// It does not consume any of the reader's bytes (whose buffer length must be at least minLengthToIdentifyBinarySaltpack). It returns a non nil error if the buffer
+// size of the reader is not large enough (ErrShortSliceOrBuffer), or if the stream does not appear to contain a binary
+// saltpack message. If err is nil, msgType will return the type of the encoded message, but this does *NOT* guarantee that the
+// rest of the message is well formed.
+func IsSaltpackBinary(stream *bufio.Reader) (msgType MessageType, version Version, err error) {
+
+	b, err := stream.Peek(minLengthToIdentifyBinarySaltpack)
+	if err == bufio.ErrBufferFull {
+		return MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+	}
+	if err != nil {
+		return MessageTypeUnknown, Version{}, err
+	}
+	return IsSaltpackBinarySlice(b)
+}
+
+// IsSaltpackBinarySlice tries to determine if the input slice encodes the beginning of a binary saltpack message. It returns a non nil error if the slice is not
+// long enough to make this determination, or if it does not appear to contain a binary saltpack message. If err is nil, msgType
+// will return the type of the encoded message, but this does *NOT* guarantee that the rest of the message is well formed.
+func IsSaltpackBinarySlice(b []byte) (msgType MessageType, version Version, err error) {
+
+	// To avoid decoding the whole header, part of the messagepack decoding is done manually
+	// instead of through go-codec. See https://github.com/msgpack/msgpack/blob/master/spec.md
+	// for details on the encoding.
+
+	if len(b) < minLengthToIdentifyBinarySaltpack {
+		return MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+	}
+
+	// The header is double-encoded, so we need to skip the "bin" tag at the front to
+	// get at the encoded header array.
+	var binTagBytesToSkip int
+	if b[0] == 0xc4 {
+		binTagBytesToSkip = 2
+	} else if b[0] == 0xc5 {
+		binTagBytesToSkip = 3
+	} else if b[0] == 0xc6 {
+		binTagBytesToSkip = 5
+	} else {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+
+	// The header should be a msg pack encoded array: verify it is, that it has at least three elements, and
+	// note how many bytes to skip to point to its first element.
+	arrayTagByte := b[binTagBytesToSkip]
+	var arrayTagBytesToSkip int
+	if 0x93 <= arrayTagByte && arrayTagByte <= 0x9f {
+		arrayTagBytesToSkip = 1
+	} else if arrayTagByte == 0xdc {
+		arrayTagBytesToSkip = 3
+	} else if arrayTagByte == 0xdd {
+		arrayTagBytesToSkip = 5
+	} else {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+
+	// Devode the first 3 elements of the header, and use them to classify the message.
+	var mh codec.MsgpackHandle
+	decoder := codec.NewDecoderBytes(b[binTagBytesToSkip+arrayTagBytesToSkip:], &mh)
+	var formatName string
+
+	if err := decoder.Decode(&formatName); err != nil {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	if formatName != FormatName {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	if err := decoder.Decode(&version); err != nil {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	if err := decoder.Decode(&msgType); err != nil {
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+	switch msgType {
+	case MessageTypeEncryption, MessageTypeSigncryption, MessageTypeAttachedSignature, MessageTypeDetachedSignature:
+		return msgType, version, nil
+	default:
+		return MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+}
+
+// IsSaltpackArmored peeks into the provided bufio.Reader to determine whether it encodes an ASCII-armored saltpack message.
+// It does not consume any of the reader's bytes. The buffer size of the reader must be sufficient to contain the header frame plus
+// the first Base62 encoded block of the payload. It returns a non nil error if the buffer
+// size of the reader is not large enough to make this determination (ErrShortSliceOrBuffer), or if the stream does not appear to contain a valid
+// saltpack message. If err is nil, then the brand, version and expected type of the message will be returned, but this does *NOT* guarantee that the
+// rest of the message is well formed.
+func IsSaltpackArmored(stream *bufio.Reader) (brand string, msgType MessageType, ver Version, err error) {
+
+	// temporary hack to compute stream.Size(), which is only available from go 1.10
+	// TODO remove after we can drop support for go 1.9 or older.
+	// If the buffer is larger then 8192, we use the first 8192 bytes (which should be
+	// enough to decode one block in the vast majority of cases)
+	sizePlusOne := sort.Search(8192, func(i int) bool {
+		_, peekErr := stream.Peek(i)
+		return peekErr == bufio.ErrBufferFull
+	})
+
+	buf, err := stream.Peek(sizePlusOne - 1)
+	if (err != nil && err != io.EOF) || len(buf) == 0 {
+		return "", MessageTypeUnknown, ver, err
+	}
+
+	return IsSaltpackArmoredPrefix(string(buf))
+}
+
+// IsSaltpackArmored tries to determine whether the string is the prefix of a valid ASCII-armored saltpack message.
+// The prefix must be large enough to contain the header frame plus the first Base62 encoded block of the payload. It returns a non nil error if the buffer
+// size of the reader is not large enough to make this determination (ErrShortSliceOrBuffer), or if the stream does not appear to contain a valid
+// saltpack message. If err is nil, then the brand, version and expected type of the message will be returned, but this does *NOT* guarantee that the
+// rest of the message is well formed.
+func IsSaltpackArmoredPrefix(pref string) (brand string, messageType MessageType, ver Version, err error) {
+	// replace blocks of characters in the set [>\n\r\t ] with a single space, so that the next regexp is simpler
+	re := regexp.MustCompile("[>\n\r\t ]+")
+	s := strings.TrimSpace(re.ReplaceAllString(pref, " "))
+
+	headerRegExpSt := "^BEGIN (?:([a-zA-Z0-9]+) )?SALTPACK (" + EncryptionArmorString + "|" + SignedArmorString + "|" + DetachedSignatureArmorString + ") ?\\.([a-zA-Z0-9 ]*)"
+	headerRegExp := regexp.MustCompile(headerRegExpSt)
+
+	m := headerRegExp.FindStringSubmatch(s)
+	if m == nil || len(m) == 0 {
+		// Matches at most five words
+		if !regexp.MustCompile("^([a-zA-Z0-9]+ ?){0,5}$").MatchString(s) {
+			return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+		}
+
+		strs := strings.Split(s, " ")
+
+		switch len(strs) {
+		case 1:
+			if strings.HasPrefix(string(headerMarker), strs[0]) {
+				return "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+			}
+			return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+		case 2:
+			if string(headerMarker) == strs[0] {
+				return "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+			}
+			return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+		case 3, 4, 5:
+			// more processing needed.
+		default:
+			panic("logic error in ClassifyStream")
+		}
+
+		headerWithoutBrand := strings.Join(append([]string{strs[0]}, strs[2:]...), " ")
+
+		if strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+EncryptionArmorString, headerWithoutBrand) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+SignedArmorString, headerWithoutBrand) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+DetachedSignatureArmorString, headerWithoutBrand) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+EncryptionArmorString, s) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+SignedArmorString, s) ||
+			strings.HasPrefix(string(headerMarker)+" "+strings.ToUpper(FormatName)+" "+DetachedSignatureArmorString, s) {
+			return "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+		}
+		return "", MessageTypeUnknown, Version{}, ErrNotASaltpackMessage
+	}
+
+	brand = m[1]
+	headerArmorType := m[2] // can be one of SignedArmorString, DetachedSignatureArmorString, EncryptionArmorString
+
+	dec, err := basex.Base62StdEncoding.DecodeString(m[3])
+	// This is not a prefix free encoding, so we need to decode a full codeword (32 bytes) to make sure we are not interpreting
+	// a truncated block as if it was a short block. Moreover, we only need one codeword, so if an error is returned but a codeword
+	// was decoded, the error can be ignored.
+	if len(dec) < 32 {
+		if err == basex.ErrInvalidEncodingLength || err == nil {
+			return "", MessageTypeUnknown, ver, ErrShortSliceOrBuffer
+		}
+		return "", MessageTypeUnknown, ver, ErrNotASaltpackMessage
+	}
+
+	messageType, ver, err = IsSaltpackBinarySlice(dec)
+	if err != nil {
+		return "", MessageTypeUnknown, ver, err
+	}
+
+	// ensure that the type of the armor matches the type of the inner header
+	if (messageType == MessageTypeSigncryption && headerArmorType != EncryptionArmorString) ||
+		(messageType == MessageTypeEncryption && headerArmorType != EncryptionArmorString) ||
+		(messageType == MessageTypeAttachedSignature && headerArmorType != SignedArmorString) ||
+		(messageType == MessageTypeDetachedSignature && headerArmorType != DetachedSignatureArmorString) {
+		return "", MessageTypeUnknown, ver, ErrNotASaltpackMessage
+	}
+
+	return m[1], messageType, ver, nil
+}
+
+// ClassifyStream peeks at the beginning of a stream and checks wether it seems to contain a valid
+// saltpack message (either armored or not).
+// The buffer size must be at least minLengthToIdentifyBinarySaltpack bytes for binary messages, and large
+// enough that if there is a header frame (i.e. "BEGIN FOO."), plus the first
+// base62 encoded block (43 characters) of the steam (the default buffer size of bufio.Reader
+// will be enough in most cases). Otherwise, ErrShortSliceOrBuffer will be returned.
+// If err is nil, then the expected message type and version will be returned, as well as a booleand
+// indicating if the message is ASCII-armored and the brand (for armored messages only).
+// Note this classification is just a guess based on the beginning of the stream, and it does not
+// guarantee that the message is valid or well formed.
+func ClassifyStream(stream *bufio.Reader) (isArmored bool, brand string, messageType MessageType, ver Version, err error) {
+	brand, messageType, ver, err = IsSaltpackArmored(stream)
+	if err == nil {
+		return true, brand, messageType, ver, err
+	} else if err == ErrShortSliceOrBuffer {
+		return false, "", MessageTypeUnknown, Version{}, ErrShortSliceOrBuffer
+	}
+	messageType, ver, err = IsSaltpackBinary(stream)
+	if err == nil {
+		return false, "", messageType, ver, err
+	}
+	return false, "", MessageTypeUnknown, Version{}, err
+}
+
+// ClassifyEncryptedStreamAndMakeDecoder takes as input an io.Reader (containing an encrypted saltpack stream),
+// a SigncryptKeyring containing the keys to use for decryption, and a SymmetricKeyResolver (used to map an
+// identifiers to symmetric keys in an application specific way). It classifies the encrypted stream
+// (encryption vs signcryption mode and binary vs armored format) and returns a reader for the decoded stream,
+// as well as some informtation about the stream. The brand is only returned for armored ciphertexts, mki only
+// for encryption-mode ciphertext, senderPublic only for signcryption-mode ciphertexts.
+func ClassifyEncryptedStreamAndMakeDecoder(source io.Reader, decryptionKeyring SigncryptKeyring, keyResolver SymmetricKeyResolver) (
+	plainsource io.Reader, msgType MessageType, mki *MessageKeyInfo, senderPublic SigningPublicKey, isArmored bool, brand string, ver Version, err error) {
+	stream := bufio.NewReader(source)
+
+	isArmored, _, msgType, ver, err = ClassifyStream(stream)
+	if err == ErrShortSliceOrBuffer {
+		return nil, MessageTypeUnknown, nil, nil, false, "", Version{}, ErrShortSliceOrBuffer
+	}
+	if err != nil {
+		return nil, MessageTypeUnknown, nil, nil, false, "", Version{}, ErrNotASaltpackMessage
+	}
+
+	switch msgType {
+	case MessageTypeEncryption:
+		if isArmored {
+			mki, plainsource, brand, err = NewDearmor62DecryptStream(CheckKnownMajorVersion, stream, decryptionKeyring)
+		} else {
+			mki, plainsource, err = NewDecryptStream(CheckKnownMajorVersion, stream, decryptionKeyring)
+		}
+		return plainsource, msgType, mki, nil, isArmored, brand, ver, err
+	case MessageTypeSigncryption:
+		if isArmored {
+			senderPublic, plainsource, brand, err = NewDearmor62SigncryptOpenStream(stream, decryptionKeyring, keyResolver)
+		} else {
+			senderPublic, plainsource, err = NewSigncryptOpenStream(stream, decryptionKeyring, keyResolver)
+		}
+		return plainsource, msgType, nil, senderPublic, isArmored, brand, ver, err
+	default:
+		return nil, MessageTypeUnknown, nil, nil, false, "", Version{}, ErrWrongMessageType{}
+	}
+}

--- a/vendor/github.com/keybase/saltpack/const.go
+++ b/vendor/github.com/keybase/saltpack/const.go
@@ -12,6 +12,12 @@ type MessageType int
 // In general, the former is one more than the latter.
 type packetSeqno uint64
 
+// MessageTypeUnknown is used by the decoding functions
+// to indicate an unknown message type or a decoding error.
+// This is NOT a constant in the saltpack spec, and is specific
+// to this library implementation.
+const MessageTypeUnknown MessageType = -1
+
 // MessageTypeEncryption is a packet type to describe an
 // encryption message.
 const MessageTypeEncryption MessageType = 0

--- a/vendor/github.com/keybase/saltpack/encoding/basex/bases.go
+++ b/vendor/github.com/keybase/saltpack/encoding/basex/bases.go
@@ -30,5 +30,5 @@ const base62EncodeStd = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrs
 var Base62StdEncodingStrict = NewEncoding(base62EncodeStd, 32, "")
 
 // Base62StdEncoding is the standard 62-encoding, with a 32-byte input block and, a
-// 43-byte output block. Foreign chracters are ignored
+// 43-byte output block.
 var Base62StdEncoding = NewEncoding(base62EncodeStd, 32, "\t\n\r >")

--- a/vendor/github.com/keybase/saltpack/encoding/basex/encoding.go
+++ b/vendor/github.com/keybase/saltpack/encoding/basex/encoding.go
@@ -154,7 +154,7 @@ func (enc *Encoding) decode(dst []byte, src []byte) (n int, err error) {
 	for sp < len(src) {
 		di, si, err := enc.decodeBlock(dst[dp:], src[sp:], sp)
 		if err != nil {
-			return 0, err
+			return dp, err
 		}
 		sp += si
 		dp += di

--- a/vendor/github.com/keybase/saltpack/errors.go
+++ b/vendor/github.com/keybase/saltpack/errors.go
@@ -71,6 +71,14 @@ var (
 	// encountered that isn't both the last one and the first one
 	// (for V2 and higher), or isn't the last one (for V1).
 	ErrUnexpectedEmptyBlock = errors.New("unexpected empty block")
+
+	// ErrShortSliceOrBuffer is returned when the input slice or buffer provided
+	// is too short to determine if it is the beginning of a binary saltpack message
+	ErrShortSliceOrBuffer = errors.New("the slice or buffer is too short to tell if it is the beginning of a saltpack message")
+
+	// ErrNotASaltpackMessage is returned when the message given as input is not
+	// a valid  saltpack message
+	ErrNotASaltpackMessage = errors.New("not a saltpack message")
 )
 
 // ErrBadTag is generated when a payload hash doesn't match the hash

--- a/vendor/github.com/keybase/saltpack/msgpack.go
+++ b/vendor/github.com/keybase/saltpack/msgpack.go
@@ -23,6 +23,15 @@ func encodeToBytes(i interface{}) ([]byte, error) {
 	return encoded, err
 }
 
+// If p has type {Encryption,Signcryption,Signature}Header, then
+// decodeFromBytes would succeed even if the version numbers or mode
+// aren't encoded as positive fixnums. Ideally, it would reject those
+// as malformed, but there's no easy way to do that.
+//
+// Similarly, we'd ideally reject strings, byte arrays, or arrays that
+// aren't minimally encoded, but there's no easy way to check that
+// either.
+
 func decodeFromBytes(p interface{}, b []byte) error {
 	return codec.NewDecoderBytes(b, codecHandle()).Decode(p)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -214,10 +214,10 @@
 			"revisionTime": "2018-05-19T05:29:12Z"
 		},
 		{
-			"checksumSHA1": "kO5n6BCMKUhMer7lgkr7pvo6j0o=",
+			"checksumSHA1": "4qOX1lI0e8cuSrktScZed1mx9i8=",
 			"path": "github.com/keybase/client/go/libkb",
-			"revision": "90037ed484afc1dcdbd238799e6fa27ab1ee2fe7",
-			"revisionTime": "2018-07-26T22:39:50Z"
+			"revision": "9411bbc199ad9db0afb717eb591b43b42f8c1b72",
+			"revisionTime": "2018-08-08T15:59:17Z"
 		},
 		{
 			"checksumSHA1": "Q0vrZ3PxpDaQedkTnygNaJveX4w=",
@@ -330,52 +330,52 @@
 			"revisionTime": "2017-03-08T15:50:15Z"
 		},
 		{
-			"checksumSHA1": "5E4DLEAVDwFt//h5K23zHP1qCew=",
+			"checksumSHA1": "1TZ1Ym1XrMztVJB6ZvkWgxpY4w0=",
 			"path": "github.com/keybase/go-crypto/openpgp",
-			"revision": "b5f4c79208fa609f364833f8c356535100d602ad",
-			"revisionTime": "2017-05-22T12:28:10Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
-			"checksumSHA1": "y61I7+hCekP1Rk0qxgUQ+iozXak=",
+			"checksumSHA1": "tin/wcIHur1IM0n5f5u8nlZ/J6U=",
 			"path": "github.com/keybase/go-crypto/openpgp/armor",
-			"revision": "df314da3158786e5ea7ae99889366febe828fbd7",
-			"revisionTime": "2016-12-08T01:54:25Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
 			"checksumSHA1": "cTboJNAg/so2wzlf6HscarfPlDE=",
 			"path": "github.com/keybase/go-crypto/openpgp/clearsign",
-			"revision": "df314da3158786e5ea7ae99889366febe828fbd7",
-			"revisionTime": "2016-12-08T01:54:25Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
-			"checksumSHA1": "nWhmwjBJqPSvkCWqaap2Z9EiS1k=",
+			"checksumSHA1": "LhCQJCoB7yqxN6hSaPP7qXW2y5s=",
 			"path": "github.com/keybase/go-crypto/openpgp/ecdh",
-			"revision": "b5f4c79208fa609f364833f8c356535100d602ad",
-			"revisionTime": "2017-05-22T12:28:10Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
 			"checksumSHA1": "uxXG9IC/XF8jwwvZUbW65+x8/+M=",
 			"path": "github.com/keybase/go-crypto/openpgp/elgamal",
-			"revision": "df314da3158786e5ea7ae99889366febe828fbd7",
-			"revisionTime": "2016-12-08T01:54:25Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
-			"checksumSHA1": "EyUf82Yknzc75m8RcA21CNQINw0=",
+			"checksumSHA1": "ofZhU2758YZAAGSEJ8UjFMQLc+k=",
 			"path": "github.com/keybase/go-crypto/openpgp/errors",
-			"revision": "df314da3158786e5ea7ae99889366febe828fbd7",
-			"revisionTime": "2016-12-08T01:54:25Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
-			"checksumSHA1": "CXTLNDL5s+SONDJdwuI3kRFGyBk=",
+			"checksumSHA1": "LDNYus5Sx+hvbFqihEQ0Dl1i6JY=",
 			"path": "github.com/keybase/go-crypto/openpgp/packet",
-			"revision": "b5f4c79208fa609f364833f8c356535100d602ad",
-			"revisionTime": "2017-05-22T12:28:10Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
 			"checksumSHA1": "BGDxg1Xtsz0DSPzdQGJLLQqfYc8=",
 			"path": "github.com/keybase/go-crypto/openpgp/s2k",
-			"revision": "df314da3158786e5ea7ae99889366febe828fbd7",
-			"revisionTime": "2016-12-08T01:54:25Z"
+			"revision": "c84d7cbef16bcd1cd873e1d5793b18865f443ba0",
+			"revisionTime": "2018-08-07T16:30:25Z"
 		},
 		{
 			"checksumSHA1": "rE3pp7b3gfcmBregzpIvN5IdFhY=",
@@ -453,16 +453,16 @@
 			"revisionTime": "2017-01-13T17:06:45Z"
 		},
 		{
-			"checksumSHA1": "UT+c8olRWpXtZIw96rRFXYfBUzY=",
+			"checksumSHA1": "AdTewzl8bd3Il/9CHP/+b4hkhyw=",
 			"path": "github.com/keybase/saltpack",
-			"revision": "282df2166aa71f1283de12d39a10addbb30bafb4",
-			"revisionTime": "2018-03-19T16:38:18Z"
+			"revision": "bcd850c0d7cab45b51f3f2edc7d4c49e69a915a0",
+			"revisionTime": "2018-08-03T21:34:16Z"
 		},
 		{
-			"checksumSHA1": "LpuohLoTQEeJxurlZ5ruBJFWh8E=",
+			"checksumSHA1": "W4AtPFFZNotMGDQpwJI59jkMLL8=",
 			"path": "github.com/keybase/saltpack/encoding/basex",
-			"revision": "282df2166aa71f1283de12d39a10addbb30bafb4",
-			"revisionTime": "2018-03-19T16:38:18Z"
+			"revision": "bcd850c0d7cab45b51f3f2edc7d4c49e69a915a0",
+			"revisionTime": "2018-08-03T21:34:16Z"
 		},
 		{
 			"checksumSHA1": "dNYxHiBLalTqluak2/Z8c3RsSEM=",


### PR DESCRIPTION
There's some early portion of the global Merkle tree where revoked keys can't be checked using our new Merkle-based checking procedure. The service now exports the error related to this, so we can check it explicitly and ignore it.

Issue: keybase/client#12987
