### PR TITLE
autogit: avoid FS access during `WrapChild` calls to avoid deadlock

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1511,7 +1511,7 @@ func (fbo *folderBlockOps) getChildNodeLocked(
 		return nil, nil
 	}
 
-	return fbo.nodeCache.GetOrCreate(de.BlockPointer, name, dir)
+	return fbo.nodeCache.GetOrCreate(de.BlockPointer, name, dir, de.Type)
 }
 
 func (fbo *folderBlockOps) GetChildNode(
@@ -3100,7 +3100,11 @@ func (fbo *folderBlockOps) searchForNodesInDirLocked(ctx context.Context,
 						childPath, childPath.path, i, name, de, nodeMap,
 						newPtrs, kmd)
 				}
-				n, err = cache.GetOrCreate(pn.BlockPointer, pn.Name, n)
+				et := Dir
+				if i == len(childPath.path)-2 {
+					et = de.Type
+				}
+				n, err = cache.GetOrCreate(pn.BlockPointer, pn.Name, n, et)
 				if err != nil {
 					return 0, err
 				}
@@ -3186,7 +3190,7 @@ func (fbo *folderBlockOps) trySearchWithCacheLocked(ctx context.Context,
 		// Root node may or may not exist.
 		var err error
 		node, err = cache.GetOrCreate(rootPtr,
-			string(kmd.GetTlfHandle().GetCanonicalName()), nil)
+			string(kmd.GetTlfHandle().GetCanonicalName()), nil, Dir)
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1865,7 +1865,7 @@ func (fbo *folderBranchOps) getRootNode(ctx context.Context) (
 
 	handle = md.GetTlfHandle()
 	node, err = fbo.nodeCache.GetOrCreate(md.data.Dir.BlockPointer,
-		string(handle.GetCanonicalName()), nil)
+		string(handle.GetCanonicalName()), nil, Dir)
 	if err != nil {
 		return nil, EntryInfo{}, nil, err
 	}
@@ -3148,7 +3148,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 	co.AddRefBlock(newPtr)
 	co.AddSelfUpdate(parentPtr)
 
-	node, err := fbo.nodeCache.GetOrCreate(newPtr, name, dir)
+	node, err := fbo.nodeCache.GetOrCreate(newPtr, name, dir, entryType)
 	if err != nil {
 		return nil, DirEntry{}, err
 	}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -249,6 +249,8 @@ type Node interface {
 	// provided context will be used, if possible, for any subsequent
 	// calls on the file.
 	GetFile(ctx context.Context) billy.File
+	// EntryType is the type of the entry represented by this node.
+	EntryType() EntryType
 }
 
 // KBFSOps handles all file system operations.  Expands all indirect
@@ -2228,7 +2230,8 @@ type NodeCache interface {
 	// support hard links, we will have to revisit the "name" and
 	// "parent" parameters here.  name must not be empty. Returns
 	// an error if parent cannot be found.
-	GetOrCreate(ptr BlockPointer, name string, parent Node) (Node, error)
+	GetOrCreate(
+		ptr BlockPointer, name string, parent Node, et EntryType) (Node, error)
 	// Get returns the Node associated with the given ptr if one
 	// already exists.  Otherwise, it returns nil.
 	Get(ref BlockRef) Node

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -704,7 +704,9 @@ func nodeFromPath(t *testing.T, ops *folderBranchOps, p path) Node {
 	// populate the node cache with all the nodes we'll need
 	for _, pathNode := range p.path {
 		n, err := ops.nodeCache.GetOrCreate(pathNode.BlockPointer,
-			pathNode.Name, prevNode)
+			pathNode.Name, prevNode,
+			/* For the purposes of these tests, the type doesn't matter. */
+			Dir)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1288,6 +1288,18 @@ func (mr *MockNodeMockRecorder) GetFile(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFile", reflect.TypeOf((*MockNode)(nil).GetFile), ctx)
 }
 
+// EntryType mocks base method
+func (m *MockNode) EntryType() EntryType {
+	ret := m.ctrl.Call(m, "EntryType")
+	ret0, _ := ret[0].(EntryType)
+	return ret0
+}
+
+// EntryType indicates an expected call of EntryType
+func (mr *MockNodeMockRecorder) EntryType() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntryType", reflect.TypeOf((*MockNode)(nil).EntryType))
+}
+
 // MockKBFSOps is a mock of KBFSOps interface
 type MockKBFSOps struct {
 	ctrl     *gomock.Controller
@@ -8158,16 +8170,16 @@ func (m *MockNodeCache) EXPECT() *MockNodeCacheMockRecorder {
 }
 
 // GetOrCreate mocks base method
-func (m *MockNodeCache) GetOrCreate(ptr BlockPointer, name string, parent Node) (Node, error) {
-	ret := m.ctrl.Call(m, "GetOrCreate", ptr, name, parent)
+func (m *MockNodeCache) GetOrCreate(ptr BlockPointer, name string, parent Node, et EntryType) (Node, error) {
+	ret := m.ctrl.Call(m, "GetOrCreate", ptr, name, parent, et)
 	ret0, _ := ret[0].(Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrCreate indicates an expected call of GetOrCreate
-func (mr *MockNodeCacheMockRecorder) GetOrCreate(ptr, name, parent interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreate", reflect.TypeOf((*MockNodeCache)(nil).GetOrCreate), ptr, name, parent)
+func (mr *MockNodeCacheMockRecorder) GetOrCreate(ptr, name, parent, et interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreate", reflect.TypeOf((*MockNodeCache)(nil).GetOrCreate), ptr, name, parent, et)
 }
 
 // Get mocks base method

--- a/libkbfs/node.go
+++ b/libkbfs/node.go
@@ -14,23 +14,26 @@ import (
 
 // nodeCore holds info shared among one or more nodeStandard objects.
 type nodeCore struct {
-	pathNode *pathNode
-	parent   Node
-	cache    *nodeCacheStandard
+	pathNode  *pathNode
+	parent    Node
+	cache     *nodeCacheStandard
+	entryType EntryType
 	// used only when parent is nil (the object has been unlinked)
 	cachedPath path
 	cachedDe   DirEntry
 }
 
-func newNodeCore(ptr BlockPointer, name string, parent Node,
-	cache *nodeCacheStandard) *nodeCore {
+func newNodeCore(
+	ptr BlockPointer, name string, parent Node,
+	cache *nodeCacheStandard, et EntryType) *nodeCore {
 	return &nodeCore{
 		pathNode: &pathNode{
 			BlockPointer: ptr,
 			Name:         name,
 		},
-		parent: parent,
-		cache:  cache,
+		parent:    parent,
+		cache:     cache,
+		entryType: et,
 	}
 }
 
@@ -112,4 +115,8 @@ func (n *nodeStandard) GetFS(_ context.Context) billy.Filesystem {
 
 func (n *nodeStandard) GetFile(_ context.Context) billy.File {
 	return nil
+}
+
+func (n *nodeStandard) EntryType() EntryType {
+	return n.core.entryType
 }

--- a/libkbfs/node_cache.go
+++ b/libkbfs/node_cache.go
@@ -99,7 +99,8 @@ func (ncs *nodeCacheStandard) makeNodeStandardForEntryLocked(
 
 // GetOrCreate implements the NodeCache interface for nodeCacheStandard.
 func (ncs *nodeCacheStandard) GetOrCreate(
-	ptr BlockPointer, name string, parent Node) (n Node, err error) {
+	ptr BlockPointer, name string, parent Node, et EntryType) (
+	n Node, err error) {
 	var rootWrappers []func(Node) Node
 	defer func() {
 		if n != nil {
@@ -143,7 +144,7 @@ func (ncs *nodeCacheStandard) GetOrCreate(
 	}
 
 	entry = &nodeCacheEntry{
-		core: newNodeCore(ptr, name, parent, ncs),
+		core: newNodeCore(ptr, name, parent, ncs, et),
 	}
 	ncs.nodes[ptr.Ref()] = entry
 	return ncs.makeNodeStandardForEntryLocked(entry), nil

--- a/libkbfs/node_cache_test.go
+++ b/libkbfs/node_cache_test.go
@@ -21,7 +21,7 @@ func setupNodeCache(t *testing.T, id tlf.ID, branch BranchName, flat bool) (
 	parentPtr := BlockPointer{ID: kbfsblock.FakeID(0)}
 	parentName := "parent"
 	var err error
-	parentNode, err = ncs.GetOrCreate(parentPtr, parentName, nil)
+	parentNode, err = ncs.GetOrCreate(parentPtr, parentName, nil, Dir)
 	if err != nil {
 		t.Errorf("Couldn't create top-level parent node: %v", err)
 	}
@@ -32,7 +32,7 @@ func setupNodeCache(t *testing.T, id tlf.ID, branch BranchName, flat bool) (
 	// now create a child node for that parent
 	childPtr1 := BlockPointer{ID: kbfsblock.FakeID(1)}
 	childName1 := "child1"
-	childNode1, err = ncs.GetOrCreate(childPtr1, childName1, parentNode)
+	childNode1, err = ncs.GetOrCreate(childPtr1, childName1, parentNode, Dir)
 	if err != nil {
 		t.Errorf("Couldn't create child node: %v", err)
 	}
@@ -47,7 +47,7 @@ func setupNodeCache(t *testing.T, id tlf.ID, branch BranchName, flat bool) (
 
 	childPtr2 := BlockPointer{ID: kbfsblock.FakeID(2)}
 	childName2 := "child2"
-	childNode2, err = ncs.GetOrCreate(childPtr2, childName2, parent2)
+	childNode2, err = ncs.GetOrCreate(childPtr2, childName2, parent2, Dir)
 	if err != nil {
 		t.Errorf("Couldn't create second child node: %v", err)
 	}
@@ -138,7 +138,8 @@ func TestNodeCacheGetOrCreateSuccess(t *testing.T) {
 	childPtr2 := path2[1].BlockPointer
 
 	// make sure we get the same node back for the second call
-	childNode1B, err := ncs.GetOrCreate(childPtr1, childNode1A.GetBasename(), parentNode)
+	childNode1B, err := ncs.GetOrCreate(
+		childPtr1, childNode1A.GetBasename(), parentNode, Dir)
 	if err != nil {
 		t.Errorf("Couldn't create child node: %v", err)
 	}
@@ -163,7 +164,7 @@ func TestNodeCacheGetOrCreateNoParent(t *testing.T) {
 	ncs := newNodeCacheStandard(FolderBranch{tlf.FakeID(0, tlf.Private), ""})
 
 	parentPtr := BlockPointer{ID: kbfsblock.FakeID(0)}
-	parentNode, err := ncs.GetOrCreate(parentPtr, "parent", nil)
+	parentNode, err := ncs.GetOrCreate(parentPtr, "parent", nil, Dir)
 	if err != nil {
 		t.Errorf("Couldn't create top-level parent node: %v", err)
 	}
@@ -172,7 +173,7 @@ func TestNodeCacheGetOrCreateNoParent(t *testing.T) {
 
 	// now try to create a child node for that parent
 	childPtr1 := BlockPointer{ID: kbfsblock.FakeID(1)}
-	_, err = ncs.GetOrCreate(childPtr1, "child", parentNode)
+	_, err = ncs.GetOrCreate(childPtr1, "child", parentNode, Dir)
 	expectedErr := ParentNodeNotFoundError{parentPtr.Ref()}
 	if err != expectedErr {
 		t.Errorf("Got unexpected error when creating w/o parent: %v", err)
@@ -184,7 +185,7 @@ func TestNodeCacheUpdatePointer(t *testing.T) {
 	ncs := newNodeCacheStandard(FolderBranch{tlf.FakeID(0, tlf.Private), ""})
 
 	parentPtr := BlockPointer{ID: kbfsblock.FakeID(0)}
-	parentNode, err := ncs.GetOrCreate(parentPtr, "parent", nil)
+	parentNode, err := ncs.GetOrCreate(parentPtr, "parent", nil, Dir)
 	if err != nil {
 		t.Errorf("Couldn't create top-level parent node: %v", err)
 	}
@@ -354,7 +355,8 @@ func TestNodeCacheUnlinkThenRelink(t *testing.T) {
 	newChildName := "newChildName"
 	newChildPtr2 := BlockPointer{ID: kbfsblock.FakeID(22)}
 	ncs.UpdatePointer(childPtr2.Ref(), newChildPtr2) // NO-OP
-	childNode2B, err := ncs.GetOrCreate(newChildPtr2, newChildName, childNode1)
+	childNode2B, err := ncs.GetOrCreate(
+		newChildPtr2, newChildName, childNode1, Dir)
 	if err != nil {
 		t.Fatalf("Couldn't relink node: %v", err)
 	}
@@ -500,12 +502,12 @@ func TestNodeCacheWrapChild(t *testing.T) {
 
 	rootPtr := BlockPointer{ID: kbfsblock.FakeID(0)}
 	rootName := "root"
-	rootNode, err := ncs.GetOrCreate(rootPtr, rootName, nil)
+	rootNode, err := ncs.GetOrCreate(rootPtr, rootName, nil, Dir)
 	require.NoError(t, err)
 
 	childPtr := BlockPointer{ID: kbfsblock.FakeID(1)}
 	childName := "child1"
-	_, err = ncs.GetOrCreate(childPtr, childName, rootNode)
+	_, err = ncs.GetOrCreate(childPtr, childName, rootNode, Dir)
 	require.NoError(t, err)
 	require.True(t, wtn1.wrapChildCalled)
 	require.True(t, wtn2.wrapChildCalled)
@@ -524,12 +526,12 @@ func TestNodeCacheAllNodeChildren(t *testing.T) {
 
 	childPtr3 := BlockPointer{ID: kbfsblock.FakeID(3)}
 	childName3 := "child3"
-	_, err := ncs.GetOrCreate(childPtr3, childName3, childNode1)
+	_, err := ncs.GetOrCreate(childPtr3, childName3, childNode1, Dir)
 	require.NoError(t, err)
 
 	childPtr4 := BlockPointer{ID: kbfsblock.FakeID(4)}
 	childName4 := "child4"
-	_, err = ncs.GetOrCreate(childPtr4, childName4, parentNode)
+	_, err = ncs.GetOrCreate(childPtr4, childName4, parentNode, Dir)
 	require.NoError(t, err)
 
 	parentChildren := ncs.AllNodeChildren(parentNode)


### PR DESCRIPTION
There was an issue where `repoDirNode.WrapChild` was calling back into the FS to get the type of the child.  But `WrapChild` happens under `folderBlockOps.blockLock`, and getting the type of the child might also require getting `blockLock`, so it would hit a deadlock.

This fixes it by just tracking the type of the `Node` in the node itself, and using that in `WrapChild` instead of needing to call back into `folderBranchOps` and friends.

Also, I noticed another similar situation in `autogitRootNode`, so I fixed that as well.