### PR TITLE
disk_block_cache: add a db for tracking the last unref revision

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -222,7 +222,7 @@ func newDiskBlockCacheLocalFromStorage(
 	// cache will block until this is done. The log will contain the beginning
 	// and end of this sync.
 	go func() {
-		err := cache.syncBlockCountsFromDb()
+		err := cache.syncBlockCountsAndUnrefsFromDb()
 		if err != nil {
 			close(startErrCh)
 			closer()
@@ -340,9 +340,9 @@ func (cache *DiskBlockCacheLocal) encodeLastUnref(rev kbfsmd.Revision) (
 	return cache.config.Codec().Encode(&entry)
 }
 
-func (cache *DiskBlockCacheLocal) syncBlockCountsFromDb() error {
-	cache.log.Debug("+ syncBlockCountsFromDb begin")
-	defer cache.log.Debug("- syncBlockCountsFromDb end")
+func (cache *DiskBlockCacheLocal) syncBlockCountsAndUnrefsFromDb() error {
+	cache.log.Debug("+ syncBlockCountsAndUnrefsFromDb begin")
+	defer cache.log.Debug("- syncBlockCountsAndUnrefsFromDb end")
 	// We take a write lock for this to prevent any reads from happening while
 	// we're syncing the block counts.
 	cache.lock.Lock()
@@ -370,6 +370,8 @@ func (cache *DiskBlockCacheLocal) syncBlockCountsFromDb() error {
 	cache.numBlocks = numBlocks
 	cache.tlfSizes = tlfSizes
 	cache.currBytes = totalSize
+
+	cache.log.Debug("+ syncBlockCountsAndUnrefsFromDb block counts done")
 
 	tlfLastUnrefs := make(map[tlf.ID]kbfsmd.Revision)
 	lastUnrefIter := cache.lastUnrefDb.NewIterator(nil, nil)

--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keybase/go-framed-msgpack-rpc/rpc"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/kbfsmd"
 	kbgitkbfs "github.com/keybase/kbfs/protocol/kbgitkbfs1"
 	"github.com/keybase/kbfs/tlf"
 )
@@ -122,6 +123,20 @@ func (dbcr *DiskBlockCacheRemote) UpdateMetadata(ctx context.Context,
 			BlockID:        blockID.Bytes(),
 			PrefetchStatus: prefetchStatus.ToProtocol(),
 		})
+}
+
+// GetLastUnrefRev implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) GetLastUnrefRev(
+	_ context.Context, _ tlf.ID) (kbfsmd.Revision, error) {
+	panic("GetLastUnrefRev() not implemented in DiskBlockCacheRemote")
+}
+
+// PutLastUnrefRev implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) PutLastUnrefRev(
+	_ context.Context, _ tlf.ID, _ kbfsmd.Revision) error {
+	panic("PutLastUnrefRev() not implemented in DiskBlockCacheRemote")
 }
 
 // Status implements the DiskBlockCache interface for DiskBlockCacheRemote.

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -630,7 +630,7 @@ func TestDiskBlockCacheLastUnrefPutAndGet(t *testing.T) {
 
 	// Force re-read from DB.
 	cache.syncCache.tlfLastUnrefs = nil
-	err = cache.syncCache.syncBlockCountsFromDb()
+	err = cache.syncCache.syncBlockCountsAndUnrefsFromDb()
 	require.NoError(t, err)
 	getRev1, err = cache.GetLastUnrefRev(ctx, tlf1)
 	require.NoError(t, err)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1233,6 +1233,13 @@ type DiskBlockCache interface {
 	// UpdateMetadata updates metadata for a given block in the disk cache.
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
 		prefetchStatus PrefetchStatus) error
+	// GetLastUnrefRev returns the last revision that has been marked
+	// unref'd for the given TLF.
+	GetLastUnrefRev(ctx context.Context, tlfID tlf.ID) (kbfsmd.Revision, error)
+	// PutLastUnrefRev saves the given revision as the last unref'd
+	// revision for the given TLF.
+	PutLastUnrefRev(
+		ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error
 	// Status returns the current status of the disk cache.
 	Status(ctx context.Context) map[string]DiskBlockCacheStatus
 	// Shutdown cleanly shuts down the disk block cache.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4311,6 +4311,31 @@ func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, blockID, prefetchS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockDiskBlockCache)(nil).UpdateMetadata), ctx, blockID, prefetchStatus)
 }
 
+// GetLastUnrefRev mocks base method
+func (m *MockDiskBlockCache) GetLastUnrefRev(ctx context.Context, tlfID tlf.ID) (kbfsmd.Revision, error) {
+	ret := m.ctrl.Call(m, "GetLastUnrefRev", ctx, tlfID)
+	ret0, _ := ret[0].(kbfsmd.Revision)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLastUnrefRev indicates an expected call of GetLastUnrefRev
+func (mr *MockDiskBlockCacheMockRecorder) GetLastUnrefRev(ctx, tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastUnrefRev", reflect.TypeOf((*MockDiskBlockCache)(nil).GetLastUnrefRev), ctx, tlfID)
+}
+
+// PutLastUnrefRev mocks base method
+func (m *MockDiskBlockCache) PutLastUnrefRev(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error {
+	ret := m.ctrl.Call(m, "PutLastUnrefRev", ctx, tlfID, rev)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutLastUnrefRev indicates an expected call of PutLastUnrefRev
+func (mr *MockDiskBlockCacheMockRecorder) PutLastUnrefRev(ctx, tlfID, rev interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLastUnrefRev", reflect.TypeOf((*MockDiskBlockCache)(nil).PutLastUnrefRev), ctx, tlfID, rev)
+}
+
 // Status mocks base method
 func (m *MockDiskBlockCache) Status(ctx context.Context) map[string]DiskBlockCacheStatus {
 	ret := m.ctrl.Call(m, "Status", ctx)


### PR DESCRIPTION
The sync cache will keep track of the last revision for which all the unreferenced blocks have been deleted from the disk cache.  A future PR will introduce a background goroutine that uses this to clean the cache, without relying on being online to process MD updates in real time.

Issue: KBFS-3507