### PR TITLE
tlf_handle_resolve: return partial handle when team doesn't match

### DIFF
--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -528,7 +528,7 @@ func (h TlfHandle) ResolvesTo(
 				}
 			}
 			if !bareHandle.ResolvedUsersEqual(wUsers, rUsers) {
-				return false, nil, err
+				return false, partialResolvedH, nil
 			}
 			// Set other's writers/readers to be equal to h's, since
 			// we already checked the team membership.  If the


### PR DESCRIPTION
During migration, when the members in the old handle doesn't match the users in a new implicit team, we should be returning the partially resolved handle and explicitly returning a nil error, to allow for better error reporting and avoid a panic in the caller.

(Note that this came about because PUK-less users are not full members of an implicit team, and thus aren't listed in the membership list even when they do exist in the old handle.  This fix just avoids a crash in this case, but there's an open question about how we should deal with those migrations that should be addressed later.)

Issue: KBFS-3437