### PR TITLE
kbfsgit: resolve sym refs and use dest ref names in ref data map

### DIFF
--- a/kbfsgit/runner.go
+++ b/kbfsgit/runner.go
@@ -1436,13 +1436,7 @@ func (r *runner) pushAll(ctx context.Context, fs *libfs.FS) (err error) {
 }
 
 func dstNameFromRefString(refStr string) plumbing.ReferenceName {
-	start := strings.Index(refStr, ":") + 1
-	dst := refStr[start:]
-	return plumbing.ReferenceName(dst)
-}
-
-func dstNameFromRefSpec(refspec gogitcfg.RefSpec) plumbing.ReferenceName {
-	return dstNameFromRefString(refspec.String())
+	return gogitcfg.RefSpec(refStr).Dst("")
 }
 
 // parentCommitsForRef returns a map of refs with a list of commits for each
@@ -1494,7 +1488,7 @@ func (r *runner) parentCommitsForRef(ctx context.Context,
 		// 3. Run out of commits.
 		walker := gogitobj.NewCommitPreorderIter(commit, haves, nil)
 		toVisit := maxCommitsToVisitPerRef
-		dstRefName := dstNameFromRefSpec(refspec)
+		dstRefName := refspec.Dst("")
 		commitsByRef[dstRefName] = &libgit.RefData{
 			IsDelete: refspec.IsDelete(),
 			Commits:  make([]*gogitobj.Commit, 0, maxCommitsToVisitPerRef),
@@ -1608,7 +1602,7 @@ func (r *runner) pushSome(
 
 		// All non-deleted refspecs in the batch get the same error.
 		for _, refspec := range refspecs {
-			dst := dstNameFromRefSpec(refspec)
+			dst := refspec.Dst("")
 			results[dst.String()] = err
 		}
 	}
@@ -1712,7 +1706,7 @@ func (r *runner) handlePushBatch(ctx context.Context, args [][]string) (
 	// Remove any errored commits so that we don't send an update
 	// message about them.
 	for refspec := range refspecs {
-		dst := dstNameFromRefSpec(refspec)
+		dst := refspec.Dst("")
 		if results[dst.String()] != nil {
 			r.log.CDebugf(
 				ctx, "Removing commit result for errored push on refspec %s",


### PR DESCRIPTION
When we construct the ref-data-by-name map to `libgit.UpdateRepoMD`, we were erroring out when trying to look up the hash corresponding to symbolic references like "HEAD".  We should resolve those before we look up the hash.

Also, we were putting the _source_ reference name as the key to the map, rather than the dest name.  That meant if someone pushed from a local branch directly to master, that would not be recorded as a master push in the server's DB.  Fix that by always using the destination ref name instead.

Issue: keybase/client#14423