### PR TITLE
block_retrieval_queue: decouple priorities from prefetching

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -72,8 +72,9 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 
 	b.log.LazyTrace(ctx, "BOps: Requesting %s", blockPtr.ID)
 
-	errCh := b.queue.Request(ctx, defaultOnDemandRequestPriority, kmd,
-		blockPtr, block, lifetime)
+	errCh := b.queue.Request(
+		ctx, defaultOnDemandRequestPriority, kmd,
+		blockPtr, block, lifetime, BlockRequestWithPrefetch)
 	err := <-errCh
 
 	b.log.LazyTrace(ctx, "BOps: Request fulfilled for %s (err=%v)", blockPtr.ID, err)

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -408,7 +408,7 @@ func (brq *blockRetrievalQueue) Request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
 	if brq.config.IsSyncedTlf(kmd.TlfID()) {
-		action = action.Combine(BlockRequestSoloWithSync)
+		action = action.AddSync()
 	}
 	return brq.request(ctx, priority, kmd, ptr, block, lifetime, action)
 }

--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -287,7 +287,7 @@ func (brq *blockRetrievalQueue) checkCaches(ctx context.Context,
 func (brq *blockRetrievalQueue) request(ctx context.Context,
 	priority int, kmd KeyMetadata, ptr BlockPointer, block Block,
 	lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
-	brq.log.CDebugf(ctx, "Request of %v, action=%d", ptr, action)
+	brq.log.CDebugf(ctx, "Request of %v, action=%s", ptr, action)
 
 	// Only continue if we haven't been shut down
 	ch := make(chan error, 1)

--- a/libkbfs/block_retrieval_queue_test.go
+++ b/libkbfs/block_retrieval_queue_test.go
@@ -87,8 +87,9 @@ func TestBlockRetrievalQueueBasic(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the request.")
 	br := q.popIfNotEmpty()
@@ -114,10 +115,11 @@ func TestBlockRetrievalQueuePreemptPriority(t *testing.T) {
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1 and a higher priority " +
 		"retrieval for ptr2.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
 	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr2,
-		block, NoCacheEntry)
+		block, NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the preempted ptr2 request.")
 	br := q.popIfNotEmpty()
@@ -145,10 +147,12 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 	ptr2 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1 and ptr2.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr2, block,
-		NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr2, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the ptr1 request.")
 	br := q.popIfNotEmpty()
@@ -159,8 +163,9 @@ func TestBlockRetrievalQueueInterleavedPreemption(t *testing.T) {
 
 	ptr3 := makeRandomBlockPointer(t)
 	t.Log("Preempt the ptr2 request with the ptr3 request.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr3,
-		block, NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr3,
+		block, NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the ptr3 request.")
 	br = q.popIfNotEmpty()
@@ -187,10 +192,12 @@ func TestBlockRetrievalQueueMultipleRequestsSameBlock(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1 twice.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has 2 requests and that the queue is now empty.")
 	br := q.popIfNotEmpty()
@@ -217,12 +224,15 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	ptr3 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request 3 block retrievals, each preempting the previous one.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
-	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr2,
-		block, NoCacheEntry)
-	_ = q.Request(ctx, defaultOnDemandRequestPriority+2, makeKMD(), ptr3,
-		block, NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr2,
+		block, NoCacheEntry, BlockRequestWithPrefetch)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority+2, makeKMD(), ptr3,
+		block, NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the ptr3 retrieval.")
 	br := q.popIfNotEmpty()
@@ -232,8 +242,9 @@ func TestBlockRetrievalQueueElevatePriorityExistingRequest(t *testing.T) {
 	require.Equal(t, uint64(2), br.insertionOrder)
 
 	t.Log("Preempt the remaining retrievals with another retrieval for ptr1.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority+2, makeKMD(), ptr1,
-		block, NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority+2, makeKMD(), ptr1,
+		block, NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has increased in priority and has 2 requests.")
 	br = q.popIfNotEmpty()
@@ -261,8 +272,9 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	ptr1 := makeRandomBlockPointer(t)
 	block := &FileBlock{}
 	t.Log("Request a block retrieval for ptr1.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
-		NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority, makeKMD(), ptr1, block,
+		NoCacheEntry, BlockRequestWithPrefetch)
 
 	t.Log("Begin working on the ptr1 retrieval. Verify that it has 1 request.")
 	br := q.popIfNotEmpty()
@@ -275,8 +287,9 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 
 	t.Log("Request another block retrieval for ptr1 before it has finished. " +
 		"Verify that the priority has elevated and there are now 2 requests.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
-		block, NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
+		block, NoCacheEntry, BlockRequestWithPrefetch)
 	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)
 	require.Equal(t, uint64(0), br.insertionOrder)
 	require.Len(t, br.requests, 2)
@@ -286,8 +299,9 @@ func TestBlockRetrievalQueueCurrentlyProcessingRequest(t *testing.T) {
 	t.Log("Finalize the existing request for ptr1.")
 	q.FinalizeRequest(br, &FileBlock{}, nil)
 	t.Log("Make another request for the same block. Verify that this is a new request.")
-	_ = q.Request(ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
-		block, NoCacheEntry)
+	_ = q.Request(
+		ctx, defaultOnDemandRequestPriority+1, makeKMD(), ptr1,
+		block, NoCacheEntry, BlockRequestWithPrefetch)
 	br = q.popIfNotEmpty()
 	defer q.FinalizeRequest(br, &FileBlock{}, io.EOF)
 	require.Equal(t, defaultOnDemandRequestPriority+1, br.priority)

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -982,6 +982,27 @@ const (
 	BlockRequestWithDeepSync BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestPrefetch | blockRequestSync | blockRequestDeepSync
 )
 
+func (bra BlockRequestAction) String() string {
+	if bra.DeepSync() {
+		return "deep-sync"
+	}
+	if bra == BlockRequestSolo {
+		return "solo"
+	}
+
+	attrs := make([]string, 0, 2)
+	if bra.Prefetch() {
+		attrs = append(attrs, "prefetch")
+	} else if bra.PrefetchTracked() {
+		attrs = append(attrs, "prefetch-tracked")
+	}
+
+	if bra.Sync() {
+		attrs = append(attrs, "sync")
+	}
+	return strings.Join(attrs, "|")
+}
+
 // Combine returns a new action by taking `other` into account.
 func (bra BlockRequestAction) Combine(
 	other BlockRequestAction) BlockRequestAction {

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -949,6 +949,7 @@ const (
 	blockRequestTrackedInPrefetch BlockRequestAction = 1 << iota
 	blockRequestPrefetch
 	blockRequestSync
+	blockRequestDeepSync
 
 	// BlockRequestSolo indicates that no action should take place
 	// after fetching the block.  However, a TLF that is configured to
@@ -972,9 +973,13 @@ const (
 	BlockRequestWithPrefetch BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestPrefetch
 	// BlockRequestWithSyncAndPrefetch indicates that the block should
 	// be stored in the sync cache after fetching it, as well as
-	// triggering a deep prefetch of all the child blocks rooted at
-	// the requested one.
+	// triggering a prefetch of one level of child blocks (and the
+	// syncing doesn't propagate to the child blocks).
 	BlockRequestWithSyncAndPrefetch BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestPrefetch | blockRequestSync
+	// BlockRequestWithDeepSync is the same as above, except both the
+	// prefetching and the sync flags propagate to the child, so the
+	// whole tree root at the block is prefetched and synced.
+	BlockRequestWithDeepSync BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestPrefetch | blockRequestSync | blockRequestDeepSync
 )
 
 // Combine returns a new action by taking `other` into account.
@@ -1004,11 +1009,30 @@ func (bra BlockRequestAction) Sync() bool {
 // DeepSync returns true if the action indicates a deep-syncing of the
 // block tree rooted at the given block.
 func (bra BlockRequestAction) DeepSync() bool {
-	return bra.Prefetch() && bra.Sync()
+	return bra == BlockRequestWithDeepSync
 }
 
-// WithoutPrefetch returns a new action similar to `bra` but with no
-// additional prefetching.
-func (bra BlockRequestAction) WithoutPrefetch() BlockRequestAction {
-	return bra &^ blockRequestPrefetch
+// ChildAction returns the action that should propagate down to any
+// children of this block.
+func (bra BlockRequestAction) ChildAction() BlockRequestAction {
+	if bra.DeepSync() {
+		return bra
+	}
+	return bra &^ (blockRequestPrefetch | blockRequestSync)
+}
+
+// SoloAction returns a solo-fetch action based on `bra` (e.g.,
+// preserving the sync bit but nothing else).
+func (bra BlockRequestAction) SoloAction() BlockRequestAction {
+	return bra & blockRequestSync
+}
+
+// AddSync returns a new action that adds syncing in addition to the
+// original request.  For prefetch requests, it returns a deep-sync
+// request (unlike `Combine`, which just adds the regular sync bit).
+func (bra BlockRequestAction) AddSync() BlockRequestAction {
+	if bra.Prefetch() {
+		return BlockRequestWithDeepSync
+	}
+	return bra | blockRequestSync
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -936,128 +936,79 @@ func syncPathListFromBlock(codec kbfscodec.Codec, b *FileBlock) (
 	return paths, nil
 }
 
+const ()
+
 // BlockRequestAction indicates what kind of action should be taken
-// after successfully fetching a block.
+// after successfully fetching a block.  This is a bit mask filled
+// with `blockRequestFlag`s.
 type BlockRequestAction int
 
 const (
+	// These unexported actions are really flags that are combined to
+	// make the other actions below.
+	blockRequestTrackedInPrefetch BlockRequestAction = 1 << iota
+	blockRequestPrefetch
+	blockRequestSync
+
 	// BlockRequestSolo indicates that no action should take place
 	// after fetching the block.  However, a TLF that is configured to
 	// be fully-synced will still be prefetched and synced.
-	BlockRequestSolo BlockRequestAction = iota
+	BlockRequestSolo BlockRequestAction = 0
 	// BlockRequestSoloWithSync indicates the the requested block
 	// should be put in the sync cache, but no prefetching should be
 	// triggered.
-	BlockRequestSoloWithSync
+	BlockRequestSoloWithSync BlockRequestAction = blockRequestSync
+	// BlockRequestPrefetchTail indicates that the block is being
+	// tracked in the prefetcher, but shouldn't kick off any more
+	// prefetches.
+	BlockRequestPrefetchTail BlockRequestAction = blockRequestTrackedInPrefetch
+	// BlockRequestPrefetchTailWithSync indicates that the block is
+	// being tracked in the prefetcher and goes in the sync cache, but
+	// shouldn't kick off any more prefetches.
+	BlockRequestPrefetchTailWithSync BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestSync
 	// BlockRequestWithPrefetch indicates that a prefetch should be
 	// triggered after fetching the block.  If a TLF is configured to
 	// be fully-synced, the block will still be put in the sync cache.
-	BlockRequestWithPrefetch
+	BlockRequestWithPrefetch BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestPrefetch
 	// BlockRequestWithSyncAndPrefetch indicates that the block should
 	// be stored in the sync cache after fetching it, as well as
 	// triggering a deep prefetch of all the child blocks rooted at
 	// the requested one.
-	BlockRequestWithSyncAndPrefetch
-	// BlockRequestPrefetchTail indicates that the block is being
-	// tracked in the prefetcher, but shouldn't kick off any more
-	// prefetches.
-	BlockRequestPrefetchTail
-	// BlockRequestPrefetchTailWithSync indicates that the block is
-	// being tracked in the prefetcher and goes in the sync cache, but
-	// shouldn't kick off any more prefetches.
-	BlockRequestPrefetchTailWithSync
+	BlockRequestWithSyncAndPrefetch BlockRequestAction = blockRequestTrackedInPrefetch | blockRequestPrefetch | blockRequestSync
 )
 
 // Combine returns a new action by taking `other` into account.
 func (bra BlockRequestAction) Combine(
 	other BlockRequestAction) BlockRequestAction {
-	switch bra {
-	case BlockRequestSolo:
-		// Anything overrides a pure solo request.
-		return other
-	case BlockRequestSoloWithSync:
-		// Upgrade a solo sync action to prefetching if needed.
-		switch other {
-		case BlockRequestSolo, BlockRequestPrefetchTailWithSync,
-			BlockRequestPrefetchTail:
-			return bra
-		case BlockRequestWithPrefetch:
-			return BlockRequestWithSyncAndPrefetch
-		default:
-			return other
-		}
-	case BlockRequestWithPrefetch:
-		// Upgrade a prefetching action to be syncing if needed.
-		switch other {
-		case BlockRequestSolo, BlockRequestPrefetchTail:
-			return bra
-		case BlockRequestSoloWithSync, BlockRequestPrefetchTailWithSync:
-			return BlockRequestWithSyncAndPrefetch
-		default:
-			return other
-		}
-	case BlockRequestWithSyncAndPrefetch:
-		return BlockRequestWithSyncAndPrefetch
-	case BlockRequestPrefetchTail:
-		// Upgrade a prefetching tail action to be syncing or non-tail
-		// if needed.
-		switch other {
-		case BlockRequestSolo:
-			return bra
-		case BlockRequestSoloWithSync:
-			return BlockRequestPrefetchTailWithSync
-		default:
-			return other
-		}
-	case BlockRequestPrefetchTailWithSync:
-		// Upgrade to a full deep sync if needed.
-		switch other {
-		case BlockRequestWithPrefetch, BlockRequestWithSyncAndPrefetch:
-			return BlockRequestWithSyncAndPrefetch
-		default:
-			return bra
-		}
-	default:
-		panic(fmt.Sprintf("Unexpected block request action: %v", bra))
-	}
+	return bra | other
 }
 
 // Prefetch returns true if the action indicates the block should
 // trigger a prefetch.
 func (bra BlockRequestAction) Prefetch() bool {
-	return bra == BlockRequestWithPrefetch ||
-		bra == BlockRequestWithSyncAndPrefetch
+	return bra&blockRequestPrefetch > 0
 }
 
 // PrefetchTracked returns true if this block is being tracked by the
 // prefetcher.
 func (bra BlockRequestAction) PrefetchTracked() bool {
-	return bra.Prefetch() || bra == BlockRequestPrefetchTail ||
-		bra == BlockRequestPrefetchTailWithSync
+	return bra.Prefetch() || bra&blockRequestTrackedInPrefetch > 0
 }
 
 // Sync returns true if the action indicates the block should go into
 // the sync cache.
 func (bra BlockRequestAction) Sync() bool {
-	return bra == BlockRequestSoloWithSync ||
-		bra == BlockRequestWithSyncAndPrefetch
+	return bra&blockRequestSync > 0
 }
 
 // DeepSync returns true if the action indicates a deep-syncing of the
 // block tree rooted at the given block.
 func (bra BlockRequestAction) DeepSync() bool {
-	return bra == BlockRequestWithSyncAndPrefetch
+	return bra.Prefetch() && bra.Sync()
 }
 
 // WithoutPrefetch returns a new action similar to `bra` but with no
 // additional prefetching.
 func (bra BlockRequestAction) WithoutPrefetch() BlockRequestAction {
-	switch bra {
-	case BlockRequestWithPrefetch:
-		return BlockRequestPrefetchTail
-	case BlockRequestWithSyncAndPrefetch:
-		return BlockRequestPrefetchTailWithSync
-	default:
-		return bra
-	}
+	return bra &^ blockRequestPrefetch
 }

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -935,3 +935,129 @@ func syncPathListFromBlock(codec kbfscodec.Codec, b *FileBlock) (
 	}
 	return paths, nil
 }
+
+// BlockRequestAction indicates what kind of action should be taken
+// after successfully fetching a block.
+type BlockRequestAction int
+
+const (
+	// BlockRequestSolo indicates that no action should take place
+	// after fetching the block.  However, a TLF that is configured to
+	// be fully-synced will still be prefetched and synced.
+	BlockRequestSolo BlockRequestAction = iota
+	// BlockRequestSoloWithSync indicates the the requested block
+	// should be put in the sync cache, but no prefetching should be
+	// triggered.
+	BlockRequestSoloWithSync
+	// BlockRequestWithPrefetch indicates that a prefetch should be
+	// triggered after fetching the block.  If a TLF is configured to
+	// be fully-synced, the block will still be put in the sync cache.
+	BlockRequestWithPrefetch
+	// BlockRequestWithSyncAndPrefetch indicates that the block should
+	// be stored in the sync cache after fetching it, as well as
+	// triggering a deep prefetch of all the child blocks rooted at
+	// the requested one.
+	BlockRequestWithSyncAndPrefetch
+	// BlockRequestPrefetchTail indicates that the block is being
+	// tracked in the prefetcher, but shouldn't kick off any more
+	// prefetches.
+	BlockRequestPrefetchTail
+	// BlockRequestPrefetchTailWithSync indicates that the block is
+	// being tracked in the prefetcher and goes in the sync cache, but
+	// shouldn't kick off any more prefetches.
+	BlockRequestPrefetchTailWithSync
+)
+
+// Combine returns a new action by taking `other` into account.
+func (bra BlockRequestAction) Combine(
+	other BlockRequestAction) BlockRequestAction {
+	switch bra {
+	case BlockRequestSolo:
+		// Anything overrides a pure solo request.
+		return other
+	case BlockRequestSoloWithSync:
+		// Upgrade a solo sync action to prefetching if needed.
+		switch other {
+		case BlockRequestSolo, BlockRequestPrefetchTailWithSync,
+			BlockRequestPrefetchTail:
+			return bra
+		case BlockRequestWithPrefetch:
+			return BlockRequestWithSyncAndPrefetch
+		default:
+			return other
+		}
+	case BlockRequestWithPrefetch:
+		// Upgrade a prefetching action to be syncing if needed.
+		switch other {
+		case BlockRequestSolo, BlockRequestPrefetchTail:
+			return bra
+		case BlockRequestSoloWithSync, BlockRequestPrefetchTailWithSync:
+			return BlockRequestWithSyncAndPrefetch
+		default:
+			return other
+		}
+	case BlockRequestWithSyncAndPrefetch:
+		return BlockRequestWithSyncAndPrefetch
+	case BlockRequestPrefetchTail:
+		// Upgrade a prefetching tail action to be syncing or non-tail
+		// if needed.
+		switch other {
+		case BlockRequestSolo:
+			return bra
+		case BlockRequestSoloWithSync:
+			return BlockRequestPrefetchTailWithSync
+		default:
+			return other
+		}
+	case BlockRequestPrefetchTailWithSync:
+		// Upgrade to a full deep sync if needed.
+		switch other {
+		case BlockRequestWithPrefetch, BlockRequestWithSyncAndPrefetch:
+			return BlockRequestWithSyncAndPrefetch
+		default:
+			return bra
+		}
+	default:
+		panic(fmt.Sprintf("Unexpected block request action: %v", bra))
+	}
+}
+
+// Prefetch returns true if the action indicates the block should
+// trigger a prefetch.
+func (bra BlockRequestAction) Prefetch() bool {
+	return bra == BlockRequestWithPrefetch ||
+		bra == BlockRequestWithSyncAndPrefetch
+}
+
+// PrefetchTracked returns true if this block is being tracked by the
+// prefetcher.
+func (bra BlockRequestAction) PrefetchTracked() bool {
+	return bra.Prefetch() || bra == BlockRequestPrefetchTail ||
+		bra == BlockRequestPrefetchTailWithSync
+}
+
+// Sync returns true if the action indicates the block should go into
+// the sync cache.
+func (bra BlockRequestAction) Sync() bool {
+	return bra == BlockRequestSoloWithSync ||
+		bra == BlockRequestWithSyncAndPrefetch
+}
+
+// DeepSync returns true if the action indicates a deep-syncing of the
+// block tree rooted at the given block.
+func (bra BlockRequestAction) DeepSync() bool {
+	return bra == BlockRequestWithSyncAndPrefetch
+}
+
+// WithoutPrefetch returns a new action similar to `bra` but with no
+// additional prefetching.
+func (bra BlockRequestAction) WithoutPrefetch() BlockRequestAction {
+	switch bra {
+	case BlockRequestWithPrefetch:
+		return BlockRequestPrefetchTail
+	case BlockRequestWithSyncAndPrefetch:
+		return BlockRequestPrefetchTailWithSync
+	default:
+		return bra
+	}
+}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -1055,5 +1055,9 @@ func (bra BlockRequestAction) AddSync() BlockRequestAction {
 	if bra.Prefetch() {
 		return BlockRequestWithDeepSync
 	}
+	// If the prefetch bit is NOT yet set (as when some component
+	// makes a solo request, for example), we should not kick off a
+	// deep sync since the action explicit prohibits any more blocks
+	// being fetched (and doing so will mess up sensitive tests).
 	return bra | blockRequestSync
 }

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -530,7 +530,8 @@ func TestDiskBlockCacheWithRetrievalQueue(t *testing.T) {
 	t.Log("Request a block retrieval for ptr1. " +
 		"Verify the block against the one we put in the disk block cache.")
 	block := &FileBlock{}
-	ch := q.Request(ctx, 1, kmd, ptr1, block, TransientEntry)
+	ch := q.Request(
+		ctx, 1, kmd, ptr1, block, TransientEntry, BlockRequestWithPrefetch)
 	err = <-ch
 	require.NoError(t, err)
 	require.Equal(t, block1, block)
@@ -543,7 +544,9 @@ func TestDiskBlockCacheWithRetrievalQueue(t *testing.T) {
 
 	block = &FileBlock{}
 	t.Log("Request the same block again to verify the memory cache.")
-	ch = q.Request(ctx, 1, makeKMD(), ptr1, block, TransientEntry)
+	ch = q.Request(
+		ctx, 1, makeKMD(), ptr1, block, TransientEntry,
+		BlockRequestWithPrefetch)
 	err = <-ch
 	require.NoError(t, err)
 	require.Equal(t, block1, block)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -387,7 +387,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 			action = action.AddSync()
 		}
 		fbo.config.BlockOps().Prefetcher().ProcessBlockForPrefetch(ctx, ptr,
-			block, kmd, defaultOnDemandRequestPriority, lifetime,
+			block, kmd, defaultOnDemandRequestPriority-1, lifetime,
 			prefetchStatus, action)
 		return block, nil
 	}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -384,7 +384,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// correctly according to the new on-demand fetch priority.
 		action := BlockRequestWithPrefetch
 		if fbo.config.IsSyncedTlf(fbo.id()) {
-			action = BlockRequestWithSyncAndPrefetch
+			action = action.AddSync()
 		}
 		fbo.config.BlockOps().Prefetcher().ProcessBlockForPrefetch(ctx, ptr,
 			block, kmd, defaultOnDemandRequestPriority, lifetime,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -795,7 +795,7 @@ func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ctx context.Context, rmd ImmutableRootMetadata) <-chan error {
 	ptr := rmd.Data().Dir.BlockPointer
 	return fbo.config.BlockOps().BlockRetriever().Request(
-		ctx, defaultOnDemandRequestPriority, rmd, ptr, NewDirBlock(),
+		ctx, defaultOnDemandRequestPriority-1, rmd, ptr, NewDirBlock(),
 		TransientEntry, BlockRequestWithPrefetch)
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -796,7 +796,7 @@ func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ptr := rmd.Data().Dir.BlockPointer
 	return fbo.config.BlockOps().BlockRetriever().Request(
 		ctx, defaultOnDemandRequestPriority, rmd, ptr, NewDirBlock(),
-		TransientEntry)
+		TransientEntry, BlockRequestWithPrefetch)
 }
 
 func (fbo *folderBranchOps) waitForRootBlockFetch(

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1572,7 +1572,7 @@ type Prefetcher interface {
 	// ProcessBlockForPrefetch potentially triggers and monitors a prefetch.
 	ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block,
 		kmd KeyMetadata, priority int, lifetime BlockCacheLifetime,
-		prefetchStatus PrefetchStatus, isDeepSync bool)
+		prefetchStatus PrefetchStatus, action BlockRequestAction)
 	// WaitChannelForBlockPrefetch returns a channel that can be used
 	// to wait for a block to finish prefetching or be canceled.  If
 	// the block isn't currently being prefetched, it will return an
@@ -2496,17 +2496,11 @@ type RekeyFSM interface {
 
 // BlockRetriever specifies how to retrieve blocks.
 type BlockRetriever interface {
-	// Request retrieves blocks asynchronously.
+	// Request retrieves blocks asynchronously.  `action` determines
+	// what happens after the block is fetched successfully.
 	Request(ctx context.Context, priority int, kmd KeyMetadata,
-		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
-	// RequestNoPrefetch retrieves blocks asynchronously, but doesn't trigger a
-	// prefetch unless the block had to be retrieved from the server.
-	RequestNoPrefetch(ctx context.Context, priority int, kmd KeyMetadata,
-		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
-	// RequestAndSync retrieves blocks asynchronously, and syncs the
-	// entire block tree rooted at `ptr`.
-	RequestAndSync(ctx context.Context, priority int, kmd KeyMetadata,
-		ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error
+		ptr BlockPointer, block Block, lifetime BlockCacheLifetime,
+		action BlockRequestAction) <-chan error
 	// PutInCaches puts the block into the in-memory cache, and ensures that
 	// the disk cache metadata is updated.
 	PutInCaches(ctx context.Context, ptr BlockPointer, tlfID tlf.ID,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5422,13 +5422,13 @@ func (m *MockPrefetcher) EXPECT() *MockPrefetcherMockRecorder {
 }
 
 // ProcessBlockForPrefetch mocks base method
-func (m *MockPrefetcher) ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, isDeepSync bool) {
-	m.ctrl.Call(m, "ProcessBlockForPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, isDeepSync)
+func (m *MockPrefetcher) ProcessBlockForPrefetch(ctx context.Context, ptr BlockPointer, block Block, kmd KeyMetadata, priority int, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus, action BlockRequestAction) {
+	m.ctrl.Call(m, "ProcessBlockForPrefetch", ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, action)
 }
 
 // ProcessBlockForPrefetch indicates an expected call of ProcessBlockForPrefetch
-func (mr *MockPrefetcherMockRecorder) ProcessBlockForPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, isDeepSync interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockForPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).ProcessBlockForPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, isDeepSync)
+func (mr *MockPrefetcherMockRecorder) ProcessBlockForPrefetch(ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, action interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockForPrefetch", reflect.TypeOf((*MockPrefetcher)(nil).ProcessBlockForPrefetch), ctx, ptr, block, kmd, priority, lifetime, prefetchStatus, action)
 }
 
 // WaitChannelForBlockPrefetch mocks base method
@@ -9024,39 +9024,15 @@ func (m *MockBlockRetriever) EXPECT() *MockBlockRetrieverMockRecorder {
 }
 
 // Request mocks base method
-func (m *MockBlockRetriever) Request(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
-	ret := m.ctrl.Call(m, "Request", ctx, priority, kmd, ptr, block, lifetime)
+func (m *MockBlockRetriever) Request(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime, action BlockRequestAction) <-chan error {
+	ret := m.ctrl.Call(m, "Request", ctx, priority, kmd, ptr, block, lifetime, action)
 	ret0, _ := ret[0].(<-chan error)
 	return ret0
 }
 
 // Request indicates an expected call of Request
-func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block, lifetime interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime)
-}
-
-// RequestNoPrefetch mocks base method
-func (m *MockBlockRetriever) RequestNoPrefetch(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
-	ret := m.ctrl.Call(m, "RequestNoPrefetch", ctx, priority, kmd, ptr, block, lifetime)
-	ret0, _ := ret[0].(<-chan error)
-	return ret0
-}
-
-// RequestNoPrefetch indicates an expected call of RequestNoPrefetch
-func (mr *MockBlockRetrieverMockRecorder) RequestNoPrefetch(ctx, priority, kmd, ptr, block, lifetime interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestNoPrefetch", reflect.TypeOf((*MockBlockRetriever)(nil).RequestNoPrefetch), ctx, priority, kmd, ptr, block, lifetime)
-}
-
-// RequestAndSync mocks base method
-func (m *MockBlockRetriever) RequestAndSync(ctx context.Context, priority int, kmd KeyMetadata, ptr BlockPointer, block Block, lifetime BlockCacheLifetime) <-chan error {
-	ret := m.ctrl.Call(m, "RequestAndSync", ctx, priority, kmd, ptr, block, lifetime)
-	ret0, _ := ret[0].(<-chan error)
-	return ret0
-}
-
-// RequestAndSync indicates an expected call of RequestAndSync
-func (mr *MockBlockRetrieverMockRecorder) RequestAndSync(ctx, priority, kmd, ptr, block, lifetime interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestAndSync", reflect.TypeOf((*MockBlockRetriever)(nil).RequestAndSync), ctx, priority, kmd, ptr, block, lifetime)
+func (mr *MockBlockRetrieverMockRecorder) Request(ctx, priority, kmd, ptr, block, lifetime, action interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Request", reflect.TypeOf((*MockBlockRetriever)(nil).Request), ctx, priority, kmd, ptr, block, lifetime, action)
 }
 
 // PutInCaches mocks base method

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -293,9 +293,6 @@ top:
 // high priority for a synced TLF.
 func (p *blockPrefetcher) calculatePriority(
 	basePriority int, action BlockRequestAction) int {
-	if action.DeepSync() {
-		return basePriority
-	}
 	return basePriority - 1
 }
 

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -397,7 +397,8 @@ func (p *blockPrefetcher) prefetchDirectDirBlock(
 				"unknown type %d", entry.Type)
 			continue
 		}
-		p.log.CDebugf(ctx, "Prefetching %v, action=%d", entry.BlockPointer, action)
+		p.log.CDebugf(ctx,
+			"Prefetching %v, action=%s", entry.BlockPointer, action)
 		totalChildEntries++
 		numBlocks += p.request(ctx, newPriority, kmd, entry.BlockPointer,
 			block, lifetime, parentBlockID, isPrefetchNew, action)

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -527,7 +527,7 @@ func testPrefetcherForSyncedTLF(
 	var block Block = &DirBlock{}
 	action := BlockRequestWithPrefetch
 	if explicitSync {
-		action = BlockRequestWithSyncAndPrefetch
+		action = BlockRequestWithDeepSync
 	}
 	ch := q.Request(
 		context.Background(), defaultOnDemandRequestPriority, kmd, rootPtr,


### PR DESCRIPTION
Introduce new action types to avoid overloading the queuing priority to be a prefetching indicator.  Now there are action types for the different combinations of:

* Prefetching.
* Writing blocks to the sync cache.
* Tail-prefetching
  * That is, blocks that are tracked by the prefetcher, but do
    not themselves trigger prefetches.

This will also be useful for partial prefetching, when we will need to fetch and sync parent blocks of partially-synced paths, without triggering a full deep-sync prefetch from those parents.

Suggested by jzila.

Issue: KBFS-3523
Issue: #1925 