### PR TITLE
bsplitter: add an env var for setting dir block split size

### DIFF
--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -51,8 +51,13 @@ func newConfigForTest(modeType InitModeType, loggerFn func(module string) logger
 		testBlockRetrievalWorkerQueueSize, testPrefetchWorkerQueueSize)
 	config.SetBlockOps(bops)
 
+	maxDirEntriesPerBlock, err := getMaxDirEntriesPerBlock()
+	if err != nil {
+		panic(err)
+	}
+
 	config.SetBlockSplitter(&BlockSplitterSimple{
-		64 * 1024, 64 * 1024 / int(bpSize), 8 * 1024, 0})
+		64 * 1024, 64 * 1024 / int(bpSize), 8 * 1024, maxDirEntriesPerBlock})
 
 	return config
 }


### PR DESCRIPTION
To make testing easier without enabling it by default (and slowing everything down).

Issue: KBFS-3303