### PR TITLE
node_cache: add and implement AllNodeChildren function

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2243,6 +2243,10 @@ type NodeCache interface {
 	PathFromNode(node Node) path
 	// AllNodes returns the complete set of nodes currently in the cache.
 	AllNodes() []Node
+	// AllNodeChildren returns the complete set of nodes currently in
+	// the cache, for which the given node `n` is a parent (direct or
+	// indirect).  The returned slice does not include `n` itself.
+	AllNodeChildren(n Node) []Node
 	// AddRootWrapper adds a new wrapper function that will be applied
 	// whenever a root Node is created.
 	AddRootWrapper(func(Node) Node)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8150,6 +8150,18 @@ func (mr *MockNodeCacheMockRecorder) AllNodes() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllNodes", reflect.TypeOf((*MockNodeCache)(nil).AllNodes))
 }
 
+// AllNodeChildren mocks base method
+func (m *MockNodeCache) AllNodeChildren(n Node) []Node {
+	ret := m.ctrl.Call(m, "AllNodeChildren", n)
+	ret0, _ := ret[0].([]Node)
+	return ret0
+}
+
+// AllNodeChildren indicates an expected call of AllNodeChildren
+func (mr *MockNodeCacheMockRecorder) AllNodeChildren(n interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllNodeChildren", reflect.TypeOf((*MockNodeCache)(nil).AllNodeChildren), n)
+}
+
 // AddRootWrapper mocks base method
 func (m *MockNodeCache) AddRootWrapper(arg0 func(Node) Node) {
 	m.ctrl.Call(m, "AddRootWrapper", arg0)

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -411,8 +411,8 @@ func (ncs *nodeCacheStandard) AllNodeChildren(n Node) (nodes []Node) {
 		}
 	}()
 
-	ncs.lock.Lock()
-	defer ncs.lock.Unlock()
+	ncs.lock.RLock()
+	defer ncs.lock.RUnlock()
 	rootWrappers = ncs.rootWrappers
 	nodes = make([]Node, 0, len(ncs.nodes))
 	entryIDs := make(map[NodeID]bool)


### PR DESCRIPTION
This function returns all the children of the current node.  It will be useful to figure out which autogit nodes need to be invalidated, after a repo is updated.

This implementation iterates through all nodes, and back through all parents, to figure out which nodes to return.  A better implementation might track the a node's children directly, but that will be a bit tricky to get right, so let'd try this for now and see if it's good enough.

Issue: KBFS-3427