### PR TITLE
prefetcher: reschedule prefetches with backoff when disk is full

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -1094,6 +1094,18 @@ func (cache *DiskBlockCacheLocal) Status(
 	}
 }
 
+// DoesSyncCacheHaveSpace returns true if we have more than 1% of space left in
+// the sync cache.
+func (cache *DiskBlockCacheLocal) DoesSyncCacheHaveSpace(
+	ctx context.Context) bool {
+	if cache.cacheType != syncCacheLimitTrackerType {
+		return false
+	}
+	limiterStatus := cache.config.DiskLimiter().getStatus(
+		ctx, keybase1.UserOrTeamID("")).(backpressureDiskLimiterStatus)
+	return limiterStatus.SyncCacheByteStatus.UsedFrac <= .99
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheLocal.
 func (cache *DiskBlockCacheLocal) Shutdown(ctx context.Context) {
 	// Wait for the cache to either finish starting or error.

--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -153,6 +153,13 @@ func (dbcr *DiskBlockCacheRemote) Status(ctx context.Context) map[string]DiskBlo
 	panic("Status() not implemented in DiskBlockCacheRemote")
 }
 
+// DoesSyncCacheHaveSpace implements the DiskBlockCache interface for
+// DiskBlockCacheRemote.
+func (dbcr *DiskBlockCacheRemote) DoesSyncCacheHaveSpace(
+	_ context.Context) bool {
+	panic("DoesSyncCacheHaveSpace() not implemented in DiskBlockCacheRemote")
+}
+
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Shutdown(ctx context.Context) {
 	dbcr.conn.Close()

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -104,9 +103,7 @@ func (cache *diskBlockCacheWrapped) DoesSyncCacheHaveSpace(
 	if !cache.IsSyncCacheEnabled() {
 		return false
 	}
-	limiterStatus := cache.config.DiskLimiter().getStatus(
-		ctx, keybase1.UserOrTeamID("")).(backpressureDiskLimiterStatus)
-	return limiterStatus.SyncCacheByteStatus.UsedFrac <= .99
+	return cache.syncCache.DoesSyncCacheHaveSpace(ctx)
 }
 
 // IsSyncCacheEnabled returns true if the sync cache is enabled.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1264,6 +1264,10 @@ type DiskBlockCache interface {
 		ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error
 	// Status returns the current status of the disk cache.
 	Status(ctx context.Context) map[string]DiskBlockCacheStatus
+	// DoesSyncCacheHaveSpace returns whether the sync cache has
+	// space.  If this cache doesn't contain a sync cache, always returns
+	// true.
+	DoesSyncCacheHaveSpace(ctx context.Context) bool
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4458,6 +4458,18 @@ func (mr *MockDiskBlockCacheMockRecorder) Status(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockDiskBlockCache)(nil).Status), ctx)
 }
 
+// DoesSyncCacheHaveSpace mocks base method
+func (m *MockDiskBlockCache) DoesSyncCacheHaveSpace(ctx context.Context) bool {
+	ret := m.ctrl.Call(m, "DoesSyncCacheHaveSpace", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DoesSyncCacheHaveSpace indicates an expected call of DoesSyncCacheHaveSpace
+func (mr *MockDiskBlockCacheMockRecorder) DoesSyncCacheHaveSpace(ctx interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesSyncCacheHaveSpace", reflect.TypeOf((*MockDiskBlockCache)(nil).DoesSyncCacheHaveSpace), ctx)
+}
+
 // Shutdown mocks base method
 func (m *MockDiskBlockCache) Shutdown(ctx context.Context) {
 	m.ctrl.Call(m, "Shutdown", ctx)

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -463,6 +463,8 @@ func (p *blockPrefetcher) rescheduleTopBlock(
 		return
 	}
 
+	// Effectively below we are transferring the request for the top
+	// block from `p.prefetches` to `p.rescheduled`.
 	delete(p.prefetches, blockID)
 	pp.Close()
 

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -672,9 +672,6 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 					"%s", req.ptr.ID)
 				continue
 			}
-			if p.rescheduleIfNeeded(ctx, req) {
-				continue
-			}
 			if isPrefetchWaiting {
 				if pre.subtreeTriggered {
 					p.log.CDebugf(ctx, "prefetch subtree already triggered "+
@@ -728,6 +725,16 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				p.log.CDebugf(ctx, "created new prefetch for block %s",
 					req.ptr.ID)
 			}
+
+			if p.rescheduleIfNeeded(ctx, req) {
+				// This is inefficient since it'd be better to know if
+				// `isTail` below is true before needlessly
+				// rescheduling this.  But currently that requires
+				// some complexity to figure out, so for now just do
+				// this early and revisit if it becomes a problem.
+				continue
+			}
+
 			// TODO: There is a potential optimization here that we can
 			// consider: Currently every time a prefetch is triggered, we
 			// iterate through all the block's child pointers. This is short

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -479,10 +479,8 @@ func (p *blockPrefetcher) rescheduleTopBlock(
 		// Prefetch already scheduled.
 		return
 	}
-	// Copy the req but use a new empty block.
+	// Copy the req, re-using the same Block as before.
 	req := *pp.req
-	req.block = pp.req.block.NewEmpty()
-	pp.req = &req
 	d := rp.off.NextBackOff()
 	if d == backoff.Stop {
 		p.log.Debug("Stopping rescheduling of %s due to stopped backoff timer",
@@ -491,7 +489,7 @@ func (p *blockPrefetcher) rescheduleTopBlock(
 	}
 	p.log.Debug("Rescheduling prefetch of %s in %s", blockID, d)
 	rp.timer = time.AfterFunc(d, func() {
-		p.triggerPrefetch(pp.req)
+		p.triggerPrefetch(&req)
 	})
 }
 


### PR DESCRIPTION
Instead of canceling prefetches when the disk is almost full, reschedule them (starting with the top-most block) using an exponential-backoff timer.  This way, the user can see a warning that the disk is full, make some space, and the prefetches will automatically resume (eventually).

If needed in the future, we can add a background process that checks for more disk space and then reschedules them immediately.  But I worry about racing with other processes needing the disk more immediately, so let's see how this works for now.

To get a reliable test, I had to move the space function into the `DiskBlockCache` interface.

@jzila this one could use your attention specifically!  I'm not 100% sure this is the best approach.

Issue: KBFS-3519