### PR TITLE
folder_update_prepper: estimate directory size of indirect blocks

### DIFF
--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -388,7 +388,7 @@ func (db *DirBlock) totalPlainSizeEstimate(plainSize int) int {
 	// unlikely that directory byte size matters for anything in real
 	// life.  Famous last words, of course...
 	if db.IPtrs[0].DirectType == DirectBlock {
-		return MaxBlockSizeBytesDefault*len(db.IPtrs) - 1
+		return MaxBlockSizeBytesDefault * (len(db.IPtrs) - 1)
 	}
 	return MaxBlockSizeBytesDefault * len(db.IPtrs)
 }

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -241,6 +241,9 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 		if err != nil {
 			return path{}, DirEntry{}, nil, err
 		}
+		if dblock, ok := currBlock.(*DirBlock); ok {
+			plainSize = dblock.totalPlainSizeEstimate(plainSize)
+		}
 
 		// prepend to path and setup next one
 		newPath.path = append([]pathNode{{info.BlockPointer, currName}},
@@ -298,9 +301,6 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 		}
 
 		if de.Type == Dir {
-			// TODO: When we use indirect dir blocks,
-			// we'll have to calculate the size some other
-			// way.
 			de.Size = uint64(plainSize)
 		}
 

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -242,7 +242,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 			return path{}, DirEntry{}, nil, err
 		}
 		if dblock, ok := currBlock.(*DirBlock); ok {
-			plainSize = dblock.totalPlainSizeEstimate(plainSize)
+			plainSize = dblock.totalPlainSizeEstimate(
+				plainSize, fup.config.BlockSplitter())
 		}
 
 		// prepend to path and setup next one


### PR DESCRIPTION
Now that dirs can have multiple levels of indirection, it doesn't make sense to always use the plain (encoded, but not encrypted) size of the top block as the `DirEntry.Size`.  But it's probably too expensive to download all leaf blocks, and encode them, to find out the "correct" value during every folder update.

Instead, use a simple heuristic based on the number of indirect pointers that isn't great, but probably good enough.

Issue: KBFS-3305