### PR TITLE
cr: collect dir block unrefs while applying actions

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2405,10 +2405,13 @@ func (cr *ConflictResolver) doOneAction(
 				}
 			}
 
-			err = action.do(
+			unrefs, err := action.do(
 				ctx, unmergedFetcher, mergedFetcher, uDir, mergedDir)
 			if err != nil {
 				return err
+			}
+			for _, info := range unrefs {
+				unmergedChains.toUnrefPointers[info.BlockPointer] = true
 			}
 		}
 	}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -4627,7 +4627,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	// the deferred writes are re-applied.
 	afterUpdateFn := func() error {
 		// Clear the dirty directories before the afterUpdateFns start
-		// replaying deferred writes, so we don't lose the deferreed
+		// replaying deferred writes, so we don't lose the deferred
 		// write state when we clear.
 		fbo.blocks.clearAllDirtyDirsLocked(ctx, lState, md)
 		var errs []error

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2239,7 +2239,7 @@ type crAction interface {
 	// part of this conflict resolution.
 	do(
 		ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier,
-		unmergedDir, mergedDir *dirData) ([]BlockInfo, error)
+		unmergedDir, mergedDir *dirData) (unrefs []BlockInfo, err error)
 	// updateOps potentially modifies, in place, the slices of
 	// unmerged and merged operations stored in the corresponding
 	// crChains for the given unmerged and merged most recent

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2232,12 +2232,14 @@ type crAction interface {
 		ctx context.Context, unmergedChains, mergedChains *crChains,
 		unmergedDir *dirData) (bool, BlockPointer, error)
 	// do modifies the given merged `dirData` in place to resolve the
-	// conflict, and potential uses the provided
+	// conflict, and potentially uses the provided
 	// `fileBlockDeepCopier`s to obtain copies of other blocks (along
-	// with new BlockPointers) when requiring a file copy.
+	// with new BlockPointers) when requiring a block copy.  It
+	// returns a set of block infos that need to be unreferenced as
+	// part of this conflict resolution.
 	do(
 		ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier,
-		unmergedDir, mergedDir *dirData) error
+		unmergedDir, mergedDir *dirData) ([]BlockInfo, error)
 	// updateOps potentially modifies, in place, the slices of
 	// unmerged and merged operations stored in the corresponding
 	// crChains for the given unmerged and merged most recent

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8117,10 +8117,11 @@ func (mr *MockcrActionMockRecorder) swapUnmergedBlock(ctx, unmergedChains, merge
 }
 
 // do mocks base method
-func (m *MockcrAction) do(ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier, unmergedDir, mergedDir *dirData) error {
+func (m *MockcrAction) do(ctx context.Context, unmergedCopier, mergedCopier fileBlockDeepCopier, unmergedDir, mergedDir *dirData) ([]BlockInfo, error) {
 	ret := m.ctrl.Call(m, "do", ctx, unmergedCopier, mergedCopier, unmergedDir, mergedDir)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].([]BlockInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // do indicates an expected call of do


### PR DESCRIPTION
(Depends on #1768.)

And during the resolution process, make sure we account both for these unrefs, and dir block refs/unrefs that occurred in previous resolutionOps that haven't made it to the server yet.

Issue: KBFS-3303