### PR TITLE
tlf_handle: don't explicitly check team membership while migrating

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -963,7 +963,7 @@ func (fbo *folderBranchOps) setHeadSuccessorLocked(ctx context.Context,
 	resolvesTo, partialResolvedOldHandle, err :=
 		oldHandle.ResolvesTo(
 			ctx, fbo.config.Codec(), fbo.config.KBPKI(),
-			constIDGetter{fbo.id()}, fbo.config.KBPKI(), *newHandle)
+			constIDGetter{fbo.id()}, *newHandle)
 	if err != nil {
 		fbo.log.CDebugf(ctx, "oldHandle=%+v, newHandle=%+v: err=%+v", oldHandle, newHandle, err)
 		return err

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -747,10 +747,6 @@ type teamMembershipChecker interface {
 	// kbfsmd.TeamMembershipChecker.IsTeamWriter.
 	IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid keybase1.UID) (
 		bool, error)
-	// ListResolvedTeamMembers returns the lists of resolved writers
-	// and readers.
-	ListResolvedTeamMembers(ctx context.Context, tid keybase1.TeamID) (
-		writers, readers []keybase1.UID, err error)
 }
 
 type teamKeysGetter interface {

--- a/libkbfs/kbpki_client.go
+++ b/libkbfs/kbpki_client.go
@@ -341,26 +341,6 @@ func (k *KBPKIClient) IsTeamReader(
 	return tid.IsPublic() || teamInfo.Writers[uid] || teamInfo.Readers[uid], nil
 }
 
-// ListResolvedTeamMembers implements the KBPKI interface for KBPKIClient.
-func (k *KBPKIClient) ListResolvedTeamMembers(
-	ctx context.Context, tid keybase1.TeamID) (
-	writers, readers []keybase1.UID, err error) {
-	teamInfo, err := k.serviceOwner.KeybaseService().LoadTeamPlusKeys(
-		ctx, tid, tlf.Unknown, kbfsmd.UnspecifiedKeyGen, keybase1.UserVersion{},
-		kbfscrypto.VerifyingKey{}, keybase1.TeamRole_NONE)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	for w := range teamInfo.Writers {
-		writers = append(writers, w)
-	}
-	for r := range teamInfo.Readers {
-		readers = append(readers, r)
-	}
-	return writers, readers, nil
-}
-
 // GetTeamRootID implements the KBPKI interface for KBPKIClient.
 func (k *KBPKIClient) GetTeamRootID(ctx context.Context, tid keybase1.TeamID) (
 	keybase1.TeamID, error) {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -2474,20 +2474,6 @@ func (mr *MockteamMembershipCheckerMockRecorder) IsTeamReader(ctx, tid, uid inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockteamMembershipChecker)(nil).IsTeamReader), ctx, tid, uid)
 }
 
-// ListResolvedTeamMembers mocks base method
-func (m *MockteamMembershipChecker) ListResolvedTeamMembers(ctx context.Context, tid keybase1.TeamID) ([]keybase1.UID, []keybase1.UID, error) {
-	ret := m.ctrl.Call(m, "ListResolvedTeamMembers", ctx, tid)
-	ret0, _ := ret[0].([]keybase1.UID)
-	ret1, _ := ret[1].([]keybase1.UID)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ListResolvedTeamMembers indicates an expected call of ListResolvedTeamMembers
-func (mr *MockteamMembershipCheckerMockRecorder) ListResolvedTeamMembers(ctx, tid interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResolvedTeamMembers", reflect.TypeOf((*MockteamMembershipChecker)(nil).ListResolvedTeamMembers), ctx, tid)
-}
-
 // MockteamKeysGetter is a mock of teamKeysGetter interface
 type MockteamKeysGetter struct {
 	ctrl     *gomock.Controller
@@ -2766,20 +2752,6 @@ func (m *MockKBPKI) IsTeamReader(ctx context.Context, tid keybase1.TeamID, uid k
 // IsTeamReader indicates an expected call of IsTeamReader
 func (mr *MockKBPKIMockRecorder) IsTeamReader(ctx, tid, uid interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTeamReader", reflect.TypeOf((*MockKBPKI)(nil).IsTeamReader), ctx, tid, uid)
-}
-
-// ListResolvedTeamMembers mocks base method
-func (m *MockKBPKI) ListResolvedTeamMembers(ctx context.Context, tid keybase1.TeamID) ([]keybase1.UID, []keybase1.UID, error) {
-	ret := m.ctrl.Call(m, "ListResolvedTeamMembers", ctx, tid)
-	ret0, _ := ret[0].([]keybase1.UID)
-	ret1, _ := ret[1].([]keybase1.UID)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ListResolvedTeamMembers indicates an expected call of ListResolvedTeamMembers
-func (mr *MockKBPKIMockRecorder) ListResolvedTeamMembers(ctx, tid interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResolvedTeamMembers", reflect.TypeOf((*MockKBPKI)(nil).ListResolvedTeamMembers), ctx, tid)
 }
 
 // GetTeamTLFCryptKeys mocks base method

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -449,9 +449,8 @@ func (pr partialResolver) Resolve(ctx context.Context, assertion string) (
 // equal other if and only if true is returned.
 func (h TlfHandle) ResolvesTo(
 	ctx context.Context, codec kbfscodec.Codec, resolver resolver,
-	idGetter tlfIDGetter, teamChecker teamMembershipChecker, other TlfHandle) (
-	resolvesTo bool, partialResolvedH *TlfHandle,
-	err error) {
+	idGetter tlfIDGetter, other TlfHandle) (
+	resolvesTo bool, partialResolvedH *TlfHandle, err error) {
 	// Check the conflict extension.
 	var conflictAdded, finalizedAdded bool
 	if !h.IsConflict() && other.IsConflict() {
@@ -494,46 +493,18 @@ func (h TlfHandle) ResolvesTo(
 			return false, nil, err
 		}
 
-		// If we're migrating, make sure the handles map to the same
-		// set of users.
-		if other.TypeForKeying() == tlf.TeamKeying && teamChecker != nil {
+		// If we're migrating, use the partially-resolved handle's
+		// list of writers, readers, and conflict info, rather than
+		// explicitly checking team membership.  This is assuming that
+		// we've already validated the migrating folder's name against
+		// the user list in the current MD head (done via
+		// `MDOps.GetIDForHandle()`).
+		if other.TypeForKeying() == tlf.TeamKeying {
 			if h.IsFinal() {
 				return false, nil,
 					errors.New("Can't migrate a finalized folder")
 			}
 
-			teamID := other.FirstResolvedWriter().AsTeamOrBust()
-			writers, readers, err := teamChecker.ListResolvedTeamMembers(
-				ctx, teamID)
-			if err != nil {
-				return false, nil, err
-			}
-
-			bareHandle, err := partialResolvedH.ToBareHandle()
-			if err != nil {
-				return false, nil, err
-			}
-
-			wUsers := make([]keybase1.UserOrTeamID, len(writers))
-			for i, w := range writers {
-				wUsers[i] = w.AsUserOrTeam()
-			}
-			var rUsers []keybase1.UserOrTeamID
-			if h.Type() == tlf.Public {
-				rUsers = append(rUsers, keybase1.PUBLIC_UID)
-			} else {
-				rUsers = make([]keybase1.UserOrTeamID, len(readers))
-				for i, r := range readers {
-					rUsers[i] = r.AsUserOrTeam()
-				}
-			}
-			if !bareHandle.ResolvedUsersEqual(wUsers, rUsers) {
-				return false, partialResolvedH, nil
-			}
-			// Set other's writers/readers to be equal to h's, since
-			// we already checked the team membership.  If the
-			// unresolved writers/readers differ, it'll cause the name
-			// to be different.
 			other.resolvedWriters = partialResolvedH.resolvedWriters
 			other.resolvedReaders = partialResolvedH.resolvedReaders
 			other.unresolvedWriters = partialResolvedH.unresolvedWriters
@@ -561,14 +532,14 @@ func (h TlfHandle) MutuallyResolvesTo(
 	resolver resolver, idGetter tlfIDGetter, other TlfHandle,
 	rev kbfsmd.Revision, tlfID tlf.ID, log logger.Logger) error {
 	handleResolvesToOther, partialResolvedHandle, err :=
-		h.ResolvesTo(ctx, codec, resolver, idGetter, nil, other)
+		h.ResolvesTo(ctx, codec, resolver, idGetter, other)
 	if err != nil {
 		return err
 	}
 
 	// TODO: If h has conflict info, other should, too.
 	otherResolvesToHandle, partialResolvedOther, err :=
-		other.ResolvesTo(ctx, codec, resolver, idGetter, nil, h)
+		other.ResolvesTo(ctx, codec, resolver, idGetter, h)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -869,7 +869,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err :=
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h1)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h1)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -882,7 +882,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -901,7 +901,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -917,7 +917,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h2.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -943,7 +943,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -967,7 +967,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	h1.SetFinalizedInfo(&info)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -984,7 +984,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 
 	resolvesTo, partialResolvedH1, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, nil, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2)
 	require.Error(t, err)
 
 	// Test positive resolution cases.
@@ -1014,7 +1014,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
 		require.NoError(t, err)
 		assert.True(t, resolvesTo, tc.name2)
 		require.Equal(t, h2, partialResolvedH1, tc.name2)
@@ -1038,7 +1038,7 @@ func TestTlfHandleResolvesTo(t *testing.T) {
 		daemon.addNewAssertionForTestOrBust(tc.resolveTo, "u2@twitter")
 
 		resolvesTo, partialResolvedH1, err =
-			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, nil, *h2)
+			h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
 		require.NoError(t, err)
 		assert.False(t, resolvesTo, tc.name2)
 
@@ -1087,7 +1087,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	h2 := makeImplicitHandle(name1, tlf.Private, id)
 
 	resolvesTo, partialResolvedH1, err :=
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h2)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h2)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1, partialResolvedH1)
@@ -1101,7 +1101,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	h2Pub := makeImplicitHandle(name1, tlf.Public, idPub)
 
 	resolvesTo, partialResolvedH1, err =
-		h1Pub.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, kbpki, *h2Pub)
+		h1Pub.ResolvesTo(ctx, codec, kbpki, constIDGetter{idPub}, *h2Pub)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h1Pub, partialResolvedH1)
@@ -1110,7 +1110,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name2 := "u1,u2,u3"
 	h3 := makeImplicitHandle(name2, tlf.Private, id)
 	resolvesTo, _, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h3)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h3)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -1118,7 +1118,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name3 := "u1"
 	h4 := makeImplicitHandle(name3, tlf.Private, id)
 	resolvesTo, _, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h4)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h4)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -1126,7 +1126,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name4 := "u1,u2#u3"
 	h5 := makeImplicitHandle(name4, tlf.Private, id)
 	resolvesTo, _, err =
-		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h5)
+		h1.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h5)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
@@ -1138,7 +1138,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 	h7 := makeImplicitHandle(name5, tlf.Private, id)
 	resolvesTo, partialResolvedH6, err :=
-		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h7)
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h7)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h6, partialResolvedH6)
@@ -1148,14 +1148,14 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	name6 := "u1,u2,u3@twitter,u4@twitter"
 	h8 := makeImplicitHandle(name6, tlf.Private, id)
 	resolvesTo, _, err =
-		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h8)
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h8)
 	require.NoError(t, err)
 	require.False(t, resolvesTo)
 
 	t.Log("Private team migration with newly-resolved user")
 	daemon.addNewAssertionForTestOrBust("u3", "u3@twitter")
 	resolvesTo, partialResolvedH6, err =
-		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h3)
+		h6.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h3)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Len(t, partialResolvedH6.UnresolvedWriters(), 0)
@@ -1167,7 +1167,7 @@ func TestTlfHandleMigrationResolvesTo(t *testing.T) {
 	require.NoError(t, err)
 	h10 := makeImplicitHandle(name7, tlf.Private, id)
 	resolvesTo, partialResolvedH9, err :=
-		h9.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, kbpki, *h10)
+		h9.ResolvesTo(ctx, codec, kbpki, constIDGetter{id}, *h10)
 	require.NoError(t, err)
 	require.True(t, resolvesTo)
 	require.Equal(t, h9, partialResolvedH9)


### PR DESCRIPTION
There's no need to explicitly check team membership while migrating an existing folder to an implicit team, because the name of the folder is already validated against the folder's current MD update during `MDOps.GetIDForHandle()`.

Plus, checking the membership here needlessly fails in some cases, such as for PUK-less members who appear in the team name, but would not be reported by the service as resolved team members.

Issue: KBFS-3441