### PR TITLE
root_metadata: clear unresolved users from MD on migration

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6928,7 +6928,7 @@ func (fbo *folderBranchOps) MigrateToImplicitTeam(
 		return err
 	}
 
-	isWriter := true // getMDForWriteLockedForFilename already checked this.
+	isWriter := true // getMDForMigrationLocked already checked this.
 	newMD, err := md.MakeSuccessorWithNewHandle(
 		ctx, newHandle, fbo.config.MetadataVersion(), fbo.config.Codec(),
 		fbo.config.KeyManager(), fbo.config.KBPKI(), fbo.config.KBPKI(),

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3608,7 +3608,7 @@ func TestKBFSOpsAutocreateNodesSym(t *testing.T) {
 }
 
 func testKBFSOpsMigrateToImplicitTeam(
-	t *testing.T, ty tlf.Type, initialMDVer kbfsmd.MetadataVer) {
+	t *testing.T, ty tlf.Type, name string, initialMDVer kbfsmd.MetadataVer) {
 	var u1, u2 kbname.NormalizedUsername = "u1", "u2"
 	config1, _, ctx, cancel := kbfsOpsConcurInit(t, u1, u2)
 	defer kbfsConcurTestShutdown(t, config1, ctx, cancel)
@@ -3619,7 +3619,6 @@ func testKBFSOpsMigrateToImplicitTeam(
 	config2.SetMetadataVersion(initialMDVer)
 
 	t.Log("Create the folder before implicit teams are enabled.")
-	name := "u1,u2"
 	h, err := ParseTlfHandle(
 		ctx, config1.KBPKI(), config1.MDOps(), string(name), ty)
 	require.NoError(t, err)
@@ -3689,22 +3688,32 @@ func testKBFSOpsMigrateToImplicitTeam(
 
 func TestKBFSOpsMigratePrivateToImplicitTeam(t *testing.T) {
 	testKBFSOpsMigrateToImplicitTeam(
-		t, tlf.Private, kbfsmd.SegregatedKeyBundlesVer)
+		t, tlf.Private, "u1,u2", kbfsmd.SegregatedKeyBundlesVer)
+}
+
+func TestKBFSOpsMigratePrivateWithReaderToImplicitTeam(t *testing.T) {
+	testKBFSOpsMigrateToImplicitTeam(
+		t, tlf.Private, "u1#u2", kbfsmd.SegregatedKeyBundlesVer)
+}
+
+func TestKBFSOpsMigratePrivateWithSBSToImplicitTeam(t *testing.T) {
+	testKBFSOpsMigrateToImplicitTeam(
+		t, tlf.Private, "u1,u2,zzz@twitter", kbfsmd.SegregatedKeyBundlesVer)
 }
 
 func TestKBFSOpsMigratePublicToImplicitTeam(t *testing.T) {
 	testKBFSOpsMigrateToImplicitTeam(
-		t, tlf.Public, kbfsmd.SegregatedKeyBundlesVer)
+		t, tlf.Public, "u1,u2", kbfsmd.SegregatedKeyBundlesVer)
 }
 
 func TestKBFSOpsMigratePrivateV2ToImplicitTeam(t *testing.T) {
 	testKBFSOpsMigrateToImplicitTeam(
-		t, tlf.Private, kbfsmd.InitialExtraMetadataVer)
+		t, tlf.Private, "u1,u2", kbfsmd.InitialExtraMetadataVer)
 }
 
 func TestKBFSOpsMigratePublicV2ToImplicitTeam(t *testing.T) {
 	testKBFSOpsMigrateToImplicitTeam(
-		t, tlf.Public, kbfsmd.InitialExtraMetadataVer)
+		t, tlf.Public, "u1,u2", kbfsmd.InitialExtraMetadataVer)
 }
 
 func TestKBFSOpsArchiveBranchType(t *testing.T) {

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -307,6 +307,11 @@ func (md *RootMetadata) MakeSuccessorWithNewHandle(
 	mdCopy.extra = nil
 	mdCopy.tlfHandle = newHandle.deepCopy()
 	mdCopy.SetWriters(newHandle.ResolvedWriters())
+	// Readers are not tracked explicitly in the MD, but their key
+	// bundles are cleared out with the `ClearForV4Migration()` call
+	// below.
+	mdCopy.SetUnresolvedWriters(newHandle.UnresolvedWriters())
+	mdCopy.SetUnresolvedReaders(newHandle.UnresolvedReaders())
 	mdCopy.bareMd.ClearForV4Migration()
 
 	return mdCopy.MakeSuccessor(


### PR DESCRIPTION
The unresolved users are now part of the implicit team.  Keeping them in the MD confuses the MD, and causes it to not return `TeamKeying` as the keying type.