### PR TITLE
reporter: don't filter error notifications

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -542,10 +542,17 @@ func (fbo *folderBlockOps) getDirBlockHelperLocked(ctx context.Context,
 		fbo.blockLock.AssertAnyLocked(lState)
 	}
 
+	// Check data version explicitly here, with the right path, since
+	// we pass an empty path below.
+	if err := checkDataVersion(fbo.config, p, ptr); err != nil {
+		return nil, err
+	}
+
 	// Pass in an empty notify path because notifications should only
 	// trigger for file reads.
 	block, err := fbo.getBlockHelperLocked(
-		ctx, lState, kmd, ptr, branch, NewDirBlock, TransientEntry, path{}, rtype)
+		ctx, lState, kmd, ptr, branch, NewDirBlock, TransientEntry,
+		path{}, rtype)
 	if err != nil {
 		return nil, err
 	}

--- a/libkbfs/reporter_kbpki.go
+++ b/libkbfs/reporter_kbpki.go
@@ -268,11 +268,13 @@ func (r *ReporterKBPKI) send(ctx context.Context) {
 				return
 			}
 			nt := notification.NotificationType
+			st := notification.StatusCode
 			// Only these notifications are used in frontend:
 			// https://github.com/keybase/client/blob/0d63795105f64289ba4ef20fbefe56aad91bc7e9/shared/util/kbfs-notifications.js#L142-L154
 			if nt != keybase1.FSNotificationType_REKEYING &&
 				nt != keybase1.FSNotificationType_INITIALIZED &&
-				nt != keybase1.FSNotificationType_CONNECTION {
+				nt != keybase1.FSNotificationType_CONNECTION &&
+				st != keybase1.FSStatusCode_ERROR {
 				continue
 			}
 			// Send them right away rather than staging it and waiting for the

--- a/libkbfs/util.go
+++ b/libkbfs/util.go
@@ -112,10 +112,10 @@ func CtxWithRandomIDReplayable(ctx context.Context, tagKey interface{},
 // block pointer is valid for the given version validator
 func checkDataVersion(versioner dataVersioner, p path, ptr BlockPointer) error {
 	if ptr.DataVer < FirstValidDataVer {
-		return InvalidDataVersionError{ptr.DataVer}
+		return errors.WithStack(InvalidDataVersionError{ptr.DataVer})
 	}
 	if versioner != nil && ptr.DataVer > versioner.DataVersion() {
-		return NewDataVersionError{p, ptr.DataVer}
+		return errors.WithStack(NewDataVersionError{p, ptr.DataVer})
 	}
 	return nil
 }


### PR DESCRIPTION
Also, make sure directory out of date errors get the right path attached to them.

Issue: KBFS-3369