### PR TITLE
file_data: generalize functions for getting blocks

### DIFF
--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -1,0 +1,247 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import "context"
+
+// blockGetter is a function that gets a block suitable for reading or
+// writing, and also returns whether the block was already dirty.  It
+// may be called from new goroutines, and must handle any required
+// locks accordingly.
+type blockGetterFn func(context.Context, KeyMetadata, BlockPointer,
+	path, blockReqType) (block Block, wasDirty bool, err error)
+
+// dirtyBlockCacher writes dirty blocks to a cache.
+type dirtyBlockCacher func(ptr BlockPointer, block Block) error
+
+type blockTree struct {
+	file   path
+	kmd    KeyMetadata
+	getter blockGetterFn
+}
+
+// parentBlockAndChildIndex is a node on a path down the tree to a
+// particular leaf node.  `pblock` is an indirect block corresponding
+// to one of that leaf node's parents, and `childIndex` is an index
+// into `pblock.IPtrs` to the next node along the path.
+type parentBlockAndChildIndex struct {
+	pblock     Block
+	childIndex int
+}
+
+func (pbci parentBlockAndChildIndex) childIPtr() (BlockInfo, Offset) {
+	return pbci.pblock.IndirectPtr(pbci.childIndex)
+}
+
+func (pbci parentBlockAndChildIndex) childBlockPtr() BlockPointer {
+	info, _ := pbci.pblock.IndirectPtr(pbci.childIndex)
+	return info.BlockPointer
+}
+
+func (bt *blockTree) rootBlockPointer() BlockPointer {
+	return bt.file.tailPointer()
+}
+
+// getBlockAtOffset returns the leaf block containing the given
+// `off`, along with the set of indirect blocks leading to that leaf
+// (if any).
+func (bt *blockTree) getBlockAtOffset(ctx context.Context,
+	topBlock Block, off Offset, rtype blockReqType) (
+	ptr BlockPointer, parentBlocks []parentBlockAndChildIndex,
+	block Block, nextBlockStartOff, startOff Offset,
+	wasDirty bool, err error) {
+	// Find the block matching the offset, if it exists.
+	ptr = bt.rootBlockPointer()
+	block = topBlock
+	nextBlockStartOff = nil
+	startOff = topBlock.FirstOffset()
+
+	if !topBlock.IsIndirect() {
+		// If it's not an indirect block, we just need to figure out
+		// if it's dirty.
+		_, wasDirty, err = bt.getter(ctx, bt.kmd, ptr, bt.file, rtype)
+		if err != nil {
+			return zeroPtr, nil, nil, nil, nil, false, err
+		}
+		return ptr, nil, block, nextBlockStartOff, startOff, wasDirty, nil
+	}
+
+	// Search until it's not an indirect block.
+	for block.IsIndirect() {
+		nextIndex := block.NumIndirectPtrs() - 1
+		for i := 0; i < block.NumIndirectPtrs(); i++ {
+			_, iptrOff := block.IndirectPtr(i)
+			if iptrOff.Equals(off) {
+				// Small optimization to avoid iterating past the correct ptr.
+				nextIndex = i
+				break
+			} else if off.Less(iptrOff) {
+				// Use the previous block.  i can never be 0, because
+				// the first ptr always has an offset at the beginning
+				// of the range.
+				nextIndex = i - 1
+				break
+			}
+		}
+		var info BlockInfo
+		info, startOff = block.IndirectPtr(nextIndex)
+		parentBlocks = append(parentBlocks,
+			parentBlockAndChildIndex{block, nextIndex})
+		// There is more to read if we ever took a path through a
+		// ptr that wasn't the final ptr in its respective list.
+		if nextIndex != block.NumIndirectPtrs()-1 {
+			_, nextBlockStartOff = block.IndirectPtr(nextIndex + 1)
+		}
+		ptr = info.BlockPointer
+		block, wasDirty, err = bt.getter(
+			ctx, bt.kmd, info.BlockPointer, bt.file, rtype)
+		if err != nil {
+			return zeroPtr, nil, nil, nil, nil, false, err
+		}
+	}
+
+	return ptr, parentBlocks, block, nextBlockStartOff, startOff, wasDirty, nil
+}
+
+// getNextDirtyFileBlockAtOffsetAtLevel does the same thing as
+// `getNextDirtyFileBlockAtOffset` (see the comments on that function)
+// on a subsection of the block tree (not necessarily starting from
+// the top block).
+func (bt *blockTree) getNextDirtyBlockAtOffsetAtLevel(ctx context.Context,
+	pblock Block, off Offset, rtype blockReqType,
+	dirtyBcache DirtyBlockCache, parentBlocks []parentBlockAndChildIndex) (
+	ptr BlockPointer, newParentBlocks []parentBlockAndChildIndex,
+	block Block, nextBlockStartOff, startOff Offset, err error) {
+	// Search along paths of dirty blocks until we find a dirty leaf
+	// block with an offset equal or greater than `off`.
+	checkedPrevBlock := false
+	for i := 0; i < pblock.NumIndirectPtrs(); i++ {
+		info, iptrOff := pblock.IndirectPtr(i)
+		if iptrOff.Less(off) && i != pblock.NumIndirectPtrs()-1 {
+			continue
+		}
+
+		// No need to check the previous block if we align exactly
+		// with `off`, or this is the right-most leaf block.
+		if iptrOff.Less(off) || iptrOff.Equals(off) {
+			checkedPrevBlock = true
+		}
+
+		// If we haven't checked the previous block yet, do so now
+		// since it contains `off`.
+		index := -1
+		nextBlockStartOff = nil
+		startOff = pblock.FirstOffset()
+		var prevPtr BlockPointer
+		if !checkedPrevBlock && i > 0 {
+			prevInfo, _ := pblock.IndirectPtr(i - 1)
+			prevPtr = prevInfo.BlockPointer
+		}
+		if prevPtr.IsValid() && dirtyBcache.IsDirty(
+			bt.file.Tlf, prevPtr, bt.file.Branch) {
+			// Since we checked the previous block, stay on this
+			// index for the next iteration.
+			i--
+			index = i
+		} else if dirtyBcache.IsDirty(
+			bt.file.Tlf, info.BlockPointer, bt.file.Branch) {
+			// Now check the current block.
+			index = i
+		}
+		checkedPrevBlock = true
+
+		// Try the next child.
+		if index == -1 {
+			continue
+		}
+
+		indexInfo, indexOff := pblock.IndirectPtr(index)
+		ptr = indexInfo.BlockPointer
+		block, _, err = bt.getter(ctx, bt.kmd, ptr, bt.file, rtype)
+		if err != nil {
+			return zeroPtr, nil, nil, nil, nil, err
+		}
+
+		newParentBlocks = append(parentBlocks,
+			parentBlockAndChildIndex{pblock, index})
+		// If this is a leaf block, we're done.
+		if !block.IsIndirect() {
+			// There is more to read if we ever took a path through a
+			// ptr that wasn't the final ptr in its respective list.
+			if index != pblock.NumIndirectPtrs()-1 {
+				_, nextBlockStartOff = pblock.IndirectPtr(index + 1)
+			}
+			return ptr, newParentBlocks, block, nextBlockStartOff, indexOff, nil
+		}
+
+		// Recurse to the next lower level.
+		ptr, newParentBlocks, block, nextBlockStartOff, startOff, err =
+			bt.getNextDirtyBlockAtOffsetAtLevel(
+				ctx, block, off, rtype, dirtyBcache, newParentBlocks)
+		if err != nil {
+			return zeroPtr, nil, nil, nil, nil, err
+		}
+		// If we found a block, we're done.
+		if block != nil {
+			// If the block didn't have an immediate sibling to the
+			// right, set the next offset to the parent block's
+			// sibling's offset.
+			if nextBlockStartOff == nil && index != pblock.NumIndirectPtrs()-1 {
+				_, nextBlockStartOff = pblock.IndirectPtr(index + 1)
+			}
+			return ptr, newParentBlocks, block, nextBlockStartOff, startOff, nil
+		}
+	}
+
+	// There's no dirty block at or after `off`.
+	return zeroPtr, nil, nil, pblock.FirstOffset(), pblock.FirstOffset(), nil
+}
+
+// getNextDirtyBlockAtOffset returns the next dirty leaf block with a
+// starting offset that is equal or greater than the given `off`.
+// This assumes that any code that dirties a leaf block also dirties
+// all of its parents, even if those parents haven't yet changed.  It
+// can be used iteratively (by feeding `nextBlockStartOff` back in as
+// `off`) to find all the dirty blocks.  Note that there is no need to
+// parallelize that process, since all the dirty blocks are guaranteed
+// to be local.  `nextBlockStartOff` is `nil` if there's no next block.
+func (bt *blockTree) getNextDirtyBlockAtOffset(ctx context.Context,
+	topBlock Block, off Offset, rtype blockReqType,
+	dirtyBcache DirtyBlockCache) (
+	ptr BlockPointer, parentBlocks []parentBlockAndChildIndex,
+	block Block, nextBlockStartOff, startOff Offset, err error) {
+	// Find the block matching the offset, if it exists.
+	ptr = bt.rootBlockPointer()
+	if !dirtyBcache.IsDirty(bt.file.Tlf, ptr, bt.file.Branch) {
+		// The top block isn't dirty, so we know none of the leaves
+		// are dirty.
+		return zeroPtr, nil, nil, topBlock.FirstOffset(),
+			topBlock.FirstOffset(), nil
+	} else if !topBlock.IsIndirect() {
+		// A dirty, direct block.
+		return bt.rootBlockPointer(), nil, topBlock, nil,
+			topBlock.FirstOffset(), nil
+	}
+
+	ptr, parentBlocks, block, nextBlockStartOff, startOff, err =
+		bt.getNextDirtyBlockAtOffsetAtLevel(
+			ctx, topBlock, off, rtype, dirtyBcache, nil)
+	if err != nil {
+		return zeroPtr, nil, nil, nil, nil, err
+	}
+	if block == nil {
+		return zeroPtr, nil, nil, topBlock.FirstOffset(),
+			topBlock.FirstOffset(), nil
+	}
+
+	// The leaf block doesn't cover this index.  (If the contents
+	// length is 0, then this is the start or end of a hole, and it
+	// should still count as dirty.)
+	if block.OffsetExceedsData(startOff, off) {
+		return zeroPtr, nil, nil, nil, topBlock.FirstOffset(), nil
+	}
+
+	return ptr, parentBlocks, block, nextBlockStartOff, startOff, nil
+}

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -21,7 +21,7 @@ var _ Offset = Int64Offset(0)
 func (i Int64Offset) Equals(other Offset) bool {
 	otherI, ok := other.(Int64Offset)
 	if !ok {
-		return false
+		panic(fmt.Sprintf("Can't compare against non-int offset: %T", other))
 	}
 	return int64(i) == int64(otherI)
 }
@@ -30,7 +30,7 @@ func (i Int64Offset) Equals(other Offset) bool {
 func (i Int64Offset) Less(other Offset) bool {
 	otherI, ok := other.(Int64Offset)
 	if !ok {
-		return false
+		panic(fmt.Sprintf("Can't compare against non-int offset: %T", other))
 	}
 	return int64(i) < int64(otherI)
 }
@@ -44,7 +44,7 @@ var _ Offset = StringOffset("")
 func (s StringOffset) Equals(other Offset) bool {
 	otherS, ok := other.(StringOffset)
 	if !ok {
-		return false
+		panic(fmt.Sprintf("Can't compare against non-string offset: %T", other))
 	}
 	return string(s) == string(otherS)
 }
@@ -53,7 +53,7 @@ func (s StringOffset) Equals(other Offset) bool {
 func (s StringOffset) Less(other Offset) bool {
 	otherS, ok := other.(StringOffset)
 	if !ok {
-		return false
+		panic(fmt.Sprintf("Can't compare against non-string offset: %T", other))
 	}
 	return string(s) < string(otherS)
 }

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -87,6 +87,26 @@ func (tb *TestBlock) ToCommonBlock() *CommonBlock {
 	return nil
 }
 
+func (tb *TestBlock) IsIndirect() bool {
+	return false
+}
+
+func (tb *TestBlock) FirstOffset() Offset {
+	return nil
+}
+
+func (tb *TestBlock) NumIndirectPtrs() int {
+	panic("No indirect pointers for the test block")
+}
+
+func (tb *TestBlock) IndirectPtr(_ int) (BlockInfo, Offset) {
+	panic("No indirect pointers for the test block")
+}
+
+func (tb TestBlock) OffsetExceedsData(_, _ Offset) bool {
+	return false
+}
+
 func TestCryptoCommonEncryptDecryptBlock(t *testing.T) {
 	c := MakeCryptoCommon(kbfscodec.NewMsgpack())
 
@@ -347,6 +367,26 @@ func (tba testBlockArray) ToCommonBlock() *CommonBlock {
 func (tba *testBlockArray) Set(other Block) {
 	otherTba := other.(*testBlockArray)
 	*tba = *otherTba
+}
+
+func (tba testBlockArray) IsIndirect() bool {
+	return false
+}
+
+func (tba testBlockArray) FirstOffset() Offset {
+	return nil
+}
+
+func (tba testBlockArray) NumIndirectPtrs() int {
+	panic("No indirect pointers for the test block array")
+}
+
+func (tba testBlockArray) IndirectPtr(_ int) (BlockInfo, Offset) {
+	panic("No indirect pointers for the test block array")
+}
+
+func (tba testBlockArray) OffsetExceedsData(_, _ Offset) bool {
+	return false
 }
 
 // Test that block encrypted data length is the same for data

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1811,7 +1811,7 @@ func (fbo *folderBlockOps) Read(
 
 	var id keybase1.UserOrTeamID // Data reads don't depend on the id.
 	fd := fbo.newFileData(lState, filePath, id, kmd)
-	return fd.read(ctx, dest, off)
+	return fd.read(ctx, dest, Int64Offset(off))
 }
 
 func (fbo *folderBlockOps) maybeWaitOnDeferredWrites(
@@ -1987,7 +1987,7 @@ func (fbo *folderBlockOps) writeDataLocked(
 	}
 
 	newDe, dirtyPtrs, unrefs, newlyDirtiedChildBytes, bytesExtended, err :=
-		fd.write(ctx, data, off, fblock, de, df)
+		fd.write(ctx, data, Int64Offset(off), fblock, de, df)
 	// Record the unrefs before checking the error so we remember the
 	// state of newly dirtied blocks.
 	si.unrefs = append(si.unrefs, unrefs...)
@@ -2173,7 +2173,7 @@ func (fbo *folderBlockOps) truncateLocked(
 	// find the block where the file should now end
 	iSize := int64(size) // TODO: deal with overflow
 	_, parentBlocks, block, nextBlockOff, startOff, _, err :=
-		fd.getFileBlockAtOffset(ctx, fblock, iSize, blockWrite)
+		fd.getFileBlockAtOffset(ctx, fblock, Int64Offset(iSize), blockWrite)
 	if err != nil {
 		return &WriteRange{}, nil, 0, err
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -665,7 +665,8 @@ func makeBI(id kbfsblock.ID, kmd KeyMetadata, config Config,
 }
 
 func makeIFP(id kbfsblock.ID, kmd KeyMetadata, config Config,
-	u keybase1.UserOrTeamID, encodedSize uint32, off int64) IndirectFilePtr {
+	u keybase1.UserOrTeamID, encodedSize uint32,
+	off Int64Offset) IndirectFilePtr {
 	return IndirectFilePtr{
 		BlockInfo{
 			BlockPointer: makeBP(id, kmd, config, u),

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -629,6 +629,53 @@ func (mr *MockblockRetrieverGetterMockRecorder) BlockRetriever() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockRetriever", reflect.TypeOf((*MockblockRetrieverGetter)(nil).BlockRetriever))
 }
 
+// MockOffset is a mock of Offset interface
+type MockOffset struct {
+	ctrl     *gomock.Controller
+	recorder *MockOffsetMockRecorder
+}
+
+// MockOffsetMockRecorder is the mock recorder for MockOffset
+type MockOffsetMockRecorder struct {
+	mock *MockOffset
+}
+
+// NewMockOffset creates a new mock instance
+func NewMockOffset(ctrl *gomock.Controller) *MockOffset {
+	mock := &MockOffset{ctrl: ctrl}
+	mock.recorder = &MockOffsetMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockOffset) EXPECT() *MockOffsetMockRecorder {
+	return m.recorder
+}
+
+// Equals mocks base method
+func (m *MockOffset) Equals(other Offset) bool {
+	ret := m.ctrl.Call(m, "Equals", other)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Equals indicates an expected call of Equals
+func (mr *MockOffsetMockRecorder) Equals(other interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Equals", reflect.TypeOf((*MockOffset)(nil).Equals), other)
+}
+
+// Less mocks base method
+func (m *MockOffset) Less(other Offset) bool {
+	ret := m.ctrl.Call(m, "Less", other)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Less indicates an expected call of Less
+func (mr *MockOffsetMockRecorder) Less(other interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Less", reflect.TypeOf((*MockOffset)(nil).Less), other)
+}
+
 // MockBlock is a mock of Block interface
 type MockBlock struct {
 	ctrl     *gomock.Controller
@@ -718,6 +765,67 @@ func (m *MockBlock) ToCommonBlock() *CommonBlock {
 // ToCommonBlock indicates an expected call of ToCommonBlock
 func (mr *MockBlockMockRecorder) ToCommonBlock() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToCommonBlock", reflect.TypeOf((*MockBlock)(nil).ToCommonBlock))
+}
+
+// IsIndirect mocks base method
+func (m *MockBlock) IsIndirect() bool {
+	ret := m.ctrl.Call(m, "IsIndirect")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsIndirect indicates an expected call of IsIndirect
+func (mr *MockBlockMockRecorder) IsIndirect() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIndirect", reflect.TypeOf((*MockBlock)(nil).IsIndirect))
+}
+
+// FirstOffset mocks base method
+func (m *MockBlock) FirstOffset() Offset {
+	ret := m.ctrl.Call(m, "FirstOffset")
+	ret0, _ := ret[0].(Offset)
+	return ret0
+}
+
+// FirstOffset indicates an expected call of FirstOffset
+func (mr *MockBlockMockRecorder) FirstOffset() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirstOffset", reflect.TypeOf((*MockBlock)(nil).FirstOffset))
+}
+
+// NumIndirectPtrs mocks base method
+func (m *MockBlock) NumIndirectPtrs() int {
+	ret := m.ctrl.Call(m, "NumIndirectPtrs")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// NumIndirectPtrs indicates an expected call of NumIndirectPtrs
+func (mr *MockBlockMockRecorder) NumIndirectPtrs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumIndirectPtrs", reflect.TypeOf((*MockBlock)(nil).NumIndirectPtrs))
+}
+
+// IndirectPtr mocks base method
+func (m *MockBlock) IndirectPtr(i int) (BlockInfo, Offset) {
+	ret := m.ctrl.Call(m, "IndirectPtr", i)
+	ret0, _ := ret[0].(BlockInfo)
+	ret1, _ := ret[1].(Offset)
+	return ret0, ret1
+}
+
+// IndirectPtr indicates an expected call of IndirectPtr
+func (mr *MockBlockMockRecorder) IndirectPtr(i interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndirectPtr", reflect.TypeOf((*MockBlock)(nil).IndirectPtr), i)
+}
+
+// OffsetExceedsData mocks base method
+func (m *MockBlock) OffsetExceedsData(startOff, off Offset) bool {
+	ret := m.ctrl.Call(m, "OffsetExceedsData", startOff, off)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// OffsetExceedsData indicates an expected call of OffsetExceedsData
+func (mr *MockBlockMockRecorder) OffsetExceedsData(startOff, off interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OffsetExceedsData", reflect.TypeOf((*MockBlock)(nil).OffsetExceedsData), startOff, off)
 }
 
 // MockNodeID is a mock of NodeID interface

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -37,7 +37,7 @@ func makeRandomDirEntry(
 		codec.UnknownFieldSetHandler{},
 	}
 }
-func makeFakeIndirectFilePtr(t *testing.T, off int64) IndirectFilePtr {
+func makeFakeIndirectFilePtr(t *testing.T, off Int64Offset) IndirectFilePtr {
 	return IndirectFilePtr{
 		makeRandomBlockInfo(t),
 		off,
@@ -46,7 +46,7 @@ func makeFakeIndirectFilePtr(t *testing.T, off int64) IndirectFilePtr {
 	}
 }
 
-func makeFakeIndirectDirPtr(t *testing.T, off string) IndirectDirPtr {
+func makeFakeIndirectDirPtr(t *testing.T, off StringOffset) IndirectDirPtr {
 	return IndirectDirPtr{
 		makeRandomBlockInfo(t),
 		off,


### PR DESCRIPTION
When we introduce indirect directory blocks, we'll want to reuse the logic for navigating a tree of blocks.  Do this by adding generic offset types and some new helper functions to the Block interface, and refactoring functions from `fileData` into a new generic `blockTree` struct that can operate on any type of block.

This commit shouldn't change any logicc, it's just a refactor

Issue: KBFS-3299