### PR TITLE
folder_branch_ops: remove almost all direct uses of `DirBlock`

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -676,7 +676,7 @@ func (fbo *folderBlockOps) getFileLocked(ctx context.Context,
 	// Callers should have already done this check, but it doesn't
 	// hurt to do it again.
 	if !file.isValid() {
-		return nil, InvalidPathError{file}
+		return nil, errors.WithStack(InvalidPathError{file})
 	}
 	fblock, _, err := fbo.getFileBlockLocked(
 		ctx, lState, kmd, file.tailPointer(), file, rtype)
@@ -849,7 +849,7 @@ func (fbo *folderBlockOps) getDirLocked(ctx context.Context,
 	// Callers should have already done this check, but it doesn't
 	// hurt to do it again.
 	if !dir.isValid() {
-		return nil, false, InvalidPathError{dir}
+		return nil, false, errors.WithStack(InvalidPathError{dir})
 	}
 
 	// Get the block for the last element in the path.
@@ -1430,7 +1430,7 @@ func (fbo *folderBlockOps) Lookup(
 
 	dirPath := fbo.nodeCache.PathFromNode(dir)
 	if !dirPath.isValid() {
-		return nil, DirEntry{}, InvalidPathError{dirPath}
+		return nil, DirEntry{}, errors.WithStack(InvalidPathError{dirPath})
 	}
 
 	childPath := dirPath.ChildPathNoPtr(name)
@@ -1811,7 +1811,7 @@ func (fbo *folderBlockOps) pathFromNodeForBlockWriteLocked(
 	fbo.blockLock.AssertLocked(lState)
 	p := fbo.nodeCache.PathFromNode(n)
 	if !p.isValid() {
-		return path{}, InvalidPathError{p}
+		return path{}, errors.WithStack(InvalidPathError{p})
 	}
 	return p, nil
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3756,7 +3756,7 @@ func (fbo *folderBranchOps) renameLocked(
 		return err
 	}
 
-	_, newPBlock, newDe, ro, err := fbo.blocks.PrepRename(
+	newDe, replacedDe, ro, err := fbo.blocks.PrepRename(
 		ctx, lState, md.ReadOnly(), oldParentPath, oldName, newParentPath,
 		newName)
 	if err != nil {
@@ -3764,8 +3764,7 @@ func (fbo *folderBranchOps) renameLocked(
 	}
 
 	// does name exist?
-	replacedDe, ok := newPBlock.Children[newName]
-	if ok {
+	if replacedDe.IsInitialized() {
 		// Usually higher-level programs check these, but just in case.
 		if replacedDe.Type == Dir && newDe.Type != Dir {
 			return NotDirError{newParentPath.ChildPathNoPtr(newName)}


### PR DESCRIPTION
This PR removes all the rest of the direct usage of `DirBlock` from `folderBranchOps` and `folderBlockOps`.  This includes:

* Renames.
* Searching for nodes.
* Fast-forwarding.
* Simple existences checks in `folderBranchOps`.
* `SyncAll`.

Issue: KBFS-3302