### PR TITLE
tlf_history: treat files to ignore as prefixes

### DIFF
--- a/kbfsedits/tlf_history.go
+++ b/kbfsedits/tlf_history.go
@@ -242,7 +242,17 @@ var filesToIgnore = map[string]bool{
 
 func ignoreFile(filename string) bool {
 	_, base := path.Split(filename)
-	return filesToIgnore[base] || strings.HasPrefix(base, "._")
+	if filesToIgnore[base] || strings.HasPrefix(base, "._") {
+		return true
+	}
+	// Treat the files to ignore as prefixes, since if they ever
+	// conflict they'll have the conflict suffix.
+	for prefix := range filesToIgnore {
+		if strings.HasPrefix(base, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // processNotification adds the notification to the recomputer's

--- a/kbfsedits/tlf_history_test.go
+++ b/kbfsedits/tlf_history_test.go
@@ -145,6 +145,12 @@ func TestTlfHistoryMultipleWrites(t *testing.T) {
 	_ = nn.make("._c", NotificationModify, aliceUID, nil, time.Time{})
 	aliceMessages = append(aliceMessages, nn.encode(t))
 
+	// Alice writes to ".DS_Store (conflicted copy)", which should be ignored.
+	_ = nn.make(
+		".DS_Store (conflicted copy)", NotificationModify, aliceUID, nil,
+		time.Time{})
+	aliceMessages = append(aliceMessages, nn.encode(t))
+
 	expected := writersByRevision{
 		{aliceName, []NotificationMessage{aliceModC, aliceModA}},
 		{bobName, []NotificationMessage{bobModA, bobModC, bobCreateB}},


### PR DESCRIPTION
Otherwise, conflicted copies will show up.

Issue: KBFS-3609