### PR TITLE
folder_branch_ops: commit MDs to disk after reading/prefetching

### DIFF
--- a/libkbfs/backpressure_disk_limiter.go
+++ b/libkbfs/backpressure_disk_limiter.go
@@ -1092,8 +1092,8 @@ type backpressureDiskLimiterStatus struct {
 
 func (bdl *backpressureDiskLimiter) getStatus(
 	ctx context.Context, chargedTo keybase1.UserOrTeamID) interface{} {
-	bdl.lock.RLock()
-	defer bdl.lock.RUnlock()
+	bdl.lock.Lock()
+	defer bdl.lock.Unlock()
 
 	currentDelay := bdl.getDelayLocked(
 		context.Background(), time.Now(), chargedTo)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1430,7 +1430,7 @@ func (c *ConfigLocal) MakeDiskMDCacheIfNotExists() error {
 	if c.diskMDCache != nil {
 		return nil
 	}
-	return c.resetDiskBlockCacheLocked()
+	return c.resetDiskMDCacheLocked()
 }
 
 func (c *ConfigLocal) openConfigLevelDB(configName string) (*levelDb, error) {

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3168,7 +3168,7 @@ outer:
 		return err
 	}
 
-	head := cr.fbo.getTrustedHead(lState)
+	head := cr.fbo.getTrustedHead(ctx, lState)
 	if head == (ImmutableRootMetadata{}) {
 		panic("maybeUnstageAfterFailure: head is nil (should be impossible)")
 	}
@@ -3199,7 +3199,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	defer func() {
 		cr.deferLog.CDebugf(ctx, "Finished conflict resolution: %+v", err)
 		if err != nil {
-			head := cr.fbo.getTrustedHead(lState)
+			head := cr.fbo.getTrustedHead(ctx, lState)
 			if head == (ImmutableRootMetadata{}) {
 				panic("doResolve: head is nil (should be impossible)")
 			}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -623,10 +623,12 @@ func (fbo *folderBranchOps) commitHeadLocked(
 	}
 	rev := fbo.head.Revision()
 
+	id := fbo.id()
+	log := fbo.log
 	go func() {
-		err := diskMDCache.Commit(ctx, fbo.id(), rev)
+		err := diskMDCache.Commit(ctx, id, rev)
 		if err != nil {
-			fbo.log.CDebugf(ctx, "Error commiting revision %d: %+v", rev, err)
+			log.CDebugf(ctx, "Error commiting revision %d: %+v", rev, err)
 		}
 	}()
 }

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -57,17 +57,18 @@ type FolderBranchStatus struct {
 // suitable for encoding directly as JSON.
 // TODO: implement magical status update like FolderBranchStatus
 type KBFSStatus struct {
-	CurrentUser     string
-	IsConnected     bool
-	UsageBytes      int64
-	ArchiveBytes    int64
-	LimitBytes      int64
-	GitUsageBytes   int64
-	GitArchiveBytes int64
-	GitLimitBytes   int64
-	FailingServices map[string]error
-	JournalServer   *JournalServerStatus            `json:",omitempty"`
-	DiskCacheStatus map[string]DiskBlockCacheStatus `json:",omitempty"`
+	CurrentUser          string
+	IsConnected          bool
+	UsageBytes           int64
+	ArchiveBytes         int64
+	LimitBytes           int64
+	GitUsageBytes        int64
+	GitArchiveBytes      int64
+	GitLimitBytes        int64
+	FailingServices      map[string]error
+	JournalServer        *JournalServerStatus            `json:",omitempty"`
+	DiskBlockCacheStatus map[string]DiskBlockCacheStatus `json:",omitempty"`
+	DiskMDCacheStatus    DiskMDCacheStatus               `json:",omitempty"`
 }
 
 // StatusUpdate is a dummy type used to indicate status has been updated.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -745,6 +745,19 @@ func doInit(
 			params.DiskCacheMode.String())
 	}
 
+	err = config.MakeDiskMDCacheIfNotExists()
+	if err != nil {
+		log.CWarningf(ctx, "Could not initialize MD cache: %+v", err)
+		notification := &keybase1.FSNotification{
+			StatusCode:       keybase1.FSStatusCode_ERROR,
+			NotificationType: keybase1.FSNotificationType_INITIALIZED,
+			ErrorType:        keybase1.FSErrorType_DISK_CACHE_ERROR_LOG_SEND,
+		}
+		defer config.Reporter().Notify(ctx, notification)
+	} else {
+		log.CDebugf(ctx, "Disk MD cache enabled")
+	}
+
 	if config.Mode().KBFSServiceEnabled() {
 		// Initialize kbfsService only when we run a full KBFS process.
 		// This requires the disk block cache to have been initialized, if it

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1022,18 +1022,25 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		dbcStatus = dbc.Status(ctx)
 	}
 
+	dmc := fs.config.DiskMDCache()
+	var dmcStatus DiskMDCacheStatus
+	if dmc != nil {
+		dmcStatus = dmc.Status(ctx)
+	}
+
 	return KBFSStatus{
-		CurrentUser:     session.Name.String(),
-		IsConnected:     fs.config.MDServer().IsConnected(),
-		UsageBytes:      usageBytes,
-		ArchiveBytes:    archiveBytes,
-		LimitBytes:      limitBytes,
-		GitUsageBytes:   gitUsageBytes,
-		GitArchiveBytes: gitArchiveBytes,
-		GitLimitBytes:   gitLimitBytes,
-		FailingServices: failures,
-		JournalServer:   jServerStatus,
-		DiskCacheStatus: dbcStatus,
+		CurrentUser:          session.Name.String(),
+		IsConnected:          fs.config.MDServer().IsConnected(),
+		UsageBytes:           usageBytes,
+		ArchiveBytes:         archiveBytes,
+		LimitBytes:           limitBytes,
+		GitUsageBytes:        gitUsageBytes,
+		GitArchiveBytes:      gitArchiveBytes,
+		GitLimitBytes:        gitLimitBytes,
+		FailingServices:      failures,
+		JournalServer:        jServerStatus,
+		DiskBlockCacheStatus: dbcStatus,
+		DiskMDCacheStatus:    dmcStatus,
 	}, ch, err
 }
 

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -3200,10 +3200,7 @@ func TestKBFSOpsFailToReadUnverifiableBlock(t *testing.T) {
 	// Shutdown the mdserver explicitly before the state checker tries to run
 	defer config2.MDServer().Shutdown()
 
-	rootNode2 := GetRootNodeOrBust(ctx, t, config2, "test_user", tlf.Private)
-	// Lookup the file, which should fail on block ID verification
-	kbfsOps2 := config2.KBFSOps()
-	_, _, err = kbfsOps2.Lookup(ctx, rootNode2, "a")
+	_, err = GetRootNodeForTest(ctx, config2, "test_user", tlf.Private)
 	if _, ok := errors.Cause(err).(kbfshash.HashMismatchError); !ok {
 		t.Fatalf("Could unexpectedly lookup the file: %+v", err)
 	}

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -4045,6 +4045,8 @@ func TestKBFSOpsUnsyncedMDCommit(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps2.SyncAll(ctx, rootNode2.GetFolderBranch())
 	require.NoError(t, err)
+
+	t.Log("Sync the first device")
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
 

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -21,7 +21,6 @@ const (
 	fileIndirectBlockPrefetchPriority int           = -100
 	dirEntryPrefetchPriority          int           = -200
 	updatePointerPrefetchPriority     int           = lowestTriggerPrefetchPriority
-	defaultPrefetchPriority           int           = -1024
 	prefetchTimeout                   time.Duration = 24 * time.Hour
 	maxNumPrefetches                  int           = 10000
 )
@@ -511,8 +510,9 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 					c := make(chan struct{})
 					close(c)
 					req.sendCh <- c
+				} else {
+					req.sendCh <- pre.waitCh
 				}
-				req.sendCh <- pre.waitCh
 				continue
 			}
 


### PR DESCRIPTION
`mdserverRemote` now reads the latest TLF revision from the disk when possible, and stages commits that are get/put from the remote server.

FBO nows commits staged MDs for synced TLFs to disk once one of the following conditions is met:
  1) The new revision is fully prefetched.
  2) The new revision has been read by the user.

In addition, FBO won't even show a downloaded revision to the user until at least the root block for the revision has been prefetched.

All of this is to ensure that a synced TLF contains at least some data if the user suddenly loses connectivity, or restarts in offline mode.

Also fix a few bugs, and initialize the disk MD cache on startup.

Issue: KBFS-3505
