### PR TITLE
kbfsmd: improve `ServerErrorLockConflict` error message

### DIFF
--- a/kbfsmd/server_errors.go
+++ b/kbfsmd/server_errors.go
@@ -367,8 +367,8 @@ type ServerErrorLockConflict struct{}
 
 // Error implements the Error interface.
 func (e ServerErrorLockConflict) Error() string {
-	return "This operation conflicted with another operation on the server. " +
-		"Please try again."
+	return "This operation conflicted with another operation on the server, " +
+		"or it took too long. Please try again."
 }
 
 // ToStatus implements the ExportableError interface.

--- a/kbfsmd/server_errors.go
+++ b/kbfsmd/server_errors.go
@@ -367,7 +367,8 @@ type ServerErrorLockConflict struct{}
 
 // Error implements the Error interface.
 func (e ServerErrorLockConflict) Error() string {
-	return "ServerErrorLockConflict{}"
+	return "This operation conflicted with another operation on the server. " +
+		"Please try again."
 }
 
 // ToStatus implements the ExportableError interface.


### PR DESCRIPTION
It's possible that the user actually sees this message in some rare cases.

Issue: KBFS-3407