### PR TITLE
autogit: invalidate all AG nodes associated with an updated repo

### DIFF
--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -203,13 +203,17 @@ func (arn autogitRootNode) WrapChild(child libkbfs.Node) libkbfs.Node {
 		arn.am.log.CDebugf(nil, "Error getting repo: %+v", err)
 		return child
 	}
-	return &repoDirNode{
+	rdn := &repoDirNode{
 		Node:   child,
 		am:     arn.am,
 		repoFS: repoFS.(*libfs.FS),
 		subdir: "",
 		branch: "",
 	}
+	if fs, ok := repoFS.(*libfs.FS); ok {
+		arn.am.registerRepoNode(fs.RootNode(), rdn)
+	}
+	return rdn
 }
 
 // rootNode is a Node wrapper around a TLF root node, that causes the

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -7117,6 +7117,29 @@ func (fbo *folderBranchOps) ForceFastForward(ctx context.Context) {
 	}()
 }
 
+// InvalidateNodeAndChildren implements the KBFSOps interface for
+// folderBranchOps.
+func (fbo *folderBranchOps) InvalidateNodeAndChildren(
+	ctx context.Context, node Node) (err error) {
+	fbo.log.CDebugf(ctx, "InvalidateNodeAndChildren %p", node)
+	defer func() {
+		fbo.log.CDebugf(ctx,
+			"InvalidateNodeAndChildren %p done: %+v", node, err)
+	}()
+
+	lState := makeFBOLockState()
+	changes, affectedNodeIDs, err := fbo.blocks.GetInvalidationChanges(
+		ctx, lState, node)
+	if err != nil {
+		return err
+	}
+
+	if len(changes) > 0 {
+		fbo.observers.batchChanges(ctx, changes, affectedNodeIDs)
+	}
+	return nil
+}
+
 // KickoffAllOutstandingRekeys (does not) implement the KBFSOps interface for
 // folderBranchOps.
 func (fbo *folderBranchOps) KickoffAllOutstandingRekeys() error {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -484,6 +484,13 @@ type KBFSOps interface {
 	// newest version.  It works asynchronously, so no error is
 	// returned.
 	ForceFastForward(ctx context.Context)
+	// InvalidateNodeAndChildren sends invalidation messages for the
+	// given node and all of its children that are currently in the
+	// NodeCache.  It's useful if the caller has outside knowledge of
+	// data changes to thae node or its children that didn't come
+	// through the usual MD update channels (e.g., autogit nodes need
+	// invalidation when the corresponding git repo is updated).
+	InvalidateNodeAndChildren(ctx context.Context, node Node) error
 	// TeamNameChanged indicates that a team has changed its name, and
 	// we should clean up any outstanding handle info associated with
 	// the team ID.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2248,11 +2248,15 @@ type NodeCache interface {
 	UpdateUnlinkedDirEntry(node Node, newDe DirEntry)
 	// PathFromNode creates the path up to a given Node.
 	PathFromNode(node Node) path
-	// AllNodes returns the complete set of nodes currently in the cache.
+	// AllNodes returns the complete set of nodes currently in the
+	// cache.  The returned Nodes are not wrapped, and shouldn't be
+	// used for data access.
 	AllNodes() []Node
 	// AllNodeChildren returns the complete set of nodes currently in
 	// the cache, for which the given node `n` is a parent (direct or
 	// indirect).  The returned slice does not include `n` itself.
+	// The returned Nodes are not wrapped, and shouldn't be used for
+	// data access.
 	AllNodeChildren(n Node) []Node
 	// AddRootWrapper adds a new wrapper function that will be applied
 	// whenever a root Node is created.

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -233,6 +233,17 @@ func (fs *KBFSOpsStandard) ForceFastForward(ctx context.Context) {
 	}
 }
 
+// InvalidateNodeAndChildren implements the KBFSOps interface for
+// KBFSOpsStandard.
+func (fs *KBFSOpsStandard) InvalidateNodeAndChildren(
+	ctx context.Context, node Node) error {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	ops := fs.getOpsByNode(ctx, node)
+	return ops.InvalidateNodeAndChildren(ctx, node)
+}
+
 // GetFavorites implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetFavorites(ctx context.Context) (

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1703,6 +1703,18 @@ func (mr *MockKBFSOpsMockRecorder) ForceFastForward(ctx interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceFastForward", reflect.TypeOf((*MockKBFSOps)(nil).ForceFastForward), ctx)
 }
 
+// InvalidateNodeAndChildren mocks base method
+func (m *MockKBFSOps) InvalidateNodeAndChildren(ctx context.Context, node Node) error {
+	ret := m.ctrl.Call(m, "InvalidateNodeAndChildren", ctx, node)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InvalidateNodeAndChildren indicates an expected call of InvalidateNodeAndChildren
+func (mr *MockKBFSOpsMockRecorder) InvalidateNodeAndChildren(ctx, node interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateNodeAndChildren", reflect.TypeOf((*MockKBFSOps)(nil).InvalidateNodeAndChildren), ctx, node)
+}
+
 // TeamNameChanged mocks base method
 func (m *MockKBFSOps) TeamNameChanged(ctx context.Context, tid keybase1.TeamID) {
 	m.ctrl.Call(m, "TeamNameChanged", ctx, tid)

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -385,16 +385,8 @@ func (ncs *nodeCacheStandard) PathFromNode(node Node) (p path) {
 
 // AllNodes implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) AllNodes() (nodes []Node) {
-	var rootWrappers []func(Node) Node
-	defer func() {
-		for i, n := range nodes {
-			nodes[i] = ncs.wrapNodeStandard(n, rootWrappers)
-		}
-	}()
-
-	ncs.lock.Lock()
-	defer ncs.lock.Unlock()
-	rootWrappers = ncs.rootWrappers
+	ncs.lock.RLock()
+	defer ncs.lock.RUnlock()
 	nodes = make([]Node, 0, len(ncs.nodes))
 	for _, entry := range ncs.nodes {
 		nodes = append(nodes, ncs.makeNodeStandardForEntryLocked(entry))
@@ -404,16 +396,8 @@ func (ncs *nodeCacheStandard) AllNodes() (nodes []Node) {
 
 // AllNodeChildren implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) AllNodeChildren(n Node) (nodes []Node) {
-	var rootWrappers []func(Node) Node
-	defer func() {
-		for i, n := range nodes {
-			nodes[i] = ncs.wrapNodeStandard(n, rootWrappers)
-		}
-	}()
-
 	ncs.lock.RLock()
 	defer ncs.lock.RUnlock()
-	rootWrappers = ncs.rootWrappers
 	nodes = make([]Node, 0, len(ncs.nodes))
 	entryIDs := make(map[NodeID]bool)
 	for _, entry := range ncs.nodes {


### PR DESCRIPTION
When the root of a .kbfs_git repo is updated, invalidate the associated autogit root node, and any cached subnodes below it.  Achieve this by:

1. In `AutogitManager`, tracking the association between a `.kbfs_git` repo root node, and the associated `.kbfs_autogit` repo root node.
2. When the former is updated, ask `folderBranchOps` to invalidate all nodes associated with the latter.
3. `folderBranchOps` gets all of the autogit nodes for that repo from the node cache.  (This isn't optimally implemented, but it's probably good enough for now.)
4. `folderBranchOps` sends invalidation notifications for all of those nodes, which get delivered to the kernel in the usual way.

I've tested the invalidation by hand, and I plan to write a kbfsdocker autogit test in the future, which will exercise it more.

Issue: KBFS-3428