### PR TITLE
folder_branch_ops: only commit MDs to disk on a read

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3168,7 +3168,7 @@ outer:
 		return err
 	}
 
-	head := cr.fbo.getTrustedHead(ctx, lState)
+	head := cr.fbo.getTrustedHead(ctx, lState, mdNoCommit)
 	if head == (ImmutableRootMetadata{}) {
 		panic("maybeUnstageAfterFailure: head is nil (should be impossible)")
 	}
@@ -3199,7 +3199,7 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	defer func() {
 		cr.deferLog.CDebugf(ctx, "Finished conflict resolution: %+v", err)
 		if err != nil {
-			head := cr.fbo.getTrustedHead(ctx, lState)
+			head := cr.fbo.getTrustedHead(ctx, lState, mdNoCommit)
 			if head == (ImmutableRootMetadata{}) {
 				panic("doResolve: head is nil (should be impossible)")
 			}


### PR DESCRIPTION
This fixes a test flake, where MDs could be commited during the part a `SyncFromServer` call that did a `SyncAll`.  The test's timing depends on the commit call happening only while fetching the updates from the server.

And committing only on reads is what we want anyway -- once the changes have been seen by the user, they should be committed.  But writes don't count for that (and they'll be producing a new revision anyway).