### PR TITLE
simplefs: operation for resetting TLFs

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1198,3 +1198,15 @@ func (e RevGarbageCollectedError) Error() string {
 	return fmt.Sprintf("Requested revision %d has already been garbage "+
 		"collected (last GC'd rev=%d)", e.rev, e.lastGCRev)
 }
+
+// FolderNotResetOnServer indicates that a folder can't be reset by
+// the user, because it hasn't yet been reset on the mdserver.
+type FolderNotResetOnServer struct {
+	h *TlfHandle
+}
+
+// Error implements the Error interface for FolderNotResetOnServer.
+func (e FolderNotResetOnServer) Error() string {
+	return fmt.Sprintf("Folder %s is not yet reset on the server; "+
+		"contact Keybase for help", e.h.GetCanonicalPath())
+}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -529,6 +529,10 @@ type KBFSOps interface {
 	NewNotificationChannel(
 		ctx context.Context, handle *TlfHandle, convID chat1.ConversationID,
 		channelName string)
+	// Reset completely resets the given folder.  Should only be
+	// called after explicit user confirmation.  After the call,
+	// `handle` has the new TLF ID.
+	Reset(ctx context.Context, handle *TlfHandle) error
 }
 
 type merkleRootGetter interface {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1917,6 +1917,18 @@ func (mr *MockKBFSOpsMockRecorder) NewNotificationChannel(ctx, handle, convID, c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewNotificationChannel", reflect.TypeOf((*MockKBFSOps)(nil).NewNotificationChannel), ctx, handle, convID, channelName)
 }
 
+// Reset mocks base method
+func (m *MockKBFSOps) Reset(ctx context.Context, handle *TlfHandle) error {
+	ret := m.ctrl.Call(m, "Reset", ctx, handle)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Reset indicates an expected call of Reset
+func (mr *MockKBFSOpsMockRecorder) Reset(ctx, handle interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockKBFSOps)(nil).Reset), ctx, handle)
+}
+
 // MockmerkleRootGetter is a mock of merkleRootGetter interface
 type MockmerkleRootGetter struct {
 	ctrl     *gomock.Controller

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -1897,6 +1897,22 @@ func (k *SimpleFS) SimpleFSFolderEditHistory(
 	return k.config.KBFSOps().GetEditHistory(ctx, fb)
 }
 
+// SimpleFSFolderEditHistory resets the given TLF.
+func (k *SimpleFS) SimpleFSReset(
+	ctx context.Context, path keybase1.Path) error {
+	t, tlfName, _, _, err := remoteTlfAndPath(path)
+	if err != nil {
+		return err
+	}
+	tlfHandle, err := libkbfs.GetHandleFromFolderNameAndType(
+		ctx, k.config.KBPKI(), k.config.MDOps(), tlfName, t)
+	if err != nil {
+		return err
+	}
+
+	return k.config.KBFSOps().Reset(ctx, tlfHandle)
+}
+
 var _ libkbfs.Observer = (*SimpleFS)(nil)
 
 // LocalChange implements the libkbfs.Observer interface for SimpleFS.

--- a/tlf/id.go
+++ b/tlf/id.go
@@ -5,6 +5,7 @@
 package tlf
 
 import (
+	"bytes"
 	"encoding"
 	"encoding/hex"
 	"fmt"
@@ -331,4 +332,22 @@ func MakeIDFromTeam(t Type, tid keybase1.TeamID, epoch byte) (ID, error) {
 		return NullID, err
 	}
 	return id, nil
+}
+
+// GetEpochFromTeamTLF returns 1) whether this ID matches the given
+// team TID, and 2) if so, which epoch it is.
+func (id ID) GetEpochFromTeamTLF(tid keybase1.TeamID) (
+	matches bool, epoch byte, err error) {
+	tidBytes := tid.ToBytes()
+	if len(tidBytes) != idByteLen {
+		return false, 0, errors.Errorf(
+			"The length of team ID %s doesn't match that of a TLF ID", tid)
+	}
+
+	epochIndex := idByteLen - 2
+	if !bytes.Equal(tidBytes[:epochIndex], id.id[:epochIndex]) {
+		return false, 0, nil
+	}
+
+	return true, id.id[epochIndex], nil
 }


### PR DESCRIPTION
This allows the user to reset their TLF by generating a new TLF ID for the implicit team, with the epoch incremented.  It clears the old TLF out of the running instance.  The new TLF ID is written to the implicit team sigchain, and overrides the old one.

It can only be done AFTER a Keybase admin does a server-side reset, so we can track which TLFs are being reset.

[This doesn't yet include the protocol changes in keybase/client#14358, but it should pass Circle anyway.  I'll vendor in the protocol changes once the client-side is merged.]

Issue: KBFS-3545
Issue: keybase/client#14319