### PR TITLE
dir_data: implement the read-only methods

### DIFF
--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -38,24 +38,34 @@ func (i Int64Offset) Less(other Offset) bool {
 // StringOffset represents the offset of a block within a directory.
 type StringOffset string
 
-var _ Offset = StringOffset("")
+var _ Offset = (*StringOffset)(nil)
 
 // Equals implements the Offset interface for StringOffset.
-func (s StringOffset) Equals(other Offset) bool {
-	otherS, ok := other.(StringOffset)
+func (s *StringOffset) Equals(other Offset) bool {
+	if s == nil {
+		return other == nil
+	} else if other == nil {
+		return false
+	}
+	otherS, ok := other.(*StringOffset)
 	if !ok {
 		panic(fmt.Sprintf("Can't compare against non-string offset: %T", other))
 	}
-	return string(s) == string(otherS)
+	return string(*s) == string(*otherS)
 }
 
 // Less implements the Offset interface for StringOffset.
-func (s StringOffset) Less(other Offset) bool {
-	otherS, ok := other.(StringOffset)
+func (s *StringOffset) Less(other Offset) bool {
+	if s == nil {
+		return other != nil
+	} else if other == nil {
+		return false
+	}
+	otherS, ok := other.(*StringOffset)
 	if !ok {
 		panic(fmt.Sprintf("Can't compare against non-string offset: %T", other))
 	}
-	return string(s) < string(otherS)
+	return string(*s) < string(*otherS)
 }
 
 // IndirectDirPtr pairs an indirect dir block with the start of that
@@ -241,7 +251,8 @@ func (db *DirBlock) DeepCopy() *DirBlock {
 
 // FirstOffset implements the Block interface for DirBlock.
 func (db *DirBlock) FirstOffset() Offset {
-	return StringOffset("")
+	firstString := StringOffset("")
+	return &firstString
 }
 
 // NumIndirectPtrs implements the Block interface for DirBlock.
@@ -258,7 +269,8 @@ func (db *DirBlock) IndirectPtr(i int) (BlockInfo, Offset) {
 		panic("IndirectPtr called on a direct directory block")
 	}
 	iptr := db.IPtrs[i]
-	return iptr.BlockInfo, iptr.Off
+	off := StringOffset(iptr.Off)
+	return iptr.BlockInfo, &off
 }
 
 // OffsetExceedsData implements the Block interface for DirBlock.

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -87,3 +87,24 @@ func (dd *dirData) getChildren(ctx context.Context) (
 	}
 	return children, nil
 }
+
+func (dd *dirData) lookup(ctx context.Context, name string) (DirEntry, error) {
+	topBlock, _, err := dd.getter(
+		ctx, dd.kmd, dd.rootBlockPointer(), dd.dir, blockRead)
+	if err != nil {
+		return DirEntry{}, err
+	}
+
+	off := StringOffset(name)
+	_, _, block, _, _, _, err := dd.tree.getBlockAtOffset(
+		ctx, topBlock, &off, blockRead)
+	if err != nil {
+		return DirEntry{}, err
+	}
+
+	de, ok := block.(*DirBlock).Children[name]
+	if !ok {
+		return DirEntry{}, NoSuchNameError{name}
+	}
+	return de, nil
+}

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -1,0 +1,56 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"github.com/keybase/client/go/logger"
+	"golang.org/x/net/context"
+)
+
+// dirBlockGetter is a function that gets a block suitable for
+// reading or writing, and also returns whether the block was already
+// dirty.  It may be called from new goroutines, and must handle any
+// required locks accordingly.
+type dirBlockGetter func(context.Context, KeyMetadata, BlockPointer,
+	path, blockReqType) (dblock *DirBlock, wasDirty bool, err error)
+
+// dirData is a helper struct for accessing and manipulating data
+// within a directory.  It's meant for use within a single scope, not
+// for long-term storage.  The caller must ensure goroutine-safety.
+type dirData struct {
+	dir    path
+	kmd    KeyMetadata
+	getter dirBlockGetter
+	cacher dirtyBlockCacher
+	log    logger.Logger
+	tree   *blockTree
+}
+
+func newDirData(dir path, kmd KeyMetadata, getter dirBlockGetter,
+	cacher dirtyBlockCacher, log logger.Logger) *dirData {
+	dd := &dirData{
+		dir:    dir,
+		kmd:    kmd,
+		getter: getter,
+		cacher: cacher,
+		log:    log,
+	}
+	dd.tree = &blockTree{
+		file:   dir,
+		kmd:    kmd,
+		getter: dd.blockGetter,
+	}
+	return dd
+}
+
+func (dd *dirData) rootBlockPointer() BlockPointer {
+	return dd.dir.tailPointer()
+}
+
+func (dd *dirData) blockGetter(
+	ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
+	dir path, rtype blockReqType) (block Block, wasDirty bool, err error) {
+	return dd.getter(ctx, kmd, ptr, dir, rtype)
+}

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -1,0 +1,128 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func setupDirDataTest(t *testing.T) (*dirData, BlockCache, DirtyBlockCache) {
+	// Make a fake dir.
+	ptr := BlockPointer{
+		ID:         kbfsblock.FakeID(42),
+		DirectType: DirectBlock,
+	}
+	id := tlf.FakeID(1, tlf.Private)
+	dir := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "dir"}}}
+	kmd := emptyKeyMetadata{id, 1}
+
+	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)
+	dirtyBcache := simpleDirtyBlockCacheStandard()
+	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
+		_ path, _ blockReqType) (*DirBlock, bool, error) {
+		isDirty := true
+		block, err := dirtyBcache.Get(id, ptr, MasterBranch)
+		if err != nil {
+			// Check the clean cache.
+			block, err = cleanCache.Get(ptr)
+			if err != nil {
+				return nil, false, err
+			}
+			isDirty = false
+		}
+		fblock, ok := block.(*DirBlock)
+		if !ok {
+			return nil, false,
+				fmt.Errorf("Block for %s is not a dir block", ptr)
+		}
+		return fblock, isDirty, nil
+	}
+	cacher := func(ptr BlockPointer, block Block) error {
+		return dirtyBcache.Put(id, ptr, MasterBranch, block)
+	}
+
+	dd := newDirData(
+		dir, kmd, getter, cacher, logger.NewTestLogger(t))
+	return dd, cleanCache, dirtyBcache
+}
+
+func addFakeDirDataEntry(dblock *DirBlock, name string, size uint64) {
+	dblock.Children[name] = DirEntry{
+		EntryInfo: EntryInfo{
+			Size: size,
+		},
+	}
+}
+
+func TestDirDataGetChildren(t *testing.T) {
+	dd, cleanBcache, _ := setupDirDataTest(t)
+	ctx := context.Background()
+	topBlock := NewDirBlock().(*DirBlock)
+	cleanBcache.Put(
+		dd.rootBlockPointer(), dd.dir.Tlf, topBlock, TransientEntry)
+
+	t.Log("No entries, direct block")
+	children, err := dd.getChildren(ctx)
+	require.NoError(t, err)
+	require.Len(t, children, 0)
+
+	t.Log("Single entry, direct block")
+	addFakeDirDataEntry(topBlock, "a", 1)
+	children, err = dd.getChildren(ctx)
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	require.Equal(t, uint64(1), children["a"].Size)
+
+	t.Log("Two entries, direct block")
+	addFakeDirDataEntry(topBlock, "b", 2)
+	children, err = dd.getChildren(ctx)
+	require.NoError(t, err)
+	require.Len(t, children, 2)
+	require.Equal(t, uint64(1), children["a"].Size)
+	require.Equal(t, uint64(2), children["b"].Size)
+
+	t.Log("Indirect blocks")
+	dd.dir.path[len(dd.dir.path)-1].DirectType = IndirectBlock
+	newTopBlock := NewDirBlock().(*DirBlock)
+	newTopBlock.IsInd = true
+	ptr1 := BlockPointer{
+		ID:         kbfsblock.FakeID(43),
+		DirectType: DirectBlock,
+	}
+	newTopBlock.IPtrs = append(newTopBlock.IPtrs, IndirectDirPtr{
+		BlockInfo: BlockInfo{ptr1, 0},
+		Off:       "",
+	})
+	ptr2 := BlockPointer{
+		ID:         kbfsblock.FakeID(44),
+		DirectType: DirectBlock,
+	}
+	newTopBlock.IPtrs = append(newTopBlock.IPtrs, IndirectDirPtr{
+		BlockInfo: BlockInfo{ptr2, 0},
+		Off:       "m",
+	})
+	block2 := NewDirBlock().(*DirBlock)
+	addFakeDirDataEntry(block2, "z1", 3)
+	addFakeDirDataEntry(block2, "z2", 4)
+	cleanBcache.Put(
+		dd.rootBlockPointer(), dd.dir.Tlf, newTopBlock, TransientEntry)
+	cleanBcache.Put(ptr1, dd.dir.Tlf, topBlock, TransientEntry)
+	cleanBcache.Put(ptr2, dd.dir.Tlf, block2, TransientEntry)
+	children, err = dd.getChildren(ctx)
+	require.NoError(t, err)
+	require.Len(t, children, 4)
+	require.Equal(t, uint64(1), children["a"].Size)
+	require.Equal(t, uint64(2), children["b"].Size)
+	require.Equal(t, uint64(3), children["z1"].Size)
+	require.Equal(t, uint64(4), children["z2"].Size)
+
+}


### PR DESCRIPTION
This PR introduces a `dirData` class that can understand multi-block directories, and it implements read-only operations on it and tests for them.  (But it's not in use in the rest of the code yet.)

A future PR will implement the more complicated modifying methods.

Depends on #1732 and #1734.

Issue: KBFS-3301