### PR TITLE
kbfs.service: support stop action.

### DIFF
--- a/packaging/linux/systemd/kbfs.service
+++ b/packaging/linux/systemd/kbfs.service
@@ -11,6 +11,7 @@ Type=notify
 # are any running shells cd'd into a Keybase folder.
 ExecStartPre=-/bin/sh -c 'fusermount -uz "$(keybase config get -d -b mountdir)"'
 ExecStart=/usr/bin/kbfsfuse -debug -log-to-file
+ExecStop=-/bin/sh -c 'fusermount -uz "$(keybase config get -d -b mountdir)"'
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Useful to unmount kbfs in no thrills way. It is important to have this posibility since active fuse mounts cause laptop suspend failures (as of linux kernel 4.18 at least).