### PR TITLE
disk_md_cache: introduce disk cache for the last known MD heads

### DIFF
--- a/libkbfs/count_meter.go
+++ b/libkbfs/count_meter.go
@@ -7,6 +7,24 @@ import (
 	metrics "github.com/rcrowley/go-metrics"
 )
 
+// MeterStatus represents the status of a rate meter.
+type MeterStatus struct {
+	Minutes1  float64
+	Minutes5  float64
+	Minutes15 float64
+	Count     int64
+}
+
+func rateMeterToStatus(m metrics.Meter) MeterStatus {
+	s := m.Snapshot()
+	return MeterStatus{
+		s.Rate1(),
+		s.Rate5(),
+		s.Rate15(),
+		s.Count(),
+	}
+}
+
 // CountMeter counts ticks with a sliding window into the past.
 type CountMeter struct {
 	mtx      sync.RWMutex

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -50,12 +50,12 @@ func (c testDiskBlockCacheConfig) DiskLimiter() DiskLimiter {
 func newDiskBlockCacheForTest(config *testDiskBlockCacheConfig,
 	maxBytes int64) (*diskBlockCacheWrapped, error) {
 	maxFiles := int64(10000)
-	workingSetCache, err := newDiskBlockCacheStandardForTest(config,
+	workingSetCache, err := newDiskBlockCacheLocalForTest(config,
 		workingSetCacheLimitTrackerType)
 	if err != nil {
 		return nil, err
 	}
-	syncCache, err := newDiskBlockCacheStandardForTest(
+	syncCache, err := newDiskBlockCacheLocalForTest(
 		config, syncCacheLimitTrackerType)
 	if err != nil {
 		return nil, err

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -64,11 +64,11 @@ func (cache *diskBlockCacheWrapped) enableCache(
 		return nil
 	}
 	if cache.config.IsTestMode() {
-		*cachePtr, err = newDiskBlockCacheStandardForTest(
+		*cachePtr, err = newDiskBlockCacheLocalForTest(
 			cache.config, typ)
 	} else {
 		cacheStorageRoot := filepath.Join(cache.storageRoot, cacheFolder)
-		*cachePtr, err = newDiskBlockCacheStandard(cache.config, typ,
+		*cachePtr, err = newDiskBlockCacheLocal(cache.config, typ,
 			cacheStorageRoot)
 	}
 	return err

--- a/libkbfs/disk_md_cache.go
+++ b/libkbfs/disk_md_cache.go
@@ -1,0 +1,437 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/pkg/errors"
+	ldberrors "github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+const (
+	headsDbFilename           string = "diskCacheMDHeads.leveldb"
+	initialDiskMDCacheVersion uint64 = 1
+	currentDiskMDCacheVersion uint64 = initialDiskMDCacheVersion
+	defaultMDCacheTableSize   int    = 50 * opt.MiB
+)
+
+// diskMDCacheConfig specifies the interfaces that a DiskMDCacheStandard
+// needs to perform its functions. This adheres to the standard libkbfs Config
+// API.
+type diskMDCacheConfig interface {
+	codecGetter
+	logMaker
+}
+
+type diskMDCacheStageKey struct {
+	tlfID tlf.ID
+	rev   kbfsmd.Revision
+}
+
+type diskMDBlock struct {
+	// Exported only for serialization.
+	Buf  []byte
+	Ver  kbfsmd.MetadataVer
+	Time time.Time
+}
+
+// DiskMDCacheLocal is the standard implementation for DiskMDCache.
+type DiskMDCacheLocal struct {
+	config diskMDCacheConfig
+	log    logger.Logger
+
+	// Track the cache hit rate and eviction rate
+	hitMeter  *CountMeter
+	missMeter *CountMeter
+	putMeter  *CountMeter
+	// Protect the disk caches from being shutdown while they're being
+	// accessed, and mutable data.
+	lock       sync.RWMutex
+	headsDb    *levelDb // tlfID -> metadata block
+	tlfsCached map[tlf.ID]bool
+	tlfsStaged map[diskMDCacheStageKey]diskMDBlock
+
+	startedCh  chan struct{}
+	startErrCh chan struct{}
+	shutdownCh chan struct{}
+
+	closer func()
+}
+
+var _ DiskMDCache = (*DiskMDCacheLocal)(nil)
+
+// DiskMDCacheStartState represents whether this disk MD cache has
+// started or failed.
+type DiskMDCacheStartState int
+
+// String allows DiskMDCacheStartState to be output as a string.
+func (s DiskMDCacheStartState) String() string {
+	switch s {
+	case DiskMDCacheStartStateStarting:
+		return "starting"
+	case DiskMDCacheStartStateStarted:
+		return "started"
+	case DiskMDCacheStartStateFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// DiskMDCacheStartStateStarting represents when the cache is starting.
+	DiskMDCacheStartStateStarting DiskMDCacheStartState = iota
+	// DiskMDCacheStartStateStarted represents when the cache has started.
+	DiskMDCacheStartStateStarted
+	// DiskMDCacheStartStateFailed represents when the cache has failed to
+	// start.
+	DiskMDCacheStartStateFailed
+)
+
+// DiskMDCacheStatus represents the status of the MD cache.
+type DiskMDCacheStatus struct {
+	StartState DiskMDCacheStartState
+	NumMDs     uint64
+	NumStaged  uint64
+	Hits       MeterStatus
+	Misses     MeterStatus
+	Puts       MeterStatus
+}
+
+// newDiskMDCacheLocalFromStorage creates a new *DiskMDCacheLocal
+// with the passed-in storage.Storage interfaces as storage layers for each
+// cache.
+func newDiskMDCacheLocalFromStorage(
+	config diskMDCacheConfig, headsStorage storage.Storage) (
+	cache *DiskMDCacheLocal, err error) {
+	log := config.MakeLogger("DMC")
+	closers := make([]io.Closer, 0, 1)
+	closer := func() {
+		for _, c := range closers {
+			closeErr := c.Close()
+			if closeErr != nil {
+				log.Warning("Error closing leveldb or storage: %+v", closeErr)
+			}
+		}
+	}
+	defer func() {
+		if err != nil {
+			err = errors.WithStack(err)
+			closer()
+		}
+	}()
+	mdDbOptions := *leveldbOptions
+	mdDbOptions.CompactionTableSize = defaultMDCacheTableSize
+	headsDb, err := openLevelDBWithOptions(headsStorage, &mdDbOptions)
+	if err != nil {
+		return nil, err
+	}
+	closers = append(closers, headsDb)
+
+	startedCh := make(chan struct{})
+	startErrCh := make(chan struct{})
+	cache = &DiskMDCacheLocal{
+		config:     config,
+		hitMeter:   NewCountMeter(),
+		missMeter:  NewCountMeter(),
+		putMeter:   NewCountMeter(),
+		log:        log,
+		headsDb:    headsDb,
+		tlfsCached: map[tlf.ID]bool{},
+		tlfsStaged: make(map[diskMDCacheStageKey]diskMDBlock),
+		startedCh:  startedCh,
+		startErrCh: startErrCh,
+		shutdownCh: make(chan struct{}),
+		closer:     closer,
+	}
+	// Sync the MD counts asynchronously so syncing doesn't block init.
+	// Since this method blocks, any Get or Put requests to the disk MD
+	// cache will block until this is done. The log will contain the beginning
+	// and end of this sync.
+	go func() {
+		err := cache.syncMDCountsFromDb()
+		if err != nil {
+			close(startErrCh)
+			closer()
+			log.Warning("Disabling disk MD cache due to error syncing the "+
+				"MD counts from DB: %+v", err)
+			return
+		}
+		close(startedCh)
+	}()
+	return cache, nil
+}
+
+// newDiskMDCacheLocal creates a new *DiskMDCacheLocal with a
+// specified directory on the filesystem as storage.
+func newDiskMDCacheLocal(
+	config diskBlockCacheConfig, dirPath string) (
+	cache *DiskMDCacheLocal, err error) {
+	log := config.MakeLogger("DMC")
+	defer func() {
+		if err != nil {
+			log.Error("Error initializing MD cache: %+v", err)
+		}
+	}()
+	versionPath, err := getVersionedPathForDiskCache(
+		log, dirPath, "md", currentDiskMDCacheVersion)
+	if err != nil {
+		return nil, err
+	}
+	headsDbPath := filepath.Join(versionPath, headsDbFilename)
+	headsStorage, err := storage.OpenFile(headsDbPath, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			headsStorage.Close()
+		}
+	}()
+	return newDiskMDCacheLocalFromStorage(config, headsStorage)
+}
+
+// WaitUntilStarted waits until this cache has started.
+func (cache *DiskMDCacheLocal) WaitUntilStarted() error {
+	select {
+	case <-cache.startedCh:
+		return nil
+	case <-cache.startErrCh:
+		return DiskMDCacheError{"error starting channel"}
+	}
+}
+
+func (cache *DiskMDCacheLocal) syncMDCountsFromDb() error {
+	cache.log.Debug("+ syncMDCountsFromDb begin")
+	defer cache.log.Debug("- syncMDCountsFromDb end")
+	// We take a write lock for this to prevent any reads from happening while
+	// we're syncing the MD counts.
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	tlfsCached := make(map[tlf.ID]bool)
+	iter := cache.headsDb.NewIterator(nil, nil)
+	defer iter.Release()
+	for iter.Next() {
+		var tlfID tlf.ID
+		err := tlfID.UnmarshalBinary(iter.Key())
+		if err != nil {
+			return err
+		}
+
+		tlfsCached[tlfID] = true
+	}
+	cache.tlfsCached = tlfsCached
+	return nil
+}
+
+// getMetadataLocked retrieves the metadata for a block in the cache, or
+// returns leveldb.ErrNotFound and a zero-valued metadata otherwise.
+func (cache *DiskMDCacheLocal) getMetadataLocked(
+	tlfID tlf.ID, metered bool) (metadata diskMDBlock, err error) {
+	var hitMeter, missMeter *CountMeter
+	if metered {
+		hitMeter = cache.hitMeter
+		missMeter = cache.missMeter
+	}
+
+	metadataBytes, err := cache.headsDb.GetWithMeter(
+		tlfID.Bytes(), hitMeter, missMeter)
+	if err != nil {
+		return diskMDBlock{}, err
+	}
+	err = cache.config.Codec().Decode(metadataBytes, &metadata)
+	if err != nil {
+		return diskMDBlock{}, err
+	}
+	return metadata, nil
+}
+
+// checkAndLockCache checks whether the cache is started.
+func (cache *DiskMDCacheLocal) checkCacheLocked(
+	ctx context.Context, method string) error {
+	// First see if the context has expired since we began.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	select {
+	case <-cache.startedCh:
+	case <-cache.startErrCh:
+		// The cache will never be started. No need for a stack here since this
+		// could happen anywhere.
+		return DiskCacheStartingError{method}
+	default:
+		// If the cache hasn't started yet, return an error.  No need for a
+		// stack here since this could happen anywhere.
+		return DiskCacheStartingError{method}
+	}
+	// shutdownCh has to be checked under lock, otherwise we can race.
+	select {
+	case <-cache.shutdownCh:
+		return errors.WithStack(DiskCacheClosedError{method})
+	default:
+	}
+	if cache.headsDb == nil {
+		return errors.WithStack(DiskCacheClosedError{method})
+	}
+	return nil
+}
+
+// Get implements the DiskMDCache interface for DiskMDCacheLocal.
+func (cache *DiskMDCacheLocal) Get(
+	ctx context.Context, tlfID tlf.ID) (
+	buf []byte, ver kbfsmd.MetadataVer, localTimestamp time.Time, err error) {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	err = cache.checkCacheLocked(ctx, "Get")
+	if err != nil {
+		return nil, -1, time.Time{}, err
+	}
+
+	if !cache.tlfsCached[tlfID] {
+		cache.missMeter.Mark(1)
+		return nil, -1, time.Time{}, errors.WithStack(ldberrors.ErrNotFound)
+	}
+
+	md, err := cache.getMetadataLocked(tlfID, true)
+	if err != nil {
+		return nil, -1, time.Time{}, err
+	}
+	return md.Buf, md.Ver, md.Time, nil
+}
+
+// Stage implements the DiskMDCache interface for DiskMDCacheLocal.
+func (cache *DiskMDCacheLocal) Stage(
+	ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision, buf []byte,
+	ver kbfsmd.MetadataVer, localTimestamp time.Time) error {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	err := cache.checkCacheLocked(ctx, "Stage")
+	if err != nil {
+		return err
+	}
+
+	key := diskMDCacheStageKey{tlfID, rev}
+	md := diskMDBlock{
+		Buf:  buf,
+		Ver:  ver,
+		Time: localTimestamp,
+	}
+
+	cache.tlfsStaged[key] = md
+	return nil
+}
+
+// Commit implements the DiskMDCache interface for DiskMDCacheLocal.
+func (cache *DiskMDCacheLocal) Commit(
+	ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	err := cache.checkCacheLocked(ctx, "Commit")
+	if err != nil {
+		return err
+	}
+
+	key := diskMDCacheStageKey{tlfID, rev}
+	md, ok := cache.tlfsStaged[key]
+	if !ok {
+		return errors.New("Cannot commit an unstaged revision")
+	}
+
+	encodedMetadata, err := cache.config.Codec().Encode(&md)
+	if err != nil {
+		return err
+	}
+
+	err = cache.headsDb.PutWithMeter(
+		tlfID.Bytes(), encodedMetadata, cache.putMeter)
+	if err != nil {
+		return err
+	}
+	cache.tlfsCached[tlfID] = true
+	delete(cache.tlfsStaged, key)
+	return nil
+}
+
+// Commit implements the DiskMDCache interface for DiskMDCacheLocal.
+func (cache *DiskMDCacheLocal) Unstage(
+	ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	err := cache.checkCacheLocked(ctx, "Unstage")
+	if err != nil {
+		return err
+	}
+
+	key := diskMDCacheStageKey{tlfID, rev}
+	_, ok := cache.tlfsStaged[key]
+	if !ok {
+		return errors.New("Cannot unstage an unstaged revision")
+	}
+	delete(cache.tlfsStaged, key)
+	return nil
+}
+
+// Status implements the DiskMDCache interface for DiskMDCacheLocal.
+func (cache *DiskMDCacheLocal) Status(_ context.Context) DiskMDCacheStatus {
+	select {
+	case <-cache.startedCh:
+	case <-cache.startErrCh:
+		return DiskMDCacheStatus{StartState: DiskMDCacheStartStateFailed}
+	default:
+		return DiskMDCacheStatus{StartState: DiskMDCacheStartStateStarting}
+	}
+
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	return DiskMDCacheStatus{
+		StartState: DiskMDCacheStartStateStarted,
+		NumMDs:     uint64(len(cache.tlfsCached)),
+		NumStaged:  uint64(len(cache.tlfsStaged)),
+		Hits:       rateMeterToStatus(cache.hitMeter),
+		Misses:     rateMeterToStatus(cache.missMeter),
+		Puts:       rateMeterToStatus(cache.putMeter),
+	}
+}
+
+// Shutdown implements the DiskMDCache interface for DiskMDCacheLocal.
+func (cache *DiskMDCacheLocal) Shutdown(ctx context.Context) {
+	// Wait for the cache to either finish starting or error.
+	select {
+	case <-cache.startedCh:
+	case <-cache.startErrCh:
+		return
+	}
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	// shutdownCh has to be checked under lock, otherwise we can race.
+	select {
+	case <-cache.shutdownCh:
+		cache.log.CWarningf(ctx, "Shutdown called more than once")
+	default:
+	}
+	close(cache.shutdownCh)
+	if cache.headsDb == nil {
+		return
+	}
+	cache.closer()
+	cache.headsDb = nil
+	cache.hitMeter.Shutdown()
+	cache.missMeter.Shutdown()
+	cache.putMeter.Shutdown()
+}

--- a/libkbfs/disk_md_cache_test.go
+++ b/libkbfs/disk_md_cache_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/keybase/kbfs/kbfsmd"
+	"github.com/keybase/kbfs/tlf"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"golang.org/x/net/context"
+)
+
+type testDiskMDCacheConfig struct {
+	codecGetter
+	logMaker
+}
+
+func newDiskMDCacheLocalForTestWithStorage(
+	t *testing.T, s storage.Storage) *DiskMDCacheLocal {
+	cache, err := newDiskMDCacheLocalFromStorage(&testDiskMDCacheConfig{
+		newTestCodecGetter(),
+		newTestLogMaker(t),
+	}, s)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	require.NoError(t, err)
+	err = cache.WaitUntilStarted()
+	require.NoError(t, err)
+	return cache
+}
+
+func newDiskMDCacheLocalForTest(t *testing.T) (*DiskMDCacheLocal, string) {
+	// Use a disk-based level, instead of memory storage, because we
+	// want to simulate a restart and memory storages can't be reused.
+	tempdir, err := ioutil.TempDir(os.TempDir(), "disk_md_cache")
+	require.NoError(t, err)
+	s, err := storage.OpenFile(filepath.Join(tempdir, "heads"), false)
+	require.NoError(t, err)
+
+	cache := newDiskMDCacheLocalForTestWithStorage(t, s)
+	return cache, tempdir
+}
+
+func shutdownDiskMDCacheTest(cache DiskMDCache, tempdir string) {
+	cache.Shutdown(context.Background())
+	os.RemoveAll(tempdir)
+}
+
+func makeRandomMDBuf(t *testing.T) []byte {
+	b := make([]byte, 10)
+	_, err := rand.Read(b)
+	require.NoError(t, err)
+	return b
+}
+
+func TestDiskMDCacheCommitAndGet(t *testing.T) {
+	t.Parallel()
+	t.Log("Test that basic MD cache Put and Get operations work.")
+	cache, tempdir := newDiskMDCacheLocalForTest(t)
+	defer func() {
+		shutdownDiskMDCacheTest(cache, tempdir)
+	}()
+	clock := newTestClockNow()
+
+	tlf1 := tlf.FakeID(0, tlf.Private)
+	ctx := context.Background()
+
+	buf := makeRandomMDBuf(t)
+	now := clock.Now()
+	rev := kbfsmd.Revision(1)
+
+	t.Log("Put an MD into the cache.")
+	err := cache.Stage(ctx, tlf1, rev, buf, kbfsmd.ImplicitTeamsVer, now)
+	require.NoError(t, err)
+	_, _, _, err = cache.Get(ctx, tlf1)
+	require.Error(t, err) // not commited yet
+	status := cache.Status(ctx)
+	require.Equal(t, uint64(0), status.NumMDs)
+	require.Equal(t, uint64(1), status.NumStaged)
+	err = cache.Commit(ctx, tlf1, rev)
+	require.NoError(t, err)
+	status = cache.Status(ctx)
+	require.Equal(t, uint64(1), status.NumMDs)
+	require.Equal(t, uint64(0), status.NumStaged)
+
+	t.Log("Get an MD from the cache.")
+	clock.Add(1 * time.Minute)
+	getBuf, getVer, getTime, err := cache.Get(ctx, tlf1)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(buf, getBuf))
+	require.Equal(t, kbfsmd.ImplicitTeamsVer, getVer)
+	require.True(t, now.Equal(getTime))
+
+	t.Log("Check the meters.")
+	status = cache.Status(ctx)
+	require.Equal(t, int64(1), status.Hits.Count)
+	require.Equal(t, int64(1), status.Misses.Count)
+	require.Equal(t, int64(1), status.Puts.Count)
+
+	t.Log("A second TLF")
+	tlf2 := tlf.FakeID(0, tlf.Public)
+	now2 := clock.Now()
+	buf2 := makeRandomMDBuf(t)
+	err = cache.Stage(ctx, tlf2, rev, buf2, kbfsmd.ImplicitTeamsVer, now2)
+	require.NoError(t, err)
+	err = cache.Commit(ctx, tlf2, rev)
+	require.NoError(t, err)
+	getBuf2, getVer2, getTime2, err := cache.Get(ctx, tlf2)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(buf2, getBuf2))
+	require.Equal(t, kbfsmd.ImplicitTeamsVer, getVer2)
+	require.True(t, now2.Equal(getTime2))
+
+	t.Log("Override the first TLF")
+	now3 := clock.Now()
+	buf3 := makeRandomMDBuf(t)
+	err = cache.Stage(ctx, tlf1, rev, buf3, kbfsmd.ImplicitTeamsVer, now3)
+	require.NoError(t, err)
+	err = cache.Commit(ctx, tlf1, rev)
+	require.NoError(t, err)
+	getBuf3, getVer3, getTime3, err := cache.Get(ctx, tlf1)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(buf3, getBuf3))
+	require.Equal(t, kbfsmd.ImplicitTeamsVer, getVer3)
+	require.True(t, now2.Equal(getTime3))
+
+	t.Log("Restart the cache and check the stats")
+	cache.Shutdown(ctx)
+	s, err := storage.OpenFile(filepath.Join(tempdir, "heads"), false)
+	require.NoError(t, err)
+	cache = newDiskMDCacheLocalForTestWithStorage(t, s)
+	status = cache.Status(ctx)
+	require.Equal(t, uint64(2), status.NumMDs)
+	require.Equal(t, uint64(0), status.NumStaged)
+}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1108,6 +1108,7 @@ func (e NoUpdatesWhileDirtyError) Error() string {
 const (
 	// StatusCodeDiskBlockCacheError is a generic disk cache error.
 	StatusCodeDiskBlockCacheError = 0x666
+	StatusCodeDiskMDCacheError    = 0x667
 )
 
 // DiskBlockCacheError is a generic disk cache error.
@@ -1130,6 +1131,28 @@ func (e DiskBlockCacheError) ToStatus() (s keybase1.Status) {
 // Error implements the Error interface for DiskBlockCacheError.
 func (e DiskBlockCacheError) Error() string {
 	return "DiskBlockCacheError{" + e.Msg + "}"
+}
+
+// DiskMDCacheError is a generic disk cache error.
+type DiskMDCacheError struct {
+	Msg string
+}
+
+func newDiskMDCacheError(err error) DiskMDCacheError {
+	return DiskMDCacheError{err.Error()}
+}
+
+// ToStatus implements the ExportableError interface for DiskMDCacheError.
+func (e DiskMDCacheError) ToStatus() (s keybase1.Status) {
+	s.Code = StatusCodeDiskMDCacheError
+	s.Name = "DISK_MD_CACHE_ERROR"
+	s.Desc = e.Msg
+	return
+}
+
+// Error implements the Error interface for DiskMDCacheError.
+func (e DiskMDCacheError) Error() string {
+	return "DiskMDCacheError{" + e.Msg + "}"
 }
 
 // RevokedDeviceVerificationError indicates that the user is trying to

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -83,6 +83,14 @@ type syncBlockCacheFractionSetter interface {
 	SetSyncBlockCacheFraction(float64)
 }
 
+type diskMDCacheGetter interface {
+	DiskMDCache() DiskMDCache
+}
+
+type diskMDCacheSetter interface {
+	MakeDiskMDCacheIfNotExists() error
+}
+
 type clockGetter interface {
 	Clock() Clock
 }
@@ -1225,6 +1233,28 @@ type DiskBlockCache interface {
 	Shutdown(ctx context.Context)
 }
 
+// DiskMDCache caches encrypted MD objects to the disk.
+type DiskMDCache interface {
+	// Get gets the latest cached MD for the given TLF from the disk cache.
+	Get(ctx context.Context, tlfID tlf.ID) (
+		buf []byte, ver kbfsmd.MetadataVer, localTimestamp time.Time, err error)
+	// Stage asks the disk cache to store the given MD in memory, but
+	// not yet write it to disk.  A later call to `Commit` or
+	// `Unstage` is required to avoid memory leaks.  The cache doesn't
+	// enforce that revisions within a TLF are committed in order;
+	// that is up to the caller.
+	Stage(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision, buf []byte,
+		ver kbfsmd.MetadataVer, localTimestamp time.Time) error
+	// Commit writes a previously-staged MD to disk.
+	Commit(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error
+	// Unstage unstages and forgets about a previously-staged MD.
+	Unstage(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error
+	// Status returns the current status of the disk cache.
+	Status(ctx context.Context) DiskMDCacheStatus
+	// Shutdown cleanly shuts down the disk MD cache.
+	Shutdown(ctx context.Context)
+}
+
 // cryptoPure contains all methods of Crypto that don't depend on
 // implicit state, i.e. they're pure functions of the input.
 type cryptoPure interface {
@@ -2075,6 +2105,8 @@ type Config interface {
 	diskBlockCacheSetter
 	diskBlockCacheFractionSetter
 	syncBlockCacheFractionSetter
+	diskMDCacheGetter
+	diskMDCacheSetter
 	clockGetter
 	diskLimiterGetter
 	syncedTlfGetterSetter

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -544,6 +544,76 @@ func (mr *MocksyncBlockCacheFractionSetterMockRecorder) SetSyncBlockCacheFractio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSyncBlockCacheFraction", reflect.TypeOf((*MocksyncBlockCacheFractionSetter)(nil).SetSyncBlockCacheFraction), arg0)
 }
 
+// MockdiskMDCacheGetter is a mock of diskMDCacheGetter interface
+type MockdiskMDCacheGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockdiskMDCacheGetterMockRecorder
+}
+
+// MockdiskMDCacheGetterMockRecorder is the mock recorder for MockdiskMDCacheGetter
+type MockdiskMDCacheGetterMockRecorder struct {
+	mock *MockdiskMDCacheGetter
+}
+
+// NewMockdiskMDCacheGetter creates a new mock instance
+func NewMockdiskMDCacheGetter(ctrl *gomock.Controller) *MockdiskMDCacheGetter {
+	mock := &MockdiskMDCacheGetter{ctrl: ctrl}
+	mock.recorder = &MockdiskMDCacheGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdiskMDCacheGetter) EXPECT() *MockdiskMDCacheGetterMockRecorder {
+	return m.recorder
+}
+
+// DiskMDCache mocks base method
+func (m *MockdiskMDCacheGetter) DiskMDCache() DiskMDCache {
+	ret := m.ctrl.Call(m, "DiskMDCache")
+	ret0, _ := ret[0].(DiskMDCache)
+	return ret0
+}
+
+// DiskMDCache indicates an expected call of DiskMDCache
+func (mr *MockdiskMDCacheGetterMockRecorder) DiskMDCache() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskMDCache", reflect.TypeOf((*MockdiskMDCacheGetter)(nil).DiskMDCache))
+}
+
+// MockdiskMDCacheSetter is a mock of diskMDCacheSetter interface
+type MockdiskMDCacheSetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockdiskMDCacheSetterMockRecorder
+}
+
+// MockdiskMDCacheSetterMockRecorder is the mock recorder for MockdiskMDCacheSetter
+type MockdiskMDCacheSetterMockRecorder struct {
+	mock *MockdiskMDCacheSetter
+}
+
+// NewMockdiskMDCacheSetter creates a new mock instance
+func NewMockdiskMDCacheSetter(ctrl *gomock.Controller) *MockdiskMDCacheSetter {
+	mock := &MockdiskMDCacheSetter{ctrl: ctrl}
+	mock.recorder = &MockdiskMDCacheSetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdiskMDCacheSetter) EXPECT() *MockdiskMDCacheSetterMockRecorder {
+	return m.recorder
+}
+
+// MakeDiskMDCacheIfNotExists mocks base method
+func (m *MockdiskMDCacheSetter) MakeDiskMDCacheIfNotExists() error {
+	ret := m.ctrl.Call(m, "MakeDiskMDCacheIfNotExists")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MakeDiskMDCacheIfNotExists indicates an expected call of MakeDiskMDCacheIfNotExists
+func (mr *MockdiskMDCacheSetterMockRecorder) MakeDiskMDCacheIfNotExists() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDiskMDCacheIfNotExists", reflect.TypeOf((*MockdiskMDCacheSetter)(nil).MakeDiskMDCacheIfNotExists))
+}
+
 // MockclockGetter is a mock of clockGetter interface
 type MockclockGetter struct {
 	ctrl     *gomock.Controller
@@ -4239,6 +4309,102 @@ func (mr *MockDiskBlockCacheMockRecorder) Shutdown(ctx interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockDiskBlockCache)(nil).Shutdown), ctx)
 }
 
+// MockDiskMDCache is a mock of DiskMDCache interface
+type MockDiskMDCache struct {
+	ctrl     *gomock.Controller
+	recorder *MockDiskMDCacheMockRecorder
+}
+
+// MockDiskMDCacheMockRecorder is the mock recorder for MockDiskMDCache
+type MockDiskMDCacheMockRecorder struct {
+	mock *MockDiskMDCache
+}
+
+// NewMockDiskMDCache creates a new mock instance
+func NewMockDiskMDCache(ctrl *gomock.Controller) *MockDiskMDCache {
+	mock := &MockDiskMDCache{ctrl: ctrl}
+	mock.recorder = &MockDiskMDCacheMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockDiskMDCache) EXPECT() *MockDiskMDCacheMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method
+func (m *MockDiskMDCache) Get(ctx context.Context, tlfID tlf.ID) ([]byte, kbfsmd.MetadataVer, time.Time, error) {
+	ret := m.ctrl.Call(m, "Get", ctx, tlfID)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(kbfsmd.MetadataVer)
+	ret2, _ := ret[2].(time.Time)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// Get indicates an expected call of Get
+func (mr *MockDiskMDCacheMockRecorder) Get(ctx, tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDiskMDCache)(nil).Get), ctx, tlfID)
+}
+
+// Stage mocks base method
+func (m *MockDiskMDCache) Stage(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision, buf []byte, ver kbfsmd.MetadataVer, localTimestamp time.Time) error {
+	ret := m.ctrl.Call(m, "Stage", ctx, tlfID, rev, buf, ver, localTimestamp)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stage indicates an expected call of Stage
+func (mr *MockDiskMDCacheMockRecorder) Stage(ctx, tlfID, rev, buf, ver, localTimestamp interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stage", reflect.TypeOf((*MockDiskMDCache)(nil).Stage), ctx, tlfID, rev, buf, ver, localTimestamp)
+}
+
+// Commit mocks base method
+func (m *MockDiskMDCache) Commit(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error {
+	ret := m.ctrl.Call(m, "Commit", ctx, tlfID, rev)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Commit indicates an expected call of Commit
+func (mr *MockDiskMDCacheMockRecorder) Commit(ctx, tlfID, rev interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockDiskMDCache)(nil).Commit), ctx, tlfID, rev)
+}
+
+// Unstage mocks base method
+func (m *MockDiskMDCache) Unstage(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error {
+	ret := m.ctrl.Call(m, "Unstage", ctx, tlfID, rev)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Unstage indicates an expected call of Unstage
+func (mr *MockDiskMDCacheMockRecorder) Unstage(ctx, tlfID, rev interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unstage", reflect.TypeOf((*MockDiskMDCache)(nil).Unstage), ctx, tlfID, rev)
+}
+
+// Status mocks base method
+func (m *MockDiskMDCache) Status(ctx context.Context) DiskMDCacheStatus {
+	ret := m.ctrl.Call(m, "Status", ctx)
+	ret0, _ := ret[0].(DiskMDCacheStatus)
+	return ret0
+}
+
+// Status indicates an expected call of Status
+func (mr *MockDiskMDCacheMockRecorder) Status(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockDiskMDCache)(nil).Status), ctx)
+}
+
+// Shutdown mocks base method
+func (m *MockDiskMDCache) Shutdown(ctx context.Context) {
+	m.ctrl.Call(m, "Shutdown", ctx)
+}
+
+// Shutdown indicates an expected call of Shutdown
+func (mr *MockDiskMDCacheMockRecorder) Shutdown(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockDiskMDCache)(nil).Shutdown), ctx)
+}
+
 // MockcryptoPure is a mock of cryptoPure interface
 type MockcryptoPure struct {
 	ctrl     *gomock.Controller
@@ -7226,6 +7392,30 @@ func (m *MockConfig) SetSyncBlockCacheFraction(arg0 float64) {
 // SetSyncBlockCacheFraction indicates an expected call of SetSyncBlockCacheFraction
 func (mr *MockConfigMockRecorder) SetSyncBlockCacheFraction(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSyncBlockCacheFraction", reflect.TypeOf((*MockConfig)(nil).SetSyncBlockCacheFraction), arg0)
+}
+
+// DiskMDCache mocks base method
+func (m *MockConfig) DiskMDCache() DiskMDCache {
+	ret := m.ctrl.Call(m, "DiskMDCache")
+	ret0, _ := ret[0].(DiskMDCache)
+	return ret0
+}
+
+// DiskMDCache indicates an expected call of DiskMDCache
+func (mr *MockConfigMockRecorder) DiskMDCache() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskMDCache", reflect.TypeOf((*MockConfig)(nil).DiskMDCache))
+}
+
+// MakeDiskMDCacheIfNotExists mocks base method
+func (m *MockConfig) MakeDiskMDCacheIfNotExists() error {
+	ret := m.ctrl.Call(m, "MakeDiskMDCacheIfNotExists")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MakeDiskMDCacheIfNotExists indicates an expected call of MakeDiskMDCacheIfNotExists
+func (mr *MockConfigMockRecorder) MakeDiskMDCacheIfNotExists() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDiskMDCacheIfNotExists", reflect.TypeOf((*MockConfig)(nil).MakeDiskMDCacheIfNotExists))
 }
 
 // Clock mocks base method


### PR DESCRIPTION
The cache has a Stage+Commit flow, instead of the usual Put, because according to the KBFS Offline design, we might not want to cache the MD right after learning about it.  Instead, we might want to wait until syncing is done, or until the user actually accesses it for the first time.  In the meantime, the MD must be stored in encrypted form somewhere, so this cache stages them in memory until they are fully commit to disk or unstaged.

Issue: KBFS-3503