### PR TITLE
kbfs_ops: share a quota usage instance between non-team TLFs

### DIFF
--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -31,7 +31,7 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	config.SetClock(wallClock{})
 	id := tlf.FakeID(1, tlf.Private)
 	fbo := newFolderBranchOps(ctx, env.EmptyAppStateUpdater{}, config,
-		FolderBranch{id, MasterBranch}, standard)
+		FolderBranch{id, MasterBranch}, standard, nil)
 	// usernames don't matter for these tests
 	config.mockKbpki.EXPECT().GetNormalizedUsername(gomock.Any(), gomock.Any()).
 		AnyTimes().Return(kbname.NormalizedUsername("mockUser"), nil)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -374,7 +374,8 @@ var _ fbmHelper = (*folderBranchOps)(nil)
 func newFolderBranchOps(
 	ctx context.Context, appStateUpdater env.AppStateUpdater,
 	config Config, fb FolderBranch,
-	bType branchType) *folderBranchOps {
+	bType branchType,
+	quotaUsage *EventuallyConsistentQuotaUsage) *folderBranchOps {
 	var nodeCache NodeCache
 	if config.Mode().NodeCacheEnabled() {
 		nodeCache = newNodeCacheStandard(fb)
@@ -419,7 +420,8 @@ func newFolderBranchOps(
 		unmergedBID:  kbfsmd.BranchID{},
 		bType:        bType,
 		observers:    observers,
-		status:       newFolderBranchStatusKeeper(config, nodeCache),
+		status: newFolderBranchStatusKeeper(
+			config, nodeCache, quotaUsage),
 		mdWriterLock: mdWriterLock,
 		headLock:     headLock,
 		blocks: folderBlockOps{

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -93,12 +93,14 @@ type folderBranchStatusKeeper struct {
 }
 
 func newFolderBranchStatusKeeper(
-	config Config, nodeCache NodeCache) *folderBranchStatusKeeper {
+	config Config, nodeCache NodeCache,
+	quotaUsage *EventuallyConsistentQuotaUsage) *folderBranchStatusKeeper {
 	return &folderBranchStatusKeeper{
 		config:     config,
 		nodeCache:  nodeCache,
 		dirtyNodes: make(map[NodeID]Node),
 		updateChan: make(chan StatusUpdate, 1),
+		quotaUsage: quotaUsage,
 	}
 }
 

--- a/libkbfs/folder_branch_status.go
+++ b/libkbfs/folder_branch_status.go
@@ -242,7 +242,8 @@ func (fbsk *folderBranchStatusKeeper) getStatusWithoutJournaling(
 		}
 		_, usageBytes, archiveBytes, limitBytes,
 			gitUsageBytes, gitArchiveBytes, gitLimitBytes, quErr :=
-			fbsk.quotaUsage.GetAllTypes(ctx, 0, 0)
+			fbsk.quotaUsage.GetAllTypes(
+				ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
 		if quErr != nil {
 			// The error is ignored here so that other fields can
 			// still be populated even if this fails.

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -31,7 +31,7 @@ func fbStatusTestInit(t *testing.T) (*gomock.Controller, *ConfigMock,
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(ImplicitTeamInfo{}, errors.New("No such team"))
 	nodeCache := NewMockNodeCache(mockCtrl)
-	fbsk := newFolderBranchStatusKeeper(config, nodeCache)
+	fbsk := newFolderBranchStatusKeeper(config, nodeCache, nil)
 	interposeDaemonKBPKI(config, "alice", "bob")
 	return mockCtrl, config, fbsk, nodeCache
 }

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -22,6 +22,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+const (
+	quotaUsageStaleTolerance = 10 * time.Second
+)
+
 // KBFSOpsStandard implements the KBFSOps interface, and is go-routine
 // safe by forwarding requests to individual per-folder-branch
 // handlers that are go-routine-safe.
@@ -983,7 +987,8 @@ func (fs *KBFSOpsStandard) Status(ctx context.Context) (
 		var quErr error
 		_, usageBytes, archiveBytes, limitBytes,
 			gitUsageBytes, gitArchiveBytes, gitLimitBytes, quErr =
-			fs.quotaUsage.GetAllTypes(ctx, 0, 0)
+			fs.quotaUsage.GetAllTypes(
+				ctx, quotaUsageStaleTolerance/2, quotaUsageStaleTolerance)
 		if quErr != nil {
 			// The error is ignored here so that other fields can still be populated
 			// even if this fails.

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -346,7 +346,15 @@ func (fs *KBFSOpsStandard) getOpsNoAdd(
 		if _, isRevBranch := fb.Branch.RevisionIfSpecified(); isRevBranch {
 			bType = archive
 		}
-		ops = newFolderBranchOps(ctx, fs.appStateUpdater, fs.config, fb, bType)
+		var quotaUsage *EventuallyConsistentQuotaUsage
+		if fb.Tlf.Type() != tlf.SingleTeam {
+			// If this is a non-team TLF, pass in a shared quota usage
+			// object, since the status of each non-team TLF will show
+			// the same quota usage.
+			quotaUsage = fs.quotaUsage
+		}
+		ops = newFolderBranchOps(
+			ctx, fs.appStateUpdater, fs.config, fb, bType, quotaUsage)
 		fs.ops[fb] = ops
 	}
 	return ops


### PR DESCRIPTION
So they don't each have to call the bserver it get the same info when
filling in status objects.

Also, allow quotas to be cached for 10s.  Not sure why we previously insisted on hitting the server every time, but when the user has a lot of non-team TLFs we should be able to share a single cached value between all of them.

Issue: KBFS-3558
