### PR TITLE
Remove a bunch of libkb references

### DIFF
--- a/env/context.go
+++ b/env/context.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"sync"
 
+	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -43,7 +44,7 @@ func (easu EmptyAppStateUpdater) NextAppStateUpdate(lastState *keybase1.AppState
 // Context defines the environment for this package
 type Context interface {
 	AppStateUpdater
-	GetRunMode() libkb.RunMode
+	GetRunMode() kbconst.RunMode
 	GetLogDir() string
 	GetDataDir() string
 	GetMountDir() (string, error)
@@ -109,7 +110,7 @@ func (c *KBFSContext) GetMountDir() (string, error) {
 }
 
 // GetRunMode returns run mode
-func (c *KBFSContext) GetRunMode() libkb.RunMode {
+func (c *KBFSContext) GetRunMode() kbconst.RunMode {
 	return c.g.GetRunMode()
 }
 

--- a/kbfscrypto/auth_token.go
+++ b/kbfscrypto/auth_token.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/auth"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -56,7 +56,7 @@ func NewAuthToken(signer Signer, tokenType string, expireIn int,
 // Sign is called to create a new signed authentication token.
 func (a *AuthToken) signWithUserAndKeyInfo(ctx context.Context,
 	challengeInfo keybase1.ChallengeInfo, uid keybase1.UID,
-	username libkb.NormalizedUsername, key VerifyingKey) (string, error) {
+	username kbun.NormalizedUsername, key VerifyingKey) (string, error) {
 	// create the token
 	token := auth.NewToken(uid, username, key.KID(), a.tokenType,
 		challengeInfo.Challenge, challengeInfo.Now, a.expireIn,
@@ -81,7 +81,7 @@ func (a *AuthToken) signWithUserAndKeyInfo(ctx context.Context,
 // Sign is called to create a new signed authentication token,
 // including a challenge and username/uid/kid identifiers.
 func (a *AuthToken) Sign(ctx context.Context,
-	currentUsername libkb.NormalizedUsername, currentUID keybase1.UID,
+	currentUsername kbun.NormalizedUsername, currentUID keybase1.UID,
 	currentVerifyingKey VerifyingKey,
 	challengeInfo keybase1.ChallengeInfo) (string, error) {
 	// make sure we're being asked to sign a legit challenge

--- a/kbfscrypto/auth_token.go
+++ b/kbfscrypto/auth_token.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/auth"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -56,7 +56,7 @@ func NewAuthToken(signer Signer, tokenType string, expireIn int,
 // Sign is called to create a new signed authentication token.
 func (a *AuthToken) signWithUserAndKeyInfo(ctx context.Context,
 	challengeInfo keybase1.ChallengeInfo, uid keybase1.UID,
-	username kbun.NormalizedUsername, key VerifyingKey) (string, error) {
+	username kbname.NormalizedUsername, key VerifyingKey) (string, error) {
 	// create the token
 	token := auth.NewToken(uid, username, key.KID(), a.tokenType,
 		challengeInfo.Challenge, challengeInfo.Now, a.expireIn,
@@ -81,7 +81,7 @@ func (a *AuthToken) signWithUserAndKeyInfo(ctx context.Context,
 // Sign is called to create a new signed authentication token,
 // including a challenge and username/uid/kid identifiers.
 func (a *AuthToken) Sign(ctx context.Context,
-	currentUsername kbun.NormalizedUsername, currentUID keybase1.UID,
+	currentUsername kbname.NormalizedUsername, currentUID keybase1.UID,
 	currentVerifyingKey VerifyingKey,
 	challengeInfo keybase1.ChallengeInfo) (string, error) {
 	// make sure we're being asked to sign a legit challenge

--- a/kbfsgit/git-remote-keybase/main.go
+++ b/kbfsgit/git-remote-keybase/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/kbfsgit"
@@ -56,10 +57,10 @@ func start() (startErr *libfs.Error) {
 	kbCtx := env.NewContext()
 
 	switch kbCtx.GetRunMode() {
-	case libkb.ProductionRunMode:
-	case libkb.StagingRunMode:
+	case kbconst.ProductionRunMode:
+	case kbconst.StagingRunMode:
 		fmt.Fprintf(os.Stderr, "Running in staging mode\n")
-	case libkb.DevelRunMode:
+	case kbconst.DevelRunMode:
 		fmt.Fprintf(os.Stderr, "Running in devel mode\n")
 	default:
 		panic(fmt.Sprintf("Unexpected run mode: %s", kbCtx.GetRunMode()))

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -269,7 +269,7 @@ func clearFolderListCacheLoop(ctx context.Context, r *Root) {
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbun.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbname.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -283,7 +283,7 @@ func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbun.Normalize
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
 	}
-	if newUser != kbun.NormalizedUsername("") {
+	if newUser != kbname.NormalizedUsername("") {
 		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libdokan/folderlist.go
+++ b/libdokan/folderlist.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -269,7 +269,7 @@ func clearFolderListCacheLoop(ctx context.Context, r *Root) {
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbun.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -283,7 +283,7 @@ func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.Normaliz
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
 	}
-	if newUser != libkb.NormalizedUsername("") {
+	if newUser != kbun.NormalizedUsername("") {
 		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/dokan/winacl"
@@ -630,7 +630,7 @@ func (f *FS) logEnterf(ctx context.Context, fmt string, args ...interface{}) {
 }
 
 // UserChanged is called from libfs.
-func (f *FS) UserChanged(ctx context.Context, oldName, newName kbun.NormalizedUsername) {
+func (f *FS) UserChanged(ctx context.Context, oldName, newName kbname.NormalizedUsername) {
 	f.log.CDebugf(ctx, "User changed: %q -> %q", oldName, newName)
 	f.root.public.userChanged(ctx, oldName, newName)
 	f.root.private.userChanged(ctx, oldName, newName)

--- a/libdokan/fs.go
+++ b/libdokan/fs.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/dokan/winacl"
@@ -630,7 +630,7 @@ func (f *FS) logEnterf(ctx context.Context, fmt string, args ...interface{}) {
 }
 
 // UserChanged is called from libfs.
-func (f *FS) UserChanged(ctx context.Context, oldName, newName libkb.NormalizedUsername) {
+func (f *FS) UserChanged(ctx context.Context, oldName, newName kbun.NormalizedUsername) {
 	f.log.CDebugf(ctx, "User changed: %q -> %q", oldName, newName)
 	f.root.public.userChanged(ctx, oldName, newName)
 	f.root.private.userChanged(ctx, oldName, newName)

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/ioutil"
@@ -3129,7 +3129,7 @@ func TestKbfsFileInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dst.LastWriterUnverified != kbun.NormalizedUsername("user1") {
+	if dst.LastWriterUnverified != kbname.NormalizedUsername("user1") {
 		t.Fatalf("Expected user1, %v raw %X", dst, bs)
 	}
 }

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/dokan"
 	"github.com/keybase/kbfs/ioutil"

--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -3129,7 +3129,7 @@ func TestKbfsFileInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dst.LastWriterUnverified != libkb.NormalizedUsername("user1") {
+	if dst.LastWriterUnverified != kbun.NormalizedUsername("user1") {
 		t.Fatalf("Expected user1, %v raw %X", dst, bs)
 	}
 }

--- a/libfs/remote_status.go
+++ b/libfs/remote_status.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/libkbfs"
@@ -29,14 +29,14 @@ const (
 type RemoteStatusUpdater interface {
 	// UserChanged is called when the kbfs user is changed.
 	// Either oldName or newName, or both may be empty.
-	UserChanged(ctx context.Context, oldName, newName kbun.NormalizedUsername)
+	UserChanged(ctx context.Context, oldName, newName kbname.NormalizedUsername)
 }
 
 // RemoteStatus is for maintaining status of various remote connections like keybase
 // service and md-server.
 type RemoteStatus struct {
 	sync.Mutex
-	currentUser       kbun.NormalizedUsername
+	currentUser       kbname.NormalizedUsername
 	failingServices   map[string]error
 	extraFileName     string
 	extraFileContents []byte
@@ -76,8 +76,8 @@ func (r *RemoteStatus) update(ctx context.Context, st libkbfs.KBFSStatus) {
 	r.Lock()
 	defer r.Unlock()
 
-	if newUser := kbun.NormalizedUsername(st.CurrentUser); r.currentUser != newUser {
-		oldUser := kbun.NormalizedUsername(r.currentUser)
+	if newUser := kbname.NormalizedUsername(st.CurrentUser); r.currentUser != newUser {
+		oldUser := kbname.NormalizedUsername(r.currentUser)
 		r.currentUser = newUser
 		if r.callbacks != nil {
 			go r.callbacks.UserChanged(ctx, oldUser, newUser)

--- a/libfs/remote_status.go
+++ b/libfs/remote_status.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/libkbfs"
@@ -28,14 +29,14 @@ const (
 type RemoteStatusUpdater interface {
 	// UserChanged is called when the kbfs user is changed.
 	// Either oldName or newName, or both may be empty.
-	UserChanged(ctx context.Context, oldName, newName libkb.NormalizedUsername)
+	UserChanged(ctx context.Context, oldName, newName kbun.NormalizedUsername)
 }
 
 // RemoteStatus is for maintaining status of various remote connections like keybase
 // service and md-server.
 type RemoteStatus struct {
 	sync.Mutex
-	currentUser       libkb.NormalizedUsername
+	currentUser       kbun.NormalizedUsername
 	failingServices   map[string]error
 	extraFileName     string
 	extraFileContents []byte
@@ -75,8 +76,8 @@ func (r *RemoteStatus) update(ctx context.Context, st libkbfs.KBFSStatus) {
 	r.Lock()
 	defer r.Unlock()
 
-	if newUser := libkb.NormalizedUsername(st.CurrentUser); r.currentUser != newUser {
-		oldUser := libkb.NormalizedUsername(r.currentUser)
+	if newUser := kbun.NormalizedUsername(st.CurrentUser); r.currentUser != newUser {
+		oldUser := kbun.NormalizedUsername(r.currentUser)
 		r.currentUser = newUser
 		if r.callbacks != nil {
 			go r.callbacks.UserChanged(ctx, oldUser, newUser)

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -14,7 +14,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
@@ -349,7 +349,7 @@ func (fl *FolderList) updateTlfName(ctx context.Context, oldName string,
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbun.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbname.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -361,7 +361,7 @@ func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbun.Normalize
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
 	}
-	if newUser != kbun.NormalizedUsername("") {
+	if newUser != kbname.NormalizedUsername("") {
 		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -14,7 +14,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
@@ -349,7 +349,7 @@ func (fl *FolderList) updateTlfName(ctx context.Context, oldName string,
 }
 
 // update things after user changed.
-func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.NormalizedUsername) {
+func (fl *FolderList) userChanged(ctx context.Context, _, newUser kbun.NormalizedUsername) {
 	var fs []*Folder
 	func() {
 		fl.mu.Lock()
@@ -361,7 +361,7 @@ func (fl *FolderList) userChanged(ctx context.Context, _, newUser libkb.Normaliz
 	for _, f := range fs {
 		f.TlfHandleChange(ctx, nil)
 	}
-	if newUser != libkb.NormalizedUsername("") {
+	if newUser != kbun.NormalizedUsername("") {
 		fl.fs.config.KBFSOps().ForceFastForward(ctx)
 	}
 }

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -18,7 +18,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -332,7 +332,7 @@ func (f *FS) Serve(ctx context.Context) error {
 }
 
 // UserChanged is called from libfs.
-func (f *FS) UserChanged(ctx context.Context, oldName, newName libkb.NormalizedUsername) {
+func (f *FS) UserChanged(ctx context.Context, oldName, newName kbun.NormalizedUsername) {
 	f.log.CDebugf(ctx, "User changed: %q -> %q", oldName, newName)
 	f.root.public.userChanged(ctx, oldName, newName)
 	f.root.private.userChanged(ctx, oldName, newName)

--- a/libfuse/fs.go
+++ b/libfuse/fs.go
@@ -18,7 +18,7 @@ import (
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
@@ -332,7 +332,7 @@ func (f *FS) Serve(ctx context.Context) error {
 }
 
 // UserChanged is called from libfs.
-func (f *FS) UserChanged(ctx context.Context, oldName, newName kbun.NormalizedUsername) {
+func (f *FS) UserChanged(ctx context.Context, oldName, newName kbname.NormalizedUsername) {
 	f.log.CDebugf(ctx, "User changed: %q -> %q", oldName, newName)
 	f.root.public.userChanged(ctx, oldName, newName)
 	f.root.private.userChanged(ctx, oldName, newName)

--- a/libfuse/fs_darwin.go
+++ b/libfuse/fs_darwin.go
@@ -117,7 +117,7 @@ func bundleResourcePath(path string) (string, error) {
 // disseminates renames into different TLF's trash.
 type Trash struct {
 	fs         *FS
-	kbusername libkb.NormalizedUsername
+	kbusername kbun.NormalizedUsername
 }
 
 // Lookup implements the fs.NodeRequestLookuper interface for *Trash

--- a/libfuse/fs_darwin.go
+++ b/libfuse/fs_darwin.go
@@ -14,7 +14,7 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/kardianos/osext"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )

--- a/libfuse/fs_darwin.go
+++ b/libfuse/fs_darwin.go
@@ -14,7 +14,7 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"github.com/kardianos/osext"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
@@ -117,7 +117,7 @@ func bundleResourcePath(path string) (string, error) {
 // disseminates renames into different TLF's trash.
 type Trash struct {
 	fs         *FS
-	kbusername kbun.NormalizedUsername
+	kbusername kbname.NormalizedUsername
 }
 
 // Lookup implements the fs.NodeRequestLookuper interface for *Trash

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -22,7 +22,7 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
@@ -476,8 +476,8 @@ type kbserviceBrokenIdentify struct {
 }
 
 func (k kbserviceBrokenIdentify) Identify(ctx context.Context, assertion,
-	reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+	reason string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 		errors.New("Fake identify error")
 }
 
@@ -3843,7 +3843,7 @@ func TestKbfsFileInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dst.LastWriterUnverified != libkb.NormalizedUsername("user1") {
+	if dst.LastWriterUnverified != kbun.NormalizedUsername("user1") {
 		t.Fatalf("Expected user1, %v raw %X", dst, bs)
 	}
 }

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -22,7 +22,7 @@ import (
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
 	"bazil.org/fuse/fs/fstestutil"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
@@ -476,8 +476,8 @@ type kbserviceBrokenIdentify struct {
 }
 
 func (k kbserviceBrokenIdentify) Identify(ctx context.Context, assertion,
-	reason string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+	reason string) (kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 		errors.New("Fake identify error")
 }
 
@@ -3843,7 +3843,7 @@ func TestKbfsFileInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dst.LastWriterUnverified != kbun.NormalizedUsername("user1") {
+	if dst.LastWriterUnverified != kbname.NormalizedUsername("user1") {
 		t.Fatalf("Expected user1, %v raw %X", dst, bs)
 	}
 }

--- a/libfuse/mounter.go
+++ b/libfuse/mounter.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"bazil.org/fuse"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/logger"
 )
 
@@ -22,7 +22,7 @@ type mounter struct {
 	options StartOptions
 	c       *fuse.Conn
 	log     logger.Logger
-	runMode libkb.RunMode
+	runMode kbconst.RunMode
 }
 
 // fuseMount tries to mount the mountpoint.

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libfs"
@@ -69,7 +69,7 @@ func (c *configNoShutdown) Shutdown(_ context.Context) error {
 // server implementations as the given `config`.
 type newConfigger struct {
 	config    *libkbfs.ConfigLocal
-	user      kbun.NormalizedUsername
+	user      kbname.NormalizedUsername
 	newConfig *libkbfs.ConfigLocal
 }
 

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libfs"
@@ -69,7 +69,7 @@ func (c *configNoShutdown) Shutdown(_ context.Context) error {
 // server implementations as the given `config`.
 type newConfigger struct {
 	config    *libkbfs.ConfigLocal
-	user      libkb.NormalizedUsername
+	user      kbun.NormalizedUsername
 	newConfig *libkbfs.ConfigLocal
 }
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/cache"
@@ -279,7 +279,7 @@ func (lu LocalUser) deepCopy() LocalUser {
 
 // MakeLocalUserSigningKeyOrBust returns a unique signing key for this user.
 func MakeLocalUserSigningKeyOrBust(
-	name libkb.NormalizedUsername) kbfscrypto.SigningKey {
+	name kbun.NormalizedUsername) kbfscrypto.SigningKey {
 	return kbfscrypto.MakeFakeSigningKeyOrBust(
 		string(name) + " signing key")
 }
@@ -287,14 +287,14 @@ func MakeLocalUserSigningKeyOrBust(
 // MakeLocalUserVerifyingKeyOrBust makes a new verifying key
 // corresponding to the signing key for this user.
 func MakeLocalUserVerifyingKeyOrBust(
-	name libkb.NormalizedUsername) kbfscrypto.VerifyingKey {
+	name kbun.NormalizedUsername) kbfscrypto.VerifyingKey {
 	return MakeLocalUserSigningKeyOrBust(name).GetVerifyingKey()
 }
 
 // MakeLocalUserCryptPrivateKeyOrBust returns a unique private
 // encryption key for this user.
 func MakeLocalUserCryptPrivateKeyOrBust(
-	name libkb.NormalizedUsername) kbfscrypto.CryptPrivateKey {
+	name kbun.NormalizedUsername) kbfscrypto.CryptPrivateKey {
 	return kbfscrypto.MakeFakeCryptPrivateKeyOrBust(
 		string(name) + " crypt key")
 }
@@ -302,7 +302,7 @@ func MakeLocalUserCryptPrivateKeyOrBust(
 // MakeLocalUserCryptPublicKeyOrBust returns the public key
 // corresponding to the crypt private key for this user.
 func MakeLocalUserCryptPublicKeyOrBust(
-	name libkb.NormalizedUsername) kbfscrypto.CryptPublicKey {
+	name kbun.NormalizedUsername) kbfscrypto.CryptPublicKey {
 	return MakeLocalUserCryptPrivateKeyOrBust(name).GetPublicKey()
 }
 
@@ -318,7 +318,7 @@ func MakeLocalTLFCryptKeyOrBust(
 
 // MakeLocalUsers is a helper function to generate a list of
 // LocalUsers suitable to use with KeybaseDaemonLocal.
-func MakeLocalUsers(users []libkb.NormalizedUsername) []LocalUser {
+func MakeLocalUsers(users []kbun.NormalizedUsername) []LocalUser {
 	localUsers := make([]LocalUser, len(users))
 	for i := 0; i < len(users); i++ {
 		verifyingKey := MakeLocalUserVerifyingKeyOrBust(users[i])
@@ -341,7 +341,7 @@ func MakeLocalUsers(users []libkb.NormalizedUsername) []LocalUser {
 }
 
 func makeLocalTeams(
-	teams []libkb.NormalizedUsername, startingIndex int, ty tlf.Type) (
+	teams []kbun.NormalizedUsername, startingIndex int, ty tlf.Type) (
 	localTeams []TeamInfo) {
 	localTeams = make([]TeamInfo, len(teams))
 	for index := 0; index < len(teams); index++ {
@@ -375,7 +375,7 @@ func makeLocalTeams(
 // MakeLocalTeams is a helper function to generate a list of local
 // teams suitable to use with KeybaseDaemonLocal.  Any subteams must come
 // after their root team names in the `teams` slice.
-func MakeLocalTeams(teams []libkb.NormalizedUsername) []TeamInfo {
+func MakeLocalTeams(teams []kbun.NormalizedUsername) []TeamInfo {
 	return makeLocalTeams(teams, 0, tlf.Private)
 }
 

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/cache"
@@ -279,7 +279,7 @@ func (lu LocalUser) deepCopy() LocalUser {
 
 // MakeLocalUserSigningKeyOrBust returns a unique signing key for this user.
 func MakeLocalUserSigningKeyOrBust(
-	name kbun.NormalizedUsername) kbfscrypto.SigningKey {
+	name kbname.NormalizedUsername) kbfscrypto.SigningKey {
 	return kbfscrypto.MakeFakeSigningKeyOrBust(
 		string(name) + " signing key")
 }
@@ -287,14 +287,14 @@ func MakeLocalUserSigningKeyOrBust(
 // MakeLocalUserVerifyingKeyOrBust makes a new verifying key
 // corresponding to the signing key for this user.
 func MakeLocalUserVerifyingKeyOrBust(
-	name kbun.NormalizedUsername) kbfscrypto.VerifyingKey {
+	name kbname.NormalizedUsername) kbfscrypto.VerifyingKey {
 	return MakeLocalUserSigningKeyOrBust(name).GetVerifyingKey()
 }
 
 // MakeLocalUserCryptPrivateKeyOrBust returns a unique private
 // encryption key for this user.
 func MakeLocalUserCryptPrivateKeyOrBust(
-	name kbun.NormalizedUsername) kbfscrypto.CryptPrivateKey {
+	name kbname.NormalizedUsername) kbfscrypto.CryptPrivateKey {
 	return kbfscrypto.MakeFakeCryptPrivateKeyOrBust(
 		string(name) + " crypt key")
 }
@@ -302,7 +302,7 @@ func MakeLocalUserCryptPrivateKeyOrBust(
 // MakeLocalUserCryptPublicKeyOrBust returns the public key
 // corresponding to the crypt private key for this user.
 func MakeLocalUserCryptPublicKeyOrBust(
-	name kbun.NormalizedUsername) kbfscrypto.CryptPublicKey {
+	name kbname.NormalizedUsername) kbfscrypto.CryptPublicKey {
 	return MakeLocalUserCryptPrivateKeyOrBust(name).GetPublicKey()
 }
 
@@ -318,7 +318,7 @@ func MakeLocalTLFCryptKeyOrBust(
 
 // MakeLocalUsers is a helper function to generate a list of
 // LocalUsers suitable to use with KeybaseDaemonLocal.
-func MakeLocalUsers(users []kbun.NormalizedUsername) []LocalUser {
+func MakeLocalUsers(users []kbname.NormalizedUsername) []LocalUser {
 	localUsers := make([]LocalUser, len(users))
 	for i := 0; i < len(users); i++ {
 		verifyingKey := MakeLocalUserVerifyingKeyOrBust(users[i])
@@ -341,7 +341,7 @@ func MakeLocalUsers(users []kbun.NormalizedUsername) []LocalUser {
 }
 
 func makeLocalTeams(
-	teams []kbun.NormalizedUsername, startingIndex int, ty tlf.Type) (
+	teams []kbname.NormalizedUsername, startingIndex int, ty tlf.Type) (
 	localTeams []TeamInfo) {
 	localTeams = make([]TeamInfo, len(teams))
 	for index := 0; index < len(teams); index++ {
@@ -375,7 +375,7 @@ func makeLocalTeams(
 // MakeLocalTeams is a helper function to generate a list of local
 // teams suitable to use with KeybaseDaemonLocal.  Any subteams must come
 // after their root team names in the `teams` slice.
-func MakeLocalTeams(teams []kbun.NormalizedUsername) []TeamInfo {
+func MakeLocalTeams(teams []kbname.NormalizedUsername) []TeamInfo {
 	return makeLocalTeams(teams, 0, tlf.Private)
 }
 

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -34,7 +34,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 		FolderBranch{id, MasterBranch}, standard)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(gomock.Any(), gomock.Any()).
-		AnyTimes().Return(libkb.NormalizedUsername("mockUser"), nil)
+		AnyTimes().Return(kbun.NormalizedUsername("mockUser"), nil)
 
 	mockDaemon := NewMockKeybaseService(mockCtrl)
 	mockDaemon.EXPECT().LoadUserPlusKeys(
@@ -393,7 +393,7 @@ func testCRGetCROrBust(t *testing.T, config Config,
 // and make sure the resulting unmerged path maps correctly to the
 // merged path.
 func TestCRMergedChainsSimple(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -462,7 +462,7 @@ func TestCRMergedChainsSimple(t *testing.T) {
 // different, unrelated subdirectories, forcing the resolver to use
 // mostly original block pointers when constructing the merged path.
 func TestCRMergedChainsDifferentDirectories(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -533,7 +533,7 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 // the subdirectories used by u2, forcing the resolver to generate
 // some recreateOps.
 func TestCRMergedChainsDeletedDirectories(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -639,7 +639,7 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 // the subdirectories used by u2, forcing the resolver to follow the
 // path across the rename.
 func TestCRMergedChainsRenamedDirectory(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -728,7 +728,7 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 // types of operations thrown in the mix (like u2 deleting unrelated
 // directories, etc).
 func TestCRMergedChainsComplex(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -924,7 +924,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 
 // Tests that conflict resolution detects and can fix rename cycles.
 func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1020,7 +1020,7 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 
 // Tests that conflict resolution detects and renames conflicts.
 func TestCRMergedChainsConflictSimple(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1099,7 +1099,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 
 // Tests that conflict resolution detects and renames conflicts.
 func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1219,7 +1219,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 // Test that actions get executed properly in the simple case of two
 // files being created simultaneously in the same directory.
 func TestCRDoActionsSimple(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1317,7 +1317,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 // Test that actions get executed properly in the case of two
 // simultaneous writes to the same file.
 func TestCRDoActionsWriteConflict(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -34,7 +34,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 		FolderBranch{id, MasterBranch}, standard)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(gomock.Any(), gomock.Any()).
-		AnyTimes().Return(kbun.NormalizedUsername("mockUser"), nil)
+		AnyTimes().Return(kbname.NormalizedUsername("mockUser"), nil)
 
 	mockDaemon := NewMockKeybaseService(mockCtrl)
 	mockDaemon.EXPECT().LoadUserPlusKeys(
@@ -393,7 +393,7 @@ func testCRGetCROrBust(t *testing.T, config Config,
 // and make sure the resulting unmerged path maps correctly to the
 // merged path.
 func TestCRMergedChainsSimple(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -462,7 +462,7 @@ func TestCRMergedChainsSimple(t *testing.T) {
 // different, unrelated subdirectories, forcing the resolver to use
 // mostly original block pointers when constructing the merged path.
 func TestCRMergedChainsDifferentDirectories(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -533,7 +533,7 @@ func TestCRMergedChainsDifferentDirectories(t *testing.T) {
 // the subdirectories used by u2, forcing the resolver to generate
 // some recreateOps.
 func TestCRMergedChainsDeletedDirectories(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -639,7 +639,7 @@ func TestCRMergedChainsDeletedDirectories(t *testing.T) {
 // the subdirectories used by u2, forcing the resolver to follow the
 // path across the rename.
 func TestCRMergedChainsRenamedDirectory(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -728,7 +728,7 @@ func TestCRMergedChainsRenamedDirectory(t *testing.T) {
 // types of operations thrown in the mix (like u2 deleting unrelated
 // directories, etc).
 func TestCRMergedChainsComplex(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -924,7 +924,7 @@ func TestCRMergedChainsComplex(t *testing.T) {
 
 // Tests that conflict resolution detects and can fix rename cycles.
 func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1020,7 +1020,7 @@ func TestCRMergedChainsRenameCycleSimple(t *testing.T) {
 
 // Tests that conflict resolution detects and renames conflicts.
 func TestCRMergedChainsConflictSimple(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1099,7 +1099,7 @@ func TestCRMergedChainsConflictSimple(t *testing.T) {
 
 // Tests that conflict resolution detects and renames conflicts.
 func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1219,7 +1219,7 @@ func TestCRMergedChainsConflictFileCollapse(t *testing.T) {
 // Test that actions get executed properly in the simple case of two
 // files being created simultaneously in the same directory.
 func TestCRDoActionsSimple(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1317,7 +1317,7 @@ func TestCRDoActionsSimple(t *testing.T) {
 // Test that actions get executed properly in the case of two
 // simultaneous writes to the same file.
 func TestCRDoActionsWriteConflict(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -46,7 +47,7 @@ type revokedKeyInfo struct {
 // UserInfo contains all the info about a keybase user that kbfs cares
 // about.
 type UserInfo struct {
-	Name            libkb.NormalizedUsername
+	Name            kbun.NormalizedUsername
 	UID             keybase1.UID
 	VerifyingKeys   []kbfscrypto.VerifyingKey
 	CryptPublicKeys []kbfscrypto.CryptPublicKey
@@ -65,7 +66,7 @@ type TeamInfo struct {
 	// a nice type, unfortunately.  Also note that for implicit teams,
 	// this is an auto-generated name that shouldn't be shown to
 	// users.
-	Name         libkb.NormalizedUsername
+	Name         kbun.NormalizedUsername
 	TID          keybase1.TeamID
 	CryptKeys    map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey
 	LatestKeyGen kbfsmd.KeyGen
@@ -83,7 +84,7 @@ type TeamInfo struct {
 // resolving/identifying an implicit team.  TeamInfo is used for
 // anything else.
 type ImplicitTeamInfo struct {
-	Name  libkb.NormalizedUsername // The "display" name for the i-team.
+	Name  kbun.NormalizedUsername // The "display" name for the i-team.
 	TID   keybase1.TeamID
 	TlfID tlf.ID
 }
@@ -91,7 +92,7 @@ type ImplicitTeamInfo struct {
 // SessionInfo contains all the info about the keybase session that
 // kbfs cares about.
 type SessionInfo struct {
-	Name           libkb.NormalizedUsername
+	Name           kbun.NormalizedUsername
 	UID            keybase1.UID
 	CryptPublicKey kbfscrypto.CryptPublicKey
 	VerifyingKey   kbfscrypto.VerifyingKey
@@ -687,7 +688,7 @@ type NodeMetadata struct {
 	// LastWriterUnverified is the last writer of this
 	// node according to the last writer of the TLF.
 	// A more thorough check is possible in the future.
-	LastWriterUnverified libkb.NormalizedUsername
+	LastWriterUnverified kbun.NormalizedUsername
 	BlockInfo            BlockInfo
 	PrefetchStatus       string
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -676,7 +676,7 @@ func SessionInfoFromProtocol(session keybase1.Session) (SessionInfo, error) {
 	cryptPublicKey := kbfscrypto.MakeCryptPublicKey(deviceSubkey.GetKID())
 	verifyingKey := kbfscrypto.MakeVerifyingKey(deviceSibkey.GetKID())
 	return SessionInfo{
-		Name:           libkb.NewNormalizedUsername(session.Username),
+		Name:           kbun.NewNormalizedUsername(session.Username),
 		UID:            keybase1.UID(session.Uid),
 		CryptPublicKey: cryptPublicKey,
 		VerifyingKey:   verifyingKey,

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -47,7 +47,7 @@ type revokedKeyInfo struct {
 // UserInfo contains all the info about a keybase user that kbfs cares
 // about.
 type UserInfo struct {
-	Name            kbun.NormalizedUsername
+	Name            kbname.NormalizedUsername
 	UID             keybase1.UID
 	VerifyingKeys   []kbfscrypto.VerifyingKey
 	CryptPublicKeys []kbfscrypto.CryptPublicKey
@@ -66,7 +66,7 @@ type TeamInfo struct {
 	// a nice type, unfortunately.  Also note that for implicit teams,
 	// this is an auto-generated name that shouldn't be shown to
 	// users.
-	Name         kbun.NormalizedUsername
+	Name         kbname.NormalizedUsername
 	TID          keybase1.TeamID
 	CryptKeys    map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey
 	LatestKeyGen kbfsmd.KeyGen
@@ -84,7 +84,7 @@ type TeamInfo struct {
 // resolving/identifying an implicit team.  TeamInfo is used for
 // anything else.
 type ImplicitTeamInfo struct {
-	Name  kbun.NormalizedUsername // The "display" name for the i-team.
+	Name  kbname.NormalizedUsername // The "display" name for the i-team.
 	TID   keybase1.TeamID
 	TlfID tlf.ID
 }
@@ -92,7 +92,7 @@ type ImplicitTeamInfo struct {
 // SessionInfo contains all the info about the keybase session that
 // kbfs cares about.
 type SessionInfo struct {
-	Name           kbun.NormalizedUsername
+	Name           kbname.NormalizedUsername
 	UID            keybase1.UID
 	CryptPublicKey kbfscrypto.CryptPublicKey
 	VerifyingKey   kbfscrypto.VerifyingKey
@@ -676,7 +676,7 @@ func SessionInfoFromProtocol(session keybase1.Session) (SessionInfo, error) {
 	cryptPublicKey := kbfscrypto.MakeCryptPublicKey(deviceSubkey.GetKID())
 	verifyingKey := kbfscrypto.MakeVerifyingKey(deviceSibkey.GetKID())
 	return SessionInfo{
-		Name:           kbun.NewNormalizedUsername(session.Username),
+		Name:           kbname.NewNormalizedUsername(session.Username),
 		UID:            keybase1.UID(session.Uid),
 		CryptPublicKey: cryptPublicKey,
 		VerifyingKey:   verifyingKey,
@@ -688,7 +688,7 @@ type NodeMetadata struct {
 	// LastWriterUnverified is the last writer of this
 	// node according to the last writer of the TLF.
 	// A more thorough check is possible in the future.
-	LastWriterUnverified kbun.NormalizedUsername
+	LastWriterUnverified kbname.NormalizedUsername
 	BlockInfo            BlockInfo
 	PrefetchStatus       string
 }

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -172,7 +172,7 @@ func (e ErrorFileAccessError) Error() string {
 // ReadAccessError indicates that the user tried to read from a
 // top-level folder without read permission.
 type ReadAccessError struct {
-	User     libkb.NormalizedUsername
+	User     kbun.NormalizedUsername
 	Filename string
 	Tlf      tlf.CanonicalName
 	Type     tlf.Type
@@ -186,7 +186,7 @@ func (e ReadAccessError) Error() string {
 
 // WriteAccessError indicates an error when trying to write a file
 type WriteAccessError struct {
-	User     libkb.NormalizedUsername
+	User     kbun.NormalizedUsername
 	Filename string
 	Tlf      tlf.CanonicalName
 	Type     tlf.Type
@@ -236,7 +236,7 @@ func (e UnsupportedOpInUnlinkedDirError) Error() string {
 
 // NewReadAccessError constructs a ReadAccessError for the given
 // directory and user.
-func NewReadAccessError(h *TlfHandle, username libkb.NormalizedUsername, filename string) error {
+func NewReadAccessError(h *TlfHandle, username kbun.NormalizedUsername, filename string) error {
 	tlfname := h.GetCanonicalName()
 	return ReadAccessError{
 		User:     username,
@@ -247,7 +247,7 @@ func NewReadAccessError(h *TlfHandle, username libkb.NormalizedUsername, filenam
 }
 
 // NewWriteAccessError is an access error trying to write a file
-func NewWriteAccessError(h *TlfHandle, username libkb.NormalizedUsername, filename string) error {
+func NewWriteAccessError(h *TlfHandle, username kbun.NormalizedUsername, filename string) error {
 	tlfName := tlf.CanonicalName("")
 	t := tlf.Private
 	if h != nil {
@@ -582,7 +582,7 @@ func (e VerifyingKeyNotFoundError) Error() string {
 // verified.
 type UnverifiableTlfUpdateError struct {
 	Tlf  string
-	User libkb.NormalizedUsername
+	User kbun.NormalizedUsername
 	Err  error
 }
 
@@ -835,7 +835,7 @@ var NoCurrentSessionExpectedError = "no current session"
 // RekeyPermissionError indicates that the user tried to rekey a
 // top-level folder in a manner inconsistent with their permissions.
 type RekeyPermissionError struct {
-	User libkb.NormalizedUsername
+	User kbun.NormalizedUsername
 	Dir  string
 }
 
@@ -848,7 +848,7 @@ func (e RekeyPermissionError) Error() string {
 // NewRekeyPermissionError constructs a RekeyPermissionError for the given
 // directory and user.
 func NewRekeyPermissionError(
-	dir *TlfHandle, username libkb.NormalizedUsername) error {
+	dir *TlfHandle, username kbun.NormalizedUsername) error {
 	dirname := dir.GetCanonicalPath()
 	return RekeyPermissionError{username, dirname}
 }
@@ -1019,7 +1019,7 @@ func (e TlfHandleFinalizedError) Error() string {
 // NoSigChainError means that a user we were trying to identify does
 // not have a sigchain.
 type NoSigChainError struct {
-	User libkb.NormalizedUsername
+	User kbun.NormalizedUsername
 }
 
 // Error implements the error interface for NoSigChainError.

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -172,7 +172,7 @@ func (e ErrorFileAccessError) Error() string {
 // ReadAccessError indicates that the user tried to read from a
 // top-level folder without read permission.
 type ReadAccessError struct {
-	User     kbun.NormalizedUsername
+	User     kbname.NormalizedUsername
 	Filename string
 	Tlf      tlf.CanonicalName
 	Type     tlf.Type
@@ -186,7 +186,7 @@ func (e ReadAccessError) Error() string {
 
 // WriteAccessError indicates an error when trying to write a file
 type WriteAccessError struct {
-	User     kbun.NormalizedUsername
+	User     kbname.NormalizedUsername
 	Filename string
 	Tlf      tlf.CanonicalName
 	Type     tlf.Type
@@ -236,7 +236,7 @@ func (e UnsupportedOpInUnlinkedDirError) Error() string {
 
 // NewReadAccessError constructs a ReadAccessError for the given
 // directory and user.
-func NewReadAccessError(h *TlfHandle, username kbun.NormalizedUsername, filename string) error {
+func NewReadAccessError(h *TlfHandle, username kbname.NormalizedUsername, filename string) error {
 	tlfname := h.GetCanonicalName()
 	return ReadAccessError{
 		User:     username,
@@ -247,7 +247,7 @@ func NewReadAccessError(h *TlfHandle, username kbun.NormalizedUsername, filename
 }
 
 // NewWriteAccessError is an access error trying to write a file
-func NewWriteAccessError(h *TlfHandle, username kbun.NormalizedUsername, filename string) error {
+func NewWriteAccessError(h *TlfHandle, username kbname.NormalizedUsername, filename string) error {
 	tlfName := tlf.CanonicalName("")
 	t := tlf.Private
 	if h != nil {
@@ -582,7 +582,7 @@ func (e VerifyingKeyNotFoundError) Error() string {
 // verified.
 type UnverifiableTlfUpdateError struct {
 	Tlf  string
-	User kbun.NormalizedUsername
+	User kbname.NormalizedUsername
 	Err  error
 }
 
@@ -835,7 +835,7 @@ var NoCurrentSessionExpectedError = "no current session"
 // RekeyPermissionError indicates that the user tried to rekey a
 // top-level folder in a manner inconsistent with their permissions.
 type RekeyPermissionError struct {
-	User kbun.NormalizedUsername
+	User kbname.NormalizedUsername
 	Dir  string
 }
 
@@ -848,7 +848,7 @@ func (e RekeyPermissionError) Error() string {
 // NewRekeyPermissionError constructs a RekeyPermissionError for the given
 // directory and user.
 func NewRekeyPermissionError(
-	dir *TlfHandle, username kbun.NormalizedUsername) error {
+	dir *TlfHandle, username kbname.NormalizedUsername) error {
 	dirname := dir.GetCanonicalPath()
 	return RekeyPermissionError{username, dirname}
 }
@@ -1019,7 +1019,7 @@ func (e TlfHandleFinalizedError) Error() string {
 // NoSigChainError means that a user we were trying to identify does
 // not have a sigchain.
 type NoSigChainError struct {
-	User kbun.NormalizedUsername
+	User kbname.NormalizedUsername
 }
 
 // Error implements the error interface for NoSigChainError.

--- a/libkbfs/favorites_test.go
+++ b/libkbfs/favorites_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -21,7 +21,7 @@ func favTestInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config = NewConfigMock(mockCtrl, ctr)
 	config.mockKbpki.EXPECT().GetCurrentSession(gomock.Any()).AnyTimes().
 		Return(SessionInfo{
-			Name: libkb.NormalizedUsername("tester"),
+			Name: kbun.NormalizedUsername("tester"),
 			UID:  keybase1.MakeTestUID(16),
 		}, nil)
 

--- a/libkbfs/favorites_test.go
+++ b/libkbfs/favorites_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -21,7 +21,7 @@ func favTestInit(t *testing.T) (mockCtrl *gomock.Controller,
 	config = NewConfigMock(mockCtrl, ctr)
 	config.mockKbpki.EXPECT().GetCurrentSession(gomock.Any()).AnyTimes().
 		Return(SessionInfo{
-			Name: kbun.NormalizedUsername("tester"),
+			Name: kbname.NormalizedUsername("tester"),
 			UID:  keybase1.MakeTestUID(16),
 		}, nil)
 

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -28,7 +28,7 @@ func totalBlockRefs(m map[kbfsblock.ID]blockRefMap) int {
 // does a few updates, then lets quota reclamation run, and we make
 // sure that all historical blocks have been deleted.
 func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
-	userName kbun.NormalizedUsername) {
+	userName kbname.NormalizedUsername) {
 	clock, now := newTestClockAndTimeNow()
 	config.SetClock(clock)
 
@@ -126,7 +126,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 }
 
 func TestQuotaReclamationSimple(t *testing.T) {
-	var userName kbun.NormalizedUsername = "test_user"
+	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
@@ -136,7 +136,7 @@ func TestQuotaReclamationSimple(t *testing.T) {
 // Just like the simple case, except tests that it unembeds large sets
 // of pointers correctly.
 func TestQuotaReclamationUnembedded(t *testing.T) {
-	var userName kbun.NormalizedUsername = "test_user"
+	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
@@ -159,7 +159,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 // Test that a single quota reclamation run doesn't try to reclaim too
 // much quota at once.
 func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
-	var userName kbun.NormalizedUsername = "test_user"
+	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
@@ -248,7 +248,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 
 // Test that deleted blocks are correctly flushed from the user cache.
 func TestQuotaReclamationDeletedBlocks(t *testing.T) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2)
 	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
 
@@ -497,7 +497,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 // Test that quota reclamation doesn't happen while waiting for a
 // requested rekey.
 func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -587,7 +587,7 @@ func (mtwqr modeTestWithQR) IsTestMode() bool {
 // Test that quota reclamation doesn't run unless the current head is
 // at least the minimum needed age.
 func TestQuotaReclamationMinHeadAge(t *testing.T) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -730,7 +730,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 // to make sure clients don't waste time scanning over a bunch of old
 // GCOps when there is nothing to be done.
 func TestQuotaReclamationGCOpsForGCOps(t *testing.T) {
-	var userName kbun.NormalizedUsername = "test_user"
+	var userName kbname.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 	clock := newTestClockNow()

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -28,7 +28,7 @@ func totalBlockRefs(m map[kbfsblock.ID]blockRefMap) int {
 // does a few updates, then lets quota reclamation run, and we make
 // sure that all historical blocks have been deleted.
 func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
-	userName libkb.NormalizedUsername) {
+	userName kbun.NormalizedUsername) {
 	clock, now := newTestClockAndTimeNow()
 	config.SetClock(clock)
 
@@ -126,7 +126,7 @@ func testQuotaReclamation(t *testing.T, ctx context.Context, config Config,
 }
 
 func TestQuotaReclamationSimple(t *testing.T) {
-	var userName libkb.NormalizedUsername = "test_user"
+	var userName kbun.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
@@ -136,7 +136,7 @@ func TestQuotaReclamationSimple(t *testing.T) {
 // Just like the simple case, except tests that it unembeds large sets
 // of pointers correctly.
 func TestQuotaReclamationUnembedded(t *testing.T) {
-	var userName libkb.NormalizedUsername = "test_user"
+	var userName kbun.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
@@ -159,7 +159,7 @@ func TestQuotaReclamationUnembedded(t *testing.T) {
 // Test that a single quota reclamation run doesn't try to reclaim too
 // much quota at once.
 func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
-	var userName libkb.NormalizedUsername = "test_user"
+	var userName kbun.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 
@@ -248,7 +248,7 @@ func TestQuotaReclamationIncrementalReclamation(t *testing.T) {
 
 // Test that deleted blocks are correctly flushed from the user cache.
 func TestQuotaReclamationDeletedBlocks(t *testing.T) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2)
 	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
 
@@ -497,7 +497,7 @@ func TestQuotaReclamationDeletedBlocks(t *testing.T) {
 // Test that quota reclamation doesn't happen while waiting for a
 // requested rekey.
 func TestQuotaReclamationFailAfterRekeyRequest(t *testing.T) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -587,7 +587,7 @@ func (mtwqr modeTestWithQR) IsTestMode() bool {
 // Test that quota reclamation doesn't run unless the current head is
 // at least the minimum needed age.
 func TestQuotaReclamationMinHeadAge(t *testing.T) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -730,7 +730,7 @@ func TestQuotaReclamationMinHeadAge(t *testing.T) {
 // to make sure clients don't waste time scanning over a bunch of old
 // GCOps when there is nothing to be done.
 func TestQuotaReclamationGCOpsForGCOps(t *testing.T) {
-	var userName libkb.NormalizedUsername = "test_user"
+	var userName kbun.NormalizedUsername = "test_user"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, userName)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 	clock := newTestClockNow()

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -6002,7 +6002,7 @@ func (fbo *folderBranchOps) locallyFinalizeTLF(ctx context.Context) {
 	// TLF that shouldn't matter.
 	now := fbo.config.Clock().Now()
 	finalizedInfo, err := tlf.NewHandleExtension(
-		tlf.HandleExtensionFinalized, 1, kbun.NormalizedUsername("<unknown>"),
+		tlf.HandleExtensionFinalized, 1, kbname.NormalizedUsername("<unknown>"),
 		now)
 	if err != nil {
 		fbo.log.CErrorf(ctx, "Couldn't make finalized info: %+v", err)
@@ -6657,7 +6657,7 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	fbo.log.CDebugf(ctx, "Starting name change for team %s", tid)
 
 	// First check if this is an implicit team.
-	var newName kbun.NormalizedUsername
+	var newName kbname.NormalizedUsername
 	if fbo.id().Type() != tlf.SingleTeam {
 		iteamInfo, err := fbo.config.KBPKI().ResolveImplicitTeamByID(
 			ctx, tid, fbo.id().Type())

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -6001,7 +6002,7 @@ func (fbo *folderBranchOps) locallyFinalizeTLF(ctx context.Context) {
 	// TLF that shouldn't matter.
 	now := fbo.config.Clock().Now()
 	finalizedInfo, err := tlf.NewHandleExtension(
-		tlf.HandleExtensionFinalized, 1, libkb.NormalizedUsername("<unknown>"),
+		tlf.HandleExtensionFinalized, 1, kbun.NormalizedUsername("<unknown>"),
 		now)
 	if err != nil {
 		fbo.log.CErrorf(ctx, "Couldn't make finalized info: %+v", err)
@@ -6656,7 +6657,7 @@ func (fbo *folderBranchOps) TeamNameChanged(
 	fbo.log.CDebugf(ctx, "Starting name change for team %s", tid)
 
 	// First check if this is an implicit team.
-	var newName libkb.NormalizedUsername
+	var newName kbun.NormalizedUsername
 	if fbo.id().Type() != tlf.SingleTeam {
 		iteamInfo, err := fbo.config.KBPKI().ResolveImplicitTeamByID(
 			ctx, tid, fbo.id().Type())

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -21,7 +21,7 @@ import (
 type FolderBranchStatus struct {
 	Staged              bool
 	BranchID            string
-	HeadWriter          kbun.NormalizedUsername
+	HeadWriter          kbname.NormalizedUsername
 	DiskUsage           uint64
 	RekeyPending        bool
 	LatestKeyGeneration kbfsmd.KeyGen

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
@@ -21,7 +21,7 @@ import (
 type FolderBranchStatus struct {
 	Staged              bool
 	BranchID            string
-	HeadWriter          libkb.NormalizedUsername
+	HeadWriter          kbun.NormalizedUsername
 	DiskUsage           uint64
 	RekeyPending        bool
 	LatestKeyGeneration kbfsmd.KeyGen

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
@@ -25,7 +26,7 @@ type extendedIdentify struct {
 	tlfBreaks  *keybase1.TLFBreak
 }
 
-func (ei *extendedIdentify) userBreak(username libkb.NormalizedUsername, uid keybase1.UID, breaks *keybase1.IdentifyTrackBreaks) {
+func (ei *extendedIdentify) userBreak(username kbun.NormalizedUsername, uid keybase1.UID, breaks *keybase1.IdentifyTrackBreaks) {
 	if ei.userBreaks == nil {
 		return
 	}
@@ -155,7 +156,7 @@ func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
 
 // identifyUser is the preferred way to run identifies.
 func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, name libkb.NormalizedUsername,
+	identifier identifier, name kbun.NormalizedUsername,
 	id keybase1.UserOrTeamID, t tlf.Type) error {
 	// Check to see if identify should be skipped altogether.
 	ei := getExtendedIdentify(ctx)
@@ -186,7 +187,7 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 			"You accessed a folder for private team %s.", nameAssertion)
 		nameAssertion = "team:" + nameAssertion
 	}
-	var resultName libkb.NormalizedUsername
+	var resultName kbun.NormalizedUsername
 	var resultID keybase1.UserOrTeamID
 	if isImplicit {
 		assertions, extensionSuffix, err := tlf.SplitExtension(name.String())
@@ -228,7 +229,7 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 
 // identifyUserToChan calls identifyUser and plugs the result into the error channnel.
 func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, name libkb.NormalizedUsername,
+	identifier identifier, name kbun.NormalizedUsername,
 	id keybase1.UserOrTeamID, t tlf.Type, errChan chan error) {
 	errChan <- identifyUser(ctx, nug, identifier, name, id, t)
 }
@@ -236,7 +237,7 @@ func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
 // identifyUsers identifies the users in the given maps.
 func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier,
-	names map[keybase1.UserOrTeamID]libkb.NormalizedUsername,
+	names map[keybase1.UserOrTeamID]kbun.NormalizedUsername,
 	t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -275,7 +276,7 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter,
 // identifyUsersForTLF is a helper for identifyHandle for easier testing.
 func identifyUsersForTLF(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier,
-	names map[keybase1.UserOrTeamID]libkb.NormalizedUsername,
+	names map[keybase1.UserOrTeamID]kbun.NormalizedUsername,
 	t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
@@ -26,7 +26,7 @@ type extendedIdentify struct {
 	tlfBreaks  *keybase1.TLFBreak
 }
 
-func (ei *extendedIdentify) userBreak(username kbun.NormalizedUsername, uid keybase1.UID, breaks *keybase1.IdentifyTrackBreaks) {
+func (ei *extendedIdentify) userBreak(username kbname.NormalizedUsername, uid keybase1.UID, breaks *keybase1.IdentifyTrackBreaks) {
 	if ei.userBreaks == nil {
 		return
 	}
@@ -156,7 +156,7 @@ func identifyUID(ctx context.Context, nug normalizedUsernameGetter,
 
 // identifyUser is the preferred way to run identifies.
 func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, name kbun.NormalizedUsername,
+	identifier identifier, name kbname.NormalizedUsername,
 	id keybase1.UserOrTeamID, t tlf.Type) error {
 	// Check to see if identify should be skipped altogether.
 	ei := getExtendedIdentify(ctx)
@@ -187,7 +187,7 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 			"You accessed a folder for private team %s.", nameAssertion)
 		nameAssertion = "team:" + nameAssertion
 	}
-	var resultName kbun.NormalizedUsername
+	var resultName kbname.NormalizedUsername
 	var resultID keybase1.UserOrTeamID
 	if isImplicit {
 		assertions, extensionSuffix, err := tlf.SplitExtension(name.String())
@@ -229,7 +229,7 @@ func identifyUser(ctx context.Context, nug normalizedUsernameGetter,
 
 // identifyUserToChan calls identifyUser and plugs the result into the error channnel.
 func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
-	identifier identifier, name kbun.NormalizedUsername,
+	identifier identifier, name kbname.NormalizedUsername,
 	id keybase1.UserOrTeamID, t tlf.Type, errChan chan error) {
 	errChan <- identifyUser(ctx, nug, identifier, name, id, t)
 }
@@ -237,7 +237,7 @@ func identifyUserToChan(ctx context.Context, nug normalizedUsernameGetter,
 // identifyUsers identifies the users in the given maps.
 func identifyUsers(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier,
-	names map[keybase1.UserOrTeamID]kbun.NormalizedUsername,
+	names map[keybase1.UserOrTeamID]kbname.NormalizedUsername,
 	t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 
@@ -276,7 +276,7 @@ func identifyUserList(ctx context.Context, nug normalizedUsernameGetter,
 // identifyUsersForTLF is a helper for identifyHandle for easier testing.
 func identifyUsersForTLF(ctx context.Context, nug normalizedUsernameGetter,
 	identifier identifier,
-	names map[keybase1.UserOrTeamID]kbun.NormalizedUsername,
+	names map[keybase1.UserOrTeamID]kbname.NormalizedUsername,
 	t tlf.Type) error {
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
@@ -17,14 +17,14 @@ import (
 	"golang.org/x/net/context"
 )
 
-type testNormalizedUsernameGetter map[keybase1.UserOrTeamID]kbun.NormalizedUsername
+type testNormalizedUsernameGetter map[keybase1.UserOrTeamID]kbname.NormalizedUsername
 
 func (g testNormalizedUsernameGetter) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID) (
-	kbun.NormalizedUsername, error) {
+	kbname.NormalizedUsername, error) {
 	name, ok := g[id]
 	if !ok {
-		return kbun.NormalizedUsername(""),
+		return kbname.NormalizedUsername(""),
 			NoSuchUserError{fmt.Sprintf("uid:%s", id)}
 	}
 	return name, nil
@@ -40,12 +40,12 @@ type testIdentifier struct {
 
 func (ti *testIdentifier) Identify(
 	ctx context.Context, assertion, reason string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ei := getExtendedIdentify(ctx)
 	userInfo, ok := ti.assertionsBrokenTracks[assertion]
 	if ok {
 		if !ei.behavior.WarningInsteadOfErrorOnBrokenTracks() {
-			return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 				libkb.UnmetAssertionError{
 					User:   "imtotalllymakingthisup",
 					Remote: true,
@@ -57,7 +57,7 @@ func (ti *testIdentifier) Identify(
 
 	userInfo, ok = ti.assertions[assertion]
 	if !ok {
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			NoSuchUserError{assertion}
 	}
 
@@ -123,8 +123,8 @@ func makeNugAndTIForTest() (testNormalizedUsernameGetter, *testIdentifier) {
 		}
 }
 
-func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UserOrTeamID]kbun.NormalizedUsername {
-	return (map[keybase1.UserOrTeamID]kbun.NormalizedUsername)(g)
+func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UserOrTeamID]kbname.NormalizedUsername {
+	return (map[keybase1.UserOrTeamID]kbname.NormalizedUsername)(g)
 }
 
 func TestIdentify(t *testing.T) {
@@ -197,19 +197,19 @@ func TestIdentifyImplicitTeams(t *testing.T) {
 
 	err := identifyUsersForTLF(
 		context.Background(), nug, ti,
-		map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			privID.AsUserOrTeam(): "alice,bob",
 		}, tlf.Private)
 	require.NoError(t, err)
 	err = identifyUsersForTLF(
 		context.Background(), nug, ti,
-		map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			pubID.AsUserOrTeam(): "alice,bob",
 		}, tlf.Public)
 	require.NoError(t, err)
 	err = identifyUsersForTLF(
 		context.Background(), nug, ti,
-		map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			suffixID.AsUserOrTeam(): "alice,bob (conflicted copy 2016-03-14 #3)",
 		}, tlf.Private)
 	require.NoError(t, err)

--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/tlf"
@@ -16,14 +17,14 @@ import (
 	"golang.org/x/net/context"
 )
 
-type testNormalizedUsernameGetter map[keybase1.UserOrTeamID]libkb.NormalizedUsername
+type testNormalizedUsernameGetter map[keybase1.UserOrTeamID]kbun.NormalizedUsername
 
 func (g testNormalizedUsernameGetter) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID) (
-	libkb.NormalizedUsername, error) {
+	kbun.NormalizedUsername, error) {
 	name, ok := g[id]
 	if !ok {
-		return libkb.NormalizedUsername(""),
+		return kbun.NormalizedUsername(""),
 			NoSuchUserError{fmt.Sprintf("uid:%s", id)}
 	}
 	return name, nil
@@ -39,12 +40,12 @@ type testIdentifier struct {
 
 func (ti *testIdentifier) Identify(
 	ctx context.Context, assertion, reason string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ei := getExtendedIdentify(ctx)
 	userInfo, ok := ti.assertionsBrokenTracks[assertion]
 	if ok {
 		if !ei.behavior.WarningInsteadOfErrorOnBrokenTracks() {
-			return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+			return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 				libkb.UnmetAssertionError{
 					User:   "imtotalllymakingthisup",
 					Remote: true,
@@ -56,7 +57,7 @@ func (ti *testIdentifier) Identify(
 
 	userInfo, ok = ti.assertions[assertion]
 	if !ok {
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			NoSuchUserError{assertion}
 	}
 
@@ -122,8 +123,8 @@ func makeNugAndTIForTest() (testNormalizedUsernameGetter, *testIdentifier) {
 		}
 }
 
-func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UserOrTeamID]libkb.NormalizedUsername {
-	return (map[keybase1.UserOrTeamID]libkb.NormalizedUsername)(g)
+func (g testNormalizedUsernameGetter) uidMap() map[keybase1.UserOrTeamID]kbun.NormalizedUsername {
+	return (map[keybase1.UserOrTeamID]kbun.NormalizedUsername)(g)
 }
 
 func TestIdentify(t *testing.T) {
@@ -196,19 +197,19 @@ func TestIdentifyImplicitTeams(t *testing.T) {
 
 	err := identifyUsersForTLF(
 		context.Background(), nug, ti,
-		map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			privID.AsUserOrTeam(): "alice,bob",
 		}, tlf.Private)
 	require.NoError(t, err)
 	err = identifyUsersForTLF(
 		context.Background(), nug, ti,
-		map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			pubID.AsUserOrTeam(): "alice,bob",
 		}, tlf.Public)
 	require.NoError(t, err)
 	err = identifyUsersForTLF(
 		context.Background(), nug, ti,
-		map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			suffixID.AsUserOrTeam(): "alice,bob (conflicted copy 2016-03-14 #3)",
 		}, tlf.Private)
 	require.NoError(t, err)

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -119,12 +120,12 @@ type InitParams struct {
 // defaultBServer returns the default value for the -bserver flag.
 func defaultBServer(ctx Context) string {
 	switch ctx.GetRunMode() {
-	case libkb.DevelRunMode:
+	case kbconst.DevelRunMode:
 		return memoryAddr
-	case libkb.StagingRunMode:
+	case kbconst.StagingRunMode:
 		return `
 			bserver-0.dev.keybase.io:443,bserver-1.dev.keybase.io:443`
-	case libkb.ProductionRunMode:
+	case kbconst.ProductionRunMode:
 		return `
 			bserver-0.kbfs.keybaseapi.com:443,bserver-1.kbfs.keybaseapi.com:443;
 			bserver-0.kbfs.keybase.io:443,bserver-1.kbfs.keybase.io:443`
@@ -136,12 +137,12 @@ func defaultBServer(ctx Context) string {
 // defaultMDServer returns the default value for the -mdserver flag.
 func defaultMDServer(ctx Context) string {
 	switch ctx.GetRunMode() {
-	case libkb.DevelRunMode:
+	case kbconst.DevelRunMode:
 		return memoryAddr
-	case libkb.StagingRunMode:
+	case kbconst.StagingRunMode:
 		return `
 			mdserver-0.dev.keybase.io:443,mdserver-1.dev.keybase.io:443`
-	case libkb.ProductionRunMode:
+	case kbconst.ProductionRunMode:
 		return `
 			mdserver-0.kbfs.keybaseapi.com:443,mdserver-1.kbfs.keybaseapi.com:443;
 			mdserver-0.kbfs.keybase.io:443,mdserver-1.kbfs.keybase.io:443`
@@ -153,11 +154,11 @@ func defaultMDServer(ctx Context) string {
 // defaultMetadataVersion returns the default metadata version per run mode.
 func defaultMetadataVersion(ctx Context) kbfsmd.MetadataVer {
 	switch ctx.GetRunMode() {
-	case libkb.DevelRunMode:
+	case kbconst.DevelRunMode:
 		return kbfsmd.ImplicitTeamsVer
-	case libkb.StagingRunMode:
+	case kbconst.StagingRunMode:
 		return kbfsmd.ImplicitTeamsVer
-	case libkb.ProductionRunMode:
+	case kbconst.ProductionRunMode:
 		return kbfsmd.ImplicitTeamsVer
 	default:
 		return kbfsmd.ImplicitTeamsVer

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -524,14 +524,14 @@ type KeybaseService interface {
 	// assertion before the assertion -> (username, UID) mapping
 	// can be trusted.
 	Resolve(ctx context.Context, assertion string) (
-		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
 
 	// Identify, given an assertion, returns a UserInfo struct
 	// with the user that matches that assertion, or an error
 	// otherwise. The reason string is displayed on any tracker
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (
-		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
 
 	// ResolveIdentifyImplicitTeam resolves, and optionally
 	// identifies, an implicit team.  If the implicit team doesn't yet
@@ -653,7 +653,7 @@ type resolver interface {
 	// right for subteams, which can change their name, so this may
 	// need updating.
 	Resolve(ctx context.Context, assertion string) (
-		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
 	// ResolveImplicitTeam resolves the given implicit team.
 	ResolveImplicitTeam(
 		ctx context.Context, assertions, suffix string, tlfType tlf.Type) (
@@ -676,7 +676,7 @@ type identifier interface {
 	// necessary.  The reason string is displayed on any tracker
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (
-		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbname.NormalizedUsername, keybase1.UserOrTeamID, error)
 	// IdentifyImplicitTeam identifies (and creates if necessary) the
 	// given implicit team.
 	IdentifyImplicitTeam(
@@ -688,7 +688,7 @@ type normalizedUsernameGetter interface {
 	// GetNormalizedUsername returns the normalized username
 	// corresponding to the given UID.
 	GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (
-		kbun.NormalizedUsername, error)
+		kbname.NormalizedUsername, error)
 }
 
 // CurrentSessionGetter is an interface for objects that can return

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/chat1"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -524,14 +524,14 @@ type KeybaseService interface {
 	// assertion before the assertion -> (username, UID) mapping
 	// can be trusted.
 	Resolve(ctx context.Context, assertion string) (
-		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
 
 	// Identify, given an assertion, returns a UserInfo struct
 	// with the user that matches that assertion, or an error
 	// otherwise. The reason string is displayed on any tracker
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (
-		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
 
 	// ResolveIdentifyImplicitTeam resolves, and optionally
 	// identifies, an implicit team.  If the implicit team doesn't yet
@@ -653,7 +653,7 @@ type resolver interface {
 	// right for subteams, which can change their name, so this may
 	// need updating.
 	Resolve(ctx context.Context, assertion string) (
-		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
 	// ResolveImplicitTeam resolves the given implicit team.
 	ResolveImplicitTeam(
 		ctx context.Context, assertions, suffix string, tlfType tlf.Type) (
@@ -676,7 +676,7 @@ type identifier interface {
 	// necessary.  The reason string is displayed on any tracker
 	// popups spawned.
 	Identify(ctx context.Context, assertion, reason string) (
-		libkb.NormalizedUsername, keybase1.UserOrTeamID, error)
+		kbun.NormalizedUsername, keybase1.UserOrTeamID, error)
 	// IdentifyImplicitTeam identifies (and creates if necessary) the
 	// given implicit team.
 	IdentifyImplicitTeam(
@@ -688,7 +688,7 @@ type normalizedUsernameGetter interface {
 	// GetNormalizedUsername returns the normalized username
 	// corresponding to the given UID.
 	GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (
-		libkb.NormalizedUsername, error)
+		kbun.NormalizedUsername, error)
 }
 
 // CurrentSessionGetter is an interface for objects that can return

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -146,8 +146,8 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 		setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 
-	name := kbun.NormalizedUsername("t1")
-	subname := kbun.NormalizedUsername("t1.sub")
+	name := kbname.NormalizedUsername("t1")
+	subname := kbname.NormalizedUsername("t1.sub")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, name, subname)
 	teamID := teamInfos[0].TID
 	subteamID := teamInfos[1].TID
@@ -796,7 +796,7 @@ func TestJournalServerReaderTLFs(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	// Or a team folder, where you're just a reader.
-	teamName := kbun.NormalizedUsername("t1")
+	teamName := kbname.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, teamName)
 	id := teamInfos[0].TID
 	AddTeamWriterForTestOrBust(
@@ -887,7 +887,7 @@ func TestJournalServerTeamTLFWithRestart(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 
-	name := kbun.NormalizedUsername("t1")
+	name := kbname.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, name)
 	id := teamInfos[0].TID
 	session, err := config.KBPKI().GetCurrentSession(ctx)

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -146,8 +146,8 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 		setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 
-	name := libkb.NormalizedUsername("t1")
-	subname := libkb.NormalizedUsername("t1.sub")
+	name := kbun.NormalizedUsername("t1")
+	subname := kbun.NormalizedUsername("t1.sub")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, name, subname)
 	teamID := teamInfos[0].TID
 	subteamID := teamInfos[1].TID
@@ -796,7 +796,7 @@ func TestJournalServerReaderTLFs(t *testing.T) {
 	require.Len(t, tlfIDs, 0)
 
 	// Or a team folder, where you're just a reader.
-	teamName := libkb.NormalizedUsername("t1")
+	teamName := kbun.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, teamName)
 	id := teamInfos[0].TID
 	AddTeamWriterForTestOrBust(
@@ -887,7 +887,7 @@ func TestJournalServerTeamTLFWithRestart(t *testing.T) {
 	tempdir, ctx, cancel, config, _, jServer := setupJournalServerTest(t)
 	defer teardownJournalServerTest(t, tempdir, ctx, cancel, config)
 
-	name := libkb.NormalizedUsername("t1")
+	name := kbun.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config, name)
 	id := teamInfos[0].TID
 	session, err := config.KBPKI().GetCurrentSession(ctx)

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
@@ -20,7 +20,7 @@ import (
 )
 
 func readAndCompareData(t *testing.T, config Config, ctx context.Context,
-	name string, expectedData []byte, user kbun.NormalizedUsername) {
+	name string, expectedData []byte, user kbname.NormalizedUsername) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, name, tlf.Private)
 
 	kbfsOps := config.KBFSOps()
@@ -56,7 +56,7 @@ func (t *testCRObserver) TlfHandleChange(ctx context.Context,
 }
 
 func checkStatus(t *testing.T, ctx context.Context, kbfsOps KBFSOps,
-	staged bool, headWriter kbun.NormalizedUsername, dirtyPaths []string, fb FolderBranch,
+	staged bool, headWriter kbname.NormalizedUsername, dirtyPaths []string, fb FolderBranch,
 	prefix string) {
 	status, _, err := kbfsOps.FolderStatus(ctx, fb)
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func checkStatus(t *testing.T, ctx context.Context, kbfsOps KBFSOps,
 
 func TestBasicMDUpdate(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -111,7 +111,7 @@ func TestBasicMDUpdate(t *testing.T) {
 
 func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -172,7 +172,7 @@ func TestMultipleMDUpdatesUnembedChanges(t *testing.T) {
 }
 
 func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -270,7 +270,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 // the other user will be unaffected).
 func TestUnmergedAfterRestart(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -410,7 +410,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 // without any problems.
 func TestMultiUserWrite(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -463,7 +463,7 @@ func TestMultiUserWrite(t *testing.T) {
 
 func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -597,7 +597,7 @@ func (md mdServerLocalRecordingRegisterForUpdate) RegisterForUpdate(
 
 func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -682,7 +682,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 // conflict resolution will merge them correctly.
 func TestBasicCRFileConflict(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -775,7 +775,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 // single file.
 func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -861,7 +861,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 // Test that two conflict resolutions work correctly.
 func TestCRDouble(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1003,7 +1003,7 @@ func TestCRDouble(t *testing.T) {
 // preserved until rekey.
 func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1147,7 +1147,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 // "loser" is the file write.  Regression test for KBFS-773.
 func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1282,7 +1282,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	t.Skip("Broken due to KBFS-1193")
 
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1413,7 +1413,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 // unmerged operations.  Regression test for KBFS-1133.
 func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1529,7 +1529,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 // unmerged writes blocked.
 func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1671,7 +1671,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 // resolution will fix the resulting weird state.
 func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()

--- a/libkbfs/kbfs_cr_test.go
+++ b/libkbfs/kbfs_cr_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
@@ -20,7 +20,7 @@ import (
 )
 
 func readAndCompareData(t *testing.T, config Config, ctx context.Context,
-	name string, expectedData []byte, user libkb.NormalizedUsername) {
+	name string, expectedData []byte, user kbun.NormalizedUsername) {
 	rootNode := GetRootNodeOrBust(ctx, t, config, name, tlf.Private)
 
 	kbfsOps := config.KBFSOps()
@@ -56,7 +56,7 @@ func (t *testCRObserver) TlfHandleChange(ctx context.Context,
 }
 
 func checkStatus(t *testing.T, ctx context.Context, kbfsOps KBFSOps,
-	staged bool, headWriter libkb.NormalizedUsername, dirtyPaths []string, fb FolderBranch,
+	staged bool, headWriter kbun.NormalizedUsername, dirtyPaths []string, fb FolderBranch,
 	prefix string) {
 	status, _, err := kbfsOps.FolderStatus(ctx, fb)
 	require.NoError(t, err)
@@ -67,7 +67,7 @@ func checkStatus(t *testing.T, ctx context.Context, kbfsOps KBFSOps,
 
 func TestBasicMDUpdate(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -111,7 +111,7 @@ func TestBasicMDUpdate(t *testing.T) {
 
 func testMultipleMDUpdates(t *testing.T, unembedChanges bool) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -172,7 +172,7 @@ func TestMultipleMDUpdatesUnembedChanges(t *testing.T) {
 }
 
 func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -270,7 +270,7 @@ func TestGetTLFCryptKeysWhileUnmergedAfterRestart(t *testing.T) {
 // the other user will be unaffected).
 func TestUnmergedAfterRestart(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -410,7 +410,7 @@ func TestUnmergedAfterRestart(t *testing.T) {
 // without any problems.
 func TestMultiUserWrite(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -463,7 +463,7 @@ func TestMultiUserWrite(t *testing.T) {
 
 func testBasicCRNoConflict(t *testing.T, unembedChanges bool) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -597,7 +597,7 @@ func (md mdServerLocalRecordingRegisterForUpdate) RegisterForUpdate(
 
 func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -682,7 +682,7 @@ func TestCRFileConflictWithMoreUpdatesFromOneUser(t *testing.T) {
 // conflict resolution will merge them correctly.
 func TestBasicCRFileConflict(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -775,7 +775,7 @@ func TestBasicCRFileConflict(t *testing.T) {
 // single file.
 func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -861,7 +861,7 @@ func TestBasicCRFileCreateUnmergedWriteConflict(t *testing.T) {
 // Test that two conflict resolutions work correctly.
 func TestCRDouble(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1003,7 +1003,7 @@ func TestCRDouble(t *testing.T) {
 // preserved until rekey.
 func TestBasicCRFileConflictWithRekey(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1147,7 +1147,7 @@ func TestBasicCRFileConflictWithRekey(t *testing.T) {
 // "loser" is the file write.  Regression test for KBFS-773.
 func TestBasicCRFileConflictWithMergedRekey(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1282,7 +1282,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 	t.Skip("Broken due to KBFS-1193")
 
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1413,7 +1413,7 @@ func TestCRSyncParallelBlocksErrorCleanup(t *testing.T) {
 // unmerged operations.  Regression test for KBFS-1133.
 func TestCRCanceledAfterNewOperation(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()
@@ -1529,7 +1529,7 @@ func TestCRCanceledAfterNewOperation(t *testing.T) {
 // unmerged writes blocked.
 func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1671,7 +1671,7 @@ func TestBasicCRBlockUnmergedWrites(t *testing.T) {
 // resolution will fix the resulting weird state.
 func TestUnmergedPutAfterCanceledUnmergedPut(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.MDServer().DisableRekeyUpdatesForTesting()

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -48,7 +48,7 @@ func (cl *CounterLock) GetCount() int {
 	return cl.count
 }
 
-func kbfsOpsConcurInit(t *testing.T, users ...libkb.NormalizedUsername) (
+func kbfsOpsConcurInit(t *testing.T, users ...kbun.NormalizedUsername) (
 	*ConfigLocal, keybase1.UID, context.Context, context.CancelFunc) {
 	return kbfsOpsInitNoMocks(t, users...)
 }
@@ -2387,7 +2387,7 @@ func (snc *stallingNodeCache) PathFromNode(node Node) path {
 // Test that a lookup that straddles a sync from the same file doesn't
 // have any races.  Regression test for KBFS-1717.
 func TestKBFSOpsLookupSyncRace(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/kbfs_ops_concur_test.go
+++ b/libkbfs/kbfs_ops_concur_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -48,7 +48,7 @@ func (cl *CounterLock) GetCount() int {
 	return cl.count
 }
 
-func kbfsOpsConcurInit(t *testing.T, users ...kbun.NormalizedUsername) (
+func kbfsOpsConcurInit(t *testing.T, users ...kbname.NormalizedUsername) (
 	*ConfigLocal, keybase1.UID, context.Context, context.CancelFunc) {
 	return kbfsOpsInitNoMocks(t, users...)
 }
@@ -2387,7 +2387,7 @@ func (snc *stallingNodeCache) PathFromNode(node Node) path {
 // Test that a lookup that straddles a sync from the same file doesn't
 // have any races.  Regression test for KBFS-1717.
 func TestKBFSOpsLookupSyncRace(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/env"
@@ -192,7 +192,7 @@ func (mnh modeNoHistory) SendEditNotificationsEnabled() bool {
 
 // kbfsOpsInitNoMocks returns a config that doesn't use any mocks. The
 // shutdown call is kbfsTestShutdownNoMocks.
-func kbfsOpsInitNoMocks(t *testing.T, users ...kbun.NormalizedUsername) (
+func kbfsOpsInitNoMocks(t *testing.T, users ...kbname.NormalizedUsername) (
 	*ConfigLocal, keybase1.UID, context.Context, context.CancelFunc) {
 	config := MakeTestConfigOrBust(t, users...)
 	// Turn off tlf edit history because it messes with the FBO state
@@ -482,8 +482,8 @@ type failIdentifyKBPKI struct {
 
 func (kbpki failIdentifyKBPKI) Identify(
 	ctx context.Context, assertion, reason string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 		kbpki.identifyErr
 }
 
@@ -3504,7 +3504,7 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 }
 
 func TestKBFSOpsBasicTeamTLF(t *testing.T) {
-	var u1, u2, u3 kbun.NormalizedUsername = "u1", "u2", "u3"
+	var u1, u2, u3 kbname.NormalizedUsername = "u1", "u2", "u3"
 	config1, uid1, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2, u3)
 	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
 
@@ -3527,7 +3527,7 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	// These are deterministic, and should add the same TeamInfos for
 	// both user configs.
 	t.Log("Add teams")
-	name := kbun.NormalizedUsername("t1")
+	name := kbname.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config1, name)
 	_ = AddEmptyTeamsForTestOrBust(t, config2, name)
 	_ = AddEmptyTeamsForTestOrBust(t, config3, name)
@@ -3682,7 +3682,7 @@ func TestKBFSOpsAutocreateNodesSym(t *testing.T) {
 
 func testKBFSOpsMigrateToImplicitTeam(
 	t *testing.T, ty tlf.Type, initialMDVer kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.SetMetadataVersion(initialMDVer)
@@ -3781,7 +3781,7 @@ func TestKBFSOpsMigratePublicV2ToImplicitTeam(t *testing.T) {
 }
 
 func TestKBFSOpsArchiveBranchType(t *testing.T) {
-	var u1 kbun.NormalizedUsername = "u1"
+	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/env"
@@ -192,7 +192,7 @@ func (mnh modeNoHistory) SendEditNotificationsEnabled() bool {
 
 // kbfsOpsInitNoMocks returns a config that doesn't use any mocks. The
 // shutdown call is kbfsTestShutdownNoMocks.
-func kbfsOpsInitNoMocks(t *testing.T, users ...libkb.NormalizedUsername) (
+func kbfsOpsInitNoMocks(t *testing.T, users ...kbun.NormalizedUsername) (
 	*ConfigLocal, keybase1.UID, context.Context, context.CancelFunc) {
 	config := MakeTestConfigOrBust(t, users...)
 	// Turn off tlf edit history because it messes with the FBO state
@@ -482,8 +482,8 @@ type failIdentifyKBPKI struct {
 
 func (kbpki failIdentifyKBPKI) Identify(
 	ctx context.Context, assertion, reason string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
-	return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 		kbpki.identifyErr
 }
 
@@ -3504,7 +3504,7 @@ func TestDirtyPathsAfterRemoveDir(t *testing.T) {
 }
 
 func TestKBFSOpsBasicTeamTLF(t *testing.T) {
-	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
+	var u1, u2, u3 kbun.NormalizedUsername = "u1", "u2", "u3"
 	config1, uid1, ctx, cancel := kbfsOpsInitNoMocks(t, u1, u2, u3)
 	defer kbfsTestShutdownNoMocks(t, config1, ctx, cancel)
 
@@ -3527,7 +3527,7 @@ func TestKBFSOpsBasicTeamTLF(t *testing.T) {
 	// These are deterministic, and should add the same TeamInfos for
 	// both user configs.
 	t.Log("Add teams")
-	name := libkb.NormalizedUsername("t1")
+	name := kbun.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config1, name)
 	_ = AddEmptyTeamsForTestOrBust(t, config2, name)
 	_ = AddEmptyTeamsForTestOrBust(t, config3, name)
@@ -3682,7 +3682,7 @@ func TestKBFSOpsAutocreateNodesSym(t *testing.T) {
 
 func testKBFSOpsMigrateToImplicitTeam(
 	t *testing.T, ty tlf.Type, initialMDVer kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	config1.SetMetadataVersion(initialMDVer)
@@ -3781,7 +3781,7 @@ func TestKBFSOpsMigratePublicV2ToImplicitTeam(t *testing.T) {
 }
 
 func TestKBFSOpsArchiveBranchType(t *testing.T) {
-	var u1 libkb.NormalizedUsername = "u1"
+	var u1 kbun.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -47,13 +48,13 @@ func (k *KBPKIClient) GetCurrentSession(ctx context.Context) (
 
 // Resolve implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return k.serviceOwner.KeybaseService().Resolve(ctx, assertion)
 }
 
 // Identify implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) Identify(ctx context.Context, assertion, reason string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return k.serviceOwner.KeybaseService().Identify(ctx, assertion, reason)
 }
 
@@ -115,7 +116,7 @@ func (k *KBPKIClient) IdentifyImplicitTeam(
 // KBPKIClient.
 func (k *KBPKIClient) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID) (
-	libkb.NormalizedUsername, error) {
+	kbun.NormalizedUsername, error) {
 	var assertion string
 	if id.IsUser() {
 		assertion = fmt.Sprintf("uid:%s", id)
@@ -124,7 +125,7 @@ func (k *KBPKIClient) GetNormalizedUsername(
 	}
 	username, _, err := k.Resolve(ctx, assertion)
 	if err != nil {
-		return libkb.NormalizedUsername(""), err
+		return kbun.NormalizedUsername(""), err
 	}
 	return username, nil
 }

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -48,13 +48,13 @@ func (k *KBPKIClient) GetCurrentSession(ctx context.Context) (
 
 // Resolve implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) Resolve(ctx context.Context, assertion string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return k.serviceOwner.KeybaseService().Resolve(ctx, assertion)
 }
 
 // Identify implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) Identify(ctx context.Context, assertion, reason string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return k.serviceOwner.KeybaseService().Identify(ctx, assertion, reason)
 }
 
@@ -116,7 +116,7 @@ func (k *KBPKIClient) IdentifyImplicitTeam(
 // KBPKIClient.
 func (k *KBPKIClient) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID) (
-	kbun.NormalizedUsername, error) {
+	kbname.NormalizedUsername, error) {
 	var assertion string
 	if id.IsUser() {
 		assertion = fmt.Sprintf("uid:%s", id)
@@ -125,7 +125,7 @@ func (k *KBPKIClient) GetNormalizedUsername(
 	}
 	username, _, err := k.Resolve(ctx, assertion)
 	if err != nil {
-		return kbun.NormalizedUsername(""), err
+		return kbname.NormalizedUsername(""), err
 	}
 	return username, nil
 }

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -32,9 +32,9 @@ func makeTestKBPKIClient(t *testing.T) (
 	client *KBPKIClient, currentUID keybase1.UID, users []LocalUser,
 	teams []TeamInfo) {
 	currentUID = keybase1.MakeTestUID(1)
-	names := []kbun.NormalizedUsername{"test_name1", "test_name2"}
+	names := []kbname.NormalizedUsername{"test_name1", "test_name2"}
 	users = MakeLocalUsers(names)
-	teamNames := []kbun.NormalizedUsername{"test_team1", "test_team2"}
+	teamNames := []kbname.NormalizedUsername{"test_team1", "test_team2"}
 	teams = MakeLocalTeams(teamNames)
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, users, teams, codec)
@@ -45,7 +45,7 @@ func makeTestKBPKIClient(t *testing.T) (
 func makeTestKBPKIClientWithRevokedKey(t *testing.T, revokeTime time.Time) (
 	client *KBPKIClient, currentUID keybase1.UID, users []LocalUser) {
 	currentUID = keybase1.MakeTestUID(1)
-	names := []kbun.NormalizedUsername{"test_name1", "test_name2"}
+	names := []kbname.NormalizedUsername{"test_name1", "test_name2"}
 	users = MakeLocalUsers(names)
 	// Give each user a revoked key
 	for i, user := range users {
@@ -83,7 +83,7 @@ func TestKBPKIClientGetNormalizedUsername(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if name == kbun.NormalizedUsername("") {
+	if name == kbname.NormalizedUsername("") {
 		t.Fatal("empty user")
 	}
 }

--- a/libkbfs/kbpki_client_test.go
+++ b/libkbfs/kbpki_client_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -32,9 +32,9 @@ func makeTestKBPKIClient(t *testing.T) (
 	client *KBPKIClient, currentUID keybase1.UID, users []LocalUser,
 	teams []TeamInfo) {
 	currentUID = keybase1.MakeTestUID(1)
-	names := []libkb.NormalizedUsername{"test_name1", "test_name2"}
+	names := []kbun.NormalizedUsername{"test_name1", "test_name2"}
 	users = MakeLocalUsers(names)
-	teamNames := []libkb.NormalizedUsername{"test_team1", "test_team2"}
+	teamNames := []kbun.NormalizedUsername{"test_team1", "test_team2"}
 	teams = MakeLocalTeams(teamNames)
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, users, teams, codec)
@@ -45,7 +45,7 @@ func makeTestKBPKIClient(t *testing.T) (
 func makeTestKBPKIClientWithRevokedKey(t *testing.T, revokeTime time.Time) (
 	client *KBPKIClient, currentUID keybase1.UID, users []LocalUser) {
 	currentUID = keybase1.MakeTestUID(1)
-	names := []libkb.NormalizedUsername{"test_name1", "test_name2"}
+	names := []kbun.NormalizedUsername{"test_name1", "test_name2"}
 	users = MakeLocalUsers(names)
 	// Give each user a revoked key
 	for i, user := range users {
@@ -83,7 +83,7 @@ func TestKBPKIClientGetNormalizedUsername(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if name == libkb.NormalizedUsername("") {
+	if name == kbun.NormalizedUsername("") {
 		t.Fatal("empty user")
 	}
 }

--- a/libkbfs/kbpki_util_test.go
+++ b/libkbfs/kbpki_util_test.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"sync"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
@@ -28,12 +28,12 @@ func (d *daemonKBPKI) GetCurrentSession(ctx context.Context) (
 }
 
 func (d *daemonKBPKI) Resolve(ctx context.Context, assertion string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Resolve(ctx, assertion)
 }
 
 func (d *daemonKBPKI) Identify(ctx context.Context, assertion, reason string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Identify(ctx, assertion, reason)
 }
 
@@ -47,14 +47,14 @@ func (d *daemonKBPKI) ResolveImplicitTeam(
 
 func (d *daemonKBPKI) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID) (
-	kbun.NormalizedUsername, error) {
+	kbname.NormalizedUsername, error) {
 	asUser, err := id.AsUser()
 	if err != nil {
-		return kbun.NormalizedUsername(""), err
+		return kbname.NormalizedUsername(""), err
 	}
 	userInfo, err := d.daemon.LoadUserPlusKeys(ctx, asUser, "")
 	if err != nil {
-		return kbun.NormalizedUsername(""), err
+		return kbname.NormalizedUsername(""), err
 	}
 	return userInfo.Name, nil
 }
@@ -65,7 +65,7 @@ func (d *daemonKBPKI) GetNormalizedUsername(
 // TODO: Make tests that use this just use KBPKIClient; need to figure
 // out what to do with other mocked methods of KBPKI.
 func interposeDaemonKBPKI(
-	config *ConfigMock, users ...kbun.NormalizedUsername) {
+	config *ConfigMock, users ...kbname.NormalizedUsername) {
 	localUsers := MakeLocalUsers(users)
 	loggedInUser := localUsers[0]
 
@@ -102,7 +102,7 @@ func (ik *identifyCountingKBPKI) getIdentifyCalls() int {
 
 func (ik *identifyCountingKBPKI) Identify(
 	ctx context.Context, assertion, reason string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ik.addIdentifyCall()
 	return ik.KBPKI.Identify(ctx, assertion, reason)
 }

--- a/libkbfs/kbpki_util_test.go
+++ b/libkbfs/kbpki_util_test.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"sync"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
@@ -28,12 +28,12 @@ func (d *daemonKBPKI) GetCurrentSession(ctx context.Context) (
 }
 
 func (d *daemonKBPKI) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Resolve(ctx, assertion)
 }
 
 func (d *daemonKBPKI) Identify(ctx context.Context, assertion, reason string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	return d.daemon.Identify(ctx, assertion, reason)
 }
 
@@ -47,14 +47,14 @@ func (d *daemonKBPKI) ResolveImplicitTeam(
 
 func (d *daemonKBPKI) GetNormalizedUsername(
 	ctx context.Context, id keybase1.UserOrTeamID) (
-	libkb.NormalizedUsername, error) {
+	kbun.NormalizedUsername, error) {
 	asUser, err := id.AsUser()
 	if err != nil {
-		return libkb.NormalizedUsername(""), err
+		return kbun.NormalizedUsername(""), err
 	}
 	userInfo, err := d.daemon.LoadUserPlusKeys(ctx, asUser, "")
 	if err != nil {
-		return libkb.NormalizedUsername(""), err
+		return kbun.NormalizedUsername(""), err
 	}
 	return userInfo.Name, nil
 }
@@ -65,7 +65,7 @@ func (d *daemonKBPKI) GetNormalizedUsername(
 // TODO: Make tests that use this just use KBPKIClient; need to figure
 // out what to do with other mocked methods of KBPKI.
 func interposeDaemonKBPKI(
-	config *ConfigMock, users ...libkb.NormalizedUsername) {
+	config *ConfigMock, users ...kbun.NormalizedUsername) {
 	localUsers := MakeLocalUsers(users)
 	loggedInUser := localUsers[0]
 
@@ -102,7 +102,7 @@ func (ik *identifyCountingKBPKI) getIdentifyCalls() int {
 
 func (ik *identifyCountingKBPKI) Identify(
 	ctx context.Context, assertion, reason string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ik.addIdentifyCall()
 	return ik.KBPKI.Identify(ctx, assertion, reason)
 }

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -5,7 +5,7 @@
 package libkbfs
 
 import (
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -211,7 +211,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 
 func (km *KeyManagerStandard) getTLFCryptKeyParams(
 	ctx context.Context, kmd KeyMetadata,
-	keyGen kbfsmd.KeyGen, uid keybase1.UID, username kbun.NormalizedUsername,
+	keyGen kbfsmd.KeyGen, uid keybase1.UID, username kbname.NormalizedUsername,
 	flags getTLFCryptKeyFlags) (
 	clientHalf kbfscrypto.TLFCryptKeyClientHalf,
 	serverHalfID kbfscrypto.TLFCryptKeyServerHalfID,

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -210,7 +211,7 @@ func (km *KeyManagerStandard) getTLFCryptKey(ctx context.Context,
 
 func (km *KeyManagerStandard) getTLFCryptKeyParams(
 	ctx context.Context, kmd KeyMetadata,
-	keyGen kbfsmd.KeyGen, uid keybase1.UID, username libkb.NormalizedUsername,
+	keyGen kbfsmd.KeyGen, uid keybase1.UID, username kbun.NormalizedUsername,
 	flags getTLFCryptKeyFlags) (
 	clientHalf kbfscrypto.TLFCryptKeyClientHalf,
 	serverHalfID kbfscrypto.TLFCryptKeyServerHalfID,

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -877,7 +877,7 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbf
 }
 
 func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -1136,7 +1136,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 }
 
 func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
+	var u1, u2, u3 kbun.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1243,7 +1243,7 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.Metada
 }
 
 func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1337,7 +1337,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 }
 
 func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	session1, err := config1.KBPKI().GetCurrentSession(ctx)
@@ -1426,7 +1426,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 }
 
 func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -1553,7 +1553,7 @@ func keyManagerTestSimulateSelfRekeyBit(
 // metadata and simply set the rekey bit. Then another participant rekeys the folder and they try to read.
 
 func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2, u3 libkb.NormalizedUsername = "u1", "u2", "u3"
+	var u1, u2, u3 kbun.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	doShutdown1 := true
 	defer func() {
@@ -1746,7 +1746,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 // Test that after this both can still read the latest version of the folder.
 
 func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -1904,7 +1904,7 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 }
 
 func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2017,7 +2017,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 }
 
 func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -2144,7 +2144,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 }
 
 func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2256,7 +2256,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbf
 }
 
 func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -2351,7 +2351,7 @@ func (c *protectedContext) maybeReplaceContext(newCtx context.Context) {
 }
 
 func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2365,7 +2365,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 
 	// These are deterministic, and should add the same TeamInfos for
 	// both user configs.
-	name := libkb.NormalizedUsername("t1")
+	name := kbun.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config1, name)
 	_ = AddEmptyTeamsForTestOrBust(t, config2, name)
 	tid := teamInfos[0].TID
@@ -2377,7 +2377,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
 	h := &TlfHandle{
 		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			tid.AsUserOrTeam(): name,
 		},
 		name: tlf.CanonicalName(name),
@@ -2415,7 +2415,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 }
 
 func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2431,10 +2431,10 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	_ = AddImplicitTeamForTestOrBust(t, config2, iname, "", 1, ty)
 	tlfID := tlf.FakeID(1, ty)
 
-	asUserName := libkb.NormalizedUsername(iname)
+	asUserName := kbun.NormalizedUsername(iname)
 	h := &TlfHandle{
 		tlfType: ty,
-		resolvedWriters: map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			teamID.AsUserOrTeam(): asUserName,
 		},
 		name:  tlf.CanonicalName(asUserName),

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -877,7 +877,7 @@ func testKeyManagerRekeyResolveAgainNoChangeSuccessPrivate(t *testing.T, ver kbf
 }
 
 func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -1136,7 +1136,7 @@ func testKeyManagerRekeyAddAndRevokeDevice(t *testing.T, ver kbfsmd.MetadataVer)
 }
 
 func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2, u3 kbun.NormalizedUsername = "u1", "u2", "u3"
+	var u1, u2, u3 kbname.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1243,7 +1243,7 @@ func testKeyManagerRekeyAddWriterAndReaderDevice(t *testing.T, ver kbfsmd.Metada
 }
 
 func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -1337,7 +1337,7 @@ func testKeyManagerSelfRekeyAcrossDevices(t *testing.T, ver kbfsmd.MetadataVer) 
 }
 
 func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	session1, err := config1.KBPKI().GetCurrentSession(ctx)
@@ -1426,7 +1426,7 @@ func testKeyManagerReaderRekey(t *testing.T, ver kbfsmd.MetadataVer) {
 }
 
 func testKeyManagerReaderRekeyAndRevoke(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -1553,7 +1553,7 @@ func keyManagerTestSimulateSelfRekeyBit(
 // metadata and simply set the rekey bit. Then another participant rekeys the folder and they try to read.
 
 func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2, u3 kbun.NormalizedUsername = "u1", "u2", "u3"
+	var u1, u2, u3 kbname.NormalizedUsername = "u1", "u2", "u3"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3)
 	doShutdown1 := true
 	defer func() {
@@ -1746,7 +1746,7 @@ func testKeyManagerRekeyBit(t *testing.T, ver kbfsmd.MetadataVer) {
 // Test that after this both can still read the latest version of the folder.
 
 func testKeyManagerRekeyAddAndRevokeDeviceWithConflict(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -1904,7 +1904,7 @@ func (clta *cryptoLocalTrapAny) DecryptTLFCryptKeyClientHalfAny(
 }
 
 func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2017,7 +2017,7 @@ func testKeyManagerRekeyAddDeviceWithPrompt(t *testing.T, ver kbfsmd.MetadataVer
 }
 
 func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -2144,7 +2144,7 @@ func testKeyManagerRekeyAddDeviceWithPromptAfterRestart(t *testing.T, ver kbfsmd
 }
 
 func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2256,7 +2256,7 @@ func testKeyManagerRekeyAddDeviceWithPromptViaFolderAccess(t *testing.T, ver kbf
 }
 
 func testKeyManagerRekeyMinimal(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	clock := newTestClockNow()
@@ -2351,7 +2351,7 @@ func (c *protectedContext) maybeReplaceContext(newCtx context.Context) {
 }
 
 func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2365,7 +2365,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 
 	// These are deterministic, and should add the same TeamInfos for
 	// both user configs.
-	name := kbun.NormalizedUsername("t1")
+	name := kbname.NormalizedUsername("t1")
 	teamInfos := AddEmptyTeamsForTestOrBust(t, config1, name)
 	_ = AddEmptyTeamsForTestOrBust(t, config2, name)
 	tid := teamInfos[0].TID
@@ -2377,7 +2377,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
 	h := &TlfHandle{
 		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			tid.AsUserOrTeam(): name,
 		},
 		name: tlf.CanonicalName(name),
@@ -2415,7 +2415,7 @@ func TestKeyManagerGetTeamTLFCryptKey(t *testing.T) {
 }
 
 func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 
@@ -2431,10 +2431,10 @@ func testKeyManagerGetImplicitTeamTLFCryptKey(t *testing.T, ty tlf.Type) {
 	_ = AddImplicitTeamForTestOrBust(t, config2, iname, "", 1, ty)
 	tlfID := tlf.FakeID(1, ty)
 
-	asUserName := kbun.NormalizedUsername(iname)
+	asUserName := kbname.NormalizedUsername(iname)
 	h := &TlfHandle{
 		tlfType: ty,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			teamID.AsUserOrTeam(): asUserName,
 		},
 		name:  tlf.CanonicalName(asUserName),

--- a/libkbfs/key_server_local_test.go
+++ b/libkbfs/key_server_local_test.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"testing"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
 )
@@ -15,7 +15,7 @@ import (
 // Test that Put/Get works for TLF crypt key server halves.
 func TestKeyServerLocalTLFCryptKeyServerHalves(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/key_server_local_test.go
+++ b/libkbfs/key_server_local_test.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"testing"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
 )
@@ -15,7 +15,7 @@ import (
 // Test that Put/Get works for TLF crypt key server halves.
 func TestKeyServerLocalTLFCryptKeyServerHalves(t *testing.T) {
 	// simulate two users
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, uid1, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -40,7 +41,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 			config, ctx, log, params.Debug, additionalProtocols), nil
 	}
 
-	users := []libkb.NormalizedUsername{
+	users := []kbun.NormalizedUsername{
 		"strib", "max", "chris", "akalin", "jzila", "alness",
 		"jinyang", "songgao", "taru", "zanderz",
 	}
@@ -72,7 +73,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()
 
-	teams := MakeLocalTeams([]libkb.NormalizedUsername{"kbfs", "core", "dokan"})
+	teams := MakeLocalTeams([]kbun.NormalizedUsername{"kbfs", "core", "dokan"})
 	for i := range teams {
 		teams[i].Writers = make(map[keybase1.UID]bool)
 		teams[i].Readers = make(map[keybase1.UID]bool)

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -20,7 +20,7 @@ import (
 type keybaseDaemon struct{}
 
 func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx Context, log logger.Logger) (KeybaseService, error) {
-	localUser := kbun.NewNormalizedUsername(params.LocalUser)
+	localUser := kbname.NewNormalizedUsername(params.LocalUser)
 	if len(localUser) == 0 {
 		err := ctx.ConfigureSocketInfo()
 		if err != nil {
@@ -40,7 +40,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 			config, ctx, log, params.Debug, additionalProtocols), nil
 	}
 
-	users := []kbun.NormalizedUsername{
+	users := []kbname.NormalizedUsername{
 		"strib", "max", "chris", "akalin", "jzila", "alness",
 		"jinyang", "songgao", "taru", "zanderz",
 	}
@@ -72,7 +72,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 	localUID := localUsers[userIndex].UID
 	codec := config.Codec()
 
-	teams := MakeLocalTeams([]kbun.NormalizedUsername{"kbfs", "core", "dokan"})
+	teams := MakeLocalTeams([]kbname.NormalizedUsername{"kbfs", "core", "dokan"})
 	for i := range teams {
 		teams[i].Writers = make(map[keybase1.UID]bool)
 		teams[i].Readers = make(map[keybase1.UID]bool)
@@ -117,7 +117,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 
 func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, log logger.Logger) (Crypto, error) {
 	var crypto Crypto
-	localUser := kbun.NewNormalizedUsername(params.LocalUser)
+	localUser := kbname.NewNormalizedUsername(params.LocalUser)
 	if localUser == "" {
 		crypto = NewCryptoClientRPC(config, ctx)
 	} else {
@@ -132,7 +132,7 @@ func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, 
 func (k keybaseDaemon) NewChat(
 	config Config, params InitParams, ctx Context, log logger.Logger) (
 	chat Chat, err error) {
-	localUser := kbun.NewNormalizedUsername(params.LocalUser)
+	localUser := kbname.NewNormalizedUsername(params.LocalUser)
 	if localUser == "" {
 		chat = NewChatRPC(config, ctx)
 	} else {

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 
 	"github.com/keybase/client/go/kbun"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -21,7 +21,7 @@ import (
 type keybaseDaemon struct{}
 
 func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx Context, log logger.Logger) (KeybaseService, error) {
-	localUser := libkb.NewNormalizedUsername(params.LocalUser)
+	localUser := kbun.NewNormalizedUsername(params.LocalUser)
 	if len(localUser) == 0 {
 		err := ctx.ConfigureSocketInfo()
 		if err != nil {
@@ -118,7 +118,7 @@ func (k keybaseDaemon) NewKeybaseService(config Config, params InitParams, ctx C
 
 func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, log logger.Logger) (Crypto, error) {
 	var crypto Crypto
-	localUser := libkb.NewNormalizedUsername(params.LocalUser)
+	localUser := kbun.NewNormalizedUsername(params.LocalUser)
 	if localUser == "" {
 		crypto = NewCryptoClientRPC(config, ctx)
 	} else {
@@ -133,7 +133,7 @@ func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, 
 func (k keybaseDaemon) NewChat(
 	config Config, params InitParams, ctx Context, log logger.Logger) (
 	chat Chat, err error) {
-	localUser := libkb.NewNormalizedUsername(params.LocalUser)
+	localUser := kbun.NewNormalizedUsername(params.LocalUser)
 	if localUser == "" {
 		chat = NewChatRPC(config, ctx)
 	} else {

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -218,22 +218,22 @@ func (k *KeybaseDaemonLocal) assertionToIDLocked(ctx context.Context,
 
 // Resolve implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	if err := checkContext(ctx); err != nil {
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	id, err := k.assertionToIDLocked(ctx, assertion)
 	if err != nil {
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
 	if id.IsUser() {
 		u, err := k.localUsers.getLocalUser(id.AsUserOrBust())
 		if err != nil {
-			return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+			return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 		}
 		return u.Name, id, nil
 	}
@@ -241,14 +241,14 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 	// Otherwise it's a team
 	ti, err := k.localTeams.getLocalTeam(id.AsTeamOrBust())
 	if err != nil {
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
 	_, ok := k.localImplicitTeams[id.AsTeamOrBust()]
 	if ok {
 		// An implicit team exists, so Resolve shouldn't work.  The
 		// caller should use `ResolveImplicitTeamByID` instead.
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			fmt.Errorf("Team ID %s is an implicit team", id)
 	}
 
@@ -258,17 +258,17 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 // Identify implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Identify(
 	ctx context.Context, assertion, _ string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	// The local daemon doesn't need to distinguish resolves from
 	// identifies.
 	return k.Resolve(ctx, assertion)
 }
 
 func (k *KeybaseDaemonLocal) resolveForImplicitTeam(
-	ctx context.Context, name string, r []libkb.NormalizedUsername,
+	ctx context.Context, name string, r []kbun.NormalizedUsername,
 	ur []keybase1.SocialAssertion,
-	resolvedIDs map[libkb.NormalizedUsername]keybase1.UserOrTeamID) (
-	[]libkb.NormalizedUsername, []keybase1.SocialAssertion, error) {
+	resolvedIDs map[kbun.NormalizedUsername]keybase1.UserOrTeamID) (
+	[]kbun.NormalizedUsername, []keybase1.SocialAssertion, error) {
 	id, err := k.assertionToIDLocked(ctx, name)
 	if err == nil {
 		u, err := k.localUsers.getLocalUser(id.AsUserOrBust())
@@ -310,9 +310,9 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 	if err != nil {
 		return ImplicitTeamInfo{}, err
 	}
-	var writers, readers []libkb.NormalizedUsername
+	var writers, readers []kbun.NormalizedUsername
 	var unresolvedWriters, unresolvedReaders []keybase1.SocialAssertion
-	resolvedIDs := make(map[libkb.NormalizedUsername]keybase1.UserOrTeamID)
+	resolvedIDs := make(map[kbun.NormalizedUsername]keybase1.UserOrTeamID)
 	for _, w := range writerNames {
 		writers, unresolvedWriters, err = k.resolveForImplicitTeam(
 			ctx, w, writers, unresolvedWriters, resolvedIDs)
@@ -348,10 +348,10 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 
 	// Need to make the team info as well, so get the list of user
 	// names and resolve them.  Auto-generate an implicit team name.
-	implicitName := libkb.NormalizedUsername(
+	implicitName := kbun.NormalizedUsername(
 		fmt.Sprintf("_implicit_%d", len(k.localTeams)))
 	teams := makeLocalTeams(
-		[]libkb.NormalizedUsername{implicitName}, len(k.localTeams), tlfType)
+		[]kbun.NormalizedUsername{implicitName}, len(k.localTeams), tlfType)
 	info := teams[0]
 	info.Writers = make(map[keybase1.UID]bool, len(writerNames))
 	for _, w := range writers {
@@ -381,7 +381,7 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 	k.implicitAsserts[key] = tid
 	k.localTeams[tid] = info
 
-	asUserName := libkb.NormalizedUsername(name)
+	asUserName := kbun.NormalizedUsername(name)
 	iteamInfo := ImplicitTeamInfo{
 		// TODO: use the "preferred" canonical format here by listing
 		// the logged-in user first?
@@ -602,7 +602,7 @@ func (k *KeybaseDaemonLocal) changeTeamNameForTest(
 		return keybase1.TeamID(""),
 			fmt.Errorf("No such old team name: %s/%s", oldName, tid)
 	}
-	team.Name = libkb.NormalizedUsername(newName)
+	team.Name = kbun.NormalizedUsername(newName)
 	k.localTeams[tid] = team
 
 	k.asserts[newAssert] = id
@@ -627,7 +627,7 @@ func (k *KeybaseDaemonLocal) removeAssertionForTest(assertion string) {
 	delete(k.asserts, assertion)
 }
 
-type makeKeysFunc func(libkb.NormalizedUsername, int) (
+type makeKeysFunc func(kbun.NormalizedUsername, int) (
 	kbfscrypto.CryptPublicKey, kbfscrypto.VerifyingKey)
 
 func (k *KeybaseDaemonLocal) addDeviceForTesting(uid keybase1.UID,

--- a/libkbfs/keybase_daemon_local.go
+++ b/libkbfs/keybase_daemon_local.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -218,22 +218,22 @@ func (k *KeybaseDaemonLocal) assertionToIDLocked(ctx context.Context,
 
 // Resolve implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	if err := checkContext(ctx); err != nil {
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
 	k.lock.Lock()
 	defer k.lock.Unlock()
 	id, err := k.assertionToIDLocked(ctx, assertion)
 	if err != nil {
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
 	if id.IsUser() {
 		u, err := k.localUsers.getLocalUser(id.AsUserOrBust())
 		if err != nil {
-			return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 		}
 		return u.Name, id, nil
 	}
@@ -241,14 +241,14 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 	// Otherwise it's a team
 	ti, err := k.localTeams.getLocalTeam(id.AsTeamOrBust())
 	if err != nil {
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 	}
 
 	_, ok := k.localImplicitTeams[id.AsTeamOrBust()]
 	if ok {
 		// An implicit team exists, so Resolve shouldn't work.  The
 		// caller should use `ResolveImplicitTeamByID` instead.
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			fmt.Errorf("Team ID %s is an implicit team", id)
 	}
 
@@ -258,17 +258,17 @@ func (k *KeybaseDaemonLocal) Resolve(ctx context.Context, assertion string) (
 // Identify implements KeybaseDaemon for KeybaseDaemonLocal.
 func (k *KeybaseDaemonLocal) Identify(
 	ctx context.Context, assertion, _ string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	// The local daemon doesn't need to distinguish resolves from
 	// identifies.
 	return k.Resolve(ctx, assertion)
 }
 
 func (k *KeybaseDaemonLocal) resolveForImplicitTeam(
-	ctx context.Context, name string, r []kbun.NormalizedUsername,
+	ctx context.Context, name string, r []kbname.NormalizedUsername,
 	ur []keybase1.SocialAssertion,
-	resolvedIDs map[kbun.NormalizedUsername]keybase1.UserOrTeamID) (
-	[]kbun.NormalizedUsername, []keybase1.SocialAssertion, error) {
+	resolvedIDs map[kbname.NormalizedUsername]keybase1.UserOrTeamID) (
+	[]kbname.NormalizedUsername, []keybase1.SocialAssertion, error) {
 	id, err := k.assertionToIDLocked(ctx, name)
 	if err == nil {
 		u, err := k.localUsers.getLocalUser(id.AsUserOrBust())
@@ -310,9 +310,9 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 	if err != nil {
 		return ImplicitTeamInfo{}, err
 	}
-	var writers, readers []kbun.NormalizedUsername
+	var writers, readers []kbname.NormalizedUsername
 	var unresolvedWriters, unresolvedReaders []keybase1.SocialAssertion
-	resolvedIDs := make(map[kbun.NormalizedUsername]keybase1.UserOrTeamID)
+	resolvedIDs := make(map[kbname.NormalizedUsername]keybase1.UserOrTeamID)
 	for _, w := range writerNames {
 		writers, unresolvedWriters, err = k.resolveForImplicitTeam(
 			ctx, w, writers, unresolvedWriters, resolvedIDs)
@@ -348,10 +348,10 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 
 	// Need to make the team info as well, so get the list of user
 	// names and resolve them.  Auto-generate an implicit team name.
-	implicitName := kbun.NormalizedUsername(
+	implicitName := kbname.NormalizedUsername(
 		fmt.Sprintf("_implicit_%d", len(k.localTeams)))
 	teams := makeLocalTeams(
-		[]kbun.NormalizedUsername{implicitName}, len(k.localTeams), tlfType)
+		[]kbname.NormalizedUsername{implicitName}, len(k.localTeams), tlfType)
 	info := teams[0]
 	info.Writers = make(map[keybase1.UID]bool, len(writerNames))
 	for _, w := range writers {
@@ -381,7 +381,7 @@ func (k *KeybaseDaemonLocal) ResolveIdentifyImplicitTeam(
 	k.implicitAsserts[key] = tid
 	k.localTeams[tid] = info
 
-	asUserName := kbun.NormalizedUsername(name)
+	asUserName := kbname.NormalizedUsername(name)
 	iteamInfo := ImplicitTeamInfo{
 		// TODO: use the "preferred" canonical format here by listing
 		// the logged-in user first?
@@ -602,7 +602,7 @@ func (k *KeybaseDaemonLocal) changeTeamNameForTest(
 		return keybase1.TeamID(""),
 			fmt.Errorf("No such old team name: %s/%s", oldName, tid)
 	}
-	team.Name = kbun.NormalizedUsername(newName)
+	team.Name = kbname.NormalizedUsername(newName)
 	k.localTeams[tid] = team
 
 	k.asserts[newAssert] = id
@@ -627,7 +627,7 @@ func (k *KeybaseDaemonLocal) removeAssertionForTest(assertion string) {
 	delete(k.asserts, assertion)
 }
 
-type makeKeysFunc func(kbun.NormalizedUsername, int) (
+type makeKeysFunc func(kbname.NormalizedUsername, int) (
 	kbfscrypto.CryptPublicKey, kbfscrypto.VerifyingKey)
 
 func (k *KeybaseDaemonLocal) addDeviceForTesting(uid keybase1.UID,

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -163,7 +163,7 @@ func testCurrentSession(
 
 // Test that the session cache works and is invalidated as expected.
 func TestKeybaseDaemonSessionCache(t *testing.T) {
-	name := kbun.NormalizedUsername("fake username")
+	name := kbname.NormalizedUsername("fake username")
 	k := MakeLocalUserCryptPublicKeyOrBust(name)
 	v := MakeLocalUserVerifyingKeyOrBust(name)
 	session := SessionInfo{
@@ -202,7 +202,7 @@ func TestKeybaseDaemonSessionCache(t *testing.T) {
 
 func testLoadUserPlusKeys(
 	t *testing.T, client *fakeKeybaseClient, c *KeybaseDaemonRPC,
-	uid keybase1.UID, expectedName kbun.NormalizedUsername,
+	uid keybase1.UID, expectedName kbname.NormalizedUsername,
 	expectedCalled bool) {
 	client.loadUserPlusKeysCalled = false
 
@@ -216,7 +216,7 @@ func testLoadUserPlusKeys(
 
 func testIdentify(
 	t *testing.T, client *fakeKeybaseClient, c *KeybaseDaemonRPC,
-	uid keybase1.UID, expectedName kbun.NormalizedUsername,
+	uid keybase1.UID, expectedName kbname.NormalizedUsername,
 	expectedCalled bool) {
 	client.identifyCalled = false
 
@@ -232,8 +232,8 @@ func testIdentify(
 func TestKeybaseDaemonUserCache(t *testing.T) {
 	uid1 := keybase1.UID("uid1")
 	uid2 := keybase1.UID("uid2")
-	name1 := kbun.NewNormalizedUsername("name1")
-	name2 := kbun.NewNormalizedUsername("name2")
+	name1 := kbname.NewNormalizedUsername("name1")
+	name2 := kbname.NewNormalizedUsername("name2")
 	users := map[keybase1.UID]UserInfo{
 		uid1: {Name: name1},
 		uid2: {Name: name2},
@@ -332,7 +332,7 @@ func truncateNotificationTimestamps(
 }
 
 func TestKeybaseDaemonRPCEditList(t *testing.T) {
-	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -233,8 +233,8 @@ func testIdentify(
 func TestKeybaseDaemonUserCache(t *testing.T) {
 	uid1 := keybase1.UID("uid1")
 	uid2 := keybase1.UID("uid2")
-	name1 := libkb.NewNormalizedUsername("name1")
-	name2 := libkb.NewNormalizedUsername("name2")
+	name1 := kbun.NewNormalizedUsername("name1")
+	name2 := kbun.NewNormalizedUsername("name2")
 	users := map[keybase1.UID]UserInfo{
 		uid1: {Name: name1},
 		uid2: {Name: name2},

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -163,7 +164,7 @@ func testCurrentSession(
 
 // Test that the session cache works and is invalidated as expected.
 func TestKeybaseDaemonSessionCache(t *testing.T) {
-	name := libkb.NormalizedUsername("fake username")
+	name := kbun.NormalizedUsername("fake username")
 	k := MakeLocalUserCryptPublicKeyOrBust(name)
 	v := MakeLocalUserVerifyingKeyOrBust(name)
 	session := SessionInfo{
@@ -202,7 +203,7 @@ func TestKeybaseDaemonSessionCache(t *testing.T) {
 
 func testLoadUserPlusKeys(
 	t *testing.T, client *fakeKeybaseClient, c *KeybaseDaemonRPC,
-	uid keybase1.UID, expectedName libkb.NormalizedUsername,
+	uid keybase1.UID, expectedName kbun.NormalizedUsername,
 	expectedCalled bool) {
 	client.loadUserPlusKeysCalled = false
 
@@ -216,7 +217,7 @@ func testLoadUserPlusKeys(
 
 func testIdentify(
 	t *testing.T, client *fakeKeybaseClient, c *KeybaseDaemonRPC,
-	uid keybase1.UID, expectedName libkb.NormalizedUsername,
+	uid keybase1.UID, expectedName kbun.NormalizedUsername,
 	expectedCalled bool) {
 	client.identifyCalled = false
 
@@ -332,7 +333,7 @@ func truncateNotificationTimestamps(
 }
 
 func TestKeybaseDaemonRPCEditList(t *testing.T) {
-	var userName1, userName2 libkb.NormalizedUsername = "u1", "u2"
+	var userName1, userName2 kbun.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, userName1, userName2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 	// kbfsOpsConcurInit turns off notifications, so turn them back on.

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/keybase/client/go/kbun"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -456,7 +456,7 @@ func (k *KeybaseServiceBase) Resolve(ctx context.Context, assertion string) (
 		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}
-	return libkb.NewNormalizedUsername(res.Name), res.Id, nil
+	return kbun.NewNormalizedUsername(res.Name), res.Id, nil
 }
 
 // Identify implements the KeybaseService interface for KeybaseServiceBase.
@@ -952,7 +952,7 @@ func (k *KeybaseServiceBase) processUserPlusKeys(
 	}
 
 	u := UserInfo{
-		Name: libkb.NewNormalizedUsername(
+		Name: kbun.NewNormalizedUsername(
 			upk.Current.Username),
 		UID:                    upk.Current.Uid,
 		VerifyingKeys:          verifyingKeys,

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -262,7 +263,7 @@ func (k *KeybaseServiceBase) getCachedUserInfo(uid keybase1.UID) UserInfo {
 func (k *KeybaseServiceBase) setCachedUserInfo(uid keybase1.UID, info UserInfo) {
 	k.userCacheLock.Lock()
 	defer k.userCacheLock.Unlock()
-	if info.Name == libkb.NormalizedUsername("") {
+	if info.Name == kbun.NormalizedUsername("") {
 		delete(k.userCache, uid)
 	} else {
 		k.userCache[uid] = info
@@ -301,7 +302,7 @@ func (k *KeybaseServiceBase) setCachedTeamInfo(
 	tid keybase1.TeamID, info TeamInfo) {
 	k.teamCacheLock.Lock()
 	defer k.teamCacheLock.Unlock()
-	if info.Name == libkb.NormalizedUsername("") {
+	if info.Name == kbun.NormalizedUsername("") {
 		delete(k.teamCache, tid)
 	} else {
 		k.teamCache[tid] = info
@@ -449,10 +450,10 @@ func ConvertIdentifyError(assertion string, err error) error {
 
 // Resolve implements the KeybaseService interface for KeybaseServiceBase.
 func (k *KeybaseServiceBase) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	res, err := k.identifyClient.Resolve3(ctx, assertion)
 	if err != nil {
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}
 	return libkb.NewNormalizedUsername(res.Name), res.Id, nil
@@ -460,7 +461,7 @@ func (k *KeybaseServiceBase) Resolve(ctx context.Context, assertion string) (
 
 // Identify implements the KeybaseService interface for KeybaseServiceBase.
 func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	// setting UseDelegateUI to true here will cause daemon to use
 	// registered identify ui providers instead of terminal if any
 	// are available.  If not, then it will use the terminal UI.
@@ -490,18 +491,18 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 			"Ignoring error (%s) for user %s with no sigchain; "+
 				"error type=%T", err, res.Ul.Name, err)
 	default:
-		return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}
 
 	// This is required for every identify call. The userBreak
 	// function will take care of checking if res.TrackBreaks is nil
 	// or not.
-	name := libkb.NormalizedUsername(res.Ul.Name)
+	name := kbun.NormalizedUsername(res.Ul.Name)
 	if res.Ul.Id.IsUser() {
 		asUser, err := res.Ul.Id.AsUser()
 		if err != nil {
-			return libkb.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+			return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 		}
 		ei.userBreak(name, asUser, res.TrackBreaks)
 	}
@@ -535,7 +536,7 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 	if err != nil {
 		return ImplicitTeamInfo{}, ConvertIdentifyError(assertions, err)
 	}
-	name := libkb.NormalizedUsername(res.DisplayName)
+	name := kbun.NormalizedUsername(res.DisplayName)
 
 	// This is required for every identify call. The userBreak
 	// function will take care of checking if res.TrackBreaks is nil
@@ -640,7 +641,7 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,
 	uid keybase1.UID, pollForKID keybase1.KID) (UserInfo, error) {
 	cachedUserInfo := k.getCachedUserInfo(uid)
-	if cachedUserInfo.Name != libkb.NormalizedUsername("") {
+	if cachedUserInfo.Name != kbun.NormalizedUsername("") {
 		if pollForKID == keybase1.KID("") {
 			return cachedUserInfo, nil
 		}
@@ -736,7 +737,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	}
 
 	cachedTeamInfo := k.getCachedTeamInfo(tid)
-	if cachedTeamInfo.Name != libkb.NormalizedUsername("") {
+	if cachedTeamInfo.Name != kbun.NormalizedUsername("") {
 		// If the cached team info doesn't satisfy our desires, don't
 		// use it.
 		satisfiesDesires := true
@@ -806,7 +807,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	}
 
 	info := TeamInfo{
-		Name:      libkb.NormalizedUsername(res.Name),
+		Name:      kbun.NormalizedUsername(res.Name),
 		TID:       res.Id,
 		CryptKeys: make(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey),
 		Writers:   make(map[keybase1.UID]bool),

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -263,7 +263,7 @@ func (k *KeybaseServiceBase) getCachedUserInfo(uid keybase1.UID) UserInfo {
 func (k *KeybaseServiceBase) setCachedUserInfo(uid keybase1.UID, info UserInfo) {
 	k.userCacheLock.Lock()
 	defer k.userCacheLock.Unlock()
-	if info.Name == kbun.NormalizedUsername("") {
+	if info.Name == kbname.NormalizedUsername("") {
 		delete(k.userCache, uid)
 	} else {
 		k.userCache[uid] = info
@@ -302,7 +302,7 @@ func (k *KeybaseServiceBase) setCachedTeamInfo(
 	tid keybase1.TeamID, info TeamInfo) {
 	k.teamCacheLock.Lock()
 	defer k.teamCacheLock.Unlock()
-	if info.Name == kbun.NormalizedUsername("") {
+	if info.Name == kbname.NormalizedUsername("") {
 		delete(k.teamCache, tid)
 	} else {
 		k.teamCache[tid] = info
@@ -450,18 +450,18 @@ func ConvertIdentifyError(assertion string, err error) error {
 
 // Resolve implements the KeybaseService interface for KeybaseServiceBase.
 func (k *KeybaseServiceBase) Resolve(ctx context.Context, assertion string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	res, err := k.identifyClient.Resolve3(ctx, assertion)
 	if err != nil {
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}
-	return kbun.NewNormalizedUsername(res.Name), res.Id, nil
+	return kbname.NewNormalizedUsername(res.Name), res.Id, nil
 }
 
 // Identify implements the KeybaseService interface for KeybaseServiceBase.
 func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	// setting UseDelegateUI to true here will cause daemon to use
 	// registered identify ui providers instead of terminal if any
 	// are available.  If not, then it will use the terminal UI.
@@ -491,18 +491,18 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 			"Ignoring error (%s) for user %s with no sigchain; "+
 				"error type=%T", err, res.Ul.Name, err)
 	default:
-		return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""),
+		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}
 
 	// This is required for every identify call. The userBreak
 	// function will take care of checking if res.TrackBreaks is nil
 	// or not.
-	name := kbun.NormalizedUsername(res.Ul.Name)
+	name := kbname.NormalizedUsername(res.Ul.Name)
 	if res.Ul.Id.IsUser() {
 		asUser, err := res.Ul.Id.AsUser()
 		if err != nil {
-			return kbun.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
+			return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""), err
 		}
 		ei.userBreak(name, asUser, res.TrackBreaks)
 	}
@@ -536,7 +536,7 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 	if err != nil {
 		return ImplicitTeamInfo{}, ConvertIdentifyError(assertions, err)
 	}
-	name := kbun.NormalizedUsername(res.DisplayName)
+	name := kbname.NormalizedUsername(res.DisplayName)
 
 	// This is required for every identify call. The userBreak
 	// function will take care of checking if res.TrackBreaks is nil
@@ -641,7 +641,7 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 func (k *KeybaseServiceBase) LoadUserPlusKeys(ctx context.Context,
 	uid keybase1.UID, pollForKID keybase1.KID) (UserInfo, error) {
 	cachedUserInfo := k.getCachedUserInfo(uid)
-	if cachedUserInfo.Name != kbun.NormalizedUsername("") {
+	if cachedUserInfo.Name != kbname.NormalizedUsername("") {
 		if pollForKID == keybase1.KID("") {
 			return cachedUserInfo, nil
 		}
@@ -737,7 +737,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	}
 
 	cachedTeamInfo := k.getCachedTeamInfo(tid)
-	if cachedTeamInfo.Name != kbun.NormalizedUsername("") {
+	if cachedTeamInfo.Name != kbname.NormalizedUsername("") {
 		// If the cached team info doesn't satisfy our desires, don't
 		// use it.
 		satisfiesDesires := true
@@ -807,7 +807,7 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	}
 
 	info := TeamInfo{
-		Name:      kbun.NormalizedUsername(res.Name),
+		Name:      kbname.NormalizedUsername(res.Name),
 		TID:       res.Id,
 		CryptKeys: make(map[kbfsmd.KeyGen]kbfscrypto.TLFCryptKey),
 		Writers:   make(map[keybase1.UID]bool),
@@ -952,7 +952,7 @@ func (k *KeybaseServiceBase) processUserPlusKeys(
 	}
 
 	u := UserInfo{
-		Name: kbun.NewNormalizedUsername(
+		Name: kbname.NewNormalizedUsername(
 			upk.Current.Username),
 		UID:                    upk.Current.Uid,
 		VerifyingKeys:          verifyingKeys,

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -88,7 +88,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 
 // Resolve implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
-	name kbun.NormalizedUsername, uid keybase1.UserOrTeamID, err error) {
+	name kbname.NormalizedUsername, uid keybase1.UserOrTeamID, err error) {
 	k.resolveTimer.Time(func() {
 		name, uid, err = k.delegate.Resolve(ctx, assertion)
 	})
@@ -97,7 +97,7 @@ func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
 
 // Identify implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Identify(ctx context.Context, assertion, reason string) (
-	name kbun.NormalizedUsername, id keybase1.UserOrTeamID, err error) {
+	name kbname.NormalizedUsername, id keybase1.UserOrTeamID, err error) {
 	k.identifyTimer.Time(func() {
 		name, id, err = k.delegate.Identify(ctx, assertion, reason)
 	})

--- a/libkbfs/keybase_service_measured.go
+++ b/libkbfs/keybase_service_measured.go
@@ -7,7 +7,7 @@ package libkbfs
 import (
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -88,7 +88,7 @@ func NewKeybaseServiceMeasured(delegate KeybaseService, r metrics.Registry) Keyb
 
 // Resolve implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
-	name libkb.NormalizedUsername, uid keybase1.UserOrTeamID, err error) {
+	name kbun.NormalizedUsername, uid keybase1.UserOrTeamID, err error) {
 	k.resolveTimer.Time(func() {
 		name, uid, err = k.delegate.Resolve(ctx, assertion)
 	})
@@ -97,7 +97,7 @@ func (k KeybaseServiceMeasured) Resolve(ctx context.Context, assertion string) (
 
 // Identify implements the KeybaseService interface for KeybaseServiceMeasured.
 func (k KeybaseServiceMeasured) Identify(ctx context.Context, assertion, reason string) (
-	name libkb.NormalizedUsername, id keybase1.UserOrTeamID, err error) {
+	name kbun.NormalizedUsername, id keybase1.UserOrTeamID, err error) {
 	k.identifyTimer.Time(func() {
 		name, id, err = k.delegate.Identify(ctx, assertion, reason)
 	})

--- a/libkbfs/keybase_service_util.go
+++ b/libkbfs/keybase_service_util.go
@@ -7,14 +7,15 @@ package libkbfs
 import (
 	"sync"
 
+	"github.com/keybase/client/go/kbconst"
 	"github.com/keybase/client/go/libkb"
 	"golang.org/x/net/context"
 )
 
 // EnableAdminFeature returns true if admin features should be enabled
 // for the currently-logged-in user.
-func EnableAdminFeature(ctx context.Context, runMode libkb.RunMode, config Config) bool {
-	if runMode == libkb.DevelRunMode {
+func EnableAdminFeature(ctx context.Context, runMode kbconst.RunMode, config Config) bool {
+	if runMode == kbconst.DevelRunMode {
 		// All users in devel mode are admins.
 		return true
 	}

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -74,7 +74,7 @@ func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 	writer, nameErr := md.config.KBPKI().GetNormalizedUsername(ctx,
 		rmds.MD.LastModifyingWriter().AsUserOrTeam())
 	if nameErr != nil {
-		writer = kbun.NormalizedUsername("uid: " +
+		writer = kbname.NormalizedUsername("uid: " +
 			rmds.MD.LastModifyingWriter().String())
 	}
 	md.log.CDebugf(ctx, "Unverifiable update for TLF %s: %+v",

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -73,7 +74,7 @@ func (md *MDOpsStandard) convertVerifyingKeyError(ctx context.Context,
 	writer, nameErr := md.config.KBPKI().GetNormalizedUsername(ctx,
 		rmds.MD.LastModifyingWriter().AsUserOrTeam())
 	if nameErr != nil {
-		writer = libkb.NormalizedUsername("uid: " +
+		writer = kbun.NormalizedUsername("uid: " +
 			rmds.MD.LastModifyingWriter().String())
 	}
 	md.log.CDebugf(ctx, "Unverifiable update for TLF %s: %+v",

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	merkle "github.com/keybase/go-merkle-tree"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -946,7 +946,7 @@ func testMDOpsGetFinalSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	now := time.Now()
 	finalizedInfo, err := tlf.NewHandleExtension(
-		tlf.HandleExtensionFinalized, 1, libkb.NormalizedUsername("<unknown>"),
+		tlf.HandleExtensionFinalized, 1, kbun.NormalizedUsername("<unknown>"),
 		now)
 	require.NoError(t, err)
 	finalRMDS, err := rmdses[len(rmdses)-1].MakeFinalCopy(
@@ -1097,7 +1097,7 @@ func makeEncryptedMerkleLeafForTesting(
 }
 
 func testMDOpsDecryptMerkleLeafPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1 libkb.NormalizedUsername = "u1"
+	var u1 kbun.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)
@@ -1190,7 +1190,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 		t.Skip("Teams not supported")
 	}
 
-	var u1 libkb.NormalizedUsername = "u1"
+	var u1 kbun.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)
@@ -1221,7 +1221,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 }
 
 func testMDOpsVerifyRevokedDeviceWrite(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1 libkb.NormalizedUsername = "u1"
+	var u1 kbun.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)
@@ -1321,7 +1321,7 @@ func testMDOpsVerifyRemovedUserWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 		t.Skip("Teams not supported")
 	}
 
-	var u1, u2 libkb.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	merkle "github.com/keybase/go-merkle-tree"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -946,7 +946,7 @@ func testMDOpsGetFinalSuccess(t *testing.T, ver kbfsmd.MetadataVer) {
 
 	now := time.Now()
 	finalizedInfo, err := tlf.NewHandleExtension(
-		tlf.HandleExtensionFinalized, 1, kbun.NormalizedUsername("<unknown>"),
+		tlf.HandleExtensionFinalized, 1, kbname.NormalizedUsername("<unknown>"),
 		now)
 	require.NoError(t, err)
 	finalRMDS, err := rmdses[len(rmdses)-1].MakeFinalCopy(
@@ -1097,7 +1097,7 @@ func makeEncryptedMerkleLeafForTesting(
 }
 
 func testMDOpsDecryptMerkleLeafPrivate(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1 kbun.NormalizedUsername = "u1"
+	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)
@@ -1190,7 +1190,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 		t.Skip("Teams not supported")
 	}
 
-	var u1 kbun.NormalizedUsername = "u1"
+	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)
@@ -1221,7 +1221,7 @@ func testMDOpsDecryptMerkleLeafTeam(t *testing.T, ver kbfsmd.MetadataVer) {
 }
 
 func testMDOpsVerifyRevokedDeviceWrite(t *testing.T, ver kbfsmd.MetadataVer) {
-	var u1 kbun.NormalizedUsername = "u1"
+	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)
@@ -1321,7 +1321,7 @@ func testMDOpsVerifyRemovedUserWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 		t.Skip("Teams not supported")
 	}
 
-	var u1, u2 kbun.NormalizedUsername = "u1", "u2"
+	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config, ctx, cancel)
 	config.SetMetadataVersion(ver)

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -26,7 +26,7 @@ type mdRange struct {
 
 func makeRekeyReadErrorHelper(
 	err error, kmd KeyMetadata, resolvedHandle *TlfHandle,
-	uid keybase1.UID, username libkb.NormalizedUsername) error {
+	uid keybase1.UID, username kbun.NormalizedUsername) error {
 	if resolvedHandle.Type() == tlf.Public {
 		panic("makeRekeyReadError called on public folder")
 	}
@@ -47,7 +47,7 @@ func makeRekeyReadErrorHelper(
 
 func makeRekeyReadError(
 	ctx context.Context, err error, kbpki KBPKI, kmd KeyMetadata,
-	uid keybase1.UID, username libkb.NormalizedUsername) error {
+	uid keybase1.UID, username kbun.NormalizedUsername) error {
 	h := kmd.GetTlfHandle()
 	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki, nil)
 	if resolveErr != nil {

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -26,7 +26,7 @@ type mdRange struct {
 
 func makeRekeyReadErrorHelper(
 	err error, kmd KeyMetadata, resolvedHandle *TlfHandle,
-	uid keybase1.UID, username kbun.NormalizedUsername) error {
+	uid keybase1.UID, username kbname.NormalizedUsername) error {
 	if resolvedHandle.Type() == tlf.Public {
 		panic("makeRekeyReadError called on public folder")
 	}
@@ -47,7 +47,7 @@ func makeRekeyReadErrorHelper(
 
 func makeRekeyReadError(
 	ctx context.Context, err error, kbpki KBPKI, kmd KeyMetadata,
-	uid keybase1.UID, username kbun.NormalizedUsername) error {
+	uid keybase1.UID, username kbname.NormalizedUsername) error {
 	h := kmd.GetTlfHandle()
 	resolvedHandle, resolveErr := h.ResolveAgain(ctx, kbpki, nil)
 	if resolveErr != nil {

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -97,7 +97,7 @@ func TestReembedBlockChanges(t *testing.T) {
 }
 
 func TestGetRevisionByTime(t *testing.T) {
-	var u1 libkb.NormalizedUsername = "u1"
+	var u1 kbun.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 

--- a/libkbfs/md_util_test.go
+++ b/libkbfs/md_util_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -97,7 +97,7 @@ func TestReembedBlockChanges(t *testing.T) {
 }
 
 func TestGetRevisionByTime(t *testing.T) {
-	var u1 kbun.NormalizedUsername = "u1"
+	var u1 kbname.NormalizedUsername = "u1"
 	config, _, ctx, cancel := kbfsOpsInitNoMocks(t, u1)
 	defer kbfsTestShutdownNoMocks(t, config, ctx, cancel)
 

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -25,7 +25,7 @@ func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
 	require.NoError(t, err)
 
 	nug := testNormalizedUsernameGetter{
-		id: kbun.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
+		id: kbname.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
 	}
 
 	ctx := context.Background()

--- a/libkbfs/mdcache_test.go
+++ b/libkbfs/mdcache_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/kbfscrypto"
@@ -25,7 +25,7 @@ func testMdcacheMakeHandle(t *testing.T, n uint32) *TlfHandle {
 	require.NoError(t, err)
 
 	nug := testNormalizedUsernameGetter{
-		id: libkb.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
+		id: kbun.NormalizedUsername(fmt.Sprintf("fake_user_%d", n)),
 	}
 
 	ctx := context.Background()

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -6,7 +6,7 @@ package libkbfs
 
 import (
 	gomock "github.com/golang/mock/gomock"
-	libkb "github.com/keybase/client/go/libkb"
+	kbun "github.com/keybase/client/go/kbun"
 	logger "github.com/keybase/client/go/logger"
 	chat1 "github.com/keybase/client/go/protocol/chat1"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
@@ -1878,9 +1878,9 @@ func (mr *MockKeybaseServiceMockRecorder) PutGitMetadata(ctx, folder, repoID, me
 }
 
 // Resolve mocks base method
-func (m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *MockKeybaseService) Resolve(ctx context.Context, assertion string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Resolve", ctx, assertion)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -1892,9 +1892,9 @@ func (mr *MockKeybaseServiceMockRecorder) Resolve(ctx, assertion interface{}) *g
 }
 
 // Identify mocks base method
-func (m *MockKeybaseService) Identify(ctx context.Context, assertion, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *MockKeybaseService) Identify(ctx context.Context, assertion, reason string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Identify", ctx, assertion, reason)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -2187,9 +2187,9 @@ func (m *Mockresolver) EXPECT() *MockresolverMockRecorder {
 }
 
 // Resolve mocks base method
-func (m *Mockresolver) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *Mockresolver) Resolve(ctx context.Context, assertion string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Resolve", ctx, assertion)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -2263,9 +2263,9 @@ func (m *Mockidentifier) EXPECT() *MockidentifierMockRecorder {
 }
 
 // Identify mocks base method
-func (m *Mockidentifier) Identify(ctx context.Context, assertion, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *Mockidentifier) Identify(ctx context.Context, assertion, reason string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Identify", ctx, assertion, reason)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -2313,9 +2313,9 @@ func (m *MocknormalizedUsernameGetter) EXPECT() *MocknormalizedUsernameGetterMoc
 }
 
 // GetNormalizedUsername mocks base method
-func (m *MocknormalizedUsernameGetter) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (libkb.NormalizedUsername, error) {
+func (m *MocknormalizedUsernameGetter) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (kbun.NormalizedUsername, error) {
 	ret := m.ctrl.Call(m, "GetNormalizedUsername", ctx, id)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2547,9 +2547,9 @@ func (mr *MockKBPKIMockRecorder) GetCurrentSession(ctx interface{}) *gomock.Call
 }
 
 // Resolve mocks base method
-func (m *MockKBPKI) Resolve(ctx context.Context, assertion string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *MockKBPKI) Resolve(ctx context.Context, assertion string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Resolve", ctx, assertion)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -2600,9 +2600,9 @@ func (mr *MockKBPKIMockRecorder) ResolveTeamTLFID(ctx, teamID interface{}) *gomo
 }
 
 // Identify mocks base method
-func (m *MockKBPKI) Identify(ctx context.Context, assertion, reason string) (libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+func (m *MockKBPKI) Identify(ctx context.Context, assertion, reason string) (kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	ret := m.ctrl.Call(m, "Identify", ctx, assertion, reason)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(keybase1.UserOrTeamID)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -2627,9 +2627,9 @@ func (mr *MockKBPKIMockRecorder) IdentifyImplicitTeam(ctx, assertions, suffix, t
 }
 
 // GetNormalizedUsername mocks base method
-func (m *MockKBPKI) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (libkb.NormalizedUsername, error) {
+func (m *MockKBPKI) GetNormalizedUsername(ctx context.Context, id keybase1.UserOrTeamID) (kbun.NormalizedUsername, error) {
 	ret := m.ctrl.Call(m, "GetNormalizedUsername", ctx, id)
-	ret0, _ := ret[0].(libkb.NormalizedUsername)
+	ret0, _ := ret[0].(kbun.NormalizedUsername)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
 func TestRekeyQueueBasic(t *testing.T) {
-	var u1, u2, u3, u4 libkb.NormalizedUsername = "u1", "u2", "u3", "u4"
+	var u1, u2, u3, u4 kbun.NormalizedUsername = "u1", "u2", "u3", "u4"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3, u4)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/rekey_queue_test.go
+++ b/libkbfs/rekey_queue_test.go
@@ -8,13 +8,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
 
 func TestRekeyQueueBasic(t *testing.T) {
-	var u1, u2, u3, u4 kbun.NormalizedUsername = "u1", "u2", "u3", "u4"
+	var u1, u2, u3, u4 kbname.NormalizedUsername = "u1", "u2", "u3", "u4"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2, u3, u4)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
 

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -183,7 +183,7 @@ func makeFakeTlfHandle(
 	id := keybase1.MakeTestUID(x).AsUserOrTeam()
 	return &TlfHandle{
 		tlfType: ty,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			id: "test_user",
 		},
 		unresolvedWriters: unresolvedWriters,
@@ -800,7 +800,7 @@ func TestRootMetadataTeamMembership(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
 	h := &TlfHandle{
 		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			tid.AsUserOrTeam(): "t1",
 		},
 		name: "t1",
@@ -884,7 +884,7 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
 	h := &TlfHandle{
 		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbname.NormalizedUsername{
 			tid.AsUserOrTeam(): "t1",
 		},
 		name: "t1",

--- a/libkbfs/root_metadata_test.go
+++ b/libkbfs/root_metadata_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
@@ -183,7 +183,7 @@ func makeFakeTlfHandle(
 	id := keybase1.MakeTestUID(x).AsUserOrTeam()
 	return &TlfHandle{
 		tlfType: ty,
-		resolvedWriters: map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			id: "test_user",
 		},
 		unresolvedWriters: unresolvedWriters,
@@ -800,7 +800,7 @@ func TestRootMetadataTeamMembership(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
 	h := &TlfHandle{
 		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			tid.AsUserOrTeam(): "t1",
 		},
 		name: "t1",
@@ -884,7 +884,7 @@ func TestRootMetadataTeamMakeSuccessor(t *testing.T) {
 	tlfID := tlf.FakeID(1, tlf.SingleTeam)
 	h := &TlfHandle{
 		tlfType: tlf.SingleTeam,
-		resolvedWriters: map[keybase1.UserOrTeamID]libkb.NormalizedUsername{
+		resolvedWriters: map[keybase1.UserOrTeamID]kbun.NormalizedUsername{
 			tid.AsUserOrTeam(): "t1",
 		},
 		name: "t1",

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -117,7 +117,7 @@ func newTestRPCLogFactory(t testLogger) rpc.LogFactory {
 // being logged in.
 func MakeTestConfigOrBustLoggedInWithMode(
 	t logger.TestLogBackend, loggedInIndex int,
-	mode InitModeType, users ...libkb.NormalizedUsername) *ConfigLocal {
+	mode InitModeType, users ...kbun.NormalizedUsername) *ConfigLocal {
 	log := logger.NewTestLogger(t)
 	config := newConfigForTest(mode, func(m string) logger.Logger {
 		return log
@@ -209,7 +209,7 @@ func MakeTestConfigOrBustLoggedInWithMode(
 // unit-testing with the given list of users. loggedInIndex specifies the
 // index (in the list) of the user being logged in.
 func MakeTestConfigOrBustLoggedIn(t logger.TestLogBackend, loggedInIndex int,
-	users ...libkb.NormalizedUsername) *ConfigLocal {
+	users ...kbun.NormalizedUsername) *ConfigLocal {
 	return MakeTestConfigOrBustLoggedInWithMode(
 		t, loggedInIndex, InitDefault, users...)
 }
@@ -217,7 +217,7 @@ func MakeTestConfigOrBustLoggedIn(t logger.TestLogBackend, loggedInIndex int,
 // MakeTestConfigOrBust creates and returns a config suitable for
 // unit-testing with the given list of users.
 func MakeTestConfigOrBust(t logger.TestLogBackend,
-	users ...libkb.NormalizedUsername) *ConfigLocal {
+	users ...kbun.NormalizedUsername) *ConfigLocal {
 	return MakeTestConfigOrBustLoggedIn(t, 0, users...)
 }
 
@@ -226,7 +226,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 // enabled in the returned Config, regardless of the journal status in
 // `config`.
 func ConfigAsUserWithMode(config *ConfigLocal,
-	loggedInUser libkb.NormalizedUsername, mode InitModeType) *ConfigLocal {
+	loggedInUser kbun.NormalizedUsername, mode InitModeType) *ConfigLocal {
 	c := newConfigForTest(mode, config.loggerFn)
 	c.SetMetadataVersion(config.MetadataVersion())
 	c.SetRekeyWithPromptWaitTime(config.RekeyWithPromptWaitTime())
@@ -320,7 +320,7 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 // enabled in the returned Config, regardless of the journal status in
 // `config`.
 func ConfigAsUser(config *ConfigLocal,
-	loggedInUser libkb.NormalizedUsername) *ConfigLocal {
+	loggedInUser kbun.NormalizedUsername) *ConfigLocal {
 	c := ConfigAsUserWithMode(config, loggedInUser, config.Mode().Type())
 	c.mode = config.mode // preserve any unusual test mode wrappers
 	return c
@@ -340,17 +340,17 @@ func NewEmptyTLFReaderKeyBundle() kbfsmd.TLFReaderKeyBundleV2 {
 	}
 }
 
-func keySaltForUserDevice(name libkb.NormalizedUsername,
-	index int) libkb.NormalizedUsername {
+func keySaltForUserDevice(name kbun.NormalizedUsername,
+	index int) kbun.NormalizedUsername {
 	if index > 0 {
 		// We can't include the device index when it's 0, because we
 		// have to match what's done in MakeLocalUsers.
-		return libkb.NormalizedUsername(string(name) + " " + string(index))
+		return kbun.NormalizedUsername(string(name) + " " + string(index))
 	}
 	return name
 }
 
-func makeFakeKeys(name libkb.NormalizedUsername, index int) (
+func makeFakeKeys(name kbun.NormalizedUsername, index int) (
 	kbfscrypto.CryptPublicKey, kbfscrypto.VerifyingKey) {
 	keySalt := keySaltForUserDevice(name, index)
 	newCryptPublicKey := MakeLocalUserCryptPublicKeyOrBust(keySalt)
@@ -559,7 +559,7 @@ func AddTeamKeyForTestOrBust(t logger.TestLogBackend, config Config,
 // AddEmptyTeamsForTest creates teams for the given names with empty
 // membership lists.
 func AddEmptyTeamsForTest(
-	config Config, teams ...libkb.NormalizedUsername) ([]TeamInfo, error) {
+	config Config, teams ...kbun.NormalizedUsername) ([]TeamInfo, error) {
 	teamInfos := MakeLocalTeams(teams)
 
 	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
@@ -574,7 +574,7 @@ func AddEmptyTeamsForTest(
 // AddEmptyTeamsForTestOrBust is like AddEmptyTeamsForTest, but dies
 // if there's an error.
 func AddEmptyTeamsForTestOrBust(t logger.TestLogBackend,
-	config Config, teams ...libkb.NormalizedUsername) []TeamInfo {
+	config Config, teams ...kbun.NormalizedUsername) []TeamInfo {
 	teamInfos, err := AddEmptyTeamsForTest(config, teams...)
 	if err != nil {
 		t.Fatal(err)

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
@@ -117,7 +117,7 @@ func newTestRPCLogFactory(t testLogger) rpc.LogFactory {
 // being logged in.
 func MakeTestConfigOrBustLoggedInWithMode(
 	t logger.TestLogBackend, loggedInIndex int,
-	mode InitModeType, users ...kbun.NormalizedUsername) *ConfigLocal {
+	mode InitModeType, users ...kbname.NormalizedUsername) *ConfigLocal {
 	log := logger.NewTestLogger(t)
 	config := newConfigForTest(mode, func(m string) logger.Logger {
 		return log
@@ -209,7 +209,7 @@ func MakeTestConfigOrBustLoggedInWithMode(
 // unit-testing with the given list of users. loggedInIndex specifies the
 // index (in the list) of the user being logged in.
 func MakeTestConfigOrBustLoggedIn(t logger.TestLogBackend, loggedInIndex int,
-	users ...kbun.NormalizedUsername) *ConfigLocal {
+	users ...kbname.NormalizedUsername) *ConfigLocal {
 	return MakeTestConfigOrBustLoggedInWithMode(
 		t, loggedInIndex, InitDefault, users...)
 }
@@ -217,7 +217,7 @@ func MakeTestConfigOrBustLoggedIn(t logger.TestLogBackend, loggedInIndex int,
 // MakeTestConfigOrBust creates and returns a config suitable for
 // unit-testing with the given list of users.
 func MakeTestConfigOrBust(t logger.TestLogBackend,
-	users ...kbun.NormalizedUsername) *ConfigLocal {
+	users ...kbname.NormalizedUsername) *ConfigLocal {
 	return MakeTestConfigOrBustLoggedIn(t, 0, users...)
 }
 
@@ -226,7 +226,7 @@ func MakeTestConfigOrBust(t logger.TestLogBackend,
 // enabled in the returned Config, regardless of the journal status in
 // `config`.
 func ConfigAsUserWithMode(config *ConfigLocal,
-	loggedInUser kbun.NormalizedUsername, mode InitModeType) *ConfigLocal {
+	loggedInUser kbname.NormalizedUsername, mode InitModeType) *ConfigLocal {
 	c := newConfigForTest(mode, config.loggerFn)
 	c.SetMetadataVersion(config.MetadataVersion())
 	c.SetRekeyWithPromptWaitTime(config.RekeyWithPromptWaitTime())
@@ -320,7 +320,7 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 // enabled in the returned Config, regardless of the journal status in
 // `config`.
 func ConfigAsUser(config *ConfigLocal,
-	loggedInUser kbun.NormalizedUsername) *ConfigLocal {
+	loggedInUser kbname.NormalizedUsername) *ConfigLocal {
 	c := ConfigAsUserWithMode(config, loggedInUser, config.Mode().Type())
 	c.mode = config.mode // preserve any unusual test mode wrappers
 	return c
@@ -340,17 +340,17 @@ func NewEmptyTLFReaderKeyBundle() kbfsmd.TLFReaderKeyBundleV2 {
 	}
 }
 
-func keySaltForUserDevice(name kbun.NormalizedUsername,
-	index int) kbun.NormalizedUsername {
+func keySaltForUserDevice(name kbname.NormalizedUsername,
+	index int) kbname.NormalizedUsername {
 	if index > 0 {
 		// We can't include the device index when it's 0, because we
 		// have to match what's done in MakeLocalUsers.
-		return kbun.NormalizedUsername(string(name) + " " + string(index))
+		return kbname.NormalizedUsername(string(name) + " " + string(index))
 	}
 	return name
 }
 
-func makeFakeKeys(name kbun.NormalizedUsername, index int) (
+func makeFakeKeys(name kbname.NormalizedUsername, index int) (
 	kbfscrypto.CryptPublicKey, kbfscrypto.VerifyingKey) {
 	keySalt := keySaltForUserDevice(name, index)
 	newCryptPublicKey := MakeLocalUserCryptPublicKeyOrBust(keySalt)
@@ -559,7 +559,7 @@ func AddTeamKeyForTestOrBust(t logger.TestLogBackend, config Config,
 // AddEmptyTeamsForTest creates teams for the given names with empty
 // membership lists.
 func AddEmptyTeamsForTest(
-	config Config, teams ...kbun.NormalizedUsername) ([]TeamInfo, error) {
+	config Config, teams ...kbname.NormalizedUsername) ([]TeamInfo, error) {
 	teamInfos := MakeLocalTeams(teams)
 
 	kbd, ok := config.KeybaseService().(*KeybaseDaemonLocal)
@@ -574,7 +574,7 @@ func AddEmptyTeamsForTest(
 // AddEmptyTeamsForTestOrBust is like AddEmptyTeamsForTest, but dies
 // if there's an error.
 func AddEmptyTeamsForTestOrBust(t logger.TestLogBackend,
-	config Config, teams ...kbun.NormalizedUsername) []TeamInfo {
+	config Config, teams ...kbname.NormalizedUsername) []TeamInfo {
 	teamInfos, err := AddEmptyTeamsForTest(config, teams...)
 	if err != nil {
 		t.Fatal(err)

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/keybase/client/go/externals"
 	"github.com/keybase/client/go/kbun"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
@@ -472,7 +471,7 @@ func splitAndNormalizeTLFName(name string, t tlf.Type) (
 // TODO: this function can likely be replaced with a call to
 // AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
 func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
-	if libkb.CheckUsername.F(s) {
+	if kbun.CheckUsername(s) {
 		return kbun.NewNormalizedUsername(s).String(), nil
 	}
 

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/externals"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -28,8 +29,8 @@ type TlfHandle struct {
 	// If this is not Private, resolvedReaders and unresolvedReaders
 	// should both be nil.
 	tlfType         tlf.Type
-	resolvedWriters map[keybase1.UserOrTeamID]libkb.NormalizedUsername
-	resolvedReaders map[keybase1.UserOrTeamID]libkb.NormalizedUsername
+	resolvedWriters map[keybase1.UserOrTeamID]kbun.NormalizedUsername
+	resolvedReaders map[keybase1.UserOrTeamID]kbun.NormalizedUsername
 	// Both unresolvedWriters and unresolvedReaders are stored in
 	// sorted order.
 	unresolvedWriters []keybase1.SocialAssertion
@@ -106,8 +107,8 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 }
 
 // ResolvedUsersMap returns a map of resolved users from uid to usernames.
-func (h TlfHandle) ResolvedUsersMap() map[keybase1.UserOrTeamID]libkb.NormalizedUsername {
-	m := make(map[keybase1.UserOrTeamID]libkb.NormalizedUsername,
+func (h TlfHandle) ResolvedUsersMap() map[keybase1.UserOrTeamID]kbun.NormalizedUsername {
+	m := make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername,
 		len(h.resolvedReaders)+len(h.resolvedWriters))
 	for k, v := range h.resolvedReaders {
 		m[k] = v
@@ -376,12 +377,12 @@ func (h TlfHandle) deepCopy() *TlfHandle {
 		tlfID:             h.tlfID,
 	}
 
-	hCopy.resolvedWriters = make(map[keybase1.UserOrTeamID]libkb.NormalizedUsername, len(h.resolvedWriters))
+	hCopy.resolvedWriters = make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(h.resolvedWriters))
 	for k, v := range h.resolvedWriters {
 		hCopy.resolvedWriters[k] = v
 	}
 
-	hCopy.resolvedReaders = make(map[keybase1.UserOrTeamID]libkb.NormalizedUsername, len(h.resolvedReaders))
+	hCopy.resolvedReaders = make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(h.resolvedReaders))
 	for k, v := range h.resolvedReaders {
 		hCopy.resolvedReaders[k] = v
 	}
@@ -586,7 +587,7 @@ func (h TlfHandle) IsConflict() bool {
 // tlf name which will be reordered into the preferred format.
 // An empty username is allowed here and results in the canonical ordering.
 func (h TlfHandle) GetPreferredFormat(
-	username libkb.NormalizedUsername) tlf.PreferredName {
+	username kbun.NormalizedUsername) tlf.PreferredName {
 	s, err := tlf.CanonicalToPreferredName(username, h.GetCanonicalName())
 	if err != nil {
 		panic("TlfHandle.GetPreferredFormat: Parsing canonical username failed!")

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -473,7 +473,7 @@ func splitAndNormalizeTLFName(name string, t tlf.Type) (
 // AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
 func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
 	if libkb.CheckUsername.F(s) {
-		return libkb.NewNormalizedUsername(s).String(), nil
+		return kbun.NewNormalizedUsername(s).String(), nil
 	}
 
 	// TODO: this fails for http and https right now (see CORE-2968).

--- a/libkbfs/tlf_handle.go
+++ b/libkbfs/tlf_handle.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
@@ -28,8 +28,8 @@ type TlfHandle struct {
 	// If this is not Private, resolvedReaders and unresolvedReaders
 	// should both be nil.
 	tlfType         tlf.Type
-	resolvedWriters map[keybase1.UserOrTeamID]kbun.NormalizedUsername
-	resolvedReaders map[keybase1.UserOrTeamID]kbun.NormalizedUsername
+	resolvedWriters map[keybase1.UserOrTeamID]kbname.NormalizedUsername
+	resolvedReaders map[keybase1.UserOrTeamID]kbname.NormalizedUsername
 	// Both unresolvedWriters and unresolvedReaders are stored in
 	// sorted order.
 	unresolvedWriters []keybase1.SocialAssertion
@@ -106,8 +106,8 @@ func (h TlfHandle) IsReader(user keybase1.UID) bool {
 }
 
 // ResolvedUsersMap returns a map of resolved users from uid to usernames.
-func (h TlfHandle) ResolvedUsersMap() map[keybase1.UserOrTeamID]kbun.NormalizedUsername {
-	m := make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername,
+func (h TlfHandle) ResolvedUsersMap() map[keybase1.UserOrTeamID]kbname.NormalizedUsername {
+	m := make(map[keybase1.UserOrTeamID]kbname.NormalizedUsername,
 		len(h.resolvedReaders)+len(h.resolvedWriters))
 	for k, v := range h.resolvedReaders {
 		m[k] = v
@@ -376,12 +376,12 @@ func (h TlfHandle) deepCopy() *TlfHandle {
 		tlfID:             h.tlfID,
 	}
 
-	hCopy.resolvedWriters = make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(h.resolvedWriters))
+	hCopy.resolvedWriters = make(map[keybase1.UserOrTeamID]kbname.NormalizedUsername, len(h.resolvedWriters))
 	for k, v := range h.resolvedWriters {
 		hCopy.resolvedWriters[k] = v
 	}
 
-	hCopy.resolvedReaders = make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(h.resolvedReaders))
+	hCopy.resolvedReaders = make(map[keybase1.UserOrTeamID]kbname.NormalizedUsername, len(h.resolvedReaders))
 	for k, v := range h.resolvedReaders {
 		hCopy.resolvedReaders[k] = v
 	}
@@ -471,8 +471,8 @@ func splitAndNormalizeTLFName(name string, t tlf.Type) (
 // TODO: this function can likely be replaced with a call to
 // AssertionParseAndOnly when CORE-2967 and CORE-2968 are fixed.
 func normalizeAssertionOrName(s string, t tlf.Type) (string, error) {
-	if kbun.CheckUsername(s) {
-		return kbun.NewNormalizedUsername(s).String(), nil
+	if kbname.CheckUsername(s) {
+		return kbname.NewNormalizedUsername(s).String(), nil
 	}
 
 	// TODO: this fails for http and https right now (see CORE-2968).
@@ -586,7 +586,7 @@ func (h TlfHandle) IsConflict() bool {
 // tlf name which will be reordered into the preferred format.
 // An empty username is allowed here and results in the canonical ordering.
 func (h TlfHandle) GetPreferredFormat(
-	username kbun.NormalizedUsername) tlf.PreferredName {
+	username kbname.NormalizedUsername) tlf.PreferredName {
 	s, err := tlf.CanonicalToPreferredName(username, h.GetCanonicalName())
 	if err != nil {
 		panic("TlfHandle.GetPreferredFormat: Parsing canonical username failed!")

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -24,7 +24,7 @@ import (
 )
 
 type nameIDPair struct {
-	name libkb.NormalizedUsername
+	name kbun.NormalizedUsername
 	id   keybase1.UserOrTeamID
 }
 
@@ -83,8 +83,8 @@ func resolveOneUser(
 	errCh <- fmt.Errorf("Resolving %v resulted in empty userInfo and empty socialAssertion", user)
 }
 
-func getNames(idToName map[keybase1.UserOrTeamID]libkb.NormalizedUsername) []libkb.NormalizedUsername {
-	var names []libkb.NormalizedUsername
+func getNames(idToName map[keybase1.UserOrTeamID]kbun.NormalizedUsername) []kbun.NormalizedUsername {
+	var names []kbun.NormalizedUsername
 	for _, name := range idToName {
 		names = append(names, name)
 	}
@@ -123,9 +123,9 @@ func makeTlfHandleHelper(
 	}
 
 	usedWNames :=
-		make(map[keybase1.UserOrTeamID]libkb.NormalizedUsername, len(writers))
+		make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(writers))
 	usedRNames :=
-		make(map[keybase1.UserOrTeamID]libkb.NormalizedUsername, len(readers))
+		make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(readers))
 	usedUnresolvedWriters := make(map[keybase1.SocialAssertion]bool)
 	usedUnresolvedReaders := make(map[keybase1.SocialAssertion]bool)
 	for i := 0; i < len(writers)+len(readers); i++ {
@@ -435,10 +435,10 @@ type partialResolver struct {
 }
 
 func (pr partialResolver) Resolve(ctx context.Context, assertion string) (
-	libkb.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	if pr.unresolvedAssertions[assertion] {
 		// Force an unresolved assertion.
-		return libkb.NormalizedUsername(""),
+		return kbun.NormalizedUsername(""),
 			keybase1.UserOrTeamID(""), NoSuchUserError{assertion}
 	}
 	return pr.resolver.Resolve(ctx, assertion)
@@ -660,7 +660,7 @@ func (ra resolvableAssertion) resolve(ctx context.Context) (
 					"Can't resolve an AND assertion without an identifier")
 		}
 		reason := fmt.Sprintf("You accessed a folder with %s.", ra.assertion)
-		var resName libkb.NormalizedUsername
+		var resName kbun.NormalizedUsername
 		resName, _, err = ra.identifier.Identify(ctx, ra.assertion, reason)
 		if err == nil && resName != name {
 			return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID,

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/keybase/client/go/externals"
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -24,7 +24,7 @@ import (
 )
 
 type nameIDPair struct {
-	name kbun.NormalizedUsername
+	name kbname.NormalizedUsername
 	id   keybase1.UserOrTeamID
 }
 
@@ -83,8 +83,8 @@ func resolveOneUser(
 	errCh <- fmt.Errorf("Resolving %v resulted in empty userInfo and empty socialAssertion", user)
 }
 
-func getNames(idToName map[keybase1.UserOrTeamID]kbun.NormalizedUsername) []kbun.NormalizedUsername {
-	var names []kbun.NormalizedUsername
+func getNames(idToName map[keybase1.UserOrTeamID]kbname.NormalizedUsername) []kbname.NormalizedUsername {
+	var names []kbname.NormalizedUsername
 	for _, name := range idToName {
 		names = append(names, name)
 	}
@@ -123,9 +123,9 @@ func makeTlfHandleHelper(
 	}
 
 	usedWNames :=
-		make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(writers))
+		make(map[keybase1.UserOrTeamID]kbname.NormalizedUsername, len(writers))
 	usedRNames :=
-		make(map[keybase1.UserOrTeamID]kbun.NormalizedUsername, len(readers))
+		make(map[keybase1.UserOrTeamID]kbname.NormalizedUsername, len(readers))
 	usedUnresolvedWriters := make(map[keybase1.SocialAssertion]bool)
 	usedUnresolvedReaders := make(map[keybase1.SocialAssertion]bool)
 	for i := 0; i < len(writers)+len(readers); i++ {
@@ -435,10 +435,10 @@ type partialResolver struct {
 }
 
 func (pr partialResolver) Resolve(ctx context.Context, assertion string) (
-	kbun.NormalizedUsername, keybase1.UserOrTeamID, error) {
+	kbname.NormalizedUsername, keybase1.UserOrTeamID, error) {
 	if pr.unresolvedAssertions[assertion] {
 		// Force an unresolved assertion.
-		return kbun.NormalizedUsername(""),
+		return kbname.NormalizedUsername(""),
 			keybase1.UserOrTeamID(""), NoSuchUserError{assertion}
 	}
 	return pr.resolver.Resolve(ctx, assertion)
@@ -660,7 +660,7 @@ func (ra resolvableAssertion) resolve(ctx context.Context) (
 					"Can't resolve an AND assertion without an identifier")
 		}
 		reason := fmt.Sprintf("You accessed a folder with %s.", ra.assertion)
-		var resName kbun.NormalizedUsername
+		var resName kbname.NormalizedUsername
 		resName, _, err = ra.identifier.Identify(ctx, ra.assertion, reason)
 		if err == nil && resName != name {
 			return nameIDPair{}, keybase1.SocialAssertion{}, tlf.NullID,

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -56,7 +56,7 @@ func TestParseTlfHandleEarlyFailure(t *testing.T) {
 func TestParseTlfHandleNoUserFailure(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -76,7 +76,7 @@ func TestParseTlfHandleNoUserFailure(t *testing.T) {
 func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -98,9 +98,9 @@ func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 func TestParseTlfHandleSingleTeam(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1"})
 	currentUID := localUsers[0].UID
-	localTeams := MakeLocalTeams([]kbun.NormalizedUsername{"t1"})
+	localTeams := MakeLocalTeams([]kbname.NormalizedUsername{"t1"})
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, localTeams, kbfscodec.NewMsgpack())
 
@@ -124,9 +124,9 @@ func TestParseTlfHandleSingleTeam(t *testing.T) {
 func TestParseTlfHandleSingleTeamFailures(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
-	localTeams := MakeLocalTeams([]kbun.NormalizedUsername{"t1", "t2"})
+	localTeams := MakeLocalTeams([]kbname.NormalizedUsername{"t1", "t2"})
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, localTeams, kbfscodec.NewMsgpack())
 
@@ -165,7 +165,7 @@ func TestParseTlfHandleSingleTeamFailures(t *testing.T) {
 func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	localUsers[2].Asserts = []string{"u3@twitter"}
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
@@ -192,7 +192,7 @@ func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -223,7 +223,7 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -253,7 +253,7 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 func TestTlfHandleAccessorsPrivate(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -324,7 +324,7 @@ func TestTlfHandleAccessorsPrivate(t *testing.T) {
 func TestTlfHandleAccessorsPublic(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -381,7 +381,7 @@ func TestTlfHandleAccessorsPublic(t *testing.T) {
 func TestTlfHandleConflictInfo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
@@ -443,7 +443,7 @@ func TestTlfHandleConflictInfo(t *testing.T) {
 func TestTlfHandleFinalizedInfo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
@@ -479,7 +479,7 @@ func TestTlfHandleFinalizedInfo(t *testing.T) {
 func TestTlfHandleConflictAndFinalizedInfo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
@@ -519,7 +519,7 @@ func TestTlfHandleConflictAndFinalizedInfo(t *testing.T) {
 func TestTlfHandlEqual(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{
 		"u1", "u2", "u3", "u4", "u5",
 	})
 	currentUID := localUsers[0].UID
@@ -601,7 +601,7 @@ func TestTlfHandlEqual(t *testing.T) {
 func TestParseTlfHandleSocialAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -632,7 +632,7 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 func TestParseTlfHandleUIDAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -653,7 +653,7 @@ func TestParseTlfHandleUIDAssertion(t *testing.T) {
 func TestParseTlfHandleAndAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2"})
 	localUsers[0].Asserts = []string{"u1@twitter"}
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
@@ -677,7 +677,7 @@ func TestParseTlfHandleAndAssertion(t *testing.T) {
 func TestParseTlfHandleConflictSuffix(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -703,7 +703,7 @@ func TestParseTlfHandleConflictSuffix(t *testing.T) {
 func TestParseTlfHandleFailConflictingAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2"})
 	localUsers[1].Asserts = []string{"u2@twitter"}
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
@@ -740,7 +740,7 @@ func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
 func TestResolveAgainBasic(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -766,7 +766,7 @@ func TestResolveAgainBasic(t *testing.T) {
 func TestResolveAgainDoubleAsserts(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -794,7 +794,7 @@ func TestResolveAgainDoubleAsserts(t *testing.T) {
 func TestResolveAgainWriterReader(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -820,7 +820,7 @@ func TestResolveAgainWriterReader(t *testing.T) {
 func TestResolveAgainConflict(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -851,7 +851,7 @@ func TestResolveAgainConflict(t *testing.T) {
 func TestTlfHandleResolvesTo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{
 		"u1", "u2", "u3", "u4", "u5",
 	})
 	currentUID := localUsers[0].UID
@@ -1049,7 +1049,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{
 		"u1", "u2", "u3",
 	})
 	currentUID := localUsers[0].UID
@@ -1176,7 +1176,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -1212,7 +1212,7 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 func TestParseTlfHandleImplicitTeams(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbname.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
@@ -56,7 +56,7 @@ func TestParseTlfHandleEarlyFailure(t *testing.T) {
 func TestParseTlfHandleNoUserFailure(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -76,7 +76,7 @@ func TestParseTlfHandleNoUserFailure(t *testing.T) {
 func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -98,9 +98,9 @@ func TestParseTlfHandleNotReaderFailure(t *testing.T) {
 func TestParseTlfHandleSingleTeam(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1"})
 	currentUID := localUsers[0].UID
-	localTeams := MakeLocalTeams([]libkb.NormalizedUsername{"t1"})
+	localTeams := MakeLocalTeams([]kbun.NormalizedUsername{"t1"})
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, localTeams, kbfscodec.NewMsgpack())
 
@@ -124,9 +124,9 @@ func TestParseTlfHandleSingleTeam(t *testing.T) {
 func TestParseTlfHandleSingleTeamFailures(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
-	localTeams := MakeLocalTeams([]libkb.NormalizedUsername{"t1", "t2"})
+	localTeams := MakeLocalTeams([]kbun.NormalizedUsername{"t1", "t2"})
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, localTeams, kbfscodec.NewMsgpack())
 
@@ -165,7 +165,7 @@ func TestParseTlfHandleSingleTeamFailures(t *testing.T) {
 func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	localUsers[2].Asserts = []string{"u3@twitter"}
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
@@ -192,7 +192,7 @@ func TestParseTlfHandleAssertionNotCanonicalFailure(t *testing.T) {
 func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -223,7 +223,7 @@ func TestParseTlfHandleAssertionPrivateSuccess(t *testing.T) {
 func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -253,7 +253,7 @@ func TestParseTlfHandleAssertionPublicSuccess(t *testing.T) {
 func TestTlfHandleAccessorsPrivate(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -324,7 +324,7 @@ func TestTlfHandleAccessorsPrivate(t *testing.T) {
 func TestTlfHandleAccessorsPublic(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -381,7 +381,7 @@ func TestTlfHandleAccessorsPublic(t *testing.T) {
 func TestTlfHandleConflictInfo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
@@ -443,7 +443,7 @@ func TestTlfHandleConflictInfo(t *testing.T) {
 func TestTlfHandleFinalizedInfo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
@@ -479,7 +479,7 @@ func TestTlfHandleFinalizedInfo(t *testing.T) {
 func TestTlfHandleConflictAndFinalizedInfo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	codec := kbfscodec.NewMsgpack()
 	daemon := NewKeybaseDaemonMemory(currentUID, localUsers, nil, codec)
@@ -519,7 +519,7 @@ func TestTlfHandleConflictAndFinalizedInfo(t *testing.T) {
 func TestTlfHandlEqual(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{
 		"u1", "u2", "u3", "u4", "u5",
 	})
 	currentUID := localUsers[0].UID
@@ -601,7 +601,7 @@ func TestTlfHandlEqual(t *testing.T) {
 func TestParseTlfHandleSocialAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -632,7 +632,7 @@ func TestParseTlfHandleSocialAssertion(t *testing.T) {
 func TestParseTlfHandleUIDAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -653,7 +653,7 @@ func TestParseTlfHandleUIDAssertion(t *testing.T) {
 func TestParseTlfHandleAndAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
 	localUsers[0].Asserts = []string{"u1@twitter"}
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
@@ -677,7 +677,7 @@ func TestParseTlfHandleAndAssertion(t *testing.T) {
 func TestParseTlfHandleConflictSuffix(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -703,7 +703,7 @@ func TestParseTlfHandleConflictSuffix(t *testing.T) {
 func TestParseTlfHandleFailConflictingAssertion(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
 	localUsers[1].Asserts = []string{"u2@twitter"}
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
@@ -740,7 +740,7 @@ func parseTlfHandleOrBust(t logger.TestLogBackend, config Config,
 func TestResolveAgainBasic(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -766,7 +766,7 @@ func TestResolveAgainBasic(t *testing.T) {
 func TestResolveAgainDoubleAsserts(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -794,7 +794,7 @@ func TestResolveAgainDoubleAsserts(t *testing.T) {
 func TestResolveAgainWriterReader(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -820,7 +820,7 @@ func TestResolveAgainWriterReader(t *testing.T) {
 func TestResolveAgainConflict(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -851,7 +851,7 @@ func TestResolveAgainConflict(t *testing.T) {
 func TestTlfHandleResolvesTo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{
 		"u1", "u2", "u3", "u4", "u5",
 	})
 	currentUID := localUsers[0].UID
@@ -1049,7 +1049,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{
 		"u1", "u2", "u3",
 	})
 	currentUID := localUsers[0].UID
@@ -1176,7 +1176,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())
@@ -1212,7 +1212,7 @@ func TestParseTlfHandleNoncanonicalExtensions(t *testing.T) {
 func TestParseTlfHandleImplicitTeams(t *testing.T) {
 	ctx := context.Background()
 
-	localUsers := MakeLocalUsers([]libkb.NormalizedUsername{"u1", "u2", "u3"})
+	localUsers := MakeLocalUsers([]kbun.NormalizedUsername{"u1", "u2", "u3"})
 	currentUID := localUsers[0].UID
 	daemon := NewKeybaseDaemonMemory(
 		currentUID, localUsers, nil, kbfscodec.NewMsgpack())

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -250,7 +250,7 @@ func users(ns ...username) optionOp {
 	return func(o *opt) {
 		var a []string
 		for _, u := range ns {
-			username := libkb.NewNormalizedUsername(string(u))
+			username := kbun.NewNormalizedUsername(string(u))
 			o.usernames = append(o.usernames, username)
 			a = append(a, string(username))
 		}
@@ -505,7 +505,7 @@ func as(user username, fops ...fileOp) optionOp {
 	return func(o *opt) {
 		o.tb.Log("as:", user)
 		o.runInitOnce()
-		u := libkb.NewNormalizedUsername(string(user))
+		u := kbun.NewNormalizedUsername(string(user))
 		ctx := &ctx{
 			opt:      o,
 			user:     o.users[u],

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbun"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libfs"

--- a/test/dsl_test.go
+++ b/test/dsl_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libfs"
@@ -35,7 +35,7 @@ const (
 
 type opt struct {
 	ver                      kbfsmd.MetadataVer
-	usernames                []kbun.NormalizedUsername
+	usernames                []kbname.NormalizedUsername
 	teams                    teamMap
 	implicitTeams            teamMap
 	tlfName                  string
@@ -44,8 +44,8 @@ type opt struct {
 	tlfRevision              kbfsmd.Revision
 	tlfTime                  string
 	tlfRelTime               string
-	users                    map[kbun.NormalizedUsername]User
-	stallers                 map[kbun.NormalizedUsername]*libkbfs.NaïveStaller
+	users                    map[kbname.NormalizedUsername]User
+	stallers                 map[kbname.NormalizedUsername]*libkbfs.NaïveStaller
 	tb                       testing.TB
 	initOnce                 sync.Once
 	engine                   Engine
@@ -183,8 +183,8 @@ func (o *opt) runInitOnce() {
 }
 
 func (o *opt) makeStallers() (
-	stallers map[kbun.NormalizedUsername]*libkbfs.NaïveStaller) {
-	stallers = make(map[kbun.NormalizedUsername]*libkbfs.NaïveStaller)
+	stallers map[kbname.NormalizedUsername]*libkbfs.NaïveStaller) {
+	stallers = make(map[kbname.NormalizedUsername]*libkbfs.NaïveStaller)
 	for username, user := range o.users {
 		stallers[username] = o.engine.MakeNaïveStaller(user)
 	}
@@ -249,7 +249,7 @@ func users(ns ...username) optionOp {
 	return func(o *opt) {
 		var a []string
 		for _, u := range ns {
-			username := kbun.NewNormalizedUsername(string(u))
+			username := kbname.NewNormalizedUsername(string(u))
 			o.usernames = append(o.usernames, username)
 			a = append(a, string(username))
 		}
@@ -260,7 +260,7 @@ func users(ns ...username) optionOp {
 	}
 }
 
-func team(teamName kbun.NormalizedUsername, writers string,
+func team(teamName kbname.NormalizedUsername, writers string,
 	readers string) optionOp {
 	return func(o *opt) {
 		if o.ver < kbfsmd.SegregatedKeyBundlesVer {
@@ -269,13 +269,13 @@ func team(teamName kbun.NormalizedUsername, writers string,
 		if o.teams == nil {
 			o.teams = make(teamMap)
 		}
-		var writerNames, readerNames []kbun.NormalizedUsername
+		var writerNames, readerNames []kbname.NormalizedUsername
 		for _, w := range strings.Split(writers, ",") {
-			writerNames = append(writerNames, kbun.NormalizedUsername(w))
+			writerNames = append(writerNames, kbname.NormalizedUsername(w))
 		}
 		if readers != "" {
 			for _, r := range strings.Split(readers, ",") {
-				readerNames = append(readerNames, kbun.NormalizedUsername(r))
+				readerNames = append(readerNames, kbname.NormalizedUsername(r))
 			}
 		}
 		o.teams[teamName] = teamMembers{writerNames, readerNames}
@@ -291,14 +291,14 @@ func implicitTeam(writers string, readers string) optionOp {
 			o.implicitTeams = make(teamMap)
 		}
 
-		var writerNames, readerNames []kbun.NormalizedUsername
+		var writerNames, readerNames []kbname.NormalizedUsername
 		for _, w := range strings.Split(writers, ",") {
-			writerNames = append(writerNames, kbun.NormalizedUsername(w))
+			writerNames = append(writerNames, kbname.NormalizedUsername(w))
 		}
 		isPublic := false
 		if readers != "" {
 			for _, r := range strings.Split(readers, ",") {
-				readerNames = append(readerNames, kbun.NormalizedUsername(r))
+				readerNames = append(readerNames, kbname.NormalizedUsername(r))
 			}
 			isPublic = len(readerNames) == 1 && readers == "public"
 		}
@@ -310,7 +310,7 @@ func implicitTeam(writers string, readers string) optionOp {
 			teamName = tlf.MakeCanonicalName(
 				writerNames, nil, readerNames, nil, nil)
 		}
-		o.implicitTeams[kbun.NormalizedUsername(teamName)] =
+		o.implicitTeams[kbname.NormalizedUsername(teamName)] =
 			teamMembers{writerNames, readerNames}
 	}
 }
@@ -402,9 +402,9 @@ func addNewAssertion(oldAssertion, newAssertion string) optionOp {
 
 func changeTeamName(oldName, newName string) optionOp {
 	return func(o *opt) {
-		o.teams[kbun.NormalizedUsername(newName)] =
-			o.teams[kbun.NormalizedUsername(oldName)]
-		delete(o.teams, kbun.NormalizedUsername(oldName))
+		o.teams[kbname.NormalizedUsername(newName)] =
+			o.teams[kbname.NormalizedUsername(oldName)]
+		delete(o.teams, kbname.NormalizedUsername(oldName))
 		o.tb.Logf("changeTeamName: %q -> %q", oldName, newName)
 		for _, u := range o.users {
 			err := o.engine.ChangeTeamName(u, oldName, newName)
@@ -428,7 +428,7 @@ const (
 type ctx struct {
 	*opt
 	user       User
-	username   kbun.NormalizedUsername
+	username   kbname.NormalizedUsername
 	rootNode   Node
 	noSyncInit bool
 	staller    *libkbfs.NaïveStaller
@@ -504,7 +504,7 @@ func as(user username, fops ...fileOp) optionOp {
 	return func(o *opt) {
 		o.tb.Log("as:", user)
 		o.runInitOnce()
-		u := kbun.NewNormalizedUsername(string(user))
+		u := kbname.NewNormalizedUsername(string(user))
 		ctx := &ctx{
 			opt:      o,
 			user:     o.users[u],

--- a/test/engine.go
+++ b/test/engine.go
@@ -7,7 +7,7 @@ package test
 import (
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
@@ -23,11 +23,11 @@ type Node interface{}
 type username string
 
 type teamMembers struct {
-	writers []libkb.NormalizedUsername
-	readers []libkb.NormalizedUsername
+	writers []kbun.NormalizedUsername
+	readers []kbun.NormalizedUsername
 }
 
-type teamMap map[libkb.NormalizedUsername]teamMembers
+type teamMap map[kbun.NormalizedUsername]teamMembers
 
 // Engine is the interface to the filesystem to be used by the test harness.
 // It may wrap libkbfs directly or it may wrap other users of libkbfs (e.g., libfuse).
@@ -47,9 +47,9 @@ type Engine interface {
 	// default engine timeout, or if it is zero, it has no effect.
 	InitTest(ver kbfsmd.MetadataVer, blockSize int64,
 		blockChangeSize int64, batchSize int, bwKBps int,
-		opTimeout time.Duration, users []libkb.NormalizedUsername,
+		opTimeout time.Duration, users []kbun.NormalizedUsername,
 		teams, implicitTeams teamMap, clock libkbfs.Clock,
-		journal bool) map[libkb.NormalizedUsername]User
+		journal bool) map[kbun.NormalizedUsername]User
 	// GetUID is called by the test harness to retrieve a user instance's UID.
 	GetUID(u User) keybase1.UID
 	// GetFavorites returns the set of all public or private

--- a/test/engine.go
+++ b/test/engine.go
@@ -7,7 +7,7 @@ package test
 import (
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/libkbfs"
@@ -23,11 +23,11 @@ type Node interface{}
 type username string
 
 type teamMembers struct {
-	writers []kbun.NormalizedUsername
-	readers []kbun.NormalizedUsername
+	writers []kbname.NormalizedUsername
+	readers []kbname.NormalizedUsername
 }
 
-type teamMap map[kbun.NormalizedUsername]teamMembers
+type teamMap map[kbname.NormalizedUsername]teamMembers
 
 // Engine is the interface to the filesystem to be used by the test harness.
 // It may wrap libkbfs directly or it may wrap other users of libkbfs (e.g., libfuse).
@@ -47,9 +47,9 @@ type Engine interface {
 	// default engine timeout, or if it is zero, it has no effect.
 	InitTest(ver kbfsmd.MetadataVer, blockSize int64,
 		blockChangeSize int64, batchSize int, bwKBps int,
-		opTimeout time.Duration, users []kbun.NormalizedUsername,
+		opTimeout time.Duration, users []kbname.NormalizedUsername,
 		teams, implicitTeams teamMap, clock libkbfs.Clock,
-		journal bool) map[kbun.NormalizedUsername]User
+		journal bool) map[kbname.NormalizedUsername]User
 	// GetUID is called by the test harness to retrieve a user instance's UID.
 	GetUID(u User) keybase1.UID
 	// GetFavorites returns the set of all public or private

--- a/test/engine_common.go
+++ b/test/engine_common.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 )
@@ -46,8 +46,8 @@ func maybeSetBw(t testing.TB, config libkbfs.Config, bwKBps int) {
 }
 
 func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
-	users map[kbun.NormalizedUsername]User) {
-	teamNames := make([]kbun.NormalizedUsername, 0, len(teams))
+	users map[kbname.NormalizedUsername]User) {
+	teamNames := make([]kbname.NormalizedUsername, 0, len(teams))
 	for name := range teams {
 		teamNames = append(teamNames, name)
 	}
@@ -70,7 +70,7 @@ func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
 }
 
 func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
-	implicitTeams teamMap, users map[kbun.NormalizedUsername]User) {
+	implicitTeams teamMap, users map[kbname.NormalizedUsername]User) {
 	if len(implicitTeams) > 0 {
 		err := libkbfs.EnableImplicitTeamsForTest(config)
 		if err != nil {
@@ -82,7 +82,7 @@ func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
 	for name, members := range implicitTeams {
 		ty := tlf.Private
 		if len(members.readers) == 1 &&
-			members.readers[0] == kbun.NormalizedUsername("public") {
+			members.readers[0] == kbname.NormalizedUsername("public") {
 			ty = tlf.Public
 		}
 

--- a/test/engine_common.go
+++ b/test/engine_common.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/kbfs/libkbfs"
 	"github.com/keybase/kbfs/tlf"
 )
@@ -46,8 +46,8 @@ func maybeSetBw(t testing.TB, config libkbfs.Config, bwKBps int) {
 }
 
 func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
-	users map[libkb.NormalizedUsername]User) {
-	teamNames := make([]libkb.NormalizedUsername, 0, len(teams))
+	users map[kbun.NormalizedUsername]User) {
+	teamNames := make([]kbun.NormalizedUsername, 0, len(teams))
 	for name := range teams {
 		teamNames = append(teamNames, name)
 	}
@@ -70,7 +70,7 @@ func makeTeams(t testing.TB, config libkbfs.Config, e Engine, teams teamMap,
 }
 
 func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
-	implicitTeams teamMap, users map[libkb.NormalizedUsername]User) {
+	implicitTeams teamMap, users map[kbun.NormalizedUsername]User) {
 	if len(implicitTeams) > 0 {
 		err := libkbfs.EnableImplicitTeamsForTest(config)
 		if err != nil {
@@ -82,7 +82,7 @@ func makeImplicitTeams(t testing.TB, config libkbfs.Config, e Engine,
 	for name, members := range implicitTeams {
 		ty := tlf.Private
 		if len(members.readers) == 1 &&
-			members.readers[0] == libkb.NormalizedUsername("public") {
+			members.readers[0] == kbun.NormalizedUsername("public") {
 			ty = tlf.Public
 		}
 

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -45,7 +45,7 @@ type fsNode struct {
 
 type fsUser struct {
 	mntDir   string
-	username kbun.NormalizedUsername
+	username kbname.NormalizedUsername
 	config   *libkbfs.ConfigLocal
 	cancel   func()
 	close    func()
@@ -506,7 +506,7 @@ func (e *fsEngine) Shutdown(user User) error {
 	u.shutdown()
 
 	// Get the user name before shutting everything down.
-	var userName kbun.NormalizedUsername
+	var userName kbname.NormalizedUsername
 	if e.journalDir != "" {
 		session, err :=
 			u.config.KBPKI().GetCurrentSession(context.Background())
@@ -658,10 +658,10 @@ func fiTypeString(fi os.FileInfo) string {
 
 func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []kbun.NormalizedUsername,
+	opTimeout time.Duration, users []kbname.NormalizedUsername,
 	teams, implicitTeams teamMap, clock libkbfs.Clock,
-	journal bool) map[kbun.NormalizedUsername]User {
-	res := map[kbun.NormalizedUsername]User{}
+	journal bool) map[kbname.NormalizedUsername]User {
+	res := map[kbname.NormalizedUsername]User{}
 	initSuccess := false
 	defer func() {
 		if !initSuccess {

--- a/test/engine_fs_test.go
+++ b/test/engine_fs_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -45,7 +45,7 @@ type fsNode struct {
 
 type fsUser struct {
 	mntDir   string
-	username libkb.NormalizedUsername
+	username kbun.NormalizedUsername
 	config   *libkbfs.ConfigLocal
 	cancel   func()
 	close    func()
@@ -506,7 +506,7 @@ func (e *fsEngine) Shutdown(user User) error {
 	u.shutdown()
 
 	// Get the user name before shutting everything down.
-	var userName libkb.NormalizedUsername
+	var userName kbun.NormalizedUsername
 	if e.journalDir != "" {
 		session, err :=
 			u.config.KBPKI().GetCurrentSession(context.Background())
@@ -658,10 +658,10 @@ func fiTypeString(fi os.FileInfo) string {
 
 func (e *fsEngine) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []libkb.NormalizedUsername,
+	opTimeout time.Duration, users []kbun.NormalizedUsername,
 	teams, implicitTeams teamMap, clock libkbfs.Clock,
-	journal bool) map[libkb.NormalizedUsername]User {
-	res := map[libkb.NormalizedUsername]User{}
+	journal bool) map[kbun.NormalizedUsername]User {
+	res := map[kbun.NormalizedUsername]User{}
 	initSuccess := false
 	defer func() {
 		if !initSuccess {

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
@@ -48,10 +48,10 @@ func (k *LibKBFS) Name() string {
 // InitTest implements the Engine interface.
 func (k *LibKBFS) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []libkb.NormalizedUsername,
+	opTimeout time.Duration, users []kbun.NormalizedUsername,
 	teams, implicitTeams teamMap, clock libkbfs.Clock,
-	journal bool) map[libkb.NormalizedUsername]User {
-	userMap := make(map[libkb.NormalizedUsername]User)
+	journal bool) map[kbun.NormalizedUsername]User {
+	userMap := make(map[kbun.NormalizedUsername]User)
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(k.tb, users...)
 	config.SetMetadataVersion(ver)
@@ -878,7 +878,7 @@ func (k *LibKBFS) Shutdown(u User) error {
 	delete(k.updateChannels, config)
 
 	// Get the user name before shutting everything down.
-	var userName libkb.NormalizedUsername
+	var userName kbun.NormalizedUsername
 	if k.journalDir != "" {
 		var err error
 		session, err :=

--- a/test/engine_libkbfs.go
+++ b/test/engine_libkbfs.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/logger"
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
@@ -48,10 +48,10 @@ func (k *LibKBFS) Name() string {
 // InitTest implements the Engine interface.
 func (k *LibKBFS) InitTest(ver kbfsmd.MetadataVer,
 	blockSize int64, blockChangeSize int64, batchSize int, bwKBps int,
-	opTimeout time.Duration, users []kbun.NormalizedUsername,
+	opTimeout time.Duration, users []kbname.NormalizedUsername,
 	teams, implicitTeams teamMap, clock libkbfs.Clock,
-	journal bool) map[kbun.NormalizedUsername]User {
-	userMap := make(map[kbun.NormalizedUsername]User)
+	journal bool) map[kbname.NormalizedUsername]User {
+	userMap := make(map[kbname.NormalizedUsername]User)
 	// create the first user specially
 	config := libkbfs.MakeTestConfigOrBust(k.tb, users...)
 	config.SetMetadataVersion(ver)
@@ -878,7 +878,7 @@ func (k *LibKBFS) Shutdown(u User) error {
 	delete(k.updateChannels, config)
 
 	// Get the user name before shutting everything down.
-	var userName kbun.NormalizedUsername
+	var userName kbname.NormalizedUsername
 	if k.journalDir != "" {
 		var err error
 		session, err :=

--- a/tlf/handle_extension.go
+++ b/tlf/handle_extension.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/go-codec/codec"
 )
 
@@ -69,7 +69,7 @@ var handleExtensionFinalizedRegex = regexp.MustCompile(
 )
 
 // String implements the fmt.Stringer interface for HandleExtensionType
-func (et HandleExtensionType) String(username kbun.NormalizedUsername) string {
+func (et HandleExtensionType) String(username kbname.NormalizedUsername) string {
 	switch et {
 	case HandleExtensionConflict:
 		return handleExtensionConflictString
@@ -83,7 +83,7 @@ func (et HandleExtensionType) String(username kbun.NormalizedUsername) string {
 }
 
 // parseHandleExtensionString parses an extension type and optional username from a string.
-func parseHandleExtensionString(s string) (HandleExtensionType, kbun.NormalizedUsername) {
+func parseHandleExtensionString(s string) (HandleExtensionType, kbname.NormalizedUsername) {
 	if handleExtensionConflictString == s {
 		return HandleExtensionConflict, ""
 	}
@@ -91,7 +91,7 @@ func parseHandleExtensionString(s string) (HandleExtensionType, kbun.NormalizedU
 	if len(m) < 2 {
 		return HandleExtensionUnknown, ""
 	}
-	return HandleExtensionFinalized, kbun.NewNormalizedUsername(m[1])
+	return HandleExtensionFinalized, kbname.NewNormalizedUsername(m[1])
 }
 
 // ErrHandleExtensionInvalidString is returned when a given string is not parsable as a
@@ -117,7 +117,7 @@ type HandleExtension struct {
 	Date     int64                   `codec:"date"`
 	Number   uint16                  `codec:"num"`
 	Type     HandleExtensionType     `codec:"type"`
-	Username kbun.NormalizedUsername `codec:"un,omitempty"`
+	Username kbname.NormalizedUsername `codec:"un,omitempty"`
 	codec.UnknownFieldSetHandler
 }
 
@@ -147,21 +147,21 @@ func (e HandleExtension) String() string {
 
 // NewHandleExtension returns a new HandleExtension struct
 // populated with the date from the given time and conflict number.
-func NewHandleExtension(extType HandleExtensionType, num uint16, un kbun.NormalizedUsername, now time.Time) (
+func NewHandleExtension(extType HandleExtensionType, num uint16, un kbname.NormalizedUsername, now time.Time) (
 	*HandleExtension, error) {
 	return newHandleExtension(extType, num, un, now)
 }
 
 // NewTestHandleExtensionStaticTime returns a new HandleExtension struct populated with
 // a static date for testing.
-func NewTestHandleExtensionStaticTime(extType HandleExtensionType, num uint16, un kbun.NormalizedUsername) (
+func NewTestHandleExtensionStaticTime(extType HandleExtensionType, num uint16, un kbname.NormalizedUsername) (
 	*HandleExtension, error) {
 	now := time.Unix(HandleExtensionStaticTestDate, 0)
 	return newHandleExtension(extType, num, un, now)
 }
 
 // Helper to instantiate a HandleExtension object.
-func newHandleExtension(extType HandleExtensionType, num uint16, un kbun.NormalizedUsername, now time.Time) (
+func newHandleExtension(extType HandleExtensionType, num uint16, un kbname.NormalizedUsername, now time.Time) (
 	*HandleExtension, error) {
 	if num == 0 {
 		return nil, errHandleExtensionInvalidNumber

--- a/tlf/handle_extension.go
+++ b/tlf/handle_extension.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/go-codec/codec"
 )
@@ -69,7 +70,7 @@ var handleExtensionFinalizedRegex = regexp.MustCompile(
 )
 
 // String implements the fmt.Stringer interface for HandleExtensionType
-func (et HandleExtensionType) String(username libkb.NormalizedUsername) string {
+func (et HandleExtensionType) String(username kbun.NormalizedUsername) string {
 	switch et {
 	case HandleExtensionConflict:
 		return handleExtensionConflictString
@@ -83,7 +84,7 @@ func (et HandleExtensionType) String(username libkb.NormalizedUsername) string {
 }
 
 // parseHandleExtensionString parses an extension type and optional username from a string.
-func parseHandleExtensionString(s string) (HandleExtensionType, libkb.NormalizedUsername) {
+func parseHandleExtensionString(s string) (HandleExtensionType, kbun.NormalizedUsername) {
 	if handleExtensionConflictString == s {
 		return HandleExtensionConflict, ""
 	}
@@ -114,10 +115,10 @@ var handleExtensionRegex = regexp.MustCompile(
 
 // HandleExtension is information which identifies a particular extension.
 type HandleExtension struct {
-	Date     int64                    `codec:"date"`
-	Number   uint16                   `codec:"num"`
-	Type     HandleExtensionType      `codec:"type"`
-	Username libkb.NormalizedUsername `codec:"un,omitempty"`
+	Date     int64                   `codec:"date"`
+	Number   uint16                  `codec:"num"`
+	Type     HandleExtensionType     `codec:"type"`
+	Username kbun.NormalizedUsername `codec:"un,omitempty"`
 	codec.UnknownFieldSetHandler
 }
 
@@ -147,21 +148,21 @@ func (e HandleExtension) String() string {
 
 // NewHandleExtension returns a new HandleExtension struct
 // populated with the date from the given time and conflict number.
-func NewHandleExtension(extType HandleExtensionType, num uint16, un libkb.NormalizedUsername, now time.Time) (
+func NewHandleExtension(extType HandleExtensionType, num uint16, un kbun.NormalizedUsername, now time.Time) (
 	*HandleExtension, error) {
 	return newHandleExtension(extType, num, un, now)
 }
 
 // NewTestHandleExtensionStaticTime returns a new HandleExtension struct populated with
 // a static date for testing.
-func NewTestHandleExtensionStaticTime(extType HandleExtensionType, num uint16, un libkb.NormalizedUsername) (
+func NewTestHandleExtensionStaticTime(extType HandleExtensionType, num uint16, un kbun.NormalizedUsername) (
 	*HandleExtension, error) {
 	now := time.Unix(HandleExtensionStaticTestDate, 0)
 	return newHandleExtension(extType, num, un, now)
 }
 
 // Helper to instantiate a HandleExtension object.
-func newHandleExtension(extType HandleExtensionType, num uint16, un libkb.NormalizedUsername, now time.Time) (
+func newHandleExtension(extType HandleExtensionType, num uint16, un kbun.NormalizedUsername, now time.Time) (
 	*HandleExtension, error) {
 	if num == 0 {
 		return nil, errHandleExtensionInvalidNumber

--- a/tlf/handle_extension.go
+++ b/tlf/handle_extension.go
@@ -114,9 +114,9 @@ var handleExtensionRegex = regexp.MustCompile(
 
 // HandleExtension is information which identifies a particular extension.
 type HandleExtension struct {
-	Date     int64                   `codec:"date"`
-	Number   uint16                  `codec:"num"`
-	Type     HandleExtensionType     `codec:"type"`
+	Date     int64                     `codec:"date"`
+	Number   uint16                    `codec:"num"`
+	Type     HandleExtensionType       `codec:"type"`
 	Username kbname.NormalizedUsername `codec:"un,omitempty"`
 	codec.UnknownFieldSetHandler
 }

--- a/tlf/handle_extension.go
+++ b/tlf/handle_extension.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/kbun"
-	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/go-codec/codec"
 )
 

--- a/tlf/handle_extension.go
+++ b/tlf/handle_extension.go
@@ -92,7 +92,7 @@ func parseHandleExtensionString(s string) (HandleExtensionType, kbun.NormalizedU
 	if len(m) < 2 {
 		return HandleExtensionUnknown, ""
 	}
-	return HandleExtensionFinalized, libkb.NewNormalizedUsername(m[1])
+	return HandleExtensionFinalized, kbun.NewNormalizedUsername(m[1])
 }
 
 // ErrHandleExtensionInvalidString is returned when a given string is not parsable as a

--- a/tlf/name.go
+++ b/tlf/name.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -56,7 +56,7 @@ func SplitName(name string) (writerNames, readerNames []string,
 type CanonicalName string
 
 func getSortedNames(
-	resolved []kbun.NormalizedUsername,
+	resolved []kbname.NormalizedUsername,
 	unresolved []keybase1.SocialAssertion) []string {
 	var names []string
 	for _, name := range resolved {
@@ -69,9 +69,9 @@ func getSortedNames(
 	return names
 }
 
-func makeCanonicalName(resolvedWriters []kbun.NormalizedUsername,
+func makeCanonicalName(resolvedWriters []kbname.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
-	resolvedReaders []kbun.NormalizedUsername,
+	resolvedReaders []kbname.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
 	extensions []HandleExtension, isBackedByTeam bool) CanonicalName {
 	writerNames := getSortedNames(resolvedWriters, unresolvedWriters)
@@ -93,9 +93,9 @@ func makeCanonicalName(resolvedWriters []kbun.NormalizedUsername,
 }
 
 // MakeCanonicalName makes a CanonicalName from components.
-func MakeCanonicalName(resolvedWriters []kbun.NormalizedUsername,
+func MakeCanonicalName(resolvedWriters []kbname.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
-	resolvedReaders []kbun.NormalizedUsername,
+	resolvedReaders []kbname.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
 	extensions []HandleExtension) CanonicalName {
 	return makeCanonicalName(
@@ -104,9 +104,9 @@ func MakeCanonicalName(resolvedWriters []kbun.NormalizedUsername,
 }
 
 // MakeCanonicalNameForTeam makes a CanonicalName from components for a team.
-func MakeCanonicalNameForTeam(resolvedWriters []kbun.NormalizedUsername,
+func MakeCanonicalNameForTeam(resolvedWriters []kbname.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
-	resolvedReaders []kbun.NormalizedUsername,
+	resolvedReaders []kbname.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
 	extensions []HandleExtension) CanonicalName {
 	return makeCanonicalName(
@@ -133,7 +133,7 @@ func putUserFirst(uname string, users []string) []string {
 // CanonicalToPreferredName returns the preferred TLF name, given a
 // canonical name and a username. The username may be empty, and
 // results in the canonical name being being returned unmodified.
-func CanonicalToPreferredName(username kbun.NormalizedUsername,
+func CanonicalToPreferredName(username kbname.NormalizedUsername,
 	canon CanonicalName) (PreferredName, error) {
 	tlfname := string(canon)
 	if len(username) == 0 {

--- a/tlf/name.go
+++ b/tlf/name.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -56,7 +56,7 @@ func SplitName(name string) (writerNames, readerNames []string,
 type CanonicalName string
 
 func getSortedNames(
-	resolved []libkb.NormalizedUsername,
+	resolved []kbun.NormalizedUsername,
 	unresolved []keybase1.SocialAssertion) []string {
 	var names []string
 	for _, name := range resolved {
@@ -69,9 +69,9 @@ func getSortedNames(
 	return names
 }
 
-func makeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
+func makeCanonicalName(resolvedWriters []kbun.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
-	resolvedReaders []libkb.NormalizedUsername,
+	resolvedReaders []kbun.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
 	extensions []HandleExtension, isBackedByTeam bool) CanonicalName {
 	writerNames := getSortedNames(resolvedWriters, unresolvedWriters)
@@ -93,9 +93,9 @@ func makeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
 }
 
 // MakeCanonicalName makes a CanonicalName from components.
-func MakeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
+func MakeCanonicalName(resolvedWriters []kbun.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
-	resolvedReaders []libkb.NormalizedUsername,
+	resolvedReaders []kbun.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
 	extensions []HandleExtension) CanonicalName {
 	return makeCanonicalName(
@@ -104,9 +104,9 @@ func MakeCanonicalName(resolvedWriters []libkb.NormalizedUsername,
 }
 
 // MakeCanonicalNameForTeam makes a CanonicalName from components for a team.
-func MakeCanonicalNameForTeam(resolvedWriters []libkb.NormalizedUsername,
+func MakeCanonicalNameForTeam(resolvedWriters []kbun.NormalizedUsername,
 	unresolvedWriters []keybase1.SocialAssertion,
-	resolvedReaders []libkb.NormalizedUsername,
+	resolvedReaders []kbun.NormalizedUsername,
 	unresolvedReaders []keybase1.SocialAssertion,
 	extensions []HandleExtension) CanonicalName {
 	return makeCanonicalName(
@@ -133,7 +133,7 @@ func putUserFirst(uname string, users []string) []string {
 // CanonicalToPreferredName returns the preferred TLF name, given a
 // canonical name and a username. The username may be empty, and
 // results in the canonical name being being returned unmodified.
-func CanonicalToPreferredName(username libkb.NormalizedUsername,
+func CanonicalToPreferredName(username kbun.NormalizedUsername,
 	canon CanonicalName) (PreferredName, error) {
 	tlfname := string(canon)
 	if len(username) == 0 {

--- a/tlf/name_test.go
+++ b/tlf/name_test.go
@@ -7,13 +7,13 @@ package tlf
 import (
 	"testing"
 
-	"github.com/keybase/client/go/kbun"
+	kbname "github.com/keybase/client/go/kbun"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCanonicalToPreferredName(t *testing.T) {
 	for _, q := range []struct {
-		As     kbun.NormalizedUsername
+		As     kbname.NormalizedUsername
 		Try    CanonicalName
 		Answer PreferredName
 	}{

--- a/tlf/name_test.go
+++ b/tlf/name_test.go
@@ -7,13 +7,13 @@ package tlf
 import (
 	"testing"
 
-	"github.com/keybase/client/go/libkb"
+	"github.com/keybase/client/go/kbun"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCanonicalToPreferredName(t *testing.T) {
 	for _, q := range []struct {
-		As     libkb.NormalizedUsername
+		As     kbun.NormalizedUsername
 		Try    CanonicalName
 		Answer PreferredName
 	}{

--- a/vendor/github.com/keybase/client/go/auth/credential_authority.go
+++ b/vendor/github.com/keybase/client/go/auth/credential_authority.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
+	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
@@ -33,7 +33,7 @@ type CredentialAuthority struct {
 // checkArgs are sent over the checkCh to the core loop of a CredentialAuthority
 type checkArg struct {
 	uid         keybase1.UID
-	username    *kbun.NormalizedUsername
+	username    *libkb.NormalizedUsername
 	kid         *keybase1.KID
 	sibkeys     []keybase1.KID
 	subkeys     []keybase1.KID
@@ -79,7 +79,7 @@ func (ci cleanItem) String() string {
 // are off-limits to the main thread.
 type user struct {
 	uid       keybase1.UID
-	username  kbun.NormalizedUsername
+	username  libkb.NormalizedUsername
 	sibkeys   map[keybase1.KID]struct{}
 	subkeys   map[keybase1.KID]struct{}
 	isOK      bool
@@ -120,7 +120,7 @@ type UserKeyAPIer interface {
 	// GetUser looks up the username and KIDS active for the given user.
 	// Deleted users are loaded by default.
 	GetUser(context.Context, keybase1.UID) (
-		un kbun.NormalizedUsername, sibkeys, subkeys []keybase1.KID, deleted bool, err error)
+		un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, deleted bool, err error)
 	// PollForChanges returns the UIDs that have recently changed on the server
 	// side. It will be called in a poll loop. This call should function as
 	// a *long poll*, meaning, it should not return unless there is a change
@@ -430,7 +430,7 @@ func (u *user) check(ca checkArg) {
 // getUserFromServer runs the UserKeyAPIer GetUser() API call while paying
 // attention to any shutdown events that might interrupt it.
 func (v *CredentialAuthority) getUserFromServer(uid keybase1.UID) (
-	un kbun.NormalizedUsername, sibkeys, subkeys []keybase1.KID, deleted bool, err error) {
+	un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, deleted bool, err error) {
 	err = v.runWithCancel(func(ctx context.Context) error {
 		var err error
 		un, sibkeys, subkeys, deleted, err = v.api.GetUser(ctx, uid)
@@ -440,7 +440,7 @@ func (v *CredentialAuthority) getUserFromServer(uid keybase1.UID) (
 }
 
 // checkUsername checks that a username is a match for this user.
-func (u *user) checkUsername(un kbun.NormalizedUsername) error {
+func (u *user) checkUsername(un libkb.NormalizedUsername) error {
 	var err error
 	if !u.username.Eq(un) {
 		err = BadUsernameError{u.username, un}
@@ -487,7 +487,7 @@ func (u *user) checkKey(kid keybase1.KID) error {
 // extracted from a signed authentication statement. It returns an error if the
 // check fails, and nil otherwise. If username or kid are nil they aren't checked.
 func (v *CredentialAuthority) CheckUserKey(ctx context.Context, uid keybase1.UID,
-	username *kbun.NormalizedUsername, kid *keybase1.KID, loadDeleted bool) (err error) {
+	username *libkb.NormalizedUsername, kid *keybase1.KID, loadDeleted bool) (err error) {
 	v.log.Debug("CheckUserKey uid %s, kid %s", uid, kid)
 	retCh := make(chan error, 1) // buffered in case the ctx is canceled
 	v.checkCh <- checkArg{uid: uid, username: username, kid: kid, loadDeleted: loadDeleted, retCh: retCh}

--- a/vendor/github.com/keybase/client/go/auth/errors.go
+++ b/vendor/github.com/keybase/client/go/auth/errors.go
@@ -3,7 +3,8 @@ package auth
 import (
 	"errors"
 	"fmt"
-	libkb "github.com/keybase/client/go/libkb"
+
+	"github.com/keybase/client/go/kbun"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -16,8 +17,8 @@ var ErrUserDeleted = errors.New("user was deleted")
 // BadUsernameError is raised when the given username disagrees with the expected
 // username
 type BadUsernameError struct {
-	expected libkb.NormalizedUsername
-	received libkb.NormalizedUsername
+	expected kbun.NormalizedUsername
+	received kbun.NormalizedUsername
 }
 
 func (e BadUsernameError) Error() string {

--- a/vendor/github.com/keybase/client/go/auth/errors.go
+++ b/vendor/github.com/keybase/client/go/auth/errors.go
@@ -3,8 +3,7 @@ package auth
 import (
 	"errors"
 	"fmt"
-
-	"github.com/keybase/client/go/kbun"
+	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
 
@@ -17,8 +16,8 @@ var ErrUserDeleted = errors.New("user was deleted")
 // BadUsernameError is raised when the given username disagrees with the expected
 // username
 type BadUsernameError struct {
-	expected kbun.NormalizedUsername
-	received kbun.NormalizedUsername
+	expected libkb.NormalizedUsername
+	received libkb.NormalizedUsername
 }
 
 func (e BadUsernameError) Error() string {

--- a/vendor/github.com/keybase/client/go/auth/token.go
+++ b/vendor/github.com/keybase/client/go/auth/token.go
@@ -14,7 +14,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/keybase/client/go/kbun"
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
@@ -32,9 +31,9 @@ type TokenAuth struct {
 }
 
 type TokenKey struct {
-	UID      keybase1.UID            `json:"uid"`
-	Username kbun.NormalizedUsername `json:"username"`
-	KID      keybase1.KID            `json:"kid"`
+	UID      keybase1.UID             `json:"uid"`
+	Username libkb.NormalizedUsername `json:"username"`
+	KID      keybase1.KID             `json:"kid"`
 }
 
 type TokenBody struct {
@@ -57,7 +56,7 @@ type Token struct {
 	Tag          string      `json:"tag"`
 }
 
-func NewToken(uid keybase1.UID, username kbun.NormalizedUsername, kid keybase1.KID,
+func NewToken(uid keybase1.UID, username libkb.NormalizedUsername, kid keybase1.KID,
 	server, challenge string, now int64, expireIn int,
 	clientName, clientVersion string) *Token {
 	return &Token{
@@ -171,7 +170,7 @@ func (t Token) KID() keybase1.KID {
 	return t.Body.Key.KID
 }
 
-func (t Token) Username() kbun.NormalizedUsername {
+func (t Token) Username() libkb.NormalizedUsername {
 	return t.Body.Key.Username
 }
 

--- a/vendor/github.com/keybase/client/go/auth/token.go
+++ b/vendor/github.com/keybase/client/go/auth/token.go
@@ -14,6 +14,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/keybase/client/go/kbun"
 	libkb "github.com/keybase/client/go/libkb"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 )
@@ -31,9 +32,9 @@ type TokenAuth struct {
 }
 
 type TokenKey struct {
-	UID      keybase1.UID             `json:"uid"`
-	Username libkb.NormalizedUsername `json:"username"`
-	KID      keybase1.KID             `json:"kid"`
+	UID      keybase1.UID            `json:"uid"`
+	Username kbun.NormalizedUsername `json:"username"`
+	KID      keybase1.KID            `json:"kid"`
 }
 
 type TokenBody struct {
@@ -56,7 +57,7 @@ type Token struct {
 	Tag          string      `json:"tag"`
 }
 
-func NewToken(uid keybase1.UID, username libkb.NormalizedUsername, kid keybase1.KID,
+func NewToken(uid keybase1.UID, username kbun.NormalizedUsername, kid keybase1.KID,
 	server, challenge string, now int64, expireIn int,
 	clientName, clientVersion string) *Token {
 	return &Token{
@@ -170,7 +171,7 @@ func (t Token) KID() keybase1.KID {
 	return t.Body.Key.KID
 }
 
-func (t Token) Username() libkb.NormalizedUsername {
+func (t Token) Username() kbun.NormalizedUsername {
 	return t.Body.Key.Username
 }
 

--- a/vendor/github.com/keybase/client/go/auth/user_keys_api.go
+++ b/vendor/github.com/keybase/client/go/auth/user_keys_api.go
@@ -1,11 +1,13 @@
 package auth
 
 import (
+	"time"
+
+	"github.com/keybase/client/go/kbun"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
-	"time"
 )
 
 const (
@@ -62,7 +64,7 @@ type userKeyAPI struct {
 }
 
 func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (
-	un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, isDeleted bool, err error) {
+	un kbun.NormalizedUsername, sibkeys, subkeys []keybase1.KID, isDeleted bool, err error) {
 	u.log.Debug("+ GetUser")
 	defer func() {
 		u.log.Debug("- GetUser -> %v", err)

--- a/vendor/github.com/keybase/client/go/auth/user_keys_api.go
+++ b/vendor/github.com/keybase/client/go/auth/user_keys_api.go
@@ -1,13 +1,11 @@
 package auth
 
 import (
-	"time"
-
-	"github.com/keybase/client/go/kbun"
 	libkb "github.com/keybase/client/go/libkb"
 	logger "github.com/keybase/client/go/logger"
 	keybase1 "github.com/keybase/client/go/protocol/keybase1"
 	context "golang.org/x/net/context"
+	"time"
 )
 
 const (
@@ -64,7 +62,7 @@ type userKeyAPI struct {
 }
 
 func (u *userKeyAPI) GetUser(ctx context.Context, uid keybase1.UID) (
-	un kbun.NormalizedUsername, sibkeys, subkeys []keybase1.KID, isDeleted bool, err error) {
+	un libkb.NormalizedUsername, sibkeys, subkeys []keybase1.KID, isDeleted bool, err error) {
 	u.log.Debug("+ GetUser")
 	defer func() {
 		u.log.Debug("- GetUser -> %v", err)

--- a/vendor/github.com/keybase/client/go/chat/types/interfaces.go
+++ b/vendor/github.com/keybase/client/go/chat/types/interfaces.go
@@ -272,7 +272,7 @@ type IdentifyNotifier interface {
 	Send(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks)
 }
 type UPAKFinder interface {
-	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username kbun.NormalizedUsername, deviceName string, deviceType string, err error)
+	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username libkb.NormalizedUsername, deviceName string, deviceType string, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
 }
 

--- a/vendor/github.com/keybase/client/go/chat/types/interfaces.go
+++ b/vendor/github.com/keybase/client/go/chat/types/interfaces.go
@@ -272,7 +272,7 @@ type IdentifyNotifier interface {
 	Send(ctx context.Context, update keybase1.CanonicalTLFNameAndIDWithBreaks)
 }
 type UPAKFinder interface {
-	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username libkb.NormalizedUsername, deviceName string, deviceType string, err error)
+	LookupUsernameAndDevice(ctx context.Context, uid keybase1.UID, deviceID keybase1.DeviceID) (username kbun.NormalizedUsername, deviceName string, deviceType string, err error)
 	CheckKIDForUID(ctx context.Context, uid keybase1.UID, kid keybase1.KID) (found bool, revokedAt *keybase1.KeybaseTime, deleted bool, err error)
 }
 


### PR DESCRIPTION
In particular:

libkb.NormalizedUsername -> kbun.NormalizedUsername
libkb.NewNormalizedUsername -> kbun.NewNormalizedUsername
libkb.CheckUsername.F -> kbun.CheckUsername
libkb.*RunMode -> kbconst.*RunMode

This gets rid of a whole chunk of libkb dependencies.

These changes are entirely mechanical.