### PR TITLE
cr_actions: add test and fix on setmtime + merged rename conflict

### DIFF
--- a/libkbfs/cr_actions.go
+++ b/libkbfs/cr_actions.go
@@ -707,7 +707,7 @@ func (rua *renameUnmergedAction) updateOps(
 			}
 		}
 	} else {
-		// The unmerged copy is changing it's name, so make a local
+		// The unmerged copy is changing its name, so make a local
 		// rename op for it, and a create op for the merged version.
 		rop, err := newRenameOp(rua.fromName, mergedMostRecent, rua.toName,
 			mergedMostRecent, newMergedEntry.BlockPointer,


### PR DESCRIPTION
When the merged user sets the mtime and moves a file across directories, and the unmerged user just sets the mtime, we weren't issuing the correct local op notifications to the unmerged user after conflict resolution.  Previously, the notifications made it look like the unmerged file was moved somewhere else, and the file would appear to be missing on a subsequent lookup.

To fix, detect the situation explicitly and update the notifications to make it look like a new file (the renamed merged file) is being created instead.

Note that this doesn't solve KBFS-3408, it's just a test I tried adding while debugging that issue.  The test fails to repro that issue though, but it's worth fixing in its own right.

Issue: KBFS-3408