### PR TITLE
libgit: add a git browser that doesn't require a checkout

### DIFF
--- a/libgit/browser.go
+++ b/libgit/browser.go
@@ -60,7 +60,7 @@ func NewBrowser(
 	}
 
 	if ref.Type() != plumbing.HashReference {
-		return nil, errors.Errorf("Can't browse reference type %s", ref.Type())
+		return nil, errors.Errorf("can't browse reference type %s", ref.Type())
 	}
 
 	c, err := repo.CommitObject(ref.Hash())
@@ -109,7 +109,7 @@ func (b *Browser) followSymlink(filename string) (string, error) {
 		return "", err
 	}
 	if path.IsAbs(link) {
-		return "", errors.Errorf("Can't follow absolute link: %s", link)
+		return "", errors.Errorf("can't follow absolute link: %s", link)
 	}
 
 	parts := strings.Split(filename, "/")
@@ -120,7 +120,7 @@ func (b *Browser) followSymlink(filename string) (string, error) {
 	newPath := path.Clean(path.Join(parentPath, link))
 	if strings.HasPrefix(newPath, "..") {
 		return "", errors.Errorf(
-			"Cannot follow symlink out of chroot: %s", newPath)
+			"cannot follow symlink out of chroot: %s", newPath)
 	}
 	return newPath, nil
 }
@@ -147,14 +147,14 @@ func (b *Browser) Open(filename string) (billy.File, error) {
 			return nil, err
 		}
 	}
-	return nil, errors.New("Cannot resolve deep symlink chain")
+	return nil, errors.New("cannot resolve deep symlink chain")
 }
 
 // OpenFile implements the billy.Filesystem interface for Browser.
 func (b *Browser) OpenFile(filename string, flag int, _ os.FileMode) (
 	f billy.File, err error) {
 	if flag&os.O_CREATE != 0 {
-		return nil, errors.New("Browser can't create files")
+		return nil, errors.New("browser can't create files")
 	}
 
 	return b.Open(filename)
@@ -207,7 +207,7 @@ func (b *Browser) Stat(filename string) (fi os.FileInfo, err error) {
 			return nil, err
 		}
 	}
-	return nil, errors.New("Cannot resolve deep symlink chain")
+	return nil, errors.New("cannot resolve deep symlink chain")
 }
 
 // Join implements the billy.Filesystem interface for Browser.
@@ -245,7 +245,7 @@ func (b *Browser) Readlink(link string) (target string, err error) {
 	}
 	// If it's not a symlink, error right away.
 	if fi.Mode()&os.ModeSymlink == 0 {
-		return "", errors.New("Not a symlink")
+		return "", errors.New("not a symlink")
 	}
 
 	return b.readLink(link)
@@ -272,30 +272,30 @@ func (b *Browser) Root() string {
 
 // Create implements the billy.Filesystem interface for Browser.
 func (b *Browser) Create(_ string) (billy.File, error) {
-	return nil, errors.New("Browser cannot create files")
+	return nil, errors.New("browser cannot create files")
 }
 
 // Rename implements the billy.Filesystem interface for Browser.
 func (b *Browser) Rename(_, _ string) (err error) {
-	return errors.New("Browser cannot rename files")
+	return errors.New("browser cannot rename files")
 }
 
 // Remove implements the billy.Filesystem interface for Browser.
 func (b *Browser) Remove(_ string) (err error) {
-	return errors.New("Browser cannot remove files")
+	return errors.New("browser cannot remove files")
 }
 
 // TempFile implements the billy.Filesystem interface for Browser.
 func (b *Browser) TempFile(_, _ string) (billy.File, error) {
-	return nil, errors.New("Browser cannot make temp files")
+	return nil, errors.New("browser cannot make temp files")
 }
 
 // MkdirAll implements the billy.Filesystem interface for Browser.
 func (b *Browser) MkdirAll(_ string, _ os.FileMode) (err error) {
-	return errors.New("Browser cannot mkdir")
+	return errors.New("browser cannot mkdir")
 }
 
 // Symlink implements the billy.Filesystem interface for Browser.
 func (b *Browser) Symlink(_, _ string) (err error) {
-	return errors.New("Browser cannot make symlinks")
+	return errors.New("browser cannot make symlinks")
 }

--- a/libgit/browser.go
+++ b/libgit/browser.go
@@ -75,7 +75,7 @@ func NewBrowser(
 	return &Browser{
 		tree:  tree,
 		root:  string(gitBranchName),
-		mtime: time.Now(),
+		mtime: c.Author.When,
 	}, nil
 }
 
@@ -185,8 +185,8 @@ func (b *Browser) Lstat(filename string) (fi os.FileInfo, err error) {
 		}
 	}
 
-	// Git doesn't keep track of the mtime anywhere, so just use the
-	// time this browser was created.
+	// Git doesn't keep track of the mtime of individual files
+	// anywhere, so just use the timestamp from the commit.
 	return &browserFileInfo{entry, size, b.mtime}, nil
 }
 

--- a/libgit/browser.go
+++ b/libgit/browser.go
@@ -1,0 +1,301 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+	gogit "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"gopkg.in/src-d/go-git.v4/storage"
+)
+
+// Browser presents the contents of a git repo as a read-only file
+// system, using only the dotgit directory of the repo.
+type Browser struct {
+	tree  *object.Tree
+	root  string
+	mtime time.Time
+}
+
+var _ billy.Filesystem = (*Browser)(nil)
+
+// NewBrowser makes a new Browser instance, browsing the given branch
+// of the given repo.
+func NewBrowser(
+	repoFS *libfs.FS, clock libkbfs.Clock,
+	gitBranchName plumbing.ReferenceName) (*Browser, error) {
+	var storage storage.Storer
+	storage, err := NewGitConfigWithoutRemotesStorer(repoFS)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := gogit.Open(storage, nil)
+	if errors.Cause(err) == gogit.ErrWorktreeNotProvided {
+		// This is not a bare repo (it might be for a test).  So we
+		// need to pass in a working tree, but since `Browser` is
+		// read-only and doesn't even use the worktree, it doesn't
+		// matter what we pass in.
+		repo, err = gogit.Open(storage, repoFS)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := repo.Reference(gitBranchName, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if ref.Type() != plumbing.HashReference {
+		return nil, errors.Errorf("Can't browse reference type %s", ref.Type())
+	}
+
+	c, err := repo.CommitObject(ref.Hash())
+	if err != nil {
+		return nil, err
+	}
+	tree, err := c.Tree()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Browser{
+		tree:  tree,
+		root:  string(gitBranchName),
+		mtime: time.Now(),
+	}, nil
+}
+
+///// Read-only functions:
+
+const (
+	maxSymlinkLevels = 40 // same as Linux
+)
+
+func (b *Browser) readLink(filename string) (string, error) {
+	f, err := b.tree.File(filename)
+	if err != nil {
+		return "", err
+	}
+	r, err := f.Reader()
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func (b *Browser) followSymlink(filename string) (string, error) {
+	// Otherwise, resolve the symlink and return the underlying FileInfo.
+	link, err := b.readLink(filename)
+	if err != nil {
+		return "", err
+	}
+	if path.IsAbs(link) {
+		return "", errors.Errorf("Can't follow absolute link: %s", link)
+	}
+
+	parts := strings.Split(filename, "/")
+	var parentPath string
+	if len(parts) > 0 {
+		parentPath = path.Join(parts[:len(parts)-1]...)
+	}
+	newPath := path.Clean(path.Join(parentPath, link))
+	if strings.HasPrefix(newPath, "..") {
+		return "", errors.Errorf(
+			"Cannot follow symlink out of chroot: %s", newPath)
+	}
+	return newPath, nil
+}
+
+// Open implements the billy.Filesystem interface for Browser.
+func (b *Browser) Open(filename string) (billy.File, error) {
+	for i := 0; i < maxSymlinkLevels; i++ {
+		fi, err := b.Lstat(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		// If it's not a symlink, we can return right away.
+		if fi.Mode()&os.ModeSymlink == 0 {
+			f, err := b.tree.File(filename)
+			if err != nil {
+				return nil, err
+			}
+			return newBrowserFile(f)
+		}
+
+		filename, err = b.followSymlink(filename)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, errors.New("Cannot resolve deep symlink chain")
+}
+
+// OpenFile implements the billy.Filesystem interface for Browser.
+func (b *Browser) OpenFile(filename string, flag int, _ os.FileMode) (
+	f billy.File, err error) {
+	if flag&os.O_CREATE != 0 {
+		return nil, errors.New("Browser can't create files")
+	}
+
+	return b.Open(filename)
+}
+
+// Lstat implements the billy.Filesystem interface for Browser.
+func (b *Browser) Lstat(filename string) (fi os.FileInfo, err error) {
+	entry, err := b.tree.FindEntry(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var size int64
+	if entry.Mode.IsFile() {
+		f, err := b.tree.File(filename)
+		if err != nil {
+			return nil, err
+		}
+		size = f.Size
+	} else {
+		// Estimate directory size by the number of entries.
+		dirTree, err := b.tree.Tree(filename)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range dirTree.Entries {
+			size += int64(len(e.Name))
+		}
+	}
+
+	// Git doesn't keep track of the mtime anywhere, so just use the
+	// time this browser was created.
+	return &browserFileInfo{entry, size, b.mtime}, nil
+}
+
+// Stat implements the billy.Filesystem interface for Browser.
+func (b *Browser) Stat(filename string) (fi os.FileInfo, err error) {
+	for i := 0; i < maxSymlinkLevels; i++ {
+		fi, err := b.Lstat(filename)
+		if err != nil {
+			return nil, err
+		}
+		// If it's not a symlink, we can return right away.
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return fi, nil
+		}
+
+		filename, err = b.followSymlink(filename)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, errors.New("Cannot resolve deep symlink chain")
+}
+
+// Join implements the billy.Filesystem interface for Browser.
+func (b *Browser) Join(elem ...string) string {
+	return path.Clean(path.Join(elem...))
+}
+
+// ReadDir implements the billy.Filesystem interface for Browser.
+func (b *Browser) ReadDir(p string) (fis []os.FileInfo, err error) {
+	var dirTree *object.Tree
+	if p == "" || p == "." {
+		dirTree = b.tree
+	} else {
+		dirTree, err = b.tree.Tree(p)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, e := range dirTree.Entries {
+		fi, err := b.Lstat(e.Name)
+		if err != nil {
+			return nil, err
+		}
+		fis = append(fis, fi)
+	}
+	return fis, nil
+}
+
+// Readlink implements the billy.Filesystem interface for Browser.
+func (b *Browser) Readlink(link string) (target string, err error) {
+	fi, err := b.Lstat(link)
+	if err != nil {
+		return "", err
+	}
+	// If it's not a symlink, error right away.
+	if fi.Mode()&os.ModeSymlink == 0 {
+		return "", errors.New("Not a symlink")
+	}
+
+	return b.readLink(link)
+}
+
+// Chroot implements the billy.Filesystem interface for Browser.
+func (b *Browser) Chroot(p string) (newFS billy.Filesystem, err error) {
+	newTree, err := b.tree.Tree(p)
+	if err != nil {
+		return nil, err
+	}
+	return &Browser{
+		tree: newTree,
+		root: b.Join(b.root, p),
+	}, nil
+}
+
+// Root implements the billy.Filesystem interface for Browser.
+func (b *Browser) Root() string {
+	return b.root
+}
+
+///// Modifying functions (not supported):
+
+// Create implements the billy.Filesystem interface for Browser.
+func (b *Browser) Create(_ string) (billy.File, error) {
+	return nil, errors.New("Browser cannot create files")
+}
+
+// Rename implements the billy.Filesystem interface for Browser.
+func (b *Browser) Rename(_, _ string) (err error) {
+	return errors.New("Browser cannot rename files")
+}
+
+// Remove implements the billy.Filesystem interface for Browser.
+func (b *Browser) Remove(_ string) (err error) {
+	return errors.New("Browser cannot remove files")
+}
+
+// TempFile implements the billy.Filesystem interface for Browser.
+func (b *Browser) TempFile(_, _ string) (billy.File, error) {
+	return nil, errors.New("Browser cannot make temp files")
+}
+
+// MkdirAll implements the billy.Filesystem interface for Browser.
+func (b *Browser) MkdirAll(_ string, _ os.FileMode) (err error) {
+	return errors.New("Browser cannot mkdir")
+}
+
+// Symlink implements the billy.Filesystem interface for Browser.
+func (b *Browser) Symlink(_, _ string) (err error) {
+	return errors.New("Browser cannot make symlinks")
+}

--- a/libgit/browser_file.go
+++ b/libgit/browser_file.go
@@ -60,17 +60,22 @@ func (bf *browserFile) ReadAt(p []byte, off int64) (n int, err error) {
 		_ = r.Close()
 	}()
 
-	// Skip past the data we don't care about, one chunk at a time.
 	dataToSkip := off
+	bufSize := dataToSkip
+	if bufSize > bf.maxBufSize {
+		bufSize = bf.maxBufSize
+	}
+	buf := make([]byte, bufSize)
+
+	// Skip past the data we don't care about, one chunk at a time.
 	for dataToSkip > 0 {
-		bufSize := dataToSkip
-		if bufSize > bf.maxBufSize {
-			bufSize = bf.maxBufSize
+		toRead := int64(len(buf))
+		if dataToSkip < toRead {
+			toRead = dataToSkip
 		}
 
-		buf := make([]byte, dataToSkip)
 		// Throwaway data.
-		n, err := r.Read(buf)
+		n, err := r.Read(buf[:toRead])
 		if err != nil {
 			return 0, err
 		}

--- a/libgit/browser_file.go
+++ b/libgit/browser_file.go
@@ -1,0 +1,89 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"io"
+
+	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+type browserFile struct {
+	f *object.File
+	r io.ReadCloser
+}
+
+var _ billy.File = (*browserFile)(nil)
+
+func newBrowserFile(f *object.File) (*browserFile, error) {
+	r, err := f.Reader()
+	if err != nil {
+		return nil, err
+	}
+	return &browserFile{
+		f: f,
+		r: r,
+	}, nil
+}
+
+func (bf *browserFile) Name() string {
+	return bf.Name()
+}
+
+func (bf *browserFile) Write(_ []byte) (n int, err error) {
+	return 0, errors.New("Browser files can't be written")
+}
+
+func (bf *browserFile) Read(p []byte) (n int, err error) {
+	return bf.r.Read(p)
+}
+
+func (bf *browserFile) ReadAt(p []byte, off int64) (n int, err error) {
+	// Sadly go-git doesn't expose a `ReadAt` interface for this, but
+	// we can probably implement it if needed.  Instead, use a new
+	// Reader object and just scan starting from the beginning.
+	fullData := make([]byte, int64(len(p))+off)
+	r, err := bf.f.Reader()
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = r.Close()
+	}()
+	n, err = r.Read(fullData)
+	if err != nil {
+		if int64(n) > off {
+			copy(p, fullData[off:int64(n)-off])
+			return n, err
+		}
+		return 0, err
+	}
+	copy(p, fullData[off:])
+	return n - int(off), nil
+}
+
+func (bf *browserFile) Seek(offset int64, whence int) (int64, error) {
+	// TODO if needed: we'd have to track the offset of `bf.r`
+	// manually, the same way we do in `libfs.File`.
+	return 0, errors.New("Browser files can't seek")
+}
+
+func (bf *browserFile) Close() error {
+	return bf.r.Close()
+}
+
+func (bf *browserFile) Lock() error {
+	return errors.New("Browser files can't be locked")
+}
+
+func (bf *browserFile) Unlock() error {
+	return errors.New("Browser files can't be unlocked")
+}
+
+func (bf *browserFile) Truncate(size int64) error {
+	return errors.New("Browser files can't be truncated")
+}

--- a/libgit/browser_file.go
+++ b/libgit/browser_file.go
@@ -41,7 +41,7 @@ func (bf *browserFile) Name() string {
 }
 
 func (bf *browserFile) Write(_ []byte) (n int, err error) {
-	return 0, errors.New("Browser files can't be written")
+	return 0, errors.New("browser files can't be written")
 }
 
 func (bf *browserFile) Read(p []byte) (n int, err error) {
@@ -83,7 +83,7 @@ func (bf *browserFile) ReadAt(p []byte, off int64) (n int, err error) {
 func (bf *browserFile) Seek(offset int64, whence int) (int64, error) {
 	// TODO if needed: we'd have to track the offset of `bf.r`
 	// manually, the same way we do in `libfs.File`.
-	return 0, errors.New("Browser files can't seek")
+	return 0, errors.New("browser files can't seek")
 }
 
 func (bf *browserFile) Close() error {
@@ -91,13 +91,13 @@ func (bf *browserFile) Close() error {
 }
 
 func (bf *browserFile) Lock() error {
-	return errors.New("Browser files can't be locked")
+	return errors.New("browser files can't be locked")
 }
 
 func (bf *browserFile) Unlock() error {
-	return errors.New("Browser files can't be unlocked")
+	return errors.New("browser files can't be unlocked")
 }
 
 func (bf *browserFile) Truncate(size int64) error {
-	return errors.New("Browser files can't be truncated")
+	return errors.New("browser files can't be truncated")
 }

--- a/libgit/browser_file_info.go
+++ b/libgit/browser_file_info.go
@@ -1,0 +1,51 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"os"
+	"time"
+
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+type browserFileInfo struct {
+	entry *object.TreeEntry
+	size  int64
+	mtime time.Time
+}
+
+var _ os.FileInfo = (*browserFileInfo)(nil)
+
+func (bfi *browserFileInfo) Name() string {
+	return bfi.entry.Name
+}
+
+func (bfi *browserFileInfo) Size() int64 {
+	return bfi.size
+}
+
+func (bfi *browserFileInfo) Mode() os.FileMode {
+	mode, err := bfi.entry.Mode.ToOSFileMode()
+	if err != nil {
+		panic(err)
+	}
+	// Make it read-only.
+	return mode &^ 0222
+}
+
+func (bfi *browserFileInfo) ModTime() time.Time {
+	// Unfortunately go-git doesn't give us a good way to get the time
+	// of this entry, so we have to rely on the caller.
+	return bfi.mtime
+}
+
+func (bfi *browserFileInfo) IsDir() bool {
+	return !bfi.entry.Mode.IsFile()
+}
+
+func (bfi *browserFileInfo) Sys() interface{} {
+	return nil
+}

--- a/libgit/browser_test.go
+++ b/libgit/browser_test.go
@@ -59,6 +59,16 @@ func TestBrowser(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello", string(data))
 
+	t.Log("Use ReadAt with a small buffer.")
+	bf, ok := f.(*browserFile)
+	require.True(t, ok)
+	bf.maxBufSize = 1
+	buf := make([]byte, 3)
+	n, err := f.ReadAt(buf, 2)
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+	require.Equal(t, "llo", string(buf))
+
 	addSymlink := func(target, link string) {
 		err = worktreeFS.Symlink(target, link)
 		require.NoError(t, err)

--- a/libgit/browser_test.go
+++ b/libgit/browser_test.go
@@ -1,0 +1,102 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libgit
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/libfs"
+	"github.com/keybase/kbfs/libkbfs"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+	gogit "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
+)
+
+func TestBrowser(t *testing.T) {
+	ctx, config, cancel, tempdir := initConfigForAutogit(t)
+	defer cancel()
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
+	defer os.RemoveAll(tempdir)
+
+	h, err := libkbfs.ParseTlfHandle(
+		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
+	require.NoError(t, err)
+	rootFS, err := libfs.NewFS(
+		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
+	require.NoError(t, err)
+
+	t.Log("Init a new repo directly into KBFS.")
+	dotgitFS, _, err := GetOrCreateRepoAndID(ctx, config, h, "test", "")
+	require.NoError(t, err)
+	err = rootFS.MkdirAll("worktree", 0600)
+	require.NoError(t, err)
+	worktreeFS, err := rootFS.Chroot("worktree")
+	require.NoError(t, err)
+	dotgitStorage, err := NewGitConfigWithoutRemotesStorer(dotgitFS)
+	require.NoError(t, err)
+	repo, err := gogit.Init(dotgitStorage, worktreeFS)
+	require.NoError(t, err)
+	addFileToWorktreeAndCommit(
+		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
+
+	t.Log("Browse the repo and verify the data.")
+	b, err := NewBrowser(dotgitFS, config.Clock(), "refs/heads/master")
+	require.NoError(t, err)
+	fis, err := b.ReadDir("")
+	require.NoError(t, err)
+	require.Len(t, fis, 1)
+	f, err := b.Open("foo")
+	require.NoError(t, err)
+	defer f.Close()
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, "hello", string(data))
+
+	addSymlink := func(target, link string) {
+		err = worktreeFS.Symlink(target, link)
+		require.NoError(t, err)
+		wt, err := repo.Worktree()
+		require.NoError(t, err)
+		_, err = wt.Add(link)
+		require.NoError(t, err)
+		_, err = wt.Commit("sym commit", &gogit.CommitOptions{
+			Author: &object.Signature{
+				Name:  "me",
+				Email: "me@keyba.se",
+				When:  time.Now(),
+			},
+		})
+		require.NoError(t, err)
+		b, err = NewBrowser(dotgitFS, config.Clock(), "refs/heads/master")
+		require.NoError(t, err)
+		fi, err := b.Lstat(link)
+		require.NoError(t, err)
+		require.NotZero(t, fi.Mode()&os.ModeSymlink)
+		fi, err = b.Stat(link)
+		require.NoError(t, err)
+		readTarget, err := b.Readlink(link)
+		require.NoError(t, err)
+		require.Equal(t, target, readTarget)
+		require.Zero(t, fi.Mode()&os.ModeSymlink)
+		f2, err := b.Open(link)
+		require.NoError(t, err)
+		defer f2.Close()
+		data, err = ioutil.ReadAll(f2)
+		require.NoError(t, err)
+		require.Equal(t, "hello", string(data))
+	}
+	t.Log("Add and read a symlink.")
+	addSymlink("foo", "symfoo")
+
+	t.Log("Add and read a second symlink in a chain.")
+	err = worktreeFS.MkdirAll("dir", 0700)
+	require.NoError(t, err)
+	addSymlink("../symfoo", "dir/symfoo")
+}


### PR DESCRIPTION
`Browser` uses the gogit `Tree` instance to navigate directories and read files directly from a dotgit directory, without requiring an explicit checkout.

This will be used in future commits as the basis for the new `.kbfs_autogit` directory.

The test provided is pretty simple but covers the basics.  I'm happy to add more stuff to the test if there are specific things you think would be good to add.

Issue: KBFS-3421