### PR TITLE
Address a few nits related to enabling sync

### DIFF
--- a/libfs/sync_control_file.go
+++ b/libfs/sync_control_file.go
@@ -42,6 +42,12 @@ func (a SyncAction) Execute(
 		panic("zero fb in SyncAction.Execute")
 	}
 
+	// Ensure the TLF is initialized by getting the root node first.
+	_, _, err = c.KBFSOps().GetRootNode(ctx, h, libkbfs.MasterBranch)
+	if err != nil {
+		return err
+	}
+
 	switch a {
 	case SyncEnable:
 		_, err = c.KBFSOps().SetSyncConfig(

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -7611,7 +7611,16 @@ func (fbo *folderBranchOps) SetSyncConfig(
 		newConfig.Paths = paths
 	}
 
-	return fbo.config.SetTlfSyncState(tlfID, newConfig)
+	ch, err := fbo.config.SetTlfSyncState(tlfID, newConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if config.Mode == keybase1.FolderSyncMode_ENABLED {
+		fbo.log.CDebugf(ctx, "Starting full deep sync")
+		_ = fbo.kickOffRootBlockFetch(ctx, md)
+	}
+	return ch, nil
 }
 
 // InvalidateNodeAndChildren implements the KBFSOps interface for

--- a/simplefs/simplefs.go
+++ b/simplefs/simplefs.go
@@ -1996,6 +1996,13 @@ func (k *SimpleFS) getSyncConfig(ctx context.Context, path keybase1.Path) (
 		return tlf.NullID, keybase1.FolderSyncConfig{}, err
 	}
 
+	// Ensure the TLF is initialized by getting the root node first.
+	_, _, err = k.config.KBFSOps().GetRootNode(
+		ctx, tlfHandle, libkbfs.MasterBranch)
+	if err != nil {
+		return tlf.NullID, keybase1.FolderSyncConfig{}, err
+	}
+
 	config = keybase1.FolderSyncConfig{Mode: keybase1.FolderSyncMode_DISABLED}
 	if k.config.IsSyncedTlf(tlfHandle.TlfID()) {
 		config.Mode = keybase1.FolderSyncMode_ENABLED


### PR DESCRIPTION
* folder_branch_ops: kick off a full sync when syncing is enabled
* libfs and simplefs: make sure a TLF is initialized before changing sync config
  * This is required now that we moved it into the FBO instance.