### PR TITLE
md_ops: add caching to improve validation of MDs written by revoked devices

### DIFF
--- a/libkbfs/errors.go
+++ b/libkbfs/errors.go
@@ -1234,3 +1234,16 @@ func (e OfflineUnsyncedError) Error() string {
 	return fmt.Sprintf("Unsynced data from %s is not available while offline",
 		e.h.GetCanonicalPath())
 }
+
+// NextMDNotCachedError indicates we haven't cached the next MD after
+// the given Merkle seqno.
+type NextMDNotCachedError struct {
+	TlfID     tlf.ID
+	RootSeqno keybase1.Seqno
+}
+
+// Error implements the Error interface for NextMDNotCachedError.
+func (e NextMDNotCachedError) Error() string {
+	return fmt.Sprintf("The MD following %d for folder %s is not cached",
+		e.RootSeqno, e.TlfID)
+}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1035,6 +1035,16 @@ type MDCache interface {
 	// ChangeHandleForID moves an ID to be under a new handle, if the
 	// ID is cached already.
 	ChangeHandleForID(oldHandle *TlfHandle, newHandle *TlfHandle)
+	// GetNextMD returns a cached view of the next MD following the
+	// given global Merkle root.
+	GetNextMD(tlfID tlf.ID, rootSeqno keybase1.Seqno) (
+		nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
+		nextRootSeqno keybase1.Seqno, err error)
+	// PutNextMD caches a view of the next MD following the given
+	// global Merkle root.
+	PutNextMD(tlfID tlf.ID, rootSeqno keybase1.Seqno,
+		nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte,
+		nextRootSeqno keybase1.Seqno) error
 }
 
 // KeyCache handles caching for both TLFCryptKeys and BlockCryptKeys.

--- a/libkbfs/md_ops.go
+++ b/libkbfs/md_ops.go
@@ -414,15 +414,6 @@ func (md *MDOpsStandard) checkRevisionCameBeforeMerkle(
 		"Next KBFS merkle root is %d, included in global merkle root seqno=%d",
 		kbfsRoot.SeqNo, rootSeqno)
 
-	// The FindNextMD call already validated the global root, and the
-	// fact that the root contained the given KBFS root.  Now we need
-	// to validate the hashes of the nodes all the way down to the
-	// leaf.
-	err = verifyMerkleNodes(ctx, kbfsRoot, merkleNodes, irmd.TlfID())
-	if err != nil {
-		return err
-	}
-
 	// Decode (and possibly decrypt) the leaf node, so we can see what
 	// the given MD revision number was for the MD that followed the
 	// revoke.

--- a/libkbfs/md_ops_test.go
+++ b/libkbfs/md_ops_test.go
@@ -1300,6 +1300,7 @@ func testMDOpsVerifyRevokedDeviceWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.True(t, cacheable)
 
 	t.Log("Make the server return no information, but outside the max gap")
+	config.MDCache().(*MDCacheStandard).nextMDLRU.Purge()
 	clock.Add(maxAllowedMerkleGap) // already added one minute above
 	_, err = mdOps.verifyKey(
 		ctx, allRMDSs[0], allRMDSs[0].MD.GetLastModifyingUser(),
@@ -1307,6 +1308,7 @@ func testMDOpsVerifyRevokedDeviceWrite(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.Error(t, err)
 
 	t.Log("Make the server return a root, but which is outside the max gap")
+	config.MDCache().(*MDCacheStandard).nextMDLRU.Purge()
 	root.Timestamp = clock.Now().Unix()
 	mdServer.nextMerkleRoot = root
 	mdServer.nextMerkleNodes = [][]byte{leafBytes}

--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -1381,6 +1381,12 @@ func (md *MDServerRemote) FindNextMD(
 		return nil, nil, 0, err
 	}
 
+	// Validate the hashes of the nodes all the way down to the leaf.
+	err = verifyMerkleNodes(ctx, &kbfsRoot, response.MerkleNodes, tlfID)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+
 	return &kbfsRoot, response.MerkleNodes, response.RootSeqno, nil
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -3797,6 +3797,33 @@ func (mr *MockMDCacheMockRecorder) ChangeHandleForID(oldHandle, newHandle interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeHandleForID", reflect.TypeOf((*MockMDCache)(nil).ChangeHandleForID), oldHandle, newHandle)
 }
 
+// GetNextMD mocks base method
+func (m *MockMDCache) GetNextMD(tlfID tlf.ID, rootSeqno keybase1.Seqno) (*kbfsmd.MerkleRoot, [][]byte, keybase1.Seqno, error) {
+	ret := m.ctrl.Call(m, "GetNextMD", tlfID, rootSeqno)
+	ret0, _ := ret[0].(*kbfsmd.MerkleRoot)
+	ret1, _ := ret[1].([][]byte)
+	ret2, _ := ret[2].(keybase1.Seqno)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetNextMD indicates an expected call of GetNextMD
+func (mr *MockMDCacheMockRecorder) GetNextMD(tlfID, rootSeqno interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNextMD", reflect.TypeOf((*MockMDCache)(nil).GetNextMD), tlfID, rootSeqno)
+}
+
+// PutNextMD mocks base method
+func (m *MockMDCache) PutNextMD(tlfID tlf.ID, rootSeqno keybase1.Seqno, nextKbfsRoot *kbfsmd.MerkleRoot, nextMerkleNodes [][]byte, nextRootSeqno keybase1.Seqno) error {
+	ret := m.ctrl.Call(m, "PutNextMD", tlfID, rootSeqno, nextKbfsRoot, nextMerkleNodes, nextRootSeqno)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutNextMD indicates an expected call of PutNextMD
+func (mr *MockMDCacheMockRecorder) PutNextMD(tlfID, rootSeqno, nextKbfsRoot, nextMerkleNodes, nextRootSeqno interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutNextMD", reflect.TypeOf((*MockMDCache)(nil).PutNextMD), tlfID, rootSeqno, nextKbfsRoot, nextMerkleNodes, nextRootSeqno)
+}
+
 // MockKeyCache is a mock of KeyCache interface
 type MockKeyCache struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
In #1888, a user is doing way more work than necessary to validate a bunch of MDs written by a revoked device, during garbage collection.  We can improve that a small amount of caching:

This PR:
* Moves verification of KBFS Merkle nodes into the mdserver remote, so they can be cached more effectively.
* Adds a limited size LRU cache for the (validated) results of `FindNextMD`.
* Tracks the chain of MDs that have been validated up to a given revision (the one immediately following the revoke in the Merkle tree).

This should eliminate most of the redundant work that was happening when verifying lots of MDs written by the same revoked device, as in garbage collection.

Issue: KBFS-3581
Issue: #1888 