### PR TITLE
folder_block_ops: better unref management for dirty dirs

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -976,10 +976,15 @@ func (fbo *folderBlockOps) makeDirDirtyLocked(
 	oldLen := len(oldUnrefs)
 	fbo.dirtyDirs[ptr] = append(oldUnrefs, unrefs...)
 	return func() {
+		dirtyBcache := fbo.config.DirtyBlockCache()
 		if wasDirty {
 			fbo.dirtyDirs[ptr] = oldUnrefs[:oldLen:oldLen]
 		} else {
+			dirtyBcache.Delete(fbo.id(), ptr, fbo.branch())
 			delete(fbo.dirtyDirs, ptr)
+		}
+		for _, unref := range unrefs {
+			dirtyBcache.Delete(fbo.id(), unref.BlockPointer, fbo.branch())
 		}
 	}
 }
@@ -1061,9 +1066,9 @@ func (fbo *folderBlockOps) addDirEntryInCacheLocked(
 
 	undoDirtyFn := fbo.makeDirDirtyLocked(lState, dir.tailPointer(), unrefs)
 	return func() {
+		_, _ = dd.removeEntry(ctx, newName)
 		undoDirtyFn()
 		parentUndo()
-		_, _ = dd.removeEntry(ctx, newName)
 	}, nil
 }
 
@@ -1097,6 +1102,13 @@ func (fbo *folderBlockOps) removeDirEntryInCacheLocked(
 	if err != nil {
 		return nil, err
 	}
+	if oldDe.Type == Dir {
+		// The parent dir inherits any dirty unrefs from the removed
+		// directory.
+		if childUnrefs, ok := fbo.dirtyDirs[oldDe.BlockPointer]; ok {
+			unrefs = append(unrefs, childUnrefs...)
+		}
+	}
 
 	unlinkUndoFn := fbo.nodeCache.Unlink(
 		oldDe.Ref(), dir.ChildPath(oldName, oldDe.BlockPointer), oldDe)
@@ -1111,10 +1123,10 @@ func (fbo *folderBlockOps) removeDirEntryInCacheLocked(
 
 	undoDirtyFn := fbo.makeDirDirtyLocked(lState, dir.tailPointer(), unrefs)
 	return func() {
+		_, _ = dd.addEntry(ctx, oldName, oldDe)
 		undoDirtyFn()
 		parentUndo()
 		unlinkUndoFn()
-		_, _ = dd.addEntry(ctx, oldName, oldDe)
 	}, nil
 }
 


### PR DESCRIPTION
When undoing a dir entry operation, we need to un-dirty any blocks that had been dirtied for the first time, by removing them from the dirty block cache.

Also, when deleting big dir trees, make sure the unrefs propagate all the way down to the remaining parent, so they can be counted in the final resolution.

Finally, move the unref accounting to the top of the prep loop, to make sure the first passed-in block gets properly accounted for.

Issue: KBFS-3303