### PR TITLE
kbfscrypto: add new encryption scheme that derives nonce from key

### DIFF
--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -679,7 +679,7 @@ type BlockHashKey struct {
 // MakeBlockHashKey makes a key used for encryption and decryption for
 // the v2 block encryption scheme.
 func MakeBlockHashKey(
-	serverHalf TLFCryptKeyServerHalf, key TLFCryptKey) BlockHashKey {
+	serverHalf BlockCryptKeyServerHalf, key TLFCryptKey) BlockHashKey {
 	keyData := key.Data()
 	mac := hmac.New(sha512.New, keyData[:])
 	serverHalfData := serverHalf.Data()

--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -693,11 +693,11 @@ func MakeBlockHashKey(
 }
 
 func (bhk BlockHashKey) cryptKey() (key [32]byte) {
-	copy(key[:], bhk.data[:32])
+	copy(key[:], bhk.data[:len(key)])
 	return key
 }
 
 func (bhk BlockHashKey) nonce() (n [24]byte) {
-	copy(n[:], bhk.data[32:56])
+	copy(n[:], bhk.data[32:32+len(n)])
 	return n
 }

--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -153,6 +153,10 @@ func (c privateByte32Container) Data() [32]byte {
 	return c.data
 }
 
+func (c privateByte32Container) Bytes() []byte {
+	return c.data[:]
+}
+
 func (c privateByte32Container) MarshalBinary() (data []byte, err error) {
 	return c.data[:], nil
 }
@@ -680,10 +684,8 @@ type BlockHashKey struct {
 // the v2 block encryption scheme.
 func MakeBlockHashKey(
 	serverHalf BlockCryptKeyServerHalf, key TLFCryptKey) BlockHashKey {
-	keyData := key.Data()
-	mac := hmac.New(sha512.New, keyData[:])
-	serverHalfData := serverHalf.Data()
-	mac.Write(serverHalfData[:])
+	mac := hmac.New(sha512.New, key.Bytes())
+	mac.Write(serverHalf.Bytes())
 	hash := mac.Sum(nil)
 	var hash64 [64]byte
 	copy(hash64[:], hash)

--- a/kbfscrypto/errors.go
+++ b/kbfscrypto/errors.go
@@ -50,6 +50,17 @@ func (e UnknownEncryptionVer) Error() string {
 	return fmt.Sprintf("Unknown encryption version %d", int(e.Ver))
 }
 
+// InvalidEncryptionVer indicates that we can't decrypt an
+// encryptedData object because this data type doesn't support that
+// encryption version.
+type InvalidEncryptionVer struct {
+	Ver EncryptionVer
+}
+
+func (e InvalidEncryptionVer) Error() string {
+	return fmt.Sprintf("Invalid encryption version %d", int(e.Ver))
+}
+
 // InvalidNonceError indicates that an invalid cryptographic nonce was
 // detected.
 type InvalidNonceError struct {


### PR DESCRIPTION
This introduces a new encryption scheme for blocks, that derives both the encryption key and nonce from a function of the TLF crypt key and server-side key half.

In the existing version 1 encryption scheme, we xor the TLF crypt key and server-side key half together to use as the block crypt key, and generate a nonce randomly.  This scheme has a few weaknesses though, in the case when an evil client and an evil server can collude against a second, unsuspecting client, to serve it bad data.  In particular, an evil client could choose two different server-side key halves that transform the encrypted data into two different plaintext outputs, and instruct the server to give different keys out to different clients.  This works because the server-side key has no relationship with the overall block ID that is verifiable from the global merkle tree, and so the server is free to give different keys to different clients.

In the new scheme, HMAC-SHA512 is used instead of xor to produce both the encryption key and the nonce.  This nonce (as before) is included in the data that hashes to the block ID (and thus makes its way into the merkle tree), which means an evil server can no longer give different keys to different clients without being detected.

To be clear, this is a preventative safety measure to mitigate the unlikely (and thus far, unseen) scenario of an evil client colluding with an evil server.  This PR just introduces the necessary crypto library functions.  Future PRs will put them to use when decrypting and encrypting blocks.

Issue: KBFS-3457