### PR TITLE
tlf_handle_resolve: don't fetch team TLF ID if idGetter == nil

### DIFF
--- a/libkbfs/tlf_handle_test.go
+++ b/libkbfs/tlf_handle_test.go
@@ -115,7 +115,8 @@ func TestParseTlfHandleSingleTeam(t *testing.T) {
 		},
 	}
 
-	h, err := ParseTlfHandle(ctx, kbpki, nil, "t1", tlf.SingleTeam)
+	h, err := ParseTlfHandle(
+		ctx, kbpki, constIDGetter{tlfID}, "t1", tlf.SingleTeam)
 	assert.Equal(t, 0, kbpki.getIdentifyCalls())
 	require.NoError(t, err)
 	require.Equal(t, tlfID, h.tlfID)


### PR DESCRIPTION
An `ls /keybase/team` results in a `Lookup()` call for each team in your favorites list.  This in turn requires parsing the TLF handle. The folderlist already uses `libfs.ParseTlfHandlePreferredQuick()`, which sets the `idGetter` to `nil` to skip looking up TLF IDs for private/public folders.  But team TLF IDs were treated differently, since they don't use `idGetter`.

Instead, if `idGetter` is `nil`, use that as a signal to skip looking up the team TLF ID, to make stats much faster in the team folder list.