### PR TITLE
root_metadata: add an interface for KeyMetadata + root dir entry

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2709,11 +2709,10 @@ func (cr *ConflictResolver) resolveOnePath(ctx context.Context,
 				newPtrs[ptr] = true
 			}
 
+			mdInfo := unmergedChains.mostRecentChainMDInfo
 			nodeMap, cache, err := cr.fbo.blocks.SearchForNodes(
 				ctx, cr.fbo.nodeCache, ptrs, newPtrs,
-				unmergedChains.mostRecentChainMDInfo,
-				unmergedChains.mostRecentChainMDInfo.GetRootDirEntry().
-					BlockPointer)
+				mdInfo, mdInfo.GetRootDirEntry().BlockPointer)
 			if err != nil {
 				return path{}, err
 			}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4582,8 +4582,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	syncChains.doNotUnrefPointers = syncChains.createdOriginals
 	head, _ := fbo.getHead(lState)
 	dummyHeadChains := newCRChainsEmpty()
-	dummyHeadChains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		head, head.Data().Dir.BlockInfo}
+	dummyHeadChains.mostRecentChainMDInfo = head
 
 	// Squash the batch of updates together into a set of blocks and
 	// ready `md` for putting to the server.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -853,6 +853,16 @@ type KeyMetadata interface {
 		kbfscrypto.TLFCryptKey, error)
 }
 
+// KeyMetadataWithRootDirEntry is like KeyMetadata, but can also
+// return the root dir entry for the associated MD update.
+type KeyMetadataWithRootDirEntry interface {
+	KeyMetadata
+
+	// GetRootDirEntry returns the root directory entry for the
+	// associated MD.
+	GetRootDirEntry() DirEntry
+}
+
 type encryptionKeyGetter interface {
 	// GetTLFCryptKeyForEncryption gets the crypt key to use for
 	// encryption (i.e., with the latest key generation) for the

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2983,6 +2983,156 @@ func (mr *MockKeyMetadataMockRecorder) GetHistoricTLFCryptKey(codec, keyGen, cur
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoricTLFCryptKey", reflect.TypeOf((*MockKeyMetadata)(nil).GetHistoricTLFCryptKey), codec, keyGen, currentKey)
 }
 
+// MockKeyMetadataWithRootDirEntry is a mock of KeyMetadataWithRootDirEntry interface
+type MockKeyMetadataWithRootDirEntry struct {
+	ctrl     *gomock.Controller
+	recorder *MockKeyMetadataWithRootDirEntryMockRecorder
+}
+
+// MockKeyMetadataWithRootDirEntryMockRecorder is the mock recorder for MockKeyMetadataWithRootDirEntry
+type MockKeyMetadataWithRootDirEntryMockRecorder struct {
+	mock *MockKeyMetadataWithRootDirEntry
+}
+
+// NewMockKeyMetadataWithRootDirEntry creates a new mock instance
+func NewMockKeyMetadataWithRootDirEntry(ctrl *gomock.Controller) *MockKeyMetadataWithRootDirEntry {
+	mock := &MockKeyMetadataWithRootDirEntry{ctrl: ctrl}
+	mock.recorder = &MockKeyMetadataWithRootDirEntryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockKeyMetadataWithRootDirEntry) EXPECT() *MockKeyMetadataWithRootDirEntryMockRecorder {
+	return m.recorder
+}
+
+// TlfID mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) TlfID() tlf.ID {
+	ret := m.ctrl.Call(m, "TlfID")
+	ret0, _ := ret[0].(tlf.ID)
+	return ret0
+}
+
+// TlfID indicates an expected call of TlfID
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) TlfID() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TlfID", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).TlfID))
+}
+
+// TypeForKeying mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) TypeForKeying() tlf.KeyingType {
+	ret := m.ctrl.Call(m, "TypeForKeying")
+	ret0, _ := ret[0].(tlf.KeyingType)
+	return ret0
+}
+
+// TypeForKeying indicates an expected call of TypeForKeying
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) TypeForKeying() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TypeForKeying", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).TypeForKeying))
+}
+
+// LatestKeyGeneration mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) LatestKeyGeneration() kbfsmd.KeyGen {
+	ret := m.ctrl.Call(m, "LatestKeyGeneration")
+	ret0, _ := ret[0].(kbfsmd.KeyGen)
+	return ret0
+}
+
+// LatestKeyGeneration indicates an expected call of LatestKeyGeneration
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) LatestKeyGeneration() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestKeyGeneration", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).LatestKeyGeneration))
+}
+
+// GetTlfHandle mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetTlfHandle() *TlfHandle {
+	ret := m.ctrl.Call(m, "GetTlfHandle")
+	ret0, _ := ret[0].(*TlfHandle)
+	return ret0
+}
+
+// GetTlfHandle indicates an expected call of GetTlfHandle
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTlfHandle() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTlfHandle", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetTlfHandle))
+}
+
+// IsWriter mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) IsWriter(ctx context.Context, checker kbfsmd.TeamMembershipChecker, uid keybase1.UID, verifyingKey kbfscrypto.VerifyingKey) (bool, error) {
+	ret := m.ctrl.Call(m, "IsWriter", ctx, checker, uid, verifyingKey)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsWriter indicates an expected call of IsWriter
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) IsWriter(ctx, checker, uid, verifyingKey interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWriter", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).IsWriter), ctx, checker, uid, verifyingKey)
+}
+
+// HasKeyForUser mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) HasKeyForUser(user keybase1.UID) (bool, error) {
+	ret := m.ctrl.Call(m, "HasKeyForUser", user)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasKeyForUser indicates an expected call of HasKeyForUser
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) HasKeyForUser(user interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasKeyForUser", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).HasKeyForUser), user)
+}
+
+// GetTLFCryptKeyParams mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetTLFCryptKeyParams(keyGen kbfsmd.KeyGen, user keybase1.UID, key kbfscrypto.CryptPublicKey) (kbfscrypto.TLFEphemeralPublicKey, kbfscrypto.EncryptedTLFCryptKeyClientHalf, kbfscrypto.TLFCryptKeyServerHalfID, bool, error) {
+	ret := m.ctrl.Call(m, "GetTLFCryptKeyParams", keyGen, user, key)
+	ret0, _ := ret[0].(kbfscrypto.TLFEphemeralPublicKey)
+	ret1, _ := ret[1].(kbfscrypto.EncryptedTLFCryptKeyClientHalf)
+	ret2, _ := ret[2].(kbfscrypto.TLFCryptKeyServerHalfID)
+	ret3, _ := ret[3].(bool)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
+}
+
+// GetTLFCryptKeyParams indicates an expected call of GetTLFCryptKeyParams
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetTLFCryptKeyParams(keyGen, user, key interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTLFCryptKeyParams", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetTLFCryptKeyParams), keyGen, user, key)
+}
+
+// StoresHistoricTLFCryptKeys mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) StoresHistoricTLFCryptKeys() bool {
+	ret := m.ctrl.Call(m, "StoresHistoricTLFCryptKeys")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// StoresHistoricTLFCryptKeys indicates an expected call of StoresHistoricTLFCryptKeys
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) StoresHistoricTLFCryptKeys() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoresHistoricTLFCryptKeys", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).StoresHistoricTLFCryptKeys))
+}
+
+// GetHistoricTLFCryptKey mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetHistoricTLFCryptKey(codec kbfscodec.Codec, keyGen kbfsmd.KeyGen, currentKey kbfscrypto.TLFCryptKey) (kbfscrypto.TLFCryptKey, error) {
+	ret := m.ctrl.Call(m, "GetHistoricTLFCryptKey", codec, keyGen, currentKey)
+	ret0, _ := ret[0].(kbfscrypto.TLFCryptKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetHistoricTLFCryptKey indicates an expected call of GetHistoricTLFCryptKey
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetHistoricTLFCryptKey(codec, keyGen, currentKey interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoricTLFCryptKey", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetHistoricTLFCryptKey), codec, keyGen, currentKey)
+}
+
+// GetRootDirEntry mocks base method
+func (m *MockKeyMetadataWithRootDirEntry) GetRootDirEntry() DirEntry {
+	ret := m.ctrl.Call(m, "GetRootDirEntry")
+	ret0, _ := ret[0].(DirEntry)
+	return ret0
+}
+
+// GetRootDirEntry indicates an expected call of GetRootDirEntry
+func (mr *MockKeyMetadataWithRootDirEntryMockRecorder) GetRootDirEntry() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRootDirEntry", reflect.TypeOf((*MockKeyMetadataWithRootDirEntry)(nil).GetRootDirEntry))
+}
+
 // MockencryptionKeyGetter is a mock of encryptionKeyGetter interface
 type MockencryptionKeyGetter struct {
 	ctrl     *gomock.Controller

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -166,6 +166,12 @@ func (md *RootMetadata) Data() *PrivateMetadata {
 	return &md.data
 }
 
+// GetRootDirEntry implements the KeyMetadataWithRootDirEntry
+// interface for RootMetadata.
+func (md *RootMetadata) GetRootDirEntry() DirEntry {
+	return md.data.Dir
+}
+
 // Extra returns the extra metadata of this RootMetadata.
 func (md *RootMetadata) Extra() kbfsmd.ExtraMetadata {
 	return md.extra

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1750,6 +1750,7 @@ func (j *tlfJournal) getUnflushedPathMDInfos(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
+		rmd.data = pmd
 
 		mdInfo := unflushedPathMDInfo{
 			revision:       ibrmd.RevisionNumber(),

--- a/libkbfs/unflushed_path_cache.go
+++ b/libkbfs/unflushed_path_cache.go
@@ -146,7 +146,7 @@ func (upc *unflushedPathCache) abortInitialization() {
 // unflushedPathCache.
 type unflushedPathMDInfo struct {
 	revision       kbfsmd.Revision
-	kmd            KeyMetadata
+	kmd            KeyMetadataWithRootDirEntry
 	pmd            PrivateMetadata
 	localTimestamp time.Time
 }
@@ -186,10 +186,7 @@ func addUnflushedPaths(ctx context.Context,
 	}
 
 	mostRecentMDInfo := mdInfos[len(mdInfos)-1]
-	chains.mostRecentChainMDInfo = mostRecentChainMetadataInfo{
-		kmd:      mostRecentMDInfo.kmd,
-		rootInfo: mostRecentMDInfo.pmd.Dir.BlockInfo,
-	}
+	chains.mostRecentChainMDInfo = mostRecentMDInfo.kmd
 
 	// Does the last op already have a valid path in each chain?  If
 	// so, we don't need to bother populating the paths, which can


### PR DESCRIPTION
And use this in `crChains`.

It seems kind of random, but this will be needed in an upcoming PR when we need to replace some of directory entry cache stuff in `folderBlockOps` with `dirData`.

Issue: KBFS-3302