### PR TITLE
folder_block_ops: use `dirData` and get rid of `deCache`

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -846,8 +846,8 @@ func (cr *ConflictResolver) resolveMergedPathTail(ctx context.Context,
 				"%v; skipping rm removal", parentOriginal)
 		}
 
-		de, err := cr.fbo.blocks.GetDirtyEntry(ctx, lState,
-			unmergedChains.mostRecentChainMDInfo, currPath)
+		de, err := cr.fbo.blocks.GetEntry(
+			ctx, lState, unmergedChains.mostRecentChainMDInfo, currPath)
 		if err != nil {
 			return path{}, BlockPointer{}, nil, err
 		}

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -59,7 +59,7 @@ func setupDirDataTest(t *testing.T, maxPtrsPerBlock, numDirEntries int) (
 	}
 
 	dd := newDirData(
-		dir, chargedTo, crypto, kmd, bsplit, getter, cacher,
+		dir, chargedTo, crypto, bsplit, kmd, getter, cacher,
 		logger.NewTestLogger(t))
 	return dd, cleanCache, dirtyBcache
 }

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -732,6 +732,13 @@ func (fbo *folderBlockOps) getChargedToLocked(
 	return chargedTo, nil
 }
 
+// ClearChargedTo clears out the cached chargedTo UID for this FBO.
+func (fbo *folderBlockOps) ClearChargedTo(lState *lockState) {
+	fbo.blockLock.Lock(lState)
+	defer fbo.blockLock.Unlock(lState)
+	fbo.chargedTo = keybase1.UserOrTeamID("")
+}
+
 // DeepCopyFile makes a complete copy of the given file, deduping leaf
 // blocks and making new random BlockPointers for all indirect blocks.
 // It returns the new top pointer of the copy, and all the new child

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6931,15 +6931,18 @@ func (fbo *folderBranchOps) ClearPrivateFolderMD(ctx context.Context) {
 		fbo.convID = nil
 	}()
 
-	if fbo.folderBranch.Tlf.Type() == tlf.Public {
-		return
-	}
-
 	lState := makeFBOLockState()
 	fbo.mdWriterLock.Lock(lState)
 	defer fbo.mdWriterLock.Unlock(lState)
 	fbo.headLock.Lock(lState)
 	defer fbo.headLock.Unlock(lState)
+
+	fbo.blocks.ClearChargedTo(lState)
+
+	if fbo.folderBranch.Tlf.Type() == tlf.Public {
+		return
+	}
+
 	if fbo.head == (ImmutableRootMetadata{}) {
 		// Nothing to clear.
 		return

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4633,9 +4633,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 	// write might slip in after the pointers are updated, but before
 	// the deferred writes are re-applied.
 	afterUpdateFn := func() error {
-		// Clear the dirty directories before we the afterUpdateFns
-		// start replaying deferred writes, so we don't lose the
-		// deferreed write state when we clear.
+		// Clear the dirty directories before the afterUpdateFns start
+		// replaying deferred writes, so we don't lose the deferreed
+		// write state when we clear.
 		fbo.blocks.clearAllDirtyDirsLocked(ctx, lState)
 		var errs []error
 		for _, auf := range afterUpdateFns {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2193,10 +2193,12 @@ type NodeCache interface {
 	// IsUnlinked returns whether `Unlink` has been called for the
 	// reference behind this node.
 	IsUnlinked(node Node) bool
-	// UnlinkedDirEntry returns a pointer to a modifiable directory
-	// entry if `Unlink` has been called for the reference behind this
-	// node.
+	// UnlinkedDirEntry returns a directory entry if `Unlink` has been
+	// called for the reference behind this node.
 	UnlinkedDirEntry(node Node) DirEntry
+	// UpdateUnlinkedDirEntry modifies a cached directory entry for a
+	// node that has already been unlinked.
+	UpdateUnlinkedDirEntry(node Node, newDe DirEntry)
 	// PathFromNode creates the path up to a given Node.
 	PathFromNode(node Node) path
 	// AllNodes returns the complete set of nodes currently in the cache.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8000,6 +8000,16 @@ func (mr *MockNodeCacheMockRecorder) UnlinkedDirEntry(node interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnlinkedDirEntry", reflect.TypeOf((*MockNodeCache)(nil).UnlinkedDirEntry), node)
 }
 
+// UpdateUnlinkedDirEntry mocks base method
+func (m *MockNodeCache) UpdateUnlinkedDirEntry(node Node, newDe DirEntry) {
+	m.ctrl.Call(m, "UpdateUnlinkedDirEntry", node, newDe)
+}
+
+// UpdateUnlinkedDirEntry indicates an expected call of UpdateUnlinkedDirEntry
+func (mr *MockNodeCacheMockRecorder) UpdateUnlinkedDirEntry(node, newDe interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnlinkedDirEntry", reflect.TypeOf((*MockNodeCache)(nil).UpdateUnlinkedDirEntry), node, newDe)
+}
+
 // PathFromNode mocks base method
 func (m *MockNodeCache) PathFromNode(node Node) path {
 	ret := m.ctrl.Call(m, "PathFromNode", node)

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -298,6 +298,21 @@ func (ncs *nodeCacheStandard) UnlinkedDirEntry(node Node) DirEntry {
 	return ns.core.cachedDe
 }
 
+// UpdateUnlinkedDirEntry implements the NodeCache interface for
+// nodeCacheStandard.
+func (ncs *nodeCacheStandard) UpdateUnlinkedDirEntry(
+	node Node, newDe DirEntry) {
+	ncs.lock.Lock()
+	defer ncs.lock.Unlock()
+
+	ns, ok := node.Unwrap().(*nodeStandard)
+	if !ok {
+		return
+	}
+
+	ns.core.cachedDe = newDe
+}
+
 // PathFromNode implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) PathFromNode(node Node) (p path) {
 	ncs.lock.RLock()

--- a/vendor/github.com/golang/mock/gomock/call.go
+++ b/vendor/github.com/golang/mock/gomock/call.go
@@ -17,6 +17,7 @@ package gomock
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -24,11 +25,11 @@ import (
 type Call struct {
 	t TestReporter // for triggering test failures on invalid call setup
 
-	receiver   interface{}   // the receiver of the method call
-	method     string        // the name of the method
-	methodType reflect.Type  // the type of the method
-	args       []Matcher     // the args
-	rets       []interface{} // the return values (if any)
+	receiver   interface{}  // the receiver of the method call
+	method     string       // the name of the method
+	methodType reflect.Type // the type of the method
+	args       []Matcher    // the args
+	origin     string       // file and line number of call setup
 
 	preReqs []*Call // prerequisite calls
 
@@ -37,9 +38,44 @@ type Call struct {
 
 	numCalls int // actual number made
 
-	// Actions
-	doFunc  reflect.Value
-	setArgs map[int]reflect.Value
+	// actions are called when this Call is called. Each action gets the args and
+	// can set the return values by returning a non-nil slice. Actions run in the
+	// order they are created.
+	actions []func([]interface{}) []interface{}
+}
+
+// newCall creates a *Call. It requires the method type in order to support
+// unexported methods.
+func newCall(t TestReporter, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
+	if h, ok := t.(testHelper); ok {
+		h.Helper()
+	}
+
+	// TODO: check arity, types.
+	margs := make([]Matcher, len(args))
+	for i, arg := range args {
+		if m, ok := arg.(Matcher); ok {
+			margs[i] = m
+		} else if arg == nil {
+			// Handle nil specially so that passing a nil interface value
+			// will match the typed nils of concrete args.
+			margs[i] = Nil()
+		} else {
+			margs[i] = Eq(arg)
+		}
+	}
+
+	origin := callerInfo(3)
+	actions := []func([]interface{}) []interface{}{func([]interface{}) []interface{} {
+		// Synthesize the zero value for each of the return args' types.
+		rets := make([]interface{}, methodType.NumOut())
+		for i := 0; i < methodType.NumOut(); i++ {
+			rets[i] = reflect.Zero(methodType.Out(i)).Interface()
+		}
+		return rets
+	}}
+	return &Call{t: t, receiver: receiver, method: method, methodType: methodType,
+		args: margs, origin: origin, minCalls: 1, maxCalls: 1, actions: actions}
 }
 
 // AnyTimes allows the expectation to be called 0 or more times
@@ -68,19 +104,69 @@ func (c *Call) MaxTimes(n int) *Call {
 	return c
 }
 
-// Do declares the action to run when the call is matched.
+// DoAndReturn declares the action to run when the call is matched.
+// The return values from this function are returned by the mocked function.
 // It takes an interface{} argument to support n-arity functions.
-func (c *Call) Do(f interface{}) *Call {
+func (c *Call) DoAndReturn(f interface{}) *Call {
 	// TODO: Check arity and types here, rather than dying badly elsewhere.
-	c.doFunc = reflect.ValueOf(f)
+	v := reflect.ValueOf(f)
+
+	c.addAction(func(args []interface{}) []interface{} {
+		vargs := make([]reflect.Value, len(args))
+		ft := v.Type()
+		for i := 0; i < len(args); i++ {
+			if args[i] != nil {
+				vargs[i] = reflect.ValueOf(args[i])
+			} else {
+				// Use the zero value for the arg.
+				vargs[i] = reflect.Zero(ft.In(i))
+			}
+		}
+		vrets := v.Call(vargs)
+		rets := make([]interface{}, len(vrets))
+		for i, ret := range vrets {
+			rets[i] = ret.Interface()
+		}
+		return rets
+	})
 	return c
 }
 
+// Do declares the action to run when the call is matched. The function's
+// return values are ignored to retain backward compatibility. To use the
+// return values call DoAndReturn.
+// It takes an interface{} argument to support n-arity functions.
+func (c *Call) Do(f interface{}) *Call {
+	// TODO: Check arity and types here, rather than dying badly elsewhere.
+	v := reflect.ValueOf(f)
+
+	c.addAction(func(args []interface{}) []interface{} {
+		vargs := make([]reflect.Value, len(args))
+		ft := v.Type()
+		for i := 0; i < len(args); i++ {
+			if args[i] != nil {
+				vargs[i] = reflect.ValueOf(args[i])
+			} else {
+				// Use the zero value for the arg.
+				vargs[i] = reflect.Zero(ft.In(i))
+			}
+		}
+		v.Call(vargs)
+		return nil
+	})
+	return c
+}
+
+// Return declares the values to be returned by the mocked function call.
 func (c *Call) Return(rets ...interface{}) *Call {
+	if h, ok := c.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	mt := c.methodType
 	if len(rets) != mt.NumOut() {
-		c.t.Fatalf("wrong number of arguments to Return for %T.%v: got %d, want %d",
-			c.receiver, c.method, len(rets), mt.NumOut())
+		c.t.Fatalf("wrong number of arguments to Return for %T.%v: got %d, want %d [%s]",
+			c.receiver, c.method, len(rets), mt.NumOut(), c.origin)
 	}
 	for i, ret := range rets {
 		if got, want := reflect.TypeOf(ret), mt.Out(i); got == want {
@@ -91,8 +177,8 @@ func (c *Call) Return(rets ...interface{}) *Call {
 			case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 				// ok
 			default:
-				c.t.Fatalf("argument %d to Return for %T.%v is nil, but %v is not nillable",
-					i, c.receiver, c.method, want)
+				c.t.Fatalf("argument %d to Return for %T.%v is nil, but %v is not nillable [%s]",
+					i, c.receiver, c.method, want, c.origin)
 			}
 		} else if got.AssignableTo(want) {
 			// Assignable type relation. Make the assignment now so that the generated code
@@ -101,31 +187,38 @@ func (c *Call) Return(rets ...interface{}) *Call {
 			v.Set(reflect.ValueOf(ret))
 			rets[i] = v.Interface()
 		} else {
-			c.t.Fatalf("wrong type of argument %d to Return for %T.%v: %v is not assignable to %v",
-				i, c.receiver, c.method, got, want)
+			c.t.Fatalf("wrong type of argument %d to Return for %T.%v: %v is not assignable to %v [%s]",
+				i, c.receiver, c.method, got, want, c.origin)
 		}
 	}
 
-	c.rets = rets
+	c.addAction(func([]interface{}) []interface{} {
+		return rets
+	})
+
 	return c
 }
 
+// Times declares the exact number of times a function call is expected to be executed.
 func (c *Call) Times(n int) *Call {
 	c.minCalls, c.maxCalls = n, n
 	return c
 }
 
 // SetArg declares an action that will set the nth argument's value,
-// indirected through a pointer.
+// indirected through a pointer. Or, in the case of a slice, SetArg
+// will copy value's elements into the nth argument.
 func (c *Call) SetArg(n int, value interface{}) *Call {
-	if c.setArgs == nil {
-		c.setArgs = make(map[int]reflect.Value)
+	if h, ok := c.t.(testHelper); ok {
+		h.Helper()
 	}
+
 	mt := c.methodType
 	// TODO: This will break on variadic methods.
 	// We will need to check those at invocation time.
 	if n < 0 || n >= mt.NumIn() {
-		c.t.Fatalf("SetArg(%d, ...) called for a method with %d args", n, mt.NumIn())
+		c.t.Fatalf("SetArg(%d, ...) called for a method with %d args [%s]",
+			n, mt.NumIn(), c.origin)
 	}
 	// Permit setting argument through an interface.
 	// In the interface case, we don't (nay, can't) check the type here.
@@ -134,14 +227,28 @@ func (c *Call) SetArg(n int, value interface{}) *Call {
 	case reflect.Ptr:
 		dt := at.Elem()
 		if vt := reflect.TypeOf(value); !vt.AssignableTo(dt) {
-			c.t.Fatalf("SetArg(%d, ...) argument is a %v, not assignable to %v", n, vt, dt)
+			c.t.Fatalf("SetArg(%d, ...) argument is a %v, not assignable to %v [%s]",
+				n, vt, dt, c.origin)
 		}
 	case reflect.Interface:
 		// nothing to do
+	case reflect.Slice:
+		// nothing to do
 	default:
-		c.t.Fatalf("SetArg(%d, ...) referring to argument of non-pointer non-interface type %v", n, at)
+		c.t.Fatalf("SetArg(%d, ...) referring to argument of non-pointer non-interface non-slice type %v [%s]",
+			n, at, c.origin)
 	}
-	c.setArgs[n] = reflect.ValueOf(value)
+
+	c.addAction(func(args []interface{}) []interface{} {
+		v := reflect.ValueOf(value)
+		switch reflect.TypeOf(args[n]).Kind() {
+		case reflect.Slice:
+			setSlice(args[n], v)
+		default:
+			reflect.ValueOf(args[n]).Elem().Set(v)
+		}
+		return nil
+	})
 	return c
 }
 
@@ -157,8 +264,12 @@ func (c *Call) isPreReq(other *Call) bool {
 
 // After declares that the call may only match after preReq has been exhausted.
 func (c *Call) After(preReq *Call) *Call {
+	if h, ok := c.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	if c == preReq {
-		c.t.Fatalf("A call isn't allowed to be it's own prerequisite")
+		c.t.Fatalf("A call isn't allowed to be its own prerequisite")
 	}
 	if preReq.isPreReq(c) {
 		c.t.Fatalf("Loop in call order: %v is a prerequisite to %v (possibly indirectly).", c, preReq)
@@ -168,7 +279,7 @@ func (c *Call) After(preReq *Call) *Call {
 	return c
 }
 
-// Returns true iff the minimum number of calls have been made.
+// Returns true if the minimum number of calls have been made.
 func (c *Call) satisfied() bool {
 	return c.numCalls >= c.minCalls
 }
@@ -184,31 +295,108 @@ func (c *Call) String() string {
 		args[i] = arg.String()
 	}
 	arguments := strings.Join(args, ", ")
-	return fmt.Sprintf("%T.%v(%s)", c.receiver, c.method, arguments)
+	return fmt.Sprintf("%T.%v(%s) %s", c.receiver, c.method, arguments, c.origin)
 }
 
 // Tests if the given call matches the expected call.
-func (c *Call) matches(args []interface{}) bool {
-	if len(args) != len(c.args) {
-		return false
-	}
-	for i, m := range c.args {
-		if !m.Matches(args[i]) {
-			return false
+// If yes, returns nil. If no, returns error with message explaining why it does not match.
+func (c *Call) matches(args []interface{}) error {
+	if !c.methodType.IsVariadic() {
+		if len(args) != len(c.args) {
+			return fmt.Errorf("Expected call at %s has the wrong number of arguments. Got: %d, want: %d",
+				c.origin, len(args), len(c.args))
+		}
+
+		for i, m := range c.args {
+			if !m.Matches(args[i]) {
+				return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+					c.origin, strconv.Itoa(i), args[i], m)
+			}
+		}
+	} else {
+		if len(c.args) < c.methodType.NumIn()-1 {
+			return fmt.Errorf("Expected call at %s has the wrong number of matchers. Got: %d, want: %d",
+				c.origin, len(c.args), c.methodType.NumIn()-1)
+		}
+		if len(c.args) != c.methodType.NumIn() && len(args) != len(c.args) {
+			return fmt.Errorf("Expected call at %s has the wrong number of arguments. Got: %d, want: %d",
+				c.origin, len(args), len(c.args))
+		}
+		if len(args) < len(c.args)-1 {
+			return fmt.Errorf("Expected call at %s has the wrong number of arguments. Got: %d, want: greater than or equal to %d",
+				c.origin, len(args), len(c.args)-1)
+		}
+
+		for i, m := range c.args {
+			if i < c.methodType.NumIn()-1 {
+				// Non-variadic args
+				if !m.Matches(args[i]) {
+					return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+						c.origin, strconv.Itoa(i), args[i], m)
+				}
+				continue
+			}
+			// The last arg has a possibility of a variadic argument, so let it branch
+
+			// sample: Foo(a int, b int, c ...int)
+			if i < len(c.args) && i < len(args) {
+				if m.Matches(args[i]) {
+					// Got Foo(a, b, c) want Foo(matcherA, matcherB, gomock.Any())
+					// Got Foo(a, b, c) want Foo(matcherA, matcherB, someSliceMatcher)
+					// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC)
+					// Got Foo(a, b) want Foo(matcherA, matcherB)
+					// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD)
+					continue
+				}
+			}
+
+			// The number of actual args don't match the number of matchers,
+			// or the last matcher is a slice and the last arg is not.
+			// If this function still matches it is because the last matcher
+			// matches all the remaining arguments or the lack of any.
+			// Convert the remaining arguments, if any, into a slice of the
+			// expected type.
+			vargsType := c.methodType.In(c.methodType.NumIn() - 1)
+			vargs := reflect.MakeSlice(vargsType, 0, len(args)-i)
+			for _, arg := range args[i:] {
+				vargs = reflect.Append(vargs, reflect.ValueOf(arg))
+			}
+			if m.Matches(vargs.Interface()) {
+				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, gomock.Any())
+				// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, someSliceMatcher)
+				// Got Foo(a, b) want Foo(matcherA, matcherB, gomock.Any())
+				// Got Foo(a, b) want Foo(matcherA, matcherB, someEmptySliceMatcher)
+				break
+			}
+			// Wrong number of matchers or not match. Fail.
+			// Got Foo(a, b) want Foo(matcherA, matcherB, matcherC, matcherD)
+			// Got Foo(a, b, c) want Foo(matcherA, matcherB, matcherC, matcherD)
+			// Got Foo(a, b, c, d) want Foo(matcherA, matcherB, matcherC, matcherD, matcherE)
+			// Got Foo(a, b, c, d, e) want Foo(matcherA, matcherB, matcherC, matcherD)
+			// Got Foo(a, b, c) want Foo(matcherA, matcherB)
+			return fmt.Errorf("Expected call at %s doesn't match the argument at index %s.\nGot: %v\nWant: %v",
+				c.origin, strconv.Itoa(i), args[i:], c.args[i])
+
 		}
 	}
 
 	// Check that all prerequisite calls have been satisfied.
 	for _, preReqCall := range c.preReqs {
 		if !preReqCall.satisfied() {
-			return false
+			return fmt.Errorf("Expected call at %s doesn't have a prerequisite call satisfied:\n%v\nshould be called before:\n%v",
+				c.origin, preReqCall, c)
 		}
 	}
 
-	return true
+	// Check that the call is not exhausted.
+	if c.exhausted() {
+		return fmt.Errorf("Expected call at %s has already been called the max number of times.", c.origin)
+	}
+
+	return nil
 }
 
-// dropPrereqs tells the expected Call to not re-check prerequite calls any
+// dropPrereqs tells the expected Call to not re-check prerequisite calls any
 // longer, and to return its current set.
 func (c *Call) dropPrereqs() (preReqs []*Call) {
 	preReqs = c.preReqs
@@ -216,38 +404,9 @@ func (c *Call) dropPrereqs() (preReqs []*Call) {
 	return
 }
 
-func (c *Call) call(args []interface{}) (rets []interface{}, action func()) {
+func (c *Call) call(args []interface{}) []func([]interface{}) []interface{} {
 	c.numCalls++
-
-	// Actions
-	if c.doFunc.IsValid() {
-		doArgs := make([]reflect.Value, len(args))
-		ft := c.doFunc.Type()
-		for i := 0; i < len(args); i++ {
-			if args[i] != nil {
-				doArgs[i] = reflect.ValueOf(args[i])
-			} else {
-				// Use the zero value for the arg.
-				doArgs[i] = reflect.Zero(ft.In(i))
-			}
-		}
-		action = func() { c.doFunc.Call(doArgs) }
-	}
-	for n, v := range c.setArgs {
-		reflect.ValueOf(args[n]).Elem().Set(v)
-	}
-
-	rets = c.rets
-	if rets == nil {
-		// Synthesize the zero value for each of the return args' types.
-		mt := c.methodType
-		rets = make([]interface{}, mt.NumOut())
-		for i := 0; i < mt.NumOut(); i++ {
-			rets[i] = reflect.Zero(mt.Out(i)).Interface()
-		}
-	}
-
-	return
+	return c.actions
 }
 
 // InOrder declares that the given calls should occur in order.
@@ -255,4 +414,15 @@ func InOrder(calls ...*Call) {
 	for i := 1; i < len(calls); i++ {
 		calls[i].After(calls[i-1])
 	}
+}
+
+func setSlice(arg interface{}, v reflect.Value) {
+	va := reflect.ValueOf(arg)
+	for i := 0; i < v.Len(); i++ {
+		va.Index(i).Set(v.Index(i))
+	}
+}
+
+func (c *Call) addAction(action func([]interface{}) []interface{}) {
+	c.actions = append(c.actions, action)
 }

--- a/vendor/github.com/golang/mock/gomock/callset.go
+++ b/vendor/github.com/golang/mock/gomock/callset.go
@@ -14,63 +14,95 @@
 
 package gomock
 
+import (
+	"bytes"
+	"fmt"
+)
+
 // callSet represents a set of expected calls, indexed by receiver and method
 // name.
-type callSet map[interface{}]map[string][]*Call
+type callSet struct {
+	// Calls that are still expected.
+	expected map[callSetKey][]*Call
+	// Calls that have been exhausted.
+	exhausted map[callSetKey][]*Call
+}
+
+// callSetKey is the key in the maps in callSet
+type callSetKey struct {
+	receiver interface{}
+	fname    string
+}
+
+func newCallSet() *callSet {
+	return &callSet{make(map[callSetKey][]*Call), make(map[callSetKey][]*Call)}
+}
 
 // Add adds a new expected call.
 func (cs callSet) Add(call *Call) {
-	methodMap, ok := cs[call.receiver]
-	if !ok {
-		methodMap = make(map[string][]*Call)
-		cs[call.receiver] = methodMap
+	key := callSetKey{call.receiver, call.method}
+	m := cs.expected
+	if call.exhausted() {
+		m = cs.exhausted
 	}
-	methodMap[call.method] = append(methodMap[call.method], call)
+	m[key] = append(m[key], call)
 }
 
 // Remove removes an expected call.
 func (cs callSet) Remove(call *Call) {
-	methodMap, ok := cs[call.receiver]
-	if !ok {
-		return
-	}
-	sl := methodMap[call.method]
-	for i, c := range sl {
+	key := callSetKey{call.receiver, call.method}
+	calls := cs.expected[key]
+	for i, c := range calls {
 		if c == call {
-			// quick removal; we don't need to maintain call order
-			if len(sl) > 1 {
-				sl[i] = sl[len(sl)-1]
-			}
-			methodMap[call.method] = sl[:len(sl)-1]
+			// maintain order for remaining calls
+			cs.expected[key] = append(calls[:i], calls[i+1:]...)
+			cs.exhausted[key] = append(cs.exhausted[key], call)
 			break
 		}
 	}
 }
 
-// FindMatch searches for a matching call. Returns nil if no call matched.
-func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) *Call {
-	methodMap, ok := cs[receiver]
-	if !ok {
-		return nil
-	}
-	calls, ok := methodMap[method]
-	if !ok {
-		return nil
-	}
+// FindMatch searches for a matching call. Returns error with explanation message if no call matched.
+func (cs callSet) FindMatch(receiver interface{}, method string, args []interface{}) (*Call, error) {
+	key := callSetKey{receiver, method}
 
-	// Search through the unordered set of calls expected on a method on a
-	// receiver.
-	for _, call := range calls {
-		// A call should not normally still be here if exhausted,
-		// but it can happen if, for instance, .Times(0) was used.
-		// Pretend the call doesn't match.
-		if call.exhausted() {
-			continue
-		}
-		if call.matches(args) {
-			return call
+	// Search through the expected calls.
+	expected := cs.expected[key]
+	var callsErrors bytes.Buffer
+	for _, call := range expected {
+		err := call.matches(args)
+		if err != nil {
+			fmt.Fprintf(&callsErrors, "\n%v", err)
+		} else {
+			return call, nil
 		}
 	}
 
-	return nil
+	// If we haven't found a match then search through the exhausted calls so we
+	// get useful error messages.
+	exhausted := cs.exhausted[key]
+	for _, call := range exhausted {
+		if err := call.matches(args); err != nil {
+			fmt.Fprintf(&callsErrors, "\n%v", err)
+		}
+	}
+
+	if len(expected)+len(exhausted) == 0 {
+		fmt.Fprintf(&callsErrors, "there are no expected calls of the method %q for that receiver", method)
+	}
+
+	return nil, fmt.Errorf(callsErrors.String())
+}
+
+// Failures returns the calls that are not satisfied.
+func (cs callSet) Failures() []*Call {
+	failures := make([]*Call, 0, len(cs.expected))
+	for _, calls := range cs.expected {
+		for _, call := range calls {
+			if !call.satisfied() {
+				failures = append(failures, call)
+			}
+		}
+	}
+	return failures
 }

--- a/vendor/github.com/golang/mock/gomock/controller.go
+++ b/vendor/github.com/golang/mock/gomock/controller.go
@@ -57,7 +57,9 @@ package gomock
 
 import (
 	"fmt"
+	"golang.org/x/net/context"
 	"reflect"
+	"runtime"
 	"sync"
 )
 
@@ -74,17 +76,40 @@ type TestReporter interface {
 type Controller struct {
 	mu            sync.Mutex
 	t             TestReporter
-	expectedCalls callSet
+	expectedCalls *callSet
+	finished      bool
 }
 
 func NewController(t TestReporter) *Controller {
 	return &Controller{
 		t:             t,
-		expectedCalls: make(callSet),
+		expectedCalls: newCallSet(),
 	}
 }
 
+type cancelReporter struct {
+	t      TestReporter
+	cancel func()
+}
+
+func (r *cancelReporter) Errorf(format string, args ...interface{}) { r.t.Errorf(format, args...) }
+func (r *cancelReporter) Fatalf(format string, args ...interface{}) {
+	defer r.cancel()
+	r.t.Fatalf(format, args...)
+}
+
+// WithContext returns a new Controller and a Context, which is cancelled on any
+// fatal failure.
+func WithContext(ctx context.Context, t TestReporter) (*Controller, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return NewController(&cancelReporter{t, cancel}), ctx
+}
+
 func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...interface{}) *Call {
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	recv := reflect.ValueOf(receiver)
 	for i := 0; i < recv.Type().NumMethod(); i++ {
 		if recv.Type().Method(i).Name == method {
@@ -92,72 +117,76 @@ func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...
 		}
 	}
 	ctrl.t.Fatalf("gomock: failed finding method %s on %T", method, receiver)
-	// In case t.Fatalf does not panic.
-	panic(fmt.Sprintf("gomock: failed finding method %s on %T", method, receiver))
+	panic("unreachable")
 }
 
 func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
-	// TODO: check arity, types.
-	margs := make([]Matcher, len(args))
-	for i, arg := range args {
-		if m, ok := arg.(Matcher); ok {
-			margs[i] = m
-		} else if arg == nil {
-			// Handle nil specially so that passing a nil interface value
-			// will match the typed nils of concrete args.
-			margs[i] = Nil()
-		} else {
-			margs[i] = Eq(arg)
-		}
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
 	}
+
+	call := newCall(ctrl.t, receiver, method, methodType, args...)
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
-
-	call := &Call{t: ctrl.t, receiver: receiver, method: method, methodType: methodType, args: margs, minCalls: 1, maxCalls: 1}
-
 	ctrl.expectedCalls.Add(call)
+
 	return call
 }
 
 func (ctrl *Controller) Call(receiver interface{}, method string, args ...interface{}) []interface{} {
-	ctrl.mu.Lock()
-	defer ctrl.mu.Unlock()
-
-	expected := ctrl.expectedCalls.FindMatch(receiver, method, args)
-	if expected == nil {
-		ctrl.t.Fatalf("no matching expected call: %T.%v(%v)", receiver, method, args)
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
 	}
 
-	// Two things happen here:
-	// * the matching call no longer needs to check prerequite calls,
-	// * and the prerequite calls are no longer expected, so remove them.
-	preReqCalls := expected.dropPrereqs()
-	for _, preReqCall := range preReqCalls {
-		ctrl.expectedCalls.Remove(preReqCall)
-	}
+	// Nest this code so we can use defer to make sure the lock is released.
+	actions := func() []func([]interface{}) []interface{} {
+		ctrl.mu.Lock()
+		defer ctrl.mu.Unlock()
 
-	rets, action := expected.call(args)
-	if expected.exhausted() {
-		ctrl.expectedCalls.Remove(expected)
-	}
+		expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
+		if err != nil {
+			origin := callerInfo(2)
+			ctrl.t.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
+		}
 
-	// Don't hold the lock while doing the call's action (if any)
-	// so that actions may execute concurrently.
-	// We use the deferred Unlock to capture any panics that happen above;
-	// here we add a deferred Lock to balance it.
-	ctrl.mu.Unlock()
-	defer ctrl.mu.Lock()
-	if action != nil {
-		action()
+		// Two things happen here:
+		// * the matching call no longer needs to check prerequite calls,
+		// * and the prerequite calls are no longer expected, so remove them.
+		preReqCalls := expected.dropPrereqs()
+		for _, preReqCall := range preReqCalls {
+			ctrl.expectedCalls.Remove(preReqCall)
+		}
+
+		actions := expected.call(args)
+		if expected.exhausted() {
+			ctrl.expectedCalls.Remove(expected)
+		}
+		return actions
+	}()
+
+	var rets []interface{}
+	for _, action := range actions {
+		if r := action(args); r != nil {
+			rets = r
+		}
 	}
 
 	return rets
 }
 
 func (ctrl *Controller) Finish() {
+	if h, ok := ctrl.t.(testHelper); ok {
+		h.Helper()
+	}
+
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
+
+	if ctrl.finished {
+		ctrl.t.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
+	}
+	ctrl.finished = true
 
 	// If we're currently panicking, probably because this is a deferred call,
 	// pass through the panic.
@@ -166,18 +195,23 @@ func (ctrl *Controller) Finish() {
 	}
 
 	// Check that all remaining expected calls are satisfied.
-	failures := false
-	for _, methodMap := range ctrl.expectedCalls {
-		for _, calls := range methodMap {
-			for _, call := range calls {
-				if !call.satisfied() {
-					ctrl.t.Errorf("missing call(s) to %v", call)
-					failures = true
-				}
-			}
-		}
+	failures := ctrl.expectedCalls.Failures()
+	for _, call := range failures {
+		ctrl.t.Errorf("missing call(s) to %v", call)
 	}
-	if failures {
+	if len(failures) != 0 {
 		ctrl.t.Fatalf("aborting test due to missing call(s)")
 	}
+}
+
+func callerInfo(skip int) string {
+	if _, file, line, ok := runtime.Caller(skip + 1); ok {
+		return fmt.Sprintf("%s:%d", file, line)
+	}
+	return "unknown file"
+}
+
+type testHelper interface {
+	TestReporter
+	Helper()
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -137,10 +137,10 @@
 			"revisionTime": "2017-04-21T00:56:42Z"
 		},
 		{
-			"checksumSHA1": "M3BUApw7nNipzKvYbHSpxqE04FY=",
+			"checksumSHA1": "aJpeyGQOzvYWi8HhgHQsCS3+XNs=",
 			"path": "github.com/golang/mock/gomock",
-			"revision": "13f360950a79f5864a972c786a10a50e44b69541",
-			"revisionTime": "2017-07-22T14:45:13Z"
+			"revision": "c34cdb4725f4c3844d095133c6e40e448b86589b",
+			"revisionTime": "2018-04-05T21:54:04Z"
 		},
 		{
 			"checksumSHA1": "UsY6N958JNjS0qzLTAtER7+tVPY=",


### PR DESCRIPTION
`deCache` has been outdated for a while now.  It used to be important when we allowed files to be synced individually, so that one file's directory entry changes could be preserved in memory, while flushing only another file's entry in the same directory.  Now that we only support `SyncAll`, it can be removed in favor of just keeping a single view of dirty `DirBlock`s in the dirty block cache.

The transition to `dirData` seemed like a good time to do this, so I combined the two.  Now all changes to directories are synced to the dirty blocked cache, and all changed to the root directory entry are kept in memory in the `folderBlockOps` instance.  This allowed a bunch of code to be simplified or removed.

Note that this doesn't yet allow for multi-block directories to be written.  The next PR will update `folderBranchOps` and `folderUpdatePrepper` to make that happen.

Also, vendor in the latest `gomock` release for the sweet new `DoAndReturn` function.

Issue: KBFS-3302