### PR TITLE
Use the KBFS favorites cache

### DIFF
--- a/libkbfs/favorites.go
+++ b/libkbfs/favorites.go
@@ -120,9 +120,7 @@ func (f *Favorites) handleReq(req *favReq) (err error) {
 	// Fetch a new list if:
 	//  * The user asked us to refresh
 	//  * We haven't fetched it before
-	//  * The user wants the list of favorites.  TODO: use the cached list
-	//    once we have proper invalidation from the server.
-	if req.refresh || f.cache == nil || req.favs != nil {
+	if req.refresh || f.cache == nil {
 		folders, err := kbpki.FavoriteList(req.ctx)
 		if err != nil {
 			return err
@@ -340,8 +338,9 @@ func (f *Favorites) RefreshCache(ctx context.Context) {
 	}
 }
 
-// Get returns the logged-in users list of favorites. It
-// doesn't use the cache.
+// Get returns the logged-in user's list of favorites. It uses the cache.
+// TODO: decide on behavior if we've gotten an invalidation but not an updated
+// list yet
 func (f *Favorites) Get(ctx context.Context) ([]Favorite, error) {
 	if f.disabled {
 		session, err := f.config.KBPKI().GetCurrentSession(ctx)

--- a/libkbfs/favorites.go
+++ b/libkbfs/favorites.go
@@ -5,9 +5,11 @@
 package libkbfs
 
 import (
+	"github.com/keybase/client/go/libkb"
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfssync"
@@ -67,7 +69,8 @@ type Favorites struct {
 	// It may not be consistent with the server's view of the user's
 	// favorites list, if other devices have modified the list since
 	// the last refresh.
-	cache map[Favorite]bool
+	cache           map[Favorite]bool
+	cacheExpireTime time.Time
 
 	inFlightLock sync.Mutex
 	inFlightAdds map[favToAdd]*favReq
@@ -120,13 +123,16 @@ func (f *Favorites) handleReq(req *favReq) (err error) {
 	// Fetch a new list if:
 	//  * The user asked us to refresh
 	//  * We haven't fetched it before
-	if req.refresh || f.cache == nil {
+	//  * It's stale
+	if req.refresh || f.cache == nil || time.Now().After(f.cacheExpireTime) {
 		folders, err := kbpki.FavoriteList(req.ctx)
 		if err != nil {
 			return err
 		}
 
 		f.cache = make(map[Favorite]bool)
+		f.cacheExpireTime = libkb.ForceWallClock(time.Now()).Add(time.
+			Hour * 24 * 7)
 		for _, folder := range folders {
 			f.cache[*NewFavoriteFromFolder(folder)] = true
 		}

--- a/libkbfs/keybase_daemon_rpc.go
+++ b/libkbfs/keybase_daemon_rpc.go
@@ -71,6 +71,7 @@ func (k *KeybaseDaemonRPC) addKBFSProtocols() {
 		keybase1.NotifyPaperKeyProtocol(k),
 		keybase1.NotifyFSRequestProtocol(k),
 		keybase1.NotifyTeamProtocol(k),
+		keybase1.NotifyFavoritesProtocol(k),
 		keybase1.TlfKeysProtocol(k),
 		keybase1.ReachabilityProtocol(k),
 		keybase1.ImplicitTeamMigrationProtocol(k),
@@ -327,6 +328,7 @@ func (k *KeybaseDaemonRPC) OnConnect(ctx context.Context,
 		Service:       true,
 		Team:          true,
 		Chatkbfsedits: true,
+		Favorites:     true,
 	})
 	if err != nil {
 		return err
@@ -452,4 +454,12 @@ func (s *notifyServiceHandler) Shutdown(_ context.Context, code int) error {
 func newNotifyServiceHandler(config Config, log logger.Logger) keybase1.NotifyServiceInterface {
 	s := &notifyServiceHandler{config: config, log: log}
 	return s
+}
+
+// FavoritesChanged implements keybase1.NotifyFavoritesClient
+func (k *KeybaseDaemonRPC) FavoritesChanged(ctx context.Context,
+	uid keybase1.UID) error {
+	k.log.Debug("Received FavoritesChanged RPC.")
+	k.config.KBFSOps().RefreshCachedFavorites(ctx)
+	return nil
 }


### PR DESCRIPTION
This is the same as a previous PR that was reverted because the corresponding PR in `client` was not yet approved.