### PR TITLE
kbfs_ops: initialize syncing TLFs on startup

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1664,6 +1664,19 @@ func (c *ConfigLocal) SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 	return ch, err
 }
 
+// GetAllSyncedTlfs implements the Config interface for ConfigLocal.
+func (c *ConfigLocal) GetAllSyncedTlfs() []tlf.ID {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	tlfs := make([]tlf.ID, 0, len(c.syncedTlfs))
+	for tlf, config := range c.syncedTlfs {
+		if config.Mode != keybase1.FolderSyncMode_DISABLED {
+			tlfs = append(tlfs, tlf)
+		}
+	}
+	return tlfs
+}
+
 // PrefetchStatus implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 	ptr BlockPointer) PrefetchStatus {

--- a/libkbfs/interface_test.go
+++ b/libkbfs/interface_test.go
@@ -82,6 +82,14 @@ func (t *testSyncedTlfGetterSetter) SetTlfSyncState(tlfID tlf.ID,
 	return nil, nil
 }
 
+func (t *testSyncedTlfGetterSetter) GetAllSyncedTlfs() []tlf.ID {
+	tlfs := make([]tlf.ID, 0, len(t.syncedTlfs))
+	for tlf := range t.syncedTlfs {
+		tlfs = append(tlfs, tlf)
+	}
+	return tlfs
+}
+
 type testInitModeGetter struct {
 	mode InitModeType
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -117,6 +117,7 @@ type syncedTlfGetterSetter interface {
 	IsSyncedTlf(tlfID tlf.ID) bool
 	GetTlfSyncState(tlfID tlf.ID) FolderSyncConfig
 	SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-chan error, error)
+	GetAllSyncedTlfs() []tlf.ID
 }
 
 type blockRetrieverGetter interface {

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -861,6 +861,18 @@ func (mr *MocksyncedTlfGetterSetterMockRecorder) SetTlfSyncState(tlfID, config i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).SetTlfSyncState), tlfID, config)
 }
 
+// GetAllSyncedTlfs mocks base method
+func (m *MocksyncedTlfGetterSetter) GetAllSyncedTlfs() []tlf.ID {
+	ret := m.ctrl.Call(m, "GetAllSyncedTlfs")
+	ret0, _ := ret[0].([]tlf.ID)
+	return ret0
+}
+
+// GetAllSyncedTlfs indicates an expected call of GetAllSyncedTlfs
+func (mr *MocksyncedTlfGetterSetterMockRecorder) GetAllSyncedTlfs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSyncedTlfs", reflect.TypeOf((*MocksyncedTlfGetterSetter)(nil).GetAllSyncedTlfs))
+}
+
 // MockblockRetrieverGetter is a mock of blockRetrieverGetter interface
 type MockblockRetrieverGetter struct {
 	ctrl     *gomock.Controller
@@ -7994,6 +8006,18 @@ func (m *MockConfig) SetTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (<-c
 // SetTlfSyncState indicates an expected call of SetTlfSyncState
 func (mr *MockConfigMockRecorder) SetTlfSyncState(tlfID, config interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTlfSyncState", reflect.TypeOf((*MockConfig)(nil).SetTlfSyncState), tlfID, config)
+}
+
+// GetAllSyncedTlfs mocks base method
+func (m *MockConfig) GetAllSyncedTlfs() []tlf.ID {
+	ret := m.ctrl.Call(m, "GetAllSyncedTlfs")
+	ret0, _ := ret[0].([]tlf.ID)
+	return ret0
+}
+
+// GetAllSyncedTlfs indicates an expected call of GetAllSyncedTlfs
+func (mr *MockConfigMockRecorder) GetAllSyncedTlfs() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSyncedTlfs", reflect.TypeOf((*MockConfig)(nil).GetAllSyncedTlfs))
 }
 
 // Mode mocks base method


### PR DESCRIPTION
To make sure the user has the latest data ready and synced before they look at the folder.

Issue: KBFS-3525
