### PR TITLE
folder_block_manager: background cleanup of the sync cache

### DIFF
--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -1358,8 +1358,7 @@ func (fbm *folderBlockManager) doCleanSyncCache() (err error) {
 	defer func() {
 		fbm.log.CDebugf(ctx, "Done cleaning sync cache: %+v", err)
 	}()
-	nextRev := lastRev + 1
-	for nextRev <= recentRev {
+	for nextRev := lastRev + 1; nextRev <= recentRev; nextRev++ {
 		rmd, err := getSingleMD(
 			ctx, fbm.config, fbm.id, kbfsmd.NullBranchID, nextRev,
 			kbfsmd.Merged, nil)
@@ -1382,7 +1381,6 @@ func (fbm *folderBlockManager) doCleanSyncCache() (err error) {
 			return err
 		}
 
-		nextRev++
 	}
 	return nil
 }

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -842,7 +842,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	config.SetBlockServer(bserverPutToDiskCache{config.BlockServer(), dbc})
 	defer config.SetBlockServer(oldBserver)
 
-	t.Log("Making synced private TLF")
+	t.Log("Make a synced private TLF")
 	rootNode := GetRootNodeOrBust(
 		ctx, t, config, userName.String(), tlf.Private)
 	kbfsOps := config.KBFSOps()
@@ -868,8 +868,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	status = dbc.Status(ctx)
 	require.Equal(t, uint64(3), status[syncCacheName].NumBlocks)
 
-	t.Log("Test another TLF that isn't synced until synced until " +
-		"after a few revisions")
+	t.Log("Test another TLF that isn't synced until after a few revisions")
 	rootNode = GetRootNodeOrBust(ctx, t, config, userName.String(), tlf.Public)
 	aNode, _, err = kbfsOps.CreateDir(ctx, rootNode, "a")
 	require.NoError(t, err)


### PR DESCRIPTION
A synced TLF needs to be able to clean up old cached blocks, even if it is offline when the block is unreferenced by a different device. So we track the last unref'd revision for each synced TLF, fetch each merged revision since the last one, and delete all the unreferenced blocks from it.

Issue: KBFS-3507