### PR TITLE
disk_block_cache: put blocks in working set if sync cache is full

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -597,10 +597,10 @@ func (cache *DiskBlockCacheLocal) evictUntilBytesAvailable(
 // Put implements the DiskBlockCache interface for DiskBlockCacheStandard.
 func (cache *DiskBlockCacheLocal) Put(ctx context.Context, tlfID tlf.ID,
 	blockID kbfsblock.ID, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
 	cache.lock.Lock()
 	defer cache.lock.Unlock()
-	err := cache.checkCacheLocked("Put")
+	err = cache.checkCacheLocked("Put")
 	if err != nil {
 		return err
 	}
@@ -645,11 +645,6 @@ func (cache *DiskBlockCacheLocal) Put(ctx context.Context, tlfID tlf.ID,
 				return cachePutCacheFullError{blockID}
 			}
 		} else {
-			if cache.config.IsSyncedTlf(tlfID) {
-				// TODO: Make better error type
-				return errors.New("Attempted to add a block of a synced " +
-					"TLF to the working set disk cache.")
-			}
 			hasEnoughSpace, err := cache.evictUntilBytesAvailable(ctx, encodedLen)
 			if err != nil {
 				return err


### PR DESCRIPTION
Previously, if the sync cache was full, the overall cache put would fail (without logging an error, due to the unnamed return param). However, this means that when your synced directory is bigger than your disk cache, performance crawls to a halt in that directory because all new blocks need to be fetched again, even if there's room in the working set cache.

So, if the sync cache put fails, just put it in the working set and let eviction take care of it later.