### PR TITLE
autogit: remove old autogit checkouts when a repo is accessed

### DIFF
--- a/libgit/repo.go
+++ b/libgit/repo.go
@@ -90,6 +90,12 @@ func castNoSuchNameError(err error, repoName string) error {
 
 func recursiveDelete(
 	ctx context.Context, fs *libfs.FS, fi os.FileInfo) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	if !fi.IsDir() {
 		// Delete regular files and symlinks directly.
 		return fs.Remove(fi.Name())


### PR DESCRIPTION
Whenever a repo is accessed within a particular TLF, delete all old checkouts in that TLF.

Also, remove self-checkouts on first autogit access to ANY repo, because some users (like kbpbot) only checkout repos from other TLFs, and use their own private folder as the destination.

To enable this, we allow for "unwrapped" FSes, to avoid getting entangled in recursive node wrapping.

Issue: KBFS-3431