### PR TITLE
simplefs: support sync methods and clear blocks for unsynced TLFs

### DIFF
--- a/libfs/sync_control_file.go
+++ b/libfs/sync_control_file.go
@@ -43,10 +43,10 @@ func (a SyncAction) Execute(
 
 	switch a {
 	case SyncEnable:
-		err = c.SetTlfSyncState(fb.Tlf, true)
+		_, err = c.SetTlfSyncState(fb.Tlf, true)
 
 	case SyncDisable:
-		err = c.SetTlfSyncState(fb.Tlf, false)
+		_, err = c.SetTlfSyncState(fb.Tlf, false)
 
 	default:
 		return fmt.Errorf("Unknown action %s", a)

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -108,6 +108,7 @@ type ConfigLocal struct {
 	kbfsService      *KBFSService
 	kbCtx            Context
 	rootNodeWrappers []func(Node) Node
+	tlfClearCancels  map[tlf.ID]context.CancelFunc
 
 	maxNameBytes           uint32
 	rekeyQueue             RekeyQueue
@@ -416,11 +417,12 @@ func NewConfigLocal(mode InitMode,
 	storageRoot string, diskCacheMode DiskCacheMode,
 	kbCtx Context) *ConfigLocal {
 	config := &ConfigLocal{
-		loggerFn:      loggerFn,
-		storageRoot:   storageRoot,
-		mode:          mode,
-		diskCacheMode: diskCacheMode,
-		kbCtx:         kbCtx,
+		loggerFn:        loggerFn,
+		storageRoot:     storageRoot,
+		mode:            mode,
+		diskCacheMode:   diskCacheMode,
+		kbCtx:           kbCtx,
+		tlfClearCancels: make(map[tlf.ID]context.CancelFunc),
 	}
 	if diskCacheMode == DiskCacheModeLocal {
 		config.loadSyncedTlfsLocked()
@@ -1248,6 +1250,13 @@ func (c *ConfigLocal) Shutdown(ctx context.Context) error {
 		// Aggregate errors
 		return errors.Errorf("Multiple errors on shutdown: %+v", errorList)
 	}
+
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for _, cancel := range c.tlfClearCancels {
+		cancel()
+	}
+
 	return nil
 }
 
@@ -1551,9 +1560,24 @@ func (c *ConfigLocal) SetTlfSyncState(tlfID tlf.ID, isSynced bool) error {
 			return err
 		}
 		if isSynced {
+			if cancel, ok := c.tlfClearCancels[tlfID]; ok {
+				cancel()
+			}
 			err = ldb.Put(tlfBytes, nil, nil)
 		} else {
 			err = ldb.Delete(tlfBytes, nil)
+			// Start a background goroutine deleting all the blocks
+			// from this TLF.
+			ctx, cancel := context.WithCancel(context.Background())
+			if oldCancel, ok := c.tlfClearCancels[tlfID]; ok {
+				oldCancel()
+			}
+			c.tlfClearCancels[tlfID] = cancel
+			diskBlockCache := c.diskBlockCache
+			go func() {
+				defer cancel()
+				diskBlockCache.ClearAllTlfBlocks(ctx, tlfID)
+			}()
 		}
 		if err != nil {
 			return err

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -933,6 +933,12 @@ func (cache *DiskBlockCacheLocal) deleteNextBatchFromClearedTlf(
 		return 0, err
 	}
 
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
 	_, _, err = cache.evictFromTLFLocked(ctx, tlfID, numBlocksToEvictOnClear)
 	if err != nil {
 		return 0, err

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -943,7 +943,12 @@ func (cache *DiskBlockCacheLocal) deleteNextBatchFromClearedTlf(
 // ClearAllTlfBlocks implements the DiskBlockCache interface for
 // DiskBlockCacheLocal.
 func (cache *DiskBlockCacheLocal) ClearAllTlfBlocks(
-	ctx context.Context, tlfID tlf.ID) error {
+	ctx context.Context, tlfID tlf.ID) (err error) {
+	defer func() {
+		cache.log.CDebugf(ctx,
+			"Finished clearing blocks from %s: %+v", tlfID, err)
+	}()
+
 	// Delete the blocks in batches, so we don't keep the lock for too
 	// long.
 	for {

--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -125,6 +125,13 @@ func (dbcr *DiskBlockCacheRemote) UpdateMetadata(ctx context.Context,
 		})
 }
 
+// ClearAllTlfBlocks implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) ClearAllTlfBlocks(
+	_ context.Context, _ tlf.ID) error {
+	panic("ClearAllTlfBlocks() not implemented in DiskBlockCacheRemote")
+}
+
 // GetLastUnrefRev implements the DiskBlockCache interface for
 // DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) GetLastUnrefRev(

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -216,6 +216,19 @@ func (cache *diskBlockCacheWrapped) UpdateMetadata(ctx context.Context,
 	return cache.workingSetCache.UpdateMetadata(ctx, blockID, prefetchStatus)
 }
 
+// ClearAllTlfBlocks implements the DiskBlockCache interface for
+// diskBlockCacheWrapper.
+func (cache *diskBlockCacheWrapped) ClearAllTlfBlocks(
+	ctx context.Context, tlfID tlf.ID) error {
+	cache.mtx.RLock()
+	defer cache.mtx.RUnlock()
+	// We only clear blocks from the sync cache.
+	if cache.syncCache == nil {
+		return nil
+	}
+	return cache.syncCache.ClearAllTlfBlocks(ctx, tlfID)
+}
+
 // GetLastUnrefRev implements the DiskBlockCache interface for
 // diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) GetLastUnrefRev(

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -846,7 +846,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	rootNode := GetRootNodeOrBust(
 		ctx, t, config, userName.String(), tlf.Private)
 	kbfsOps := config.KBFSOps()
-	err = config.SetTlfSyncState(rootNode.GetFolderBranch().Tlf, true)
+	_, err = config.SetTlfSyncState(rootNode.GetFolderBranch().Tlf, true)
 	require.NoError(t, err)
 	aNode, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
 	require.NoError(t, err)
@@ -883,7 +883,7 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	require.Equal(t, kbfsmd.RevisionUninitialized, lastRev)
 
 	t.Log("Set new TLF to syncing, and add a new revision")
-	err = config.SetTlfSyncState(rootNode.GetFolderBranch().Tlf, true)
+	_, err = config.SetTlfSyncState(rootNode.GetFolderBranch().Tlf, true)
 	require.NoError(t, err)
 	_, _, err = kbfsOps.CreateDir(ctx, bNode, "c")
 	require.NoError(t, err)

--- a/libkbfs/interface_test.go
+++ b/libkbfs/interface_test.go
@@ -71,9 +71,9 @@ func (t *testSyncedTlfGetterSetter) IsSyncedTlf(tlfID tlf.ID) bool {
 }
 
 func (t *testSyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID,
-	isSynced bool) error {
+	isSynced bool) (<-chan error, error) {
 	t.syncedTlfs[tlfID] = isSynced
-	return nil
+	return nil, nil
 }
 
 type testInitModeGetter struct {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -109,7 +109,7 @@ type diskLimiterGetter interface {
 
 type syncedTlfGetterSetter interface {
 	IsSyncedTlf(tlfID tlf.ID) bool
-	SetTlfSyncState(tlfID tlf.ID, isSynced bool) error
+	SetTlfSyncState(tlfID tlf.ID, isSynced bool) (<-chan error, error)
 }
 
 type blockRetrieverGetter interface {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1251,6 +1251,9 @@ type DiskBlockCache interface {
 	// UpdateMetadata updates metadata for a given block in the disk cache.
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
 		prefetchStatus PrefetchStatus) error
+	// ClearBlocks deletes all the blocks corresponding to the given
+	// TLF ID from the cache.
+	ClearAllTlfBlocks(ctx context.Context, tlfID tlf.ID) error
 	// GetLastUnrefRev returns the last revision that has been marked
 	// unref'd for the given TLF.
 	GetLastUnrefRev(ctx context.Context, tlfID tlf.ID) (kbfsmd.Revision, error)

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1251,8 +1251,9 @@ type DiskBlockCache interface {
 	// UpdateMetadata updates metadata for a given block in the disk cache.
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
 		prefetchStatus PrefetchStatus) error
-	// ClearBlocks deletes all the blocks corresponding to the given
-	// TLF ID from the cache.
+	// ClearAllTlfBlocks deletes all the synced blocks corresponding
+	// to the given TLF ID from the cache.  It doesn't affect
+	// transient blocks for unsynced TLFs.
 	ClearAllTlfBlocks(ctx context.Context, tlfID tlf.ID) error
 	// GetLastUnrefRev returns the last revision that has been marked
 	// unref'd for the given TLF.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4408,6 +4408,18 @@ func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, blockID, prefetchS
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMetadata", reflect.TypeOf((*MockDiskBlockCache)(nil).UpdateMetadata), ctx, blockID, prefetchStatus)
 }
 
+// ClearAllTlfBlocks mocks base method
+func (m *MockDiskBlockCache) ClearAllTlfBlocks(ctx context.Context, tlfID tlf.ID) error {
+	ret := m.ctrl.Call(m, "ClearAllTlfBlocks", ctx, tlfID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearAllTlfBlocks indicates an expected call of ClearAllTlfBlocks
+func (mr *MockDiskBlockCacheMockRecorder) ClearAllTlfBlocks(ctx, tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAllTlfBlocks", reflect.TypeOf((*MockDiskBlockCache)(nil).ClearAllTlfBlocks), ctx, tlfID)
+}
+
 // GetLastUnrefRev mocks base method
 func (m *MockDiskBlockCache) GetLastUnrefRev(ctx context.Context, tlfID tlf.ID) (kbfsmd.Revision, error) {
 	ret := m.ctrl.Call(m, "GetLastUnrefRev", ctx, tlfID)

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -790,10 +790,11 @@ func (mr *MocksyncedTlfGetterSetterMockRecorder) IsSyncedTlf(tlfID interface{}) 
 }
 
 // SetTlfSyncState mocks base method
-func (m *MocksyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID, isSynced bool) error {
+func (m *MocksyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID, isSynced bool) (<-chan error, error) {
 	ret := m.ctrl.Call(m, "SetTlfSyncState", tlfID, isSynced)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(<-chan error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SetTlfSyncState indicates an expected call of SetTlfSyncState
@@ -7720,10 +7721,11 @@ func (mr *MockConfigMockRecorder) IsSyncedTlf(tlfID interface{}) *gomock.Call {
 }
 
 // SetTlfSyncState mocks base method
-func (m *MockConfig) SetTlfSyncState(tlfID tlf.ID, isSynced bool) error {
+func (m *MockConfig) SetTlfSyncState(tlfID tlf.ID, isSynced bool) (<-chan error, error) {
 	ret := m.ctrl.Call(m, "SetTlfSyncState", tlfID, isSynced)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(<-chan error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SetTlfSyncState indicates an expected call of SetTlfSyncState

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -2029,9 +2029,11 @@ func (k *SimpleFS) SimpleFSSetFolderSyncConfig(
 
 	switch arg.Config.Mode {
 	case keybase1.FolderSyncMode_DISABLED:
-		return k.config.SetTlfSyncState(tlfID, false)
+		_, err = k.config.SetTlfSyncState(tlfID, false)
+		return err
 	case keybase1.FolderSyncMode_ENABLED:
-		return k.config.SetTlfSyncState(tlfID, true)
+		_, err = k.config.SetTlfSyncState(tlfID, true)
+		return err
 	default:
 		return simpleFSError{
 			fmt.Sprintf("Unknown config mode: %s", arg.Config.Mode)}

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
@@ -1104,6 +1104,61 @@ func (o SimpleFSQuotaUsage) DeepCopy() SimpleFSQuotaUsage {
 	}
 }
 
+type FolderSyncMode int
+
+const (
+	FolderSyncMode_DISABLED FolderSyncMode = 0
+	FolderSyncMode_ENABLED  FolderSyncMode = 1
+)
+
+func (o FolderSyncMode) DeepCopy() FolderSyncMode { return o }
+
+var FolderSyncModeMap = map[string]FolderSyncMode{
+	"DISABLED": 0,
+	"ENABLED":  1,
+}
+
+var FolderSyncModeRevMap = map[FolderSyncMode]string{
+	0: "DISABLED",
+	1: "ENABLED",
+}
+
+func (e FolderSyncMode) String() string {
+	if v, ok := FolderSyncModeRevMap[e]; ok {
+		return v
+	}
+	return ""
+}
+
+type FolderSyncConfig struct {
+	Mode FolderSyncMode `codec:"mode" json:"mode"`
+}
+
+func (o FolderSyncConfig) DeepCopy() FolderSyncConfig {
+	return FolderSyncConfig{
+		Mode: o.Mode.DeepCopy(),
+	}
+}
+
+type FolderSyncStatus struct {
+}
+
+func (o FolderSyncStatus) DeepCopy() FolderSyncStatus {
+	return FolderSyncStatus{}
+}
+
+type FolderSyncConfigAndStatus struct {
+	Config FolderSyncConfig `codec:"config" json:"config"`
+	Status FolderSyncStatus `codec:"status" json:"status"`
+}
+
+func (o FolderSyncConfigAndStatus) DeepCopy() FolderSyncConfigAndStatus {
+	return FolderSyncConfigAndStatus{
+		Config: o.Config.DeepCopy(),
+		Status: o.Status.DeepCopy(),
+	}
+}
+
 type SimpleFSListArg struct {
 	OpID                OpID       `codec:"opID" json:"opID"`
 	Path                Path       `codec:"path" json:"path"`
@@ -1247,6 +1302,15 @@ type SimpleFSResetArg struct {
 	Path Path `codec:"path" json:"path"`
 }
 
+type SimpleFSFolderSyncConfigAndStatusArg struct {
+	Path Path `codec:"path" json:"path"`
+}
+
+type SimpleFSSetFolderSyncConfigArg struct {
+	Path   Path             `codec:"path" json:"path"`
+	Config FolderSyncConfig `codec:"config" json:"config"`
+}
+
 type SimpleFSInterface interface {
 	// Begin list of items in directory at path.
 	// Retrieve results with readList().
@@ -1345,6 +1409,8 @@ type SimpleFSInterface interface {
 	// simpleFSReset completely resets the KBFS folder referenced in `path`.
 	// It should only be called after explicit user confirmation.
 	SimpleFSReset(context.Context, Path) error
+	SimpleFSFolderSyncConfigAndStatus(context.Context, Path) (FolderSyncConfigAndStatus, error)
+	SimpleFSSetFolderSyncConfig(context.Context, SimpleFSSetFolderSyncConfigArg) error
 }
 
 func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
@@ -1801,6 +1867,38 @@ func SimpleFSProtocol(i SimpleFSInterface) rpc.Protocol {
 				},
 				MethodType: rpc.MethodCall,
 			},
+			"simpleFSFolderSyncConfigAndStatus": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSFolderSyncConfigAndStatusArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SimpleFSFolderSyncConfigAndStatusArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSFolderSyncConfigAndStatusArg)(nil), args)
+						return
+					}
+					ret, err = i.SimpleFSFolderSyncConfigAndStatus(ctx, typedArgs[0].Path)
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
+			"simpleFSSetFolderSyncConfig": {
+				MakeArg: func() interface{} {
+					var ret [1]SimpleFSSetFolderSyncConfigArg
+					return &ret
+				},
+				Handler: func(ctx context.Context, args interface{}) (ret interface{}, err error) {
+					typedArgs, ok := args.(*[1]SimpleFSSetFolderSyncConfigArg)
+					if !ok {
+						err = rpc.NewTypeError((*[1]SimpleFSSetFolderSyncConfigArg)(nil), args)
+						return
+					}
+					err = i.SimpleFSSetFolderSyncConfig(ctx, typedArgs[0])
+					return
+				},
+				MethodType: rpc.MethodCall,
+			},
 		},
 	}
 }
@@ -2032,5 +2130,16 @@ func (c SimpleFSClient) SimpleFSGetUserQuotaUsage(ctx context.Context) (res Simp
 func (c SimpleFSClient) SimpleFSReset(ctx context.Context, path Path) (err error) {
 	__arg := SimpleFSResetArg{Path: path}
 	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSReset", []interface{}{__arg}, nil)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSFolderSyncConfigAndStatus(ctx context.Context, path Path) (res FolderSyncConfigAndStatus, err error) {
+	__arg := SimpleFSFolderSyncConfigAndStatusArg{Path: path}
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSFolderSyncConfigAndStatus", []interface{}{__arg}, &res)
+	return
+}
+
+func (c SimpleFSClient) SimpleFSSetFolderSyncConfig(ctx context.Context, __arg SimpleFSSetFolderSyncConfigArg) (err error) {
+	err = c.Cli.Call(ctx, "keybase.1.SimpleFS.simpleFSSetFolderSyncConfig", []interface{}{__arg}, nil)
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -346,10 +346,10 @@
 			"revisionTime": "2018-10-12T20:20:19Z"
 		},
 		{
-			"checksumSHA1": "UBW6KDh1z8hqxV9PDLxoLb1vj5A=",
+			"checksumSHA1": "J0IaXen5PBxmc+o7sJEYPnHoVFc=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "675bfc30009781abeddc95b9c8b0d5715612201b",
-			"revisionTime": "2018-11-16T22:20:07Z"
+			"revision": "3eb26ba304090b8c1d9365f034477e13b5a96b3f",
+			"revisionTime": "2018-11-19T22:20:54Z"
 		},
 		{
 			"checksumSHA1": "jlxTK07TEsCuy7DdIbB1bJu8Afw=",


### PR DESCRIPTION
This vendors in keybase/client#14666, and supports setting/getting the sync config for individual TLFs.

It also starts deleting blocks asynchronously when a TLF is unsynced, to clear space in the disk block cache.  Though if KBFS crashes before all the blocks are cleared, it doesn't try to restart the deletion; the user must re-enable then re-disable the TLF to clear all the blocks again.  (We can fix that in a future PR, if needed.)

Will fail CircleCI until keybase/client#14666 is merged; will revendor when it is.