### PR TITLE
disk_quota_cache: cache quotas to disk, and use when needed

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1233,6 +1233,10 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 	if dmc != nil {
 		dmc.Shutdown(ctx)
 	}
+	dqc := c.DiskQuotaCache()
+	if dqc != nil {
+		dqc.Shutdown(ctx)
+	}
 	kbfsServ := c.kbfsService
 	if kbfsServ != nil {
 		kbfsServ.Shutdown()

--- a/libkbfs/disk_md_cache_test.go
+++ b/libkbfs/disk_md_cache_test.go
@@ -6,7 +6,6 @@ package libkbfs
 
 import (
 	"crypto/rand"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,9 +30,6 @@ func newDiskMDCacheLocalForTestWithStorage(
 		newTestCodecGetter(),
 		newTestLogMaker(t),
 	}, s)
-	if err != nil {
-		fmt.Println(err.Error())
-	}
 	require.NoError(t, err)
 	err = cache.WaitUntilStarted()
 	require.NoError(t, err)

--- a/libkbfs/disk_quota_cache.go
+++ b/libkbfs/disk_quota_cache.go
@@ -1,0 +1,369 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"sync"
+
+	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/pkg/errors"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+)
+
+const (
+	quotaDbFilename              string = "diskCacheQuota.leveldb"
+	initialDiskQuotaCacheVersion uint64 = 1
+	currentDiskQuotaCacheVersion uint64 = initialDiskQuotaCacheVersion
+	defaultQuotaCacheTableSize   int    = 50 * opt.MiB
+	quotaCacheFolderName         string = "kbfs_quota_cache"
+)
+
+// diskQuotaCacheConfig specifies the interfaces that a DiskQuotaCacheLocal
+// needs to perform its functions. This adheres to the standard libkbfs Config
+// API.
+type diskQuotaCacheConfig interface {
+	codecGetter
+	logMaker
+}
+
+// DiskQuotaCacheLocal is the standard implementation for DiskQuotaCache.
+type DiskQuotaCacheLocal struct {
+	config diskQuotaCacheConfig
+	log    logger.Logger
+
+	// Track the cache hit rate and eviction rate
+	hitMeter  *CountMeter
+	missMeter *CountMeter
+	putMeter  *CountMeter
+	// Protect the disk caches from being shutdown while they're being
+	// accessed, and mutable data.
+	lock         sync.RWMutex
+	db           *levelDb // id -> quota info
+	quotasCached map[keybase1.UserOrTeamID]bool
+
+	startedCh  chan struct{}
+	startErrCh chan struct{}
+	shutdownCh chan struct{}
+
+	closer func()
+}
+
+var _ DiskQuotaCache = (*DiskQuotaCacheLocal)(nil)
+
+// DiskQuotaCacheStartState represents whether this disk Quota cache has
+// started or failed.
+type DiskQuotaCacheStartState int
+
+// String allows DiskQuotaCacheStartState to be output as a string.
+func (s DiskQuotaCacheStartState) String() string {
+	switch s {
+	case DiskQuotaCacheStartStateStarting:
+		return "starting"
+	case DiskQuotaCacheStartStateStarted:
+		return "started"
+	case DiskQuotaCacheStartStateFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+const (
+	// DiskQuotaCacheStartStateStarting represents when the cache is starting.
+	DiskQuotaCacheStartStateStarting DiskQuotaCacheStartState = iota
+	// DiskQuotaCacheStartStateStarted represents when the cache has started.
+	DiskQuotaCacheStartStateStarted
+	// DiskQuotaCacheStartStateFailed represents when the cache has failed to
+	// start.
+	DiskQuotaCacheStartStateFailed
+)
+
+// DiskQuotaCacheStatus represents the status of the Quota cache.
+type DiskQuotaCacheStatus struct {
+	StartState DiskQuotaCacheStartState
+	NumQuotas  uint64
+	Hits       MeterStatus
+	Misses     MeterStatus
+	Puts       MeterStatus
+}
+
+// newDiskQuotaCacheLocalFromStorage creates a new *DiskQuotaCacheLocal
+// with the passed-in storage.Storage interfaces as storage layers for each
+// cache.
+func newDiskQuotaCacheLocalFromStorage(
+	config diskQuotaCacheConfig, quotaStorage storage.Storage) (
+	cache *DiskQuotaCacheLocal, err error) {
+	log := config.MakeLogger("DQC")
+	closers := make([]io.Closer, 0, 1)
+	closer := func() {
+		for _, c := range closers {
+			closeErr := c.Close()
+			if closeErr != nil {
+				log.Warning("Error closing leveldb or storage: %+v", closeErr)
+			}
+		}
+	}
+	defer func() {
+		if err != nil {
+			err = errors.WithStack(err)
+			closer()
+		}
+	}()
+	quotaDbOptions := *leveldbOptions
+	quotaDbOptions.CompactionTableSize = defaultQuotaCacheTableSize
+	db, err := openLevelDBWithOptions(quotaStorage, &quotaDbOptions)
+	if err != nil {
+		return nil, err
+	}
+	closers = append(closers, db)
+
+	startedCh := make(chan struct{})
+	startErrCh := make(chan struct{})
+	cache = &DiskQuotaCacheLocal{
+		config:       config,
+		hitMeter:     NewCountMeter(),
+		missMeter:    NewCountMeter(),
+		putMeter:     NewCountMeter(),
+		log:          log,
+		db:           db,
+		quotasCached: make(map[keybase1.UserOrTeamID]bool),
+		startedCh:    startedCh,
+		startErrCh:   startErrCh,
+		shutdownCh:   make(chan struct{}),
+		closer:       closer,
+	}
+	// Sync the quota counts asynchronously so syncing doesn't block init.
+	// Since this method blocks, any Get or Put requests to the disk Quota
+	// cache will block until this is done. The log will contain the beginning
+	// and end of this sync.
+	go func() {
+		err := cache.syncQuotaCountsFromDb()
+		if err != nil {
+			close(startErrCh)
+			closer()
+			log.Warning("Disabling disk quota cache due to error syncing the "+
+				"quota counts from DB: %+v", err)
+			return
+		}
+		close(startedCh)
+	}()
+	return cache, nil
+}
+
+// newDiskQuotaCacheLocal creates a new *DiskQuotaCacheLocal with a
+// specified directory on the filesystem as storage.
+func newDiskQuotaCacheLocal(
+	config diskBlockCacheConfig, dirPath string) (
+	cache *DiskQuotaCacheLocal, err error) {
+	log := config.MakeLogger("DQC")
+	defer func() {
+		if err != nil {
+			log.Error("Error initializing quota cache: %+v", err)
+		}
+	}()
+	cachePath := filepath.Join(dirPath, quotaCacheFolderName)
+	versionPath, err := getVersionedPathForDiskCache(
+		log, cachePath, "quota", currentDiskQuotaCacheVersion)
+	if err != nil {
+		return nil, err
+	}
+	dbPath := filepath.Join(versionPath, quotaDbFilename)
+	quotaStorage, err := storage.OpenFile(dbPath, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			quotaStorage.Close()
+		}
+	}()
+	return newDiskQuotaCacheLocalFromStorage(config, quotaStorage)
+}
+
+// WaitUntilStarted waits until this cache has started.
+func (cache *DiskQuotaCacheLocal) WaitUntilStarted() error {
+	select {
+	case <-cache.startedCh:
+		return nil
+	case <-cache.startErrCh:
+		return DiskQuotaCacheError{"error starting channel"}
+	}
+}
+
+func (cache *DiskQuotaCacheLocal) syncQuotaCountsFromDb() error {
+	cache.log.Debug("+ syncQuotaCountsFromDb begin")
+	defer cache.log.Debug("- syncQuotaCountsFromDb end")
+	// We take a write lock for this to prevent any reads from happening while
+	// we're syncing the Quota counts.
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	quotasCached := make(map[keybase1.UserOrTeamID]bool)
+	iter := cache.db.NewIterator(nil, nil)
+	defer iter.Release()
+	for iter.Next() {
+		var id keybase1.UserOrTeamID
+		id, err := keybase1.UserOrTeamIDFromString(string(iter.Key()))
+		if err != nil {
+			return err
+		}
+
+		quotasCached[id] = true
+	}
+	cache.quotasCached = quotasCached
+	return nil
+}
+
+// getQuotaLocked retrieves the quota info for a block in the cache,
+// or returns leveldb.ErrNotFound and a zero-valued metadata
+// otherwise.
+func (cache *DiskQuotaCacheLocal) getQuotaLocked(
+	id keybase1.UserOrTeamID, metered bool) (
+	info kbfsblock.QuotaInfo, err error) {
+	var hitMeter, missMeter *CountMeter
+	if metered {
+		hitMeter = cache.hitMeter
+		missMeter = cache.missMeter
+	}
+
+	quotaBytes, err := cache.db.GetWithMeter(
+		[]byte(id.String()), hitMeter, missMeter)
+	if err != nil {
+		return kbfsblock.QuotaInfo{}, err
+	}
+	err = cache.config.Codec().Decode(quotaBytes, &info)
+	if err != nil {
+		return kbfsblock.QuotaInfo{}, err
+	}
+	return info, nil
+}
+
+// checkAndLockCache checks whether the cache is started.
+func (cache *DiskQuotaCacheLocal) checkCacheLocked(
+	ctx context.Context, method string) error {
+	// First see if the context has expired since we began.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	select {
+	case <-cache.startedCh:
+	case <-cache.startErrCh:
+		// The cache will never be started. No need for a stack here since this
+		// could happen anywhere.
+		return DiskCacheStartingError{method}
+	default:
+		// If the cache hasn't started yet, return an error.  No need for a
+		// stack here since this could happen anywhere.
+		return DiskCacheStartingError{method}
+	}
+	// shutdownCh has to be checked under lock, otherwise we can race.
+	select {
+	case <-cache.shutdownCh:
+		return errors.WithStack(DiskCacheClosedError{method})
+	default:
+	}
+	if cache.db == nil {
+		return errors.WithStack(DiskCacheClosedError{method})
+	}
+	return nil
+}
+
+// Get implements the DiskQuotaCache interface for DiskQuotaCacheLocal.
+func (cache *DiskQuotaCacheLocal) Get(
+	ctx context.Context, id keybase1.UserOrTeamID) (
+	info kbfsblock.QuotaInfo, err error) {
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+	err = cache.checkCacheLocked(ctx, "Quota(Get)")
+	if err != nil {
+		return kbfsblock.QuotaInfo{}, err
+	}
+
+	return cache.getQuotaLocked(id, metered)
+}
+
+// Put implements the DiskQuotaCache interface for DiskQuotaCacheLocal.
+func (cache *DiskQuotaCacheLocal) Put(
+	ctx context.Context, id keybase1.UserOrTeamID,
+	info kbfsblock.QuotaInfo) (err error) {
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	err = cache.checkCacheLocked(ctx, "Quota(Put)")
+	if err != nil {
+		return err
+	}
+
+	encodedInfo, err := cache.config.Codec().Encode(&info)
+	if err != nil {
+		return err
+	}
+
+	err = cache.db.PutWithMeter(
+		[]byte(id.String()), encodedInfo, cache.putMeter)
+	if err != nil {
+		return err
+	}
+
+	cache.quotasCached[id] = true
+	return nil
+}
+
+// Status implements the DiskQuotaCache interface for DiskQuotaCacheLocal.
+func (cache *DiskQuotaCacheLocal) Status(_ context.Context) DiskQuotaCacheStatus {
+	select {
+	case <-cache.startedCh:
+	case <-cache.startErrCh:
+		return DiskQuotaCacheStatus{StartState: DiskQuotaCacheStartStateFailed}
+	default:
+		return DiskQuotaCacheStatus{StartState: DiskQuotaCacheStartStateStarting}
+	}
+
+	cache.lock.RLock()
+	defer cache.lock.RUnlock()
+
+	return DiskQuotaCacheStatus{
+		StartState: DiskQuotaCacheStartStateStarted,
+		NumQuotas:  uint64(len(cache.quotasCached)),
+		Hits:       rateMeterToStatus(cache.hitMeter),
+		Misses:     rateMeterToStatus(cache.missMeter),
+		Puts:       rateMeterToStatus(cache.putMeter),
+	}
+}
+
+// Shutdown implements the DiskQuotaCache interface for DiskQuotaCacheLocal.
+func (cache *DiskQuotaCacheLocal) Shutdown(ctx context.Context) {
+	// Wait for the cache to either finish starting or error.
+	select {
+	case <-cache.startedCh:
+	case <-cache.startErrCh:
+		return
+	}
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+	// shutdownCh has to be checked under lock, otherwise we can race.
+	select {
+	case <-cache.shutdownCh:
+		cache.log.CWarningf(ctx, "Shutdown called more than once")
+	default:
+	}
+	close(cache.shutdownCh)
+	if cache.db == nil {
+		return
+	}
+	cache.closer()
+	cache.db = nil
+	cache.hitMeter.Shutdown()
+	cache.missMeter.Shutdown()
+	cache.putMeter.Shutdown()
+}

--- a/libkbfs/disk_quota_cache.go
+++ b/libkbfs/disk_quota_cache.go
@@ -355,6 +355,7 @@ func (cache *DiskQuotaCacheLocal) Shutdown(ctx context.Context) {
 	select {
 	case <-cache.shutdownCh:
 		cache.log.CWarningf(ctx, "Shutdown called more than once")
+		return
 	default:
 	}
 	close(cache.shutdownCh)

--- a/libkbfs/disk_quota_cache_test.go
+++ b/libkbfs/disk_quota_cache_test.go
@@ -1,0 +1,128 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb/storage"
+	"golang.org/x/net/context"
+)
+
+type testDiskQuotaCacheConfig struct {
+	codecGetter
+	logMaker
+}
+
+func newDiskQuotaCacheLocalForTestWithStorage(
+	t *testing.T, s storage.Storage) *DiskQuotaCacheLocal {
+	cache, err := newDiskQuotaCacheLocalFromStorage(&testDiskQuotaCacheConfig{
+		newTestCodecGetter(),
+		newTestLogMaker(t),
+	}, s)
+	require.NoError(t, err)
+	err = cache.WaitUntilStarted()
+	require.NoError(t, err)
+	return cache
+}
+
+func newDiskQuotaCacheLocalForTest(t *testing.T) (
+	*DiskQuotaCacheLocal, string) {
+	// Use a disk-based level, instead of memory storage, because we
+	// want to simulate a restart and memory storages can't be reused.
+	tempdir, err := ioutil.TempDir(os.TempDir(), "disk_quota_cache")
+	require.NoError(t, err)
+	s, err := storage.OpenFile(filepath.Join(tempdir, "quota"), false)
+	require.NoError(t, err)
+
+	cache := newDiskQuotaCacheLocalForTestWithStorage(t, s)
+	return cache, tempdir
+}
+
+func shutdownDiskQuotaCacheTest(cache DiskQuotaCache, tempdir string) {
+	cache.Shutdown(context.Background())
+	os.RemoveAll(tempdir)
+}
+
+func makeRandomQuotaWithUsageWrite(t *testing.T) kbfsblock.QuotaInfo {
+	qi := kbfsblock.NewQuotaInfo()
+	qi.Total.Bytes[kbfsblock.UsageWrite] = rand.Int63()
+	return *qi
+}
+
+func TestDiskQuotaCacheCommitAndGet(t *testing.T) {
+	t.Parallel()
+	t.Log("Test that basic quota cache Put and Get operations work.")
+	cache, tempdir := newDiskQuotaCacheLocalForTest(t)
+	defer func() {
+		shutdownDiskQuotaCacheTest(cache, tempdir)
+	}()
+
+	ctx := context.Background()
+	id1 := keybase1.MakeTestUID(1).AsUserOrTeam()
+	qi1 := makeRandomQuotaWithUsageWrite(t)
+
+	t.Log("Put a quota into the cache.")
+	_, err := cache.Get(ctx, id1)
+	require.Error(t, err) // not cached yet
+	err = cache.Put(ctx, id1, qi1)
+	require.NoError(t, err)
+	status := cache.Status(ctx)
+	require.Equal(t, uint64(1), status.NumQuotas)
+
+	t.Log("Get a quota from the cache.")
+	getQI1, err := cache.Get(ctx, id1)
+	require.NoError(t, err)
+	checkWrite := func(a, b kbfsblock.QuotaInfo) {
+		require.Equal(
+			t, a.Total.Bytes[kbfsblock.UsageWrite],
+			b.Total.Bytes[kbfsblock.UsageWrite])
+	}
+	checkWrite(qi1, getQI1)
+
+	t.Log("Check the meters.")
+	status = cache.Status(ctx)
+	require.Equal(t, int64(1), status.Hits.Count)
+	require.Equal(t, int64(1), status.Misses.Count)
+	require.Equal(t, int64(1), status.Puts.Count)
+
+	t.Log("A second entry.")
+	id2 := keybase1.MakeTestTeamID(2, false).AsUserOrTeam()
+	qi2 := makeRandomQuotaWithUsageWrite(t)
+	err = cache.Put(ctx, id2, qi2)
+	require.NoError(t, err)
+	getQI2, err := cache.Get(ctx, id2)
+	require.NoError(t, err)
+	checkWrite(qi2, getQI2)
+
+	t.Log("Override the first user.")
+	qi3 := makeRandomQuotaWithUsageWrite(t)
+	err = cache.Put(ctx, id1, qi3)
+	require.NoError(t, err)
+	getQI3, err := cache.Get(ctx, id1)
+	require.NoError(t, err)
+	checkWrite(qi3, getQI3)
+
+	t.Log("Restart the cache and check the stats")
+	cache.Shutdown(ctx)
+	s, err := storage.OpenFile(filepath.Join(tempdir, "quota"), false)
+	require.NoError(t, err)
+	cache = newDiskQuotaCacheLocalForTestWithStorage(t, s)
+	status = cache.Status(ctx)
+	require.Equal(t, uint64(2), status.NumQuotas)
+	getQI3, err = cache.Get(ctx, id1)
+	require.NoError(t, err)
+	checkWrite(qi3, getQI3)
+	getQI2, err = cache.Get(ctx, id2)
+	require.NoError(t, err)
+	checkWrite(qi2, getQI2)
+}

--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1108,7 +1108,10 @@ func (e NoUpdatesWhileDirtyError) Error() string {
 const (
 	// StatusCodeDiskBlockCacheError is a generic disk cache error.
 	StatusCodeDiskBlockCacheError = 0x666
-	StatusCodeDiskMDCacheError    = 0x667
+	// StatusCodeDiskMDCacheError is a generic disk cache error.
+	StatusCodeDiskMDCacheError = 0x667
+	// StatusCodeDiskQuotaCacheError is a generic disk cache error.
+	StatusCodeDiskQuotaCacheError = 0x668
 )
 
 // DiskBlockCacheError is a generic disk cache error.
@@ -1153,6 +1156,28 @@ func (e DiskMDCacheError) ToStatus() (s keybase1.Status) {
 // Error implements the Error interface for DiskMDCacheError.
 func (e DiskMDCacheError) Error() string {
 	return "DiskMDCacheError{" + e.Msg + "}"
+}
+
+// DiskQuotaCacheError is a generic disk cache error.
+type DiskQuotaCacheError struct {
+	Msg string
+}
+
+func newDiskQuotaCacheError(err error) DiskQuotaCacheError {
+	return DiskQuotaCacheError{err.Error()}
+}
+
+// ToStatus implements the ExportableError interface for DiskQuotaCacheError.
+func (e DiskQuotaCacheError) ToStatus() (s keybase1.Status) {
+	s.Code = StatusCodeDiskQuotaCacheError
+	s.Name = "DISK_QUOTA_CACHE_ERROR"
+	s.Desc = e.Msg
+	return
+}
+
+// Error implements the Error interface for DiskQuotaCacheError.
+func (e DiskQuotaCacheError) Error() string {
+	return "DiskQuotaCacheError{" + e.Msg + "}"
 }
 
 // RevokedDeviceVerificationError indicates that the user is trying to

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -69,6 +69,7 @@ type KBFSStatus struct {
 	JournalServer        *JournalServerStatus            `json:",omitempty"`
 	DiskBlockCacheStatus map[string]DiskBlockCacheStatus `json:",omitempty"`
 	DiskMDCacheStatus    DiskMDCacheStatus               `json:",omitempty"`
+	DiskQuotaCacheStatus DiskQuotaCacheStatus            `json:",omitempty"`
 }
 
 // StatusUpdate is a dummy type used to indicate status has been updated.

--- a/libkbfs/init.go
+++ b/libkbfs/init.go
@@ -758,6 +758,19 @@ func doInit(
 		log.CDebugf(ctx, "Disk MD cache enabled")
 	}
 
+	err = config.MakeDiskQuotaCacheIfNotExists()
+	if err != nil {
+		log.CWarningf(ctx, "Could not initialize disk quota cache: %+v", err)
+		notification := &keybase1.FSNotification{
+			StatusCode:       keybase1.FSStatusCode_ERROR,
+			NotificationType: keybase1.FSNotificationType_INITIALIZED,
+			ErrorType:        keybase1.FSErrorType_DISK_CACHE_ERROR_LOG_SEND,
+		}
+		defer config.Reporter().Notify(ctx, notification)
+	} else {
+		log.CDebugf(ctx, "Disk quota cache enabled")
+	}
+
 	if config.Mode().KBFSServiceEnabled() {
 		// Initialize kbfsService only when we run a full KBFS process.
 		// This requires the disk block cache to have been initialized, if it

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -91,6 +91,14 @@ type diskMDCacheSetter interface {
 	MakeDiskMDCacheIfNotExists() error
 }
 
+type diskQuotaCacheGetter interface {
+	DiskQuotaCache() DiskQuotaCache
+}
+
+type diskQuotaCacheSetter interface {
+	MakeDiskQuotaCacheIfNotExists() error
+}
+
 type clockGetter interface {
 	Clock() Clock
 }
@@ -1285,6 +1293,22 @@ type DiskMDCache interface {
 	Shutdown(ctx context.Context)
 }
 
+// DiskQuotaCache caches encrypts per-ID quotas to the disk.
+type DiskQuotaCache interface {
+	// Get gets the latest cached quota for the given ID from the disk
+	// cache.
+	Get(ctx context.Context, id keybase1.UserOrTeamID) (
+		info kbfsblock.QuotaInfo, err error)
+	// Put stores the latest cached quota for the given ID to the disk
+	// cache.
+	Put(ctx context.Context, id keybase1.UserOrTeamID,
+		info kbfsblock.QuotaInfo) (err error)
+	// Status returns the current status of the disk cache.
+	Status(ctx context.Context) DiskQuotaCacheStatus
+	// Shutdown cleanly shuts down the disk quota cache.
+	Shutdown(ctx context.Context)
+}
+
 // cryptoPure contains all methods of Crypto that don't depend on
 // implicit state, i.e. they're pure functions of the input.
 type cryptoPure interface {
@@ -2145,6 +2169,8 @@ type Config interface {
 	syncBlockCacheFractionSetter
 	diskMDCacheGetter
 	diskMDCacheSetter
+	diskQuotaCacheGetter
+	diskQuotaCacheSetter
 	clockGetter
 	diskLimiterGetter
 	syncedTlfGetterSetter

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1029,6 +1029,11 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 	if dmc != nil {
 		dmcStatus = dmc.Status(ctx)
 	}
+	dqc := fs.config.DiskQuotaCache()
+	var dqcStatus DiskQuotaCacheStatus
+	if dqc != nil {
+		dqcStatus = dqc.Status(ctx)
+	}
 
 	return KBFSStatus{
 		CurrentUser:          session.Name.String(),
@@ -1043,6 +1048,7 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		JournalServer:        jServerStatus,
 		DiskBlockCacheStatus: dbcStatus,
 		DiskMDCacheStatus:    dmcStatus,
+		DiskQuotaCacheStatus: dqcStatus,
 	}, ch, err
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -614,6 +614,76 @@ func (mr *MockdiskMDCacheSetterMockRecorder) MakeDiskMDCacheIfNotExists() *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDiskMDCacheIfNotExists", reflect.TypeOf((*MockdiskMDCacheSetter)(nil).MakeDiskMDCacheIfNotExists))
 }
 
+// MockdiskQuotaCacheGetter is a mock of diskQuotaCacheGetter interface
+type MockdiskQuotaCacheGetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockdiskQuotaCacheGetterMockRecorder
+}
+
+// MockdiskQuotaCacheGetterMockRecorder is the mock recorder for MockdiskQuotaCacheGetter
+type MockdiskQuotaCacheGetterMockRecorder struct {
+	mock *MockdiskQuotaCacheGetter
+}
+
+// NewMockdiskQuotaCacheGetter creates a new mock instance
+func NewMockdiskQuotaCacheGetter(ctrl *gomock.Controller) *MockdiskQuotaCacheGetter {
+	mock := &MockdiskQuotaCacheGetter{ctrl: ctrl}
+	mock.recorder = &MockdiskQuotaCacheGetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdiskQuotaCacheGetter) EXPECT() *MockdiskQuotaCacheGetterMockRecorder {
+	return m.recorder
+}
+
+// DiskQuotaCache mocks base method
+func (m *MockdiskQuotaCacheGetter) DiskQuotaCache() DiskQuotaCache {
+	ret := m.ctrl.Call(m, "DiskQuotaCache")
+	ret0, _ := ret[0].(DiskQuotaCache)
+	return ret0
+}
+
+// DiskQuotaCache indicates an expected call of DiskQuotaCache
+func (mr *MockdiskQuotaCacheGetterMockRecorder) DiskQuotaCache() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskQuotaCache", reflect.TypeOf((*MockdiskQuotaCacheGetter)(nil).DiskQuotaCache))
+}
+
+// MockdiskQuotaCacheSetter is a mock of diskQuotaCacheSetter interface
+type MockdiskQuotaCacheSetter struct {
+	ctrl     *gomock.Controller
+	recorder *MockdiskQuotaCacheSetterMockRecorder
+}
+
+// MockdiskQuotaCacheSetterMockRecorder is the mock recorder for MockdiskQuotaCacheSetter
+type MockdiskQuotaCacheSetterMockRecorder struct {
+	mock *MockdiskQuotaCacheSetter
+}
+
+// NewMockdiskQuotaCacheSetter creates a new mock instance
+func NewMockdiskQuotaCacheSetter(ctrl *gomock.Controller) *MockdiskQuotaCacheSetter {
+	mock := &MockdiskQuotaCacheSetter{ctrl: ctrl}
+	mock.recorder = &MockdiskQuotaCacheSetterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockdiskQuotaCacheSetter) EXPECT() *MockdiskQuotaCacheSetterMockRecorder {
+	return m.recorder
+}
+
+// MakeDiskQuotaCacheIfNotExists mocks base method
+func (m *MockdiskQuotaCacheSetter) MakeDiskQuotaCacheIfNotExists() error {
+	ret := m.ctrl.Call(m, "MakeDiskQuotaCacheIfNotExists")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MakeDiskQuotaCacheIfNotExists indicates an expected call of MakeDiskQuotaCacheIfNotExists
+func (mr *MockdiskQuotaCacheSetterMockRecorder) MakeDiskQuotaCacheIfNotExists() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDiskQuotaCacheIfNotExists", reflect.TypeOf((*MockdiskQuotaCacheSetter)(nil).MakeDiskQuotaCacheIfNotExists))
+}
+
 // MockclockGetter is a mock of clockGetter interface
 type MockclockGetter struct {
 	ctrl     *gomock.Controller
@@ -4481,6 +4551,76 @@ func (mr *MockDiskMDCacheMockRecorder) Shutdown(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockDiskMDCache)(nil).Shutdown), ctx)
 }
 
+// MockDiskQuotaCache is a mock of DiskQuotaCache interface
+type MockDiskQuotaCache struct {
+	ctrl     *gomock.Controller
+	recorder *MockDiskQuotaCacheMockRecorder
+}
+
+// MockDiskQuotaCacheMockRecorder is the mock recorder for MockDiskQuotaCache
+type MockDiskQuotaCacheMockRecorder struct {
+	mock *MockDiskQuotaCache
+}
+
+// NewMockDiskQuotaCache creates a new mock instance
+func NewMockDiskQuotaCache(ctrl *gomock.Controller) *MockDiskQuotaCache {
+	mock := &MockDiskQuotaCache{ctrl: ctrl}
+	mock.recorder = &MockDiskQuotaCacheMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockDiskQuotaCache) EXPECT() *MockDiskQuotaCacheMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method
+func (m *MockDiskQuotaCache) Get(ctx context.Context, id keybase1.UserOrTeamID) (kbfsblock.QuotaInfo, error) {
+	ret := m.ctrl.Call(m, "Get", ctx, id)
+	ret0, _ := ret[0].(kbfsblock.QuotaInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (mr *MockDiskQuotaCacheMockRecorder) Get(ctx, id interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDiskQuotaCache)(nil).Get), ctx, id)
+}
+
+// Put mocks base method
+func (m *MockDiskQuotaCache) Put(ctx context.Context, id keybase1.UserOrTeamID, info kbfsblock.QuotaInfo) error {
+	ret := m.ctrl.Call(m, "Put", ctx, id, info)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Put indicates an expected call of Put
+func (mr *MockDiskQuotaCacheMockRecorder) Put(ctx, id, info interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDiskQuotaCache)(nil).Put), ctx, id, info)
+}
+
+// Status mocks base method
+func (m *MockDiskQuotaCache) Status(ctx context.Context) DiskQuotaCacheStatus {
+	ret := m.ctrl.Call(m, "Status", ctx)
+	ret0, _ := ret[0].(DiskQuotaCacheStatus)
+	return ret0
+}
+
+// Status indicates an expected call of Status
+func (mr *MockDiskQuotaCacheMockRecorder) Status(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockDiskQuotaCache)(nil).Status), ctx)
+}
+
+// Shutdown mocks base method
+func (m *MockDiskQuotaCache) Shutdown(ctx context.Context) {
+	m.ctrl.Call(m, "Shutdown", ctx)
+}
+
+// Shutdown indicates an expected call of Shutdown
+func (mr *MockDiskQuotaCacheMockRecorder) Shutdown(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockDiskQuotaCache)(nil).Shutdown), ctx)
+}
+
 // MockcryptoPure is a mock of cryptoPure interface
 type MockcryptoPure struct {
 	ctrl     *gomock.Controller
@@ -7505,6 +7645,30 @@ func (m *MockConfig) MakeDiskMDCacheIfNotExists() error {
 // MakeDiskMDCacheIfNotExists indicates an expected call of MakeDiskMDCacheIfNotExists
 func (mr *MockConfigMockRecorder) MakeDiskMDCacheIfNotExists() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDiskMDCacheIfNotExists", reflect.TypeOf((*MockConfig)(nil).MakeDiskMDCacheIfNotExists))
+}
+
+// DiskQuotaCache mocks base method
+func (m *MockConfig) DiskQuotaCache() DiskQuotaCache {
+	ret := m.ctrl.Call(m, "DiskQuotaCache")
+	ret0, _ := ret[0].(DiskQuotaCache)
+	return ret0
+}
+
+// DiskQuotaCache indicates an expected call of DiskQuotaCache
+func (mr *MockConfigMockRecorder) DiskQuotaCache() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiskQuotaCache", reflect.TypeOf((*MockConfig)(nil).DiskQuotaCache))
+}
+
+// MakeDiskQuotaCacheIfNotExists mocks base method
+func (m *MockConfig) MakeDiskQuotaCacheIfNotExists() error {
+	ret := m.ctrl.Call(m, "MakeDiskQuotaCacheIfNotExists")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MakeDiskQuotaCacheIfNotExists indicates an expected call of MakeDiskQuotaCacheIfNotExists
+func (mr *MockConfigMockRecorder) MakeDiskQuotaCacheIfNotExists() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeDiskQuotaCacheIfNotExists", reflect.TypeOf((*MockConfig)(nil).MakeDiskQuotaCacheIfNotExists))
 }
 
 // Clock mocks base method


### PR DESCRIPTION
This introduces a new disk-based cache for quota infos (keyed by `UserOrTeamID`).  The eventually-consistent quota fetcher uses the disk-cached value, if the current quota can't be fetched from the server within a small amount of time (500ms).

Issue: KBFS-3506