### PR TITLE
folder_block_ops: option for excluding non-live blocks from sums

### DIFF
--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -178,7 +178,7 @@ func (s *blockDiskStore) addRefs(id kbfsblock.ID, contexts []kbfsblock.Context,
 	if len(info.Refs) > 0 {
 		// Check existing contexts, if any.
 		for _, context := range contexts {
-			_, err := info.Refs.checkExists(context)
+			_, _, err := info.Refs.checkExists(context)
 			if err != nil {
 				return err
 			}
@@ -253,10 +253,10 @@ func (s *blockDiskStore) hasNonArchivedRef(id kbfsblock.ID) (bool, error) {
 }
 
 func (s *blockDiskStore) hasContext(id kbfsblock.ID, context kbfsblock.Context) (
-	bool, error) {
+	bool, blockRefStatus, error) {
 	info, err := s.getInfo(id)
 	if err != nil {
-		return false, err
+		return false, unknownBlockRef, err
 	}
 
 	return info.Refs.checkExists(context)
@@ -313,7 +313,7 @@ func (s *blockDiskStore) getDataSize(id kbfsblock.ID) (int64, error) {
 
 func (s *blockDiskStore) getDataWithContext(id kbfsblock.ID, context kbfsblock.Context) (
 	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	hasContext, err := s.hasContext(id, context)
+	hasContext, _, err := s.hasContext(id, context)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
 	}

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -93,7 +93,7 @@ func (b *BlockOpsStandard) GetEncodedSize(ctx context.Context, kmd KeyMetadata,
 		if err != nil {
 			return 0, 0, err
 		}
-		if found {
+		if found && size > 0 {
 			return size, keybase1.BlockStatus_LIVE, nil
 		}
 	}

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
@@ -83,31 +84,22 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 // GetEncodedSize implements the BlockOps interface for
 // BlockOpsStandard.
 func (b *BlockOpsStandard) GetEncodedSize(ctx context.Context, kmd KeyMetadata,
-	blockPtr BlockPointer) (uint32, error) {
+	blockPtr BlockPointer) (uint32, keybase1.BlockStatus, error) {
 	// Check the journal explicitly first, so we don't get stuck in
 	// the block-fetching queue.
 	if journalBServer, ok := b.config.BlockServer().(journalBlockServer); ok {
 		size, found, err := journalBServer.getBlockSizeFromJournal(
 			kmd.TlfID(), blockPtr.ID)
 		if err != nil {
-			return 0, err
+			return 0, 0, err
 		}
 		if found {
-			return size, nil
+			return size, keybase1.BlockStatus_LIVE, nil
 		}
 	}
 
-	// Otherwise fetch the entire block from the server, since we
-	// can't trust the server to report the size without being able
-	// to verify the BlockID.
-	block := NewCommonBlock()
-	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd,
-		blockPtr, block, NoCacheEntry)
-	err := <-errCh
-	if err != nil {
-		return 0, err
-	}
-	return block.GetEncodedSize(), nil
+	return b.config.BlockServer().GetEncodedSize(
+		ctx, kmd.TlfID(), blockPtr.ID, blockPtr.Context)
 }
 
 // Ready implements the BlockOps interface for BlockOpsStandard.

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -417,7 +417,7 @@ func (b *BlockServerRemote) GetEncodedSize(
 				id, tlfID, context, err)
 		} else {
 			b.deferLog.CDebugf(
-				ctx, "Get id=%s tlf=%s context=%s sz=%d status=%s",
+				ctx, "GetEncodedSize id=%s tlf=%s context=%s sz=%d status=%s",
 				id, tlfID, context, size, status)
 		}
 	}()

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -287,8 +287,17 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	}
 
 	if assumeCacheIsLive {
+		// If we're assuming all blocks in the cache are live, we just
+		// need to get the block size, which we can do from either one
+		// of the caches.
 		if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
 			return block.GetEncodedSize(), keybase1.BlockStatus_LIVE, nil
+		}
+		if diskBCache := fbo.config.DiskBlockCache(); diskBCache != nil {
+			if buf, _, _, err := diskBCache.Get(
+				ctx, fbo.id(), ptr.ID); err != nil {
+				return uint32(len(buf)), keybase1.BlockStatus_LIVE, nil
+			}
 		}
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -313,10 +313,10 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	var err error
 	if rtype != blockReadParallel && rtype != blockLookup {
 		fbo.blockLock.DoRUnlockedIfPossible(lState, func(*lockState) {
-			size, err = bops.GetEncodedSize(ctx, kmd, ptr)
+			size, _, err = bops.GetEncodedSize(ctx, kmd, ptr)
 		})
 	} else {
-		size, err = bops.GetEncodedSize(ctx, kmd, ptr)
+		size, _, err = bops.GetEncodedSize(ctx, kmd, ptr)
 	}
 	if err != nil {
 		return 0, err

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -270,7 +270,8 @@ func (fbo *folderBlockOps) GetState(lState *lockState) overallBlockState {
 // locks, and in that case `lState` must be `nil`.
 func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	lState *lockState, kmd KeyMetadata, ptr BlockPointer, branch BranchName,
-	rtype blockReqType) (uint32, error) {
+	rtype blockReqType, assumeCacheIsLive bool) (
+	size uint32, status keybase1.BlockStatus, err error) {
 	if rtype != blockReadParallel {
 		if rtype == blockWrite {
 			panic("Cannot get the size of a block for writing")
@@ -282,21 +283,37 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	}
 
 	if !ptr.IsValid() {
-		return 0, InvalidBlockRefError{ptr.Ref()}
+		return 0, 0, InvalidBlockRefError{ptr.Ref()}
 	}
 
-	// Try to get the encoded size from the cache before escalating to
-	// the block retriever (even though it's supposed to do a similar
-	// thing with checking caches before checking the data version).
-	// TODO: Figure out how to remove this without breaking journal
-	// tests in kbfs/test.
-	if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
-		return block.GetEncodedSize(), nil
+	if assumeCacheIsLive {
+		if block, err := fbo.config.BlockCache().Get(ptr); err == nil {
+			return block.GetEncodedSize(), keybase1.BlockStatus_LIVE, nil
+		}
 	}
 
 	if err := checkDataVersion(fbo.config, path{}, ptr); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
+
+	defer func() {
+		fbo.log.CDebugf(ctx, "GetEncodedSize ptr=%v size=%d status=%s: %+v",
+			ptr, size, status, err)
+		// In certain testing situations, a block might be represented
+		// with a 0 size in our journal or be missing from our local
+		// data stores, and we need to reconstruct the size using the
+		// cache in order to make the accounting work out for the test.
+		_, isBlockNotFound :=
+			errors.Cause(err).(kbfsblock.ServerErrorBlockNonExistent)
+		if isBlockNotFound || size == 0 {
+			if block, cerr := fbo.config.BlockCache().Get(ptr); cerr == nil {
+				fbo.log.CDebugf(
+					ctx, "Fixing encoded size of %v with cached copy", ptr)
+				size = block.GetEncodedSize()
+				err = nil
+			}
+		}
+	}()
 
 	// Unlock the blockLock while we wait for the network, only if
 	// it's locked for reading by a single goroutine.  If it's locked
@@ -309,20 +326,18 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 	// goroutines may be operating on the data assuming they have the
 	// lock.
 	bops := fbo.config.BlockOps()
-	var size uint32
-	var err error
 	if rtype != blockReadParallel && rtype != blockLookup {
 		fbo.blockLock.DoRUnlockedIfPossible(lState, func(*lockState) {
-			size, _, err = bops.GetEncodedSize(ctx, kmd, ptr)
+			size, status, err = bops.GetEncodedSize(ctx, kmd, ptr)
 		})
 	} else {
-		size, _, err = bops.GetEncodedSize(ctx, kmd, ptr)
+		size, status, err = bops.GetEncodedSize(ctx, kmd, ptr)
 	}
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	return size, nil
+	return size, status, nil
 }
 
 // getBlockHelperLocked retrieves the block pointed to by ptr, which
@@ -470,10 +485,14 @@ func (fbo *folderBlockOps) GetBlockForReading(ctx context.Context,
 // resolution and state checking, which don't know what kind of block
 // the pointers refer to.  Any downloaded blocks will not be cached,
 // if they weren't in the cache already.
+//
+// If `onlyCountIfLive` is true, the sum includes blocks that the
+// bserver thinks are currently reachable from the merged branch
+// (i.e., un-archived).
 func (fbo *folderBlockOps) GetCleanEncodedBlocksSizeSum(ctx context.Context,
 	lState *lockState, kmd KeyMetadata, ptrs []BlockPointer,
 	ignoreRecoverableForRemovalErrors map[BlockPointer]bool,
-	branch BranchName) (uint64, error) {
+	branch BranchName, onlyCountIfLive bool) (uint64, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 
@@ -489,11 +508,16 @@ func (fbo *folderBlockOps) GetCleanEncodedBlocksSizeSum(ctx context.Context,
 		numWorkers = len(ptrs)
 	}
 
+	// If we don't care if something's live or not, there's no reason
+	// not to use the cached block.
+	assumeCacheIsLive := !onlyCountIfLive
+
 	for i := 0; i < numWorkers; i++ {
 		eg.Go(func() error {
 			for ptr := range ptrCh {
-				size, err := fbo.getCleanEncodedBlockSizeLocked(groupCtx, nil,
-					kmd, ptr, branch, blockReadParallel)
+				size, status, err := fbo.getCleanEncodedBlockSizeLocked(
+					groupCtx, nil, kmd, ptr, branch, blockReadParallel,
+					assumeCacheIsLive)
 				// TODO: we might be able to recover the size of the
 				// top-most block of a removed file using the merged
 				// directory entry, the same way we do in
@@ -508,7 +532,11 @@ func (fbo *folderBlockOps) GetCleanEncodedBlocksSizeSum(ctx context.Context,
 				if err != nil {
 					return err
 				}
-				sumCh <- size
+				if onlyCountIfLive && status != keybase1.BlockStatus_LIVE {
+					sumCh <- 0
+				} else {
+					sumCh <- size
+				}
 			}
 			return nil
 		})

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -615,7 +615,7 @@ func (fup *folderUpdatePrepper) updateResolutionUsageLockedCache(
 	// them up generically.  Ignore any recoverable errors for unrefs.
 	// Note that we can't combine these with the above ref fetches
 	// since they require a different MD.  If the merged changes
-	// didn't changes any blocks (in particular, the root block), we
+	// didn't change any blocks (in particular, the root block), we
 	// can assume all the blocks we are unreferencing were live;
 	// otherwise, we need to check with the server to make sure.
 	onlyCountIfLive := len(mergedChains.byOriginal) != 0

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -568,7 +568,7 @@ func (fup *folderUpdatePrepper) updateResolutionUsageLockedCache(
 	// well (such as its directory entry or its indirect file block)
 	// if we happened to have come across it before.
 	refSumFetched, err := fup.blocks.GetCleanEncodedBlocksSizeSum(
-		ctx, lState, md.ReadOnly(), refPtrsToFetch, nil, fup.branch())
+		ctx, lState, md.ReadOnly(), refPtrsToFetch, nil, fup.branch(), false)
 	if err != nil {
 		return err
 	}
@@ -614,10 +614,14 @@ func (fup *folderUpdatePrepper) updateResolutionUsageLockedCache(
 	// we don't know whether these are files or directories, just look
 	// them up generically.  Ignore any recoverable errors for unrefs.
 	// Note that we can't combine these with the above ref fetches
-	// since they require a different MD.
+	// since they require a different MD.  If the merged changes
+	// didn't changes any blocks (in particular, the root block), we
+	// can assume all the blocks we are unreferencing were live;
+	// otherwise, we need to check with the server to make sure.
+	onlyCountIfLive := len(mergedChains.byOriginal) != 0
 	unrefSumFetched, err := fup.blocks.GetCleanEncodedBlocksSizeSum(
 		ctx, lState, mostRecentMergedMD, unrefPtrsToFetch, unrefs,
-		fup.branch())
+		fup.branch(), onlyCountIfLive)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1449,7 +1449,7 @@ type BlockOps interface {
 	// with the given block pointer (which belongs to the TLF with the
 	// given key metadata).
 	GetEncodedSize(ctx context.Context, kmd KeyMetadata,
-		blockPtr BlockPointer) (uint32, error)
+		blockPtr BlockPointer) (uint32, keybase1.BlockStatus, error)
 
 	// Ready turns the given block (which belongs to the TLF with
 	// the given key metadata) into encoded (and encrypted) data,
@@ -1698,6 +1698,14 @@ type BlockServer interface {
 	// block.
 	Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context) (
 		[]byte, kbfscrypto.BlockCryptKeyServerHalf, error)
+
+	// GetEncodedSize gets the encoded size of the block associated
+	// with the given block pointer (which belongs to the TLF with the
+	// given key metadata).
+	GetEncodedSize(
+		ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+		context kbfsblock.Context) (uint32, keybase1.BlockStatus, error)
+
 	// Put stores the (encrypted) block data under the given ID
 	// and context on the server, along with the server half of
 	// the block key.  context should contain a kbfsblock.RefNonce

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4942,11 +4942,12 @@ func (mr *MockBlockOpsMockRecorder) Get(ctx, kmd, blockPtr, block, cacheLifetime
 }
 
 // GetEncodedSize mocks base method
-func (m *MockBlockOps) GetEncodedSize(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer) (uint32, error) {
+func (m *MockBlockOps) GetEncodedSize(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer) (uint32, keybase1.BlockStatus, error) {
 	ret := m.ctrl.Call(m, "GetEncodedSize", ctx, kmd, blockPtr)
 	ret0, _ := ret[0].(uint32)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(keybase1.BlockStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // GetEncodedSize indicates an expected call of GetEncodedSize
@@ -5831,6 +5832,20 @@ func (mr *MockBlockServerMockRecorder) Get(ctx, tlfID, id, context interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockServer)(nil).Get), ctx, tlfID, id, context)
 }
 
+// GetEncodedSize mocks base method
+func (m *MockBlockServer) GetEncodedSize(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context) (uint32, keybase1.BlockStatus, error) {
+	ret := m.ctrl.Call(m, "GetEncodedSize", ctx, tlfID, id, context)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(keybase1.BlockStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetEncodedSize indicates an expected call of GetEncodedSize
+func (mr *MockBlockServerMockRecorder) GetEncodedSize(ctx, tlfID, id, context interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSize", reflect.TypeOf((*MockBlockServer)(nil).GetEncodedSize), ctx, tlfID, id, context)
+}
+
 // Put mocks base method
 func (m *MockBlockServer) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
 	ret := m.ctrl.Call(m, "Put", ctx, tlfID, id, context, buf, serverHalf)
@@ -5986,6 +6001,20 @@ func (m *MockblockServerLocal) Get(ctx context.Context, tlfID tlf.ID, id kbfsblo
 // Get indicates an expected call of Get
 func (mr *MockblockServerLocalMockRecorder) Get(ctx, tlfID, id, context interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockblockServerLocal)(nil).Get), ctx, tlfID, id, context)
+}
+
+// GetEncodedSize mocks base method
+func (m *MockblockServerLocal) GetEncodedSize(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context) (uint32, keybase1.BlockStatus, error) {
+	ret := m.ctrl.Call(m, "GetEncodedSize", ctx, tlfID, id, context)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(keybase1.BlockStatus)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetEncodedSize indicates an expected call of GetEncodedSize
+func (mr *MockblockServerLocalMockRecorder) GetEncodedSize(ctx, tlfID, id, context interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEncodedSize", reflect.TypeOf((*MockblockServerLocal)(nil).GetEncodedSize), ctx, tlfID, id, context)
 }
 
 // Put mocks base method


### PR DESCRIPTION
(I won't merge it until the corresponding kbfs-server work is merged and deployed.)

We can check with the server to figure out whether a block is "live" or not, and if not, we can avoid counting its size in the sum.  This is then used by the `folderUpdatePrepper` to know exactly which blocks need to have their sizes included in the "unref" sum, so that the MD byte counts can be managed correctly.  This will matter when other PRs start including dirData refs and unrefs in `resolutionOp`s.


Issue: KBFS-3303