### PR TITLE
block_tree: fix shifting logic, and add a useful String method

### DIFF
--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -618,6 +618,8 @@ func (bt *blockTree) String() string {
 	}
 
 	level := []BlockWithPtrs{block}
+	// TODO: use a `bytes.Buffer` instead of a regular string here if
+	// we ever use this function from real code.
 	res := "\n---------------\n"
 	for len(level) > 0 {
 		var nextLevel []BlockWithPtrs

--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -684,8 +684,7 @@ func (bt *blockTree) shiftBlocksToFillHole(
 		"position", newBlockStartOff, bt.rootBlockPointer())
 
 	// Swap left as needed.
-	loopedOnce := false
-	for {
+	for loopedOnce := false; ; loopedOnce = true {
 		var leftOff Offset
 		var newParents []parentBlockAndChildIndex
 		immedPblock := immedParent.pblock
@@ -742,7 +741,6 @@ func (bt *blockTree) shiftBlocksToFillHole(
 					childBlock.NumIndirectPtrs() - 1)
 			}
 		}
-		loopedOnce = true
 
 		// We're done!
 		if leftOff.Less(newBlockStartOff) {

--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -703,7 +703,7 @@ func (bt *blockTree) shiftBlocksToFillHole(
 					return nil, nil, 0, err
 				}
 				newDirtyPtrs = append(newDirtyPtrs, ndp...)
-				nu = append(newUnrefs, nu...)
+				newUnrefs = append(newUnrefs, nu...)
 			}
 
 			// Construct the new set of parents for the shifted block,
@@ -812,7 +812,7 @@ func (bt *blockTree) shiftBlocksToFillHole(
 			return nil, nil, 0, err
 		}
 		newDirtyPtrs = append(newDirtyPtrs, ndp...)
-		nu = append(newUnrefs, nu...)
+		newUnrefs = append(newUnrefs, nu...)
 
 		immedParent = newImmedParent
 		currIndex = newCurrIndex

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -212,44 +212,10 @@ type testDirDataLeaf struct {
 	dirty      bool
 }
 
-func printTestTree(
-	t *testing.T, dd *dirData, cleanBcache BlockCache,
-	dirtyBcache DirtyBlockCache) {
-	cacheBlock, err := dirtyBcache.Get(
-		dd.tree.file.Tlf, dd.tree.rootBlockPointer(), MasterBranch)
-	require.NoError(t, err)
-	topBlock := cacheBlock.(*DirBlock)
-	level := []*DirBlock{topBlock}
-	t.Log("---------------")
-	for len(level) > 0 {
-		var nextLevel []*DirBlock
-		var levelString string
-		for i, block := range level {
-			for _, iptr := range block.IPtrs {
-				levelString += fmt.Sprintf("\"%s\" ", iptr.Off)
-				cacheBlock, err = dirtyBcache.Get(
-					dd.tree.file.Tlf, iptr.BlockPointer, MasterBranch)
-				wasDirty := err == nil
-				if !wasDirty {
-					cacheBlock, err = cleanBcache.Get(iptr.BlockPointer)
-				}
-				nextLevel = append(nextLevel, cacheBlock.(*DirBlock))
-			}
-			if i+1 < len(level) {
-				levelString += "| "
-			}
-		}
-		t.Log(levelString)
-		level = nextLevel
-	}
-	t.Log("---------------")
-}
-
 func testDirDataCheckLeafs(
 	t *testing.T, dd *dirData, cleanBcache BlockCache,
 	dirtyBcache DirtyBlockCache, expectedLeafs []testDirDataLeaf,
 	maxPtrsPerBlock, numDirEntries int) {
-	printTestTree(t, dd, cleanBcache, dirtyBcache)
 	// Top block should always be dirty.
 	cacheBlock, err := dirtyBcache.Get(
 		dd.tree.file.Tlf, dd.tree.rootBlockPointer(), MasterBranch)


### PR DESCRIPTION
While debugging new multi-block directory tests, I noticed some `blockTree` errors.  I added a `String` method to help with debugging, and fixed two bugs:

* If a block got shifted all the way to the left side of an existing block, and that was its final location, we were failing to update the new parent pointers to that block.  Instead, update those pointers at the top of the loop, before breaking when we figure out that it's in the right location.  This PR adds a new test that fails without the fix.
* `shiftBlocksToFillHole` was dropping some of the unref pointers when setting parent offsets.  This will be tested in a future PR that adds more multi-block dir DSL tests.

Issue: KBFS-3304