### PR TITLE
kbfscrypto: move encryption version switch to lower-level logic

### DIFF
--- a/kbfsblock/id.go
+++ b/kbfsblock/id.go
@@ -94,10 +94,9 @@ func (id *ID) UnmarshalText(buf []byte) error {
 	return id.h.UnmarshalText(buf)
 }
 
-// UseV2 returns true if the caller should employ v2
-// encryption/decryption on the block represented by this ID.
-func (id *ID) UseV2() bool {
-	return id.h.GetHashType() == kbfshash.SHA256HashV2
+// HashType returns the type used for this ID.
+func (id *ID) HashType() kbfshash.HashType {
+	return id.h.GetHashType()
 }
 
 // MakeTemporaryID generates a temporary block ID using a CSPRNG. This
@@ -150,18 +149,11 @@ func MakeRandomIDInRange(start, end float64) (ID, error) {
 
 // MakePermanentID computes the permanent ID of a block given its
 // encoded and encrypted contents.
-func MakePermanentID(encodedEncryptedData []byte) (ID, error) {
-	h, err := kbfshash.DefaultHash(encodedEncryptedData)
-	if err != nil {
-		return ID{}, err
-	}
-	return ID{h}, nil
-}
-
-// MakePermanentIDV2 computes the permanent ID of a block given its
-// encoded and encrypted contents using v2 encryption.
-func MakePermanentIDV2(encodedEncryptedData []byte) (ID, error) {
-	h, err := kbfshash.HashV2(encodedEncryptedData)
+func MakePermanentID(
+	encodedEncryptedData []byte, encryptionVer kbfscrypto.EncryptionVer) (
+	ID, error) {
+	h, err := kbfshash.DoHash(
+		encodedEncryptedData, encryptionVer.ToHashType())
 	if err != nil {
 		return ID{}, err
 	}

--- a/kbfscrypto/encrypted_data.go
+++ b/kbfscrypto/encrypted_data.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keybase/client/go/libkb"
 	"github.com/keybase/kbfs/cache"
 	"github.com/keybase/kbfs/kbfscodec"
+	"github.com/keybase/kbfs/kbfshash"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -35,8 +36,23 @@ func (v EncryptionVer) String() string {
 	switch v {
 	case EncryptionSecretbox:
 		return "EncryptionSecretbox"
+	case EncryptionSecretboxWithKeyNonce:
+		return "EncryptionSecretboxWithKeyNonce"
 	default:
 		return fmt.Sprintf("EncryptionVer(%d)", v)
+	}
+}
+
+// ToHashType returns the type of the hash that should be used for the
+// given encryption version.
+func (v EncryptionVer) ToHashType() kbfshash.HashType {
+	switch v {
+	case EncryptionSecretbox:
+		return kbfshash.SHA256Hash
+	case EncryptionSecretboxWithKeyNonce:
+		return kbfshash.SHA256HashV2
+	default:
+		return kbfshash.InvalidHash
 	}
 }
 
@@ -205,11 +221,6 @@ func DecryptPrivateMetadata(
 // EncryptedBlock is an encrypted Block object.
 type EncryptedBlock struct {
 	encryptedData
-}
-
-// UsesV2 returns true if this block uses V2 encryption.
-func (eb EncryptedBlock) UsesV2() bool {
-	return eb.encryptedData.Version == EncryptionSecretboxWithKeyNonce
 }
 
 // EncryptPaddedEncodedBlock encrypts a padded, encoded block.

--- a/libkbfs/block_disk_store_test.go
+++ b/libkbfs/block_disk_store_test.go
@@ -36,7 +36,7 @@ func teardownBlockDiskStoreTest(t *testing.T, tempdir string) {
 func putBlockDisk(
 	t *testing.T, s *blockDiskStore, data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
@@ -107,7 +107,7 @@ func TestBlockDiskStoreAddReference(t *testing.T) {
 	defer teardownBlockDiskStoreTest(t, tempdir)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	// Add a reference, which should succeed.
@@ -148,7 +148,7 @@ func TestBlockDiskStoreArchiveNonExistentReference(t *testing.T) {
 		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	// Archive references.

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -142,7 +142,7 @@ func putBlockData(
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
 	oldLength := j.length()
 
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
@@ -227,7 +227,7 @@ func TestBlockJournalDuplicatePut(t *testing.T) {
 
 	oldLength := j.length()
 
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	uid1 := keybase1.MakeTestUID(1)
@@ -262,7 +262,7 @@ func TestBlockJournalAddReference(t *testing.T) {
 	defer teardownBlockJournalTest(t, ctx, cancel, tempdir, j)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	// Add a reference, which should succeed.
@@ -304,7 +304,7 @@ func TestBlockJournalArchiveNonExistentReference(t *testing.T) {
 		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
 
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	// Archive references.
@@ -1048,7 +1048,8 @@ func TestBlockJournalByteCounters(t *testing.T) {
 	requireCounts(expectedSize, 2*filesPerBlockMax)
 
 	data3 := []byte{1, 2, 3}
-	bID3, err := kbfsblock.MakePermanentID(data3)
+	bID3, err := kbfsblock.MakePermanentID(
+		data3, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	_ = addBlockRef(ctx, t, j, bID3)
 	require.NoError(t, err)

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -7,7 +7,6 @@ package libkbfs
 import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
-	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/tlf"
 	"golang.org/x/net/context"
 )
@@ -154,12 +153,7 @@ func (b *BlockOpsStandard) Ready(ctx context.Context, kmd KeyMetadata,
 		return
 	}
 
-	switch b.config.BlockCryptVersion() {
-	case kbfscrypto.EncryptionSecretboxWithKeyNonce:
-		id, err = kbfsblock.MakePermanentIDV2(buf)
-	default:
-		id, err = kbfsblock.MakePermanentID(buf)
-	}
+	id, err = kbfsblock.MakePermanentID(buf, encryptedBlock.Version)
 	if err != nil {
 		return
 	}

--- a/libkbfs/block_util.go
+++ b/libkbfs/block_util.go
@@ -184,13 +184,13 @@ func assembleBlock(ctx context.Context, keyGetter blockKeyGetter,
 		return err
 	}
 
-	if idV2, blockV2 :=
-		blockPtr.ID.UseV2(), encryptedBlock.UsesV2(); idV2 != blockV2 {
-		// V2 block IDs MUST point to V2-encrypted blocks.
+	if idType, blockType :=
+		blockPtr.ID.HashType(),
+		encryptedBlock.Version.ToHashType(); idType != blockType {
 		return errors.Errorf(
 			"Block ID %s and encrypted block disagree on encryption method "+
-				"(block ID v2: %t, encrypted block v2: %t)",
-			blockPtr.ID, idV2, blockV2)
+				"(block ID: %s, encrypted block: %s)",
+			blockPtr.ID, idType, blockType)
 	}
 
 	// decrypt the block

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -101,7 +101,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	bCtx := kbfsblock.MakeFirstContext(
 		currentUID.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -253,9 +253,8 @@ func testDecryptEncryptedBlock(t *testing.T, c CryptoCommon) {
 		&block, tlfCryptKey, blockServerHalf)
 	require.NoError(t, err)
 
-	v2 := c.blockCryptVersioner.BlockCryptVersion() ==
-		kbfscrypto.EncryptionSecretboxWithKeyNonce
-	require.Equal(t, v2, encryptedBlock.UsesV2())
+	require.Equal(
+		t, c.blockCryptVersioner.BlockCryptVersion(), encryptedBlock.Version)
 
 	var decryptedBlock TestBlock
 	err = c.DecryptBlock(

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -355,16 +355,19 @@ func TestSecretboxEncryptedLen(t *testing.T) {
 	err := kbfscrypto.RandRead(randomData)
 	require.NoError(t, err)
 
-	cryptKeys := make([]kbfscrypto.BlockCryptKey, iterations)
+	cryptKeys := make([]kbfscrypto.TLFCryptKey, iterations)
+	serverHalfs := make([]kbfscrypto.BlockCryptKeyServerHalf, iterations)
 	for j := 0; j < iterations; j++ {
-		_, _, cryptKeys[j] = makeFakeBlockCryptKey(t)
+		cryptKeys[j], serverHalfs[j], _ = makeFakeBlockCryptKey(t)
 	}
 
 	for i := startSize; i < endSize; i += 1000 {
 		var enclen int
 		for j := 0; j < iterations; j++ {
 			data := randomData[j : j+i]
-			enc, err := kbfscrypto.EncryptPaddedEncodedBlock(data, cryptKeys[j])
+			enc, err := kbfscrypto.EncryptPaddedEncodedBlock(
+				data, cryptKeys[j], serverHalfs[j],
+				kbfscrypto.EncryptionSecretbox)
 			require.NoError(t, err)
 			if j == 0 {
 				enclen = len(enc.EncryptedData)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1992,7 +1992,8 @@ func (fbo *folderBranchOps) makeFakeDirEntry(
 	fbo.log.CDebugf(ctx, "Faking directory entry for %s", name)
 	dirPath := fbo.nodeCache.PathFromNode(dir)
 	id, err := kbfsblock.MakePermanentID(
-		[]byte(dirPath.ChildPathNoPtr(name).String()))
+		[]byte(dirPath.ChildPathNoPtr(name).String()),
+		fbo.config.BlockCryptVersion())
 	if err != nil {
 		return DirEntry{}, err
 	}
@@ -2092,7 +2093,8 @@ func (fbo *folderBranchOps) statUsingFS(
 	// within `fbo.nodeCache`.
 	nodePath := fbo.nodeCache.PathFromNode(node)
 	id, err := kbfsblock.MakePermanentID(
-		[]byte(nodePath.ChildPathNoPtr(name).String()))
+		[]byte(nodePath.ChildPathNoPtr(name).String()),
+		fbo.config.BlockCryptVersion())
 	if err != nil {
 		return DirEntry{}, false, err
 	}

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -99,7 +99,7 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	bCtx := kbfsblock.MakeFirstContext(
 		uid1.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 
 	// Put a block.

--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -201,7 +201,7 @@ func TestJournalServerOverQuotaError(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -312,7 +312,7 @@ func TestJournalServerOverDiskLimitError(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -378,7 +378,7 @@ func TestJournalServerRestart(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -451,7 +451,7 @@ func TestJournalServerLogOutLogIn(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -561,7 +561,8 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	bCtx1 := kbfsblock.MakeFirstContext(id1, keybase1.BlockType_DATA)
 	data1 := []byte{1, 2, 3, 4}
-	bID1, err := kbfsblock.MakePermanentID(data1)
+	bID1, err := kbfsblock.MakePermanentID(
+		data1, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf1, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -614,7 +615,8 @@ func TestJournalServerMultiUser(t *testing.T) {
 
 	bCtx2 := kbfsblock.MakeFirstContext(id2, keybase1.BlockType_DATA)
 	data2 := []byte{1, 2, 3, 4, 5}
-	bID2, err := kbfsblock.MakePermanentID(data2)
+	bID2, err := kbfsblock.MakePermanentID(
+		data2, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf2, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -726,7 +728,7 @@ func TestJournalServerEnableAuto(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -845,7 +847,7 @@ func TestJournalServerNukeEmptyJournalsOnRestart(t *testing.T) {
 	// Access a TLF, which should create a journal automatically.
 	bCtx := kbfsblock.MakeFirstContext(id, keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
@@ -914,7 +916,7 @@ func TestJournalServerTeamTLFWithRestart(t *testing.T) {
 	bCtx := kbfsblock.MakeFirstContext(
 		id.AsUserOrTeam(), keybase1.BlockType_DATA)
 	data := []byte{1, 2, 3, 4}
-	bID, err := kbfsblock.MakePermanentID(data)
+	bID, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(t, err)
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -162,7 +162,7 @@ func (c testTLFJournalConfig) BGFlushDirOpBatchSize() int {
 
 func (c testTLFJournalConfig) makeBlock(data []byte) (
 	kbfsblock.ID, kbfsblock.Context, kbfscrypto.BlockCryptKeyServerHalf) {
-	id, err := kbfsblock.MakePermanentID(data)
+	id, err := kbfsblock.MakePermanentID(data, kbfscrypto.EncryptionSecretbox)
 	require.NoError(c.t, err)
 	bCtx := kbfsblock.MakeFirstContext(
 		c.uid.AsUserOrTeam(), keybase1.BlockType_DATA)


### PR DESCRIPTION
And make hash type dependent on encryption type.

This is cleanup suggested by @akalin-keybase in #1836, #1837 and #1838.  It shouldn't change any logic.