### PR TITLE
folder_block_ops: improve locking situation with dirData

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2317,10 +2317,10 @@ func (cr *ConflictResolver) doOneAction(
 	// and the subsequent `newDirData` calls can assume it's
 	// locked already.
 	var unmergedDir *dirData
-	unmergedDir, undoFn := cr.fbo.blocks.newDirDataWithLBC(
+	unmergedDir, cleanupFn := cr.fbo.blocks.newDirDataWithLBC(
 		lState, unmergedPath, chargedTo,
 		unmergedChains.mostRecentChainMDInfo, nil)
-	defer undoFn()
+	defer cleanupFn()
 
 	if unmergedPath.tailPointer() == mergedPath.tailPointer() {
 		// recreateOps update the merged paths using original

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -296,9 +296,9 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 		FolderBranch: fbo.folderBranch,
 		path:         []pathNode{{parentMostRecent, ""}},
 	}
-	parentDD, undoFn := fbo.newDirDataWithLBC(
+	parentDD, cleanupFn := fbo.newDirDataWithLBC(
 		makeFBOLockState(), parentPath, keybase1.UserOrTeamID(""), kmd, nil)
-	defer undoFn()
+	defer cleanupFn()
 	entries, err := parentDD.getEntries(ctx)
 	if err != nil {
 		return err

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -296,8 +296,9 @@ func (cc *crChain) identifyType(ctx context.Context, fbo *folderBlockOps,
 		FolderBranch: fbo.folderBranch,
 		path:         []pathNode{{parentMostRecent, ""}},
 	}
-	parentDD := fbo.newDirDataWithLBC(
+	parentDD, undoFn := fbo.newDirDataWithLBC(
 		makeFBOLockState(), parentPath, keybase1.UserOrTeamID(""), kmd, nil)
+	defer undoFn()
 	entries, err := parentDD.getEntries(ctx)
 	if err != nil {
 		return err

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -955,17 +955,17 @@ func (fbo *folderBlockOps) newDirDataWithLBCLocked(lState *lockState,
 				return block, true, nil
 			}
 
-			lState := lState
+			localLState := lState
 			getRtype := rtype
 			switch rtype {
 			case blockReadParallel:
-				lState = nil
+				localLState = nil
 			case blockWrite:
 				getRtype = blockRead
 			}
 
 			block, wasDirty, err := fbo.getDirLocked(
-				ctx, lState, kmd, ptr, dir, getRtype)
+				ctx, localLState, kmd, ptr, dir, getRtype)
 			if err != nil {
 				return nil, false, err
 			}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -992,8 +992,9 @@ func (fbo *folderBlockOps) newDirDataWithLBC(
 	// Lock and fetch for reading only, we want any dirty
 	// blocks to go into the lbc.
 	fbo.blockLock.RLock(lState)
-	undoFn := func() { fbo.blockLock.RUnlock(lState) }
-	return fbo.newDirDataWithLBCLocked(lState, dir, chargedTo, kmd, lbc), undoFn
+	cleanupFn := func() { fbo.blockLock.RUnlock(lState) }
+	return fbo.newDirDataWithLBCLocked(lState, dir, chargedTo, kmd, lbc),
+		cleanupFn
 }
 
 func (fbo *folderBlockOps) makeDirDirtyLocked(

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -690,6 +690,15 @@ func (fbo *folderBlockOps) getFileLocked(ctx context.Context,
 	return fblock, err
 }
 
+func (fbo *folderBlockOps) getIndirectFileBlockInfosLocked(
+	ctx context.Context, lState *lockState, kmd KeyMetadata, file path) (
+	[]BlockInfo, error) {
+	fbo.blockLock.AssertRLocked(lState)
+	var id keybase1.UserOrTeamID // Data reads don't depend on the id.
+	fd := fbo.newFileData(lState, file, id, kmd)
+	return fd.getIndirectFileBlockInfos(ctx)
+}
+
 // GetIndirectFileBlockInfos returns a list of BlockInfos for all
 // indirect blocks of the given file. If the returned error is a
 // recoverable one (as determined by
@@ -700,9 +709,7 @@ func (fbo *folderBlockOps) GetIndirectFileBlockInfos(ctx context.Context,
 	lState *lockState, kmd KeyMetadata, file path) ([]BlockInfo, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	var id keybase1.UserOrTeamID // Data reads don't depend on the id.
-	fd := fbo.newFileData(lState, file, id, kmd)
-	return fd.getIndirectFileBlockInfos(ctx)
+	return fbo.getIndirectFileBlockInfosLocked(ctx, lState, kmd, file)
 }
 
 // GetIndirectDirBlockInfos returns a list of BlockInfos for all
@@ -717,7 +724,7 @@ func (fbo *folderBlockOps) GetIndirectDirBlockInfos(
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
 	var id keybase1.UserOrTeamID // Data reads don't depend on the id.
-	fd := fbo.newDirData(lState, dir, id, kmd)
+	fd := fbo.newDirDataLocked(lState, dir, id, kmd)
 	return fd.getIndirectDirBlockInfos(ctx)
 }
 
@@ -767,14 +774,13 @@ func (fbo *folderBlockOps) ClearChargedTo(lState *lockState) {
 // It returns the new top pointer of the copy, and all the new child
 // pointers in the copy.  It takes a custom DirtyBlockCache, which
 // directs where the resulting block copies are stored.
-func (fbo *folderBlockOps) DeepCopyFile(
+func (fbo *folderBlockOps) deepCopyFileLocked(
 	ctx context.Context, lState *lockState, kmd KeyMetadata, file path,
 	dirtyBcache DirtyBlockCache, dataVer DataVer) (
 	newTopPtr BlockPointer, allChildPtrs []BlockPointer, err error) {
 	// Deep copying doesn't alter any data in use, it only makes copy,
 	// so only a read lock is needed.
-	fbo.blockLock.RLock(lState)
-	defer fbo.blockLock.RUnlock(lState)
+	fbo.blockLock.AssertRLocked(lState)
 	chargedTo, err := chargedToForTLF(
 		ctx, fbo.config.KBPKI(), fbo.config.KBPKI(), kmd.GetTlfHandle())
 	if err != nil {
@@ -912,7 +918,7 @@ func (fbo *folderBlockOps) wrapWithBlockLock(fn func()) dirCacheUndoFn {
 	}
 }
 
-func (fbo *folderBlockOps) newDirData(lState *lockState,
+func (fbo *folderBlockOps) newDirDataLocked(lState *lockState,
 	dir path, chargedTo keybase1.UserOrTeamID, kmd KeyMetadata) *dirData {
 	fbo.blockLock.AssertAnyLocked(lState)
 	return newDirData(dir, chargedTo, fbo.config.Crypto(),
@@ -932,13 +938,14 @@ func (fbo *folderBlockOps) newDirData(lState *lockState,
 		}, fbo.log)
 }
 
-// newDirDataWithLBC creates a new `dirData` that reads from and puts
-// into a local block cache.  It is only intended for non-parallel
-// write-based usage.  If it reads a block out from anything but the
-// `lbc`, it makes a copy of it before inserting it into the `lbc`.
-func (fbo *folderBlockOps) newDirDataWithLBC(lState *lockState,
+// newDirDataWithLBCLocked creates a new `dirData` that reads from and
+// puts into a local block cache.  If it reads a block out from
+// anything but the `lbc`, it makes a copy of it before inserting it
+// into the `lbc`.
+func (fbo *folderBlockOps) newDirDataWithLBCLocked(lState *lockState,
 	dir path, chargedTo keybase1.UserOrTeamID, kmd KeyMetadata,
 	lbc localBcache) *dirData {
+	fbo.blockLock.AssertRLocked(lState)
 	return newDirData(dir, chargedTo, fbo.config.Crypto(),
 		fbo.config.BlockSplitter(), kmd,
 		func(ctx context.Context, kmd KeyMetadata, ptr BlockPointer,
@@ -948,17 +955,17 @@ func (fbo *folderBlockOps) newDirDataWithLBC(lState *lockState,
 				return block, true, nil
 			}
 
-			if rtype == blockReadParallel {
-				return nil, false, errors.New(
-					"LBC must be used with parallel reads")
+			lState := lState
+			getRtype := rtype
+			switch rtype {
+			case blockReadParallel:
+				lState = nil
+			case blockWrite:
+				getRtype = blockRead
 			}
 
-			// Lock and fetch for reading only, we want any dirty
-			// blocks to go into the lbc.
-			fbo.blockLock.RLock(lState)
-			defer fbo.blockLock.RUnlock(lState)
 			block, wasDirty, err := fbo.getDirLocked(
-				ctx, lState, kmd, ptr, dir, blockRead)
+				ctx, lState, kmd, ptr, dir, getRtype)
 			if err != nil {
 				return nil, false, err
 			}
@@ -974,6 +981,19 @@ func (fbo *folderBlockOps) newDirDataWithLBC(lState *lockState,
 			lbc[ptr] = block.(*DirBlock)
 			return nil
 		}, fbo.log)
+}
+
+// newDirDataWithLBC is like `newDirDataWithLBCLocked`, but it must be
+// called with `blockLock` unlocked, and the returned function must be
+// called when the returned `dirData` is no longer in use.
+func (fbo *folderBlockOps) newDirDataWithLBC(
+	lState *lockState, dir path, chargedTo keybase1.UserOrTeamID,
+	kmd KeyMetadata, lbc localBcache) (*dirData, func()) {
+	// Lock and fetch for reading only, we want any dirty
+	// blocks to go into the lbc.
+	fbo.blockLock.RLock(lState)
+	undoFn := func() { fbo.blockLock.RUnlock(lState) }
+	return fbo.newDirDataWithLBCLocked(lState, dir, chargedTo, kmd, lbc), undoFn
 }
 
 func (fbo *folderBlockOps) makeDirDirtyLocked(
@@ -1007,7 +1027,7 @@ func (fbo *folderBlockOps) updateParentDirEntryLocked(
 	now := fbo.nowUnixNano()
 	pp := *dir.parentPath()
 	if pp.isValid() {
-		dd := fbo.newDirData(lState, pp, chargedTo, kmd)
+		dd := fbo.newDirDataLocked(lState, pp, chargedTo, kmd)
 		de, err := dd.lookup(ctx, dir.tailName())
 		if err != nil {
 			return nil, err
@@ -1059,7 +1079,7 @@ func (fbo *folderBlockOps) addDirEntryInCacheLocked(
 	if err != nil {
 		return nil, err
 	}
-	dd := fbo.newDirData(lState, dir, chargedTo, kmd)
+	dd := fbo.newDirDataLocked(lState, dir, chargedTo, kmd)
 	unrefs, err := dd.addEntry(ctx, newName, newDe)
 	if err != nil {
 		return nil, err
@@ -1104,7 +1124,7 @@ func (fbo *folderBlockOps) removeDirEntryInCacheLocked(
 	if err != nil {
 		return nil, err
 	}
-	dd := fbo.newDirData(lState, dir, chargedTo, kmd)
+	dd := fbo.newDirDataLocked(lState, dir, chargedTo, kmd)
 	unrefs, err := dd.removeEntry(ctx, oldName)
 	if err != nil {
 		return nil, err
@@ -1252,7 +1272,7 @@ func (fbo *folderBlockOps) setCachedAttrLocked(
 	var de DirEntry
 	var unlinkedNode Node
 
-	dd := fbo.newDirData(lState, dir, chargedTo, kmd)
+	dd := fbo.newDirDataLocked(lState, dir, chargedTo, kmd)
 	de, err = dd.lookup(ctx, name)
 	if _, noExist := errors.Cause(err).(NoSuchNameError); noExist {
 		// The node may be unlinked.
@@ -1343,7 +1363,7 @@ func (fbo *folderBlockOps) GetChildren(
 	dir path) (map[string]EntryInfo, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	dd := fbo.newDirData(lState, dir, keybase1.UserOrTeamID(""), kmd)
+	dd := fbo.newDirDataLocked(lState, dir, keybase1.UserOrTeamID(""), kmd)
 	return dd.getChildren(ctx)
 }
 
@@ -1354,7 +1374,7 @@ func (fbo *folderBlockOps) GetEntries(
 	dir path) (map[string]DirEntry, error) {
 	fbo.blockLock.RLock(lState)
 	defer fbo.blockLock.RUnlock(lState)
-	dd := fbo.newDirData(lState, dir, keybase1.UserOrTeamID(""), kmd)
+	dd := fbo.newDirDataLocked(lState, dir, keybase1.UserOrTeamID(""), kmd)
 	return dd.getEntries(ctx)
 }
 
@@ -1371,7 +1391,7 @@ func (fbo *folderBlockOps) getEntryLocked(ctx context.Context,
 		return kmd.GetRootDirEntry(), nil
 	}
 
-	dd := fbo.newDirData(
+	dd := fbo.newDirDataLocked(
 		lState, *file.parentPath(), keybase1.UserOrTeamID(""), kmd)
 	de, err = dd.lookup(ctx, file.tailName())
 	_, noExist := errors.Cause(err).(NoSuchNameError)
@@ -1398,7 +1418,7 @@ func (fbo *folderBlockOps) updateEntryLocked(ctx context.Context,
 		return err
 	}
 	parentPath := *file.parentPath()
-	dd := fbo.newDirData(lState, parentPath, chargedTo, kmd)
+	dd := fbo.newDirDataLocked(lState, parentPath, chargedTo, kmd)
 	unrefs, err := dd.updateEntry(ctx, file.tailName(), de)
 	_, noExist := errors.Cause(err).(NoSuchNameError)
 	if noExist && includeDeleted {
@@ -1548,12 +1568,11 @@ func (fbo *folderBlockOps) GetDirtyDirBlockRefs(lState *lockState) []BlockRef {
 	return dirtyRefs
 }
 
-// GetDirtyDirUnrefs returns a list of block infos that need to be
+// getDirtyDirUnrefsLocked returns a list of block infos that need to be
 // unreferenced for the given directory.
-func (fbo *folderBlockOps) GetDirtyDirUnrefs(
+func (fbo *folderBlockOps) getDirtyDirUnrefsLocked(
 	lState *lockState, ptr BlockPointer) []BlockInfo {
-	fbo.blockLock.RLock(lState)
-	defer fbo.blockLock.RUnlock(lState)
+	fbo.blockLock.AssertRLocked(lState)
 	return fbo.dirtyDirs[ptr]
 }
 
@@ -2296,7 +2315,7 @@ func (fbo *folderBlockOps) clearAllDirtyDirsLocked(
 			FolderBranch: fbo.folderBranch,
 			path:         []pathNode{{ptr, ptr.String()}},
 		}
-		dd := fbo.newDirData(lState, dir, keybase1.UserOrTeamID(""), kmd)
+		dd := fbo.newDirDataLocked(lState, dir, keybase1.UserOrTeamID(""), kmd)
 		childPtrs, err := dd.getDirtyChildPtrs(ctx, dirtyBCache)
 		if err != nil {
 			fbo.log.CDebugf(ctx, "Failed to get child ptrs for %v: %+v",
@@ -2599,7 +2618,7 @@ func (fbo *folderBlockOps) startSyncWrite(ctx context.Context,
 
 	// Capture the current de before we release the block lock, so
 	// other deferred writes don't slip in.
-	dd := fbo.newDirData(lState, *file.parentPath(), chargedTo, md)
+	dd := fbo.newDirDataLocked(lState, *file.parentPath(), chargedTo, md)
 	de, err := dd.lookup(ctx, file.tailName())
 	if err != nil {
 		return nil, nil, syncState, nil, err
@@ -2644,15 +2663,18 @@ func prepDirtyEntryForSync(md *RootMetadata, si *syncInfo, dirtyDe *DirEntry) {
 func (fbo *folderBlockOps) mergeDirtyEntryWithLBC(
 	ctx context.Context, lState *lockState, file path, md KeyMetadata,
 	lbc localBcache, dirtyDe DirEntry) error {
-	fbo.blockLock.Lock(lState)
-	defer fbo.blockLock.Unlock(lState)
+	// Lock and fetch for reading only, any dirty blocks will go into
+	// the lbc.
+	fbo.blockLock.RLock(lState)
+	defer fbo.blockLock.RUnlock(lState)
 
 	chargedTo, err := fbo.getChargedToLocked(ctx, lState, md)
 	if err != nil {
 		return err
 	}
 
-	dd := fbo.newDirDataWithLBC(lState, *file.parentPath(), chargedTo, md, lbc)
+	dd := fbo.newDirDataWithLBCLocked(
+		lState, *file.parentPath(), chargedTo, md, lbc)
 	unrefs, err := dd.setEntry(ctx, file.tailName(), dirtyDe)
 	if err != nil {
 		return err
@@ -2981,7 +3003,7 @@ func (fbo *folderBlockOps) searchForNodesInDirLocked(ctx context.Context,
 	if err != nil {
 		return 0, err
 	}
-	dd := fbo.newDirData(lState, currDir, chargedTo, kmd)
+	dd := fbo.newDirDataLocked(lState, currDir, chargedTo, kmd)
 	entries, err := dd.getEntries(ctx)
 	if err != nil {
 		return 0, err
@@ -3329,7 +3351,7 @@ func (fbo *folderBlockOps) fastForwardDirAndChildrenLocked(ctx context.Context,
 	if err != nil {
 		return nil, nil, err
 	}
-	dd := fbo.newDirData(lState, currDir, chargedTo, kmd)
+	dd := fbo.newDirDataLocked(lState, currDir, chargedTo, kmd)
 	entries, err := dd.getEntries(ctx)
 	if err != nil {
 		return nil, nil, err

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -836,6 +836,50 @@ func (fup *folderUpdatePrepper) updateResolutionUsageAndPointersLockedCache(
 	return blocksToDelete, nil
 }
 
+func (fup *folderUpdatePrepper) setChildrenNodes(
+	ctx context.Context, lState *lockState, kmd KeyMetadata, p path,
+	indexInPath int, lbc localBcache, nextNode *pathTreeNode, currPath path,
+	blocks map[string]*FileBlock) {
+	dd, cleanupFn := fup.blocks.newDirDataWithLBC(
+		lState, currPath, keybase1.UserOrTeamID(""), kmd, lbc)
+	defer cleanupFn()
+
+	pnode := p.path[indexInPath]
+	for name := range blocks {
+		if _, ok := nextNode.children[name]; ok {
+			continue
+		}
+		// Try to lookup the block pointer, but this might be
+		// for a new file.
+		var filePtr BlockPointer
+		de, err := dd.lookup(ctx, name)
+		switch errors.Cause(err).(type) {
+		case nil:
+			filePtr = de.BlockPointer
+		case NoSuchNameError:
+		default:
+			fup.log.CWarningf(ctx, "Couldn't look up child: %+v", err)
+			continue
+		}
+
+		fup.log.CDebugf(ctx, "Creating child node for name %s for "+
+			"parent %v", name, pnode.BlockPointer)
+		childPath := path{
+			FolderBranch: p.FolderBranch,
+			path:         make([]pathNode, indexInPath+2),
+		}
+		copy(childPath.path[0:indexInPath+1], p.path[0:indexInPath+1])
+		childPath.path[indexInPath+1] = pathNode{Name: name}
+		childNode := &pathTreeNode{
+			ptr:        filePtr,
+			parent:     nextNode,
+			children:   make(map[string]*pathTreeNode),
+			mergedPath: childPath,
+		}
+		nextNode.children[name] = childNode
+	}
+}
+
 func (fup *folderUpdatePrepper) makeSyncTree(
 	ctx context.Context, lState *lockState, resolvedPaths map[BlockPointer]path,
 	kmd KeyMetadata, lbc localBcache,
@@ -895,45 +939,8 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 				FolderBranch: p.FolderBranch,
 				path:         p.path[:i+1],
 			}
-			var dd *dirData
-			dd, cleanupFn = fup.blocks.newDirDataWithLBC(
-				lState, currPath, keybase1.UserOrTeamID(""), kmd, lbc)
-
-			for name := range blocks {
-				if _, ok := nextNode.children[name]; ok {
-					continue
-				}
-				// Try to lookup the block pointer, but this might be
-				// for a new file.
-				var filePtr BlockPointer
-				de, err := dd.lookup(ctx, name)
-				switch errors.Cause(err).(type) {
-				case nil:
-					filePtr = de.BlockPointer
-				case NoSuchNameError:
-				default:
-					fup.log.CWarningf(ctx, "Couldn't look up child: %+v", err)
-					continue
-				}
-
-				fup.log.CDebugf(ctx, "Creating child node for name %s for "+
-					"parent %v", name, pnode.BlockPointer)
-				childPath := path{
-					FolderBranch: p.FolderBranch,
-					path:         make([]pathNode, i+2),
-				}
-				copy(childPath.path[0:i+1], p.path[0:i+1])
-				childPath.path[i+1] = pathNode{Name: name}
-				childNode := &pathTreeNode{
-					ptr:        filePtr,
-					parent:     nextNode,
-					children:   make(map[string]*pathTreeNode),
-					mergedPath: childPath,
-				}
-				nextNode.children[name] = childNode
-			}
-			cleanupFn()
-			cleanupFn = nil
+			fup.setChildrenNodes(
+				ctx, lState, kmd, p, i, lbc, nextNode, currPath, blocks)
 		}
 	}
 	return root

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -198,9 +198,15 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 	// in the path
 	currBlock := newBlock
 	var currDD *dirData
+	var undoFn func()
+	defer func() {
+		if undoFn != nil {
+			undoFn()
+		}
+	}()
 	if _, isDir := newBlock.(*DirBlock); isDir {
 		newPath := dir.ChildPath(name, newBlockPtr)
-		currDD = fup.blocks.newDirDataWithLBC(
+		currDD, undoFn = fup.blocks.newDirDataWithLBC(
 			lState, newPath, chargedTo, md, lbc)
 	}
 	currName := name
@@ -209,7 +215,6 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 		path:         make([]pathNode, 0, len(dir.path)),
 	}
 	bps := newBlockPutState(len(dir.path))
-	refPath := dir.ChildPathNoPtr(name)
 	var newDe DirEntry
 	doSetTime := true
 	now := fup.nowUnixNano()
@@ -233,6 +238,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			for _, unref := range dirUnrefs {
 				md.AddUnrefBlock(unref)
 			}
+			undoFn()
+			undoFn = nil
 		}
 
 		info, plainSize, err := fup.readyBlockMultiple(
@@ -260,7 +267,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 				path:         dir.path[:prevIdx+1],
 			}
 
-			dd := fup.blocks.newDirDataWithLBC(
+			var dd *dirData
+			dd, undoFn = fup.blocks.newDirDataWithLBC(
 				lState, prevDir, chargedTo, md, lbc)
 			de, err = dd.lookup(ctx, currName)
 			if _, noExists := errors.Cause(err).(NoSuchNameError); noExists {
@@ -295,6 +303,14 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			currBlock = prevDblock
 			currDD = dd
 			nextName = prevDir.tailName()
+<<<<<<< bd552cd6c38fe50663b1020744cbfc880b69b276
+=======
+			dirUnrefs := fup.blocks.getDirtyDirUnrefsLocked(
+				lState, prevDir.tailPointer())
+			for _, unref := range dirUnrefs {
+				md.AddUnrefBlock(unref)
+			}
+>>>>>>> folder_block_ops: improve locking situation with dirData
 		}
 
 		if de.Type == Dir {
@@ -315,9 +331,6 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			md.AddRefBlock(info)
 		}
 
-		if len(refPath.path) > 1 {
-			refPath = *refPath.parentPath()
-		}
 		de.BlockInfo = info
 		de.PrevRevisions = de.PrevRevisions.addRevision(
 			md.Revision(), md.data.LastGCRevision)
@@ -836,6 +849,12 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 	kmd KeyMetadata, lbc localBcache,
 	newFileBlocks fileBlockMap) *pathTreeNode {
 	var root *pathTreeNode
+	var undoFn func()
+	defer func() {
+		if undoFn != nil {
+			undoFn()
+		}
+	}()
 	for _, p := range resolvedPaths {
 		fup.log.CDebugf(ctx, "Creating tree from merged path: %v", p.path)
 		var parent *pathTreeNode
@@ -884,7 +903,8 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 				FolderBranch: p.FolderBranch,
 				path:         p.path[:i+1],
 			}
-			dd := fup.blocks.newDirDataWithLBC(
+			var dd *dirData
+			dd, undoFn = fup.blocks.newDirDataWithLBC(
 				lState, currPath, keybase1.UserOrTeamID(""), kmd, lbc)
 
 			for name := range blocks {
@@ -920,6 +940,8 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 				}
 				nextNode.children[name] = childNode
 			}
+			undoFn()
+			undoFn = nil
 		}
 	}
 	return root

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -198,15 +198,15 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 	// in the path
 	currBlock := newBlock
 	var currDD *dirData
-	var undoFn func()
+	var cleanupFn func()
 	defer func() {
-		if undoFn != nil {
-			undoFn()
+		if cleanupFn != nil {
+			cleanupFn()
 		}
 	}()
 	if _, isDir := newBlock.(*DirBlock); isDir {
 		newPath := dir.ChildPath(name, newBlockPtr)
-		currDD, undoFn = fup.blocks.newDirDataWithLBC(
+		currDD, cleanupFn = fup.blocks.newDirDataWithLBC(
 			lState, newPath, chargedTo, md, lbc)
 	}
 	currName := name
@@ -233,13 +233,13 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 				md.AddRefBlock(newInfo)
 			}
 
-			dirUnrefs := fup.blocks.GetDirtyDirUnrefs(
+			dirUnrefs := fup.blocks.getDirtyDirUnrefsLocked(
 				lState, currDD.rootBlockPointer())
 			for _, unref := range dirUnrefs {
 				md.AddUnrefBlock(unref)
 			}
-			undoFn()
-			undoFn = nil
+			cleanupFn()
+			cleanupFn = nil
 		}
 
 		info, plainSize, err := fup.readyBlockMultiple(
@@ -268,7 +268,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			}
 
 			var dd *dirData
-			dd, undoFn = fup.blocks.newDirDataWithLBC(
+			dd, cleanupFn = fup.blocks.newDirDataWithLBC(
 				lState, prevDir, chargedTo, md, lbc)
 			de, err = dd.lookup(ctx, currName)
 			if _, noExists := errors.Cause(err).(NoSuchNameError); noExists {
@@ -303,14 +303,6 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			currBlock = prevDblock
 			currDD = dd
 			nextName = prevDir.tailName()
-<<<<<<< bd552cd6c38fe50663b1020744cbfc880b69b276
-=======
-			dirUnrefs := fup.blocks.getDirtyDirUnrefsLocked(
-				lState, prevDir.tailPointer())
-			for _, unref := range dirUnrefs {
-				md.AddUnrefBlock(unref)
-			}
->>>>>>> folder_block_ops: improve locking situation with dirData
 		}
 
 		if de.Type == Dir {
@@ -849,10 +841,10 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 	kmd KeyMetadata, lbc localBcache,
 	newFileBlocks fileBlockMap) *pathTreeNode {
 	var root *pathTreeNode
-	var undoFn func()
+	var cleanupFn func()
 	defer func() {
-		if undoFn != nil {
-			undoFn()
+		if cleanupFn != nil {
+			cleanupFn()
 		}
 	}()
 	for _, p := range resolvedPaths {
@@ -904,7 +896,7 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 				path:         p.path[:i+1],
 			}
 			var dd *dirData
-			dd, undoFn = fup.blocks.newDirDataWithLBC(
+			dd, cleanupFn = fup.blocks.newDirDataWithLBC(
 				lState, currPath, keybase1.UserOrTeamID(""), kmd, lbc)
 
 			for name := range blocks {
@@ -940,8 +932,8 @@ func (fup *folderUpdatePrepper) makeSyncTree(
 				}
 				nextNode.children[name] = childNode
 			}
-			undoFn()
-			undoFn = nil
+			cleanupFn()
+			cleanupFn = nil
 		}
 	}
 	return root


### PR DESCRIPTION
When fetching child directory blocks in parallel in `dirData` (via `blockTree`), we need to hold `blockLock` the whole time.  That means we have to lock `blockLock` when we create the `dirData`, and release it when we're done with that instance.

So if it's not already locked, have the `dirData` constructor method return an undo function that must be called when the `dirData` goes out of scope, which unlocks `blockLock`.

And fix up all other `folderBlockOps` calls that previously locked it during the course of conflict resolution.

Issue: KBFS-3303