### PR TITLE
cr: replace `DirBlock.Children` uses with `dirData`

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2398,15 +2398,15 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 					cr.log.CDebugf(ctx, "Swapping out dir %v for %v",
 						newPtr, unmergedPath.tailPointer())
 					if newPtr == zeroPtr {
-						// Use this merged block
+						// Use the merged `dirData`.
 						uDir = mergedDir
 					} else {
-						// Use the specified block, and supply a `nil`
-						// local block cache to ensure that a) only
-						// clean blocks are used, as blocks in the
-						// `lbc` might have already been touched by
-						// previous actions, and b) no new blocks are
-						// cached.
+						// Use the specified `dirData`, and supply a
+						// `nil` local block cache to ensure that a)
+						// only clean blocks are used, as blocks in
+						// the `lbc` might have already been touched
+						// by previous actions, and b) no new blocks
+						// are cached.
 						newPath := path{
 							FolderBranch: mergedPath.FolderBranch,
 							path: []pathNode{{

--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -139,22 +139,24 @@ func (cuea *copyUnmergedEntryAction) swapUnmergedBlock(
 func uniquifyName(
 	ctx context.Context, dir *dirData, name string) (string, error) {
 	_, err := dir.lookup(ctx, name)
-	_, notExists := errors.Cause(err).(NoSuchNameError)
-	if err != nil && !notExists {
-		return "", err
-	} else if notExists {
+	switch errors.Cause(err).(type) {
+	case nil:
+	case NoSuchNameError:
 		return name, nil
+	default:
+		return "", err
 	}
 
 	base, ext := splitExtension(name)
 	for i := 1; i <= 100; i++ {
 		newName := fmt.Sprintf("%s (%d)%s", base, i, ext)
 		_, err := dir.lookup(ctx, newName)
-		_, notExists := errors.Cause(err).(NoSuchNameError)
-		if err != nil && !notExists {
-			return "", err
-		} else if notExists {
+		switch errors.Cause(err).(type) {
+		case nil:
+		case NoSuchNameError:
 			return newName, nil
+		default:
+			return "", err
 		}
 	}
 
@@ -186,9 +188,11 @@ func (cuea *copyUnmergedEntryAction) do(
 
 	mergedEntry, err := mergedDir.lookup(ctx, cuea.toName)
 	mergedEntryOk := true
-	if _, notExists := errors.Cause(err).(NoSuchNameError); notExists {
+	switch errors.Cause(err).(type) {
+	case nil:
+	case NoSuchNameError:
 		mergedEntryOk = false
-	} else if err != nil {
+	default:
 		return err
 	}
 

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -292,14 +292,19 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 
 	// If we get down here, we have an ambiguity, and need to fetch
 	// the block to figure out the file type.
-	dblock, err := fbo.GetDirBlockForReading(ctx, makeFBOLockState(),
-		kmd, parentMostRecent, fbo.folderBranch.Branch, path{})
+	parentPath := path{
+		FolderBranch: fbo.folderBranch,
+		path:         []pathNode{{parentMostRecent, ""}},
+	}
+	parentDD := fbo.newDirDataWithLBC(
+		makeFBOLockState(), parentPath, keybase1.UserOrTeamID(""), kmd, nil)
+	entries, err := parentDD.getEntries(ctx)
 	if err != nil {
 		return err
 	}
 	// We don't have the file name handy, so search for the pointer.
 	found := false
-	for _, entry := range dblock.Children {
+	for _, entry := range entries {
 		if entry.BlockPointer != cc.mostRecent {
 			continue
 		}

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -891,13 +891,15 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 				// for a new file.
 				var filePtr BlockPointer
 				de, err := dd.lookup(ctx, name)
-				_, notExists := errors.Cause(err).(NoSuchNameError)
-				if err != nil && !notExists {
+				switch errors.Cause(err).(type) {
+				case nil:
+					filePtr = de.BlockPointer
+				case NoSuchNameError:
+				default:
 					fup.log.CWarningf(ctx, "Couldn't look up child: %+v", err)
 					continue
-				} else if !notExists {
-					filePtr = de.BlockPointer
 				}
+
 				fup.log.CDebugf(ctx, "Creating child node for name %s for "+
 					"parent %v", name, pnode.BlockPointer)
 				childPath := path{

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2231,10 +2231,10 @@ type crAction interface {
 	swapUnmergedBlock(
 		ctx context.Context, unmergedChains, mergedChains *crChains,
 		unmergedDir *dirData) (bool, BlockPointer, error)
-	// do modifies the given merged block in place to resolve the
-	// conflict, and potential uses the provided blockCopyFetchers to
-	// obtain copies of other blocks (along with new BlockPointers)
-	// when requiring a block copy.
+	// do modifies the given merged `dirData` in place to resolve the
+	// conflict, and potential uses the provided
+	// `fileBlockDeepCopier`s to obtain copies of other blocks (along
+	// with new BlockPointers) when requiring a file copy.
 	do(
 		ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier,
 		unmergedDir, mergedDir *dirData) error
@@ -2254,7 +2254,7 @@ type crAction interface {
 	//   chains.
 	// * updateOps doesn't necessarily result in correct BlockPointers within
 	//   each of those ops; that must happen in a later phase.
-	// * mergedBlock can be nil if the chain is for a file.
+	// * mergedDir can be nil if the chain is for a file.
 	updateOps(
 		ctx context.Context, unmergedMostRecent, mergedMostRecent BlockPointer,
 		unmergedDir, mergedDir *dirData,

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2228,15 +2228,16 @@ type crAction interface {
 	// corresponding to the returned BlockPointer instead of
 	// unmergedBlock when calling do().  If BlockPointer{} is zeroPtr
 	// (and true is returned), just swap in the regular mergedBlock.
-	swapUnmergedBlock(unmergedChains *crChains, mergedChains *crChains,
-		unmergedBlock *DirBlock) (bool, BlockPointer, error)
+	swapUnmergedBlock(
+		ctx context.Context, unmergedChains, mergedChains *crChains,
+		unmergedDir *dirData) (bool, BlockPointer, error)
 	// do modifies the given merged block in place to resolve the
 	// conflict, and potential uses the provided blockCopyFetchers to
 	// obtain copies of other blocks (along with new BlockPointers)
 	// when requiring a block copy.
-	do(ctx context.Context, unmergedCopier fileBlockDeepCopier,
-		mergedCopier fileBlockDeepCopier, unmergedBlock *DirBlock,
-		mergedBlock *DirBlock) error
+	do(
+		ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier,
+		unmergedDir, mergedDir *dirData) error
 	// updateOps potentially modifies, in place, the slices of
 	// unmerged and merged operations stored in the corresponding
 	// crChains for the given unmerged and merged most recent
@@ -2254,9 +2255,10 @@ type crAction interface {
 	// * updateOps doesn't necessarily result in correct BlockPointers within
 	//   each of those ops; that must happen in a later phase.
 	// * mergedBlock can be nil if the chain is for a file.
-	updateOps(unmergedMostRecent BlockPointer, mergedMostRecent BlockPointer,
-		unmergedBlock *DirBlock, mergedBlock *DirBlock,
-		unmergedChains *crChains, mergedChains *crChains) error
+	updateOps(
+		ctx context.Context, unmergedMostRecent, mergedMostRecent BlockPointer,
+		unmergedDir, mergedDir *dirData,
+		unmergedChains, mergedChains *crChains) error
 	// String returns a string representation for this crAction, used
 	// for debugging.
 	String() string

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8103,8 +8103,8 @@ func (m *MockcrAction) EXPECT() *MockcrActionMockRecorder {
 }
 
 // swapUnmergedBlock mocks base method
-func (m *MockcrAction) swapUnmergedBlock(unmergedChains, mergedChains *crChains, unmergedBlock *DirBlock) (bool, BlockPointer, error) {
-	ret := m.ctrl.Call(m, "swapUnmergedBlock", unmergedChains, mergedChains, unmergedBlock)
+func (m *MockcrAction) swapUnmergedBlock(ctx context.Context, unmergedChains, mergedChains *crChains, unmergedDir *dirData) (bool, BlockPointer, error) {
+	ret := m.ctrl.Call(m, "swapUnmergedBlock", ctx, unmergedChains, mergedChains, unmergedDir)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(BlockPointer)
 	ret2, _ := ret[2].(error)
@@ -8112,32 +8112,32 @@ func (m *MockcrAction) swapUnmergedBlock(unmergedChains, mergedChains *crChains,
 }
 
 // swapUnmergedBlock indicates an expected call of swapUnmergedBlock
-func (mr *MockcrActionMockRecorder) swapUnmergedBlock(unmergedChains, mergedChains, unmergedBlock interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "swapUnmergedBlock", reflect.TypeOf((*MockcrAction)(nil).swapUnmergedBlock), unmergedChains, mergedChains, unmergedBlock)
+func (mr *MockcrActionMockRecorder) swapUnmergedBlock(ctx, unmergedChains, mergedChains, unmergedDir interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "swapUnmergedBlock", reflect.TypeOf((*MockcrAction)(nil).swapUnmergedBlock), ctx, unmergedChains, mergedChains, unmergedDir)
 }
 
 // do mocks base method
-func (m *MockcrAction) do(ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier, unmergedBlock, mergedBlock *DirBlock) error {
-	ret := m.ctrl.Call(m, "do", ctx, unmergedCopier, mergedCopier, unmergedBlock, mergedBlock)
+func (m *MockcrAction) do(ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier, unmergedDir, mergedDir *dirData) error {
+	ret := m.ctrl.Call(m, "do", ctx, unmergedCopier, mergedCopier, unmergedDir, mergedDir)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // do indicates an expected call of do
-func (mr *MockcrActionMockRecorder) do(ctx, unmergedCopier, mergedCopier, unmergedBlock, mergedBlock interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "do", reflect.TypeOf((*MockcrAction)(nil).do), ctx, unmergedCopier, mergedCopier, unmergedBlock, mergedBlock)
+func (mr *MockcrActionMockRecorder) do(ctx, unmergedCopier, mergedCopier, unmergedDir, mergedDir interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "do", reflect.TypeOf((*MockcrAction)(nil).do), ctx, unmergedCopier, mergedCopier, unmergedDir, mergedDir)
 }
 
 // updateOps mocks base method
-func (m *MockcrAction) updateOps(unmergedMostRecent, mergedMostRecent BlockPointer, unmergedBlock, mergedBlock *DirBlock, unmergedChains, mergedChains *crChains) error {
-	ret := m.ctrl.Call(m, "updateOps", unmergedMostRecent, mergedMostRecent, unmergedBlock, mergedBlock, unmergedChains, mergedChains)
+func (m *MockcrAction) updateOps(ctx context.Context, unmergedMostRecent, mergedMostRecent BlockPointer, unmergedDir, mergedDir *dirData, unmergedChains, mergedChains *crChains) error {
+	ret := m.ctrl.Call(m, "updateOps", ctx, unmergedMostRecent, mergedMostRecent, unmergedDir, mergedDir, unmergedChains, mergedChains)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // updateOps indicates an expected call of updateOps
-func (mr *MockcrActionMockRecorder) updateOps(unmergedMostRecent, mergedMostRecent, unmergedBlock, mergedBlock, unmergedChains, mergedChains interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateOps", reflect.TypeOf((*MockcrAction)(nil).updateOps), unmergedMostRecent, mergedMostRecent, unmergedBlock, mergedBlock, unmergedChains, mergedChains)
+func (mr *MockcrActionMockRecorder) updateOps(ctx, unmergedMostRecent, mergedMostRecent, unmergedDir, mergedDir, unmergedChains, mergedChains interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateOps", reflect.TypeOf((*MockcrAction)(nil).updateOps), ctx, unmergedMostRecent, mergedMostRecent, unmergedDir, mergedDir, unmergedChains, mergedChains)
 }
 
 // String mocks base method


### PR DESCRIPTION
This removes all direct uses of directory blocks from the conflict resolution process, and replaces them with `dirData` uses that support multiple levels of indirection in directories.

Note that this probably won't do block pointer accounting correctly when there are levels of indirection.  I'll do that in a followup PR.

Issue: KBFS-3303