### PR TITLE
libgit: support for browsing branches

### DIFF
--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -53,6 +53,9 @@ const (
 	// AutogitBranchPrefix is a prefix of a subdirectory name
 	// containing one element of a git reference name.
 	AutogitBranchPrefix = ".kbfs_autogit_branch_"
+	// branchSlash can substitute for slashes in branch names,
+	// following `AutogitBranchPrefix`.
+	branchSlash = ":"
 )
 
 type repoFileNode struct {
@@ -144,8 +147,9 @@ func (rdn repoDirNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 			am:     rdn.am,
 			repoFS: rdn.repoFS,
 			subdir: "",
-			branch: plumbing.ReferenceName(
-				path.Join(string(rdn.branch), branchName)),
+			branch: plumbing.ReferenceName(path.Join(
+				string(rdn.branch),
+				strings.Replace(branchName, branchSlash, "/", -1))),
 		}
 	}
 

--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -149,6 +149,15 @@ func TestAutogitRepoNode(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello3", string(data3))
 
+	t.Logf("Use colons instead of slashes in the branch name")
+	f4, err := rootFS.Open(
+		".kbfs_autogit/test/.kbfs_autogit_branch_dir:test-branch/foo3")
+	require.NoError(t, err)
+	defer f4.Close()
+	data4, err := ioutil.ReadAll(f4)
+	require.NoError(t, err)
+	require.Equal(t, "hello3", string(data4))
+
 	err = dotgitFS.SyncAll()
 	require.NoError(t, err)
 }

--- a/libgit/browser.go
+++ b/libgit/browser.go
@@ -32,7 +32,10 @@ type Browser struct {
 var _ billy.Filesystem = (*Browser)(nil)
 
 // NewBrowser makes a new Browser instance, browsing the given branch
-// of the given repo.
+// of the given repo.  If `gitBranchName` is empty,
+// "refs/heads/master" is used.  If `gitBranchName` is not empty, but
+// it doesn't begin with "refs/", then "refs/heads/" is prepended to
+// it.
 func NewBrowser(
 	repoFS *libfs.FS, clock libkbfs.Clock,
 	gitBranchName plumbing.ReferenceName) (*Browser, error) {
@@ -52,6 +55,12 @@ func NewBrowser(
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if gitBranchName == "" {
+		gitBranchName = "refs/heads/master"
+	} else if !strings.HasPrefix(string(gitBranchName), "refs/") {
+		gitBranchName = "refs/heads/" + gitBranchName
 	}
 
 	ref, err := repo.Reference(gitBranchName, true)

--- a/libgit/browser_test.go
+++ b/libgit/browser_test.go
@@ -22,8 +22,8 @@ import (
 func TestBrowser(t *testing.T) {
 	ctx, config, cancel, tempdir := initConfigForAutogit(t)
 	defer cancel()
-	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 	defer os.RemoveAll(tempdir)
+	defer libkbfs.CheckConfigAndShutdown(ctx, t, config)
 
 	h, err := libkbfs.ParseTlfHandle(
 		ctx, config.KBPKI(), config.MDOps(), "user1", tlf.Private)
@@ -47,7 +47,7 @@ func TestBrowser(t *testing.T) {
 		t, ctx, config, h, repo, worktreeFS, "foo", "hello")
 
 	t.Log("Browse the repo and verify the data.")
-	b, err := NewBrowser(dotgitFS, config.Clock(), "refs/heads/master")
+	b, err := NewBrowser(dotgitFS, config.Clock(), "")
 	require.NoError(t, err)
 	fis, err := b.ReadDir("")
 	require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestBrowser(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		b, err = NewBrowser(dotgitFS, config.Clock(), "refs/heads/master")
+		b, err = NewBrowser(dotgitFS, config.Clock(), "")
 		require.NoError(t, err)
 		fi, err := b.Lstat(link)
 		require.NoError(t, err)


### PR DESCRIPTION
With the root of an autogit repo, you can now navigate to the branch of a version by using `.kbfs_autogit_branch_<name>`.  Branch names can contain slashes, so you can stack these.  For example, to navigate to a branch a/b/c in repo "test", use this path:

```
.kbfs_autogit/test/.kbfs_autogit_branch_a/.kbfs_autogit_branch_b/.kbfs_autogit_branch_c/
```

It's a bit unwieldy, but it will be fine for GUI-based browsing, and I don't see a good alternative for CLI-based browsing, besides shortening the prefix somehow.

If the branch names doesn't start with "refs/", then "refs/heads/" is prepended to it.  But e.g. tags can be shown with a full path like "refs/tags/v2.6.0".

Issue: KBFS-3426