### PR TITLE
ioutil: quick workaround to try to reduce test flakes

### DIFF
--- a/ioutil/os_wrap.go
+++ b/ioutil/os_wrap.go
@@ -42,9 +42,17 @@ func Mkdir(path string, perm os.FileMode) error {
 
 // MkdirAll wraps MkdirAll from "os".
 func MkdirAll(path string, perm os.FileMode) error {
+	twoAttempts := false
 	err := os.MkdirAll(path, perm)
+	// KBFS-3245: Simple workaround for test flake where a directory
+	// seems to disappear out from under us.
+	if os.IsNotExist(err) {
+		twoAttempts = true
+		err = os.MkdirAll(path, perm)
+	}
 	if err != nil {
-		return errors.Wrapf(err, "failed to mkdir (all) %q", path)
+		return errors.Wrapf(err,
+			"failed to mkdir (all) %q, twoAttempts=%t", path, twoAttempts)
 	}
 
 	return nil


### PR DESCRIPTION
TestJournalCoalescing* tests have a problem where sometimes `os.MkdirAll()` calls return a "No such file or directory", which doesn't make much sense.  I suspect it's a race where a directory exists, but then is wiped before the next child can be made, or something like that.  I don't know what is deleting those directories though, whether it's something in Jenkins or something in the code or test.

For now, let's try re-trying the `MkdirAll` call once, to see if it helps.  If not, we can drill deeper into exactly what's going on.

Issue: KBFS-3245