### PR TITLE
folderlist: use "quick" parsing when ignoring a favorite

### DIFF
--- a/libfuse/folderlist.go
+++ b/libfuse/folderlist.go
@@ -281,8 +281,8 @@ func (fl *FolderList) Remove(ctx context.Context, req *fuse.RemoveRequest) (err 
 	fl.fs.log.CDebugf(ctx, "FolderList Remove %s", req.Name)
 	defer func() { err = fl.fs.processError(ctx, libkbfs.WriteMode, err) }()
 
-	h, err := libkbfs.ParseTlfHandlePreferred(
-		ctx, fl.fs.config.KBPKI(), fl.fs.config.MDOps(), req.Name, fl.tlfType)
+	h, err := libfs.ParseTlfHandlePreferredQuick(
+		ctx, fl.fs.config.KBPKI(), req.Name, fl.tlfType)
 
 	switch err := errors.Cause(err).(type) {
 	case nil:


### PR DESCRIPTION
There's no reason to look up implicit teams and TLF IDs before removing a favorite.  And if it's a pre-reset folder, that might cause a failure because the MDs can't be read by the current device.

Issue: #1759