### PR TITLE
libfuse/libdokan: ensure runtime exists before writing it

### DIFF
--- a/libdokan/start.go
+++ b/libdokan/start.go
@@ -85,6 +85,10 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	defer libkbfs.Shutdown()
 
 	if options.RuntimeDir != "" {
+		err := os.MkdirAll(options.RuntimeDir, libkb.PermDir)
+		if err != nil {
+			return libfs.InitError(err.Error())
+		}
 		info := libkb.NewServiceInfo(libkbfs.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
 		err = info.WriteFile(path.Join(options.RuntimeDir, "kbfs.info"), log)
 		if err != nil {

--- a/libfuse/start.go
+++ b/libfuse/start.go
@@ -115,8 +115,12 @@ func Start(options StartOptions, kbCtx libkbfs.Context) *libfs.Error {
 	}
 
 	if options.RuntimeDir != "" {
+		err := os.MkdirAll(options.RuntimeDir, libkb.PermDir)
+		if err != nil {
+			return libfs.InitError(err.Error())
+		}
 		info := libkb.NewServiceInfo(libkbfs.Version, libkbfs.PrereleaseBuild, options.Label, os.Getpid())
-		err := info.WriteFile(path.Join(options.RuntimeDir, "kbfs.info"), log)
+		err = info.WriteFile(path.Join(options.RuntimeDir, "kbfs.info"), log)
 		if err != nil {
 			return libfs.InitError(err.Error())
 		}


### PR DESCRIPTION
If for some reason the service doesn't get started, KBFS will try to write a file to this directory before it exists, and will fail in a loop.

Issue: KBFS-3450