### PR TITLE
autogit: use '^' as branch separator

### DIFF
--- a/libgit/autogit_node_wrappers.go
+++ b/libgit/autogit_node_wrappers.go
@@ -55,7 +55,7 @@ const (
 	AutogitBranchPrefix = ".kbfs_autogit_branch_"
 	// branchSlash can substitute for slashes in branch names,
 	// following `AutogitBranchPrefix`.
-	branchSlash = ":"
+	branchSlash = "^"
 )
 
 type repoFileNode struct {

--- a/libgit/autogit_node_wrappers_test.go
+++ b/libgit/autogit_node_wrappers_test.go
@@ -151,7 +151,7 @@ func TestAutogitRepoNode(t *testing.T) {
 
 	t.Logf("Use colons instead of slashes in the branch name")
 	f4, err := rootFS.Open(
-		".kbfs_autogit/test/.kbfs_autogit_branch_dir:test-branch/foo3")
+		".kbfs_autogit/test/.kbfs_autogit_branch_dir^test-branch/foo3")
 	require.NoError(t, err)
 	defer f4.Close()
 	data4, err := ioutil.ReadAll(f4)


### PR DESCRIPTION
Because ':' is a bad character on Windows paths.

(Open to other suggestions.)