### PR TITLE
add CORS and custom error pages to .kbp_config

### DIFF
--- a/kbpagesconfig/cmd_per_path.go
+++ b/kbpagesconfig/cmd_per_path.go
@@ -172,6 +172,64 @@ var perPathSetPermissionCmd = cli.Command{
 	},
 }
 
+var perPathSetCmd = cli.Command{
+	Name:  "set",
+	Usage: "configure a parameter on path(s)",
+	UsageText: "set Access-Control-Allow-Origin <''|'*'> <path> [path ...]\n" +
+		"   set <403|404> <path_relative_to_site_root> <path> [path ...]",
+	Action: func(c *cli.Context) {
+		if len(c.Args()) < 3 {
+			fmt.Fprintln(os.Stderr, "need at least 3 args")
+			os.Exit(1)
+		}
+		editor, err := newKBPConfigEditor(c.GlobalString("dir"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"creating config editor error: %v\n", err)
+			os.Exit(1)
+		}
+		switch c.Args()[0] {
+		case "Access-Control-Allow-Origin":
+			for _, p := range c.Args()[2:] {
+				err := editor.setAccessControlAllowOrigin(p, c.Args()[1])
+				if err != nil {
+					fmt.Fprintf(os.Stderr,
+						"setting Access-Control-Allow-Origin %q on %q error: %v\n",
+						c.Args()[1], p, err)
+					os.Exit(1)
+				}
+			}
+		case "403":
+			for _, p := range c.Args()[2:] {
+				err := editor.set403(p, c.Args()[1])
+				if err != nil {
+					fmt.Fprintf(os.Stderr,
+						"setting custom 403 page %q on %q error: %v\n",
+						c.Args()[1], p, err)
+					os.Exit(1)
+				}
+			}
+		case "404":
+			for _, p := range c.Args()[2:] {
+				err := editor.set404(p, c.Args()[1])
+				if err != nil {
+					fmt.Fprintf(os.Stderr,
+						"setting custom 404 page %q on %q error: %v\n",
+						c.Args()[1], p, err)
+					os.Exit(1)
+				}
+			}
+		default:
+			fmt.Fprintf(os.Stderr, "unknown parameter: %s\n", c.Args()[0])
+			os.Exit(1)
+		}
+		if err := editor.confirmAndWrite(); err != nil {
+			fmt.Fprintf(os.Stderr, "writing new config error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 var perPathCmd = cli.Command{
 	Name:      "per-path",
 	Usage:     "make changes to the 'per_path_configs' section of the config",
@@ -181,5 +239,6 @@ var perPathCmd = cli.Command{
 		perPathClearCmd,
 		perPathUnsetUserPermissionsCmd,
 		perPathGetPermissionCmd,
+		perPathSetCmd,
 	},
 }

--- a/kbpagesconfig/cmd_per_path.go
+++ b/kbpagesconfig/cmd_per_path.go
@@ -12,9 +12,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-var aclClearCmd = cli.Command{
+var perPathClearCmd = cli.Command{
 	Name:      "clear",
-	Usage:     "clear the ACL for the given path(s)",
+	Usage:     "clear the PerPathConfig for the given path(s)",
 	UsageText: "clear <path> [path ...]",
 	Action: func(c *cli.Context) {
 		if len(c.Args()) < 1 {
@@ -28,7 +28,7 @@ var aclClearCmd = cli.Command{
 			os.Exit(1)
 		}
 		for _, p := range c.Args() {
-			editor.clearACL(p)
+			editor.clearPerPathConfig(p)
 		}
 		if err := editor.confirmAndWrite(); err != nil {
 			fmt.Fprintf(os.Stderr, "writing new config error: %v\n", err)
@@ -37,10 +37,12 @@ var aclClearCmd = cli.Command{
 	},
 }
 
-var aclRemoveCmd = cli.Command{
-	Name:      "remove",
-	Usage:     "remove a user from the ACL(s) of the given path(s)",
-	UsageText: "remove <username> <path> [path ...]",
+var perPathUnsetUserPermissionsCmd = cli.Command{
+	Name: "unset-user",
+	Usage: "remove a user from the PerPathConfig(s) additional " +
+		"permissions of the given path(s). This essentially reverts the " +
+		"user's effective permission back to anonymous.",
+	UsageText: "unset-user <username> <path> [path ...]",
 	Action: func(c *cli.Context) {
 		if len(c.Args()) < 2 {
 			fmt.Fprintln(os.Stderr, "need at least 2 args")
@@ -53,7 +55,7 @@ var aclRemoveCmd = cli.Command{
 			os.Exit(1)
 		}
 		for _, p := range c.Args()[1:] {
-			editor.removeUserFromACL(c.Args()[0], p)
+			editor.removeUserPermissionsFromPerPathConfig(c.Args()[0], p)
 		}
 		if err := editor.confirmAndWrite(); err != nil {
 			fmt.Fprintf(os.Stderr, "writing new config error: %v\n", err)
@@ -62,10 +64,10 @@ var aclRemoveCmd = cli.Command{
 	},
 }
 
-var aclGetCmd = cli.Command{
-	Name:      "get",
+var perPathGetPermissionCmd = cli.Command{
+	Name:      "get-permission",
 	Usage:     "get permissions for a user on the given path(s)",
-	UsageText: "get <username> <path> [path ...]",
+	UsageText: "get-permission <username> <path> [path ...]",
 	Action: func(c *cli.Context) {
 		if len(c.Args()) < 2 {
 			fmt.Fprintln(os.Stderr, "need at least 2 args")
@@ -80,7 +82,7 @@ var aclGetCmd = cli.Command{
 		writer := tabwriter.NewWriter(os.Stdout, 0, 4, 1, '\t', 0)
 		fmt.Fprintln(writer, "read\tlist\tpath")
 		for _, p := range c.Args()[1:] {
-			read, list, err := editor.getUserOnPath(c.Args()[0], p)
+			read, list, err := editor.getUserPermissionsOnPath(c.Args()[0], p)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "getting permissions for "+
 					"%q on %q error: %v\n", c.Args()[0], p, err)
@@ -95,7 +97,7 @@ var aclGetCmd = cli.Command{
 	},
 }
 
-var aclSetDefaultCmd = cli.Command{
+var perPathSetPermissionDefaultCmd = cli.Command{
 	Name: "default",
 	Usage: "set default permission(s) that all users are granted, " +
 		"for the given path(s)",
@@ -127,7 +129,7 @@ var aclSetDefaultCmd = cli.Command{
 	},
 }
 
-var aclSetAdditionalCmd = cli.Command{
+var perPathSetPermissionAdditionalCmd = cli.Command{
 	Name: "additional",
 	Usage: "set additional permission(s) that <username> are granted on " +
 		"top of default ones on the given path(s) ",
@@ -160,24 +162,24 @@ var aclSetAdditionalCmd = cli.Command{
 	},
 }
 
-var aclSetCmd = cli.Command{
-	Name:      "set",
+var perPathSetPermissionCmd = cli.Command{
+	Name:      "set-permission",
 	Usage:     "set default or additional permissions on path(s)",
-	UsageText: "set <default|additional> [args]",
+	UsageText: "set-permission <default|additional> [args]",
 	Subcommands: []cli.Command{
-		aclSetDefaultCmd,
-		aclSetAdditionalCmd,
+		perPathSetPermissionDefaultCmd,
+		perPathSetPermissionAdditionalCmd,
 	},
 }
 
-var aclCmd = cli.Command{
-	Name:      "acl",
-	Usage:     "make changes to the 'acls' section of the config",
-	UsageText: "acl <set|clear|remove|get> [args]",
+var perPathCmd = cli.Command{
+	Name:      "per-path",
+	Usage:     "make changes to the 'per_path_configs' section of the config",
+	UsageText: "per-path <set|clear|remove|get> [args]",
 	Subcommands: []cli.Command{
-		aclSetCmd,
-		aclClearCmd,
-		aclRemoveCmd,
-		aclGetCmd,
+		perPathSetPermissionCmd,
+		perPathClearCmd,
+		perPathUnsetUserPermissionsCmd,
+		perPathGetPermissionCmd,
 	},
 }

--- a/kbpagesconfig/cmd_upgrade.go
+++ b/kbpagesconfig/cmd_upgrade.go
@@ -97,10 +97,17 @@ func upgradeToSHA256WithPrompter(kbpConfigDir string, prompter prompter) (err er
 	newConfig := config.DefaultV1()
 	for p, acl := range oldConfig.ACLs {
 		if newConfig.ACLs == nil {
-			newConfig.ACLs = make(map[string]config.AccessControlV1)
+			newConfig.ACLs = make(map[string]config.PerPathConfigV1)
 		}
 		// shadow copy since oldConfig is one-time use anyway
 		newConfig.ACLs[p] = acl
+	}
+	for p, perPathConfig := range oldConfig.PerPathConfigs {
+		if newConfig.PerPathConfigs == nil {
+			newConfig.PerPathConfigs = make(map[string]config.PerPathConfigV1)
+		}
+		// shadow copy since oldConfig is one-time use anyway
+		newConfig.PerPathConfigs[p] = perPathConfig
 	}
 	for user := range oldConfig.Users {
 		if newConfig.Users == nil {

--- a/kbpagesconfig/editor.go
+++ b/kbpagesconfig/editor.go
@@ -133,48 +133,49 @@ func (e *kbpConfigEditor) removeUser(username string) {
 
 func (e *kbpConfigEditor) setAnonymousPermission(
 	permsStr string, pathStr string) error {
-	if e.kbpConfig.ACLs == nil {
-		e.kbpConfig.ACLs = make(map[string]config.AccessControlV1)
+	if e.kbpConfig.PerPathConfigs == nil {
+		e.kbpConfig.PerPathConfigs = make(map[string]config.PerPathConfigV1)
 	}
-	pathACL := e.kbpConfig.ACLs[pathStr]
-	pathACL.AnonymousPermissions = permsStr
-	e.kbpConfig.ACLs[pathStr] = pathACL
+	pathPerPathConfig := e.kbpConfig.PerPathConfigs[pathStr]
+	pathPerPathConfig.AnonymousPermissions = permsStr
+	e.kbpConfig.PerPathConfigs[pathStr] = pathPerPathConfig
 	return e.kbpConfig.Validate()
 }
 
-func (e *kbpConfigEditor) clearACL(pathStr string) {
-	delete(e.kbpConfig.ACLs, pathStr)
+func (e *kbpConfigEditor) clearPerPathConfig(pathStr string) {
+	delete(e.kbpConfig.PerPathConfigs, pathStr)
 }
 
 func (e *kbpConfigEditor) setAdditionalPermission(
 	username string, permsStr string, pathStr string) error {
-	if e.kbpConfig.ACLs == nil {
-		e.kbpConfig.ACLs = make(map[string]config.AccessControlV1)
+	if e.kbpConfig.PerPathConfigs == nil {
+		e.kbpConfig.PerPathConfigs = make(map[string]config.PerPathConfigV1)
 	}
-	pathACL := e.kbpConfig.ACLs[pathStr]
-	if pathACL.WhitelistAdditionalPermissions == nil {
+	pathPerPathConfig := e.kbpConfig.PerPathConfigs[pathStr]
+	if pathPerPathConfig.WhitelistAdditionalPermissions == nil {
 		// If permsStr is empty, we'd leave an empty permission entry behind.
 		// But that's OK since it doesn't change any behavior, i.e., no
 		// additional permission is granted for the user on the path. If user
 		// really wants the entry gone, they can use the "remove" command.
-		pathACL.WhitelistAdditionalPermissions = make(map[string]string)
+		pathPerPathConfig.WhitelistAdditionalPermissions = make(map[string]string)
 	}
-	pathACL.WhitelistAdditionalPermissions[username] = permsStr
-	e.kbpConfig.ACLs[pathStr] = pathACL
+	pathPerPathConfig.WhitelistAdditionalPermissions[username] = permsStr
+	e.kbpConfig.PerPathConfigs[pathStr] = pathPerPathConfig
 	return e.kbpConfig.Validate()
 }
 
-func (e *kbpConfigEditor) removeUserFromACL(username string, pathStr string) {
-	if e.kbpConfig.ACLs == nil {
+func (e *kbpConfigEditor) removeUserPermissionsFromPerPathConfig(
+	username string, pathStr string) {
+	if e.kbpConfig.PerPathConfigs == nil {
 		return
 	}
-	if e.kbpConfig.ACLs[pathStr].WhitelistAdditionalPermissions == nil {
+	if e.kbpConfig.PerPathConfigs[pathStr].WhitelistAdditionalPermissions == nil {
 		return
 	}
-	delete(e.kbpConfig.ACLs[pathStr].WhitelistAdditionalPermissions, username)
+	delete(e.kbpConfig.PerPathConfigs[pathStr].WhitelistAdditionalPermissions, username)
 }
 
-func (e *kbpConfigEditor) getUserOnPath(
+func (e *kbpConfigEditor) getUserPermissionsOnPath(
 	username string, pathStr string) (read, list bool, err error) {
 	read, list, _, _, _, err = e.kbpConfig.GetPermissions(
 		pathStr, &username)

--- a/kbpagesconfig/editor.go
+++ b/kbpagesconfig/editor.go
@@ -129,17 +129,24 @@ func (e *kbpConfigEditor) setUser(username string, isAdd bool) error {
 
 func (e *kbpConfigEditor) removeUser(username string) {
 	delete(e.kbpConfig.Users, username)
+
 }
 
-func (e *kbpConfigEditor) setAnonymousPermission(
-	permsStr string, pathStr string) error {
+func (e *kbpConfigEditor) setFieldSimple(pathStr string, setter func(c *config.PerPathConfigV1)) error {
 	if e.kbpConfig.PerPathConfigs == nil {
 		e.kbpConfig.PerPathConfigs = make(map[string]config.PerPathConfigV1)
 	}
 	pathPerPathConfig := e.kbpConfig.PerPathConfigs[pathStr]
-	pathPerPathConfig.AnonymousPermissions = permsStr
+	setter(&pathPerPathConfig)
 	e.kbpConfig.PerPathConfigs[pathStr] = pathPerPathConfig
 	return e.kbpConfig.Validate()
+}
+
+func (e *kbpConfigEditor) setAnonymousPermission(
+	permsStr string, pathStr string) error {
+	return e.setFieldSimple(pathStr, func(c *config.PerPathConfigV1) {
+		c.AnonymousPermissions = permsStr
+	})
 }
 
 func (e *kbpConfigEditor) clearPerPathConfig(pathStr string) {
@@ -180,4 +187,25 @@ func (e *kbpConfigEditor) getUserPermissionsOnPath(
 	read, list, _, _, _, err = e.kbpConfig.GetPermissions(
 		pathStr, &username)
 	return read, list, err
+}
+
+func (e *kbpConfigEditor) setAccessControlAllowOrigin(
+	pathStr string, acao string) error {
+	return e.setFieldSimple(pathStr, func(c *config.PerPathConfigV1) {
+		c.AccessControlAllowOrigin = acao
+	})
+}
+
+func (e *kbpConfigEditor) set403(
+	pathStr string, p string) error {
+	return e.setFieldSimple(pathStr, func(c *config.PerPathConfigV1) {
+		c.Custom403Forbidden = p
+	})
+}
+
+func (e *kbpConfigEditor) set404(
+	pathStr string, p string) error {
+	return e.setFieldSimple(pathStr, func(c *config.PerPathConfigV1) {
+		c.Custom404NotFound = p
+	})
 }

--- a/kbpagesconfig/main.go
+++ b/kbpagesconfig/main.go
@@ -23,7 +23,7 @@ func main() {
 	}
 	app.Commands = []cli.Command{
 		userCmd,
-		aclCmd,
+		perPathCmd,
 		upgradeCmd,
 	}
 

--- a/libpages/config/config_test.go
+++ b/libpages/config/config_test.go
@@ -21,8 +21,8 @@ func TestParseConfigV1(t *testing.T) {
 			"alice": string(generateBcryptPasswordHashForTestOrBust(t, "12345")),
 			"bob":   string(generateSHA256PasswordHashForTestOrBust(t, "54321")),
 		},
-		ACLs: map[string]AccessControlV1{
-			"/alice-and-bob": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/alice-and-bob": PerPathConfigV1{
 				WhitelistAdditionalPermissions: map[string]string{
 					"alice": PermReadAndList,
 					"bob":   PermRead,
@@ -37,7 +37,7 @@ func TestParseConfigV1(t *testing.T) {
 	require.NoError(t, err)
 	parsedV1, ok := parsed.(*V1)
 	require.True(t, ok)
-	require.Equal(t, config.ACLs, parsedV1.ACLs)
+	require.Equal(t, config.PerPathConfigs, parsedV1.PerPathConfigs)
 	require.Equal(t, config.Common, parsedV1.Common)
 	require.Equal(t, config.Users, parsedV1.Users)
 }

--- a/libpages/config/config_v1.go
+++ b/libpages/config/config_v1.go
@@ -18,10 +18,10 @@ import (
 // V1 defines a V1 config. Public fields are accessible by `json`
 // encoders and decoder.
 //
-// On first call to GetPermission* methods, it initializes an internal ACL
-// checker. If the object is constructed from ParseConfig, its internal ACL
-// checker is initialized automatically. Any changes to the ACL fields
-// afterwards have no effect.
+// On first call to GetPermission* methods, it initializes an internal per-path
+// config reader. If the object is constructed from ParseConfig, its internal
+// per-path config reader is initialized automatically. Any changes to the
+// PerPathConfigs fields afterwards have no effect.
 type V1 struct {
 	Common
 
@@ -33,13 +33,18 @@ type V1 struct {
 
 	bcryptLimiter *rate.Limiter
 
-	// ACLs is a path -> AccessControlV1 map that defines ACLs for different
-	// paths.
-	ACLs map[string]AccessControlV1 `json:"acls"`
+	// ACLs is deprecated, and kept around for back-compability. Now it serves
+	// as an alias to PerPathConfigs. If both ACLs and PerPathConfigs are
+	// present, it's a parsing error.
+	ACLs map[string]PerPathConfigV1 `json:"acls,omitempty"`
 
-	initOnce          sync.Once
-	aclChecker        *aclCheckerV1
-	aclCheckerInitErr error
+	// PerPathConfigs is a path -> PerPathConfig map to configure parameters
+	// for individual paths. Configured paths apply to their sub paths too.
+	PerPathConfigs map[string]PerPathConfigV1 `json:"per_path_configs"`
+
+	initOnce                    sync.Once
+	perPathConfigsReader        *perPathConfigsReaderV1
+	perPathConfigsReaderInitErr error
 }
 
 var _ Config = (*V1)(nil)
@@ -51,8 +56,8 @@ func DefaultV1() *V1 {
 		Common: Common{
 			Version: Version1Str,
 		},
-		ACLs: map[string]AccessControlV1{
-			"/": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/": PerPathConfigV1{
 				AnonymousPermissions: "read,list",
 			},
 		},
@@ -63,27 +68,48 @@ func DefaultV1() *V1 {
 
 const bcryptRateLimitInterval = time.Second / 2
 
+func (c *V1) checkAndRenameACLsIfNeeded() error {
+	if c.PerPathConfigs != nil && c.ACLs != nil {
+		return ErrACLsPerPathConfigsBothPresent{}
+	}
+	if c.ACLs != nil {
+		c.PerPathConfigs = c.ACLs
+		c.ACLs = nil
+	}
+	return nil
+}
+
 func (c *V1) init() {
 	c.bcryptLimiter = rate.NewLimiter(rate.Every(bcryptRateLimitInterval), 1)
-	c.aclChecker, c.aclCheckerInitErr = makeACLCheckerV1(c.ACLs, c.Users)
-	if c.aclCheckerInitErr != nil {
+
+	c.perPathConfigsReaderInitErr = c.checkAndRenameACLsIfNeeded()
+	if c.perPathConfigsReaderInitErr != nil {
 		return
 	}
+	c.perPathConfigsReader, c.perPathConfigsReaderInitErr =
+		makePerPathConfigsReaderV1(c.PerPathConfigs, c.Users)
+	if c.perPathConfigsReaderInitErr != nil {
+		return
+	}
+
 	c.users = make(map[string]password)
 	for username, passwordHash := range c.Users {
-		c.users[username], c.aclCheckerInitErr = newPassword(passwordHash)
-		if c.aclCheckerInitErr != nil {
+		c.users[username], c.perPathConfigsReaderInitErr = newPassword(passwordHash)
+		if c.perPathConfigsReaderInitErr != nil {
 			return
 		}
 	}
 }
 
 // EnsureInit initializes c, and returns any error encountered during the
-// initialization. It is not necessary to call EnsureInit. Methods that need it
-// does it automatically.
+// initialization. Additionally, it also moves ACLs into PerPathConfigs if
+// needed.
+//
+// It is not necessary to call EnsureInit. Methods that need it does it
+// automatically.
 func (c *V1) EnsureInit() error {
 	c.initOnce.Do(c.init)
-	return c.aclCheckerInitErr
+	return c.perPathConfigsReaderInitErr
 }
 
 // Version implements the Config interface.
@@ -114,7 +140,7 @@ func (c *V1) GetPermissions(path string, username *string) (
 		return false, false, false, false, "", err
 	}
 
-	perms, maxPerms, realm := c.aclChecker.getPermissions(path, username)
+	perms, maxPerms, realm := c.perPathConfigsReader.getPermissions(path, username)
 	return perms.read, perms.list, maxPerms.read, maxPerms.list, realm, nil
 }
 
@@ -130,15 +156,19 @@ func (c *V1) Encode(w io.Writer, prettify bool) error {
 // Validate checks all public fields of c, and returns an error if any of them
 // is invalid, or a nil-error if they are all valid.
 //
-// Although changes to ACL fields have no effect to ACL checkings once the
-// internal ACL checker is intialized (see comment on V1), this method still
-// checks the updated ACL feilds. So it's OK to use Validate directly on a
-// *V1 that has been modified since it was initialized.
+// Although changes to per-path config fields have no effect to per-path config
+// checkings once the internal per-path config reader is intialized (see
+// comment on V1), this method still checks the updated per-path config feilds.
+// So it's OK to use Validate directly on a *V1 that has been modified since it
+// was initialized.
 //
 // As a result, unlike other methods on the type, this method is not goroutine
 // safe against changes to the public fields.
-func (c *V1) Validate() error {
-	_, err := makeACLCheckerV1(c.ACLs, c.Users)
+func (c *V1) Validate() (err error) {
+	if err := c.checkAndRenameACLsIfNeeded(); err != nil {
+		return err
+	}
+	_, err = makePerPathConfigsReaderV1(c.PerPathConfigs, c.Users)
 	return err
 }
 

--- a/libpages/config/config_v1_test.go
+++ b/libpages/config/config_v1_test.go
@@ -31,8 +31,8 @@ func TestConfigV1Invalid(t *testing.T) {
 		Common: Common{
 			Version: Version1Str,
 		},
-		ACLs: map[string]AccessControlV1{
-			"/": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/": PerPathConfigV1{
 				WhitelistAdditionalPermissions: map[string]string{
 					"alice": PermRead,
 				},
@@ -46,40 +46,40 @@ func TestConfigV1Invalid(t *testing.T) {
 		Common: Common{
 			Version: Version1Str,
 		},
-		ACLs: map[string]AccessControlV1{
-			"/": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/": PerPathConfigV1{
 				AnonymousPermissions: "",
 			},
-			"": AccessControlV1{
+			"": PerPathConfigV1{
 				AnonymousPermissions: PermRead,
 			},
 		},
 	}).EnsureInit()
 	require.Error(t, err)
-	require.IsType(t, ErrDuplicateAccessControlPath{}, err)
+	require.IsType(t, ErrDuplicatePerPathConfigPath{}, err)
 
 	err = (&V1{
 		Common: Common{
 			Version: Version1Str,
 		},
-		ACLs: map[string]AccessControlV1{
-			"/foo": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/foo": PerPathConfigV1{
 				AnonymousPermissions: "",
 			},
-			"/foo/../foo": AccessControlV1{
+			"/foo/../foo": PerPathConfigV1{
 				AnonymousPermissions: PermRead,
 			},
 		},
 	}).EnsureInit()
 	require.Error(t, err)
-	require.IsType(t, ErrDuplicateAccessControlPath{}, err)
+	require.IsType(t, ErrDuplicatePerPathConfigPath{}, err)
 
 	err = (&V1{
 		Common: Common{
 			Version: Version1Str,
 		},
-		ACLs: map[string]AccessControlV1{
-			"/": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/": PerPathConfigV1{
 				AnonymousPermissions: "huh?",
 			},
 		},
@@ -97,32 +97,32 @@ func TestConfigV1Full(t *testing.T) {
 			"alice": string(generateBcryptPasswordHashForTestOrBust(t, "12345")),
 			"bob":   string(generateSHA256PasswordHashForTestOrBust(t, "54321")),
 		},
-		ACLs: map[string]AccessControlV1{
-			"/": AccessControlV1{
+		PerPathConfigs: map[string]PerPathConfigV1{
+			"/": PerPathConfigV1{
 				AnonymousPermissions: "read,list",
 			},
-			"/alice-and-bob": AccessControlV1{
+			"/alice-and-bob": PerPathConfigV1{
 				WhitelistAdditionalPermissions: map[string]string{
 					"alice": PermReadAndList,
 					"bob":   PermRead,
 				},
 			},
-			"/bob": AccessControlV1{
+			"/bob": PerPathConfigV1{
 				AnonymousPermissions: "",
 				WhitelistAdditionalPermissions: map[string]string{
 					"bob": PermReadAndList,
 				},
 			},
-			"/public": AccessControlV1{
+			"/public": PerPathConfigV1{
 				AnonymousPermissions: PermReadAndList,
 			},
-			"/public/not-really": AccessControlV1{
+			"/public/not-really": PerPathConfigV1{
 				AnonymousPermissions: "",
 				WhitelistAdditionalPermissions: map[string]string{
 					"alice": PermReadAndList,
 				},
 			},
-			"/bob/dir/deep-dir/deep-deep-dir": AccessControlV1{},
+			"/bob/dir/deep-dir/deep-deep-dir": PerPathConfigV1{},
 		},
 	}
 
@@ -348,7 +348,44 @@ func TestV1EncodeObjectKeyOrder(t *testing.T) {
 	err := v1.Encode(buf, false)
 	require.NoError(t, err)
 	const expectedJSON = `{"version":"v1","users":null,` +
-		`"acls":{"/":{"whitelist_additional_permissions":null,` +
+		`"per_path_configs":{"/":{"whitelist_additional_permissions":null,` +
 		`"anonymous_permissions":"read,list"}}}`
 	require.Equal(t, expectedJSON, strings.TrimSpace(buf.String()))
+}
+
+func TestV1DeprecatingACLsField(t *testing.T) {
+	perPathConfigs := map[string]PerPathConfigV1{
+		"/": PerPathConfigV1{
+			WhitelistAdditionalPermissions: map[string]string{
+				"alice": PermRead,
+			},
+		},
+	}
+
+	configWithDeprecatedACLs := &V1{
+		Common: Common{
+			Version: Version1Str,
+		},
+		Users: map[string]string{
+			"alice": string(generateBcryptPasswordHashForTestOrBust(t, "12345")),
+		},
+		ACLs: perPathConfigs,
+	}
+	err := (configWithDeprecatedACLs).EnsureInit()
+	require.NoError(t, err)
+	require.Nil(t, configWithDeprecatedACLs.ACLs)
+	require.Equal(t, perPathConfigs, configWithDeprecatedACLs.PerPathConfigs)
+
+	err = (&V1{
+		Common: Common{
+			Version: Version1Str,
+		},
+		Users: map[string]string{
+			"alice": string(generateBcryptPasswordHashForTestOrBust(t, "12345")),
+		},
+		ACLs:           perPathConfigs,
+		PerPathConfigs: perPathConfigs,
+	}).EnsureInit()
+	require.Error(t, err)
+	require.IsType(t, ErrACLsPerPathConfigsBothPresent{}, err)
 }

--- a/libpages/config/errors.go
+++ b/libpages/config/errors.go
@@ -49,7 +49,18 @@ func (e ErrUndefinedUsername) Error() string {
 // that has both ACLs and PerPathConfigs defined.
 type ErrACLsPerPathConfigsBothPresent struct{}
 
+// Error implements the error interface.
 func (ErrACLsPerPathConfigsBothPresent) Error() string {
 	return "We are deprecating `acls` and moving to `per_path_configs`. " +
 		"Please use `per_path_configs`."
+}
+
+// ErrInvalidConfig is returned when an invalid config is provided.
+type ErrInvalidConfig struct {
+	msg string
+}
+
+// Error implements the error interface.
+func (e ErrInvalidConfig) Error() string {
+	return fmt.Sprintf("invalid config: %s", e.msg)
 }

--- a/libpages/config/errors.go
+++ b/libpages/config/errors.go
@@ -13,14 +13,14 @@ func (e ErrInvalidPermissions) Error() string {
 	return "invalid permission(s) " + e.permissions
 }
 
-// ErrDuplicateAccessControlPath is returned when multiple ACLs are defined for
-// the same path in config.
-type ErrDuplicateAccessControlPath struct {
+// ErrDuplicatePerPathConfigPath is returned when multiple per-user configs are
+// defined for the same path in config.
+type ErrDuplicatePerPathConfigPath struct {
 	cleanedPath string
 }
 
 // Error implements the error interface.
-func (e ErrDuplicateAccessControlPath) Error() string {
+func (e ErrDuplicatePerPathConfigPath) Error() string {
 	return "duplicate access control for " + e.cleanedPath
 }
 
@@ -34,8 +34,8 @@ func (e ErrInvalidVersion) Error() string {
 	return fmt.Sprintf("invalid version %s", e.versionStr)
 }
 
-// ErrUndefinedUsername is returned when a username appears in a ACL but it's
-// not defined in the config's Users section.
+// ErrUndefinedUsername is returned when a username appears in a per-path
+// config but it's not defined in the config's Users section.
 type ErrUndefinedUsername struct {
 	username string
 }
@@ -43,4 +43,13 @@ type ErrUndefinedUsername struct {
 // Error implements the error interface.
 func (e ErrUndefinedUsername) Error() string {
 	return fmt.Sprintf("undefined username %s", e.username)
+}
+
+// ErrACLsPerPathConfigsBothPresent is returned when we are parsing a ConfigV1
+// that has both ACLs and PerPathConfigs defined.
+type ErrACLsPerPathConfigsBothPresent struct{}
+
+func (ErrACLsPerPathConfigsBothPresent) Error() string {
+	return "We are deprecating `acls` and moving to `per_path_configs`. " +
+		"Please use `per_path_configs`."
 }

--- a/libpages/server.go
+++ b/libpages/server.go
@@ -165,7 +165,7 @@ func (s *Server) handleError(w http.ResponseWriter, err error) {
 	case ErrKeybasePagesRecordTooMany, ErrInvalidKeybasePagesRecord:
 		http.Error(w, err.Error(), http.StatusPreconditionFailed)
 		return
-	case config.ErrDuplicateAccessControlPath, config.ErrInvalidPermissions,
+	case config.ErrDuplicatePerPathConfigPath, config.ErrInvalidPermissions,
 		config.ErrInvalidVersion, config.ErrUndefinedUsername:
 		http.Error(w, "invalid .kbp_config", http.StatusPreconditionFailed)
 		return


### PR DESCRIPTION
These are per-path settings, just like the ACLs. So rename `acls` to `per_path_configs`, and just add them there.

Both commits are independently review-able. The first commit is just the rename. The second commit adds the new fields to the config.

Note that this doesn't actually do anything for those fields. I'll have another PR up (which should be much smaller than this) for actually using them when I get more time. Will hold off merging this until that one is up and reviewed.

Thanks for looking!

cc @buoyad 