### PR TITLE
always set the number on pagination param when fetching chat threads CORE-9096

### DIFF
--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -490,17 +490,20 @@ func (c *ChatRPC) GetChannels(
 	return convIDs, channelNames, nil
 }
 
+const readChannelPageSize = 100
+
 // ReadChannel implements the Chat interface.
 func (c *ChatRPC) ReadChannel(
 	ctx context.Context, convID chat1.ConversationID, startPage []byte) (
 	messages []string, nextPage []byte, err error) {
-	var pagination *chat1.Pagination
+	pagination := &chat1.Pagination{Num: readChannelPageSize}
 	if startPage != nil {
-		pagination = &chat1.Pagination{Next: startPage}
+		pagination = &chat1.Pagination{Num: readChannelPageSize, Next: startPage}
 	}
 	arg := chat1.GetThreadLocalArg{
 		ConversationID:   convID,
 		Pagination:       pagination,
+		Reason:           chat1.GetThreadReason_KBFSFILEACTIVITY,
 		IdentifyBehavior: keybase1.TLFIdentifyBehavior_KBFS_CHAT,
 	}
 	res, err := c.client.GetThreadLocal(ctx, arg)

--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -536,7 +536,7 @@ func (c *ChatRPC) ReadChannel(
 		}
 
 	}
-	if res.Thread.Pagination != nil {
+	if res.Thread.Pagination != nil && !res.Thread.Pagination.Last {
 		nextPage = res.Thread.Pagination.Next
 	}
 	return messages, nextPage, nil

--- a/libkbfs/chat_rpc.go
+++ b/libkbfs/chat_rpc.go
@@ -498,7 +498,7 @@ func (c *ChatRPC) ReadChannel(
 	messages []string, nextPage []byte, err error) {
 	pagination := &chat1.Pagination{Num: readChannelPageSize}
 	if startPage != nil {
-		pagination = &chat1.Pagination{Num: readChannelPageSize, Next: startPage}
+		pagination.Next = startPage
 	}
 	arg := chat1.GetThreadLocalArg{
 		ConversationID:   convID,

--- a/vendor/github.com/keybase/client/go/protocol/chat1/chat_ui.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/chat_ui.go
@@ -422,20 +422,30 @@ func (o UIAssetUrlInfo) DeepCopy() UIAssetUrlInfo {
 }
 
 type UIPaymentInfo struct {
+	AccountID         *stellar1.AccountID    `codec:"accountID,omitempty" json:"accountID,omitempty"`
 	AmountDescription string                 `codec:"amountDescription" json:"amountDescription"`
 	Worth             string                 `codec:"worth" json:"worth"`
 	Delta             stellar1.BalanceDelta  `codec:"delta" json:"delta"`
 	Note              string                 `codec:"note" json:"note"`
+	PaymentID         stellar1.PaymentID     `codec:"paymentID" json:"paymentID"`
 	Status            stellar1.PaymentStatus `codec:"status" json:"status"`
 	StatusDescription string                 `codec:"statusDescription" json:"statusDescription"`
 }
 
 func (o UIPaymentInfo) DeepCopy() UIPaymentInfo {
 	return UIPaymentInfo{
+		AccountID: (func(x *stellar1.AccountID) *stellar1.AccountID {
+			if x == nil {
+				return nil
+			}
+			tmp := (*x).DeepCopy()
+			return &tmp
+		})(o.AccountID),
 		AmountDescription: o.AmountDescription,
 		Worth:             o.Worth,
 		Delta:             o.Delta.DeepCopy(),
 		Note:              o.Note,
+		PaymentID:         o.PaymentID.DeepCopy(),
 		Status:            o.Status.DeepCopy(),
 		StatusDescription: o.StatusDescription,
 	}

--- a/vendor/github.com/keybase/client/go/protocol/chat1/common.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/common.go
@@ -1821,6 +1821,7 @@ const (
 	GetThreadReason_PREPARE            GetThreadReason = 5
 	GetThreadReason_SEARCHER           GetThreadReason = 6
 	GetThreadReason_INDEXED_SEARCH     GetThreadReason = 7
+	GetThreadReason_KBFSFILEACTIVITY   GetThreadReason = 8
 )
 
 func (o GetThreadReason) DeepCopy() GetThreadReason { return o }
@@ -1834,6 +1835,7 @@ var GetThreadReasonMap = map[string]GetThreadReason{
 	"PREPARE":            5,
 	"SEARCHER":           6,
 	"INDEXED_SEARCH":     7,
+	"KBFSFILEACTIVITY":   8,
 }
 
 var GetThreadReasonRevMap = map[GetThreadReason]string{
@@ -1845,6 +1847,7 @@ var GetThreadReasonRevMap = map[GetThreadReason]string{
 	5: "PREPARE",
 	6: "SEARCHER",
 	7: "INDEXED_SEARCH",
+	8: "KBFSFILEACTIVITY",
 }
 
 func (e GetThreadReason) String() string {

--- a/vendor/github.com/keybase/client/go/protocol/chat1/extras.go
+++ b/vendor/github.com/keybase/client/go/protocol/chat1/extras.go
@@ -1108,6 +1108,10 @@ func (r *DownloadAttachmentLocalRes) SetOffline() {
 	r.Offline = true
 }
 
+func (r *DownloadFileAttachmentLocalRes) SetOffline() {
+	r.Offline = true
+}
+
 func (r *FindConversationsLocalRes) SetOffline() {
 	r.Offline = true
 }
@@ -1334,6 +1338,14 @@ func (r *DownloadAttachmentLocalRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimits = rl
 }
 
+func (r *DownloadFileAttachmentLocalRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *DownloadFileAttachmentLocalRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
 func (r *FindConversationsLocalRes) GetRateLimit() []RateLimit {
 	return r.RateLimits
 }
@@ -1379,6 +1391,14 @@ func (r *GetSearchRegexpRes) GetRateLimit() []RateLimit {
 }
 
 func (r *GetSearchRegexpRes) SetRateLimits(rl []RateLimit) {
+	r.RateLimits = rl
+}
+
+func (r *FullInboxSearchRes) GetRateLimit() []RateLimit {
+	return r.RateLimits
+}
+
+func (r *FullInboxSearchRes) SetRateLimits(rl []RateLimit) {
 	r.RateLimits = rl
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -304,10 +304,10 @@
 			"revisionTime": "2018-09-29T23:42:17Z"
 		},
 		{
-			"checksumSHA1": "5CoH8uMGVGf0WQH4GzEvLkb+X0s=",
+			"checksumSHA1": "Cr01JLpafAABQB59wgf9J4CXxjc=",
 			"path": "github.com/keybase/client/go/protocol/chat1",
-			"revision": "5652205fac3bae80c62bb976f13fbccd280e4089",
-			"revisionTime": "2018-09-29T23:42:17Z"
+			"revision": "c05545fda87aa2706a70949f17dcb5244f90b961",
+			"revisionTime": "2018-10-04T14:19:59Z"
 		},
 		{
 			"checksumSHA1": "4E1elcDjvoBWsIqrg2O3yPXziZw=",


### PR DESCRIPTION
Otherwise it would send 0 over on the subsequent pages and get 0 results.

Also, do we really need the entire thread? Can we check in this loop to see if we have enough data to reasonably render the widget? It seems like we can abort out of this loop and save a bunch of traffic.