### PR TITLE
use new team refresher that is aware of saved KBFS crypt keys CORE-9030

### DIFF
--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -790,13 +790,18 @@ func (k *KeybaseServiceBase) LoadTeamPlusKeys(
 	}
 
 	arg := keybase1.LoadTeamPlusApplicationKeysArg{
-		Id:          tid,
-		Application: keybase1.TeamApplication_KBFS,
+		Id:              tid,
+		Application:     keybase1.TeamApplication_KBFS,
+		IncludeKBFSKeys: true,
 	}
 
 	if desiredKeyGen >= kbfsmd.FirstValidKeyGen {
-		arg.Refreshers.NeedKeyGeneration =
-			keybase1.PerTeamKeyGeneration(desiredKeyGen)
+		arg.Refreshers.NeedApplicationsAtGenerationsWithKBFS =
+			map[keybase1.PerTeamKeyGeneration][]keybase1.TeamApplication{
+				keybase1.PerTeamKeyGeneration(desiredKeyGen): []keybase1.TeamApplication{
+					keybase1.TeamApplication_KBFS,
+				},
+			}
 	}
 
 	if desiredUser.Uid.Exists() && desiredKey.IsNil() {

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/teams.go
@@ -1934,11 +1934,12 @@ func (o TeamKBFSKeyRefresher) DeepCopy() TeamKBFSKeyRefresher {
 // * TeamRefreshData are needed or wanted data requirements that, if unmet, will cause
 // * a refresh of the cache.
 type TeamRefreshers struct {
-	NeedKeyGeneration             PerTeamKeyGeneration                       `codec:"needKeyGeneration" json:"needKeyGeneration"`
-	NeedApplicationsAtGenerations map[PerTeamKeyGeneration][]TeamApplication `codec:"needApplicationsAtGenerations" json:"needApplicationsAtGenerations"`
-	WantMembers                   []UserVersion                              `codec:"wantMembers" json:"wantMembers"`
-	WantMembersRole               TeamRole                                   `codec:"wantMembersRole" json:"wantMembersRole"`
-	NeedKBFSKeyGeneration         TeamKBFSKeyRefresher                       `codec:"needKBFSKeyGeneration" json:"needKBFSKeyGeneration"`
+	NeedKeyGeneration                     PerTeamKeyGeneration                       `codec:"needKeyGeneration" json:"needKeyGeneration"`
+	NeedApplicationsAtGenerations         map[PerTeamKeyGeneration][]TeamApplication `codec:"needApplicationsAtGenerations" json:"needApplicationsAtGenerations"`
+	NeedApplicationsAtGenerationsWithKBFS map[PerTeamKeyGeneration][]TeamApplication `codec:"needApplicationsAtGenerationsWithKBFS" json:"needApplicationsAtGenerationsWithKBFS"`
+	WantMembers                           []UserVersion                              `codec:"wantMembers" json:"wantMembers"`
+	WantMembersRole                       TeamRole                                   `codec:"wantMembersRole" json:"wantMembersRole"`
+	NeedKBFSKeyGeneration                 TeamKBFSKeyRefresher                       `codec:"needKBFSKeyGeneration" json:"needKBFSKeyGeneration"`
 }
 
 func (o TeamRefreshers) DeepCopy() TeamRefreshers {
@@ -1966,6 +1967,28 @@ func (o TeamRefreshers) DeepCopy() TeamRefreshers {
 			}
 			return ret
 		})(o.NeedApplicationsAtGenerations),
+		NeedApplicationsAtGenerationsWithKBFS: (func(x map[PerTeamKeyGeneration][]TeamApplication) map[PerTeamKeyGeneration][]TeamApplication {
+			if x == nil {
+				return nil
+			}
+			ret := make(map[PerTeamKeyGeneration][]TeamApplication, len(x))
+			for k, v := range x {
+				kCopy := k.DeepCopy()
+				vCopy := (func(x []TeamApplication) []TeamApplication {
+					if x == nil {
+						return nil
+					}
+					ret := make([]TeamApplication, len(x))
+					for i, v := range x {
+						vCopy := v.DeepCopy()
+						ret[i] = vCopy
+					}
+					return ret
+				})(v)
+				ret[kCopy] = vCopy
+			}
+			return ret
+		})(o.NeedApplicationsAtGenerationsWithKBFS),
 		WantMembers: (func(x []UserVersion) []UserVersion {
 			if x == nil {
 				return nil
@@ -2759,10 +2782,11 @@ type TeamReAddMemberAfterResetArg struct {
 }
 
 type LoadTeamPlusApplicationKeysArg struct {
-	SessionID   int             `codec:"sessionID" json:"sessionID"`
-	Id          TeamID          `codec:"id" json:"id"`
-	Application TeamApplication `codec:"application" json:"application"`
-	Refreshers  TeamRefreshers  `codec:"refreshers" json:"refreshers"`
+	SessionID       int             `codec:"sessionID" json:"sessionID"`
+	Id              TeamID          `codec:"id" json:"id"`
+	Application     TeamApplication `codec:"application" json:"application"`
+	Refreshers      TeamRefreshers  `codec:"refreshers" json:"refreshers"`
+	IncludeKBFSKeys bool            `codec:"includeKBFSKeys" json:"includeKBFSKeys"`
 }
 
 type GetTeamRootIDArg struct {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -316,10 +316,10 @@
 			"revisionTime": "2018-09-29T23:42:17Z"
 		},
 		{
-			"checksumSHA1": "5CuHUk9XHcKSLYlryTjoD958Fjc=",
+			"checksumSHA1": "Ka9mdcgnQg7ujPhIL0RIna9JjkI=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "5652205fac3bae80c62bb976f13fbccd280e4089",
-			"revisionTime": "2018-09-29T23:42:17Z"
+			"revision": "3782ef5d0aa68aba151bf3b2973be7026a353434",
+			"revisionTime": "2018-10-01T14:29:15Z"
 		},
 		{
 			"checksumSHA1": "3KQoKylFjCl1wMMULQiMgmxuvWo=",


### PR DESCRIPTION
The previous team refresher would not work with keys offset by the saved KBFS crypt key generation, so it could give stale results for upgraded TLFs.