### PR TITLE
cr_chains: use default path for unknown, deleted-chain ops

### DIFF
--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -1109,7 +1109,28 @@ func (ccs *crChains) findPathForDeleted(mostRecent BlockPointer) path {
 			}
 		}
 	}
-	return path{}
+	// We can get here if the entry in question was also created
+	// during the chain period, in which case `mostRecent` doesn't
+	// need to be unreferenced explicitly.  There's nothing easy we
+	// can do here.  But the path isn't very important; for the most
+	// part, it's just informational for log messages and journal
+	// status.  So if we are stuck, just pick use the root directory
+	// and a fake name.
+	var rootMostRecent BlockPointer
+	if ccs.mostRecentChainMDInfo != nil {
+		rootMostRecent =
+			ccs.mostRecentChainMDInfo.GetRootDirEntry().BlockPointer
+	}
+	return path{
+		FolderBranch: FolderBranch{
+			Tlf:    ccs.mostRecentChainMDInfo.TlfID(),
+			Branch: MasterBranch,
+		},
+		path: []pathNode{{
+			BlockPointer: rootMostRecent,
+			Name:         mostRecent.String(),
+		}},
+	}
 }
 
 // getPaths returns a sorted slice of most recent paths to all the


### PR DESCRIPTION
When an entry is both created and deleted within a set of operations across a set of MD updates, we won't be able to find its corresponding `rmOp` using the `mostRecent` pointer, because that pointer doesn't need to be unreferenced.  Instead, just use a default using the root pointer.

An op without a path can lead to a crash in conflict resolution and/or while getting the journal status.

Issue: KBFS-3408
Issue: KBFS-3414 (maybe)