### PR TITLE
folder_block_ops: fix block cache access error

### DIFF
--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -295,7 +295,7 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 		}
 		if diskBCache := fbo.config.DiskBlockCache(); diskBCache != nil {
 			if buf, _, _, err := diskBCache.Get(
-				ctx, fbo.id(), ptr.ID); err != nil {
+				ctx, fbo.id(), ptr.ID); err == nil {
 				return uint32(len(buf)), keybase1.BlockStatus_LIVE, nil
 			}
 		}


### PR DESCRIPTION
Before this fix, we were never able to get the encoded block size from the disk block cache.

Found by inspection during other work.