### PR TITLE
cr: ignore `changeOriginal` call between two same pointers

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -649,6 +649,9 @@ func (cr *ConflictResolver) checkPathForMerge(ctx context.Context,
 			continue
 		} else if err != nil {
 			return nil, err
+		} else if unmergedOriginal == mergedOriginal {
+			cr.log.CDebugf(ctx,
+				"Treating self-conflicting directory like a normal conflict")
 		}
 
 		unmergedChain, ok := unmergedChains.byOriginal[mergedOriginal]

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -1052,6 +1052,13 @@ func (ccs *crChains) copyOpAndRevertUnrefsToOriginals(currOp op) op {
 // original, which originated in some other branch.
 func (ccs *crChains) changeOriginal(oldOriginal BlockPointer,
 	newOriginal BlockPointer) error {
+	if oldOriginal == newOriginal {
+		// This apparently can happen, but I'm not sure how.  (See
+		// KBFS-2946.)  Maybe because of a self-conflict in some weird
+		// error conditions. In this case, we can just pretend the
+		// change worked, and let CR continue it's normal process.
+		return nil
+	}
 	chain, ok := ccs.byOriginal[oldOriginal]
 	if !ok {
 		return NoChainFoundError{oldOriginal}


### PR DESCRIPTION
I've been unable to get good logs that reproduce this issue, and it seems safe to just ignore the case where CR is trying to change an original between two identical pointers.  This probably indicates something like the device putting an MD, but failing before it finds out that the put succeeds. Then later it tries to resolve the conflict against itself.  In theory, we have other protections against this, and it would be nice to figure out why it's causing problems in this case, but it's probably best to paper over it for now and just give the user a smoother experience.

It's possible that when the CR finally succeeds, it will end up with a bunch of conflict files, which might get the user's attention quickly and entice them to send logs soon (thus capturing the original source of the problem).

Issue: KBFS-2946