### PR TITLE
test: clean up some goroutine leaks

### DIFF
--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -113,8 +113,11 @@ func (sc *StateChecker) getLastGCData(ctx context.Context,
 	var latestTime time.Time
 	var latestRev kbfsmd.Revision
 	for _, c := range *config.allKnownConfigsForTesting {
-		ops := c.KBFSOps().(*KBFSOpsStandard).getOps(context.Background(),
-			FolderBranch{tlfID, MasterBranch}, FavoritesOpNoChange)
+		ops := c.KBFSOps().(*KBFSOpsStandard).getOpsIfExists(
+			context.Background(), FolderBranch{tlfID, MasterBranch})
+		if ops == nil {
+			continue
+		}
 		rt, rev := ops.fbm.getLastQRData()
 		if rt.After(latestTime) && rev > latestRev {
 			latestTime = rt


### PR DESCRIPTION
* Properly cancel FUSE background context in DSL tests; the parent context wasn't getting canceled.

* state_checker: when checking GC last data, don't create new ops. Because this happens during shut down, the new ops will never be cleaned up!  We only care about ones that actually ran GC here, so no need to create new ones.

cc: @jakob223 these are a few leaks I found.  Maybe there are more, but this should be a good start.  (I don't think they were related to the timeouts we saw earlier though.)