### PR TITLE
keybase_service_base: avoid concurrent map access panic

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -59,6 +59,35 @@ type UserInfo struct {
 	RevokedCryptPublicKeys map[kbfscrypto.CryptPublicKey]revokedKeyInfo
 }
 
+// DeepCopy returns a copy of `ui`, including deep copies of all slice
+// and map members.
+func (ui UserInfo) DeepCopy() UserInfo {
+	copyUI := ui
+	copyUI.VerifyingKeys = make(
+		[]kbfscrypto.VerifyingKey, len(ui.VerifyingKeys))
+	copy(copyUI.VerifyingKeys, ui.VerifyingKeys)
+	copyUI.CryptPublicKeys = make(
+		[]kbfscrypto.CryptPublicKey, len(ui.CryptPublicKeys))
+	copy(copyUI.CryptPublicKeys, ui.CryptPublicKeys)
+	copyUI.KIDNames = make(map[keybase1.KID]string, len(ui.KIDNames))
+	for k, v := range ui.KIDNames {
+		copyUI.KIDNames[k] = v
+	}
+	copyUI.RevokedVerifyingKeys = make(
+		map[kbfscrypto.VerifyingKey]revokedKeyInfo,
+		len(ui.RevokedVerifyingKeys))
+	for k, v := range ui.RevokedVerifyingKeys {
+		copyUI.RevokedVerifyingKeys[k] = v
+	}
+	copyUI.RevokedCryptPublicKeys = make(
+		map[kbfscrypto.CryptPublicKey]revokedKeyInfo,
+		len(ui.RevokedCryptPublicKeys))
+	for k, v := range ui.RevokedCryptPublicKeys {
+		copyUI.RevokedCryptPublicKeys[k] = v
+	}
+	return copyUI
+}
+
 // TeamInfo contains all the info about a keybase team that kbfs cares
 // about.
 type TeamInfo struct {

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -579,6 +579,7 @@ func (k *KeybaseServiceBase) ResolveImplicitTeamByID(
 func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 	ctx context.Context, currUserInfo UserInfo, kid keybase1.KID) (
 	newUserInfo UserInfo, exists bool, err error) {
+	newUserInfo = currUserInfo
 	for key, info := range currUserInfo.RevokedVerifyingKeys {
 		if !key.KID().Equal(kid) {
 			continue
@@ -628,12 +629,13 @@ func (k *KeybaseServiceBase) checkForRevokedVerifyingKey(
 			}
 		}
 		info.filledInMerkle = true
-		currUserInfo.RevokedVerifyingKeys[key] = info
-		k.setCachedUserInfo(currUserInfo.UID, currUserInfo)
+		newUserInfo = currUserInfo.DeepCopy()
+		newUserInfo.RevokedVerifyingKeys[key] = info
+		k.setCachedUserInfo(newUserInfo.UID, newUserInfo)
 		break
 	}
 
-	return currUserInfo, exists, nil
+	return newUserInfo, exists, nil
 }
 
 // LoadUserPlusKeys implements the KeybaseService interface for


### PR DESCRIPTION
Make a copy of the UserInfo before we modify it, in case multiple goroutines are modifying/accessing it at the same time.

I think this was why this function returns a different UserInfo object in the first place, but I forgot to do the actual copy.