### PR TITLE
mdserver_remote: better err when no revision is found by timestamp

### DIFF
--- a/libkbfs/mdserver_remote.go
+++ b/libkbfs/mdserver_remote.go
@@ -653,6 +653,8 @@ func (md *MDServerRemote) GetForTLFByTime(
 	block, err := md.getClient().GetMetadataByTimestamp(ctx, arg)
 	if err != nil {
 		return nil, err
+	} else if len(block.Block) == 0 {
+		return nil, errors.Errorf("No revision available at %s", serverTime)
 	}
 
 	ver, max := kbfsmd.MetadataVer(block.Version), md.config.MetadataVersion()


### PR DESCRIPTION
Found by jakob223.