### PR TITLE
ops: track "uncommitted" unrefs in `resolutionOp`

### DIFF
--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -641,7 +641,7 @@ func addUnrefToFinalResOp(ops opsList, ptr BlockPointer,
 		resOp = newResolutionOp()
 		ops = append(ops, resOp)
 	}
-	resOp.AddUnrefBlock(ptr)
+	resOp.AddUncommittedUnrefBlock(ptr)
 	return ops
 }
 
@@ -698,6 +698,19 @@ func (fup *folderUpdatePrepper) updateResolutionUsageAndPointersLockedCache(
 				unrefs[update.Unref] = true
 				delete(refs, update.Unref)
 				refs[update.Ref] = true
+			}
+		}
+	}
+
+	for _, resOp := range unmergedChains.resOps {
+		for _, ptr := range resOp.CommittedUnrefs() {
+			original, err := unmergedChains.originalFromMostRecentOrSame(ptr)
+			if err != nil {
+				return nil, err
+			}
+			if !unmergedChains.isCreated(original) {
+				fup.log.CDebugf(ctx, "Unref'ing %v from old resOp", ptr)
+				unrefs[ptr] = true
 			}
 		}
 	}

--- a/libkbfs/ops_test.go
+++ b/libkbfs/ops_test.go
@@ -407,6 +407,7 @@ func makeFakeResolutionOpFuture(t *testing.T) resolutionOpFuture {
 	rof := resolutionOpFuture{
 		resolutionOp{
 			makeFakeOpCommon(t, true),
+			nil,
 		},
 		kbfscodec.MakeExtraOrBust("resolutionOp", t),
 	}


### PR DESCRIPTION
When we run through conflict resolution, sometimes we need to unref blocks that have been pushed to the bserver, but not actually committed as part of any MD because _another_ conflict was hit before we could put the MD.  These blocks are special because they still need to be marked as unreferenced in the next successful PR (so they can be archived/deleted from the bserver), but without actually counting their bytes toward the TLF byte usage stored in the MD update.

So this PR introduces a new field in `resolutionOp` to track these blocks separately, so we can tell whether or not to count their bytes on a future resolution.

Issue: KBFS-3303