### PR TITLE
dir_data: implement dirblock-splitting and add/remove/update methods

### DIFF
--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -571,8 +571,8 @@ func (bt *blockTree) newRightBlock(
 }
 
 // setParentOffsets updates the parent offsets for a newly-moved
-// block, all the way up to its common ancestor (which is the one with
-// the one that doesn't have a childIndex of 0).
+// block, all the way up to its common ancestor (which is the one that
+// doesn't have a childIndex of 0).
 func (bt *blockTree) setParentOffsets(
 	ctx context.Context, newOff Offset,
 	parents []parentBlockAndChildIndex, currIndex int) (

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/keybase/go-codec/codec"
@@ -33,6 +34,10 @@ func (i Int64Offset) Less(other Offset) bool {
 		panic(fmt.Sprintf("Can't compare against non-int offset: %T", other))
 	}
 	return int64(i) < int64(otherI)
+}
+
+func (i Int64Offset) String() string {
+	return strconv.FormatInt(int64(i), 10)
 }
 
 // StringOffset represents the offset of a block within a directory.
@@ -66,6 +71,10 @@ func (s *StringOffset) Less(other Offset) bool {
 		panic(fmt.Sprintf("Can't compare against non-string offset: %T", other))
 	}
 	return string(*s) < string(*otherS)
+}
+
+func (s *StringOffset) String() string {
+	return string(*s)
 }
 
 // IndirectDirPtr pairs an indirect dir block with the start of that

--- a/libkbfs/bsplitter_simple.go
+++ b/libkbfs/bsplitter_simple.go
@@ -175,8 +175,7 @@ func (b *BlockSplitterSimple) SplitDirIfNeeded(block *DirBlock) (
 	// and add to the new block.
 	newBlock := NewDirBlock().(*DirBlock)
 	startOff := int(len(names) / 2)
-	for i := startOff; i < len(names); i++ {
-		name := names[i]
+	for _, name := range names[int(len(names)/2):] {
 		newBlock.Children[name] = block.Children[name]
 		delete(block.Children, name)
 	}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2709,11 +2709,10 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 				newPtrs[ptr] = true
 			}
 
+			mdInfo := unmergedChains.mostRecentChainMDInfo
 			nodeMap, cache, err := cr.fbo.blocks.SearchForNodes(
 				ctx, cr.fbo.nodeCache, ptrs, newPtrs,
-				unmergedChains.mostRecentChainMDInfo,
-				unmergedChains.mostRecentChainMDInfo.GetRootDirEntry().
-					BlockPointer)
+				mdInfo, mdInfo.GetRootDirEntry().BlockPointer)
 			if err != nil {
 				return path{}, err
 			}

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -114,8 +114,9 @@ func (dd *dirData) lookup(ctx context.Context, name string) (DirEntry, error) {
 // createIndirectBlock creates a new indirect block and pick a new id
 // for the existing block, and use the existing block's ID for the new
 // indirect block that becomes the parent.
-func (dd *dirData) createIndirectBlock(ctx context.Context) (*DirBlock, error) {
-	newID, err := dd.crypto.MakeTemporaryBlockID()
+func (dd *dirData) createIndirectBlock(ctx context.Context, dver DataVer) (
+	BlockWithPtrs, error) {
+	newID, err := dd.tree.crypto.MakeTemporaryBlockID()
 	if err != nil {
 		return nil, err
 	}
@@ -128,10 +129,11 @@ func (dd *dirData) createIndirectBlock(ctx context.Context) (*DirBlock, error) {
 				BlockInfo: BlockInfo{
 					BlockPointer: BlockPointer{
 						ID:      newID,
-						KeyGen:  dd.kmd.LatestKeyGeneration(),
-						DataVer: IndirectDirsDataVer,
+						KeyGen:  dd.tree.kmd.LatestKeyGeneration(),
+						DataVer: dver,
 						Context: kbfsblock.MakeFirstContext(
-							dd.chargedTo, dd.rootBlockPointer().GetBlockType()),
+							dd.tree.chargedTo,
+							dd.rootBlockPointer().GetBlockType()),
 						DirectType: dd.rootBlockPointer().DirectType,
 					},
 					EncodedSize: 0,
@@ -141,13 +143,95 @@ func (dd *dirData) createIndirectBlock(ctx context.Context) (*DirBlock, error) {
 		},
 	}
 
-	dd.log.CDebugf(ctx, "Creating new level of indirection for dir %v, "+
+	dd.tree.log.CDebugf(ctx, "Creating new level of indirection for dir %v, "+
 		"new block id for old top level is %v", dd.rootBlockPointer(), newID)
 
-	err = dd.cacher(dd.rootBlockPointer(), dblock)
+	err = dd.tree.cacher(dd.rootBlockPointer(), dblock)
 	if err != nil {
 		return nil, err
 	}
 
 	return dblock, nil
+}
+
+func (dd *dirData) processModifiedBlock(
+	ctx context.Context, ptr BlockPointer,
+	parentBlocks []parentBlockAndChildIndex, block *DirBlock) error {
+	newBlocks, newOffset := dd.tree.bsplit.SplitDirIfNeeded(block)
+
+	err := dd.tree.cacher(ptr, block)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = dd.tree.markParentsDirty(parentBlocks)
+	if err != nil {
+		return err
+	}
+
+	if len(newBlocks) > 1 {
+		dd.tree.log.CDebugf(ctx, "Making new right block for %v",
+			dd.rootBlockPointer())
+
+		rightParents, _, err := dd.tree.newRightBlock(
+			ctx, parentBlocks, newOffset, FirstValidDataVer,
+			NewDirBlockWithPtrs, dd.createIndirectBlock)
+		if err != nil {
+			return err
+		}
+
+		if len(parentBlocks) == 0 {
+			// We just created the first level of indirection. In that
+			// case `newRightBlock` doesn't cache the old top block,
+			// so we should do it here.
+			err = dd.tree.cacher(
+				rightParents[0].pblock.(*DirBlock).IPtrs[0].BlockPointer,
+				newBlocks[0])
+			if err != nil {
+				return err
+			}
+		}
+
+		// Cache the split block in place of the blank one made by
+		// `newRightBlock`.
+		pb := rightParents[len(rightParents)-1]
+		err = dd.tree.cacher(pb.childBlockPtr(), newBlocks[1])
+		if err != nil {
+			return err
+		}
+
+		// Shift it over if needed.
+		topBlock := rightParents[0].pblock
+		_, _, _, err =
+			dd.tree.shiftBlocksToFillHole(ctx, topBlock, rightParents)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (dd *dirData) addEntry(
+	ctx context.Context, newName string, newDe DirEntry) error {
+	topBlock, _, err := dd.getter(
+		ctx, dd.tree.kmd, dd.rootBlockPointer(), dd.tree.file, blockRead)
+	if err != nil {
+		return err
+	}
+
+	off := StringOffset(newName)
+	ptr, parentBlocks, block, _, _, _, err := dd.tree.getBlockAtOffset(
+		ctx, topBlock, &off, blockRead)
+	if err != nil {
+		return err
+	}
+	dblock := block.(*DirBlock)
+
+	if _, exists := dblock.Children[newName]; exists {
+		return NameExistsError{newName}
+	}
+	dblock.Children[newName] = newDe
+
+	return dd.processModifiedBlock(ctx, ptr, parentBlocks, dblock)
 }

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -235,3 +235,30 @@ func (dd *dirData) addEntry(
 
 	return dd.processModifiedBlock(ctx, ptr, parentBlocks, dblock)
 }
+
+func (dd *dirData) removeEntry(ctx context.Context, name string) error {
+	topBlock, _, err := dd.getter(
+		ctx, dd.tree.kmd, dd.rootBlockPointer(), dd.tree.file, blockRead)
+	if err != nil {
+		return err
+	}
+
+	off := StringOffset(name)
+	ptr, parentBlocks, block, _, _, _, err := dd.tree.getBlockAtOffset(
+		ctx, topBlock, &off, blockRead)
+	if err != nil {
+		return err
+	}
+	dblock := block.(*DirBlock)
+
+	if _, exists := dblock.Children[name]; !exists {
+		// Nothing to do.
+		return nil
+	}
+	delete(dblock.Children, name)
+
+	// For now, just leave the block empty, at its current place in
+	// the tree.  TODO: remove empty blocks all the way up the tree
+	// and shift parent pointers around as needed.
+	return dd.processModifiedBlock(ctx, ptr, parentBlocks, dblock)
+}

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/keybase/client/go/logger"
@@ -17,7 +18,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-func setupDirDataTest(t *testing.T) (*dirData, BlockCache, DirtyBlockCache) {
+func setupDirDataTest(t *testing.T, maxPtrsPerBlock, numDirEntries int) (
+	*dirData, BlockCache, DirtyBlockCache) {
 	// Make a fake dir.
 	ptr := BlockPointer{
 		ID:         kbfsblock.FakeID(42),
@@ -27,11 +29,8 @@ func setupDirDataTest(t *testing.T) (*dirData, BlockCache, DirtyBlockCache) {
 	dir := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "dir"}}}
 	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
 	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
-	bsplit := &BlockSplitterSimple{10, 10, 10}
+	bsplit := &BlockSplitterSimple{10, maxPtrsPerBlock, 10, numDirEntries}
 	kmd := emptyKeyMetadata{id, 1}
-
-	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
-	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
 
 	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)
 	dirtyBcache := simpleDirtyBlockCacheStandard()
@@ -55,6 +54,7 @@ func setupDirDataTest(t *testing.T) (*dirData, BlockCache, DirtyBlockCache) {
 		return dblock, isDirty, nil
 	}
 	cacher := func(ptr BlockPointer, block Block) error {
+		t.Logf("Caching %v", ptr)
 		return dirtyBcache.Put(id, ptr, MasterBranch, block)
 	}
 
@@ -64,7 +64,7 @@ func setupDirDataTest(t *testing.T) (*dirData, BlockCache, DirtyBlockCache) {
 	return dd, cleanCache, dirtyBcache
 }
 
-func addFakeDirDataEntry(dblock *DirBlock, name string, size uint64) {
+func addFakeDirDataEntryToBlock(dblock *DirBlock, name string, size uint64) {
 	dblock.Children[name] = DirEntry{
 		EntryInfo: EntryInfo{
 			Size: size,
@@ -73,7 +73,7 @@ func addFakeDirDataEntry(dblock *DirBlock, name string, size uint64) {
 }
 
 func TestDirDataGetChildren(t *testing.T) {
-	dd, cleanBcache, _ := setupDirDataTest(t)
+	dd, cleanBcache, _ := setupDirDataTest(t, 2, 2)
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
@@ -85,14 +85,14 @@ func TestDirDataGetChildren(t *testing.T) {
 	require.Len(t, children, 0)
 
 	t.Log("Single entry, direct block")
-	addFakeDirDataEntry(topBlock, "a", 1)
+	addFakeDirDataEntryToBlock(topBlock, "a", 1)
 	children, err = dd.getChildren(ctx)
 	require.NoError(t, err)
 	require.Len(t, children, 1)
 	require.Equal(t, uint64(1), children["a"].Size)
 
 	t.Log("Two entries, direct block")
-	addFakeDirDataEntry(topBlock, "b", 2)
+	addFakeDirDataEntryToBlock(topBlock, "b", 2)
 	children, err = dd.getChildren(ctx)
 	require.NoError(t, err)
 	require.Len(t, children, 2)
@@ -120,8 +120,8 @@ func TestDirDataGetChildren(t *testing.T) {
 		Off:       "m",
 	})
 	block2 := NewDirBlock().(*DirBlock)
-	addFakeDirDataEntry(block2, "z1", 3)
-	addFakeDirDataEntry(block2, "z2", 4)
+	addFakeDirDataEntryToBlock(block2, "z1", 3)
+	addFakeDirDataEntryToBlock(block2, "z2", 4)
 	cleanBcache.Put(
 		dd.rootBlockPointer(), dd.tree.file.Tlf, newTopBlock, TransientEntry)
 	cleanBcache.Put(ptr1, dd.tree.file.Tlf, topBlock, TransientEntry)
@@ -136,8 +136,15 @@ func TestDirDataGetChildren(t *testing.T) {
 
 }
 
+func testDirDataCheckLookup(
+	t *testing.T, ctx context.Context, dd *dirData, name string, size uint64) {
+	de, err := dd.lookup(ctx, name)
+	require.NoError(t, err)
+	require.Equal(t, size, de.Size)
+}
+
 func TestDirDataLookup(t *testing.T) {
-	dd, cleanBcache, _ := setupDirDataTest(t)
+	dd, cleanBcache, _ := setupDirDataTest(t, 2, 2)
 	ctx := context.Background()
 	topBlock := NewDirBlock().(*DirBlock)
 	cleanBcache.Put(
@@ -148,18 +155,13 @@ func TestDirDataLookup(t *testing.T) {
 	require.Equal(t, NoSuchNameError{"a"}, err)
 
 	t.Log("Single entry, direct block")
-	addFakeDirDataEntry(topBlock, "a", 1)
-	checkLookup := func(name string, size uint64) {
-		de, err := dd.lookup(ctx, name)
-		require.NoError(t, err)
-		require.Equal(t, size, de.Size)
-	}
-	checkLookup("a", 1)
+	addFakeDirDataEntryToBlock(topBlock, "a", 1)
+	testDirDataCheckLookup(t, ctx, dd, "a", 1)
 	_, err = dd.lookup(ctx, "b")
 	require.Equal(t, NoSuchNameError{"b"}, err)
 
 	t.Log("Indirect blocks")
-	addFakeDirDataEntry(topBlock, "b", 2)
+	addFakeDirDataEntryToBlock(topBlock, "b", 2)
 	dd.tree.file.path[len(dd.tree.file.path)-1].DirectType = IndirectBlock
 	newTopBlock := NewDirBlock().(*DirBlock)
 	newTopBlock.IsInd = true
@@ -180,15 +182,236 @@ func TestDirDataLookup(t *testing.T) {
 		Off:       "m",
 	})
 	block2 := NewDirBlock().(*DirBlock)
-	addFakeDirDataEntry(block2, "z1", 3)
-	addFakeDirDataEntry(block2, "z2", 4)
+	addFakeDirDataEntryToBlock(block2, "z1", 3)
+	addFakeDirDataEntryToBlock(block2, "z2", 4)
 	cleanBcache.Put(
 		dd.rootBlockPointer(), dd.tree.file.Tlf, newTopBlock, TransientEntry)
 	cleanBcache.Put(ptr1, dd.tree.file.Tlf, topBlock, TransientEntry)
 	cleanBcache.Put(ptr2, dd.tree.file.Tlf, block2, TransientEntry)
 
-	checkLookup("a", 1)
-	checkLookup("b", 2)
-	checkLookup("z1", 3)
-	checkLookup("z2", 4)
+	testDirDataCheckLookup(t, ctx, dd, "a", 1)
+	testDirDataCheckLookup(t, ctx, dd, "b", 2)
+	testDirDataCheckLookup(t, ctx, dd, "z1", 3)
+	testDirDataCheckLookup(t, ctx, dd, "z2", 4)
+}
+
+func addFakeDirDataEntry(
+	t *testing.T, ctx context.Context, dd *dirData, name string, size uint64) {
+	err := dd.addEntry(ctx, name, DirEntry{
+		EntryInfo: EntryInfo{
+			Size: size,
+		},
+	})
+	require.NoError(t, err)
+}
+
+type testDirDataLeaf struct {
+	off        StringOffset
+	numEntries int
+	dirty      bool
+}
+
+func printTestTree(
+	t *testing.T, dd *dirData, cleanBcache BlockCache,
+	dirtyBcache DirtyBlockCache) {
+	cacheBlock, err := dirtyBcache.Get(
+		dd.tree.file.Tlf, dd.tree.rootBlockPointer(), MasterBranch)
+	require.NoError(t, err)
+	topBlock := cacheBlock.(*DirBlock)
+	level := []*DirBlock{topBlock}
+	t.Log("---------------")
+	for len(level) > 0 {
+		var nextLevel []*DirBlock
+		var levelString string
+		for i, block := range level {
+			for _, iptr := range block.IPtrs {
+				levelString += fmt.Sprintf("\"%s\" ", iptr.Off)
+				cacheBlock, err = dirtyBcache.Get(
+					dd.tree.file.Tlf, iptr.BlockPointer, MasterBranch)
+				wasDirty := err == nil
+				if !wasDirty {
+					cacheBlock, err = cleanBcache.Get(iptr.BlockPointer)
+				}
+				nextLevel = append(nextLevel, cacheBlock.(*DirBlock))
+			}
+			if i+1 < len(level) {
+				levelString += "| "
+			}
+		}
+		t.Log(levelString)
+		level = nextLevel
+	}
+	t.Log("---------------")
+}
+
+func testDirDataCheckLeafs(
+	t *testing.T, dd *dirData, cleanBcache BlockCache,
+	dirtyBcache DirtyBlockCache, expectedLeafs []testDirDataLeaf,
+	maxPtrsPerBlock, numDirEntries int) {
+	printTestTree(t, dd, cleanBcache, dirtyBcache)
+	// Top block should always be dirty.
+	cacheBlock, err := dirtyBcache.Get(
+		dd.tree.file.Tlf, dd.tree.rootBlockPointer(), MasterBranch)
+	require.NoError(t, err)
+	topBlock := cacheBlock.(*DirBlock)
+	require.True(t, topBlock.IsIndirect())
+
+	dirtyBlocks := make(map[*DirBlock]bool)
+	dirtyBlocks[topBlock] = true
+
+	var leafs []testDirDataLeaf
+	// Iterate and collect leafs.
+	indBlocks := []*DirBlock{topBlock}
+	for len(indBlocks) > 0 {
+		var newIndBlocks []*DirBlock
+		for i, iptr := range indBlocks[0].IPtrs {
+			var nextOff *StringOffset
+			if i+1 < len(indBlocks[0].IPtrs) {
+				nextOff = &indBlocks[0].IPtrs[i+1].Off
+			}
+
+			cacheBlock, err = dirtyBcache.Get(
+				dd.tree.file.Tlf, iptr.BlockPointer, MasterBranch)
+			wasDirty := err == nil
+			if wasDirty {
+				dirtyBlocks[cacheBlock.(*DirBlock)] = true
+				// Parent must have also been dirty.
+				require.Contains(t, dirtyBlocks, indBlocks[0])
+			} else {
+				cacheBlock, err = cleanBcache.Get(iptr.BlockPointer)
+				require.NoError(t, err)
+			}
+			dblock := cacheBlock.(*DirBlock)
+			if dblock.IsIndirect() {
+				require.True(t, len(dblock.IPtrs) <= maxPtrsPerBlock)
+				// Make sure all the offsets are between the two
+				// parent offsets.
+				for _, childIPtr := range dblock.IPtrs {
+					require.True(t, childIPtr.Off >= iptr.Off,
+						fmt.Sprintf("Child off %s comes before iptr off %s",
+							childIPtr.Off, iptr.Off))
+					if nextOff != nil {
+						require.True(t, childIPtr.Off < *nextOff,
+							fmt.Sprintf("Child off %s comes after next off %s",
+								childIPtr.Off, *nextOff))
+					}
+				}
+				newIndBlocks = append(newIndBlocks, dblock)
+			} else {
+				require.True(t, len(dblock.Children) <= numDirEntries)
+				// Make sure all the children are between the two
+				// parent offsets.
+				for name := range dblock.Children {
+					require.True(t, name >= string(iptr.Off))
+					if nextOff != nil {
+						require.True(t, name < string(*nextOff))
+					}
+				}
+				leafs = append(leafs, testDirDataLeaf{
+					iptr.Off, len(dblock.Children), wasDirty})
+			}
+		}
+		indBlocks = append(newIndBlocks, indBlocks[1:]...)
+	}
+
+	require.True(t, reflect.DeepEqual(leafs, expectedLeafs),
+		fmt.Sprintf("leafs=%v, expectedLeafs=%v", leafs, expectedLeafs))
+}
+
+func testDirDataCleanCache(
+	dd *dirData, cleanBCache BlockCache, dirtyBCache DirtyBlockCache) {
+	dbc := dirtyBCache.(*DirtyBlockCacheStandard)
+	for id, block := range dbc.cache {
+		ptr := BlockPointer{ID: id.id}
+		cleanBCache.Put(ptr, dd.tree.file.Tlf, block, TransientEntry)
+	}
+	dbc.cache = make(map[dirtyBlockID]Block)
+}
+
+func TestDirDataAddEntry(t *testing.T) {
+	dd, cleanBcache, dirtyBcache := setupDirDataTest(t, 2, 2)
+	ctx := context.Background()
+	topBlock := NewDirBlock().(*DirBlock)
+	cleanBcache.Put(
+		dd.rootBlockPointer(), dd.tree.file.Tlf, topBlock, TransientEntry)
+
+	t.Log("Add first entry")
+	addFakeDirDataEntry(t, ctx, dd, "a", 1)
+	require.True(t, dirtyBcache.IsDirty(
+		dd.tree.file.Tlf, dd.rootBlockPointer(), MasterBranch))
+	require.Len(t, topBlock.Children, 1)
+
+	t.Log("Force a split")
+	addFakeDirDataEntry(t, ctx, dd, "b", 2)
+	addFakeDirDataEntry(t, ctx, dd, "c", 3)
+	expectedLeafs := []testDirDataLeaf{
+		{"", 1, true},
+		{"b", 2, true},
+	}
+	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
+
+	t.Log("Fill in the first block")
+	addFakeDirDataEntry(t, ctx, dd, "a1", 4)
+	expectedLeafs = []testDirDataLeaf{
+		{"", 2, true},
+		{"b", 2, true},
+	}
+	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
+
+	t.Log("Shift a block over")
+	addFakeDirDataEntry(t, ctx, dd, "a2", 5)
+	expectedLeafs = []testDirDataLeaf{
+		{"", 1, true},
+		{"a1", 2, true},
+		{"b", 2, true},
+	}
+	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
+
+	t.Log("Clean up the cache and dirty just one leaf")
+	testDirDataCleanCache(dd, cleanBcache, dirtyBcache)
+	addFakeDirDataEntry(t, ctx, dd, "a0", 6)
+	expectedLeafs = []testDirDataLeaf{
+		{"", 2, true},
+		{"a1", 2, false},
+		{"b", 2, false},
+	}
+	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
+
+	t.Log("Expand a bunch more")
+	addFakeDirDataEntry(t, ctx, dd, "a00", 7)
+	addFakeDirDataEntry(t, ctx, dd, "b1", 8)
+	addFakeDirDataEntry(t, ctx, dd, "d", 9)
+	addFakeDirDataEntry(t, ctx, dd, "a000", 10)
+	addFakeDirDataEntry(t, ctx, dd, "z", 11)
+	addFakeDirDataEntry(t, ctx, dd, "q", 12)
+	addFakeDirDataEntry(t, ctx, dd, "b2", 13)
+	addFakeDirDataEntry(t, ctx, dd, " 1", 14)
+	expectedLeafs = []testDirDataLeaf{
+		{"", 2, true},    // " 1" and "a"
+		{"a0", 1, true},  // "a0"
+		{"a00", 2, true}, // "a00" and "a000"
+		{"a1", 2, true},  // "a1" and "a2"
+		{"b", 1, true},   // "b"
+		{"b1", 2, true},  // "b1" and "b2"
+		{"c", 1, true},   // "c"
+		{"d", 1, true},   // "d"
+		{"q", 2, true},   // "q" and "z"
+	}
+	testDirDataCheckLeafs(t, dd, cleanBcache, dirtyBcache, expectedLeafs, 2, 2)
+
+	t.Log("Verify lookups")
+	testDirDataCheckLookup(t, ctx, dd, "a", 1)
+	testDirDataCheckLookup(t, ctx, dd, "b", 2)
+	testDirDataCheckLookup(t, ctx, dd, "c", 3)
+	testDirDataCheckLookup(t, ctx, dd, "a1", 4)
+	testDirDataCheckLookup(t, ctx, dd, "a2", 5)
+	testDirDataCheckLookup(t, ctx, dd, "a0", 6)
+	testDirDataCheckLookup(t, ctx, dd, "a00", 7)
+	testDirDataCheckLookup(t, ctx, dd, "b1", 8)
+	testDirDataCheckLookup(t, ctx, dd, "d", 9)
+	testDirDataCheckLookup(t, ctx, dd, "a000", 10)
+	testDirDataCheckLookup(t, ctx, dd, "z", 11)
+	testDirDataCheckLookup(t, ctx, dd, "q", 12)
+	testDirDataCheckLookup(t, ctx, dd, "b2", 13)
+	testDirDataCheckLookup(t, ctx, dd, " 1", 14)
 }

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -30,6 +30,9 @@ func setupDirDataTest(t *testing.T) (*dirData, BlockCache, DirtyBlockCache) {
 	bsplit := &BlockSplitterSimple{10, 10, 10}
 	kmd := emptyKeyMetadata{id, 1}
 
+	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
+	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
+
 	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -31,7 +31,7 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 	file := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "file"}}}
 	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
 	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
-	bsplit := &BlockSplitterSimple{maxBlockSize, maxPtrsPerBlock, 10}
+	bsplit := &BlockSplitterSimple{maxBlockSize, maxPtrsPerBlock, 10, 0}
 	kmd := emptyKeyMetadata{id, 1}
 
 	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4582,8 +4582,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	syncChains.doNotUnrefPointers = syncChains.createdOriginals
 	head, _ := fbo.getHead(lState)
 	dummyHeadChains := newCRChainsEmpty()
-	dummyHeadChains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		head, head.Data().Dir.BlockInfo}
+	dummyHeadChains.mostRecentChainMDInfo = head
 
 	// Squash the batch of updates together into a set of blocks and
 	// ready `md` for putting to the server.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -853,6 +853,16 @@ type KeyMetadata interface {
 		kbfscrypto.TLFCryptKey, error)
 }
 
+// KeyMetadataWithRootDirEntry is like KeyMetadata, but can also
+// return the root dir entry for the associated MD update.
+type KeyMetadataWithRootDirEntry interface {
+	KeyMetadata
+
+	// GetRootDirEntry returns the root directory entry for the
+	// associated MD.
+	GetRootDirEntry() DirEntry
+}
+
 type encryptionKeyGetter interface {
 	// GetTLFCryptKeyForEncryption gets the crypt key to use for
 	// encryption (i.e., with the latest key generation) for the

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1797,6 +1797,12 @@ type BlockSplitter interface {
 	// ShouldEmbedBlockChanges decides whether we should keep the
 	// block changes embedded in the MD or not.
 	ShouldEmbedBlockChanges(bc *BlockChanges) bool
+
+	// SplitDirIfNeeded splits a direct DirBlock into multiple blocks
+	// if needed.  It may modify `block`.  If a split isn't needed, it
+	// returns a one-element slice containing `block`.  If a split is
+	// needed, it returns a non-nil offset for the new block.
+	SplitDirIfNeeded(block *DirBlock) ([]*DirBlock, *StringOffset)
 }
 
 // KeyServer fetches/writes server-side key halves from/to the key server.

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -1300,7 +1300,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	// make the unembedded size large, so we don't create thousands of
 	// unembedded block change blocks.
 	blockSize := int64(5)
-	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024, 0}
 	config1.SetBlockSplitter(bsplit)
 
 	// create and write to a file

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -1045,7 +1045,7 @@ func TestKBFSOpsConcurWriteDuringSyncMultiBlocks(t *testing.T) {
 	// make the unembedded size large, so we don't create thousands of
 	// unembedded block change blocks.
 	blockSize := int64(5)
-	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024, 0}
 	config.SetBlockSplitter(bsplit)
 
 	// create and write to a file
@@ -1242,7 +1242,7 @@ func TestKBFSOpsConcurWriteParallelBlocksCanceled(t *testing.T) {
 	// make the unembedded size large, so we don't create thousands of
 	// unembedded block change blocks.
 	blockSize := int64(5)
-	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024, 0}
 	config.SetBlockSplitter(bsplit)
 
 	// create and write to a file
@@ -1395,7 +1395,7 @@ func TestKBFSOpsConcurWriteParallelBlocksError(t *testing.T) {
 	// make the unembedded size large, so we don't create thousands of
 	// unembedded block change blocks.
 	blockSize := int64(5)
-	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024, 0}
 	config.SetBlockSplitter(bsplit)
 
 	// create and write to a file

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3182,7 +3182,7 @@ func TestKBFSOpsMultiBlockSyncWithArchivedBlock(t *testing.T) {
 	// make the unembedded size large, so we don't create thousands of
 	// unembedded block change blocks.
 	blockSize := int64(5)
-	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024}
+	bsplit := &BlockSplitterSimple{blockSize, 2, 100 * 1024, 0}
 	config.SetBlockSplitter(bsplit)
 
 	// create a file.

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -75,7 +75,8 @@ func setupMDJournalTest(t testing.TB, ver kbfsmd.MetadataVer) (
 		tlfID, ver, tempdir, log)
 	require.NoError(t, err)
 
-	bsplit = &BlockSplitterSimple{64 * 1024, int(64 * 1024 / bpSize), 8 * 1024}
+	bsplit = &BlockSplitterSimple{
+		64 * 1024, int(64 * 1024 / bpSize), 8 * 1024, 0}
 
 	return codec, crypto, tlfID, signer, ekg, bsplit, tempdir, j
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5997,6 +5997,19 @@ func (mr *MockBlockSplitterMockRecorder) ShouldEmbedBlockChanges(bc interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldEmbedBlockChanges", reflect.TypeOf((*MockBlockSplitter)(nil).ShouldEmbedBlockChanges), bc)
 }
 
+// SplitDirIfNeeded mocks base method
+func (m *MockBlockSplitter) SplitDirIfNeeded(block *DirBlock) ([]*DirBlock, *StringOffset) {
+	ret := m.ctrl.Call(m, "SplitDirIfNeeded", block)
+	ret0, _ := ret[0].([]*DirBlock)
+	ret1, _ := ret[1].(*StringOffset)
+	return ret0, ret1
+}
+
+// SplitDirIfNeeded indicates an expected call of SplitDirIfNeeded
+func (mr *MockBlockSplitterMockRecorder) SplitDirIfNeeded(block interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SplitDirIfNeeded", reflect.TypeOf((*MockBlockSplitter)(nil).SplitDirIfNeeded), block)
+}
+
 // MockKeyServer is a mock of KeyServer interface
 type MockKeyServer struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2983,6 +2983,156 @@ func (mr *MockKeyMetadataMockRecorder) GetHistoricTLFCryptKey(codec, keyGen, cur
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoricTLFCryptKey", reflect.TypeOf((*MockKeyMetadata)(nil).GetHistoricTLFCryptKey), codec, keyGen, currentKey)
 }
 
+// MockKeyMetadataWithRootDirEntry is a mock of KeyMetadataWithRootDirEntry interface
+type MockKeyMetadataWithRootDirEntry struct {
+	ctrl     *gomock.Controller
+	recorder *MockKeyMetadataWithRootDirEntryMockRecorder
+}
+
+// MockKeyMetadataWithRootDirEntryMockRecorder is the mock recorder for MockKeyMetadataWithRootDirEntry
+type MockKeyMetadataWithRootDirEntryMockRecorder struct {
+	mock *MockKeyMetadataWithRootDirEntry
+}
+
+// NewMockKeyMetadataWithRootDirEntry creates a new mock instance
+func NewMockKeyMetadataWithRootDirEntry(ctrl *gomock.Controller) *MockKeyMetadataWithRootDirEntry {
+	mock := &MockKeyMetadataWithRootDirEntry{ctrl: ctrl}
+	mock.recorder = &MockKeyMetadataWithRootDirEntryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockKeyMetadataWithRootDirEntry) EXPECT() *MockKeyMetadataWithRootDirEntryMockRecorder {
+	return m.recorder
+}
+
+// TlfID mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) TlfID() tlf.ID {
+	ret := m.ctrl.Call(m, "TlfID")
+	ret0, _ := ret[0].(tlf.ID)
+	return ret0
+}
+
+// TlfID indicates an expected call of TlfID
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) TlfID() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TlfID", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).TlfID))
+}
+
+// TypeForKeying mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) TypeForKeying() tlf.KeyingType {
+	ret := m.ctrl.Call(m, "TypeForKeying")
+	ret0, _ := ret[0].(tlf.KeyingType)
+	return ret0
+}
+
+// TypeForKeying indicates an expected call of TypeForKeying
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) TypeForKeying() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TypeForKeying", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).TypeForKeying))
+}
+
+// LatestKeyGeneration mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) LatestKeyGeneration() kbfsmd.KeyGen {
+	ret := m.ctrl.Call(m, "LatestKeyGeneration")
+	ret0, _ := ret[0].(kbfsmd.KeyGen)
+	return ret0
+}
+
+// LatestKeyGeneration indicates an expected call of LatestKeyGeneration
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) LatestKeyGeneration() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestKeyGeneration", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).LatestKeyGeneration))
+}
+
+// GetTlfHandle mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetTlfHandle() *TlfHandle {
+	ret := m.ctrl.Call(m, "GetTlfHandle")
+	ret0, _ := ret[0].(*TlfHandle)
+	return ret0
+}
+
+// GetTlfHandle indicates an expected call of GetTlfHandle
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTlfHandle() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTlfHandle", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetTlfHandle))
+}
+
+// IsWriter mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, uid, verifyingKey)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsWriter indicates an expected call of IsWriter
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) IsWriter(ctx, checker, uid, verifyingKey interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).IsWriter), ctx, checker, uid, verifyingKey)
+}
+
+// HasKeyForUser mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) HasKeyForUser(user keybase1.UID) (bool, error) {
+	ret := m.ctrl.Call(m, "HasKeyForUser", user)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasKeyForUser indicates an expected call of HasKeyForUser
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) HasKeyForUser(user interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasKeyForUser", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).HasKeyForUser), user)
+}
+
+// GetTLFCryptKeyParams mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetTLFCryptKeyParams(keyGen kbfsmd.KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf, kbfscrypto.TLFCryptKeyServerHalfID, bool, error) {
+	ret := m.ctrl.Call(m, "GetTLFCryptKeyParams", keyGen, user, key)
+	ret0, _ := ret[0].(kbfscrypto.TLFEphemeralPublicKey)
+	ret1, _ := ret[1].(kbfscrypto.EncryptedTLFCryptKeyClientHalf)
+	ret2, _ := ret[2].(kbfscrypto.TLFCryptKeyServerHalfID)
+	ret3, _ := ret[3].(bool)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// GetTLFCryptKeyParams indicates an expected call of GetTLFCryptKeyParams
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTLFCryptKeyParams(keyGen, user, key interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyParams", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetTLFCryptKeyParams), keyGen, user, key)
+}
+
+// StoresHistoricTLFCryptKeys mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) StoresHistoricTLFCryptKeys() bool {
+	ret := m.ctrl.Call(m, "StoresHistoricTLFCryptKeys")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// StoresHistoricTLFCryptKeys indicates an expected call of StoresHistoricTLFCryptKeys
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) StoresHistoricTLFCryptKeys() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoresHistoricTLFCryptKeys", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).StoresHistoricTLFCryptKeys))
+}
+
+// GetHistoricTLFCryptKey mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetHistoricTLFCryptKey(codec kbfscodec.Codec, keyGen kbfsmd.KeyGen, currentKey kbfscrypto.TLFCryptKey) (kbfscrypto.TLFCryptKey, error) {
+	ret := m.ctrl.Call(m, "GetHistoricTLFCryptKey", codec, keyGen, currentKey)
+	ret0, _ := ret[0].(kbfscrypto.TLFCryptKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHistoricTLFCryptKey indicates an expected call of GetHistoricTLFCryptKey
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetHistoricTLFCryptKey(codec, keyGen, currentKey interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoricTLFCryptKey", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetHistoricTLFCryptKey), codec, keyGen, currentKey)
+}
+
+// GetRootDirEntry mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetRootDirEntry() DirEntry {
+	ret := m.ctrl.Call(m, "GetRootDirEntry")
+	ret0, _ := ret[0].(DirEntry)
+	return ret0
+}
+
+// GetRootDirEntry indicates an expected call of GetRootDirEntry
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetRootDirEntry() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRootDirEntry", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetRootDirEntry))
+}
+
 // MockencryptionKeyGetter is a mock of encryptionKeyGetter interface
 type MockencryptionKeyGetter struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -166,6 +166,12 @@ func (md *RootMetadata) Data() *PrivateMetadata {
 	return &md.data
 }
 
+// GetRootDirEntry implements the KeyMetadataWithRootDirEntry
+// interface for RootMetadata.
+func (md *RootMetadata) GetRootDirEntry() DirEntry {
+	return md.data.Dir
+}
+
 // Extra returns the extra metadata of this RootMetadata.
 func (md *RootMetadata) Extra() kbfsmd.ExtraMetadata {
 	return md.extra

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -52,7 +52,7 @@ func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger
 	config.SetBlockOps(bops)
 
 	config.SetBlockSplitter(&BlockSplitterSimple{
-		64 * 1024, 64 * 1024 / int(bpSize), 8 * 1024})
+		64 * 1024, 64 * 1024 / int(bpSize), 8 * 1024, 0})
 
 	return config
 }

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1750,6 +1750,7 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+		rmd.data = pmd
 
 		mdInfo := unflushedPathMDInfo{
 			revision:       ibrmd.RevisionNumber(),

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -215,7 +215,7 @@ func setupTLFJournalTest(
 	delegate testBWDelegate) {
 	// Set up config and dependencies.
 	bsplitter := &BlockSplitterSimple{
-		64 * 1024, int(64 * 1024 / bpSize), 8 * 1024}
+		64 * 1024, int(64 * 1024 / bpSize), 8 * 1024, 0}
 	codec := kbfscodec.NewMsgpack()
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("client sign")
 	cryptPrivateKey := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("client crypt private")

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -146,7 +146,7 @@ func (upc *unflushedPathCache) abortInitialization() {
 // unflushedPathCache.
 type unflushedPathMDInfo struct {
 	revision       kbfsmd.Revision
-	kmd            KeyMetadata
+	kmd            KeyMetadataWithRootDirEntry
 	pmd            PrivateMetadata
 	localTimestamp time.Time
 }
@@ -186,10 +186,7 @@ func addUnflushedPaths(ctx context.Context,
 	}
 
 	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
-	chains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		kmd:      mostRecentMDInfo.kmd,
-		rootInfo: mostRecentMDInfo.pmd.Dir.BlockInfo,
-	}
+	chains.mostRecentChainMDInfo = mostRecentMDInfo.kmd
 
 	// Does the last op already have a valid path in each chain?  If
 	// so, we don't need to bother populating the paths, which can


### PR DESCRIPTION
This adds a `BlockSplitter` function for splitting up directory blocks that get too big, and implements `addEntry`, `removeEntry` and `updateEntry` methods for `dirData`.

It also adds a bunch of tests for these new methods in `dir_data_test.go` (which github has collapsed).

The basic algorithm is the same as for files.  If a leaf directory block has more child entries than it can handle, traverse up the path of the block tree until we find a parent with an empty indirect pointer slot, and add a block to the right.  (If no parent has room, add another layer of indirection at the top.)  Then shift the new block over at its level in the tree, until reaching the place where its offset fits in.

Note that this builds on #1736, and also modifies the existing block-shifting code a bit because, unlike for file trees, directory trees are **not** necessarily balanced when they are built.  This means that any indirect-pointer list in the tree, and not just those along the right edge, can be less than full, which required a little extra code to handle.

If we decide it's important later, we can write code to rebalance the trees.  It won't change anything about the data structures or the way directories are read, so it's not imperative that we do it now, and I think it would be tricky and take a long time to get right.

Also note that this code doesn't yet try to handle the updated pointers and block refs that are dirtied when the leaf blocks are modified.  The next PR will likely need to fix a few issues with block accounting that may occur when integrating this into `folderBlockOps`.  So none of that stuff is tested yet, or made available in the `dirData` interface.

Issue: KBFS-3301