### PR TITLE
disk_block_cache: the caller of Get/Put specifies the cache type

### DIFF
--- a/kbfstool/md_reset.go
+++ b/kbfstool/md_reset.go
@@ -90,7 +90,7 @@ func mdResetOne(
 	err = libkbfs.PutBlockCheckLimitErrs(
 		ctx, config.BlockServer(), config.Reporter(),
 		rmdNext.TlfID(), info.BlockPointer, readyBlockData,
-		irmd.GetTlfHandle().GetCanonicalName())
+		irmd.GetTlfHandle().GetCanonicalName(), libkbfs.DiskBlockAnyCache)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/block_getter.go
+++ b/libkbfs/block_getter.go
@@ -14,7 +14,9 @@ import (
 
 // blockGetter provides the API for the block retrieval worker to obtain blocks.
 type blockGetter interface {
-	getBlock(context.Context, KeyMetadata, BlockPointer, Block) error
+	getBlock(
+		context.Context, KeyMetadata, BlockPointer, Block,
+		DiskBlockCacheType) error
 	assembleBlock(context.Context, KeyMetadata, BlockPointer, Block, []byte,
 		kbfscrypto.BlockCryptKeyServerHalf) error
 }
@@ -25,10 +27,12 @@ type realBlockGetter struct {
 }
 
 // getBlock implements the interface for realBlockGetter.
-func (bg *realBlockGetter) getBlock(ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer, block Block) error {
+func (bg *realBlockGetter) getBlock(
+	ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
+	block Block, cacheType DiskBlockCacheType) error {
 	bserv := bg.config.BlockServer()
 	buf, blockServerHalf, err := bserv.Get(
-		ctx, kmd.TlfID(), blockPtr.ID, blockPtr.Context)
+		ctx, kmd.TlfID(), blockPtr.ID, blockPtr.Context, cacheType)
 	if err != nil {
 		// Temporary code to track down bad block
 		// requests. Remove when not needed anymore.

--- a/libkbfs/block_journal.go
+++ b/libkbfs/block_journal.go
@@ -776,7 +776,8 @@ func flushNonBPSBlockJournalEntry(
 
 func flushBlockEntries(ctx context.Context, log, deferLog traceLogger,
 	bserver BlockServer, bcache BlockCache, reporter Reporter, tlfID tlf.ID,
-	tlfName tlf.CanonicalName, entries blockEntriesToFlush) error {
+	tlfName tlf.CanonicalName, entries blockEntriesToFlush,
+	cacheType DiskBlockCacheType) error {
 	if !entries.flushNeeded() {
 		// Avoid logging anything when there's nothing to flush.
 		return nil
@@ -787,7 +788,7 @@ func flushBlockEntries(ctx context.Context, log, deferLog traceLogger,
 	// reference the former.
 	log.CDebugf(ctx, "Putting %d blocks", len(entries.puts.blockStates))
 	blocksToRemove, err := doBlockPuts(ctx, bserver, bcache, reporter,
-		log, deferLog, tlfID, tlfName, *entries.puts)
+		log, deferLog, tlfID, tlfName, *entries.puts, cacheType)
 	if err != nil {
 		if isRecoverableBlockError(err) {
 			log.CWarningf(ctx,
@@ -801,7 +802,7 @@ func flushBlockEntries(ctx context.Context, log, deferLog traceLogger,
 	log.CDebugf(ctx, "Adding %d block references",
 		len(entries.adds.blockStates))
 	blocksToRemove, err = doBlockPuts(ctx, bserver, bcache, reporter,
-		log, deferLog, tlfID, tlfName, *entries.adds)
+		log, deferLog, tlfID, tlfName, *entries.adds, cacheType)
 	if err != nil {
 		if isRecoverableBlockError(err) {
 			log.CWarningf(ctx,

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -467,7 +467,7 @@ func TestBlockJournalFlush(t *testing.T) {
 
 		err = flushBlockEntries(
 			ctx, j.log, j.deferLog, blockServer, bcache, reporter,
-			tlfID, tlf.CanonicalName("fake TLF"), entries)
+			tlfID, tlf.CanonicalName("fake TLF"), entries, DiskBlockAnyCache)
 		require.NoError(t, err)
 
 		flushedBytes, err = j.removeFlushedEntries(
@@ -487,19 +487,19 @@ func TestBlockJournalFlush(t *testing.T) {
 	require.Equal(t, int64(filesPerBlockMax), removedFiles)
 
 	// Check the Put.
-	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx)
+	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
 
 	// Check the AddReference.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
 
 	// Check the archiving.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -518,11 +518,11 @@ func TestBlockJournalFlush(t *testing.T) {
 	require.Equal(t, int64(0), removedFiles)
 
 	// Check they're all gone.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx, DiskBlockAnyCache)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2, DiskBlockAnyCache)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3, DiskBlockAnyCache)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
 
 	length := j.length()
@@ -544,7 +544,7 @@ func flushBlockJournalOne(ctx context.Context, t *testing.T,
 	require.Equal(t, 1, entries.length())
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 		bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
-		entries)
+		entries, DiskBlockAnyCache)
 	require.NoError(t, err)
 	flushedBytes, err = j.removeFlushedEntries(
 		ctx, entries, tlfID, reporter)
@@ -593,7 +593,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 	require.Equal(t, int64(0), removedBytes)
 	require.Equal(t, int64(0), removedFiles)
 
-	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx)
+	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -618,7 +618,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 	flushOneZero()
 
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -630,7 +630,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 	require.Equal(t, int64(len(data)), removedBytes)
 	require.Equal(t, int64(filesPerBlockMax), removedFiles)
 
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -647,13 +647,13 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 	flushOneZero()
 
-	_, _, err = blockServer.Get(ctx, tlfID, bID, bCtx)
+	_, _, err = blockServer.Get(ctx, tlfID, bID, bCtx, DiskBlockAnyCache)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
 
-	_, _, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	_, _, err = blockServer.Get(ctx, tlfID, bID, bCtx2, DiskBlockAnyCache)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
 
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -671,7 +671,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 	flushOneZero()
 
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -680,7 +680,7 @@ func TestBlockJournalFlushInterleaved(t *testing.T) {
 
 	flushOneZero()
 
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx3, DiskBlockAnyCache)
 	require.IsType(t, kbfsblock.ServerErrorBlockNonExistent{}, err)
 
 	end, err := j.end()
@@ -725,7 +725,7 @@ func TestBlockJournalFlushMDRevMarker(t *testing.T) {
 	require.Equal(t, 2, entries.length())
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 		bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
-		entries)
+		entries, DiskBlockAnyCache)
 	require.NoError(t, err)
 	flushedBytes, err := j.removeFlushedEntries(
 		ctx, entries, tlfID, reporter)
@@ -792,7 +792,7 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 		bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
-		entries)
+		entries, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	flushedBytes, err := j.removeFlushedEntries(
@@ -867,7 +867,7 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.Equal(t, bID4, entries.puts.blockStates[1].blockPtr.ID)
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 		bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
-		entries)
+		entries, DiskBlockAnyCache)
 	require.NoError(t, err)
 	flushedBytes, err := j.removeFlushedEntries(
 		ctx, entries, tlfID, reporter)
@@ -927,7 +927,7 @@ func TestBlockJournalSaveUntilMDFlush(t *testing.T) {
 		require.NoError(t, err)
 		err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 			bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
-			entries)
+			entries, DiskBlockAnyCache)
 		require.NoError(t, err)
 		flushedBytes, err := j.removeFlushedEntries(
 			ctx, entries, tlfID, reporter)
@@ -1118,7 +1118,8 @@ func TestBlockJournalByteCounters(t *testing.T) {
 	require.NoError(t, err)
 
 	err = blockServer.Put(
-		context.Background(), tlfID, bID3, bCtx3, data3, serverHalf3)
+		context.Background(), tlfID, bID3, bCtx3, data3, serverHalf3,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	flushOneZero()

--- a/libkbfs/block_ops_test.go
+++ b/libkbfs/block_ops_test.go
@@ -330,8 +330,9 @@ func TestBlockOpsGetSuccess(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
-	err = config.bserver.Put(ctx, tlfID, id, bCtx,
-		readyBlockData.buf, readyBlockData.serverHalf)
+	err = config.bserver.Put(
+		ctx, tlfID, id, bCtx, readyBlockData.buf, readyBlockData.serverHalf,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	kmd2 := makeFakeKeyMetadata(tlfID, keyGen+3)
@@ -376,9 +377,10 @@ type badGetBlockServer struct {
 
 func (bserver badGetBlockServer) Get(
 	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
+	context kbfsblock.Context, cacheType DiskBlockCacheType) (
 	[]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	buf, serverHalf, err := bserver.BlockServer.Get(ctx, tlfID, id, context)
+	buf, serverHalf, err := bserver.BlockServer.Get(
+		ctx, tlfID, id, context, cacheType)
 	if err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, nil
 	}
@@ -405,8 +407,9 @@ func TestBlockOpsGetFailVerify(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
-	err = config.bserver.Put(ctx, tlfID, id, bCtx,
-		readyBlockData.buf, readyBlockData.serverHalf)
+	err = config.bserver.Put(
+		ctx, tlfID, id, bCtx, readyBlockData.buf, readyBlockData.serverHalf,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	var decryptedBlock FileBlock
@@ -435,8 +438,9 @@ func TestBlockOpsGetFailKeyGet(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
-	err = config.bserver.Put(ctx, tlfID, id, bCtx,
-		readyBlockData.buf, readyBlockData.serverHalf)
+	err = config.bserver.Put(
+		ctx, tlfID, id, bCtx, readyBlockData.buf, readyBlockData.serverHalf,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	var decryptedBlock FileBlock
@@ -506,8 +510,9 @@ func TestBlockOpsGetFailDecode(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
-	err = config.bserver.Put(ctx, tlfID, id, bCtx,
-		readyBlockData.buf, readyBlockData.serverHalf)
+	err = config.bserver.Put(
+		ctx, tlfID, id, bCtx, readyBlockData.buf, readyBlockData.serverHalf,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	var decryptedBlock FileBlock
@@ -547,8 +552,9 @@ func TestBlockOpsGetFailDecrypt(t *testing.T) {
 
 	bCtx := kbfsblock.MakeFirstContext(
 		keybase1.MakeTestUID(1).AsUserOrTeam(), keybase1.BlockType_DATA)
-	err = config.bserver.Put(ctx, tlfID, id, bCtx,
-		readyBlockData.buf, readyBlockData.serverHalf)
+	err = config.bserver.Put(
+		ctx, tlfID, id, bCtx, readyBlockData.buf, readyBlockData.serverHalf,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	var decryptedBlock FileBlock

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -247,7 +247,8 @@ func (brq *blockRetrievalQueue) PutInCaches(ctx context.Context,
 
 // checkCaches copies a block into `block` if it's in one of our caches.
 func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
-	kmd KeyMetadata, ptr BlockPointer, block Block) (PrefetchStatus, error) {
+	kmd KeyMetadata, ptr BlockPointer, block Block, doSync bool) (
+	PrefetchStatus, error) {
 	// Attempt to retrieve the block from the cache. This might be a specific
 	// type where the request blocks are CommonBlocks, but that direction can
 	// Set correctly. The cache will never have CommonBlocks.
@@ -263,8 +264,12 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 	if dbc == nil {
 		return NoPrefetch, NoSuchBlockError{ptr.ID}
 	}
-	blockBuf, serverHalf, prefetchStatus, err := dbc.Get(ctx, kmd.TlfID(),
-		ptr.ID)
+	preferredCacheType := DiskBlockAnyCache
+	if doSync {
+		preferredCacheType = DiskBlockSyncCache
+	}
+	blockBuf, serverHalf, prefetchStatus, err := dbc.Get(
+		ctx, kmd.TlfID(), ptr.ID, preferredCacheType)
 	if err != nil {
 		return NoPrefetch, err
 	}
@@ -309,7 +314,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	}
 
 	// Check caches before locking the mutex.
-	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block)
+	prefetchStatus, err := brq.checkCaches(ctx, kmd, ptr, block, action.Sync())
 	if err == nil {
 		brq.log.CDebugf(ctx, "Found %v in caches: %s", ptr, prefetchStatus)
 		if action.PrefetchTracked() {

--- a/libkbfs/block_retrieval_worker.go
+++ b/libkbfs/block_retrieval_worker.go
@@ -71,13 +71,21 @@ func (brw *blockRetrievalWorker) HandleRequest() (err error) {
 	default:
 	}
 
+	var action BlockRequestAction
 	func() {
 		retrieval.reqMtx.RLock()
 		defer retrieval.reqMtx.RUnlock()
 		block = retrieval.requests[0].block.NewEmpty()
+		action = retrieval.action
 	}()
 
-	return brw.getBlock(retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block)
+	cacheType := DiskBlockAnyCache
+	if action.Sync() {
+		cacheType = DiskBlockSyncCache
+	}
+
+	return brw.getBlock(
+		retrieval.ctx, retrieval.kmd, retrieval.blockPtr, block, cacheType)
 }
 
 // Shutdown shuts down the blockRetrievalWorker once its current work is done.

--- a/libkbfs/block_retrieval_worker_test.go
+++ b/libkbfs/block_retrieval_worker_test.go
@@ -58,8 +58,9 @@ func (bg *fakeBlockGetter) setBlockToReturn(blockPtr BlockPointer,
 }
 
 // getBlock implements the interface for realBlockGetter.
-func (bg *fakeBlockGetter) getBlock(ctx context.Context, kmd KeyMetadata,
-	blockPtr BlockPointer, block Block) error {
+func (bg *fakeBlockGetter) getBlock(
+	ctx context.Context, kmd KeyMetadata, blockPtr BlockPointer,
+	block Block, _ DiskBlockCacheType) error {
 	bg.mtx.RLock()
 	defer bg.mtx.RUnlock()
 	source, ok := bg.blockMap[blockPtr]

--- a/libkbfs/block_util_test.go
+++ b/libkbfs/block_util_test.go
@@ -41,9 +41,10 @@ func TestBlockUtilPutNewBlockSuccess(t *testing.T) {
 	}
 
 	bserver.EXPECT().Put(ctx, tlfID, id, blockPtr.Context,
-		readyBlockData.buf, readyBlockData.serverHalf).Return(nil)
+		readyBlockData.buf, readyBlockData.serverHalf, gomock.Any()).Return(nil)
 
-	err := putBlockToServer(ctx, bserver, tlfID, blockPtr, readyBlockData)
+	err := putBlockToServer(
+		ctx, bserver, tlfID, blockPtr, readyBlockData, DiskBlockAnyCache)
 	require.NoError(t, err)
 }
 
@@ -71,7 +72,8 @@ func TestBlockUtilPutIncRefSuccess(t *testing.T) {
 	bserver.EXPECT().AddBlockReference(ctx, tlfID, id,
 		blockPtr.Context).Return(nil)
 
-	err := putBlockToServer(ctx, bserver, tlfID, blockPtr, readyBlockData)
+	err := putBlockToServer(
+		ctx, bserver, tlfID, blockPtr, readyBlockData, DiskBlockAnyCache)
 	require.NoError(t, err)
 }
 
@@ -92,10 +94,11 @@ func TestBlockUtilPutFail(t *testing.T) {
 		buf: encData,
 	}
 
-	bserver.EXPECT().Put(ctx, tlfID, id, blockPtr.Context,
-		readyBlockData.buf, readyBlockData.serverHalf).Return(
-		expectedErr)
+	bserver.EXPECT().Put(
+		ctx, tlfID, id, blockPtr.Context, readyBlockData.buf,
+		readyBlockData.serverHalf, gomock.Any()).Return(expectedErr)
 
-	err := putBlockToServer(ctx, bserver, tlfID, blockPtr, readyBlockData)
+	err := putBlockToServer(
+		ctx, bserver, tlfID, blockPtr, readyBlockData, DiskBlockAnyCache)
 	require.Equal(t, expectedErr, err)
 }

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -122,8 +122,9 @@ func (b *BlockServerDisk) getStorage(tlfID tlf.ID) (
 }
 
 // Get implements the BlockServer interface for BlockServerDisk.
-func (b *BlockServerDisk) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
+func (b *BlockServerDisk) Get(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, _ DiskBlockCacheType) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	if err := checkContext(ctx); err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
@@ -197,9 +198,11 @@ func (b *BlockServerDisk) GetEncodedSize(
 }
 
 // Put implements the BlockServer interface for BlockServerDisk.
-func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+func (b *BlockServerDisk) Put(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	_ DiskBlockCacheType) (err error) {
 	if err := checkContext(ctx); err != nil {
 		return err
 	}
@@ -234,9 +237,11 @@ func (b *BlockServerDisk) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID
 }
 
 // PutAgain implements the BlockServer interface for BlockServerDisk.
-func (b *BlockServerDisk) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+func (b *BlockServerDisk) PutAgain(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	_ DiskBlockCacheType) (err error) {
 	if err := checkContext(ctx); err != nil {
 		return err
 	}

--- a/libkbfs/bserver_measured.go
+++ b/libkbfs/bserver_measured.go
@@ -53,11 +53,13 @@ func NewBlockServerMeasured(delegate BlockServer, r metrics.Registry) BlockServe
 }
 
 // Get implements the BlockServer interface for BlockServerMeasured.
-func (b BlockServerMeasured) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	context kbfsblock.Context) (
+func (b BlockServerMeasured) Get(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, cacheType DiskBlockCacheType) (
 	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	b.getTimer.Time(func() {
-		buf, serverHalf, err = b.delegate.Get(ctx, tlfID, id, context)
+		buf, serverHalf, err = b.delegate.Get(
+			ctx, tlfID, id, context, cacheType)
 	})
 	return buf, serverHalf, err
 }
@@ -74,21 +76,27 @@ func (b BlockServerMeasured) GetEncodedSize(
 }
 
 // Put implements the BlockServer interface for BlockServerMeasured.
-func (b BlockServerMeasured) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+func (b BlockServerMeasured) Put(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	cacheType DiskBlockCacheType) (err error) {
 	b.putTimer.Time(func() {
-		err = b.delegate.Put(ctx, tlfID, id, context, buf, serverHalf)
+		err = b.delegate.Put(
+			ctx, tlfID, id, context, buf, serverHalf, cacheType)
 	})
 	return err
 }
 
 // PutAgain implements the BlockServer interface for BlockServerMeasured.
-func (b BlockServerMeasured) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+func (b BlockServerMeasured) PutAgain(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	context kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	cacheType DiskBlockCacheType) (err error) {
 	b.putAgainTimer.Time(func() {
-		err = b.delegate.PutAgain(ctx, tlfID, id, context, buf, serverHalf)
+		err = b.delegate.PutAgain(
+			ctx, tlfID, id, context, buf, serverHalf, cacheType)
 	})
 	return err
 }

--- a/libkbfs/bserver_memory.go
+++ b/libkbfs/bserver_memory.go
@@ -48,8 +48,9 @@ func NewBlockServerMemory(log logger.Logger) *BlockServerMemory {
 var errBlockServerMemoryShutdown = errors.New("BlockServerMemory is shutdown")
 
 // Get implements the BlockServer interface for BlockServerMemory.
-func (b *BlockServerMemory) Get(ctx context.Context, tlfID tlf.ID,
-	id kbfsblock.ID, context kbfsblock.Context) (
+func (b *BlockServerMemory) Get(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, _ DiskBlockCacheType) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	if err := checkContext(ctx); err != nil {
 		return nil, kbfscrypto.BlockCryptKeyServerHalf{}, err
@@ -214,9 +215,11 @@ func (b *BlockServerMemory) doPut(isRegularPut bool, tlfID tlf.ID, id kbfsblock.
 }
 
 // Put implements the BlockServer interface for BlockServerMemory.
-func (b *BlockServerMemory) Put(ctx context.Context, tlfID tlf.ID,
-	id kbfsblock.ID, context kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+func (b *BlockServerMemory) Put(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	_ DiskBlockCacheType) (err error) {
 	if err := checkContext(ctx); err != nil {
 		return err
 	}
@@ -227,9 +230,11 @@ func (b *BlockServerMemory) Put(ctx context.Context, tlfID tlf.ID,
 }
 
 // PutAgain implements the BlockServer interface for BlockServerMemory.
-func (b *BlockServerMemory) PutAgain(ctx context.Context, tlfID tlf.ID,
-	id kbfsblock.ID, context kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+func (b *BlockServerMemory) PutAgain(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	_ DiskBlockCacheType) (err error) {
 	if err := checkContext(ctx); err != nil {
 		return err
 	}

--- a/libkbfs/bserver_remote_test.go
+++ b/libkbfs/bserver_remote_test.go
@@ -107,11 +107,11 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
 	ctx := context.Background()
-	err = b.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
+	err = b.Put(ctx, tlfID, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	// Now get the same block back.
-	buf, sh, err := b.Get(ctx, tlfID, bID, bCtx)
+	buf, sh, err := b.Get(ctx, tlfID, bID, bCtx, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, sh)
@@ -126,7 +126,7 @@ func TestBServerRemotePutAndGet(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now get the same block back.
-	buf, sh, err = b.Get(ctx, tlfID, bID, bCtx2)
+	buf, sh, err = b.Get(ctx, tlfID, bID, bCtx2, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, sh)
@@ -149,7 +149,7 @@ func TestBServerRemotePutCanceled(t *testing.T) {
 		data := []byte{1, 2, 3, 4}
 		serverHalf := kbfscrypto.MakeBlockCryptKeyServerHalf(
 			[32]byte{0x1})
-		return b.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
+		return b.Put(ctx, tlfID, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 	}
 	testRPCWithCanceledContext(t, serverConn, f)
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1660,7 +1660,8 @@ func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 		prefetchStatus = NoPrefetch
 		dbc := c.DiskBlockCache()
 		if dbc != nil {
-			_, _, prefetchStatus, err = dbc.Get(ctx, tlfID, ptr.ID)
+			_, _, prefetchStatus, err = dbc.Get(
+				ctx, tlfID, ptr.ID, DiskBlockAnyCache)
 			if err != nil {
 				prefetchStatus = NoPrefetch
 			}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3118,9 +3118,14 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	}
 
 	// Put all the blocks.  TODO: deal with recoverable block errors?
-	_, err = doBlockPuts(ctx, cr.config.BlockServer(), cr.config.BlockCache(),
+	cacheType := DiskBlockAnyCache
+	if cr.config.IsSyncedTlf(md.TlfID()) {
+		cacheType = DiskBlockSyncCache
+	}
+	_, err = doBlockPuts(
+		ctx, cr.config.BlockServer(), cr.config.BlockCache(),
 		cr.config.Reporter(), cr.log, cr.deferLog, md.TlfID(),
-		md.GetTlfHandle().GetCanonicalName(), *bps)
+		md.GetTlfHandle().GetCanonicalName(), *bps, cacheType)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -1072,3 +1072,12 @@ func (bra BlockRequestAction) AddSync() BlockRequestAction {
 	// being fetched (and doing so will mess up sensitive tests).
 	return bra | blockRequestSync
 }
+
+// CacheType returns the disk block cache type that should be used,
+// according to the type of action.
+func (bra BlockRequestAction) CacheType() DiskBlockCacheType {
+	if bra.Sync() {
+		return DiskBlockSyncCache
+	}
+	return DiskBlockAnyCache
+}

--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -51,7 +51,7 @@ func NewDiskBlockCacheRemote(kbCtx Context, config diskBlockCacheRemoteConfig) (
 
 // Get implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Get(ctx context.Context, tlfID tlf.ID,
-	blockID kbfsblock.ID) (buf []byte,
+	blockID kbfsblock.ID, _ DiskBlockCacheType) (buf []byte,
 	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
 	prefetchStatus PrefetchStatus, err error) {
 	dbcr.log.LazyTrace(ctx, "DiskBlockCacheRemote: Get %s", blockID)
@@ -79,7 +79,8 @@ func (dbcr *DiskBlockCacheRemote) Get(ctx context.Context, tlfID tlf.ID,
 // Put implements the DiskBlockCache interface for DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) Put(ctx context.Context, tlfID tlf.ID,
 	blockID kbfsblock.ID, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	_ DiskBlockCacheType) (err error) {
 	dbcr.log.LazyTrace(ctx, "DiskBlockCacheRemote: Put %s", blockID)
 	defer func() {
 		dbcr.log.LazyTrace(ctx, "DiskBlockCacheRemote: Put %s done (err=%+v)", blockID, err)

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -749,7 +749,10 @@ func TestDiskBlockCacheMoveBlock(t *testing.T) {
 	t.Log("Move the block by getting it with a different preferred cache.")
 	_, _, _, err = cache.Get(ctx, tlf1, block1Ptr.ID, DiskBlockSyncCache)
 	require.NoError(t, err)
+	err = cache.waitForDeletes(ctx)
+	require.NoError(t, err)
 	require.Equal(t, 1, cache.syncCache.numBlocks)
+	require.Equal(t, 0, cache.workingSetCache.numBlocks)
 
 	t.Log("After the move, make sure the prefetch status is right.")
 	_, _, prefetchStatus, err := cache.Get(

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -124,7 +124,8 @@ func (cache *diskBlockCacheWrapped) Get(
 	secondaryCache := cache.syncCache
 	if preferredCacheType == DiskBlockSyncCache {
 		if cache.syncCache != nil {
-			primaryCache, secondaryCache = secondaryCache, primaryCache
+			primaryCache, secondaryCache =
+				cache.syncCache, cache.workingSetCache
 		} else {
 			log := cache.config.MakeLogger("DBC")
 			log.Warning("Sync cache is preferred, but there is no sync cache")
@@ -153,6 +154,8 @@ func (cache *diskBlockCacheWrapped) Get(
 				// The cache will log the non-fatal error, so just return nil.
 				return buf, serverHalf, prefetchStatus, nil
 			}
+			// Remove the block from the non-preferred cache (which is
+			// set to be the secondary cache at this point).
 			cache.deleteGroup.Add(1)
 			go func() {
 				defer cache.deleteGroup.Done()

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -856,6 +856,8 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
+	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
+	require.NoError(t, err)
 	status := dbc.Status(ctx)
 	require.Equal(t, uint64(2), status[syncCacheName].NumBlocks)
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -294,8 +294,12 @@ func (fbo *folderBlockOps) getCleanEncodedBlockSizeLocked(ctx context.Context,
 			return block.GetEncodedSize(), keybase1.BlockStatus_LIVE, nil
 		}
 		if diskBCache := fbo.config.DiskBlockCache(); diskBCache != nil {
+			cacheType := DiskBlockAnyCache
+			if fbo.config.IsSyncedTlf(fbo.id()) {
+				cacheType = DiskBlockSyncCache
+			}
 			if buf, _, _, err := diskBCache.Get(
-				ctx, fbo.id(), ptr.ID); err == nil {
+				ctx, fbo.id(), ptr.ID, cacheType); err == nil {
 				return uint32(len(buf)), keybase1.BlockStatus_LIVE, nil
 			}
 		}

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1268,8 +1268,8 @@ const (
 	// DiskBlockWorkingSetCache indicates that the working set cache
 	// should be used.
 	DiskBlockWorkingSetCache
-	// DiskBlockSyncCache indicates that the working set cache should
-	// be used.
+	// DiskBlockSyncCache indicates that the sync cache should be
+	// used.
 	DiskBlockSyncCache
 )
 

--- a/libkbfs/journal_block_server.go
+++ b/libkbfs/journal_block_server.go
@@ -70,7 +70,8 @@ func (j journalBlockServer) getBlockSizeFromJournal(
 }
 
 func (j journalBlockServer) Get(
-	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context) (
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, cacheType DiskBlockCacheType) (
 	data []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	j.jServer.log.LazyTrace(ctx, "jBServer: Get %s", id)
 	defer func() {
@@ -85,12 +86,14 @@ func (j journalBlockServer) Get(
 		return data, serverHalf, nil
 	}
 
-	return j.BlockServer.Get(ctx, tlfID, id, context)
+	return j.BlockServer.Get(ctx, tlfID, id, context, cacheType)
 }
 
 func (j journalBlockServer) Put(
-	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context,
-	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) (err error) {
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	context kbfsblock.Context, buf []byte,
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	cacheType DiskBlockCacheType) (err error) {
 	// Don't trace this function, as it gets too verbose and is
 	// called in parallel anyway. Rely on caller (usually
 	// doBlockPuts) to do the tracing.
@@ -114,7 +117,8 @@ func (j journalBlockServer) Put(
 		}
 	}
 
-	return j.BlockServer.Put(ctx, tlfID, id, context, buf, serverHalf)
+	return j.BlockServer.Put(
+		ctx, tlfID, id, context, buf, serverHalf, cacheType)
 }
 
 func (j journalBlockServer) AddBlockReference(

--- a/libkbfs/journal_block_server_test.go
+++ b/libkbfs/journal_block_server_test.go
@@ -105,11 +105,12 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	// Put a block.
 	serverHalf, err := kbfscrypto.MakeRandomBlockCryptKeyServerHalf()
 	require.NoError(t, err)
-	err = blockServer.Put(ctx, tlfID, bID, bCtx, data, serverHalf)
+	err = blockServer.Put(
+		ctx, tlfID, bID, bCtx, data, serverHalf, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	// Now get the same block back.
-	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx)
+	buf, key, err := blockServer.Get(ctx, tlfID, bID, bCtx, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)
@@ -125,7 +126,7 @@ func TestJournalBlockServerPutGetAddReference(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now get the same block back.
-	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2)
+	buf, key, err = blockServer.Get(ctx, tlfID, bID, bCtx2, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, data, buf)
 	require.Equal(t, serverHalf, key)

--- a/libkbfs/kbfs_service.go
+++ b/libkbfs/kbfs_service.go
@@ -60,6 +60,7 @@ func (eu KBFSErrorUnwrapper) UnwrapError(arg interface{}) (appError error,
 type kbfsServiceConfig interface {
 	diskBlockCacheGetter
 	logMaker
+	syncedTlfGetterSetter
 }
 
 // KBFSService represents a running KBFS service.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4454,8 +4454,8 @@ func (m *MockDiskBlockCache) EXPECT() *MockDiskBlockCacheMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockDiskBlockCache) Get(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, PrefetchStatus, error) {
-	ret := m.ctrl.Call(m, "Get", ctx, tlfID, blockID)
+func (m *MockDiskBlockCache) Get(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, preferredCacheType DiskBlockCacheType) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, PrefetchStatus, error) {
+	ret := m.ctrl.Call(m, "Get", ctx, tlfID, blockID, preferredCacheType)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(kbfscrypto.BlockCryptKeyServerHalf)
 	ret2, _ := ret[2].(PrefetchStatus)
@@ -4464,20 +4464,20 @@ func (m *MockDiskBlockCache) Get(ctx context.Context, tlfID tlf.ID, blockID kbfs
 }
 
 // Get indicates an expected call of Get
-func (mr *MockDiskBlockCacheMockRecorder) Get(ctx, tlfID, blockID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDiskBlockCache)(nil).Get), ctx, tlfID, blockID)
+func (mr *MockDiskBlockCacheMockRecorder) Get(ctx, tlfID, blockID, preferredCacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDiskBlockCache)(nil).Get), ctx, tlfID, blockID, preferredCacheType)
 }
 
 // Put mocks base method
-func (m *MockDiskBlockCache) Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
-	ret := m.ctrl.Call(m, "Put", ctx, tlfID, blockID, buf, serverHalf)
+func (m *MockDiskBlockCache) Put(ctx context.Context, tlfID tlf.ID, blockID kbfsblock.ID, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "Put", ctx, tlfID, blockID, buf, serverHalf, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put
-func (mr *MockDiskBlockCacheMockRecorder) Put(ctx, tlfID, blockID, buf, serverHalf interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDiskBlockCache)(nil).Put), ctx, tlfID, blockID, buf, serverHalf)
+func (mr *MockDiskBlockCacheMockRecorder) Put(ctx, tlfID, blockID, buf, serverHalf, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDiskBlockCache)(nil).Put), ctx, tlfID, blockID, buf, serverHalf, cacheType)
 }
 
 // Delete mocks base method
@@ -6556,8 +6556,8 @@ func (mr *MockBlockServerMockRecorder) RefreshAuthToken(arg0 interface{}) *gomoc
 }
 
 // Get mocks base method
-func (m *MockBlockServer) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	ret := m.ctrl.Call(m, "Get", ctx, tlfID, id, context)
+func (m *MockBlockServer) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, cacheType DiskBlockCacheType) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
+	ret := m.ctrl.Call(m, "Get", ctx, tlfID, id, context, cacheType)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(kbfscrypto.BlockCryptKeyServerHalf)
 	ret2, _ := ret[2].(error)
@@ -6565,8 +6565,8 @@ func (m *MockBlockServer) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID
 }
 
 // Get indicates an expected call of Get
-func (mr *MockBlockServerMockRecorder) Get(ctx, tlfID, id, context interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockServer)(nil).Get), ctx, tlfID, id, context)
+func (mr *MockBlockServerMockRecorder) Get(ctx, tlfID, id, context, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBlockServer)(nil).Get), ctx, tlfID, id, context, cacheType)
 }
 
 // GetEncodedSize mocks base method
@@ -6584,27 +6584,27 @@ func (mr *MockBlockServerMockRecorder) GetEncodedSize(ctx, tlfID, id, context in
 }
 
 // Put mocks base method
-func (m *MockBlockServer) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
-	ret := m.ctrl.Call(m, "Put", ctx, tlfID, id, context, buf, serverHalf)
+func (m *MockBlockServer) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "Put", ctx, tlfID, id, context, buf, serverHalf, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put
-func (mr *MockBlockServerMockRecorder) Put(ctx, tlfID, id, context, buf, serverHalf interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockBlockServer)(nil).Put), ctx, tlfID, id, context, buf, serverHalf)
+func (mr *MockBlockServerMockRecorder) Put(ctx, tlfID, id, context, buf, serverHalf, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockBlockServer)(nil).Put), ctx, tlfID, id, context, buf, serverHalf, cacheType)
 }
 
 // PutAgain mocks base method
-func (m *MockBlockServer) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
-	ret := m.ctrl.Call(m, "PutAgain", ctx, tlfID, id, context, buf, serverHalf)
+func (m *MockBlockServer) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "PutAgain", ctx, tlfID, id, context, buf, serverHalf, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutAgain indicates an expected call of PutAgain
-func (mr *MockBlockServerMockRecorder) PutAgain(ctx, tlfID, id, context, buf, serverHalf interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAgain", reflect.TypeOf((*MockBlockServer)(nil).PutAgain), ctx, tlfID, id, context, buf, serverHalf)
+func (mr *MockBlockServerMockRecorder) PutAgain(ctx, tlfID, id, context, buf, serverHalf, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAgain", reflect.TypeOf((*MockBlockServer)(nil).PutAgain), ctx, tlfID, id, context, buf, serverHalf, cacheType)
 }
 
 // AddBlockReference mocks base method
@@ -6727,8 +6727,8 @@ func (mr *MockblockServerLocalMockRecorder) RefreshAuthToken(arg0 interface{}) *
 }
 
 // Get mocks base method
-func (m *MockblockServerLocal) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
-	ret := m.ctrl.Call(m, "Get", ctx, tlfID, id, context)
+func (m *MockblockServerLocal) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, cacheType DiskBlockCacheType) ([]byte, kbfscrypto.BlockCryptKeyServerHalf, error) {
+	ret := m.ctrl.Call(m, "Get", ctx, tlfID, id, context, cacheType)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(kbfscrypto.BlockCryptKeyServerHalf)
 	ret2, _ := ret[2].(error)
@@ -6736,8 +6736,8 @@ func (m *MockblockServerLocal) Get(ctx context.Context, tlfID tlf.ID, id kbfsblo
 }
 
 // Get indicates an expected call of Get
-func (mr *MockblockServerLocalMockRecorder) Get(ctx, tlfID, id, context interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockblockServerLocal)(nil).Get), ctx, tlfID, id, context)
+func (mr *MockblockServerLocalMockRecorder) Get(ctx, tlfID, id, context, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockblockServerLocal)(nil).Get), ctx, tlfID, id, context, cacheType)
 }
 
 // GetEncodedSize mocks base method
@@ -6755,27 +6755,27 @@ func (mr *MockblockServerLocalMockRecorder) GetEncodedSize(ctx, tlfID, id, conte
 }
 
 // Put mocks base method
-func (m *MockblockServerLocal) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
-	ret := m.ctrl.Call(m, "Put", ctx, tlfID, id, context, buf, serverHalf)
+func (m *MockblockServerLocal) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "Put", ctx, tlfID, id, context, buf, serverHalf, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put
-func (mr *MockblockServerLocalMockRecorder) Put(ctx, tlfID, id, context, buf, serverHalf interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockblockServerLocal)(nil).Put), ctx, tlfID, id, context, buf, serverHalf)
+func (mr *MockblockServerLocalMockRecorder) Put(ctx, tlfID, id, context, buf, serverHalf, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockblockServerLocal)(nil).Put), ctx, tlfID, id, context, buf, serverHalf, cacheType)
 }
 
 // PutAgain mocks base method
-func (m *MockblockServerLocal) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
-	ret := m.ctrl.Call(m, "PutAgain", ctx, tlfID, id, context, buf, serverHalf)
+func (m *MockblockServerLocal) PutAgain(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID, context kbfsblock.Context, buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "PutAgain", ctx, tlfID, id, context, buf, serverHalf, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutAgain indicates an expected call of PutAgain
-func (mr *MockblockServerLocalMockRecorder) PutAgain(ctx, tlfID, id, context, buf, serverHalf interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAgain", reflect.TypeOf((*MockblockServerLocal)(nil).PutAgain), ctx, tlfID, id, context, buf, serverHalf)
+func (mr *MockblockServerLocalMockRecorder) PutAgain(ctx, tlfID, id, context, buf, serverHalf, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutAgain", reflect.TypeOf((*MockblockServerLocal)(nil).PutAgain), ctx, tlfID, id, context, buf, serverHalf, cacheType)
 }
 
 // AddBlockReference mocks base method

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -1125,11 +1125,15 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 	_, _ = bg.setBlockToReturn(rootPtr, root)
 	_, _ = bg.setBlockToReturn(aPtr, a)
 	_, _ = bg.setBlockToReturn(bPtr, b)
-	err := cache.Put(ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot)
+	err := cache.Put(
+		ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.Put(ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA)
+	err = cache.Put(
+		ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA, DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.Put(ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB)
+	err = cache.Put(
+		ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Fetch dir root.")
@@ -1312,9 +1316,12 @@ func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
 
 	_, _ = bg.setBlockToReturn(rootPtr, root)
 	_, _ = bg.setBlockToReturn(aPtr, a)
-	err := dbc.Put(ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot)
+	err := dbc.Put(
+		ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = dbc.Put(ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA)
+	err = dbc.Put(
+		ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Fetch dir root.")
@@ -1404,11 +1411,15 @@ func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
 	_, _ = bg.setBlockToReturn(rootPtr, root)
 	_, _ = bg.setBlockToReturn(aPtr, a)
 	_, _ = bg.setBlockToReturn(bPtr, b)
-	err := dbc.Put(ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot)
+	err := dbc.Put(
+		ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = dbc.Put(ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA)
+	err = dbc.Put(
+		ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA, DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = dbc.Put(ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB)
+	err = dbc.Put(
+		ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Fetch dir root.")
@@ -1514,11 +1525,15 @@ func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
 	_, _ = bg.setBlockToReturn(rootPtr, root)
 	_, _ = bg.setBlockToReturn(aPtr, a)
 	_, _ = bg.setBlockToReturn(bPtr, b)
-	err := dbc.Put(ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot)
+	err := dbc.Put(
+		ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = dbc.Put(ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA)
+	err = dbc.Put(
+		ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA, DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = dbc.Put(ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB)
+	err = dbc.Put(
+		ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Fetch dir root.")
@@ -1649,15 +1664,21 @@ func TestPrefetcherReschedules(t *testing.T) {
 	_, _ = bg.setBlockToReturn(aaPtr, aa)
 	_, _ = bg.setBlockToReturn(abPtr, ab)
 	_, _ = bg.setBlockToReturn(bPtr, b)
-	err := cache.Put(ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot)
+	err := cache.Put(
+		ctx, kmd.TlfID(), rootPtr.ID, encRoot, serverHalfRoot,
+		DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.Put(ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA)
+	err = cache.Put(
+		ctx, kmd.TlfID(), aPtr.ID, encA, serverHalfA, DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.Put(ctx, kmd.TlfID(), aaPtr.ID, encAA, serverHalfAA)
+	err = cache.Put(
+		ctx, kmd.TlfID(), aaPtr.ID, encAA, serverHalfAA, DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.Put(ctx, kmd.TlfID(), abPtr.ID, encAB, serverHalfAB)
+	err = cache.Put(
+		ctx, kmd.TlfID(), abPtr.ID, encAB, serverHalfAB, DiskBlockAnyCache)
 	require.NoError(t, err)
-	err = cache.Put(ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB)
+	err = cache.Put(
+		ctx, kmd.TlfID(), bPtr.ID, encB, serverHalfB, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	config.SetTlfSyncState(kmd.TlfID(), FolderSyncConfig{

--- a/libkbfs/test_stallers.go
+++ b/libkbfs/test_stallers.go
@@ -368,24 +368,29 @@ func (f *stallingBlockServer) maybeStall(ctx context.Context, opName StallableBl
 		f.stallKey, f.staller)
 }
 
-func (f *stallingBlockServer) Get(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
-	bctx kbfsblock.Context) (
+func (f *stallingBlockServer) Get(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+	bctx kbfsblock.Context, cacheType DiskBlockCacheType) (
 	buf []byte, serverHalf kbfscrypto.BlockCryptKeyServerHalf, err error) {
 	f.maybeStall(ctx, StallableBlockGet)
 	err = runWithContextCheck(ctx, func(ctx context.Context) error {
 		var errGet error
-		buf, serverHalf, errGet = f.BlockServer.Get(ctx, tlfID, id, bctx)
+		buf, serverHalf, errGet = f.BlockServer.Get(
+			ctx, tlfID, id, bctx, cacheType)
 		return errGet
 	})
 	return buf, serverHalf, err
 }
 
-func (f *stallingBlockServer) Put(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
+func (f *stallingBlockServer) Put(
+	ctx context.Context, tlfID tlf.ID, id kbfsblock.ID,
 	bctx kbfsblock.Context, buf []byte,
-	serverHalf kbfscrypto.BlockCryptKeyServerHalf) error {
+	serverHalf kbfscrypto.BlockCryptKeyServerHalf,
+	cacheType DiskBlockCacheType) error {
 	f.maybeStall(ctx, StallableBlockPut)
 	return runWithContextCheck(ctx, func(ctx context.Context) error {
-		return f.BlockServer.Put(ctx, tlfID, id, bctx, buf, serverHalf)
+		return f.BlockServer.Put(
+			ctx, tlfID, id, bctx, buf, serverHalf, cacheType)
 	})
 }
 


### PR DESCRIPTION
In anticipation of partial syncing, where the `*folderBranchOps` instance is the only place that knows whether a given block needs to be in the sync cache or not, this commit removes usage of `config.IsSyncedTlf` from the disk block cache.

Instead, it plumbs through a "cache type" with every `Get` and `Put` call.  For `Get` calls, if the block isn't already in the desired cache type, it will be moved there (which will be useful when a path is marked as syncing after some of its blocks are already in the working set cache).

This commit plumbs the cache type down from the places where the get/put calls originate from.  Future work will need to make decisions in those places about whether a particular block goes into the sync cache; for now, it just uses `config.IsSyncedTlf` there.

This depends on #1925 and #1932.

Issue: KBFS-3523