### PR TITLE
dir_data: fix lookup semantics

### DIFF
--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -102,7 +102,7 @@ func (dd *dirData) lookup(ctx context.Context, name string) (DirEntry, error) {
 
 	off := StringOffset(name)
 	_, _, block, _, _, _, err := dd.tree.getBlockAtOffset(
-		ctx, topBlock, &off, blockRead)
+		ctx, topBlock, &off, blockLookup)
 	if err != nil {
 		return DirEntry{}, err
 	}


### PR DESCRIPTION
Before the previous commit that got rid of `deCache` in favor of `dirData`, `folderBlockOps.getDirtyEntryLocked` used `blockLookup` as the request type when reading blocks.  This was to make sure we did not release `blockLock` when making network accesses to fetch blocks, like we normally do with `blockRead`.  It's a minor optimization, but if we do that while creating an entry, we could end up in a bad race situation where two Nodes are created for the same entry name.

So revive those old semantics so that race doesn't come back to haunt us.

Commit 1a9a77ed3a91f05fbcf2b7fd932cd494b78e8a14 has a few details about it.

Issue: KBFS-3302