### PR TITLE
block_retrieval_queue: track deep sync status explicitly

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -382,9 +382,10 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
+		isDeepSync := fbo.config.IsSyncedTlf(fbo.id())
 		fbo.config.BlockOps().Prefetcher().ProcessBlockForPrefetch(ctx, ptr,
 			block, kmd, defaultOnDemandRequestPriority, lifetime,
-			prefetchStatus)
+			prefetchStatus, isDeepSync)
 		return block, nil
 	}
 

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1556,7 +1556,7 @@ type Prefetcher interface {
 	// ProcessBlockForPrefetch potentially triggers and monitors a prefetch.
 	ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		prefetchStatus PrefetchStatus)
+		prefetchStatus PrefetchStatus, isDeepSync bool)
 	// WaitChannelForBlockPrefetch returns a channel that can be used
 	// to wait for a block to finish prefetching or be canceled.  If
 	// the block isn't currently being prefetched, it will return an
@@ -2486,6 +2486,10 @@ type BlockRetriever interface {
 	// RequestNoPrefetch retrieves blocks asynchronously, but doesn't trigger a
 	// prefetch unless the block had to be retrieved from the server.
 	RequestNoPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
+		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+	// RequestAndSync retrieves blocks asynchronously, and syncs the
+	// entire block tree rooted at `ptr`.
+	RequestAndSync(ctx context.Context, priority int, kmd KeyMetadata,
 		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
 	// PutInCaches puts the block into the in-memory cache, and ensures that
 	// the disk cache metadata is updated.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5384,13 +5384,13 @@ func (m *MockPrefetcher) EXPECT() *MockPrefetcherMockRecorder {
 }
 
 // ProcessBlockForPrefetch mocks base method
-func (m *MockPrefetcher) ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) {
-	m.ctrl.Call(m, "ProcessBlockForPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
+func (m *MockPrefetcher) ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, isDeepSync bool) {
+	m.ctrl.Call(m, "ProcessBlockForPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, isDeepSync)
 }
 
 // ProcessBlockForPrefetch indicates an expected call of ProcessBlockForPrefetch
-func (mr *MockPrefetcherMockRecorder) ProcessBlockForPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockForPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).ProcessBlockForPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus)
+func (mr *MockPrefetcherMockRecorder) ProcessBlockForPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, isDeepSync interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockForPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).ProcessBlockForPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, isDeepSync)
 }
 
 // WaitChannelForBlockPrefetch mocks base method
@@ -8995,6 +8995,18 @@ func (m *MockBlockRetriever) RequestNoPrefetch(ctx context.Context, priority int
 // RequestNoPrefetch indicates an expected call of RequestNoPrefetch
 func (mr *MockBlockRetrieverMockRecorder) RequestNoPrefetch(ctx, priority, kmd, ptr, block, lifetime interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestNoPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestNoPrefetch), ctx, priority, kmd, ptr, block, lifetime)
+}
+
+// RequestAndSync mocks base method
+func (m *MockBlockRetriever) RequestAndSync(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
+	ret := m.ctrl.Call(m, "RequestAndSync", ctx, priority, kmd, ptr, block, lifetime)
+	ret0, _ := ret[0].(<-chan error)
+	return ret0
+}
+
+// RequestAndSync indicates an expected call of RequestAndSync
+func (mr *MockBlockRetrieverMockRecorder) RequestAndSync(ctx, priority, kmd, ptr, block, lifetime interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestAndSync", reflect.TypeOf((*MockBlockRetriever)(nil).RequestAndSync), ctx, priority, kmd, ptr, block, lifetime)
 }
 
 // PutInCaches mocks base method

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -473,17 +473,10 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 		FinishedPrefetch, TransientEntry)
 }
 
-func TestPrefetcherForSyncedTLF(t *testing.T) {
-	t.Log("Test synced TLF prefetching.")
-	q, bg, config := initPrefetcherTest(t)
-	defer shutdownPrefetcherTest(q)
-	prefetchSyncCh := make(chan struct{})
-	q.TogglePrefetcher(true, prefetchSyncCh)
-	notifySyncCh(t, prefetchSyncCh)
-
-	kmd := makeKMD()
-	config.SetTlfSyncState(kmd.TlfID(), true)
-
+func testPrefetcherForSyncedTLF(
+	t *testing.T, q *blockRetrievalQueue, bg *fakeBlockGetter,
+	config *testBlockRetrievalConfig, prefetchSyncCh chan struct{},
+	kmd KeyMetadata, explicitSync bool) {
 	t.Log("Initialize a direct dir block with entries pointing to 2 files " +
 		"and 1 directory. The directory has an entry pointing to another " +
 		"file, which has 2 indirect blocks.")
@@ -523,7 +516,11 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 		bg.setBlockToReturn(dirBfileDptrs[1].BlockPointer, dirBfileDblock2)
 
 	var block Block = &DirBlock{}
-	ch := q.Request(context.Background(),
+	requester := q.Request
+	if explicitSync {
+		requester = q.RequestAndSync
+	}
+	ch := requester(context.Background(),
 		defaultOnDemandRequestPriority, kmd, rootPtr, block, TransientEntry)
 	continueChRootDir <- nil
 	err := <-ch
@@ -623,6 +620,31 @@ func TestPrefetcherForSyncedTLF(t *testing.T) {
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
 		FinishedPrefetch, TransientEntry)
+}
+
+func TestPrefetcherForSyncedTLF(t *testing.T) {
+	t.Log("Test synced TLF prefetching.")
+	q, bg, config := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q)
+	prefetchSyncCh := make(chan struct{})
+	q.TogglePrefetcher(true, prefetchSyncCh)
+	notifySyncCh(t, prefetchSyncCh)
+
+	kmd := makeKMD()
+	config.SetTlfSyncState(kmd.TlfID(), true)
+	testPrefetcherForSyncedTLF(t, q, bg, config, prefetchSyncCh, kmd, false)
+}
+
+func TestPrefetcherForRequestedSync(t *testing.T) {
+	t.Log("Test explicitly-requested synced prefetching.")
+	q, bg, config := initPrefetcherTest(t)
+	defer shutdownPrefetcherTest(q)
+	prefetchSyncCh := make(chan struct{})
+	q.TogglePrefetcher(true, prefetchSyncCh)
+	notifySyncCh(t, prefetchSyncCh)
+
+	kmd := makeKMD()
+	testPrefetcherForSyncedTLF(t, q, bg, config, prefetchSyncCh, kmd, true)
 }
 
 func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {


### PR DESCRIPTION
To get ready for partial syncing, this removes uses of `IsSyncedTlf` from the prefetcher, in favor of explicitly passing in the deep-sync-edness of the request from the caller.

@jzila you in particular should look at this one probably.

Issue: KBFS-3523