### PR TITLE
prefetcher: allow caller to wait for a block prefetch to complete

### DIFF
--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1504,6 +1504,14 @@ type Prefetcher interface {
 	ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
 		prefetchStatus PrefetchStatus)
+	// WaitChannelForBlockPrefetch returns a channel that can be used
+	// to wait for a block to finish prefetching or be canceled.  If
+	// the block isn't currently being prefetched, it will return an
+	// already-closed channel.  When the channel is closed, the caller
+	// should still verify that the prefetch status of the block is
+	// `FinishedPrefetch`, in case there was an error.
+	WaitChannelForBlockPrefetch(ctx context.Context, ptr BlockPointer) (
+		<-chan struct{}, error)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
 	CancelPrefetch(kbfsblock.ID)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5164,6 +5164,19 @@ func (mr *MockPrefetcherMockRecorder) ProcessBlockForPrefetch(ctx, ptr, block, k
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockForPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).ProcessBlockForPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
 }
 
+// WaitChannelForBlockPrefetch mocks base method
+func (m *MockPrefetcher) WaitChannelForBlockPrefetch(ctx context.Context, ptr BlockPointer) (<-chan struct{}, error) {
+	ret := m.ctrl.Call(m, "WaitChannelForBlockPrefetch", ctx, ptr)
+	ret0, _ := ret[0].(<-chan struct{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitChannelForBlockPrefetch indicates an expected call of WaitChannelForBlockPrefetch
+func (mr *MockPrefetcherMockRecorder) WaitChannelForBlockPrefetch(ctx, ptr interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitChannelForBlockPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).WaitChannelForBlockPrefetch), ctx, ptr)
+}
+
 // CancelPrefetch mocks base method
 func (m *MockPrefetcher) CancelPrefetch(arg0 kbfsblock.ID) {
 	m.ctrl.Call(m, "CancelPrefetch", arg0)


### PR DESCRIPTION
This will let a future PR take an action when a TLF is fully synced. (They will have to verify the block's prefetch status is indeed `FinishedPrefetch` after the channel is closed, of course.)

Issue: KBFS-3505