### PR TITLE
folder_update_prepper: use `dirData` when prepping paths

### DIFF
--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -132,7 +132,7 @@ func (bt *blockTree) getBlockAtOffset(ctx context.Context,
 // the top block).
 func (bt *blockTree) getNextDirtyBlockAtOffsetAtLevel(ctx context.Context,
 	pblock BlockWithPtrs, off Offset, rtype blockReqType,
-	dirtyBcache DirtyBlockCache, parentBlocks []parentBlockAndChildIndex) (
+	dirtyBcache isDirtyProvider, parentBlocks []parentBlockAndChildIndex) (
 	ptr BlockPointer, newParentBlocks []parentBlockAndChildIndex,
 	block BlockWithPtrs, nextBlockStartOff, startOff Offset, err error) {
 	// Search along paths of dirty blocks until we find a dirty leaf
@@ -231,7 +231,7 @@ func (bt *blockTree) getNextDirtyBlockAtOffsetAtLevel(ctx context.Context,
 // to be local.  `nextBlockStartOff` is `nil` if there's no next block.
 func (bt *blockTree) getNextDirtyBlockAtOffset(ctx context.Context,
 	topBlock BlockWithPtrs, off Offset, rtype blockReqType,
-	dirtyBcache DirtyBlockCache) (
+	dirtyBcache isDirtyProvider) (
 	ptr BlockPointer, parentBlocks []parentBlockAndChildIndex,
 	block BlockWithPtrs, nextBlockStartOff, startOff Offset, err error) {
 	// Find the block matching the offset, if it exists.
@@ -871,7 +871,7 @@ func (bt *blockTree) readyHelper(
 // info from any readied block to its corresponding old block pointer.
 func (bt *blockTree) ready(
 	ctx context.Context, id tlf.ID, bcache BlockCache,
-	dirtyBcache DirtyBlockCache, bops BlockOps, bps *blockPutState,
+	dirtyBcache isDirtyProvider, bops BlockOps, bps *blockPutState,
 	topBlock BlockWithPtrs, makeSync makeSyncFunc) (
 	map[BlockInfo]BlockPointer, error) {
 	if !topBlock.IsIndirect() {

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -349,7 +349,7 @@ func (db *DirBlock) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
 // SetIndirectPtrOff implements the BlockWithPtrs interface for DirBlock.
 func (db *DirBlock) SetIndirectPtrOff(i int, off Offset) {
 	if !db.IsInd {
-		panic("SetIndirectPtrOff called on a direct file block")
+		panic("SetIndirectPtrOff called on a direct directory block")
 	}
 	sOff, ok := off.(*StringOffset)
 	if !ok {
@@ -357,6 +357,14 @@ func (db *DirBlock) SetIndirectPtrOff(i int, off Offset) {
 			"with a %T offset", off))
 	}
 	db.IPtrs[i].Off = *sOff
+}
+
+// SetIndirectPtrInfo implements the BlockWithPtrs interface for DirBlock.
+func (db *DirBlock) SetIndirectPtrInfo(i int, info BlockInfo) {
+	if !db.IsInd {
+		panic("SetIndirectPtrInfo called on a direct directory block")
+	}
+	db.IPtrs[i].BlockInfo = info
 }
 
 // FileBlock is the contents of a file
@@ -611,6 +619,14 @@ func (fb *FileBlock) SetIndirectPtrOff(i int, off Offset) {
 			"with a %T offset", off))
 	}
 	fb.IPtrs[i].Off = iOff
+}
+
+// SetIndirectPtrInfo implements the BlockWithPtrs interface for FileBlock.
+func (fb *FileBlock) SetIndirectPtrInfo(i int, info BlockInfo) {
+	if !fb.IsInd {
+		panic("SetIndirectPtrInfo called on a direct file block")
+	}
+	fb.IPtrs[i].BlockInfo = info
 }
 
 // DefaultNewBlockDataVersion returns the default data version for new blocks.

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -1005,7 +1005,7 @@ func (fd *fileData) split(ctx context.Context, id tlf.ID,
 // indirect pointers.  It returns a map pointing from the new block
 // info from any readied block to its corresponding old block pointer.
 func (fd *fileData) ready(ctx context.Context, id tlf.ID, bcache BlockCache,
-	dirtyBcache DirtyBlockCache, bops BlockOps, bps *blockPutState,
+	dirtyBcache isDirtyProvider, bops BlockOps, bps *blockPutState,
 	topBlock *FileBlock, df *dirtyFile) (map[BlockInfo]BlockPointer, error) {
 	return fd.tree.ready(
 		ctx, id, bcache, dirtyBcache, bops, bps, topBlock,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -154,6 +154,9 @@ type BlockWithPtrs interface {
 	// SetIndirectPtrOff set the offset of the indirect pointer stored
 	// at index `i`.
 	SetIndirectPtrOff(i int, off Offset)
+	// SetIndirectPtrInfo sets the block info of the indirect pointer
+	// stored at index `i`.
+	SetIndirectPtrInfo(i int, info BlockInfo)
 	// SwapIndirectPtrs swaps the indirect ptr at `i` in this block
 	// with the one at `otherI` in `other`.
 	SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1086,6 +1086,12 @@ type BlockCache interface {
 // struct{}.
 type DirtyPermChan <-chan struct{}
 
+type isDirtyProvider interface {
+	// IsDirty states whether or not the block associated with the
+	// given block pointer and branch name is dirty in this cache.
+	IsDirty(tlfID tlf.ID, ptr BlockPointer, branch BranchName) bool
+}
+
 // DirtyBlockCache gets and puts plaintext dir blocks and file blocks
 // into a cache, which have been modified by the application and not
 // yet committed on the KBFS servers.  They are identified by a
@@ -1094,6 +1100,8 @@ type DirtyPermChan <-chan struct{}
 // modified via multiple branches.  Dirty blocks are never evicted,
 // they must be deleted explicitly.
 type DirtyBlockCache interface {
+	isDirtyProvider
+
 	// Get gets the block associated with the given block ID.  Returns
 	// the dirty block for the given ID, if one exists.
 	Get(tlfID tlf.ID, ptr BlockPointer, branch BranchName) (Block, error)
@@ -1104,9 +1112,6 @@ type DirtyBlockCache interface {
 	// pointer and branch from the cache.  No error is returned if no
 	// block exists for the given ID.
 	Delete(tlfID tlf.ID, ptr BlockPointer, branch BranchName) error
-	// IsDirty states whether or not the block associated with the
-	// given block pointer and branch name is dirty in this cache.
-	IsDirty(tlfID tlf.ID, ptr BlockPointer, branch BranchName) bool
 	// IsAnyDirty returns whether there are any dirty blocks in the
 	// cache. tlfID may be ignored.
 	IsAnyDirty(tlfID tlf.ID) bool

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3841,6 +3841,41 @@ func (mr *MockBlockCacheMockRecorder) GetCleanBytesCapacity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCleanBytesCapacity", reflect.TypeOf((*MockBlockCache)(nil).GetCleanBytesCapacity))
 }
 
+// MockisDirtyProvider is a mock of isDirtyProvider interface
+type MockisDirtyProvider struct {
+	ctrl     *gomock.Controller
+	recorder *MockisDirtyProviderMockRecorder
+}
+
+// MockisDirtyProviderMockRecorder is the mock recorder for MockisDirtyProvider
+type MockisDirtyProviderMockRecorder struct {
+	mock *MockisDirtyProvider
+}
+
+// NewMockisDirtyProvider creates a new mock instance
+func NewMockisDirtyProvider(ctrl *gomock.Controller) *MockisDirtyProvider {
+	mock := &MockisDirtyProvider{ctrl: ctrl}
+	mock.recorder = &MockisDirtyProviderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockisDirtyProvider) EXPECT() *MockisDirtyProviderMockRecorder {
+	return m.recorder
+}
+
+// IsDirty mocks base method
+func (m *MockisDirtyProvider) IsDirty(tlfID tlf.ID, ptr BlockPointer, branch BranchName) bool {
+	ret := m.ctrl.Call(m, "IsDirty", tlfID, ptr, branch)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDirty indicates an expected call of IsDirty
+func (mr *MockisDirtyProviderMockRecorder) IsDirty(tlfID, ptr, branch interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockisDirtyProvider)(nil).IsDirty), tlfID, ptr, branch)
+}
+
 // MockDirtyBlockCache is a mock of DirtyBlockCache interface
 type MockDirtyBlockCache struct {
 	ctrl     *gomock.Controller
@@ -3862,6 +3897,18 @@ func NewMockDirtyBlockCache(ctrl *gomock.Controller) *MockDirtyBlockCache {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockDirtyBlockCache) EXPECT() *MockDirtyBlockCacheMockRecorder {
 	return m.recorder
+}
+
+// IsDirty mocks base method
+func (m *MockDirtyBlockCache) IsDirty(tlfID tlf.ID, ptr BlockPointer, branch BranchName) bool {
+	ret := m.ctrl.Call(m, "IsDirty", tlfID, ptr, branch)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDirty indicates an expected call of IsDirty
+func (mr *MockDirtyBlockCacheMockRecorder) IsDirty(tlfID, ptr, branch interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockDirtyBlockCache)(nil).IsDirty), tlfID, ptr, branch)
 }
 
 // Get mocks base method
@@ -3899,18 +3946,6 @@ func (m *MockDirtyBlockCache) Delete(tlfID tlf.ID, ptr BlockPointer, branch Bran
 // Delete indicates an expected call of Delete
 func (mr *MockDirtyBlockCacheMockRecorder) Delete(tlfID, ptr, branch interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDirtyBlockCache)(nil).Delete), tlfID, ptr, branch)
-}
-
-// IsDirty mocks base method
-func (m *MockDirtyBlockCache) IsDirty(tlfID tlf.ID, ptr BlockPointer, branch BranchName) bool {
-	ret := m.ctrl.Call(m, "IsDirty", tlfID, ptr, branch)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsDirty indicates an expected call of IsDirty
-func (mr *MockDirtyBlockCacheMockRecorder) IsDirty(tlfID, ptr, branch interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDirty", reflect.TypeOf((*MockDirtyBlockCache)(nil).IsDirty), tlfID, ptr, branch)
 }
 
 // IsAnyDirty mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1007,6 +1007,16 @@ func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrOff(i, off interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrOff", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrOff), i, off)
 }
 
+// SetIndirectPtrInfo mocks base method
+func (m *MockBlockWithPtrs) SetIndirectPtrInfo(i int, info BlockInfo) {
+	m.ctrl.Call(m, "SetIndirectPtrInfo", i, info)
+}
+
+// SetIndirectPtrInfo indicates an expected call of SetIndirectPtrInfo
+func (mr *MockBlockWithPtrsMockRecorder) SetIndirectPtrInfo(i, info interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetIndirectPtrInfo", reflect.TypeOf((*MockBlockWithPtrs)(nil).SetIndirectPtrInfo), i, info)
+}
+
 // SwapIndirectPtrs mocks base method
 func (m *MockBlockWithPtrs) SwapIndirectPtrs(i int, other BlockWithPtrs, otherI int) {
 	m.ctrl.Call(m, "SwapIndirectPtrs", i, other, otherI)


### PR DESCRIPTION
This updates `folderUpdatePrepper` to use `dirData` when updating dir entries, and to ready any dirty blocks within the directory when prepping the paths for commit.

The ready path() isn't yet exercised in any tests though; a future PR may end up having to fix bugs here.  It's split out in this way, pre-testing, for ease of review.

In addition, this PR:
* refactors ready functions out of `fileData` into `blockTree` (no behavior change)
* makes `blockTree` use a restricted interface for checking dirtiness, to make it easier to pass in other kinds of dirty-block-holders, like `localBcache`.

Issue: KBFS-3302
