### PR TITLE
Revendor externals

### DIFF
--- a/vendor/github.com/keybase/client/go/externals/proof_checkers.go
+++ b/vendor/github.com/keybase/client/go/externals/proof_checkers.go
@@ -2,3 +2,18 @@
 // this source code is governed by the included BSD license.
 
 package externals
+
+import libkb "github.com/keybase/client/go/libkb"
+
+func getStaticProofServices() []libkb.ServiceType {
+	services := []libkb.ServiceType{
+		DNSServiceType{},
+		FacebookServiceType{},
+		GithubServiceType{},
+		HackerNewsServiceType{},
+		RedditServiceType{},
+		TwitterServiceType{},
+		WebServiceType{},
+	}
+	return append(services, getBuildSpecificStaticProofServices()...)
+}

--- a/vendor/github.com/keybase/client/go/externals/proof_checkers_devel.go
+++ b/vendor/github.com/keybase/client/go/externals/proof_checkers_devel.go
@@ -5,4 +5,12 @@
 
 package externals
 
+import libkb "github.com/keybase/client/go/libkb"
+
 const useDevelProofCheckers = true
+
+func getBuildSpecificStaticProofServices() []libkb.ServiceType {
+	return []libkb.ServiceType{
+		RooterServiceType{},
+	}
+}

--- a/vendor/github.com/keybase/client/go/externals/proof_checkers_production.go
+++ b/vendor/github.com/keybase/client/go/externals/proof_checkers_production.go
@@ -5,4 +5,10 @@
 
 package externals
 
+import libkb "github.com/keybase/client/go/libkb"
+
 const useDevelProofCheckers = false
+
+func getBuildSpecificStaticProofServices() []libkb.ServiceType {
+	return nil
+}

--- a/vendor/github.com/keybase/client/go/externals/services.go
+++ b/vendor/github.com/keybase/client/go/externals/services.go
@@ -11,19 +11,6 @@ import (
 	libkb "github.com/keybase/client/go/libkb"
 )
 
-func getStaticProofServices() []libkb.ServiceType {
-	return []libkb.ServiceType{
-		DNSServiceType{},
-		FacebookServiceType{},
-		GithubServiceType{},
-		HackerNewsServiceType{},
-		RedditServiceType{},
-		RooterServiceType{},
-		TwitterServiceType{},
-		WebServiceType{},
-	}
-}
-
 // staticProofServies are only used for testing or for basic assertion
 // validation
 type staticProofServices struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -243,10 +243,10 @@
 			"revisionTime": "2018-08-28T18:44:39Z"
 		},
 		{
-			"checksumSHA1": "Vc2KNvlc9/7IfK8akpw3H/qQy34=",
+			"checksumSHA1": "uRIxAmwciiyx808wRFQ0qYmQaKQ=",
 			"path": "github.com/keybase/client/go/externals",
-			"revision": "db1530488437a88f2dd00221706e81bc83bf0dc9",
-			"revisionTime": "2018-09-14T15:22:44Z"
+			"revision": "fd643720c7413d917e1c6ee50bdd1d9c83041cc8",
+			"revisionTime": "2018-09-14T23:10:04Z"
 		},
 		{
 			"checksumSHA1": "sN2RBTeKHJ2ZTm1dgQQWOdCHiG8=",


### PR DESCRIPTION
There was an issue with externals referencing a devel build variable in the production build, kbfs production build would break because of this.  fixed in  https://github.com/keybase/client/pull/13767

```
$ go build --tags=production ./...
# github.com/keybase/kbfs/vendor/github.com/keybase/client/go/externals
vendor/github.com/keybase/client/go/externals/services.go:21:3: undefined: RooterServiceType
```