### PR TITLE
throttle NotifySync and NotifyPathUpdated to one per second

### DIFF
--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -283,30 +283,30 @@ func (r *ReporterKBPKI) send(ctx context.Context) {
 					"notification: %s", err)
 			}
 		case <-sendTicker.C:
-		inTicker:
-			for {
-				select {
-				case path, ok := <-r.notifyPathBuffer:
-					if !ok {
-						return
-					}
-					if err := r.config.KeybaseService().NotifyPathUpdated(
-						ctx, path); err != nil {
-						r.log.CDebugf(ctx, "ReporterDaemon: error sending "+
-							"notification for path: %s", err)
-					}
-				case status, ok := <-r.notifySyncBuffer:
-					if !ok {
-						return
-					}
-					if err := r.config.KeybaseService().NotifySyncStatus(ctx,
-						status); err != nil {
-						r.log.CDebugf(ctx, "ReporterDaemon: error sending "+
-							"sync status: %s", err)
-					}
-				default:
-					break inTicker
+			select {
+			case path, ok := <-r.notifyPathBuffer:
+				if !ok {
+					return
 				}
+				if err := r.config.KeybaseService().NotifyPathUpdated(
+					ctx, path); err != nil {
+					r.log.CDebugf(ctx, "ReporterDaemon: error sending "+
+						"notification for path: %s", err)
+				}
+			default:
+			}
+
+			select {
+			case status, ok := <-r.notifySyncBuffer:
+				if !ok {
+					return
+				}
+				if err := r.config.KeybaseService().NotifySyncStatus(ctx,
+					status); err != nil {
+					r.log.CDebugf(ctx, "ReporterDaemon: error sending "+
+						"sync status: %s", err)
+				}
+			default:
 			}
 		case <-ctx.Done():
 			return

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -6,6 +6,7 @@ package simplefs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1885,8 +1886,7 @@ func (k *SimpleFS) TlfHandleChange(_ context.Context, _ *libkbfs.TlfHandle) {
 // SimpleFSSuppressNotifications suppresses FSEvent and FSSyncEvent
 // notifications.
 func (k *SimpleFS) SimpleFSSuppressNotifications(ctx context.Context, suppressDurationSec int) error {
-	k.config.Reporter().SuppressNotifications(ctx, time.Duration(suppressDurationSec)*time.Second)
-	return nil
+	return errors.New("this rpc is deprecated")
 }
 
 // SimpleFSGetUserQuotaUsage returns the quota usage information for


### PR DESCRIPTION
The NotifySync notifications tend to come in clustered (up to more than 10 within a second), so this seems pretty helpful.

This will need to go in at the same time as https://github.com/keybase/client/pull/13408