### PR TITLE
cr: fill in final paths for ops on created chains

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -1240,7 +1240,7 @@ func (cr *ConflictResolver) buildChainsAndPaths(
 	// chain of unmerged operations, and which was not created or
 	// deleted within in the unmerged branch.
 	unmergedPaths, err = unmergedChains.getPaths(ctx, &cr.fbo.blocks,
-		cr.log, cr.fbo.nodeCache, false)
+		cr.log, cr.fbo.nodeCache, false, cr.config.Mode().IsTestMode())
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, merged, err
 	}
@@ -1500,7 +1500,7 @@ func (cr *ConflictResolver) getSingleUnmergedPath(
 	}
 	newChains.mostRecentChainMDInfo = unmergedChains.mostRecentChainMDInfo
 	unmergedPaths, err := newChains.getPaths(ctx, &cr.fbo.blocks,
-		cr.log, cr.fbo.nodeCache, false)
+		cr.log, cr.fbo.nodeCache, false, cr.config.Mode().IsTestMode())
 	if err != nil {
 		return path{}, err
 	}

--- a/libkbfs/cr_chains.go
+++ b/libkbfs/cr_chains.go
@@ -1224,7 +1224,7 @@ func (ccs *crChains) getPaths(ctx context.Context, blocks *folderBlockOps,
 	}
 
 	if checkOpFinalPaths {
-		// If we plans to check all the paths, clear them out first.
+		// If we plan to check all the paths, clear them out first.
 		for _, chain := range ccs.byMostRecent {
 			for _, op := range chain.ops {
 				op.setFinalPath(path{})

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3624,7 +3624,9 @@ type chainsPathPopulator interface {
 // `chains`, using the main nodeCache.
 func (fbo *folderBlockOps) populateChainPaths(ctx context.Context,
 	log logger.Logger, chains *crChains, includeCreates bool) error {
-	_, err := chains.getPaths(ctx, fbo, log, fbo.nodeCache, includeCreates)
+	_, err := chains.getPaths(
+		ctx, fbo, log, fbo.nodeCache, includeCreates,
+		fbo.config.Mode().IsTestMode())
 	return err
 }
 


### PR DESCRIPTION
Even if the `getPaths()` caller doesn't explicitly request the paths of created chains, we still need to fill in the final paths on the ops of those chains, because they might be used later (for example, in the case where the same directory is created in both the unmerged and merged branches, and the child entries need to be compared for conflicts).

Also, to test this and help prevent all similar issues like this in the past, when in test mode the code now first clears all paths, and afterwards checks that paths were set on all ops.  Before this PR, this resulted in several test failures that are now fixed.

Issue: KBFS-3493
