### PR TITLE
keybase_service_base: don't send breaks when resolving i-teams

### DIFF
--- a/libkbfs/keybase_service_base.go
+++ b/libkbfs/keybase_service_base.go
@@ -550,16 +550,18 @@ func (k *KeybaseServiceBase) ResolveIdentifyImplicitTeam(
 	name := kbname.NormalizedUsername(res.DisplayName)
 
 	// Exactly one break callback is required for every identify call.
-	if len(res.TrackBreaks) > 0 {
-		// Iterate the map to get one entry, then break.
-		for userVer, breaks := range res.TrackBreaks {
-			// TODO: resolve the UID into a username so we don't have to
-			// pass in the full display name here?
-			ei.userBreak(ctx, name, userVer.Uid, &breaks)
-			break
+	if doIdentifies {
+		if len(res.TrackBreaks) > 0 {
+			// Iterate the map to get one entry, then break.
+			for userVer, breaks := range res.TrackBreaks {
+				// TODO: resolve the UID into a username so we don't have to
+				// pass in the full display name here?
+				ei.userBreak(ctx, name, userVer.Uid, &breaks)
+				break
+			}
+		} else {
+			ei.teamBreak(ctx, keybase1.TeamID(""), nil)
 		}
-	} else {
-		ei.teamBreak(ctx, keybase1.TeamID(""), nil)
 	}
 
 	iteamInfo := ImplicitTeamInfo{

--- a/libkbfs/tlf_handle_resolve.go
+++ b/libkbfs/tlf_handle_resolve.go
@@ -108,7 +108,7 @@ func makeTlfHandleHelper(
 
 	wc := make(chan nameIDPair, len(writers))
 	uwc := make(chan keybase1.SocialAssertion, len(writers))
-	// We are only expecting at most one ID.  `resolveOneError` should
+	// We are only expecting at most one ID.  `resolveOneUser` should
 	// error if it can't send an ID immediately.
 	idc := make(chan tlf.ID, 1)
 	for _, writer := range writers {
@@ -144,7 +144,7 @@ func makeTlfHandleHelper(
 		}
 	}
 	// It's safe to close the channel now before we receive from it,
-	// since the ID is always sent first, because the usernames and
+	// since the ID is always sent first, before the usernames and
 	// assertions.
 	close(idc)
 	tlfID := tlf.NullID
@@ -156,7 +156,7 @@ func makeTlfHandleHelper(
 
 	if more {
 		// Just make sure a second one didn't slip in (only possible if
-		// `resolveOneUser` has a bug.
+		// `resolveOneUser` has a bug).
 		select {
 		case tlfID2, more := <-idc:
 			if more {


### PR DESCRIPTION
When SimpleFS calls Stat(), it sets the identify behavior to CHAT_GUI, which means the implicit team _identify_ code will be expecting breaks to be sent over channels.  However, the implicit team _resolve_ code does not wait for the breaks to be sent, and so `ResolveIdentifyImplicitTeam` just hangs trying to send them.

This only affects SimpleFS, since the normal KBFS code doesn't use any extended identify behavior, and chat doesn't try to resolve any implicit teams.

Also fix up a few comment typos in tlf_handle_resolve.go.

Issue: KBFS-3451