### PR TITLE
tlf_handle_resolve: never skip implicit team resolution

### DIFF
--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -723,22 +723,8 @@ func (rit resolvableImplicitTeam) resolve(ctx context.Context) (
 	}, keybase1.SocialAssertion{}, iteamInfo.TlfID, nil
 }
 
-func doResolveImplicit(ctx context.Context, t tlf.Type) bool {
-	if t == tlf.SingleTeam {
-		return false
-	}
-
-	// Chat calls will never need us to resolve implicit teams for
-	// them.
-	switch getExtendedIdentify(ctx).behavior {
-	case keybase1.TLFIdentifyBehavior_CHAT_CLI,
-		keybase1.TLFIdentifyBehavior_CHAT_GUI,
-		keybase1.TLFIdentifyBehavior_CHAT_GUI_STRICT,
-		keybase1.TLFIdentifyBehavior_CHAT_SKIP:
-		return false
-	default:
-		return true
-	}
+func doResolveImplicit(_ context.Context, t tlf.Type) bool {
+	return t != tlf.SingleTeam
 }
 
 // parseTlfHandleLoose parses a TLF handle but leaves some of the canonicality


### PR DESCRIPTION
For non-single-team folders, we should always check whether something is an implicit team, now that we've started migrating TLFs.  This was originally intended to avoid extra implicit team calls for chat, but now that chat is all upgraded, it almost never calls into KBFS, so this shouldn't change the behavior at all.

Issue: KBFS-3480
