### PR TITLE
crypto_common: decrypt v2 data blocks, and option for encrypting

### DIFF
--- a/kbfsblock/id.go
+++ b/kbfsblock/id.go
@@ -94,6 +94,12 @@ func (id *ID) UnmarshalText(buf []byte) error {
 	return id.h.UnmarshalText(buf)
 }
 
+// UseV2 returns true if the caller should employ v2
+// encryption/decryption on the block represented by this ID.
+func (id *ID) UseV2() bool {
+	return id.h.GetHashType() == kbfshash.SHA256HashV2
+}
+
 // MakeTemporaryID generates a temporary block ID using a CSPRNG. This
 // is used for indirect blocks before they're committed to the server.
 func MakeTemporaryID() (ID, error) {

--- a/kbfscrypto/encrypted_data.go
+++ b/kbfscrypto/encrypted_data.go
@@ -203,6 +203,11 @@ type EncryptedBlock struct {
 	encryptedData
 }
 
+// UsesV2 returns true if this block uses V2 encryption.
+func (eb EncryptedBlock) UsesV2() bool {
+	return eb.encryptedData.Version == EncryptionSecretboxWithKeyNonce
+}
+
 // EncryptPaddedEncodedBlock encrypts a padded, encoded block.
 func EncryptPaddedEncodedBlock(paddedEncodedBlock []byte, key BlockCryptKey) (
 	encryptedBlock EncryptedBlock, err error) {

--- a/kbfshash/hash_test.go
+++ b/kbfshash/hash_test.go
@@ -115,7 +115,12 @@ func TestHashVerify(t *testing.T) {
 	err = invalidH.Verify(data)
 	require.Equal(t, InvalidHashError{invalidH}, errors.Cause(err))
 
-	unknownType := validH.hashType() + 1
+	// v2 should verify the same way as v1.
+	v2ValidH := hashFromRawNoCheck(SHA256HashV2, validH.hashData())
+	err = v2ValidH.Verify(data)
+	require.NoError(t, err)
+
+	unknownType := validH.hashType() + 2
 	unknownH := hashFromRawNoCheck(unknownType, validH.hashData())
 	err = unknownH.Verify(data)
 	require.Equal(t, UnknownHashTypeError{unknownType}, errors.Cause(err))

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -7,7 +7,6 @@ package libkbfs
 import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
@@ -128,8 +127,8 @@ func (b *BlockOpsStandard) Ready(ctx context.Context, kmd KeyMetadata,
 		return
 	}
 
-	blockKey := kbfscrypto.UnmaskBlockCryptKey(serverHalf, tlfCryptKey)
-	plainSize, encryptedBlock, err := crypto.EncryptBlock(block, blockKey)
+	plainSize, encryptedBlock, err := crypto.EncryptBlock(
+		block, tlfCryptKey, serverHalf)
 	if err != nil {
 		return
 	}

--- a/libkbfs/bsplitter_simple_test.go
+++ b/libkbfs/bsplitter_simple_test.go
@@ -158,7 +158,7 @@ func TestBsplitterOverhead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Encoding block failed: %v", err)
 	}
-	crypto := MakeCryptoCommon(codec)
+	crypto := MakeCryptoCommon(codec, makeBlockCryptV1())
 	paddedBlock, err := crypto.padBlock(encodedBlock)
 	if err != nil {
 		t.Fatalf("Padding block failed: %v", err)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -838,6 +838,11 @@ func (c *ConfigLocal) DataVersion() DataVer {
 	return IndirectDirsDataVer
 }
 
+// BlockCryptVersion implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) BlockCryptVersion() kbfscrypto.EncryptionVer {
+	return kbfscrypto.EncryptionSecretbox
+}
+
 // DefaultBlockType implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) DefaultBlockType() keybase1.BlockType {
 	c.lock.RLock()

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -118,7 +118,7 @@ func TestCRInput(t *testing.T) {
 	unmergedHead := kbfsmd.Revision(5)
 	mergedHead := kbfsmd.Revision(15)
 
-	crypto := MakeCryptoCommon(config.Codec())
+	crypto := MakeCryptoCommon(config.Codec(), makeBlockCryptV1())
 	bid, err := crypto.MakeRandomBranchID()
 	if err != nil {
 		t.Fatalf("Branch id err: %+v", bid)
@@ -180,7 +180,7 @@ func TestCRInputFracturedRange(t *testing.T) {
 	unmergedHead := kbfsmd.Revision(5)
 	mergedHead := kbfsmd.Revision(15)
 
-	crypto := MakeCryptoCommon(config.Codec())
+	crypto := MakeCryptoCommon(config.Codec(), makeBlockCryptV1())
 	bid, err := crypto.MakeRandomBranchID()
 	if err != nil {
 		t.Fatalf("Branch id err: %+v", bid)

--- a/libkbfs/crypto_client_rpc.go
+++ b/libkbfs/crypto_client_rpc.go
@@ -29,7 +29,7 @@ func NewCryptoClientRPC(config Config, kbCtx Context) *CryptoClientRPC {
 	deferLog := log.CloneWithAddedDepth(1)
 	c := &CryptoClientRPC{
 		CryptoClient: CryptoClient{
-			CryptoCommon: MakeCryptoCommon(config.Codec()),
+			CryptoCommon: MakeCryptoCommon(config.Codec(), config),
 			log:          log,
 			deferLog:     deferLog,
 		},
@@ -47,7 +47,7 @@ func newCryptoClientWithClient(codec kbfscodec.Codec, log logger.Logger, client 
 	deferLog := log.CloneWithAddedDepth(1)
 	return &CryptoClientRPC{
 		CryptoClient: CryptoClient{
-			CryptoCommon: MakeCryptoCommon(codec),
+			CryptoCommon: MakeCryptoCommon(codec, nil),
 			log:          log,
 			deferLog:     deferLog,
 			client:       keybase1.CryptoClient{Cli: client},

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -33,7 +33,8 @@ func NewFakeCryptoClient(
 	cryptPrivateKey kbfscrypto.CryptPrivateKey, readyChan chan<- struct{},
 	goChan <-chan struct{}) *FakeCryptoClient {
 	return &FakeCryptoClient{
-		Local:     NewCryptoLocal(codec, signingKey, cryptPrivateKey),
+		Local: NewCryptoLocal(
+			codec, signingKey, cryptPrivateKey, makeBlockCryptV1()),
 		readyChan: readyChan,
 		goChan:    goChan,
 	}

--- a/libkbfs/crypto_local.go
+++ b/libkbfs/crypto_local.go
@@ -35,9 +35,10 @@ var _ Crypto = (*CryptoLocal)(nil)
 // signing key.
 func NewCryptoLocal(codec kbfscodec.Codec,
 	signingKey kbfscrypto.SigningKey,
-	cryptPrivateKey kbfscrypto.CryptPrivateKey) *CryptoLocal {
+	cryptPrivateKey kbfscrypto.CryptPrivateKey,
+	blockCryptVersioner blockCryptVersioner) *CryptoLocal {
 	return &CryptoLocal{
-		MakeCryptoCommon(codec),
+		MakeCryptoCommon(codec, blockCryptVersioner),
 		kbfscrypto.SigningKeySigner{Key: signingKey},
 		cryptPrivateKey,
 		make(map[keybase1.TeamID]perTeamKeyPairs),

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -29,7 +29,7 @@ func setupDirDataTest(t *testing.T, maxPtrsPerBlock, numDirEntries int) (
 	id := tlf.FakeID(1, tlf.Private)
 	dir := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "dir"}}}
 	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
-	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
+	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack(), makeBlockCryptV1())
 	bsplit := &BlockSplitterSimple{10, maxPtrsPerBlock, 10, numDirEntries}
 	kmd := emptyKeyMetadata{id, 1}
 

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -30,7 +30,7 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 	id := tlf.FakeID(1, tlf.Private)
 	file := path{FolderBranch{Tlf: id}, []pathNode{{ptr, "file"}}}
 	chargedTo := keybase1.MakeTestUID(1).AsUserOrTeam()
-	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
+	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack(), makeBlockCryptV1())
 	bsplit := &BlockSplitterSimple{maxBlockSize, maxPtrsPerBlock, 10, 0}
 	kmd := emptyKeyMetadata{id, 1}
 
@@ -368,7 +368,7 @@ func testFileDataLevelExistingBlocks(t *testing.T, fd *fileData,
 
 	// Now fill in any parents.
 	numLevels := 1
-	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack())
+	crypto := MakeCryptoCommon(kbfscodec.NewMsgpack(), makeBlockCryptV1())
 	for len(prevChildren) != 1 {
 		prevChildIndex := 0
 		var level []*FileBlock

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1266,14 +1266,18 @@ type cryptoPure interface {
 	// EncryptBlocks encrypts a block. plainSize is the size of the encoded
 	// block; EncryptBlock() must guarantee that plainSize <=
 	// len(encryptedBlock).
-	EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (
+	EncryptBlock(
+		block Block, tlfCryptKey kbfscrypto.TLFCryptKey,
+		blockServerHalf kbfscrypto.BlockCryptKeyServerHalf) (
 		plainSize int, encryptedBlock kbfscrypto.EncryptedBlock, err error)
 
 	// DecryptBlock decrypts a block. Similar to EncryptBlock(),
 	// DecryptBlock() must guarantee that (size of the decrypted
 	// block) <= len(encryptedBlock).
-	DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock,
-		key kbfscrypto.BlockCryptKey, block Block) error
+	DecryptBlock(
+		encryptedBlock kbfscrypto.EncryptedBlock,
+		tlfCryptKey kbfscrypto.TLFCryptKey,
+		blockServerHalf kbfscrypto.BlockCryptKeyServerHalf, block Block) error
 }
 
 // Crypto signs, verifies, encrypts, and decrypts stuff.
@@ -2037,11 +2041,18 @@ type initModeGetter interface {
 	IsTestMode() bool
 }
 
+type blockCryptVersioner interface {
+	// BlockCryptVersion returns the block encryption version to be used for
+	// new blocks.
+	BlockCryptVersion() kbfscrypto.EncryptionVer
+}
+
 // Config collects all the singleton instance instantiations needed to
 // run KBFS in one place.  The methods below are self-explanatory and
 // do not require comments.
 type Config interface {
 	dataVersioner
+	blockCryptVersioner
 	logMaker
 	blockCacher
 	blockServerGetter

--- a/libkbfs/key_manager_test.go
+++ b/libkbfs/key_manager_test.go
@@ -53,7 +53,7 @@ func keyManagerInit(t *testing.T, ver kbfsmd.MetadataVer) (mockCtrl *gomock.Cont
 	ctx = context.Background()
 	codec := kbfscodec.NewMsgpack()
 	config.SetCodec(codec)
-	cryptoPure := MakeCryptoCommon(codec)
+	cryptoPure := MakeCryptoCommon(codec, makeBlockCryptV1())
 	config.SetCrypto(shimKMCrypto{config.Crypto(), cryptoPure})
 	config.SetMetadataVersion(ver)
 

--- a/libkbfs/keybase_daemon.go
+++ b/libkbfs/keybase_daemon.go
@@ -124,7 +124,7 @@ func (k keybaseDaemon) NewCrypto(config Config, params InitParams, ctx Context, 
 		signingKey := MakeLocalUserSigningKeyOrBust(localUser)
 		cryptPrivateKey := MakeLocalUserCryptPrivateKeyOrBust(localUser)
 		crypto = NewCryptoLocal(
-			config.Codec(), signingKey, cryptPrivateKey)
+			config.Codec(), signingKey, cryptPrivateKey, config)
 	}
 	return crypto, nil
 }

--- a/libkbfs/md_journal_test.go
+++ b/libkbfs/md_journal_test.go
@@ -44,7 +44,7 @@ func setupMDJournalTest(t testing.TB, ver kbfsmd.MetadataVer) (
 	signer kbfscrypto.Signer, ekg singleEncryptionKeyGetter,
 	bsplit BlockSplitter, tempdir string, j *mdJournal) {
 	codec = kbfscodec.NewMsgpack()
-	crypto = MakeCryptoCommon(codec)
+	crypto = MakeCryptoCommon(codec, makeBlockCryptV1())
 
 	uid := keybase1.MakeTestUID(1)
 	tlfID = tlf.FakeID(1, tlf.Private)
@@ -731,7 +731,7 @@ func testMDJournalResolveAndClear(t *testing.T, ver kbfsmd.MetadataVer, bid kbfs
 
 func testMDJournalResolveAndClearRemoteBranch(t *testing.T, ver kbfsmd.MetadataVer) {
 	codec := kbfscodec.NewMsgpack()
-	crypto := MakeCryptoCommon(codec)
+	crypto := MakeCryptoCommon(codec, makeBlockCryptV1())
 	bid, err := crypto.MakeRandomBranchID()
 	require.NoError(t, err)
 	testMDJournalResolveAndClear(t, ver, bid)

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -49,7 +49,7 @@ func injectShimCrypto(config Config) {
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("test key")
 	crypto := shimCrypto{
 		config.Crypto(),
-		MakeCryptoCommon(kbfscodec.NewMsgpack()),
+		MakeCryptoCommon(kbfscodec.NewMsgpack(), makeBlockCryptV1()),
 		signingKey,
 	}
 	config.SetCrypto(crypto)

--- a/libkbfs/mdserver_local_config_test.go
+++ b/libkbfs/mdserver_local_config_test.go
@@ -35,7 +35,7 @@ func newTestMDServerLocalConfig(
 		codecGetter: cg,
 		logMaker:    newTestLogMaker(t),
 		clock:       newTestClockNow(),
-		crypto:      MakeCryptoCommon(cg.Codec()),
+		crypto:      MakeCryptoCommon(cg.Codec(), makeBlockCryptV1()),
 		csg:         csg,
 	}
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4317,8 +4317,8 @@ func (mr *MockcryptoPureMockRecorder) DecryptPrivateMetadata(encryptedPMD, key i
 }
 
 // EncryptBlock mocks base method
-func (m *MockcryptoPure) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (int, kbfscrypto.EncryptedBlock, error) {
-	ret := m.ctrl.Call(m, "EncryptBlock", block, key)
+func (m *MockcryptoPure) EncryptBlock(block Block, tlfCryptKey kbfscrypto.TLFCryptKey, blockServerHalf kbfscrypto.BlockCryptKeyServerHalf) (int, kbfscrypto.EncryptedBlock, error) {
+	ret := m.ctrl.Call(m, "EncryptBlock", block, tlfCryptKey, blockServerHalf)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(kbfscrypto.EncryptedBlock)
 	ret2, _ := ret[2].(error)
@@ -4326,20 +4326,20 @@ func (m *MockcryptoPure) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey)
 }
 
 // EncryptBlock indicates an expected call of EncryptBlock
-func (mr *MockcryptoPureMockRecorder) EncryptBlock(block, key interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptBlock", reflect.TypeOf((*MockcryptoPure)(nil).EncryptBlock), block, key)
+func (mr *MockcryptoPureMockRecorder) EncryptBlock(block, tlfCryptKey, blockServerHalf interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptBlock", reflect.TypeOf((*MockcryptoPure)(nil).EncryptBlock), block, tlfCryptKey, blockServerHalf)
 }
 
 // DecryptBlock mocks base method
-func (m *MockcryptoPure) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey, block Block) error {
-	ret := m.ctrl.Call(m, "DecryptBlock", encryptedBlock, key, block)
+func (m *MockcryptoPure) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock, tlfCryptKey kbfscrypto.TLFCryptKey, blockServerHalf kbfscrypto.BlockCryptKeyServerHalf, block Block) error {
+	ret := m.ctrl.Call(m, "DecryptBlock", encryptedBlock, tlfCryptKey, blockServerHalf, block)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DecryptBlock indicates an expected call of DecryptBlock
-func (mr *MockcryptoPureMockRecorder) DecryptBlock(encryptedBlock, key, block interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptBlock", reflect.TypeOf((*MockcryptoPure)(nil).DecryptBlock), encryptedBlock, key, block)
+func (mr *MockcryptoPureMockRecorder) DecryptBlock(encryptedBlock, tlfCryptKey, blockServerHalf, block interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptBlock", reflect.TypeOf((*MockcryptoPure)(nil).DecryptBlock), encryptedBlock, tlfCryptKey, blockServerHalf, block)
 }
 
 // MockCrypto is a mock of Crypto interface
@@ -4486,8 +4486,8 @@ func (mr *MockCryptoMockRecorder) DecryptPrivateMetadata(encryptedPMD, key inter
 }
 
 // EncryptBlock mocks base method
-func (m *MockCrypto) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (int, kbfscrypto.EncryptedBlock, error) {
-	ret := m.ctrl.Call(m, "EncryptBlock", block, key)
+func (m *MockCrypto) EncryptBlock(block Block, tlfCryptKey kbfscrypto.TLFCryptKey, blockServerHalf kbfscrypto.BlockCryptKeyServerHalf) (int, kbfscrypto.EncryptedBlock, error) {
+	ret := m.ctrl.Call(m, "EncryptBlock", block, tlfCryptKey, blockServerHalf)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(kbfscrypto.EncryptedBlock)
 	ret2, _ := ret[2].(error)
@@ -4495,20 +4495,20 @@ func (m *MockCrypto) EncryptBlock(block Block, key kbfscrypto.BlockCryptKey) (in
 }
 
 // EncryptBlock indicates an expected call of EncryptBlock
-func (mr *MockCryptoMockRecorder) EncryptBlock(block, key interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptBlock", reflect.TypeOf((*MockCrypto)(nil).EncryptBlock), block, key)
+func (mr *MockCryptoMockRecorder) EncryptBlock(block, tlfCryptKey, blockServerHalf interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncryptBlock", reflect.TypeOf((*MockCrypto)(nil).EncryptBlock), block, tlfCryptKey, blockServerHalf)
 }
 
 // DecryptBlock mocks base method
-func (m *MockCrypto) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock, key kbfscrypto.BlockCryptKey, block Block) error {
-	ret := m.ctrl.Call(m, "DecryptBlock", encryptedBlock, key, block)
+func (m *MockCrypto) DecryptBlock(encryptedBlock kbfscrypto.EncryptedBlock, tlfCryptKey kbfscrypto.TLFCryptKey, blockServerHalf kbfscrypto.BlockCryptKeyServerHalf, block Block) error {
+	ret := m.ctrl.Call(m, "DecryptBlock", encryptedBlock, tlfCryptKey, blockServerHalf, block)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DecryptBlock indicates an expected call of DecryptBlock
-func (mr *MockCryptoMockRecorder) DecryptBlock(encryptedBlock, key, block interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptBlock", reflect.TypeOf((*MockCrypto)(nil).DecryptBlock), encryptedBlock, key, block)
+func (mr *MockCryptoMockRecorder) DecryptBlock(encryptedBlock, tlfCryptKey, blockServerHalf, block interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptBlock", reflect.TypeOf((*MockCrypto)(nil).DecryptBlock), encryptedBlock, tlfCryptKey, blockServerHalf, block)
 }
 
 // Sign mocks base method
@@ -6916,6 +6916,41 @@ func (mr *MockinitModeGetterMockRecorder) IsTestMode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTestMode", reflect.TypeOf((*MockinitModeGetter)(nil).IsTestMode))
 }
 
+// MockblockCryptVersioner is a mock of blockCryptVersioner interface
+type MockblockCryptVersioner struct {
+	ctrl     *gomock.Controller
+	recorder *MockblockCryptVersionerMockRecorder
+}
+
+// MockblockCryptVersionerMockRecorder is the mock recorder for MockblockCryptVersioner
+type MockblockCryptVersionerMockRecorder struct {
+	mock *MockblockCryptVersioner
+}
+
+// NewMockblockCryptVersioner creates a new mock instance
+func NewMockblockCryptVersioner(ctrl *gomock.Controller) *MockblockCryptVersioner {
+	mock := &MockblockCryptVersioner{ctrl: ctrl}
+	mock.recorder = &MockblockCryptVersionerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockblockCryptVersioner) EXPECT() *MockblockCryptVersionerMockRecorder {
+	return m.recorder
+}
+
+// BlockCryptVersion mocks base method
+func (m *MockblockCryptVersioner) BlockCryptVersion() kbfscrypto.EncryptionVer {
+	ret := m.ctrl.Call(m, "BlockCryptVersion")
+	ret0, _ := ret[0].(kbfscrypto.EncryptionVer)
+	return ret0
+}
+
+// BlockCryptVersion indicates an expected call of BlockCryptVersion
+func (mr *MockblockCryptVersionerMockRecorder) BlockCryptVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockCryptVersion", reflect.TypeOf((*MockblockCryptVersioner)(nil).BlockCryptVersion))
+}
+
 // MockConfig is a mock of Config interface
 type MockConfig struct {
 	ctrl     *gomock.Controller
@@ -6949,6 +6984,18 @@ func (m *MockConfig) DataVersion() DataVer {
 // DataVersion indicates an expected call of DataVersion
 func (mr *MockConfigMockRecorder) DataVersion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DataVersion", reflect.TypeOf((*MockConfig)(nil).DataVersion))
+}
+
+// BlockCryptVersion mocks base method
+func (m *MockConfig) BlockCryptVersion() kbfscrypto.EncryptionVer {
+	ret := m.ctrl.Call(m, "BlockCryptVersion")
+	ret0, _ := ret[0].(kbfscrypto.EncryptionVer)
+	return ret0
+}
+
+// BlockCryptVersion indicates an expected call of BlockCryptVersion
+func (mr *MockConfigMockRecorder) BlockCryptVersion() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockCryptVersion", reflect.TypeOf((*MockConfig)(nil).BlockCryptVersion))
 }
 
 // MakeLogger mocks base method

--- a/libkbfs/test_common.go
+++ b/libkbfs/test_common.go
@@ -153,7 +153,8 @@ func MakeTestConfigOrBustLoggedInWithMode(
 
 	signingKey := MakeLocalUserSigningKeyOrBust(loggedInUser.Name)
 	cryptPrivateKey := MakeLocalUserCryptPrivateKeyOrBust(loggedInUser.Name)
-	crypto := NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey)
+	crypto := NewCryptoLocal(
+		config.Codec(), signingKey, cryptPrivateKey, config)
 	config.SetCrypto(crypto)
 
 	blockServer := MakeTestBlockServerOrBust(
@@ -272,7 +273,8 @@ func ConfigAsUserWithMode(config *ConfigLocal,
 
 	signingKey := MakeLocalUserSigningKeyOrBust(loggedInUser)
 	cryptPrivateKey := MakeLocalUserCryptPrivateKeyOrBust(loggedInUser)
-	crypto := NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey)
+	crypto := NewCryptoLocal(
+		config.Codec(), signingKey, cryptPrivateKey, config)
 	c.SetCrypto(crypto)
 	c.noBGFlush = config.noBGFlush
 
@@ -423,7 +425,7 @@ func SwitchDeviceForLocalUserOrBust(t logger.TestLogBackend, config Config, inde
 	signingKey := MakeLocalUserSigningKeyOrBust(keySalt)
 	cryptPrivateKey := MakeLocalUserCryptPrivateKeyOrBust(keySalt)
 	config.SetCrypto(
-		NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey))
+		NewCryptoLocal(config.Codec(), signingKey, cryptPrivateKey, config))
 }
 
 // AddNewAssertionForTest makes newAssertion, which should be a single

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -219,7 +219,8 @@ func setupTLFJournalTest(
 	codec := kbfscodec.NewMsgpack()
 	signingKey := kbfscrypto.MakeFakeSigningKeyOrBust("client sign")
 	cryptPrivateKey := kbfscrypto.MakeFakeCryptPrivateKeyOrBust("client crypt private")
-	crypto := NewCryptoLocal(codec, signingKey, cryptPrivateKey)
+	crypto := NewCryptoLocal(
+		codec, signingKey, cryptPrivateKey, makeBlockCryptV1())
 	uid := keybase1.MakeTestUID(1)
 	verifyingKey := signingKey.GetVerifyingKey()
 	ekg := singleEncryptionKeyGetter{kbfscrypto.MakeTLFCryptKey([32]byte{0x1})}


### PR DESCRIPTION
This changes the `cryptoPure` block-related interfaces to pass in the TLF crypt key and block server half explicitly, so that `CryptoCommon` can make a decision about the right way to construct the block key and encrypt/decrypt the data.  With this commit, clients are able to understand v2 blocks.

This also adds an option to `CryptoCommon` for encrypting the data in the new format, though it's off by default except in select tests.  A future commit will wire the option to a command line argument.

It also adds a new `02` prefix for block ID hashes, and ensures that any v2-encrypted blocks use one of these new ID hashes.  This will make it easier in the future for the block server to quickly recognize to policy which blocks are using the new scheme, without decoding the block's buffer into a struct.

Issue: KBFS-3458
