### PR TITLE
init: add command line flag for setting encryption version

### DIFF
--- a/kbfsblock/id.go
+++ b/kbfsblock/id.go
@@ -158,6 +158,16 @@ func MakePermanentID(encodedEncryptedData []byte) (ID, error) {
 	return ID{h}, nil
 }
 
+// MakePermanentIDV2 computes the permanent ID of a block given its
+// encoded and encrypted contents using v2 encryption.
+func MakePermanentIDV2(encodedEncryptedData []byte) (ID, error) {
+	h, err := kbfshash.HashV2(encodedEncryptedData)
+	if err != nil {
+		return ID{}, err
+	}
+	return ID{h}, nil
+}
+
 // VerifyID verifies that the given block ID is the permanent block ID
 // for the given encoded and encrypted data.
 func VerifyID(encodedEncryptedData []byte, id ID) error {

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -111,6 +111,10 @@ func (config testBlockOpsConfig) DataVersion() DataVer {
 	return ChildHolesDataVer
 }
 
+func (config testBlockOpsConfig) BlockCryptVersion() kbfscrypto.EncryptionVer {
+	return kbfscrypto.EncryptionSecretbox
+}
+
 func makeTestBlockOpsConfig(t *testing.T) testBlockOpsConfig {
 	lm := newTestLogMaker(t)
 	codecGetter := newTestCodecGetter()

--- a/libkbfs/chat_local.go
+++ b/libkbfs/chat_local.go
@@ -75,7 +75,7 @@ func newChatLocal(config Config) *chatLocal {
 		convs:     make(convLocalByTypeMap),
 		convsByID: make(convLocalByIDMap),
 		newChannelCBs: map[Config]newConvCB{
-			config: config.KBFSOps().NewNotificationChannel,
+			config: nil,
 		},
 	})
 }
@@ -142,6 +142,10 @@ func (c *chatLocal) GetConversationID(
 		}
 		if !isReader {
 			continue
+		}
+
+		if cb == nil && config.KBFSOps() != nil {
+			cb = config.KBFSOps().NewNotificationChannel
 		}
 
 		cb(ctx, h, id, channelName)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2124,6 +2124,7 @@ type Config interface {
 	SetUserHistory(*kbfsedits.UserHistory)
 	MetadataVersion() kbfsmd.MetadataVer
 	SetMetadataVersion(kbfsmd.MetadataVer)
+	SetBlockCryptVersion(kbfscrypto.EncryptionVer)
 	DefaultBlockType() keybase1.BlockType
 	SetDefaultBlockType(blockType keybase1.BlockType)
 	RekeyQueue() RekeyQueue

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -7800,6 +7800,16 @@ func (mr *MockConfigMockRecorder) SetMetadataVersion(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMetadataVersion", reflect.TypeOf((*MockConfig)(nil).SetMetadataVersion), arg0)
 }
 
+// SetBlockCryptVersion mocks base method
+func (m *MockConfig) SetBlockCryptVersion(arg0 kbfscrypto.EncryptionVer) {
+	m.ctrl.Call(m, "SetBlockCryptVersion", arg0)
+}
+
+// SetBlockCryptVersion indicates an expected call of SetBlockCryptVersion
+func (mr *MockConfigMockRecorder) SetBlockCryptVersion(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBlockCryptVersion", reflect.TypeOf((*MockConfig)(nil).SetBlockCryptVersion), arg0)
+}
+
 // DefaultBlockType mocks base method
 func (m *MockConfig) DefaultBlockType() keybase1.BlockType {
 	ret := m.ctrl.Call(m, "DefaultBlockType")


### PR DESCRIPTION
And use it in `BlockOpsStandard` to choose the hash type for the block.  Tested on a local instance of KBFS.

This also includes a small fix in `ChatLocal` to avoid a panic when starting up in local mode.


Issue: KBFS-3459