### PR TITLE
identify: call userBreak callback on all paths

### DIFF
--- a/libkbfs/identify_util_test.go
+++ b/libkbfs/identify_util_test.go
@@ -52,7 +52,8 @@ func (ti *testIdentifier) Identify(
 					Remote: true,
 				}
 		}
-		ei.userBreak(userInfo.Name, userInfo.UID, &keybase1.IdentifyTrackBreaks{})
+		ei.userBreak(
+			ctx, userInfo.Name, userInfo.UID, &keybase1.IdentifyTrackBreaks{})
 		return userInfo.Name, userInfo.UID.AsUserOrTeam(), nil
 	}
 
@@ -71,7 +72,7 @@ func (ti *testIdentifier) Identify(
 		ti.identifiedIDs[userInfo.UID.AsUserOrTeam()] = true
 	}()
 
-	ei.userBreak(userInfo.Name, userInfo.UID, nil)
+	ei.userBreak(ctx, userInfo.Name, userInfo.UID, nil)
 	return userInfo.Name, userInfo.UID.AsUserOrTeam(), nil
 }
 

--- a/libkbfs/keybase_daemon_rpc_test.go
+++ b/libkbfs/keybase_daemon_rpc_test.go
@@ -168,7 +168,7 @@ func TestKeybaseDaemonSessionCache(t *testing.T) {
 	v := MakeLocalUserVerifyingKeyOrBust(name)
 	session := SessionInfo{
 		Name:           name,
-		UID:            keybase1.UID("fake uid"),
+		UID:            keybase1.MakeTestUID(1),
 		CryptPublicKey: k,
 		VerifyingKey:   v,
 	}
@@ -230,8 +230,8 @@ func testIdentify(
 
 // Test that the user cache works and is invalidated as expected.
 func TestKeybaseDaemonUserCache(t *testing.T) {
-	uid1 := keybase1.UID("uid1")
-	uid2 := keybase1.UID("uid2")
+	uid1 := keybase1.MakeTestUID(1)
+	uid2 := keybase1.MakeTestUID(2)
 	name1 := kbname.NewNormalizedUsername("name1")
 	name2 := kbname.NewNormalizedUsername("name2")
 	users := map[keybase1.UID]UserInfo{


### PR DESCRIPTION
And check context for cancellation on all paths as well.

The new widget behavior of use CHAT_GUI identify behavior on SimpleFSStat() calls, as the initializing call into a KBFS folder, was exercising new paths in the identify code that lead to deadlock. Specifically:

* When calling `IdentifyLite` on single-team folder names, we weren't passing any track-break messages back to the goroutine waiting for them.
* When trying to resolve implicit teams, if there were no track breaks, we weren't passing any track-break messages back to the goroutine either.  And now that we're trying to resolve implicit teams for all private and public folders, this was always happening.

Put these two together, and every type of folder was getting deadlocked if the widget stat'd it before its first access via FUSE.

Also fix another potential deadlock noticed via the CHAT_SKIP path.

Issue: KBFS-3487