### PR TITLE
Fix offline mode when mdserver is disconnected

### DIFF
--- a/kbfsfuse/kbfsfuse.sh
+++ b/kbfsfuse/kbfsfuse.sh
@@ -26,12 +26,13 @@ fi
 git config --global user.email "you@example.com"
 git config --global user.name "Your Name"
 
+# Journaling is turned off by default for all tests, since some tests
+# depend on sync semantics.
+journalFlag="-enable-journal=${KBFS_JOURNAL_ENABLE:-false}"
+
 keybase -debug service &
 SERVICE=$!
-# Journaling is turned off for all tests until we change the tests to
-# turn it on/off when needed, since some tests depend on sync
-# semantics.
-KEYBASE_DEBUG=1 kbfsfuse -debug -disk-cache-mode=local -enable-journal=false -mdserver $MDSERVER_ADDR -bserver $BSERVER_ADDR -localuser= -md-version $KBFS_METADATA_VERSION -log-to-file /keybase &
+KEYBASE_DEBUG=1 kbfsfuse -debug -disk-cache-mode=local "$journalFlag" -mdserver $MDSERVER_ADDR -bserver $BSERVER_ADDR -localuser= -md-version $KBFS_METADATA_VERSION -log-to-file /keybase &
 KBFS=$!
 
 wait "$SERVICE"

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6118,10 +6118,8 @@ func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 		return err
 	}
 
-	services, _ := fbo.serviceStatus.CurrentStatus()
-	if len(services) > 0 {
-		fbo.log.CDebugf(ctx, "Not fetching new updates while offline; "+
-			"failing services=%v", services)
+	if !fbo.config.MDServer().IsConnected() {
+		fbo.log.CDebugf(ctx, "Not fetching new updates while offline")
 		return nil
 	}
 
@@ -6195,7 +6193,6 @@ func (fbo *folderBranchOps) SyncFromServer(ctx context.Context,
 	if err := fbo.fbm.waitForSyncCacheCleans(ctx); err != nil {
 		return err
 	}
-
 	// A second journal flush if needed, to clear out any
 	// archive/remove calls caused by the above operations.
 	return WaitForTLFJournal(ctx, fbo.config, fbo.id(), fbo.log)

--- a/libkbfs/journal_md_ops.go
+++ b/libkbfs/journal_md_ops.go
@@ -257,6 +257,12 @@ func (j journalMDOps) getForTLF(ctx context.Context, id tlf.ID, bid kbfsmd.Branc
 		return irmd, nil
 	}
 
+	if mStatus == kbfsmd.Unmerged {
+		// Journal users always store their unmerged heads locally, so
+		// no need to check with the server.
+		return ImmutableRootMetadata{}, nil
+	}
+
 	// Otherwise, consult the server instead.
 	return delegateFn(ctx, id, lockBeforeGet)
 }


### PR DESCRIPTION
Three things here:
1. Allow kbfsdocker tests to turn on journaling via an environment variable, because...
2. When journaling is turned on, we can skip checking the mdserver for unmerged MDs (and we don't/can't cache the absence of these, so otherwise it blocks TLF access if the mdserver if offline)
3. Use a simpler mdserver connectivity check in `SyncFromServer` to avoid extra checks while offline, because the "services" map takes much longer to be updated.

With these changes, the mdserver offline test now passes.

Issue: KBFS-3622