### PR TITLE
test: don't set darwin timeout on overall test context

### DIFF
--- a/test/run_fuse_test.go
+++ b/test/run_fuse_test.go
@@ -59,7 +59,7 @@ func createUserFuse(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 	}
 	tb.Logf("FUSE HasInvalidate=%v", mnt.Conn.Protocol().HasInvalidate())
 
-	ctx := context.Background()
+	ctx := libkbfs.BackgroundContextWithCancellationDelayer()
 
 	session, err := config.KBPKI().GetCurrentSession(ctx)
 	if err != nil {
@@ -68,7 +68,6 @@ func createUserFuse(tb testing.TB, ith int, config *libkbfs.ConfigLocal,
 
 	ctx, cancelFn := context.WithCancel(ctx)
 
-	ctx = filesys.WithContext(ctx)
 	logTags := logger.CtxLogTags{
 		CtxUserKey: CtxOpUser,
 	}


### PR DESCRIPTION
When launching darwin fuse DSL tests, we were calling `FS.WithContext()` to created the context that gets passed to `FS.LaunchProcessor()`.  The context therefore got stuck with a 19-second per-operation darwin timeout.  So if the overall test took more than 19s, the goroutine that processed invalidation notifications would exit, and the kernel cache would stop getting updates, leading to weird, rare data failures.

Instead, just make a context with the required properties, without the actual timeout (or an unnecessary FID tag).

Issue: KBFS-3394