### PR TITLE
libgit: autogit browses git repos directly, without a checkout

### DIFF
--- a/kbpagesd/main.go
+++ b/kbpagesd/main.go
@@ -97,7 +97,6 @@ func removeEmpty(strs []string) (ret []string) {
 	return ret
 }
 
-const autoGitNumWorkers = 10
 const activityStatsReportInterval = 5 * time.Minute
 const activityStatsPath = "./kbp-stats"
 
@@ -129,8 +128,7 @@ func main() {
 		rpc.Protocol, error) {
 		// Start autogit before the RPC connection to the service is
 		// fully initialized.
-		shutdownGit = libgit.StartAutogit(
-			kbCtx, config, &params, autoGitNumWorkers)
+		shutdownGit = libgit.StartAutogit(config)
 
 		return keybase1.SimpleFSProtocol(
 			simplefs.NewSimpleFS(libkbfsCtx, config)), nil

--- a/libgit/autogit_manager.go
+++ b/libgit/autogit_manager.go
@@ -6,70 +6,11 @@ package libgit
 
 import (
 	"context"
-	"fmt"
-	"io"
-	"os"
-	"path"
 	"sync"
-	"time"
 
-	"github.com/eapache/channels"
 	"github.com/keybase/client/go/logger"
-	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/kbfs/kbfssync"
-	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
-	billy "gopkg.in/src-d/go-billy.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
 )
-
-type resetReq struct {
-	srcTLF     *libkbfs.TlfHandle
-	srcRepo    string
-	branchName string
-	dstTLF     *libkbfs.TlfHandle
-	dstDir     string
-	doneCh     chan struct{}
-}
-
-func (r resetReq) id() string {
-	return path.Join(r.dstTLF.GetCanonicalPath(), r.dstDir, r.srcRepo)
-}
-
-type deleteReq struct {
-	dstTLF     *libkbfs.TlfHandle
-	dstDir     string
-	repo       string
-	branchName string
-	doneCh     chan struct{}
-}
-
-const (
-	cloneFileName = "CLONING"
-
-	// Debug tag ID for an individual autogit operation
-	ctxOpID = "AGM"
-
-	workTimeLimit = 1 * time.Hour
-)
-
-type ctxTagKey int
-
-const (
-	ctxIDKey ctxTagKey = iota
-)
-
-func autogitLockName(srcRepo string) string {
-	return fmt.Sprintf(".autogit_%s.lock", srcRepo)
-}
-
-func autogitWorkingName(srcRepo string) string {
-	return fmt.Sprintf(".autogit_%s.working", srcRepo)
-}
-
-func autogitLastErrName(srcRepo string) string {
-	return fmt.Sprintf(".autogit_%s.lasterr", srcRepo)
-}
 
 type getNewConfigFn func(context.Context) (
 	context.Context, libkbfs.Config, string, error)
@@ -80,606 +21,38 @@ type getNewConfigFn func(context.Context) (
 // ongoing requests for the same folder, and multiple outstanding
 // requests for the same destination folder get rolled up into one.
 type AutogitManager struct {
-	config         libkbfs.Config
-	kbCtx          libkbfs.Context
-	kbfsInitParams *libkbfs.InitParams
-	log            logger.Logger
-	deferLog       logger.Logger
-	resetQueue     channels.Channel
-	queueDoneCh    chan struct{}
-	getNewConfig   getNewConfigFn
-	resetsWG       kbfssync.RepeatedWaitGroup
-	updatingWG     kbfssync.RepeatedWaitGroup
-	deleteQueue    channels.Channel
-	deleteDoneCh   chan struct{}
-
-	lock             sync.Mutex
-	resetsInQueue    map[string]resetReq // key: resetReq.id()
-	resetsInProgress map[string]resetReq // key: resetReq.id()
+	config   libkbfs.Config
+	log      logger.Logger
+	deferLog logger.Logger
 
 	registryLock           sync.RWMutex
 	registeredFBs          map[libkbfs.FolderBranch]bool
-	repoNodesForWatchedIDs map[libkbfs.NodeID]*repoNode
+	repoNodesForWatchedIDs map[libkbfs.NodeID]*repoDirNode
 	watchedNodes           []libkbfs.Node // preventing GC on the watched nodes
-	populatedRepos         map[libkbfs.NodeID]bool
 }
 
-// NewAutogitManager constructs a new AutogitManager instance, and
-// launches `numWorkers` processing goroutines in the background.
-func NewAutogitManager(
-	config libkbfs.Config, kbCtx libkbfs.Context,
-	kbfsInitParams *libkbfs.InitParams, numWorkers int) *AutogitManager {
+// NewAutogitManager constructs a new AutogitManager instance.
+func NewAutogitManager(config libkbfs.Config) *AutogitManager {
 	log := config.MakeLogger("")
-	am := &AutogitManager{
+	return &AutogitManager{
 		config:                 config,
-		kbCtx:                  kbCtx,
-		kbfsInitParams:         kbfsInitParams,
 		log:                    log,
 		deferLog:               log.CloneWithAddedDepth(1),
-		resetQueue:             libkbfs.NewInfiniteChannelWrapper(),
-		queueDoneCh:            make(chan struct{}),
-		deleteQueue:            libkbfs.NewInfiniteChannelWrapper(),
-		deleteDoneCh:           make(chan struct{}),
-		resetsInQueue:          make(map[string]resetReq),
-		resetsInProgress:       make(map[string]resetReq),
 		registeredFBs:          make(map[libkbfs.FolderBranch]bool),
-		repoNodesForWatchedIDs: make(map[libkbfs.NodeID]*repoNode),
-		populatedRepos:         make(map[libkbfs.NodeID]bool),
+		repoNodesForWatchedIDs: make(map[libkbfs.NodeID]*repoDirNode),
 	}
-	am.getNewConfig = am.getNewConfigDefault
-	go am.resetLoop(numWorkers)
-	go am.deleteLoop()
-	return am
 }
 
 // Shutdown shuts down this manager.
 func (am *AutogitManager) Shutdown() {
-	am.resetQueue.Close()
-	am.deleteQueue.Close()
-	<-am.queueDoneCh
-	<-am.deleteDoneCh
-}
-
-func (am *AutogitManager) getNewConfigDefault(ctx context.Context) (
-	context.Context, libkbfs.Config, string, error) {
-	return getNewConfig(ctx, am.config, am.kbCtx, am.kbfsInitParams, am.log)
-}
-
-func (am *AutogitManager) canWorkOnRepo(
-	ctx context.Context, dstFS *libfs.FS, repo string) (
-	canWork bool, err error) {
-	am.log.CDebugf(ctx, "Checking if we can work on %s", repo)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Work check completed: canWork=%t, %+v",
-			canWork, err)
-	}()
-
-	// Take the lock for the dst repo while checking the work time.
-	lockFile, err := dstFS.Create(autogitLockName(repo))
-	if err != nil {
-		return false, err
-	}
-	defer func() {
-		// Because we took the lock, this Close will sync/flush the
-		// whole journal.
-		closeErr := lockFile.Close()
-		if err == nil {
-			err = closeErr
-		} else if closeErr != nil {
-			am.log.CDebugf(ctx, "Lock close error: %+v", closeErr)
-		}
-	}()
-	err = lockFile.Lock()
-	if err != nil {
-		return false, err
-	}
-
-	// See if someone else is already working on this repo by seeing
-	// if the timestamp (converted to "common" time) is within the
-	// expected time limit for a worker.
-	return canDoWork(
-		ctx, am.config.MDServer(), am.config.Clock(), dstFS,
-		autogitWorkingName(repo), workTimeLimit, am.log)
-}
-
-func (am *AutogitManager) workDoneOnRepo(
-	ctx context.Context, dstFS *libfs.FS, repo string, workErr error) (
-	err error) {
-	am.log.CDebugf(ctx, "Completing work on %s, workErr=%+v", repo, workErr)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Work done completed: %+v", err)
-	}()
-
-	// Take the lock for the dst repo while checking the work time.
-	lockFile, err := dstFS.Create(autogitLockName(repo))
-	if err != nil {
-		return err
-	}
-	defer func() {
-		// Because we took the lock, this Close will sync/flush the
-		// whole journal.
-		closeErr := lockFile.Close()
-		if err == nil {
-			err = closeErr
-			// TODO: if `closeErr != nil`, write it to the lasterr
-			// file somehow, even though we're no longer under lock?
-		} else if closeErr != nil {
-			am.log.CDebugf(ctx, "Lock close error: %+v", closeErr)
-		}
-	}()
-	err = lockFile.Lock()
-	if err != nil {
-		return err
-	}
-
-	err = dstFS.Remove(autogitWorkingName(repo))
-	if err != nil {
-		return err
-	}
-
-	// Remove the old lasterr file if it exists.  TODO: check if we
-	// are the user who was supposed to be doing work?
-	err = dstFS.Remove(autogitLastErrName(repo))
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	if workErr == nil {
-		return nil
-	}
-
-	// Otherwise write the last error
-	lastErrFile, err := dstFS.Create(autogitLastErrName(repo))
-	if err != nil {
-		return err
-	}
-	defer lastErrFile.Close()
-	_, err = io.WriteString(lastErrFile, workErr.Error())
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (am *AutogitManager) doReset(ctx context.Context, req resetReq) (
-	err error) {
-	am.log.CDebugf(ctx, "Processing reset request from %s/%s to %s/%s",
-		req.srcTLF.GetCanonicalPath(), req.srcRepo,
-		req.dstTLF.GetCanonicalPath(), req.dstDir)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Reset request completed: %+v", err)
-	}()
-
-	// Make a new single-op config for processing this request.
-	ctx, gitConfig, tempDir, err := am.getNewConfig(ctx)
-	if err != nil {
-		return err
-	}
-	// Cloned/pull data should be regular data blocks.
-	gitConfig.SetDefaultBlockType(keybase1.BlockType_DATA)
-	defer func() {
-		gitConfig.Shutdown(ctx)
-		rmErr := os.RemoveAll(tempDir)
-		if rmErr != nil {
-			am.log.CWarningf(
-				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-		}
-	}()
-
-	uniqID, err := makeUniqueID(ctx, gitConfig)
-	if err != nil {
-		return err
-	}
-
-	// Construct a src repo FS.
-	srcRepoFS, _, err := GetRepoAndID(
-		ctx, gitConfig, req.srcTLF, req.srcRepo, uniqID)
-	if err != nil {
-		return err
-	}
-
-	// And a dst parent checkout FS, which better already exist.
-	dstFS, err := libfs.NewFS(
-		ctx, gitConfig, req.dstTLF, libkbfs.MasterBranch, req.dstDir, uniqID,
-		keybase1.MDPriorityNormal)
-	if err != nil {
-		return err
-	}
-
-	canWork, err := am.canWorkOnRepo(ctx, dstFS, req.srcRepo)
-	if err != nil {
-		return err
-	}
-	if !canWork {
-		am.log.CDebugf(ctx,
-			"Another worker is currently in charge; skipping reset")
-		// TODO: retry in a little while?
-		return nil
-	}
-	defer func() {
-		workDoneErr := am.workDoneOnRepo(ctx, dstFS, req.srcRepo, err)
-		if err == nil {
-			err = workDoneErr
-		}
-	}()
-
-	dstRepoFS, err := dstFS.Chroot(req.srcRepo)
-	if err != nil {
-		return err
-	}
-
-	// For now, assume the branch name refers to a ref head.
-	branch := plumbing.ReferenceName(
-		fmt.Sprintf("refs/heads/%s", req.branchName))
-	am.log.CDebugf(ctx, "Starting the reset")
-	return Reset(ctx, srcRepoFS, dstRepoFS, branch)
-}
-
-func (am *AutogitManager) markResetReqInProgress(req resetReq) (
-	waitCh <-chan struct{}) {
-	am.lock.Lock()
-	defer am.lock.Unlock()
-	inProgress, ok := am.resetsInProgress[req.id()]
-	if ok {
-		return inProgress.doneCh
-	}
-	delete(am.resetsInQueue, req.id())
-	am.resetsInProgress[req.id()] = req
-	return nil
-}
-
-func (am *AutogitManager) clearFromInProgress(req resetReq) {
-	am.lock.Lock()
-	defer am.lock.Unlock()
-	delete(am.resetsInProgress, req.id())
-	am.resetsWG.Done()
-}
-
-func (am *AutogitManager) resetWorker(wg *sync.WaitGroup) {
-	defer wg.Done()
-	for reqInt := range am.resetQueue.Out() {
-		req := reqInt.(resetReq)
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		ctx = libkbfs.CtxWithRandomIDReplayable(
-			ctx, ctxIDKey, ctxOpID, am.log)
-		for {
-			waitCh := am.markResetReqInProgress(req)
-			if waitCh == nil {
-				break
-			}
-			// We need to wait for any in-progress resets, since the
-			// File.Lock is taken per-instance, not per-goroutine.
-			am.log.CDebugf(ctx, "Waiting to process reset request from "+
-				"%s/%s to %s/%s",
-				req.srcTLF.GetCanonicalPath(), req.srcRepo,
-				req.dstTLF.GetCanonicalPath(), req.dstDir)
-			<-waitCh
-			am.log.CDebugf(ctx, "Done waiting")
-		}
-
-		_ = am.doReset(ctx, req)
-
-		// We can clear from in-progress or close in any order.  If
-		// there's a race in between, the only thinga affected in the
-		// `for` loop above, perhaps resulting in one needless
-		// iteration before the in-progress channel is closed.
-		am.clearFromInProgress(req)
-		close(req.doneCh)
-	}
-}
-
-func (am *AutogitManager) resetLoop(numWorkers int) {
-	var wg sync.WaitGroup
-	wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
-		go am.resetWorker(&wg)
-	}
-	wg.Wait()
-	close(am.queueDoneCh)
-}
-
-func (am *AutogitManager) queueReset(ctx context.Context, req resetReq) (
-	doneCh chan struct{}, err error) {
-	id := req.id()
-	doneCh = func() chan struct{} {
-		am.lock.Lock()
-		defer am.lock.Unlock()
-		if req, ok := am.resetsInQueue[id]; ok {
-			return req.doneCh
-		}
-		am.resetsWG.Add(1)
-		am.resetsInQueue[id] = req
-		return nil
-	}()
-	if doneCh != nil {
-		return doneCh, nil
-	}
-	select {
-	case am.resetQueue.In() <- req:
-		am.log.CDebugf(ctx, "Queued new reset request for %s", id)
-	case <-ctx.Done():
-		// We've already promised to queue this, and may have turned
-		// away other requests for it already, so we better queue it.
-		go func() { am.resetQueue.In() <- req }()
-		return nil, ctx.Err()
-	}
-	return req.doneCh, nil
-}
-
-func (am *AutogitManager) removeLock(
-	ctx context.Context, gitConfig libkbfs.Config, fs *libfs.FS, repo string) (
-	err error) {
-	err = fs.Remove(autogitLockName(repo))
-	if err != nil {
-		return err
-	}
-	err = fs.SyncAll()
-	if err != nil {
-		return err
-	}
-	jServer, err := libkbfs.GetJournalServer(gitConfig)
-	if err != nil {
-		return err
-	}
-	return jServer.FinishSingleOp(
-		ctx, fs.RootNode().GetFolderBranch().Tlf, nil,
-		keybase1.MDPriorityNormal)
-}
-
-func (am *AutogitManager) doDelete(req deleteReq) (err error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	ctx = libkbfs.CtxWithRandomIDReplayable(
-		ctx, ctxIDKey, ctxOpID, am.log)
-
-	am.log.CDebugf(ctx, "Processing delete request of %s/%s/%s",
-		req.dstTLF.GetCanonicalPath(), req.dstDir, req.repo)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Delete request completed: %+v", err)
-	}()
-
-	// Make a new single-op config for processing this request.
-	ctx, gitConfig, tempDir, err := am.getNewConfig(ctx)
-	if err != nil {
-		return err
-	}
-	// Autogit data should be regular data blocks.
-	gitConfig.SetDefaultBlockType(keybase1.BlockType_DATA)
-	defer func() {
-		gitConfig.Shutdown(ctx)
-		rmErr := os.RemoveAll(tempDir)
-		if rmErr != nil {
-			am.log.CWarningf(
-				ctx, "Error cleaning storage dir %s: %+v\n", tempDir, rmErr)
-		}
-	}()
-
-	uniqID, err := makeUniqueID(ctx, gitConfig)
-	if err != nil {
-		return err
-	}
-
-	dstFS, err := libfs.NewFS(
-		ctx, gitConfig, req.dstTLF, libkbfs.MasterBranch, req.dstDir, uniqID,
-		keybase1.MDPriorityNormal)
-	if err != nil {
-		return err
-	}
-
-	canWork, err := am.canWorkOnRepo(ctx, dstFS, req.repo)
-	if err != nil {
-		return err
-	}
-	if !canWork {
-		am.log.CDebugf(ctx,
-			"Another worker is currently in charge; skipping delete")
-		// TODO: retry in a little while?
-		return nil
-	}
-	defer func() {
-		workDoneErr := am.workDoneOnRepo(ctx, dstFS, req.repo, err)
-		if err == nil {
-			err = workDoneErr
-		}
-		// Remove the lock file.  This happens outside of the main
-		// deletion single-op, and so won't appear strictly atomically
-		// with the rest of the delete.
-		rmErr := am.removeLock(ctx, gitConfig, dstFS, req.repo)
-		if err == nil {
-			err = rmErr
-		}
-	}()
-
-	fi, err := dstFS.Stat(req.repo)
-	if err != nil {
-		return err
-	}
-	return recursiveDelete(ctx, dstFS, fi)
-}
-
-func (am *AutogitManager) deleteLoop() {
-	for reqInt := range am.deleteQueue.Out() {
-		req := reqInt.(deleteReq)
-		_ = am.doDelete(req)
-		close(req.doneCh)
-	}
-	close(am.deleteDoneCh)
-}
-
-func (am *AutogitManager) makeCloningFile(
-	ctx context.Context, dstRepoFS billy.Filesystem, srcTLF *libkbfs.TlfHandle,
-	srcRepo, branchName string) error {
-	am.log.CDebugf(ctx, "Making CLONING file")
-	cloneFile, err := dstRepoFS.Create(cloneFileName)
-	if err != nil {
-		return err
-	}
-	defer cloneFile.Close()
-	_, err = io.WriteString(cloneFile,
-		fmt.Sprintf("%s/%s:%s", srcTLF.GetCanonicalPath(), srcRepo, branchName))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// Clone queues a request to clone the `branchName` branch of the
-// `srcRepo` repo from the TLF `srcTLF`, into a subdirectory named
-// `dstDir/srcRepo` in the TLF `dstTLF`. `dstDir` must already exist
-// in `dstTLF`.
-//
-// It returns a channel that, when closed, indicates the clone request
-// has finished (though not necessarily successfully).  The caller may
-// have to sync from the server to ensure they are see the changes,
-// however.
-//
-// If the cloned directory doesn't exist yet, this function creates a
-// placeholder "CLONING" file to let users know the clone is happening
-// in the background.
-//
-// Note that if there's already data in `dstDir/srcRepo`, this
-// tramples it, so the caller must ensure that they are requesting a
-// clone from the same repo/branch as the existing repo that might
-// have already been there.
-//
-// If the caller specifies a non-master `branchName`, they should make
-// sure `dstDir` is unique for that branch; i.e., the branch name
-// should appear in the path somewhere.
-func (am *AutogitManager) Clone(
-	ctx context.Context, srcTLF *libkbfs.TlfHandle, srcRepo, branchName string,
-	dstTLF *libkbfs.TlfHandle, dstDir string) (
-	doneCh <-chan struct{}, err error) {
-	am.log.CDebugf(ctx, "Autogit clone request from %s/%s:%s to %s/%s",
-		srcTLF.GetCanonicalPath(), srcRepo, branchName,
-		dstTLF.GetCanonicalPath(), dstDir)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Clone request processed: %+v", err)
-	}()
-
-	dstFS, err := libfs.NewFS(
-		ctx, am.config, dstTLF, libkbfs.MasterBranch, dstDir, "",
-		keybase1.MDPriorityNormal)
-	if err != nil {
-		return nil, err
-	}
-
-	// Take dst lock and create "CLONING" file if needed.
-	lockFile, err := dstFS.Create(autogitLockName(srcRepo))
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		closeErr := lockFile.Close()
-		if err == nil {
-			err = closeErr
-		}
-	}()
-	err = lockFile.Lock()
-	if err != nil {
-		return nil, err
-	}
-
-	err = dstFS.MkdirAll(srcRepo, 0600)
-	if err != nil {
-		return nil, err
-	}
-
-	dstRepoFS, err := dstFS.Chroot(srcRepo)
-	if err != nil {
-		return nil, err
-	}
-
-	fis, err := dstRepoFS.ReadDir("")
-	if err != nil {
-		return nil, err
-	}
-	if len(fis) == 0 {
-		err = am.makeCloningFile(ctx, dstRepoFS, srcTLF, srcRepo, branchName)
-		if err != nil {
-			return nil, err
-		}
-		// Sync the CLONING file before starting the reset.
-		err = lockFile.Unlock()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	req := resetReq{
-		srcTLF, srcRepo, branchName, dstTLF, dstDir, make(chan struct{}),
-	}
-	return am.queueReset(ctx, req)
-}
-
-// Pull queues a request to pull the `branchName` branch of the
-// `srcRepo` repo from the TLF `srcTLF`, into a subdirectory named
-// `dstDir/srcRepo` in the TLF `dstTLF`. `dstDir/srcRepo` must already
-// exist in `dstTLF`.
-//
-// It returns a channel that, when closed, indicates the pull request
-// has finished (though not necessarily successfully).  The caller may
-// have to sync from the server to ensure they are see the changes,
-// however.
-//
-// Note that this tramples any data that was previously in
-// `dstDir/srcRepo`, so the caller must ensure that they are
-// requesting a pull from the correct repo/branch as the existing repo
-// that was already there.
-//
-// If the caller specifies a non-master `branchName`, they should make
-// sure `dstDir` is unique for that branch; i.e., the branch name
-// should appear in the path somewhere.
-func (am *AutogitManager) Pull(
-	ctx context.Context, srcTLF *libkbfs.TlfHandle, srcRepo, branchName string,
-	dstTLF *libkbfs.TlfHandle, dstDir string) (
-	doneCh <-chan struct{}, err error) {
-	am.log.CDebugf(ctx, "Autogit pull request from %s/%s:%s to %s/%s",
-		srcTLF.GetCanonicalPath(), srcRepo, branchName,
-		dstTLF.GetCanonicalPath(), dstDir)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Pull request processed: %+v", err)
-	}()
-
-	req := resetReq{
-		srcTLF, srcRepo, branchName, dstTLF, dstDir, make(chan struct{}),
-	}
-	return am.queueReset(ctx, req)
-}
-
-// Delete queues a request to delete an autogit destination subdir
-// named `dstDir/srcRepo` in the TLF `dstTLF`.
-//
-// It returns a channel that, when closed, indicates the pull request
-// has finished (though not necessarily successfully).  The caller may
-// have to sync from the server to ensure they are see the changes,
-// however.
-func (am *AutogitManager) Delete(
-	ctx context.Context, dstTLF *libkbfs.TlfHandle, dstDir string,
-	repo, branchName string) (doneCh <-chan struct{}, err error) {
-	am.log.CDebugf(ctx, "Autogit delete request for %s/%s/%s:%s",
-		dstTLF.GetCanonicalPath(), dstDir, repo, branchName)
-	defer func() {
-		am.deferLog.CDebugf(ctx, "Delete request processed: %+v", err)
-	}()
-
-	req := deleteReq{
-		dstTLF, dstDir, repo, branchName, make(chan struct{}),
-	}
-
-	select {
-	case am.deleteQueue.In() <- req:
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
-	return req.doneCh, nil
+	// No-op.
 }
 
 func (am *AutogitManager) registerRepoNode(
-	nodeToWatch libkbfs.Node, rn *repoNode) {
+	nodeToWatch libkbfs.Node, rdn *repoDirNode) {
 	am.registryLock.Lock()
 	defer am.registryLock.Unlock()
-	am.repoNodesForWatchedIDs[nodeToWatch.GetID()] = rn
+	am.repoNodesForWatchedIDs[nodeToWatch.GetID()] = rdn
 	am.watchedNodes = append(am.watchedNodes, nodeToWatch)
 	fb := nodeToWatch.GetFolderBranch()
 	if !am.registeredFBs[fb] {
@@ -693,39 +66,10 @@ func (am *AutogitManager) registerRepoNode(
 	}
 }
 
-func (am *AutogitManager) isRepoNodePopulated(rn *repoNode) bool {
-	am.registryLock.RLock()
-	defer am.registryLock.RUnlock()
-	return am.populatedRepos[rn.GetID()]
-}
-
-func (am *AutogitManager) populateDone(rn *repoNode) {
-	am.registryLock.Lock()
-	defer am.registryLock.Unlock()
-	am.populatedRepos[rn.GetID()] = true
-}
-
 // LocalChange implements the libkbfs.Observer interface for AutogitManager.
 func (am *AutogitManager) LocalChange(
 	ctx context.Context, node libkbfs.Node, wr libkbfs.WriteRange) {
 	// Do nothing.
-}
-
-func (am *AutogitManager) notifyNodeLocked(
-	ctx context.Context, id libkbfs.NodeID) {
-	rn, ok := am.repoNodesForWatchedIDs[id]
-	if !ok {
-		return
-	}
-
-	am.updatingWG.Add(1)
-	go func() {
-		defer am.updatingWG.Done()
-		ctx := libkbfs.BackgroundContextWithCancellationDelayer()
-		ctx = libkbfs.CtxWithRandomIDReplayable(
-			ctx, ctxIDKey, ctxOpID, am.log)
-		rn.updated(ctx)
-	}()
 }
 
 // BatchChanges implements the libkbfs.Observer interface for AutogitManager.
@@ -734,8 +78,8 @@ func (am *AutogitManager) BatchChanges(
 	affectedNodeIDs []libkbfs.NodeID) {
 	am.registryLock.RLock()
 	defer am.registryLock.RUnlock()
-	for _, id := range affectedNodeIDs {
-		am.notifyNodeLocked(ctx, id)
+	for range affectedNodeIDs {
+		// TODO(KBFS-3428).
 	}
 }
 
@@ -748,9 +92,8 @@ func (am *AutogitManager) TlfHandleChange(
 
 // StartAutogit launches autogit, and returns a function that should
 // be called on shutdown.
-func StartAutogit(kbCtx libkbfs.Context, config libkbfs.Config,
-	kbfsInitParams *libkbfs.InitParams, numWorkers int) func() {
-	am := NewAutogitManager(config, kbCtx, kbfsInitParams, numWorkers)
+func StartAutogit(config libkbfs.Config) func() {
+	am := NewAutogitManager(config)
 	rw := rootWrapper{am}
 	config.AddRootNodeWrapper(rw.wrap)
 	return am.Shutdown

--- a/libgit/autogit_manager_test.go
+++ b/libgit/autogit_manager_test.go
@@ -12,12 +12,9 @@ import (
 	"testing"
 	"time"
 
-	kbname "github.com/keybase/client/go/kbun"
 	"github.com/keybase/client/go/protocol/keybase1"
-	"github.com/keybase/kbfs/env"
 	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
-	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
 	billy "gopkg.in/src-d/go-billy.v4"
 	gogit "gopkg.in/src-d/go-git.v4"
@@ -53,63 +50,12 @@ func initConfigForAutogit(t *testing.T) (
 	return ctx, config, cancel, tempdir
 }
 
-// configNoShutdown shields a config from being shutdown, to prevent
-// test mdservers from being shut down in the middle of a test.
-type configNoShutdown struct {
-	libkbfs.Config
-}
-
-// Shutdown implements the libkbfs.Config interface for configNoShutdown.
-func (c *configNoShutdown) Shutdown(_ context.Context) error {
-	// Ignore.
-	return nil
-}
-
-// newConfigger constructs a new test config that shares the same test
-// server implementations as the given `config`.
-type newConfigger struct {
-	config    *libkbfs.ConfigLocal
-	user      kbname.NormalizedUsername
-	newConfig *libkbfs.ConfigLocal
-}
-
-func (nc *newConfigger) shutdown(t *testing.T, ctx context.Context) {
-	if nc.newConfig != nil {
-		libkbfs.CheckConfigAndShutdown(ctx, t, nc.newConfig)
-	}
-}
-
-func (nc *newConfigger) getNewConfigForTestWithMode(
-	ctx context.Context, mode libkbfs.InitModeType) (
-	newCtx context.Context, gitConfig libkbfs.Config,
-	tempDir string, err error) {
-	ctx, err = libkbfs.NewContextWithCancellationDelayer(ctx)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	config := libkbfs.ConfigAsUserWithMode(nc.config, nc.user, mode)
-	tempdir, err := ioutil.TempDir(os.TempDir(), "journal_server")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	err = config.EnableDiskLimiter(tempdir)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	err = config.EnableJournaling(
-		ctx, tempdir, libkbfs.TLFJournalSingleOpBackgroundWorkEnabled)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	nc.newConfig = config
-	return ctx, &configNoShutdown{config}, tempdir, nil
-}
-
-func (nc *newConfigger) getNewConfigForTest(
-	ctx context.Context) (
-	newCtx context.Context, gitConfig libkbfs.Config,
-	tempDir string, err error) {
-	return nc.getNewConfigForTestWithMode(ctx, libkbfs.InitSingleOp)
+func addFileToWorktreeAndCommit(
+	t *testing.T, ctx context.Context, config libkbfs.Config,
+	h *libkbfs.TlfHandle, repo *gogit.Repository, worktreeFS billy.Filesystem,
+	name, data string) {
+	addFileToWorktree(t, repo, worktreeFS, name, data)
+	commitWorktree(t, ctx, config, h, worktreeFS)
 }
 
 func addFileToWorktree(
@@ -147,103 +93,4 @@ func commitWorktree(
 	err = jServer.FinishSingleOp(ctx,
 		rootNode.GetFolderBranch().Tlf, nil, keybase1.MDPriorityNormal)
 	require.NoError(t, err)
-}
-
-func addFileToWorktreeAndCommit(
-	t *testing.T, ctx context.Context, config libkbfs.Config,
-	h *libkbfs.TlfHandle, repo *gogit.Repository, worktreeFS billy.Filesystem,
-	name, data string) {
-	addFileToWorktree(t, repo, worktreeFS, name, data)
-	commitWorktree(t, ctx, config, h, worktreeFS)
-}
-
-func checkFileInRootFS(
-	t *testing.T, ctx context.Context, config libkbfs.Config,
-	h *libkbfs.TlfHandle, rootFS billy.Filesystem, name, expectedData string) {
-	rootNode, _, err := config.KBFSOps().GetOrCreateRootNode(
-		ctx, h, libkbfs.MasterBranch)
-	require.NoError(t, err)
-	err = config.KBFSOps().SyncFromServer(
-		ctx, rootNode.GetFolderBranch(), nil)
-	require.NoError(t, err)
-
-	f, err := rootFS.Open(name)
-	require.NoError(t, err)
-	defer f.Close()
-	data, err := ioutil.ReadAll(f)
-	require.NoError(t, err)
-	require.Equal(t, expectedData, string(data))
-}
-
-func TestAutogitManager(t *testing.T) {
-	ctx, config, cancel, tempdir := initConfigForAutogit(t)
-	defer cancel()
-	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
-	defer os.RemoveAll(tempdir)
-
-	h, err := libkbfs.ParseTlfHandle(
-		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
-	require.NoError(t, err)
-	rootFS, err := libfs.NewFS(
-		ctx, config, h, libkbfs.MasterBranch, "", "", keybase1.MDPriorityNormal)
-	require.NoError(t, err)
-
-	t.Log("Init a new repo directly into KBFS.")
-	dotgitFS, _, err := GetOrCreateRepoAndID(ctx, config, h, "test", "")
-	require.NoError(t, err)
-	err = rootFS.MkdirAll("worktree", 0600)
-	require.NoError(t, err)
-	worktreeFS, err := rootFS.Chroot("worktree")
-	require.NoError(t, err)
-	dotgitStorage, err := NewGitConfigWithoutRemotesStorer(dotgitFS)
-	require.NoError(t, err)
-	repo, err := gogit.Init(dotgitStorage, worktreeFS)
-	require.NoError(t, err)
-	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
-
-	kbCtx := env.NewContext()
-	kbfsInitParams := libkbfs.DefaultInitParams(kbCtx)
-	am := NewAutogitManager(config, kbCtx, &kbfsInitParams, 1)
-	defer am.Shutdown()
-	nc := &newConfigger{config: config, user: "user1"}
-	defer nc.shutdown(t, ctx)
-	am.getNewConfig = nc.getNewConfigForTest
-
-	err = rootFS.MkdirAll("checkout", 0600)
-
-	doneCh, err := am.Clone(ctx, h, "test", "master", h, "checkout")
-	require.NoError(t, err)
-	select {
-	case <-doneCh:
-	case <-ctx.Done():
-		t.Fatal(ctx.Err().Error())
-	}
-
-	checkFileInRootFS(t, ctx, config, h, rootFS, "checkout/test/foo", "hello")
-
-	t.Log("Add a new file and try a pull.")
-	addFileToWorktreeAndCommit(
-		t, ctx, config, h, repo, worktreeFS, "foo2", "hello2")
-	doneCh, err = am.Pull(ctx, h, "test", "master", h, "checkout")
-	require.NoError(t, err)
-	select {
-	case <-doneCh:
-	case <-ctx.Done():
-		t.Fatal(ctx.Err().Error())
-	}
-
-	checkFileInRootFS(t, ctx, config, h, rootFS, "checkout/test/foo2", "hello2")
-
-	t.Log("Deleting repo")
-	doneCh, err = am.Delete(ctx, h, "checkout", "test", "master")
-	require.NoError(t, err)
-	select {
-	case <-doneCh:
-	case <-ctx.Done():
-		t.Fatal(ctx.Err().Error())
-	}
-
-	_, err = rootFS.Stat("checkout/test")
-	require.True(t, os.IsNotExist(err))
 }

--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"path"
 	"sync"
-	"time"
 
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/libfs"
 	"github.com/keybase/kbfs/libkbfs"
-	"github.com/keybase/kbfs/tlf"
-	"github.com/pkg/errors"
+	billy "gopkg.in/src-d/go-billy.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 )
 
 // This file contains libkbfs.Node wrappers for implementing the
@@ -23,405 +24,150 @@ import (
 // * `rootNode` allows .kbfs_autogit to be auto-created when it is
 //   looked up, and wraps it two ways, as both a `libkbfs.ReadonlyNode`, and
 //   an `autogitRootNode`.
-// * `autogitRootNode` allows the auto-creation of subdirectories
-//   representing TLF types, e.g. .kbfs_autogit/private or
-//   .kbfs_autogit/public.  It wraps child nodes two ways, as both a
-//   `libkbfs.ReadonlyNode`, and an `tlfTypeNode`.
-// * `tlfTypeNode` allows the auto-creation of subdirectories
-//   representing TLFs, e.g. .kbfs_autogit/private/max or
-//   .kbfs_autogit/team/keybase.  It wraps child nodes in two ways, as
-//   a `libkbfs.ReadonlyNode` and a `tlfNode`.
-// * `tlfNode` allows auto-creation of subdirectories representing
-//   valid repository checkouts of the corresponding TLF, e.g.
-//   `.kbfs_autogit/private/chris/dotfiles`.  It wraps child nodes in
-//   two ways, as both a `libkbfs.ReadonlyNode` and a `repoNode`.  It allows
-//   repo directories to be removed via `RemoveDir` if the caller has
-//   write permissions to the TLF where the autogit resides.
-// * `repoNode` allow auto-clone and auto-pull of the corresponding
-//   repository on its first access.  When the directory corresponding
-//   to the node is read for the first time for this KBFS instance,
-//   the `repoNode` asks `AutogitManager` to either kick off a clone
-//   or a pull for the repository in question, which will checkout a
-//   copy of the source repo under that directory.  The operation will
-//   block on that clone/pull operation until it is finished, until
-//   the given context is canceled, or until 10 seconds is up.  But if
-//   it doesn't finish in time, the operation continues in the
-//   background and should update the directory asynchronously.  It
-//   registers with the `AutogitManager` in order to keep the checkout
-//   up-to-date asynchronously if the repo changes.  If the operation
-//   is a clone, a "CLONING" file will be visible in the directory
-//   until the clone completes.  `repoNode` wraps each child node as a
-//   `libkbfs.ReadonlyNode`.
-
-type ctxReadWriteKeyType int
-type ctxSkipPopulateKeyType int
+// * `autogitRootNode` lists all the git repos associated with this
+//   folder-branch.  It wraps child nodes two ways, as both a
+//   `libkbfs.ReadonlyNode` (inherited from `rootNode`), and an
+//   `repoDirNode`.
+// * `repoDirNode` returns a `*Browser` object when `GetFS()` is
+//   called, which is configured to access the corresponding
+//   subdirectory within the git repository.  It makes a new
+//   `*Browser` instance for each `GetFS()` call, which is slightly
+//   inefficient, but necessary to put the right context debug log
+//   tags into place for the subsequent browsing.  (We can revisit
+//   this later if it proves to be a bottleneck, though I suspect the
+//   bottleneck is in fetching and processing the actual git data
+//   needed to reconstruct the files.)  It wraps all children as a
+//   `libkbfs.ReadonlyNode` (inherited from `rootNode`); it also wraps
+//   subdirectories in `repoDirNode`, and file entries in
+//   `repoFileNode`.
+// * `repoFileNode` returns a `*browserFile` object when `GetFile()`
+//   is called, which is expected to be closed by the caller.  It
+//   constructs a new `*Browser` on each call (for the same reasons as
+//   above).
 
 const (
-	autogitRoot = ".kbfs_autogit"
-
-	autogitWrapTimeout = 10 * time.Second
-
-	ctxSkipPopulateKey ctxSkipPopulateKeyType = 1
-
-	public  = "public"
-	private = "private"
-	team    = "team"
+	// AutogitRoot is the subdirectory name within a TLF where autogit
+	// can be accessed.
+	AutogitRoot = ".kbfs_autogit"
 )
 
-type repoNode struct {
+type repoFileNode struct {
 	libkbfs.Node
-	am            *AutogitManager
-	srcRepoHandle *libkbfs.TlfHandle
-	repoName      string
-
-	lock                 sync.Mutex
-	populated            bool
-	populatingInProgress chan struct{}
+	am       *AutogitManager
+	repoFS   *libfs.FS
+	filePath string
+	branch   plumbing.ReferenceName
 }
 
-var _ libkbfs.Node = (*repoNode)(nil)
+var _ libkbfs.Node = (*repoFileNode)(nil)
 
-func newRepoNode(
-	n libkbfs.Node, am *AutogitManager, srcRepoHandle *libkbfs.TlfHandle,
-	repoName string) *repoNode {
-	rn := &repoNode{
-		Node:          n,
-		am:            am,
-		srcRepoHandle: srcRepoHandle,
-		repoName:      repoName,
-	}
-	// We can't rely on a particular repo node being passed back into
-	// libkbfs by callers, since they may not keep a reference to it
-	// after looking it up, and `WrapChild` makes a new `repoNode` for
-	// each call to it, even for the same underlying NodeID.  So we
-	// keep the populated state in the AutogitManager.
-	rn.populated = am.isRepoNodePopulated(rn)
-	return rn
-}
-
-// AutogitTLFListDir returns `.kbfs_autogit/<tlf_type>` where <tlf_type> is
-// "private", "public", or "team" depending on tlfType.
-func AutogitTLFListDir(tlfType tlf.Type) string {
-	var typeStr string
-	switch tlfType {
-	case tlf.Public:
-		typeStr = public
-	case tlf.Private:
-		typeStr = private
-	case tlf.SingleTeam:
-		typeStr = team
-	}
-	return path.Join(autogitRoot, typeStr)
-}
-
-func autogitDstDir(h *libkbfs.TlfHandle) string {
-	return path.Join(AutogitTLFListDir(h.Type()), string(h.GetCanonicalName()))
-}
-
-func (rn *repoNode) dstDir() string {
-	return autogitDstDir(rn.srcRepoHandle)
-}
-
-func (rn *repoNode) populate(ctx context.Context) bool {
-	ctx = context.WithValue(ctx, ctxSkipPopulateKey, 1)
-	children, err := rn.am.config.KBFSOps().GetDirChildren(ctx, rn)
+func (rfn repoFileNode) GetFile(ctx context.Context) billy.File {
+	// Make a new Browser for every request, for the sole purpose of
+	// using the appropriate debug tags.
+	repoFS := rfn.repoFS.WithContext(ctx)
+	b, err := NewBrowser(repoFS, rfn.am.config.Clock(), rfn.branch)
 	if err != nil {
-		rn.am.log.CDebugf(ctx, "Error getting children: %+v", err)
-		return false
+		rfn.am.log.CDebugf(ctx, "Error making browser: %+v", err)
+		return nil
 	}
-
-	h, err := rn.am.config.KBFSOps().GetTLFHandle(ctx, rn)
+	f, err := b.Open(rfn.filePath)
 	if err != nil {
-		rn.am.log.CDebugf(ctx, "Error getting handle: %+v", err)
-		return false
+		rfn.am.log.CDebugf(ctx, "Error opening file: %+v", err)
+		return nil
 	}
-
-	// Associate this autogit repo node with the node corresponding to
-	// the top-level of the source repo.  This means it will detect
-	// changes more often then necessary (e.g., when a different
-	// branch is updated, or when just objects are updated), but we
-	// can't just depend on the branch reference file because a
-	// particular branch could be defined in packed-refs as well, and
-	// that could change during the lifetime of the repo.
-	srcRepoFS, _, err := GetRepoAndID(
-		ctx, rn.am.config, rn.srcRepoHandle, rn.repoName, "")
-	if err != nil {
-		rn.am.log.CDebugf(ctx, "Couldn't get repo: %+v", err)
-		return false
-	}
-	rn.am.registerRepoNode(srcRepoFS.RootNode(), rn)
-
-	// If the directory is empty, clone it.  Otherwise, pull it.
-	var doneCh <-chan struct{}
-	cloneNeeded := len(children) == 0
-	ctx = context.WithValue(ctx, libkbfs.CtxReadWriteKey, struct{}{})
-	branch := "master"
-	if cloneNeeded {
-		doneCh, err = rn.am.Clone(
-			ctx, rn.srcRepoHandle, rn.repoName, branch, h, rn.dstDir())
-	} else {
-		doneCh, err = rn.am.Pull(
-			ctx, rn.srcRepoHandle, rn.repoName, branch, h, rn.dstDir())
-	}
-	if err != nil {
-		rn.am.log.CDebugf(ctx, "Error starting population: %+v", err)
-		return false
-	}
-
-	select {
-	case <-doneCh:
-		return true
-	case <-ctx.Done():
-		rn.am.log.CDebugf(ctx, "Error waiting for population: %+v", ctx.Err())
-		// If we did a clone, ask for a refresh anyway, so they will
-		// see the CLONING file at least.  The clone operation will
-		// continue on in the background, so it's ok to consider this
-		// node `populated`.
-		return cloneNeeded
-	}
+	return f
 }
 
-func (rn *repoNode) shouldPopulate() (bool, <-chan struct{}) {
-	rn.lock.Lock()
-	defer rn.lock.Unlock()
-	if rn.populated {
-		return false, nil
-	}
-	if rn.populatingInProgress != nil {
-		return false, rn.populatingInProgress
-	}
-	rn.populatingInProgress = make(chan struct{})
-	return true, rn.populatingInProgress
-}
-
-func (rn *repoNode) finishPopulate(populated bool) {
-	rn.lock.Lock()
-	defer rn.lock.Unlock()
-	rn.populated = populated
-	close(rn.populatingInProgress)
-	rn.populatingInProgress = nil
-	rn.am.populateDone(rn)
-}
-
-func (rn *repoNode) updated(ctx context.Context) {
-	h, err := rn.am.config.KBFSOps().GetTLFHandle(ctx, rn)
-	if err != nil {
-		rn.am.log.CDebugf(ctx, "Error getting handle: %+v", err)
-		return
-	}
-
-	dstDir := rn.dstDir()
-	rn.am.log.CDebugf(
-		ctx, "Repo %s/%s/%s updated", h.GetCanonicalPath(), dstDir, rn.repoName)
-	_, err = rn.am.Pull(ctx, rn.srcRepoHandle, rn.repoName, "master", h, dstDir)
-	if err != nil {
-		rn.am.log.CDebugf(ctx, "Error calling pull: %+v", err)
-		return
-	}
-}
-
-// ShouldRetryOnDirRead implements the Node interface for
-// repoNode.
-func (rn *repoNode) ShouldRetryOnDirRead(ctx context.Context) (
-	shouldRetry bool) {
-	if ctx.Value(ctxSkipPopulateKey) != nil {
-		return false
-	}
-
-	// Don't let this operation take more than a fixed amount of time.
-	// We should just let the caller see the CLONING file if it takes
-	// too long.
-	ctx, cancel := context.WithTimeout(ctx, autogitWrapTimeout)
-	defer cancel()
-
-	for {
-		doPopulate, ch := rn.shouldPopulate()
-		if ch == nil {
-			return shouldRetry
-		}
-		// If it wasn't populated on the first check, always force the
-		// caller to retry.
-		shouldRetry = true
-
-		if doPopulate {
-			rn.am.log.CDebugf(ctx, "Populating repo node on first access")
-			shouldRetry = rn.populate(ctx)
-			rn.finishPopulate(shouldRetry)
-			return shouldRetry
-		}
-
-		// Wait for the existing populate to succeed or fail.
-		rn.am.log.CDebugf(ctx, "Waiting for existing populate to finish")
-		select {
-		case <-ch:
-		case <-ctx.Done():
-			rn.am.log.CDebugf(ctx, "Error waiting for populate: %+v", ctx.Err())
-			return false
-		}
-	}
-}
-
-type tlfNode struct {
+type repoDirNode struct {
 	libkbfs.Node
-	am *AutogitManager
-	h  *libkbfs.TlfHandle
+	am     *AutogitManager
+	repoFS *libfs.FS
+	subdir string
+	branch plumbing.ReferenceName
 }
 
-var _ libkbfs.Node = (*tlfNode)(nil)
+var _ libkbfs.Node = (*repoDirNode)(nil)
 
-// ShouldCreateMissedLookup implements the Node interface for
-// tlfNode.
-func (tn tlfNode) ShouldCreateMissedLookup(
-	ctx context.Context, name string) (
-	bool, context.Context, libkbfs.EntryType, string) {
-	normalizedRepoName := normalizeRepoName(name)
-
-	// Is this a legit repo?
-	_, _, err := GetRepoAndID(ctx, tn.am.config, tn.h, name, "")
+func (rdn repoDirNode) GetFS(ctx context.Context) billy.Filesystem {
+	// Make a new Browser for every request, for the sole purpose of
+	// using the appropriate debug tags.
+	repoFS := rdn.repoFS.WithContext(ctx)
+	b, err := NewBrowser(repoFS, rdn.am.config.Clock(), rdn.branch)
 	if err != nil {
-		return false, ctx, libkbfs.File, ""
+		rdn.am.log.CDebugf(ctx, "Error making browser: %+v", err)
+		return nil
+	}
+	if rdn.subdir == "" || rdn.subdir == "." {
+		return b
 	}
 
-	ctx = context.WithValue(ctx, libkbfs.CtxReadWriteKey, struct{}{})
-	if name != normalizedRepoName {
-		return true, ctx, libkbfs.Sym, normalizedRepoName
-	}
-	return true, ctx, libkbfs.Dir, ""
-}
-
-// RemoveDir implements the Node interface for tlfNode.
-func (tn tlfNode) RemoveDir(ctx context.Context, name string) (
-	removeHandled bool, err error) {
-	// Is this a legit repo?
-	_, _, err = GetRepoAndID(ctx, tn.am.config, tn.h, name, "")
+	childB, err := b.Chroot(rdn.subdir)
 	if err != nil {
-		return false, err
+		rdn.am.log.CDebugf(ctx, "Error chroot'ing browser: %+v", err)
+		return nil
 	}
+	return childB
+}
 
-	if normalizeRepoName(name) != name {
-		// Can't remove a symlink as if it were a directory.
-		return false, nil
-	}
-	ctx, cancel := context.WithTimeout(ctx, autogitWrapTimeout)
-	defer cancel()
-
-	h, err := tn.am.config.KBFSOps().GetTLFHandle(ctx, tn)
+func (rdn repoDirNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+	child = rdn.Node.WrapChild(child)
+	name := child.GetBasename()
+	// Wrap this child so that it will show all the
+	// repos. TODO(KBFS-3429): fill in context.
+	ctx := context.TODO()
+	fs := rdn.GetFS(ctx)
+	fi, err := fs.Lstat(name)
 	if err != nil {
-		return false, err
-	}
-	doneCh, err := tn.am.Delete(ctx, h, autogitDstDir(tn.h), name, "master")
-	if err != nil {
-		return false, err
-	}
-
-	select {
-	case <-doneCh:
-	case <-ctx.Done():
-		// The delete will continue in the background.
-		tn.am.log.CDebugf(ctx,
-			"Timeout waiting for background delete: %+v", ctx.Err())
-	}
-	return true, nil
-}
-
-// WrapChild implements the Node interface for tlfNode.
-func (tn tlfNode) WrapChild(child libkbfs.Node) libkbfs.Node {
-	child = tn.Node.WrapChild(child)
-	return newRepoNode(child, tn.am, tn.h, child.GetBasename())
-}
-
-// tlfTypeNode represents an autogit subdirectory corresponding to a
-// specific TLF type.  It can only contain subdirectories that
-// correspond to valid TLF name for the TLF type.
-type tlfTypeNode struct {
-	libkbfs.Node
-	am      *AutogitManager
-	tlfType tlf.Type
-}
-
-var _ libkbfs.Node = (*tlfTypeNode)(nil)
-
-// ShouldCreateMissedLookup implements the Node interface for
-// tlfTypeNode.
-func (ttn tlfTypeNode) ShouldCreateMissedLookup(
-	ctx context.Context, name string) (
-	bool, context.Context, libkbfs.EntryType, string) {
-	_, err := libkbfs.ParseTlfHandle(
-		ctx, ttn.am.config.KBPKI(), ttn.am.config.MDOps(), name, ttn.tlfType)
-
-	ctx = context.WithValue(ctx, libkbfs.CtxReadWriteKey, struct{}{})
-	switch e := errors.Cause(err).(type) {
-	case nil:
-		return true, ctx, libkbfs.Dir, ""
-	case libkbfs.TlfNameNotCanonical:
-		return true, ctx, libkbfs.Sym, e.NameToTry
-	default:
-		ttn.am.log.CDebugf(ctx,
-			"Error parsing handle for name %s: %+v", name, err)
-		return ttn.Node.ShouldCreateMissedLookup(ctx, name)
-	}
-}
-
-// WrapChild implements the Node interface for tlfTypeNode.
-func (ttn tlfTypeNode) WrapChild(child libkbfs.Node) libkbfs.Node {
-	child = ttn.Node.WrapChild(child)
-	ctx, cancel := context.WithTimeout(context.Background(), autogitWrapTimeout)
-	defer cancel()
-	h, err := libkbfs.ParseTlfHandle(
-		ctx, ttn.am.config.KBPKI(), ttn.am.config.MDOps(),
-		child.GetBasename(), ttn.tlfType)
-	if err != nil {
-		// If we have a node for the child already, it can't be
-		// non-canonical because symlinks don't have Nodes.
-		ttn.am.log.CDebugf(ctx,
-			"Error parsing handle for tlfTypeNode child: %+v", err)
+		rdn.am.log.CDebugf(nil, "Error getting type of child: %+v", err)
 		return child
 	}
-
-	return &tlfNode{child, ttn.am, h}
+	if fi.IsDir() {
+		return &repoDirNode{
+			Node:   child,
+			am:     rdn.am,
+			repoFS: rdn.repoFS,
+			subdir: path.Join(rdn.subdir, name),
+			branch: rdn.branch,
+		}
+	}
+	return &repoFileNode{
+		Node:     child,
+		am:       rdn.am,
+		repoFS:   rdn.repoFS,
+		filePath: path.Join(rdn.subdir, name),
+		branch:   rdn.branch,
+	}
 }
 
-// autogitRootNode represents the .kbfs_autogit folder, and can only
-// contain subdirectories corresponding to TLF types.
+// autogitRootNode represents the .kbfs_autogit folder, and lists all
+// the git repos associated with the member Node's TLF.
 type autogitRootNode struct {
 	libkbfs.Node
 	am *AutogitManager
+	fs *libfs.FS
 }
 
 var _ libkbfs.Node = (*autogitRootNode)(nil)
 
-// ShouldCreateMissedLookup implements the Node interface for
-// autogitRootNode.
-func (arn autogitRootNode) ShouldCreateMissedLookup(
-	ctx context.Context, name string) (
-	bool, context.Context, libkbfs.EntryType, string) {
-	switch name {
-	case public, private, team:
-		ctx = context.WithValue(ctx, libkbfs.CtxReadWriteKey, struct{}{})
-		return true, ctx, libkbfs.Dir, ""
-	default:
-		return arn.Node.ShouldCreateMissedLookup(ctx, name)
-	}
+func (arn autogitRootNode) GetFS(ctx context.Context) billy.Filesystem {
+	arn.am.log.CDebugf(ctx, "autogit root node GetFS() called")
+	return arn.fs.WithContext(ctx)
 }
 
 // WrapChild implements the Node interface for autogitRootNode.
 func (arn autogitRootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 	child = arn.Node.WrapChild(child)
-	var tlfType tlf.Type
-	switch child.GetBasename() {
-	case public:
-		tlfType = tlf.Public
-	case private:
-		tlfType = tlf.Private
-	case team:
-		tlfType = tlf.SingleTeam
-	default:
+	repoFS, err := arn.fs.Chroot(child.GetBasename())
+	if err != nil {
+		arn.am.log.CDebugf(nil, "Error getting repo: %+v", err)
 		return child
 	}
-	return &tlfTypeNode{
-		Node:    child,
-		am:      arn.am,
-		tlfType: tlfType,
+	return &repoDirNode{
+		Node:   child,
+		am:     arn.am,
+		repoFS: repoFS.(*libfs.FS),
+		subdir: "",
+		branch: "refs/heads/master",
 	}
 }
 
@@ -430,32 +176,68 @@ func (arn autogitRootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 type rootNode struct {
 	libkbfs.Node
 	am *AutogitManager
+
+	lock sync.RWMutex
+	fs   *libfs.FS
 }
 
 var _ libkbfs.Node = (*rootNode)(nil)
 
 // ShouldCreateMissedLookup implements the Node interface for
 // rootNode.
-func (rn rootNode) ShouldCreateMissedLookup(ctx context.Context, name string) (
+func (rn *rootNode) ShouldCreateMissedLookup(ctx context.Context, name string) (
 	bool, context.Context, libkbfs.EntryType, string) {
-	if name == autogitRoot {
-		ctx = context.WithValue(ctx, libkbfs.CtxReadWriteKey, struct{}{})
-		ctx = context.WithValue(ctx, libkbfs.CtxAllowNameKey, autogitRoot)
-		return true, ctx, libkbfs.Dir, ""
+	if name != AutogitRoot {
+		return rn.Node.ShouldCreateMissedLookup(ctx, name)
 	}
-	return rn.Node.ShouldCreateMissedLookup(ctx, name)
+
+	rn.lock.Lock()
+	defer rn.lock.Unlock()
+	if rn.fs == nil {
+		// Make the FS once, in a place where we know the NodeCache
+		// won't be locked (to avoid deadlock).
+
+		// Wrap this child so that it will show all the
+		// repos. TODO(KBFS-3429): fill in context.
+		ctx := context.TODO()
+		h, err := rn.am.config.KBFSOps().GetTLFHandle(ctx, rn)
+		if err != nil {
+			rn.am.log.CDebugf(nil, "Error getting handle: %+v", err)
+			return rn.Node.ShouldCreateMissedLookup(ctx, name)
+		}
+
+		fs, err := libfs.NewFS(
+			ctx, rn.am.config, h, rn.GetFolderBranch().Branch, kbfsRepoDir, "",
+			keybase1.MDPriorityNormal)
+		if err != nil {
+			rn.am.log.CDebugf(nil, "Error making repo FS: %+v", err)
+			return rn.Node.ShouldCreateMissedLookup(ctx, name)
+		}
+		rn.fs = fs
+	}
+	return true, ctx, libkbfs.FakeDir, ""
 }
 
 // WrapChild implements the Node interface for rootNode.
-func (rn rootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
+func (rn *rootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 	child = rn.Node.WrapChild(child)
-	if child.GetBasename() == autogitRoot {
-		return &autogitRootNode{
-			Node: &libkbfs.ReadonlyNode{Node: child},
-			am:   rn.am,
-		}
+	if child.GetBasename() != AutogitRoot {
+		return child
 	}
-	return child
+
+	rn.lock.RLock()
+	defer rn.lock.RUnlock()
+	if rn.fs == nil {
+		rn.am.log.CDebugf(nil, "FS not available on WrapChild")
+		return child
+	}
+
+	rn.am.log.CDebugf(nil, "Making autogit root node")
+	return &autogitRootNode{
+		Node: &libkbfs.ReadonlyNode{Node: child},
+		am:   rn.am,
+		fs:   rn.fs,
+	}
 }
 
 // rootWrapper is a struct that manages wrapping root nodes with
@@ -465,5 +247,8 @@ type rootWrapper struct {
 }
 
 func (rw rootWrapper) wrap(node libkbfs.Node) libkbfs.Node {
-	return &rootNode{node, rw.am}
+	return &rootNode{
+		Node: node,
+		am:   rw.am,
+	}
 }

--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -197,15 +197,15 @@ func (rn *rootNode) ShouldCreateMissedLookup(ctx context.Context, name string) (
 		// Make the FS once, in a place where we know the NodeCache
 		// won't be locked (to avoid deadlock).
 
-		// Wrap this child so that it will show all the
-		// repos. TODO(KBFS-3429): fill in context.
-		ctx := context.TODO()
 		h, err := rn.am.config.KBFSOps().GetTLFHandle(ctx, rn)
 		if err != nil {
 			rn.am.log.CDebugf(nil, "Error getting handle: %+v", err)
 			return rn.Node.ShouldCreateMissedLookup(ctx, name)
 		}
 
+		// Wrap this child so that it will show all the
+		// repos. TODO(KBFS-3429): fill in context.
+		ctx := context.TODO()
 		fs, err := libfs.NewFS(
 			ctx, rn.am.config, h, rn.GetFolderBranch().Branch, kbfsRepoDir, "",
 			keybase1.MDPriorityNormal)

--- a/libgit/browser.go
+++ b/libgit/browser.go
@@ -258,8 +258,9 @@ func (b *Browser) Chroot(p string) (newFS billy.Filesystem, err error) {
 		return nil, err
 	}
 	return &Browser{
-		tree: newTree,
-		root: b.Join(b.root, p),
+		tree:  newTree,
+		root:  b.Join(b.root, p),
+		mtime: b.mtime,
 	}, nil
 }
 

--- a/libgit/rpc.go
+++ b/libgit/rpc.go
@@ -28,7 +28,7 @@ type RPCHandler struct {
 // NewRPCHandlerWithCtx returns a new instance of a Git RPC handler.
 func NewRPCHandlerWithCtx(kbCtx libkbfs.Context, config libkbfs.Config,
 	kbfsInitParams *libkbfs.InitParams) (*RPCHandler, func()) {
-	shutdown := StartAutogit(kbCtx, config, kbfsInitParams, 10)
+	shutdown := StartAutogit(config)
 	return &RPCHandler{
 		kbCtx:          kbCtx,
 		config:         config,

--- a/libgit/util.go
+++ b/libgit/util.go
@@ -14,6 +14,10 @@ import (
 	"github.com/keybase/kbfs/libkbfs"
 )
 
+const (
+	workTimeLimit = 1 * time.Hour
+)
+
 // commonTime computes the current time according to our estimate of
 // the mdserver's time.  It's a very crude way of normalizing the
 // local clock.

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -2001,7 +2001,8 @@ func (fbo *folderBranchOps) makeFakeDirEntry(
 	de = DirEntry{
 		BlockInfo: BlockInfo{
 			BlockPointer: BlockPointer{
-				ID: id,
+				ID:      id,
+				DataVer: FirstValidDataVer,
 			},
 		},
 		EntryInfo: EntryInfo{
@@ -2098,7 +2099,8 @@ func (fbo *folderBranchOps) statUsingFS(
 	de = DirEntry{
 		BlockInfo: BlockInfo{
 			BlockPointer: BlockPointer{
-				ID: id,
+				ID:      id,
+				DataVer: FirstValidDataVer,
 			},
 		},
 		EntryInfo: EntryInfoFromFileInfo(fi),
@@ -2115,12 +2117,6 @@ func (fbo *folderBranchOps) statUsingFS(
 
 func (fbo *folderBranchOps) lookup(ctx context.Context, dir Node, name string) (
 	node Node, de DirEntry, err error) {
-	if fbo.nodeCache.IsUnlinked(dir) {
-		fbo.log.CDebugf(ctx, "Refusing a lookup for unlinked directory %v",
-			fbo.nodeCache.PathFromNode(dir).tailPointer())
-		return nil, DirEntry{}, NoSuchNameError{name}
-	}
-
 	lState := makeFBOLockState()
 
 	de, ok, err := fbo.statUsingFS(ctx, lState, dir, name)
@@ -2133,6 +2129,12 @@ func (fbo *folderBranchOps) lookup(ctx context.Context, dir Node, name string) (
 			return nil, DirEntry{}, err
 		}
 		return node, de, nil
+	}
+
+	if fbo.nodeCache.IsUnlinked(dir) {
+		fbo.log.CDebugf(ctx, "Refusing a lookup for unlinked directory %v",
+			fbo.nodeCache.PathFromNode(dir).tailPointer())
+		return nil, DirEntry{}, NoSuchNameError{name}
 	}
 
 	md, err := fbo.getMDForReadNeedIdentify(ctx, lState)

--- a/libpages/root.go
+++ b/libpages/root.go
@@ -6,7 +6,6 @@ package libpages
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/keybase/client/go/protocol/keybase1"
@@ -149,24 +148,15 @@ func (r *Root) MakeFS(
 		}
 		return cacheableFS, tlfHandle.TlfID(), cancel, nil
 	case GitRoot:
-		session, err := kbfsConfig.KeybaseService().CurrentSession(ctx, 0)
-		if err != nil {
-			return CacheableFS{}, tlf.ID{}, nil, err
-		}
 		tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
 			ctx, kbfsConfig.KBPKI(), kbfsConfig.MDOps(),
-			// We'll just checkout to the bot's private TLF for now. Note that
-			// this means git remote is only supported by kbp servers that have
-			// logged into a bot account.
-			string(session.Name), tlf.Private)
+			r.TlfNameUnparsed, r.TlfType)
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}
 		autogitTLFFS, err := libfs.NewFS(
 			fsCtx, kbfsConfig, tlfHandle, libkbfs.MasterBranch,
-			fmt.Sprintf("%s/%s", libgit.AutogitTLFListDir(r.TlfType),
-				r.TlfNameUnparsed), "",
-			keybase1.MDPriorityNormal)
+			libgit.AutogitRoot, "", keybase1.MDPriorityNormal)
 		if err != nil {
 			return CacheableFS{}, tlf.ID{}, nil, err
 		}


### PR DESCRIPTION
This also changes the directory structure, so there's no more need for the `tlf_type/tlf_name` prefix in the autogit path.  You can browse repos under TLFs for which you don't have write access.

However, this does NOT yet support invalidating kernel caches when the commits happen to the underlying repo.  So we shouldn't yet update kbpbot after this is merged, until subsequent PRs are also merged.

Due to some nasty potential deadlocks, I had to rework the way that NodeCache wraps its children, to make sure it happens without taking a lock.

Issue: KBFS-3425