### PR TITLE
kbfscrypto: add a cause to a few DecryptionErrors

### DIFF
--- a/kbfscrypto/crypto_key_types.go
+++ b/kbfscrypto/crypto_key_types.go
@@ -522,13 +522,15 @@ func DecryptTLFCryptKeyClientHalf(
 		&nonce, &publicKeyData, &privateKeyData)
 	if !ok {
 		return TLFCryptKeyClientHalf{},
-			errors.WithStack(libkb.DecryptionError{})
+			errors.WithStack(libkb.DecryptionError{Cause: errors.New(
+				"Can't unbox TLF crypt key client half")})
 	}
 
 	var clientHalfData [32]byte
 	if len(decryptedData) != len(clientHalfData) {
 		return TLFCryptKeyClientHalf{},
-			errors.WithStack(libkb.DecryptionError{})
+			errors.WithStack(libkb.DecryptionError{Cause: errors.New(
+				"TLF crypt key client half has wrong data length")})
 	}
 
 	copy(clientHalfData[:], decryptedData)

--- a/libkbfs/crypto_client_test.go
+++ b/libkbfs/crypto_client_test.go
@@ -453,7 +453,7 @@ func TestCryptoClientDecryptTLFCryptKeyClientHalfFailures(t *testing.T) {
 		ephPublicKeyCorruptData)
 	_, err = c.DecryptTLFCryptKeyClientHalf(ctx, ephPublicKeyCorrupt,
 		encryptedClientHalf)
-	assert.Equal(t, libkb.DecryptionError{}, errors.Cause(err))
+	assert.IsType(t, libkb.DecryptionError{}, errors.Cause(err))
 
 	// Corrupt data.
 
@@ -461,7 +461,7 @@ func TestCryptoClientDecryptTLFCryptKeyClientHalfFailures(t *testing.T) {
 	encryptedClientHalfCorruptData.EncryptedData[0] = ^encryptedClientHalfCorruptData.EncryptedData[0]
 	_, err = c.DecryptTLFCryptKeyClientHalf(ctx, ephPublicKey,
 		encryptedClientHalfCorruptData)
-	assert.Equal(t, libkb.DecryptionError{}, errors.Cause(err))
+	assert.IsType(t, libkb.DecryptionError{}, errors.Cause(err))
 }
 
 // Test that canceling a signing RPC returns the correct error


### PR DESCRIPTION
I don't think this was causing any actual errors, but @maxtaco says it's a bug not to set the `Cause` on a `DecryptionError`.

Issue: KBFS-3588