### PR TITLE
interfaces: add methods to `Node` for direct FS data access

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keybase/kbfs/tlf"
 	metrics "github.com/rcrowley/go-metrics"
 	"golang.org/x/net/context"
+	billy "gopkg.in/src-d/go-billy.v4"
 )
 
 type dataVersioner interface {
@@ -226,6 +227,14 @@ type Node interface {
 	// Unwrap returns the initial, unwrapped Node that was used to
 	// create this Node.
 	Unwrap() Node
+	// GetFS returns a file system interface that, if non-nil, should
+	// be used to satisfy any directory-related calls on this Node,
+	// instead of the standard, block-based method of acessing data.
+	GetFS() billy.Filesystem
+	// GetFile returns a file interface that, if non-nil, should be
+	// used to satisfy any file-related calls on this Node, instead of
+	// the standard, block-based method of accessing data.
+	GetFile() billy.File
 }
 
 // KBFSOps handles all file system operations.  Expands all indirect

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -230,11 +230,15 @@ type Node interface {
 	// GetFS returns a file system interface that, if non-nil, should
 	// be used to satisfy any directory-related calls on this Node,
 	// instead of the standard, block-based method of acessing data.
-	GetFS() billy.Filesystem
+	// The provided context will be used, if possible, for any
+	// subsequent calls on the file system.
+	GetFS(ctx context.Context) billy.Filesystem
 	// GetFile returns a file interface that, if non-nil, should be
 	// used to satisfy any file-related calls on this Node, instead of
-	// the standard, block-based method of accessing data.
-	GetFile() billy.File
+	// the standard, block-based method of accessing data.  The
+	// provided context will be used, if possible, for any subsequent
+	// calls on the file.
+	GetFile(ctx context.Context) billy.File
 }
 
 // KBFSOps handles all file system operations.  Expands all indirect

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1199,27 +1199,27 @@ func (mr *MockNodeMockRecorder) Unwrap() *gomock.Call {
 }
 
 // GetFS mocks base method
-func (m *MockNode) GetFS() go_billy_v4.Filesystem {
-	ret := m.ctrl.Call(m, "GetFS")
+func (m *MockNode) GetFS(ctx context.Context) go_billy_v4.Filesystem {
+	ret := m.ctrl.Call(m, "GetFS", ctx)
 	ret0, _ := ret[0].(go_billy_v4.Filesystem)
 	return ret0
 }
 
 // GetFS indicates an expected call of GetFS
-func (mr *MockNodeMockRecorder) GetFS() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFS", reflect.TypeOf((*MockNode)(nil).GetFS))
+func (mr *MockNodeMockRecorder) GetFS(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFS", reflect.TypeOf((*MockNode)(nil).GetFS), ctx)
 }
 
 // GetFile mocks base method
-func (m *MockNode) GetFile() go_billy_v4.File {
-	ret := m.ctrl.Call(m, "GetFile")
+func (m *MockNode) GetFile(ctx context.Context) go_billy_v4.File {
+	ret := m.ctrl.Call(m, "GetFile", ctx)
 	ret0, _ := ret[0].(go_billy_v4.File)
 	return ret0
 }
 
 // GetFile indicates an expected call of GetFile
-func (mr *MockNodeMockRecorder) GetFile() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockNode)(nil).GetFile))
+func (mr *MockNodeMockRecorder) GetFile(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockNode)(nil).GetFile), ctx)
 }
 
 // MockKBFSOps is a mock of KBFSOps interface

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -18,6 +18,7 @@ import (
 	tlf "github.com/keybase/kbfs/tlf"
 	go_metrics "github.com/rcrowley/go-metrics"
 	context "golang.org/x/net/context"
+	go_billy_v4 "gopkg.in/src-d/go-billy.v4"
 	reflect "reflect"
 	time "time"
 )
@@ -1195,6 +1196,30 @@ func (m *MockNode) Unwrap() Node {
 // Unwrap indicates an expected call of Unwrap
 func (mr *MockNodeMockRecorder) Unwrap() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unwrap", reflect.TypeOf((*MockNode)(nil).Unwrap))
+}
+
+// GetFS mocks base method
+func (m *MockNode) GetFS() go_billy_v4.Filesystem {
+	ret := m.ctrl.Call(m, "GetFS")
+	ret0, _ := ret[0].(go_billy_v4.Filesystem)
+	return ret0
+}
+
+// GetFS indicates an expected call of GetFS
+func (mr *MockNodeMockRecorder) GetFS() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFS", reflect.TypeOf((*MockNode)(nil).GetFS))
+}
+
+// GetFile mocks base method
+func (m *MockNode) GetFile() go_billy_v4.File {
+	ret := m.ctrl.Call(m, "GetFile")
+	ret0, _ := ret[0].(go_billy_v4.File)
+	return ret0
+}
+
+// GetFile indicates an expected call of GetFile
+func (mr *MockNodeMockRecorder) GetFile() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockNode)(nil).GetFile))
 }
 
 // MockKBFSOps is a mock of KBFSOps interface

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+
+	billy "gopkg.in/src-d/go-billy.v4"
 )
 
 // nodeCore holds info shared among one or more nodeStandard objects.
@@ -102,4 +104,12 @@ func (n *nodeStandard) WrapChild(child Node) Node {
 
 func (n *nodeStandard) Unwrap() Node {
 	return n
+}
+
+func (n *nodeStandard) GetFS() billy.Filesystem {
+	return nil
+}
+
+func (n *nodeStandard) GetFile() billy.File {
+	return nil
 }

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -106,10 +106,10 @@ func (n *nodeStandard) Unwrap() Node {
 	return n
 }
 
-func (n *nodeStandard) GetFS() billy.Filesystem {
+func (n *nodeStandard) GetFS(_ context.Context) billy.Filesystem {
 	return nil
 }
 
-func (n *nodeStandard) GetFile() billy.File {
+func (n *nodeStandard) GetFile(_ context.Context) billy.File {
 	return nil
 }


### PR DESCRIPTION
This will let the future Autogit browser circumvent the normal block-based data access layer using custom Nodes.

Issue: KBFS-3422