### PR TITLE
folder_branch_ops: commit MDs to disk after reading/prefetching

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1430,7 +1430,7 @@ func (c *ConfigLocal) MakeDiskMDCacheIfNotExists() error {
 	if c.diskMDCache != nil {
 		return nil
 	}
-	return c.resetDiskBlockCacheLocked()
+	return c.resetDiskMDCacheLocked()
 }
 
 func (c *ConfigLocal) openConfigLevelDB(configName string) (*levelDb, error) {

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3168,7 +3168,7 @@ outer:
 		return err
 	}
 
-	head := cr.fbo.getTrustedHead(lState)
+	head := cr.fbo.getTrustedHead(ctx, lState)
 	if head == (ImmutableRootMetadata{}) {
 		panic("maybeUnstageAfterFailure: head is nil (should be impossible)")
 	}
@@ -3199,7 +3199,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	defer func() {
 		cr.deferLog.CDebugf(ctx, "Finished conflict resolution: %+v", err)
 		if err != nil {
-			head := cr.fbo.getTrustedHead(lState)
+			head := cr.fbo.getTrustedHead(ctx, lState)
 			if head == (ImmutableRootMetadata{}) {
 				panic("doResolve: head is nil (should be impossible)")
 			}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -267,6 +267,7 @@ type folderBranchOps struct {
 	headStatus headTrustStatus
 	// latestMergedRevision tracks the latest heard merged revision on server
 	latestMergedRevision kbfsmd.Revision
+	latestMergedUpdated  chan struct{}
 	// Has this folder ever been cleared?
 	hasBeenCleared bool
 
@@ -542,7 +543,7 @@ func (fbo *folderBranchOps) AddFavorite(ctx context.Context,
 func (fbo *folderBranchOps) addToFavorites(ctx context.Context,
 	favorites *Favorites, created bool) (err error) {
 	lState := makeFBOLockState()
-	head := fbo.getTrustedHead(lState)
+	head := fbo.getTrustedHead(ctx, lState)
 	if head == (ImmutableRootMetadata{}) {
 		return OpsCantHandleFavorite{"Can't add a favorite without a handle"}
 	}
@@ -569,7 +570,7 @@ func (fbo *folderBranchOps) deleteFromFavorites(ctx context.Context,
 	}
 
 	lState := makeFBOLockState()
-	head := fbo.getTrustedHead(lState)
+	head := fbo.getTrustedHead(ctx, lState)
 	if head == (ImmutableRootMetadata{}) {
 		// This can happen when identifies fail and the head is never set.
 		return OpsCantHandleFavorite{"Can't delete a favorite without a handle"}
@@ -607,10 +608,32 @@ func (fbo *folderBranchOps) updateLastGetHeadTimestamp() {
 	fbo.lastGetHead = fbo.config.Clock().Now()
 }
 
+func (fbo *folderBranchOps) commitHeadLocked(
+	ctx context.Context, lState *lockState) {
+	fbo.headLock.AssertRLocked(lState)
+	diskMDCache := fbo.config.DiskMDCache()
+	if diskMDCache == nil {
+		return
+	}
+
+	if !fbo.head.putToServer {
+		return
+	}
+	rev := fbo.head.Revision()
+
+	go func() {
+		err := diskMDCache.Commit(ctx, fbo.id(), rev)
+		if err != nil {
+			fbo.log.CDebugf(ctx, "Error commiting revision %d: %+v", rev, err)
+		}
+	}()
+}
+
 // getTrustedHead should not be called outside of folder_branch_ops.go.
 // Returns ImmutableRootMetadata{} when the head is not trusted.
 // See the comment on headTrustedStatus for more information.
-func (fbo *folderBranchOps) getTrustedHead(lState *lockState) ImmutableRootMetadata {
+func (fbo *folderBranchOps) getTrustedHead(
+	ctx context.Context, lState *lockState) ImmutableRootMetadata {
 	fbo.headLock.RLock(lState)
 	defer fbo.headLock.RUnlock(lState)
 	if fbo.headStatus == headUntrusted {
@@ -624,12 +647,14 @@ func (fbo *folderBranchOps) getTrustedHead(lState *lockState) ImmutableRootMetad
 	// called this method would get latest MD.
 	fbo.config.MDServer().FastForwardBackoff()
 	fbo.updateLastGetHeadTimestamp()
+	fbo.commitHeadLocked(ctx, lState)
 
 	return fbo.head
 }
 
 // getHead should not be called outside of folder_branch_ops.go.
-func (fbo *folderBranchOps) getHead(lState *lockState) (
+func (fbo *folderBranchOps) getHead(
+	ctx context.Context, lState *lockState) (
 	ImmutableRootMetadata, headTrustStatus) {
 	fbo.headLock.RLock(lState)
 	defer fbo.headLock.RUnlock(lState)
@@ -637,6 +662,7 @@ func (fbo *folderBranchOps) getHead(lState *lockState) (
 	// See getTrustedHead for explanation.
 	fbo.config.MDServer().FastForwardBackoff()
 	fbo.updateLastGetHeadTimestamp()
+	fbo.commitHeadLocked(ctx, lState)
 
 	return fbo.head, fbo.headStatus
 }
@@ -736,6 +762,109 @@ func (fbo *folderBranchOps) startMonitorChat(tlfName tlf.CanonicalName) {
 		fbo.editChannels <- editChannelActivity{nil, "", ""}
 		go fbo.monitorEditsChat(tlfName)
 	})
+}
+
+func (fbo *folderBranchOps) kickOffRootBlockFetch(
+	ctx context.Context, rmd ImmutableRootMetadata) <-chan error {
+	ptr := rmd.Data().Dir.BlockPointer
+	return fbo.config.BlockOps().BlockRetriever().Request(
+		ctx, defaultOnDemandRequestPriority, rmd, ptr, NewDirBlock(),
+		TransientEntry)
+}
+
+func (fbo *folderBranchOps) waitForRootBlockFetch(
+	ctx context.Context, rmd ImmutableRootMetadata,
+	fetchChan <-chan error) error {
+	fbo.log.CDebugf(ctx, "Ensuring that the latest root directory "+
+		"block for revision %d is available", rmd.Revision())
+	select {
+	case err := <-fetchChan:
+		fbo.log.CDebugf(ctx, "Root block fetch complete: +%v", err)
+		return err
+	case <-ctx.Done():
+		return errors.WithStack(ctx.Err())
+	}
+}
+
+func (fbo *folderBranchOps) commitFlushedMD(
+	rmd ImmutableRootMetadata, updatedCh <-chan struct{}) {
+	diskMDCache := fbo.config.DiskMDCache()
+	if diskMDCache == nil {
+		return
+	}
+
+	// Bail out if the latest merged revision has already been updated.
+	select {
+	case <-updatedCh:
+		return
+	default:
+	}
+
+	ctx := fbo.ctxWithFBOID(context.Background())
+	rev := rmd.Revision()
+	if fbo.config.IsSyncedTlf(fbo.id()) {
+		// For synced TLFs, wait for prefetching to complete for
+		// `rootPtr`. When it's successfully done, commit the
+		// corresponding MD.
+		rootPtr := rmd.Data().Dir.BlockPointer
+		fbo.log.CDebugf(ctx, "Fetching root block of revision %d, ptr %v",
+			rev, rootPtr)
+		rootCh := fbo.kickOffRootBlockFetch(ctx, rmd)
+		select {
+		case err := <-rootCh:
+			if err != nil {
+				fbo.log.CDebugf(ctx, "Error getting root block: %+v", err)
+				return
+			}
+		case <-updatedCh:
+			fbo.log.CDebugf(ctx, "The latest merged rev has been updated")
+			return
+		case <-fbo.shutdownChan:
+			fbo.log.CDebugf(ctx, "Shutdown, canceling root block wait")
+			return
+		}
+
+		fbo.log.CDebugf(ctx, "Waiting for prefetch of revision %d, ptr %v",
+			rev, rootPtr)
+		waitCh, err := fbo.config.BlockOps().Prefetcher().
+			WaitChannelForBlockPrefetch(ctx, rootPtr)
+		if err != nil {
+			fbo.log.CDebugf(ctx,
+				"Error getting wait channel for prefetch: %+v", err)
+			return
+		}
+
+		select {
+		case <-waitCh:
+		case <-updatedCh:
+			fbo.log.CDebugf(ctx, "The latest merged rev has been updated")
+			fbo.config.BlockOps().Prefetcher().CancelPrefetch(rootPtr.ID)
+			return
+		case <-fbo.shutdownChan:
+			fbo.log.CDebugf(ctx, "Shutdown, canceling prefetch wait")
+			return
+		}
+
+		_, prefetchStatus, _, err := fbo.config.BlockCache().GetWithPrefetch(
+			rootPtr)
+		if err != nil {
+			fbo.log.CDebugf(ctx, "Error getting prefetched block: %+v", err)
+			return
+		}
+		if prefetchStatus != FinishedPrefetch {
+			fbo.log.CDebugf(ctx, "Revision was not fully prefetched: status=%s",
+				prefetchStatus)
+			return
+		}
+
+		fbo.log.CDebugf(ctx, "Prefetch for revision %d complete; commiting",
+			rev)
+	}
+
+	err := diskMDCache.Commit(ctx, fbo.id(), rev)
+	if err != nil {
+		fbo.log.CDebugf(ctx, "Error commiting revision %d: %+v", rev, err)
+	}
 }
 
 func (fbo *folderBranchOps) setHeadLocked(
@@ -864,6 +993,10 @@ func (fbo *folderBranchOps) setHeadLocked(
 			// well.
 			fbo.setLatestMergedRevisionLocked(ctx, lState, md.Revision(), false)
 		}
+	}
+
+	if md.putToServer {
+		go fbo.commitFlushedMD(md, fbo.latestMergedUpdated)
 	}
 
 	// Make sure that any unembedded block changes have been swapped
@@ -1109,7 +1242,7 @@ func (fbo *folderBranchOps) getMDForRead(
 		panic("Invalid rtype in getMDLockedForRead")
 	}
 
-	md = fbo.getTrustedHead(lState)
+	md = fbo.getTrustedHead(ctx, lState)
 	if md != (ImmutableRootMetadata{}) {
 		if rtype != mdReadNoIdentify {
 			err = fbo.identifyOnce(ctx, md.ReadOnly())
@@ -1124,7 +1257,7 @@ func (fbo *folderBranchOps) getMDForRead(
 func (fbo *folderBranchOps) GetTLFHandle(ctx context.Context, _ Node) (
 	*TlfHandle, error) {
 	lState := makeFBOLockState()
-	md, _ := fbo.getHead(lState)
+	md, _ := fbo.getHead(ctx, lState)
 	return md.GetTlfHandle(), nil
 }
 
@@ -1142,7 +1275,7 @@ func (fbo *folderBranchOps) getMDForWriteOrRekeyLocked(
 		err = fbo.identifyOnce(ctx, md.ReadOnly())
 	}()
 
-	md = fbo.getTrustedHead(lState)
+	md = fbo.getTrustedHead(ctx, lState)
 	if md != (ImmutableRootMetadata{}) {
 		return md, nil
 	}
@@ -1569,7 +1702,7 @@ func (fbo *folderBranchOps) initMDLocked(
 
 	// Some other thread got here first, so give up and let it go
 	// before we push anything to the servers.
-	if h, _ := fbo.getHead(lState); h != (ImmutableRootMetadata{}) {
+	if h, _ := fbo.getHead(ctx, lState); h != (ImmutableRootMetadata{}) {
 		fbo.log.CDebugf(ctx, "Head was already set, aborting")
 		return nil
 	}
@@ -1698,6 +1831,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 			md.Revision(), md.MergedStatus(), err)
 	}()
 
+	var latestRootBlockFetch <-chan error
 	if md.IsReadable() && fbo.config.Mode().PrefetchWorkers() > 0 {
 		// We `Get` the root block to ensure downstream prefetches
 		// occur.  Use a fresh context, in case `ctx` is canceled by
@@ -1706,9 +1840,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 		fbo.log.CDebugf(ctx,
 			"Prefetching root block with a new context: FBOID=%s",
 			prefetchCtx.Value(CtxFBOIDKey))
-		_ = fbo.config.BlockOps().BlockRetriever().Request(prefetchCtx,
-			defaultOnDemandRequestPriority, md, md.data.Dir.BlockPointer,
-			&DirBlock{}, TransientEntry)
+		latestRootBlockFetch = fbo.kickOffRootBlockFetch(ctx, md)
 	} else {
 		fbo.log.CDebugf(ctx,
 			"Setting an unreadable head with revision=%d", md.Revision())
@@ -1719,7 +1851,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	// (e.g., calling `identifyOnce` and downloading the merged
 	// head) if head is already set.
 	lState := makeFBOLockState()
-	head, headStatus := fbo.getHead(lState)
+	head, headStatus := fbo.getHead(ctx, lState)
 	if headStatus == headTrusted && head != (ImmutableRootMetadata{}) && head.mdID == md.mdID {
 		fbo.log.CDebugf(ctx, "Head MD already set to revision %d (%s), no "+
 			"need to set initial head again", md.Revision(), md.MergedStatus())
@@ -1762,6 +1894,13 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 				fbo.setLatestMergedRevisionLocked(ctx, lState,
 					mergedMD.Revision(), false)
 			}()
+		}
+
+		if latestRootBlockFetch != nil {
+			err := fbo.waitForRootBlockFetch(ctx, md, latestRootBlockFetch)
+			if err != nil {
+				return err
+			}
 		}
 
 		fbo.headLock.Lock(lState)
@@ -4687,7 +4826,7 @@ func (fbo *folderBranchOps) syncAllLocked(
 	// All originals never made it to the server, so don't unmerged
 	// them.
 	syncChains.doNotUnrefPointers = syncChains.createdOriginals
-	head, _ := fbo.getHead(lState)
+	head, _ := fbo.getHead(ctx, lState)
 	dummyHeadChains := newCRChainsEmpty()
 	dummyHeadChains.mostRecentChainMDInfo = head
 
@@ -5236,6 +5375,11 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 	lState *lockState, rmds []ImmutableRootMetadata) error {
 	fbo.mdWriterLock.AssertLocked(lState)
 
+	if len(rmds) == 0 {
+		return nil
+	}
+	latestMerged := rmds[len(rmds)-1]
+
 	// If there's anything in the journal, don't apply these MDs.
 	// Wait for CR to happen.
 	if !fbo.isUnmergedLocked(lState) {
@@ -5255,7 +5399,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 					fbo.headLock.Lock(lState)
 					defer fbo.headLock.Unlock(lState)
 					fbo.setLatestMergedRevisionLocked(
-						ctx, lState, rmds[len(rmds)-1].Revision(), false)
+						ctx, lState, latestMerged.Revision(), false)
 				}()
 			}
 
@@ -5271,28 +5415,31 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 	// if we have staged changes, ignore all updates until conflict
 	// resolution kicks in.  TODO: cache these for future use.
 	if fbo.isUnmergedLocked(lState) {
-		if len(rmds) > 0 {
-			latestMerged := rmds[len(rmds)-1]
-			// Don't trust un-put updates here because they might have
-			// come from our own journal before the conflict was
-			// detected.  Assume we'll hear about the conflict via
-			// callbacks from the journal.
-			if !latestMerged.putToServer {
-				return UnmergedError{}
-			}
-
-			// setHeadLocked takes care of merged case
-			fbo.setLatestMergedRevisionLocked(
-				ctx, lState, latestMerged.Revision(), false)
-
-			unmergedRev := kbfsmd.RevisionUninitialized
-			if fbo.head != (ImmutableRootMetadata{}) {
-				unmergedRev = fbo.head.Revision()
-			}
-			fbo.cr.Resolve(ctx, unmergedRev, latestMerged.Revision())
+		// Don't trust un-put updates here because they might have
+		// come from our own journal before the conflict was
+		// detected.  Assume we'll hear about the conflict via
+		// callbacks from the journal.
+		if !latestMerged.putToServer {
+			return UnmergedError{}
 		}
+
+		// setHeadLocked takes care of merged case
+		fbo.setLatestMergedRevisionLocked(
+			ctx, lState, latestMerged.Revision(), false)
+
+		unmergedRev := kbfsmd.RevisionUninitialized
+		if fbo.head != (ImmutableRootMetadata{}) {
+			unmergedRev = fbo.head.Revision()
+		}
+		fbo.cr.Resolve(ctx, unmergedRev, latestMerged.Revision())
 		return UnmergedError{}
 	}
+
+	// Kick off a fetch of the latest root directory block, to make
+	// sure we have it locally before we expose these changes to the
+	// user.  That way, if we go offline we can be reasonably sure the
+	// user can at least list the root directory.
+	latestRootBlockFetch := fbo.kickOffRootBlockFetch(ctx, latestMerged)
 
 	// Don't allow updates while we're in the dirty state; the next
 	// sync will put us into an unmerged state anyway and we'll
@@ -5302,7 +5449,7 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 	}
 
 	appliedRevs := make([]ImmutableRootMetadata, 0, len(rmds))
-	for _, rmd := range rmds {
+	for i, rmd := range rmds {
 		// check that we're applying the expected MD revision
 		if rmd.Revision() <= fbo.getCurrMDRevisionLocked(lState) {
 			// Already caught up!
@@ -5310,6 +5457,14 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 		}
 		if err := isReadableOrError(ctx, fbo.config.KBPKI(), rmd.ReadOnly()); err != nil {
 			return err
+		}
+
+		if i == len(rmds)-1 {
+			err := fbo.waitForRootBlockFetch(
+				ctx, latestMerged, latestRootBlockFetch)
+			if err != nil {
+				return err
+			}
 		}
 
 		err := fbo.setHeadSuccessorLocked(ctx, lState, rmd, false)
@@ -5433,6 +5588,11 @@ func (fbo *folderBranchOps) setLatestMergedRevisionLocked(ctx context.Context, l
 		fbo.log.CDebugf(ctx, "Local latestMergedRevision (%d) is higher than "+
 			"the new revision (%d); won't update.", fbo.latestMergedRevision, rev)
 	}
+
+	if fbo.latestMergedUpdated != nil {
+		close(fbo.latestMergedUpdated)
+	}
+	fbo.latestMergedUpdated = make(chan struct{})
 }
 
 // Assumes all necessary locking is either already done by caller, or
@@ -5700,7 +5860,7 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 	}
 
 	// untrusted head is ok here.
-	head, _ := fbo.getHead(lState)
+	head, _ := fbo.getHead(ctx, lState)
 	if head != (ImmutableRootMetadata{}) {
 		// If we already have a cached revision, make sure we're
 		// up-to-date with the latest revision before inspecting the
@@ -6016,6 +6176,12 @@ func (fbo *folderBranchOps) doFastForwardLocked(ctx context.Context,
 		fbo.latestMergedRevision, currHead.Revision())
 	changes, affectedNodeIDs, err := fbo.blocks.FastForwardAllNodes(
 		ctx, lState, currHead.ReadOnly())
+	if err != nil {
+		return err
+	}
+
+	latestRootBlockFetch := fbo.kickOffRootBlockFetch(ctx, currHead)
+	err = fbo.waitForRootBlockFetch(ctx, currHead, latestRootBlockFetch)
 	if err != nil {
 		return err
 	}
@@ -6695,10 +6861,12 @@ func (fbo *folderBranchOps) handleMDFlush(
 		"Considering archiving references for flushed MD revision %d", rev)
 
 	lState := makeFBOLockState()
+	var latestMergedUpdated <-chan struct{}
 	func() {
 		fbo.headLock.Lock(lState)
 		defer fbo.headLock.Unlock(lState)
 		fbo.setLatestMergedRevisionLocked(ctx, lState, rev, false)
+		latestMergedUpdated = fbo.latestMergedUpdated
 	}()
 
 	// Get that revision.
@@ -6730,8 +6898,9 @@ func (fbo *folderBranchOps) handleMDFlush(
 			ctx, "Skipping archiving references for flushed MD revision %d: %s", rev, err)
 		return
 	}
-
 	fbo.fbm.archiveUnrefBlocks(rmd.ReadOnly())
+
+	go fbo.commitFlushedMD(rmd, latestMergedUpdated)
 }
 
 func (fbo *folderBranchOps) onMDFlush(
@@ -7024,7 +7193,7 @@ func (fbo *folderBranchOps) GetEditHistory(
 	}
 
 	lState := makeFBOLockState()
-	md, _ := fbo.getHead(lState)
+	md, _ := fbo.getHead(ctx, lState)
 	name := md.GetTlfHandle().GetCanonicalName()
 	return fbo.config.UserHistory().GetTlfHistory(name, fbo.id().Type()), nil
 }

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -745,6 +745,19 @@ func doInit(
 			params.DiskCacheMode.String())
 	}
 
+	err = config.MakeDiskMDCacheIfNotExists()
+	if err != nil {
+		log.CWarningf(ctx, "Could not initialize MD cache: %+v", err)
+		notification := &keybase1.FSNotification{
+			StatusCode:       keybase1.FSStatusCode_ERROR,
+			NotificationType: keybase1.FSNotificationType_INITIALIZED,
+			ErrorType:        keybase1.FSErrorType_DISK_CACHE_ERROR_LOG_SEND,
+		}
+		defer config.Reporter().Notify(ctx, notification)
+	} else {
+		log.CDebugf(ctx, "Disk MD cache enabled")
+	}
+
 	if config.Mode().KBFSServiceEnabled() {
 		// Initialize kbfsService only when we run a full KBFS process.
 		// This requires the disk block cache to have been initialized, if it

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3200,10 +3200,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	// Shutdown the mdserver explicitly before the state checker tries to run
 	defer config2.MDServer().Shutdown()
 
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, "test_user", tlf.Private)
-	// Lookup the file, which should fail on block ID verification
-	kbfsOps2 := config2.KBFSOps()
-	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	_, err = GetRootNodeForTest(ctx, config2, "test_user", tlf.Private)
 	if _, ok := errors.Cause(err).(kbfshash.HashMismatchError); !ok {
 		t.Fatalf("Could unexpectedly lookup the file: %+v", err)
 	}

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -21,7 +21,6 @@ const (
 	fileIndirectBlockPrefetchPriority int           = -100
 	dirEntryPrefetchPriority          int           = -200
 	updatePointerPrefetchPriority     int           = lowestTriggerPrefetchPriority
-	defaultPrefetchPriority           int           = -1024
 	prefetchTimeout                   time.Duration = 24 * time.Hour
 	maxNumPrefetches                  int           = 10000
 )
@@ -511,8 +510,9 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 					c := make(chan struct{})
 					close(c)
 					req.sendCh <- c
+				} else {
+					req.sendCh <- pre.waitCh
 				}
-				req.sendCh <- pre.waitCh
 				continue
 			}
 


### PR DESCRIPTION
`mdserverRemote` now reads the latest TLF revision from the disk when possible, and stages commits that are get/put from the remote server.

FBO nows commits staged MDs for synced TLFs to disk once one of the following conditions is met:
  1) The new revision is fully prefetched.
  2) The new revision has been read by the user.

In addition, FBO won't even show a downloaded revision to the user until at least the root block for the revision has been prefetched.

All of this is to ensure that a synced TLF contains at least some data if the user suddenly loses connectivity, or restarts in offline mode.

Also fix a few bugs, and initialize the disk MD cache on startup.

Issue: KBFS-3505
