### PR TITLE
folder_branch_ops: support partial sync config

### DIFF
--- a/libfs/sync_control_file.go
+++ b/libfs/sync_control_file.go
@@ -7,6 +7,7 @@ package libfs
 import (
 	"fmt"
 
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/libkbfs"
 	"golang.org/x/net/context"
 )
@@ -43,10 +44,16 @@ func (a SyncAction) Execute(
 
 	switch a {
 	case SyncEnable:
-		_, err = c.SetTlfSyncState(fb.Tlf, true)
+		_, err = c.KBFSOps().SetSyncConfig(
+			ctx, fb.Tlf, keybase1.FolderSyncConfig{
+				Mode: keybase1.FolderSyncMode_ENABLED,
+			})
 
 	case SyncDisable:
-		_, err = c.SetTlfSyncState(fb.Tlf, false)
+		_, err = c.KBFSOps().SetSyncConfig(
+			ctx, fb.Tlf, keybase1.FolderSyncConfig{
+				Mode: keybase1.FolderSyncMode_DISABLED,
+			})
 
 	default:
 		return fmt.Errorf("Unknown action %s", a)

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -556,7 +556,9 @@ func seedDiskBlockCacheForTest(
 	clock := config.Clock().(*TestClock)
 	for i := byte(0); int(i) < numTlfs; i++ {
 		currTlf := tlf.FakeID(i, tlf.Private)
-		_, err := config.SetTlfSyncState(currTlf, true)
+		_, err := config.SetTlfSyncState(currTlf, FolderSyncConfig{
+			Mode: keybase1.FolderSyncMode_ENABLED,
+		})
 		require.NoError(t, err)
 		for j := 0; j < numBlocksPerTlf; j++ {
 			blockPtr, _, blockEncoded, serverHalf := setupBlockForDiskCache(
@@ -680,7 +682,9 @@ func TestDiskBlockCacheUnsyncTlf(t *testing.T) {
 	require.Equal(t, numBlocks, standardCache.numBlocks)
 
 	tlfToUnsync := tlf.FakeID(1, tlf.Private)
-	ch, err := config.SetTlfSyncState(tlfToUnsync, false)
+	ch, err := config.SetTlfSyncState(tlfToUnsync, FolderSyncConfig{
+		Mode: keybase1.FolderSyncMode_DISABLED,
+	})
 	require.NoError(t, err)
 	t.Log("Waiting for unsynced blocks to be cleared.")
 	err = <-ch

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	kbname "github.com/keybase/client/go/kbun"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/ioutil"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfsmd"
@@ -846,7 +847,10 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	rootNode := GetRootNodeOrBust(
 		ctx, t, config, userName.String(), tlf.Private)
 	kbfsOps := config.KBFSOps()
-	_, err = config.SetTlfSyncState(rootNode.GetFolderBranch().Tlf, true)
+	_, err = config.SetTlfSyncState(
+		rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
+			Mode: keybase1.FolderSyncMode_ENABLED,
+		})
 	require.NoError(t, err)
 	aNode, _, err := kbfsOps.CreateDir(ctx, rootNode, "a")
 	require.NoError(t, err)
@@ -883,7 +887,10 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	require.Equal(t, kbfsmd.RevisionUninitialized, lastRev)
 
 	t.Log("Set new TLF to syncing, and add a new revision")
-	_, err = config.SetTlfSyncState(rootNode.GetFolderBranch().Tlf, true)
+	_, err = config.SetTlfSyncState(
+		rootNode.GetFolderBranch().Tlf, FolderSyncConfig{
+			Mode: keybase1.FolderSyncMode_ENABLED,
+		})
 	require.NoError(t, err)
 	_, _, err = kbfsOps.CreateDir(ctx, bNode, "c")
 	require.NoError(t, err)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -7504,7 +7504,7 @@ func (fbo *folderBranchOps) makeEncryptedPartialPathsLocked(
 	}
 
 	// Make sure the new path list doesn't contain duplicates,
-	// contains no duplicates, and each path is cleaned.
+	// contains no absolute paths, and each path is cleaned.
 	seenPaths := make(map[string]bool, len(paths))
 	var pathList syncPathList
 	pathList.Paths = make([]string, len(paths))
@@ -7530,6 +7530,9 @@ func (fbo *folderBranchOps) makeEncryptedPartialPathsLocked(
 		"Setting partial sync config for %s; paths=%v",
 		fbo.id(), pathList.Paths)
 
+	// Place the config data in a block that will be stored locally on
+	// this device. It is not subject to the usual block size
+	// limitations, and will not be sent to the bserver.
 	b, err := pathList.makeBlock(fbo.config.Codec())
 	if err != nil {
 		return FolderSyncEncryptedPartialPaths{}, err

--- a/libkbfs/interface_test.go
+++ b/libkbfs/interface_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/keybase/client/go/logger"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/kbfs/kbfscodec"
 	"github.com/keybase/kbfs/tlf"
 )
@@ -55,24 +56,29 @@ func (cg *testClockGetter) TestClock() *TestClock {
 }
 
 type testSyncedTlfGetterSetter struct {
-	syncedTlfs map[tlf.ID]bool
+	syncedTlfs map[tlf.ID]FolderSyncConfig
 }
 
 var _ syncedTlfGetterSetter = (*testSyncedTlfGetterSetter)(nil)
 
 func newTestSyncedTlfGetterSetter() *testSyncedTlfGetterSetter {
 	return &testSyncedTlfGetterSetter{
-		syncedTlfs: make(map[tlf.ID]bool),
+		syncedTlfs: make(map[tlf.ID]FolderSyncConfig),
 	}
 }
 
-func (t *testSyncedTlfGetterSetter) IsSyncedTlf(tlfID tlf.ID) bool {
+func (t *testSyncedTlfGetterSetter) GetTlfSyncState(
+	tlfID tlf.ID) FolderSyncConfig {
 	return t.syncedTlfs[tlfID]
 }
 
+func (t *testSyncedTlfGetterSetter) IsSyncedTlf(tlfID tlf.ID) bool {
+	return t.syncedTlfs[tlfID].Mode == keybase1.FolderSyncMode_ENABLED
+}
+
 func (t *testSyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID,
-	isSynced bool) (<-chan error, error) {
-	t.syncedTlfs[tlfID] = isSynced
+	config FolderSyncConfig) (<-chan error, error) {
+	t.syncedTlfs[tlfID] = config
 	return nil, nil
 }
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -109,7 +109,8 @@ type diskLimiterGetter interface {
 
 type syncedTlfGetterSetter interface {
 	IsSyncedTlf(tlfID tlf.ID) bool
-	SetTlfSyncState(tlfID tlf.ID, isSynced bool) (<-chan error, error)
+	GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig
+	SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-chan error, error)
 }
 
 type blockRetrieverGetter interface {
@@ -541,6 +542,20 @@ type KBFSOps interface {
 	// called after explicit user confirmation.  After the call,
 	// `handle` has the new TLF ID.
 	Reset(ctx context.Context, handle *TlfHandle) error
+
+	// GetSyncConfig returns the sync state configuration for the
+	// given TLF.
+	GetSyncConfig(ctx context.Context, tlfID tlf.ID) (
+		keybase1.FolderSyncConfig, error)
+	// SetSyncConfig set the sync state configuration for the given
+	// TLF to either fully enabled, or fully disabled.  If syncing is
+	// disabled, it returns a channel that is closed when all of the
+	// TLF's blocks have been removed from the sync cache.  The config
+	// must contain no absolute paths, no duplicate paths, and no
+	// relative paths that go out of the TLF.
+	SetSyncConfig(
+		ctx context.Context, tlfID tlf.ID, config keybase1.FolderSyncConfig) (
+		<-chan error, error)
 }
 
 type merkleRootGetter interface {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -547,12 +547,13 @@ type KBFSOps interface {
 	// given TLF.
 	GetSyncConfig(ctx context.Context, tlfID tlf.ID) (
 		keybase1.FolderSyncConfig, error)
-	// SetSyncConfig set the sync state configuration for the given
-	// TLF to either fully enabled, or fully disabled.  If syncing is
-	// disabled, it returns a channel that is closed when all of the
-	// TLF's blocks have been removed from the sync cache.  The config
-	// must contain no absolute paths, no duplicate paths, and no
-	// relative paths that go out of the TLF.
+	// SetSyncConfig sets the sync state configuration for the given
+	// TLF to either fully enabled, fully disabled, or partially
+	// syncing selected paths.  If syncing is disabled, it returns a
+	// channel that is closed when all of the TLF's blocks have been
+	// removed from the sync cache.  For a partially-synced folder,
+	// the config must contain no absolute paths, no duplicate paths,
+	// and no relative paths that go out of the TLF.
 	SetSyncConfig(
 		ctx context.Context, tlfID tlf.ID, config keybase1.FolderSyncConfig) (
 		<-chan error, error)

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -1285,6 +1285,29 @@ func (fs *KBFSOpsStandard) Reset(
 	return fs.resetTlfID(ctx, handle)
 }
 
+// GetSyncConfig implements the KBFSOps interface for KBFSOpsStandard.
+func (fs *KBFSOpsStandard) GetSyncConfig(
+	ctx context.Context, tlfID tlf.ID) (keybase1.FolderSyncConfig, error) {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	ops := fs.getOps(ctx,
+		FolderBranch{Tlf: tlfID, Branch: MasterBranch}, FavoritesOpNoChange)
+	return ops.GetSyncConfig(ctx, tlfID)
+}
+
+// SetSyncConfig implements the KBFSOps interface for KBFSOpsStandard.
+func (fs *KBFSOpsStandard) SetSyncConfig(
+	ctx context.Context, tlfID tlf.ID,
+	config keybase1.FolderSyncConfig) (<-chan error, error) {
+	timeTrackerDone := fs.longOperationDebugDumper.Begin(ctx)
+	defer timeTrackerDone()
+
+	ops := fs.getOps(ctx,
+		FolderBranch{Tlf: tlfID, Branch: MasterBranch}, FavoritesOpNoChange)
+	return ops.SetSyncConfig(ctx, tlfID, config)
+}
+
 func (fs *KBFSOpsStandard) changeHandle(ctx context.Context,
 	oldFav Favorite, newHandle *TlfHandle) {
 	fs.opsLock.Lock()

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -4296,7 +4296,7 @@ func TestKBFSOpsPartialSyncConfig(t *testing.T) {
 	syncConfig.Paths = []string{"a/b/c", "a/b/c"}
 	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
 	require.Error(t, err)
-	syncConfig.Paths = []string{"/a/b/c", "a/b/c"}
+	syncConfig.Paths = []string{"/a/b/c", "d/e/f"}
 	_, err = kbfsOps.SetSyncConfig(ctx, h.tlfID, syncConfig)
 	require.Error(t, err)
 	syncConfig.Paths = []string{"a/../a/b/c", "a/b/c"}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -789,17 +789,29 @@ func (mr *MocksyncedTlfGetterSetterMockRecorder) IsSyncedTlf(tlfID interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSyncedTlf", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).IsSyncedTlf), tlfID)
 }
 
+// GetTlfSyncState mocks base method
+func (m *MocksyncedTlfGetterSetter) GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig {
+	ret := m.ctrl.Call(m, "GetTlfSyncState", tlfID)
+	ret0, _ := ret[0].(FolderSyncConfig)
+	return ret0
+}
+
+// GetTlfSyncState indicates an expected call of GetTlfSyncState
+func (mr *MocksyncedTlfGetterSetterMockRecorder) GetTlfSyncState(tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTlfSyncState", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).GetTlfSyncState), tlfID)
+}
+
 // SetTlfSyncState mocks base method
-func (m *MocksyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID, isSynced bool) (<-chan error, error) {
-	ret := m.ctrl.Call(m, "SetTlfSyncState", tlfID, isSynced)
+func (m *MocksyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-chan error, error) {
+	ret := m.ctrl.Call(m, "SetTlfSyncState", tlfID, config)
 	ret0, _ := ret[0].(<-chan error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetTlfSyncState indicates an expected call of SetTlfSyncState
-func (mr *MocksyncedTlfGetterSetterMockRecorder) SetTlfSyncState(tlfID, isSynced interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).SetTlfSyncState), tlfID, isSynced)
+func (mr *MocksyncedTlfGetterSetterMockRecorder) SetTlfSyncState(tlfID, config interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).SetTlfSyncState), tlfID, config)
 }
 
 // MockblockRetrieverGetter is a mock of blockRetrieverGetter interface
@@ -1998,6 +2010,32 @@ func (m *MockKBFSOps) Reset(ctx context.Context, handle *TlfHandle) error {
 // Reset indicates an expected call of Reset
 func (mr *MockKBFSOpsMockRecorder) Reset(ctx, handle interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockKBFSOps)(nil).Reset), ctx, handle)
+}
+
+// GetSyncConfig mocks base method
+func (m *MockKBFSOps) GetSyncConfig(ctx context.Context, tlfID tlf.ID) (keybase1.FolderSyncConfig, error) {
+	ret := m.ctrl.Call(m, "GetSyncConfig", ctx, tlfID)
+	ret0, _ := ret[0].(keybase1.FolderSyncConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSyncConfig indicates an expected call of GetSyncConfig
+func (mr *MockKBFSOpsMockRecorder) GetSyncConfig(ctx, tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncConfig", reflect.TypeOf((*MockKBFSOps)(nil).GetSyncConfig), ctx, tlfID)
+}
+
+// SetSyncConfig mocks base method
+func (m *MockKBFSOps) SetSyncConfig(ctx context.Context, tlfID tlf.ID, config keybase1.FolderSyncConfig) (<-chan error, error) {
+	ret := m.ctrl.Call(m, "SetSyncConfig", ctx, tlfID, config)
+	ret0, _ := ret[0].(<-chan error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetSyncConfig indicates an expected call of SetSyncConfig
+func (mr *MockKBFSOpsMockRecorder) SetSyncConfig(ctx, tlfID, config interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSyncConfig", reflect.TypeOf((*MockKBFSOps)(nil).SetSyncConfig), ctx, tlfID, config)
 }
 
 // MockmerkleRootGetter is a mock of merkleRootGetter interface
@@ -7732,17 +7770,29 @@ func (mr *MockConfigMockRecorder) IsSyncedTlf(tlfID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSyncedTlf", reflect.TypeOf((*MockConfig)(nil).IsSyncedTlf), tlfID)
 }
 
+// GetTlfSyncState mocks base method
+func (m *MockConfig) GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig {
+	ret := m.ctrl.Call(m, "GetTlfSyncState", tlfID)
+	ret0, _ := ret[0].(FolderSyncConfig)
+	return ret0
+}
+
+// GetTlfSyncState indicates an expected call of GetTlfSyncState
+func (mr *MockConfigMockRecorder) GetTlfSyncState(tlfID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTlfSyncState", reflect.TypeOf((*MockConfig)(nil).GetTlfSyncState), tlfID)
+}
+
 // SetTlfSyncState mocks base method
-func (m *MockConfig) SetTlfSyncState(tlfID tlf.ID, isSynced bool) (<-chan error, error) {
-	ret := m.ctrl.Call(m, "SetTlfSyncState", tlfID, isSynced)
+func (m *MockConfig) SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-chan error, error) {
+	ret := m.ctrl.Call(m, "SetTlfSyncState", tlfID, config)
 	ret0, _ := ret[0].(<-chan error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetTlfSyncState indicates an expected call of SetTlfSyncState
-func (mr *MockConfigMockRecorder) SetTlfSyncState(tlfID, isSynced interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MockConfig)(nil).SetTlfSyncState), tlfID, isSynced)
+func (mr *MockConfigMockRecorder) SetTlfSyncState(tlfID, config interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MockConfig)(nil).SetTlfSyncState), tlfID, config)
 }
 
 // Mode mocks base method

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/keybase/backoff"
+	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/stretchr/testify/require"
@@ -482,7 +483,9 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	kmd := makeKMD()
-	config.SetTlfSyncState(kmd.TlfID(), true)
+	config.SetTlfSyncState(kmd.TlfID(), FolderSyncConfig{
+		Mode: keybase1.FolderSyncMode_ENABLED,
+	})
 
 	t.Log("Initialize a direct dir block with entries pointing to 2 files " +
 		"and 1 directory. The directory has an entry pointing to another " +
@@ -955,7 +958,9 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Now set the folder to sync.")
-	config.SetTlfSyncState(kmd.TlfID(), true)
+	config.SetTlfSyncState(kmd.TlfID(), FolderSyncConfig{
+		Mode: keybase1.FolderSyncMode_ENABLED,
+	})
 	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
@@ -1085,7 +1090,9 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	t.Log("Now set the folder to sync.")
-	config.SetTlfSyncState(kmd.TlfID(), true)
+	config.SetTlfSyncState(kmd.TlfID(), FolderSyncConfig{
+		Mode: keybase1.FolderSyncMode_ENABLED,
+	})
 	q.TogglePrefetcher(true, prefetchSyncCh)
 	notifySyncCh(t, prefetchSyncCh)
 
@@ -1581,7 +1588,9 @@ func TestPrefetcherReschedules(t *testing.T) {
 	err = cache.Put(ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB)
 	require.NoError(t, err)
 
-	config.SetTlfSyncState(kmd.TlfID(), true)
+	config.SetTlfSyncState(kmd.TlfID(), FolderSyncConfig{
+		Mode: keybase1.FolderSyncMode_ENABLED,
+	})
 	q.TogglePrefetcher(true, prefetchSyncCh)
 	q.Prefetcher().(*blockPrefetcher).makeNewBackOff = func() backoff.BackOff {
 		t.Log("ZERO\n")

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -2029,25 +2029,11 @@ func (k *SimpleFS) SimpleFSFolderSyncConfigAndStatus(
 // SimpleFSSetFolderSyncConfig implements the SimpleFSInterface.
 func (k *SimpleFS) SimpleFSSetFolderSyncConfig(
 	ctx context.Context, arg keybase1.SimpleFSSetFolderSyncConfigArg) error {
-	tlfID, config, err := k.getSyncConfig(ctx, arg.Path)
+	tlfID, _, err := k.getSyncConfig(ctx, arg.Path)
 	if err != nil {
 		return err
 	}
 
-	if arg.Config.Mode == config.Mode {
-		// Already done!
-		return nil
-	}
-
-	switch arg.Config.Mode {
-	case keybase1.FolderSyncMode_DISABLED:
-		_, err = k.config.SetTlfSyncState(tlfID, false)
-		return err
-	case keybase1.FolderSyncMode_ENABLED:
-		_, err = k.config.SetTlfSyncState(tlfID, true)
-		return err
-	default:
-		return simpleFSError{
-			fmt.Sprintf("Unknown config mode: %s", arg.Config.Mode)}
-	}
+	_, err = k.config.KBFSOps().SetSyncConfig(ctx, tlfID, arg.Config)
+	return err
 }

--- a/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
+++ b/vendor/github.com/keybase/client/go/protocol/keybase1/simple_fs.go
@@ -1109,6 +1109,7 @@ type FolderSyncMode int
 const (
 	FolderSyncMode_DISABLED FolderSyncMode = 0
 	FolderSyncMode_ENABLED  FolderSyncMode = 1
+	FolderSyncMode_PARTIAL  FolderSyncMode = 2
 )
 
 func (o FolderSyncMode) DeepCopy() FolderSyncMode { return o }
@@ -1116,11 +1117,13 @@ func (o FolderSyncMode) DeepCopy() FolderSyncMode { return o }
 var FolderSyncModeMap = map[string]FolderSyncMode{
 	"DISABLED": 0,
 	"ENABLED":  1,
+	"PARTIAL":  2,
 }
 
 var FolderSyncModeRevMap = map[FolderSyncMode]string{
 	0: "DISABLED",
 	1: "ENABLED",
+	2: "PARTIAL",
 }
 
 func (e FolderSyncMode) String() string {
@@ -1131,12 +1134,24 @@ func (e FolderSyncMode) String() string {
 }
 
 type FolderSyncConfig struct {
-	Mode FolderSyncMode `codec:"mode" json:"mode"`
+	Mode  FolderSyncMode `codec:"mode" json:"mode"`
+	Paths []string       `codec:"paths" json:"paths"`
 }
 
 func (o FolderSyncConfig) DeepCopy() FolderSyncConfig {
 	return FolderSyncConfig{
 		Mode: o.Mode.DeepCopy(),
+		Paths: (func(x []string) []string {
+			if x == nil {
+				return nil
+			}
+			ret := make([]string, len(x))
+			for i, v := range x {
+				vCopy := v
+				ret[i] = vCopy
+			}
+			return ret
+		})(o.Paths),
 	}
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -346,10 +346,10 @@
 			"revisionTime": "2018-11-20T20:41:27Z"
 		},
 		{
-			"checksumSHA1": "BoyesXyRV+uc6dig+V/cwai/qeo=",
+			"checksumSHA1": "z3d1W26rbHvUFzgRm/u4KC8PeTU=",
 			"path": "github.com/keybase/client/go/protocol/keybase1",
-			"revision": "b2310d56f1a1de6003b0fa74e0dc204315fb84f3",
-			"revisionTime": "2018-11-20T20:41:27Z"
+			"revision": "489aa746c0c403f8a3479cef29f7b8d194892c8c",
+			"revisionTime": "2018-11-21T20:36:32Z"
 		},
 		{
 			"checksumSHA1": "jvFWbgb5/iEJfgJBUJDBpBuAR5Y=",


### PR DESCRIPTION
[CircleCI depends on keybase/client#14780, which is vendored here and will be updated with the correct hash when it is merged.]

We want to cache the list of partially-synced paths in an encrypted block on disk.  Since that has to happen in folderBranchOps, this moves the main interface for setting/getting sync config into the KBFSOps interface.  (Of course the paths, including this exact sync config list, is still logged, but at least logs can be easily deleted without side effects, while the sync config DB cannot.)

In the lower-level interface, we move from storing the keybase1 sync config object in the DB (which contains the plaintext path list) to storing a new struct which contains a block pointer, buffer, and key half.  This struct is backwards compatible with any current sync configs stored using the old struct.

We don't yet act on this partial sync config; that will happen in a separate PR.

Issue: KBFS-3522