### PR TITLE
libgit: avoid using nil return values in deferred function

### DIFF
--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -95,9 +95,9 @@ func (rh *RPCHandler) waitForJournal(
 
 func (rh *RPCHandler) getHandleAndConfig(
 	ctx context.Context, folder keybase1.Folder) (
-	newCtx context.Context, gitConfig libkbfs.Config,
-	tlfHandle *libkbfs.TlfHandle, tempDir string, err error) {
-	newCtx, gitConfig, tempDir, err = getNewConfig(
+	newCtx context.Context, gitConfigRet libkbfs.Config,
+	tlfHandle *libkbfs.TlfHandle, tempDirRet string, err error) {
+	newCtx, gitConfig, tempDir, err := getNewConfig(
 		ctx, rh.config, rh.kbCtx, rh.kbfsInitParams, rh.log)
 	if err != nil {
 		return nil, nil, nil, "", err


### PR DESCRIPTION
Give the return params different names, so we don't try to access them when they're explicitly set to nil on an error return.

Issue: KBFS-3415