### PR TITLE
keybase_service_base: on an identify error, notify user breaks

### DIFF
--- a/libkbfs/identify_util.go
+++ b/libkbfs/identify_util.go
@@ -40,6 +40,20 @@ func (ei *extendedIdentify) userBreak(username kbname.NormalizedUsername, uid ke
 	}
 }
 
+func (ei *extendedIdentify) onError() {
+	if ei.userBreaks == nil {
+		return
+	}
+
+	// The identify got an error, so just send a nil breaks list so
+	// that the goroutine waiting on the breaks can finish and the
+	// error can be returned.
+	ei.userBreaks <- keybase1.TLFIdentifyFailure{
+		Breaks: nil,
+		User:   keybase1.User{},
+	}
+}
+
 func (ei *extendedIdentify) makeTlfBreaksIfNeeded(
 	ctx context.Context, numUserInTlf int) error {
 	if ei.userBreaks == nil {

--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -491,6 +491,8 @@ func (k *KeybaseServiceBase) Identify(ctx context.Context, assertion, reason str
 			"Ignoring error (%s) for user %s with no sigchain; "+
 				"error type=%T", err, res.Ul.Name, err)
 	default:
+		// If the caller is waiting for breaks, let them know we got an error.
+		ei.onError()
 		return kbname.NormalizedUsername(""), keybase1.UserOrTeamID(""),
 			ConvertIdentifyError(assertion, err)
 	}


### PR DESCRIPTION
Otherwise, the original identifier will hang because `makeTlfBreaksIfNeeded` won't return.

Issue: KBFS-3480