### PR TITLE
kbfscrypto: set a Cause on libkb.DecryptionErrors

### DIFF
--- a/kbfscrypto/encrypted_data.go
+++ b/kbfscrypto/encrypted_data.go
@@ -132,7 +132,8 @@ func decryptData(
 	decryptedData, ok := secretbox.Open(
 		nil, encryptedData.EncryptedData, &nonce, &key)
 	if !ok {
-		return nil, errors.WithStack(libkb.DecryptionError{})
+		return nil, errors.WithStack(
+			libkb.DecryptionError{Cause: errors.New("Cannot open secret box")})
 	}
 
 	return decryptedData, nil
@@ -378,7 +379,8 @@ func DecryptMerkleLeaf(
 	decryptedData, ok := box.Open(nil, encryptedMerkleLeaf.EncryptedData,
 		&nonce, &publicKeyData, &privateKeyData)
 	if !ok {
-		return nil, errors.WithStack(libkb.DecryptionError{})
+		return nil, errors.WithStack(
+			libkb.DecryptionError{Cause: errors.New("Cannot open box")})
 	}
 	return decryptedData, nil
 }

--- a/kbfscrypto/encrypted_data_test.go
+++ b/kbfscrypto/encrypted_data_test.go
@@ -93,14 +93,14 @@ func TestDecryptDataFailure(t *testing.T) {
 	keyCorrupt := key
 	keyCorrupt[0] = ^keyCorrupt[0]
 	_, err = decryptData(encryptedData, keyCorrupt, nonce)
-	assert.Equal(t, libkb.DecryptionError{}, errors.Cause(err))
+	assert.IsType(t, errors.Cause(err), libkb.DecryptionError{})
 
 	// Corrupt data.
 
 	encryptedDataCorruptData := encryptedData
 	encryptedDataCorruptData.EncryptedData[0] = ^encryptedDataCorruptData.EncryptedData[0]
 	_, err = decryptData(encryptedDataCorruptData, key, nonce)
-	assert.Equal(t, libkb.DecryptionError{}, errors.Cause(err))
+	assert.IsType(t, errors.Cause(err), libkb.DecryptionError{})
 }
 
 // Test that EncryptTLFCryptKeyClientHalf() encrypts its passed-in


### PR DESCRIPTION
Otherwise there's a panic when sending the error back over RPC.

Issue: KBFS-3514