### PR TITLE
block_tree: fix race condition

### DIFF
--- a/libkbfs/block_tree.go
+++ b/libkbfs/block_tree.go
@@ -537,7 +537,6 @@ func (bt *blockTree) getBlocksForOffsetRange(ctx context.Context,
 			} else {
 				errors = append(errors, res.err)
 			}
-			wp.Stop()
 			cancel()
 		}
 		if res.pathFromRoot != nil {


### PR DESCRIPTION
If the context is cancelled at an inconvenient time, one worker
could submit more tasks after another has stopped the worker
pool. To fix this, let the workerpool drain on context
cancellation, which will cancel the workerpool when the call to
`wg.Done()` returns.