### PR TITLE
block_tree: refactor tree update methods out of fileData

### DIFF
--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -156,10 +156,10 @@ func (cb *CommonBlock) OffsetExceedsData(_, _ Offset) bool {
 
 // Set implements the Block interface for CommonBlock.
 func (cb *CommonBlock) Set(other Block) {
-	otherCopy := other.ToCommonBlock()
-	cb.IsInd = otherCopy.IsInd
-	cb.UnknownFieldSetHandler = otherCopy.UnknownFieldSetHandler
-	cb.SetEncodedSize(otherCopy.GetEncodedSize())
+	otherCommon := other.ToCommonBlock()
+	cb.IsInd = otherCommon.IsInd
+	cb.UnknownFieldSetHandler = otherCommon.UnknownFieldSetHandler
+	cb.SetEncodedSize(otherCommon.GetEncodedSize())
 }
 
 // BytesCanBeDirtied implements the Block interface for CommonBlock.

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -270,7 +270,7 @@ func (db *DirBlock) FirstOffset() Offset {
 	return &firstString
 }
 
-// NumIndirectPtrs implements the Block interface for DirBlock.
+// NumIndirectPtrs implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) NumIndirectPtrs() int {
 	if !db.IsInd {
 		panic("NumIndirectPtrs called on a direct directory block")
@@ -278,7 +278,7 @@ func (db *DirBlock) NumIndirectPtrs() int {
 	return len(db.IPtrs)
 }
 
-// IndirectPtr implements the Block interface for DirBlock.
+// IndirectPtr implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) IndirectPtr(i int) (BlockInfo, Offset) {
 	if !db.IsInd {
 		panic("IndirectPtr called on a direct directory block")
@@ -288,7 +288,7 @@ func (db *DirBlock) IndirectPtr(i int) (BlockInfo, Offset) {
 	return iptr.BlockInfo, &off
 }
 
-// AppendNewIndirectPtr implements the Block interface for FileBlock.
+// AppendNewIndirectPtr implements the BlockWithPtrs interface for FileBlock.
 func (db *DirBlock) AppendNewIndirectPtr(ptr BlockPointer, off Offset) {
 	if !db.IsInd {
 		panic("AppendNewIndirectPtr called on a direct directory block")
@@ -307,7 +307,7 @@ func (db *DirBlock) AppendNewIndirectPtr(ptr BlockPointer, off Offset) {
 	})
 }
 
-// ClearIndirectPtrSize implements the Block interface for DirBlock.
+// ClearIndirectPtrSize implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) ClearIndirectPtrSize(i int) {
 	if !db.IsInd {
 		panic("ClearIndirectPtrSize called on a direct directory block")
@@ -315,7 +315,7 @@ func (db *DirBlock) ClearIndirectPtrSize(i int) {
 	db.IPtrs[i].EncodedSize = 0
 }
 
-// SetIndirectPtrType implements the Block interface for DirBlock.
+// SetIndirectPtrType implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) SetIndirectPtrType(i int, dt BlockDirectType) {
 	if !db.IsInd {
 		panic("SetIndirectPtrType called on a direct directory block")
@@ -323,7 +323,7 @@ func (db *DirBlock) SetIndirectPtrType(i int, dt BlockDirectType) {
 	db.IPtrs[i].DirectType = dt
 }
 
-// SwapIndirectPtrs implements the Block interface for DirBlock.
+// SwapIndirectPtrs implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
 	otherDB, ok := other.(*DirBlock)
 	if !ok {
@@ -334,7 +334,7 @@ func (db *DirBlock) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
 	db.IPtrs[i], otherDB.IPtrs[otherI] = otherDB.IPtrs[otherI], db.IPtrs[i]
 }
 
-// SetIndirectPtrOff implements the Block interface for DirBlock.
+// SetIndirectPtrOff implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) SetIndirectPtrOff(i int, off Offset) {
 	if !db.IsInd {
 		panic("SetIndirectPtrOff called on a direct file block")
@@ -525,7 +525,7 @@ func (fb *FileBlock) FirstOffset() Offset {
 	return Int64Offset(0)
 }
 
-// NumIndirectPtrs implements the Block interface for FileBlock.
+// NumIndirectPtrs implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) NumIndirectPtrs() int {
 	if !fb.IsInd {
 		panic("NumIndirectPtrs called on a direct file block")
@@ -533,7 +533,7 @@ func (fb *FileBlock) NumIndirectPtrs() int {
 	return len(fb.IPtrs)
 }
 
-// IndirectPtr implements the Block interface for FileBlock.
+// IndirectPtr implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) IndirectPtr(i int) (BlockInfo, Offset) {
 	if !fb.IsInd {
 		panic("IndirectPtr called on a direct file block")
@@ -542,7 +542,7 @@ func (fb *FileBlock) IndirectPtr(i int) (BlockInfo, Offset) {
 	return iptr.BlockInfo, iptr.Off
 }
 
-// AppendNewIndirectPtr implements the Block interface for FileBlock.
+// AppendNewIndirectPtr implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) AppendNewIndirectPtr(ptr BlockPointer, off Offset) {
 	if !fb.IsInd {
 		panic("AppendNewIndirectPtr called on a direct file block")
@@ -561,7 +561,7 @@ func (fb *FileBlock) AppendNewIndirectPtr(ptr BlockPointer, off Offset) {
 	})
 }
 
-// ClearIndirectPtrSize implements the Block interface for FileBlock.
+// ClearIndirectPtrSize implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) ClearIndirectPtrSize(i int) {
 	if !fb.IsInd {
 		panic("ClearIndirectPtrSize called on a direct file block")
@@ -569,7 +569,7 @@ func (fb *FileBlock) ClearIndirectPtrSize(i int) {
 	fb.IPtrs[i].EncodedSize = 0
 }
 
-// SetIndirectPtrType implements the Block interface for FileBlock.
+// SetIndirectPtrType implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) SetIndirectPtrType(i int, dt BlockDirectType) {
 	if !fb.IsInd {
 		panic("SetIndirectPtrType called on a direct file block")
@@ -577,7 +577,7 @@ func (fb *FileBlock) SetIndirectPtrType(i int, dt BlockDirectType) {
 	fb.IPtrs[i].DirectType = dt
 }
 
-// SwapIndirectPtrs implements the Block interface for FileBlock.
+// SwapIndirectPtrs implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
 	otherFB, ok := other.(*FileBlock)
 	if !ok {
@@ -588,7 +588,7 @@ func (fb *FileBlock) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
 	fb.IPtrs[i], otherFB.IPtrs[otherI] = otherFB.IPtrs[otherI], fb.IPtrs[i]
 }
 
-// SetIndirectPtrOff implements the Block interface for FileBlock.
+// SetIndirectPtrOff implements the BlockWithPtrs interface for FileBlock.
 func (fb *FileBlock) SetIndirectPtrOff(i int, off Offset) {
 	if !fb.IsInd {
 		panic("SetIndirectPtrOff called on a direct file block")

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -91,20 +91,12 @@ func (tb *TestBlock) IsIndirect() bool {
 	return false
 }
 
-func (tb *TestBlock) FirstOffset() Offset {
-	return nil
-}
-
-func (tb *TestBlock) NumIndirectPtrs() int {
-	panic("No indirect pointers for the test block")
-}
-
-func (tb *TestBlock) IndirectPtr(_ int) (BlockInfo, Offset) {
-	panic("No indirect pointers for the test block")
-}
-
 func (tb TestBlock) OffsetExceedsData(_, _ Offset) bool {
 	return false
+}
+
+func (tb TestBlock) BytesCanBeDirtied() int64 {
+	return 0
 }
 
 func TestCryptoCommonEncryptDecryptBlock(t *testing.T) {
@@ -373,20 +365,12 @@ func (tba testBlockArray) IsIndirect() bool {
 	return false
 }
 
-func (tba testBlockArray) FirstOffset() Offset {
-	return nil
-}
-
-func (tba testBlockArray) NumIndirectPtrs() int {
-	panic("No indirect pointers for the test block array")
-}
-
-func (tba testBlockArray) IndirectPtr(_ int) (BlockInfo, Offset) {
-	panic("No indirect pointers for the test block array")
-}
-
 func (tba testBlockArray) OffsetExceedsData(_, _ Offset) bool {
 	return false
+}
+
+func (tba testBlockArray) BytesCanBeDirtied() int64 {
+	return 0
 }
 
 // Test that block encrypted data length is the same for data

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"golang.org/x/net/context"
 )
 
@@ -20,45 +21,45 @@ type dirBlockGetter func(context.Context, KeyMetadata, BlockPointer,
 // within a directory.  It's meant for use within a single scope, not
 // for long-term storage.  The caller must ensure goroutine-safety.
 type dirData struct {
-	dir    path
-	kmd    KeyMetadata
 	getter dirBlockGetter
-	cacher dirtyBlockCacher
-	log    logger.Logger
 	tree   *blockTree
 }
 
-func newDirData(dir path, kmd KeyMetadata, getter dirBlockGetter,
-	cacher dirtyBlockCacher, log logger.Logger) *dirData {
+func newDirData(dir path, chargedTo keybase1.UserOrTeamID,
+	crypto cryptoPure, kmd KeyMetadata, bsplit BlockSplitter,
+	getter dirBlockGetter, cacher dirtyBlockCacher,
+	log logger.Logger) *dirData {
 	dd := &dirData{
-		dir:    dir,
-		kmd:    kmd,
 		getter: getter,
-		cacher: cacher,
-		log:    log,
 	}
 	dd.tree = &blockTree{
-		file:   dir,
-		kmd:    kmd,
-		getter: dd.blockGetter,
+		file:      dir,
+		chargedTo: chargedTo,
+		crypto:    crypto,
+		kmd:       kmd,
+		bsplit:    bsplit,
+		getter:    dd.blockGetter,
+		cacher:    cacher,
+		log:       log,
 	}
 	return dd
 }
 
 func (dd *dirData) rootBlockPointer() BlockPointer {
-	return dd.dir.tailPointer()
+	return dd.tree.file.tailPointer()
 }
 
 func (dd *dirData) blockGetter(
 	ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
-	dir path, rtype blockReqType) (block Block, wasDirty bool, err error) {
+	dir path, rtype blockReqType) (
+	block BlockWithPtrs, wasDirty bool, err error) {
 	return dd.getter(ctx, kmd, ptr, dir, rtype)
 }
 
 func (dd *dirData) getChildren(ctx context.Context) (
 	children map[string]EntryInfo, err error) {
 	topBlock, _, err := dd.getter(
-		ctx, dd.kmd, dd.rootBlockPointer(), dd.dir, blockRead)
+		ctx, dd.tree.kmd, dd.rootBlockPointer(), dd.tree.file, blockRead)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func (dd *dirData) getChildren(ctx context.Context) (
 
 func (dd *dirData) lookup(ctx context.Context, name string) (DirEntry, error) {
 	topBlock, _, err := dd.getter(
-		ctx, dd.kmd, dd.rootBlockPointer(), dd.dir, blockRead)
+		ctx, dd.tree.kmd, dd.rootBlockPointer(), dd.tree.file, blockRead)
 	if err != nil {
 		return DirEntry{}, err
 	}

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -209,7 +209,8 @@ func (tfdl testFileDataLevel) check(t *testing.T, fd *fileData,
 	if tfdl.dirty {
 		dirtyPtrs[ptr] = true
 		require.True(
-			t, dirtyBcache.IsDirty(fd.file.Tlf, ptr, MasterBranch), levelString)
+			t, dirtyBcache.IsDirty(fd.tree.file.Tlf, ptr, MasterBranch),
+			levelString)
 	}
 
 	fblock, isDirty, err := fd.getter(nil, nil, ptr, path{}, blockRead)
@@ -277,7 +278,7 @@ func testFileDataWriteExtendEmptyFile(t *testing.T, maxBlockSize Int64Offset,
 		t, int64(maxBlockSize), maxPtrsPerBlock)
 	topBlock := NewFileBlock().(*FileBlock)
 	cleanBcache.Put(
-		fd.rootBlockPointer(), fd.file.Tlf, topBlock, TransientEntry)
+		fd.rootBlockPointer(), fd.tree.file.Tlf, topBlock, TransientEntry)
 	de := DirEntry{}
 	data := make([]byte, fullDataLen)
 	for i := 0; i < int(fullDataLen); i++ {
@@ -406,7 +407,7 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 					BlockInfo: BlockInfo{ptr, 0},
 					Off:       off,
 				})
-				cleanBcache.Put(ptr, fd.file.Tlf, child, TransientEntry)
+				cleanBcache.Put(ptr, fd.tree.file.Tlf, child, TransientEntry)
 			}
 			prevChildIndex = newIndex
 			level = append(level, fblock)
@@ -416,11 +417,12 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 	}
 
 	if numLevels > 1 {
-		fd.file.path[len(fd.file.path)-1].DirectType = IndirectBlock
+		fd.tree.file.path[len(fd.tree.file.path)-1].DirectType = IndirectBlock
 	}
 
 	cleanBcache.Put(
-		fd.rootBlockPointer(), fd.file.Tlf, prevChildren[0], TransientEntry)
+		fd.rootBlockPointer(), fd.tree.file.Tlf, prevChildren[0],
+		TransientEntry)
 	return prevChildren[0], numLevels
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -779,43 +779,6 @@ func (mr *MockBlockMockRecorder) IsIndirect() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIndirect", reflect.TypeOf((*MockBlock)(nil).IsIndirect))
 }
 
-// FirstOffset mocks base method
-func (m *MockBlock) FirstOffset() Offset {
-	ret := m.ctrl.Call(m, "FirstOffset")
-	ret0, _ := ret[0].(Offset)
-	return ret0
-}
-
-// FirstOffset indicates an expected call of FirstOffset
-func (mr *MockBlockMockRecorder) FirstOffset() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirstOffset", reflect.TypeOf((*MockBlock)(nil).FirstOffset))
-}
-
-// NumIndirectPtrs mocks base method
-func (m *MockBlock) NumIndirectPtrs() int {
-	ret := m.ctrl.Call(m, "NumIndirectPtrs")
-	ret0, _ := ret[0].(int)
-	return ret0
-}
-
-// NumIndirectPtrs indicates an expected call of NumIndirectPtrs
-func (mr *MockBlockMockRecorder) NumIndirectPtrs() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumIndirectPtrs", reflect.TypeOf((*MockBlock)(nil).NumIndirectPtrs))
-}
-
-// IndirectPtr mocks base method
-func (m *MockBlock) IndirectPtr(i int) (BlockInfo, Offset) {
-	ret := m.ctrl.Call(m, "IndirectPtr", i)
-	ret0, _ := ret[0].(BlockInfo)
-	ret1, _ := ret[1].(Offset)
-	return ret0, ret1
-}
-
-// IndirectPtr indicates an expected call of IndirectPtr
-func (mr *MockBlockMockRecorder) IndirectPtr(i interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndirectPtr", reflect.TypeOf((*MockBlock)(nil).IndirectPtr), i)
-}
-
 // OffsetExceedsData mocks base method
 func (m *MockBlock) OffsetExceedsData(startOff, off Offset) bool {
 	ret := m.ctrl.Call(m, "OffsetExceedsData", startOff, off)
@@ -826,6 +789,232 @@ func (m *MockBlock) OffsetExceedsData(startOff, off Offset) bool {
 // OffsetExceedsData indicates an expected call of OffsetExceedsData
 func (mr *MockBlockMockRecorder) OffsetExceedsData(startOff, off interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OffsetExceedsData", reflect.TypeOf((*MockBlock)(nil).OffsetExceedsData), startOff, off)
+}
+
+// BytesCanBeDirtied mocks base method
+func (m *MockBlock) BytesCanBeDirtied() int64 {
+	ret := m.ctrl.Call(m, "BytesCanBeDirtied")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// BytesCanBeDirtied indicates an expected call of BytesCanBeDirtied
+func (mr *MockBlockMockRecorder) BytesCanBeDirtied() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BytesCanBeDirtied", reflect.TypeOf((*MockBlock)(nil).BytesCanBeDirtied))
+}
+
+// MockBlockWithPtrs is a mock of BlockWithPtrs interface
+type MockBlockWithPtrs struct {
+	ctrl     *gomock.Controller
+	recorder *MockBlockWithPtrsMockRecorder
+}
+
+// MockBlockWithPtrsMockRecorder is the mock recorder for MockBlockWithPtrs
+type MockBlockWithPtrsMockRecorder struct {
+	mock *MockBlockWithPtrs
+}
+
+// NewMockBlockWithPtrs creates a new mock instance
+func NewMockBlockWithPtrs(ctrl *gomock.Controller) *MockBlockWithPtrs {
+	mock := &MockBlockWithPtrs{ctrl: ctrl}
+	mock.recorder = &MockBlockWithPtrsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockBlockWithPtrs) EXPECT() *MockBlockWithPtrsMockRecorder {
+	return m.recorder
+}
+
+// DataVersion mocks base method
+func (m *MockBlockWithPtrs) DataVersion() DataVer {
+	ret := m.ctrl.Call(m, "DataVersion")
+	ret0, _ := ret[0].(DataVer)
+	return ret0
+}
+
+// DataVersion indicates an expected call of DataVersion
+func (mr *MockBlockWithPtrsMockRecorder) DataVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataVersion", reflect.TypeOf((*MockBlockWithPtrs)(nil).DataVersion))
+}
+
+// GetEncodedSize mocks base method
+func (m *MockBlockWithPtrs) GetEncodedSize() uint32 {
+	ret := m.ctrl.Call(m, "GetEncodedSize")
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// GetEncodedSize indicates an expected call of GetEncodedSize
+func (mr *MockBlockWithPtrsMockRecorder) GetEncodedSize() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).GetEncodedSize))
+}
+
+// SetEncodedSize mocks base method
+func (m *MockBlockWithPtrs) SetEncodedSize(size uint32) {
+	m.ctrl.Call(m, "SetEncodedSize", size)
+}
+
+// SetEncodedSize indicates an expected call of SetEncodedSize
+func (mr *MockBlockWithPtrsMockRecorder) SetEncodedSize(size interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetEncodedSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetEncodedSize), size)
+}
+
+// NewEmpty mocks base method
+func (m *MockBlockWithPtrs) NewEmpty() Block {
+	ret := m.ctrl.Call(m, "NewEmpty")
+	ret0, _ := ret[0].(Block)
+	return ret0
+}
+
+// NewEmpty indicates an expected call of NewEmpty
+func (mr *MockBlockWithPtrsMockRecorder) NewEmpty() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEmpty", reflect.TypeOf((*MockBlockWithPtrs)(nil).NewEmpty))
+}
+
+// Set mocks base method
+func (m *MockBlockWithPtrs) Set(other Block) {
+	m.ctrl.Call(m, "Set", other)
+}
+
+// Set indicates an expected call of Set
+func (mr *MockBlockWithPtrsMockRecorder) Set(other interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockBlockWithPtrs)(nil).Set), other)
+}
+
+// ToCommonBlock mocks base method
+func (m *MockBlockWithPtrs) ToCommonBlock() *CommonBlock {
+	ret := m.ctrl.Call(m, "ToCommonBlock")
+	ret0, _ := ret[0].(*CommonBlock)
+	return ret0
+}
+
+// ToCommonBlock indicates an expected call of ToCommonBlock
+func (mr *MockBlockWithPtrsMockRecorder) ToCommonBlock() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToCommonBlock", reflect.TypeOf((*MockBlockWithPtrs)(nil).ToCommonBlock))
+}
+
+// IsIndirect mocks base method
+func (m *MockBlockWithPtrs) IsIndirect() bool {
+	ret := m.ctrl.Call(m, "IsIndirect")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsIndirect indicates an expected call of IsIndirect
+func (mr *MockBlockWithPtrsMockRecorder) IsIndirect() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIndirect", reflect.TypeOf((*MockBlockWithPtrs)(nil).IsIndirect))
+}
+
+// OffsetExceedsData mocks base method
+func (m *MockBlockWithPtrs) OffsetExceedsData(startOff, off Offset) bool {
+	ret := m.ctrl.Call(m, "OffsetExceedsData", startOff, off)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// OffsetExceedsData indicates an expected call of OffsetExceedsData
+func (mr *MockBlockWithPtrsMockRecorder) OffsetExceedsData(startOff, off interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OffsetExceedsData", reflect.TypeOf((*MockBlockWithPtrs)(nil).OffsetExceedsData), startOff, off)
+}
+
+// BytesCanBeDirtied mocks base method
+func (m *MockBlockWithPtrs) BytesCanBeDirtied() int64 {
+	ret := m.ctrl.Call(m, "BytesCanBeDirtied")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// BytesCanBeDirtied indicates an expected call of BytesCanBeDirtied
+func (mr *MockBlockWithPtrsMockRecorder) BytesCanBeDirtied() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BytesCanBeDirtied", reflect.TypeOf((*MockBlockWithPtrs)(nil).BytesCanBeDirtied))
+}
+
+// FirstOffset mocks base method
+func (m *MockBlockWithPtrs) FirstOffset() Offset {
+	ret := m.ctrl.Call(m, "FirstOffset")
+	ret0, _ := ret[0].(Offset)
+	return ret0
+}
+
+// FirstOffset indicates an expected call of FirstOffset
+func (mr *MockBlockWithPtrsMockRecorder) FirstOffset() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirstOffset", reflect.TypeOf((*MockBlockWithPtrs)(nil).FirstOffset))
+}
+
+// NumIndirectPtrs mocks base method
+func (m *MockBlockWithPtrs) NumIndirectPtrs() int {
+	ret := m.ctrl.Call(m, "NumIndirectPtrs")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// NumIndirectPtrs indicates an expected call of NumIndirectPtrs
+func (mr *MockBlockWithPtrsMockRecorder) NumIndirectPtrs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NumIndirectPtrs", reflect.TypeOf((*MockBlockWithPtrs)(nil).NumIndirectPtrs))
+}
+
+// IndirectPtr mocks base method
+func (m *MockBlockWithPtrs) IndirectPtr(i int) (BlockInfo, Offset) {
+	ret := m.ctrl.Call(m, "IndirectPtr", i)
+	ret0, _ := ret[0].(BlockInfo)
+	ret1, _ := ret[1].(Offset)
+	return ret0, ret1
+}
+
+// IndirectPtr indicates an expected call of IndirectPtr
+func (mr *MockBlockWithPtrsMockRecorder) IndirectPtr(i interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndirectPtr", reflect.TypeOf((*MockBlockWithPtrs)(nil).IndirectPtr), i)
+}
+
+// AppendNewIndirectPtr mocks base method
+func (m *MockBlockWithPtrs) AppendNewIndirectPtr(ptr BlockPointer, off Offset) {
+	m.ctrl.Call(m, "AppendNewIndirectPtr", ptr, off)
+}
+
+// AppendNewIndirectPtr indicates an expected call of AppendNewIndirectPtr
+func (mr *MockBlockWithPtrsMockRecorder) AppendNewIndirectPtr(ptr, off interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendNewIndirectPtr", reflect.TypeOf((*MockBlockWithPtrs)(nil).AppendNewIndirectPtr), ptr, off)
+}
+
+// ClearIndirectPtrSize mocks base method
+func (m *MockBlockWithPtrs) ClearIndirectPtrSize(i int) {
+	m.ctrl.Call(m, "ClearIndirectPtrSize", i)
+}
+
+// ClearIndirectPtrSize indicates an expected call of ClearIndirectPtrSize
+func (mr *MockBlockWithPtrsMockRecorder) ClearIndirectPtrSize(i interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearIndirectPtrSize", reflect.TypeOf((*MockBlockWithPtrs)(nil).ClearIndirectPtrSize), i)
+}
+
+// SetIndirectPtrType mocks base method
+func (m *MockBlockWithPtrs) SetIndirectPtrType(i int, dt BlockDirectType) {
+	m.ctrl.Call(m, "SetIndirectPtrType", i, dt)
+}
+
+// SetIndirectPtrType indicates an expected call of SetIndirectPtrType
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrType(i, dt interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrType", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrType), i, dt)
+}
+
+// SetIndirectPtrOff mocks base method
+func (m *MockBlockWithPtrs) SetIndirectPtrOff(i int, off Offset) {
+	m.ctrl.Call(m, "SetIndirectPtrOff", i, off)
+}
+
+// SetIndirectPtrOff indicates an expected call of SetIndirectPtrOff
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrOff(i, off interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrOff", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrOff), i, off)
+}
+
+// SwapIndirectPtrs mocks base method
+func (m *MockBlockWithPtrs) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
+	m.ctrl.Call(m, "SwapIndirectPtrs", i, other, otherI)
+}
+
+// SwapIndirectPtrs indicates an expected call of SwapIndirectPtrs
+func (mr *MockBlockWithPtrsMockRecorder) SwapIndirectPtrs(i, other, otherI interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SwapIndirectPtrs", reflect.TypeOf((*MockBlockWithPtrs)(nil).SwapIndirectPtrs), i, other, otherI)
 }
 
 // MockNodeID is a mock of NodeID interface


### PR DESCRIPTION
In a future PR, `dirData` will start using these methods.

Also, a few other cleanups:

* Separate the indirect pointer methods of blocks out into their own interface, so we don't have to implement them in `CommonBlock` and test block types.
* Have `dirData` and `fileData` use the fields of `blockTree` for most of their internal fields, to simplify things and avoid unnecessary overhead.

Issue: KBFS-3301