### PR TITLE
disk_block_cache: refactor interface to use cache types more

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1644,7 +1644,8 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 		diskBlockCache := c.diskBlockCache
 		go func() {
 			defer cancel()
-			ch <- diskBlockCache.ClearAllTlfBlocks(ctx, tlfID)
+			ch <- diskBlockCache.ClearAllTlfBlocks(
+				ctx, tlfID, DiskBlockSyncCache)
 		}()
 	} else {
 		ch <- nil

--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -129,21 +129,23 @@ func (dbcr *DiskBlockCacheRemote) UpdateMetadata(ctx context.Context,
 // ClearAllTlfBlocks implements the DiskBlockCache interface for
 // DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) ClearAllTlfBlocks(
-	_ context.Context, _ tlf.ID) error {
+	_ context.Context, _ tlf.ID, _ DiskBlockCacheType) error {
 	panic("ClearAllTlfBlocks() not implemented in DiskBlockCacheRemote")
 }
 
 // GetLastUnrefRev implements the DiskBlockCache interface for
 // DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) GetLastUnrefRev(
-	_ context.Context, _ tlf.ID) (kbfsmd.Revision, error) {
+	_ context.Context, _ tlf.ID, _ DiskBlockCacheType) (
+	kbfsmd.Revision, error) {
 	panic("GetLastUnrefRev() not implemented in DiskBlockCacheRemote")
 }
 
 // PutLastUnrefRev implements the DiskBlockCache interface for
 // DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) PutLastUnrefRev(
-	_ context.Context, _ tlf.ID, _ kbfsmd.Revision) error {
+	_ context.Context, _ tlf.ID, _ kbfsmd.Revision,
+	_ DiskBlockCacheType) error {
 	panic("PutLastUnrefRev() not implemented in DiskBlockCacheRemote")
 }
 
@@ -154,10 +156,10 @@ func (dbcr *DiskBlockCacheRemote) Status(ctx context.Context) map[string]DiskBlo
 	panic("Status() not implemented in DiskBlockCacheRemote")
 }
 
-// DoesSyncCacheHaveSpace implements the DiskBlockCache interface for
+// DoesCacheHaveSpace implements the DiskBlockCache interface for
 // DiskBlockCacheRemote.
-func (dbcr *DiskBlockCacheRemote) DoesSyncCacheHaveSpace(
-	_ context.Context) bool {
+func (dbcr *DiskBlockCacheRemote) DoesCacheHaveSpace(
+	_ context.Context, _ DiskBlockCacheType) (bool, error) {
 	panic("DoesSyncCacheHaveSpace() not implemented in DiskBlockCacheRemote")
 }
 

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -1324,7 +1324,7 @@ func (fbm *folderBlockManager) doCleanSyncCache() (err error) {
 	lState := makeFBOLockState()
 	recentRev := fbm.helper.getLatestMergedRevision(lState)
 
-	lastRev, err := dbc.GetLastUnrefRev(ctx, fbm.id)
+	lastRev, err := dbc.GetLastUnrefRev(ctx, fbm.id, DiskBlockSyncCache)
 	if err != nil {
 		return err
 	}
@@ -1345,7 +1345,8 @@ func (fbm *folderBlockManager) doCleanSyncCache() (err error) {
 			lastRev = recentRev - 1
 		} else {
 			// No revisions to clean yet.
-			return dbc.PutLastUnrefRev(ctx, fbm.id, recentRev)
+			return dbc.PutLastUnrefRev(
+				ctx, fbm.id, recentRev, DiskBlockSyncCache)
 		}
 	}
 
@@ -1377,7 +1378,7 @@ func (fbm *folderBlockManager) doCleanSyncCache() (err error) {
 			return err
 		}
 
-		err = dbc.PutLastUnrefRev(ctx, fbm.id, nextRev)
+		err = dbc.PutLastUnrefRev(ctx, fbm.id, nextRev, DiskBlockSyncCache)
 		if err != nil {
 			return err
 		}

--- a/libkbfs/folder_block_manager_test.go
+++ b/libkbfs/folder_block_manager_test.go
@@ -884,7 +884,8 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps.SyncAll(ctx, rootNode.GetFolderBranch())
 	require.NoError(t, err)
-	lastRev, err := dbc.GetLastUnrefRev(ctx, rootNode.GetFolderBranch().Tlf)
+	lastRev, err := dbc.GetLastUnrefRev(
+		ctx, rootNode.GetFolderBranch().Tlf, DiskBlockSyncCache)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.RevisionUninitialized, lastRev)
 
@@ -900,7 +901,8 @@ func TestFolderBlockManagerCleanSyncCache(t *testing.T) {
 	require.NoError(t, err)
 	err = kbfsOps.SyncFromServer(ctx, rootNode.GetFolderBranch(), nil)
 	require.NoError(t, err)
-	lastRev, err = dbc.GetLastUnrefRev(ctx, rootNode.GetFolderBranch().Tlf)
+	lastRev, err = dbc.GetLastUnrefRev(
+		ctx, rootNode.GetFolderBranch().Tlf, DiskBlockSyncCache)
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.Revision(4), lastRev)
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1298,20 +1298,24 @@ type DiskBlockCache interface {
 	// ClearAllTlfBlocks deletes all the synced blocks corresponding
 	// to the given TLF ID from the cache.  It doesn't affect
 	// transient blocks for unsynced TLFs.
-	ClearAllTlfBlocks(ctx context.Context, tlfID tlf.ID) error
+	ClearAllTlfBlocks(
+		ctx context.Context, tlfID tlf.ID, cacheType DiskBlockCacheType) error
 	// GetLastUnrefRev returns the last revision that has been marked
 	// unref'd for the given TLF.
-	GetLastUnrefRev(ctx context.Context, tlfID tlf.ID) (kbfsmd.Revision, error)
+	GetLastUnrefRev(
+		ctx context.Context, tlfID tlf.ID, cacheType DiskBlockCacheType) (
+		kbfsmd.Revision, error)
 	// PutLastUnrefRev saves the given revision as the last unref'd
 	// revision for the given TLF.
 	PutLastUnrefRev(
-		ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error
+		ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision,
+		cacheType DiskBlockCacheType) error
 	// Status returns the current status of the disk cache.
 	Status(ctx context.Context) map[string]DiskBlockCacheStatus
-	// DoesSyncCacheHaveSpace returns whether the sync cache has
-	// space.  If this cache doesn't contain a sync cache, always returns
-	// true.
-	DoesSyncCacheHaveSpace(ctx context.Context) bool
+	// DoesCacheHaveSpace returns whether the given cache has
+	// space.
+	DoesCacheHaveSpace(
+		ctx context.Context, cacheType DiskBlockCacheType) (bool, error)
 	// Shutdown cleanly shuts down the disk block cache.
 	Shutdown(ctx context.Context)
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4507,40 +4507,40 @@ func (mr *MockDiskBlockCacheMockRecorder) UpdateMetadata(ctx, blockID, prefetchS
 }
 
 // ClearAllTlfBlocks mocks base method
-func (m *MockDiskBlockCache) ClearAllTlfBlocks(ctx context.Context, tlfID tlf.ID) error {
-	ret := m.ctrl.Call(m, "ClearAllTlfBlocks", ctx, tlfID)
+func (m *MockDiskBlockCache) ClearAllTlfBlocks(ctx context.Context, tlfID tlf.ID, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "ClearAllTlfBlocks", ctx, tlfID, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ClearAllTlfBlocks indicates an expected call of ClearAllTlfBlocks
-func (mr *MockDiskBlockCacheMockRecorder) ClearAllTlfBlocks(ctx, tlfID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAllTlfBlocks", reflect.TypeOf((*MockDiskBlockCache)(nil).ClearAllTlfBlocks), ctx, tlfID)
+func (mr *MockDiskBlockCacheMockRecorder) ClearAllTlfBlocks(ctx, tlfID, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAllTlfBlocks", reflect.TypeOf((*MockDiskBlockCache)(nil).ClearAllTlfBlocks), ctx, tlfID, cacheType)
 }
 
 // GetLastUnrefRev mocks base method
-func (m *MockDiskBlockCache) GetLastUnrefRev(ctx context.Context, tlfID tlf.ID) (kbfsmd.Revision, error) {
-	ret := m.ctrl.Call(m, "GetLastUnrefRev", ctx, tlfID)
+func (m *MockDiskBlockCache) GetLastUnrefRev(ctx context.Context, tlfID tlf.ID, cacheType DiskBlockCacheType) (kbfsmd.Revision, error) {
+	ret := m.ctrl.Call(m, "GetLastUnrefRev", ctx, tlfID, cacheType)
 	ret0, _ := ret[0].(kbfsmd.Revision)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetLastUnrefRev indicates an expected call of GetLastUnrefRev
-func (mr *MockDiskBlockCacheMockRecorder) GetLastUnrefRev(ctx, tlfID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastUnrefRev", reflect.TypeOf((*MockDiskBlockCache)(nil).GetLastUnrefRev), ctx, tlfID)
+func (mr *MockDiskBlockCacheMockRecorder) GetLastUnrefRev(ctx, tlfID, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastUnrefRev", reflect.TypeOf((*MockDiskBlockCache)(nil).GetLastUnrefRev), ctx, tlfID, cacheType)
 }
 
 // PutLastUnrefRev mocks base method
-func (m *MockDiskBlockCache) PutLastUnrefRev(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision) error {
-	ret := m.ctrl.Call(m, "PutLastUnrefRev", ctx, tlfID, rev)
+func (m *MockDiskBlockCache) PutLastUnrefRev(ctx context.Context, tlfID tlf.ID, rev kbfsmd.Revision, cacheType DiskBlockCacheType) error {
+	ret := m.ctrl.Call(m, "PutLastUnrefRev", ctx, tlfID, rev, cacheType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutLastUnrefRev indicates an expected call of PutLastUnrefRev
-func (mr *MockDiskBlockCacheMockRecorder) PutLastUnrefRev(ctx, tlfID, rev interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLastUnrefRev", reflect.TypeOf((*MockDiskBlockCache)(nil).PutLastUnrefRev), ctx, tlfID, rev)
+func (mr *MockDiskBlockCacheMockRecorder) PutLastUnrefRev(ctx, tlfID, rev, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutLastUnrefRev", reflect.TypeOf((*MockDiskBlockCache)(nil).PutLastUnrefRev), ctx, tlfID, rev, cacheType)
 }
 
 // Status mocks base method
@@ -4555,16 +4555,17 @@ func (mr *MockDiskBlockCacheMockRecorder) Status(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockDiskBlockCache)(nil).Status), ctx)
 }
 
-// DoesSyncCacheHaveSpace mocks base method
-func (m *MockDiskBlockCache) DoesSyncCacheHaveSpace(ctx context.Context) bool {
-	ret := m.ctrl.Call(m, "DoesSyncCacheHaveSpace", ctx)
+// DoesCacheHaveSpace mocks base method
+func (m *MockDiskBlockCache) DoesCacheHaveSpace(ctx context.Context, cacheType DiskBlockCacheType) (bool, error) {
+	ret := m.ctrl.Call(m, "DoesCacheHaveSpace", ctx, cacheType)
 	ret0, _ := ret[0].(bool)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// DoesSyncCacheHaveSpace indicates an expected call of DoesSyncCacheHaveSpace
-func (mr *MockDiskBlockCacheMockRecorder) DoesSyncCacheHaveSpace(ctx interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesSyncCacheHaveSpace", reflect.TypeOf((*MockDiskBlockCache)(nil).DoesSyncCacheHaveSpace), ctx)
+// DoesCacheHaveSpace indicates an expected call of DoesCacheHaveSpace
+func (mr *MockDiskBlockCacheMockRecorder) DoesCacheHaveSpace(ctx, cacheType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoesCacheHaveSpace", reflect.TypeOf((*MockDiskBlockCache)(nil).DoesCacheHaveSpace), ctx, cacheType)
 }
 
 // Shutdown mocks base method

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -498,7 +498,12 @@ func (p *blockPrefetcher) rescheduleIfNeeded(
 	ctx context.Context, req *prefetchRequest) (rescheduled bool) {
 	dbc := p.config.DiskBlockCache()
 	if req.action.Sync() && dbc != nil {
-		if !dbc.DoesSyncCacheHaveSpace(ctx) {
+		hasRoom, err := dbc.DoesCacheHaveSpace(ctx, DiskBlockSyncCache)
+		if err != nil {
+			p.log.CDebugf(ctx, "Error checking space: +%v", err)
+			return false
+		}
+		if !hasRoom {
 			// If the sync cache is close to full, reschedule the prefetch.
 			p.log.CDebugf(ctx, "rescheduling prefetch for block %s due to "+
 				"full sync cache.", req.ptr.ID)


### PR DESCRIPTION
And remove cache types from `DiskBlockCacheLocal`, which doesn't need to implement the main interface.

This will be useful in future PRs when tracking last-unref'd revision in the working set cache, and checking for space in the working set cache.

Issue: KBFS-3525
Issue: KBFS-3527