### PR TITLE
prefetcher: handle de-duplicated blocks

### DIFF
--- a/libkbfs/block_retrieval_queue.go
+++ b/libkbfs/block_retrieval_queue.go
@@ -304,7 +304,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	case <-brq.doneCh:
 		ch <- io.EOF
 		if action.PrefetchTracked() {
-			brq.Prefetcher().CancelPrefetch(ptr.ID)
+			brq.Prefetcher().CancelPrefetch(ptr)
 		}
 		return ch
 	default:
@@ -312,7 +312,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	if block == nil {
 		ch <- errors.New("nil block passed to blockRetrievalQueue.Request")
 		if action.PrefetchTracked() {
-			brq.Prefetcher().CancelPrefetch(ptr.ID)
+			brq.Prefetcher().CancelPrefetch(ptr)
 		}
 		return ch
 	}
@@ -331,7 +331,7 @@ func (brq *blockRetrievalQueue) request(ctx context.Context,
 	err = checkDataVersion(brq.config, path{}, ptr)
 	if err != nil {
 		if action.PrefetchTracked() {
-			brq.Prefetcher().CancelPrefetch(ptr.ID)
+			brq.Prefetcher().CancelPrefetch(ptr)
 		}
 		ch <- err
 		return ch
@@ -459,7 +459,7 @@ func (brq *blockRetrievalQueue) FinalizeRequest(
 				retrieval.blockPtr, block, retrieval.kmd, retrieval.priority,
 				retrieval.cacheLifetime, NoPrefetch, retrieval.action)
 		} else {
-			brq.Prefetcher().CancelPrefetch(retrieval.blockPtr.ID)
+			brq.Prefetcher().CancelPrefetch(retrieval.blockPtr)
 		}
 	}
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -3369,7 +3369,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 			lifetime, BlockRequestWithPrefetch)
 	}
 	// Cancel any prefetches for the old pointer from the prefetcher.
-	fbo.config.BlockOps().Prefetcher().CancelPrefetch(oldPtr.ID)
+	fbo.config.BlockOps().Prefetcher().CancelPrefetch(oldPtr)
 	return updatedNode
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1100,7 +1100,7 @@ func (fbo *folderBranchOps) commitFlushedMD(
 		case <-waitCh:
 		case <-updatedCh:
 			fbo.log.CDebugf(ctx, "The latest merged rev has been updated")
-			fbo.config.BlockOps().Prefetcher().CancelPrefetch(rootPtr.ID)
+			fbo.config.BlockOps().Prefetcher().CancelPrefetch(rootPtr)
 			return
 		case <-fbo.shutdownChan:
 			fbo.log.CDebugf(ctx, "Shutdown, canceling prefetch wait")
@@ -5501,7 +5501,7 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 
 	// Cancel any block prefetches for unreferenced blocks.
 	for _, ptr := range op.Unrefs() {
-		fbo.config.BlockOps().Prefetcher().CancelPrefetch(ptr.ID)
+		fbo.config.BlockOps().Prefetcher().CancelPrefetch(ptr)
 	}
 
 	var changes []NodeChange

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1646,7 +1646,7 @@ type Prefetcher interface {
 		<-chan struct{}, error)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be
 	// canceled.
-	CancelPrefetch(kbfsblock.ID)
+	CancelPrefetch(BlockPointer)
 	// Shutdown shuts down the prefetcher idempotently. Future calls to
 	// the various Prefetch* methods will return io.EOF. The returned channel
 	// allows upstream components to block until all pending prefetches are

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5623,7 +5623,7 @@ func (mr *MockPrefetcherMockRecorder) WaitChannelForBlockPrefetch(ctx, ptr inter
 }
 
 // CancelPrefetch mocks base method
-func (m *MockPrefetcher) CancelPrefetch(arg0 kbfsblock.ID) {
+func (m *MockPrefetcher) CancelPrefetch(arg0 BlockPointer) {
 	m.ctrl.Call(m, "CancelPrefetch", arg0)
 }
 

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -198,6 +198,9 @@ func (p *blockPrefetcher) applyToPtrParentsRecursive(
 		}
 		p.applyToPtrParentsRecursive(f, pptr, parent)
 	}
+	if len(pre.parents[ptr.RefNonce]) == 0 {
+		delete(pre.parents, ptr.RefNonce)
+	}
 	f(ptr, pre)
 }
 


### PR DESCRIPTION
This fixes two issues when using the prefetcher with TLFs that contain deduplicated blocks (i.e., they were written by a client that didn't have journaling enabled):

1. If one directory contains multiple references to the same block ID, the block ID will only be prefetched once, but the parent block's count will be incremented multiple times, leading to a situation where the prefetch of the parent never seems finished.  This PR addresses that by tracking the unique IDs seen in each parent block and only incrementing the count once for each unique ID.

2. If one reference of an ID gets archived, its prefetch is canceled by `folderBlockOps`.  However, there could be a different reference that's still live and part of a valid prefetch tree, with a different set of parents.  That other prefetch tree should NOT be canceled.  This PR addresses that by separately tracking each unique reference's parents, by `BlockPointer`, and only canceling the parents of the specific reference that was canceled.

The PR includes some regression tests for these, although #1945 also causes the second behavior to fail tests without these changes.

Issue: KBFS-3657