### PR TITLE
prefetcher: fix memory leak and possible hang when skipping fetch

### DIFF
--- a/libdokan/mount_test.go
+++ b/libdokan/mount_test.go
@@ -3109,6 +3109,14 @@ func TestKbfsFileInfo(t *testing.T) {
 	defer mnt2.Close()
 	defer cancelFn2()
 
+	// Turn off the prefetcher to avoid races when reading the file info file.
+	ch := config2.BlockOps().TogglePrefetcher(false)
+	select {
+	case <-ch:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
 	mydir1 := filepath.Join(mnt1.Dir, PrivateName, "user1,user2", "mydir")
 	if err := ioutil.Mkdir(mydir1, 0755); err != nil {
 		t.Fatal(err)

--- a/libfuse/mount_test.go
+++ b/libfuse/mount_test.go
@@ -3829,6 +3829,14 @@ func TestKbfsFileInfo(t *testing.T) {
 	defer cancelFn2()
 	defer libkbfs.CheckConfigAndShutdown(ctx, t, config2)
 
+	// Turn off the prefetcher to avoid races when reading the file info file.
+	ch := config2.BlockOps().TogglePrefetcher(false)
+	select {
+	case <-ch:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+
 	mydir1 := path.Join(mnt1.Dir, PrivateName, "user1,user2", "mydir")
 	if err := ioutil.Mkdir(mydir1, 0755); err != nil {
 		t.Fatal(err)

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -158,6 +158,11 @@ func (cb *CommonBlock) IsIndirect() bool {
 	return cb.IsInd
 }
 
+// IsTail implements the Block interface for CommonBlock.
+func (cb *CommonBlock) IsTail() bool {
+	panic("CommonBlock doesn't know how to compute IsTail")
+}
+
 // OffsetExceedsData implements the Block interface for CommonBlock.
 func (cb *CommonBlock) OffsetExceedsData(_, _ Offset) bool {
 	panic("CommonBlock doesn't implement data methods")
@@ -219,6 +224,20 @@ func NewDirBlockWithPtrs(isInd bool) BlockWithPtrs {
 // NewEmpty implements the Block interface for DirBlock
 func (db *DirBlock) NewEmpty() Block {
 	return NewDirBlock()
+}
+
+// IsTail implements the Block interface for DirBlock.
+func (db *DirBlock) IsTail() bool {
+	if db.IsInd {
+		return len(db.IPtrs) == 0
+	}
+	syms := 0
+	for _, de := range db.Children {
+		if de.Type == Sym {
+			syms++
+		}
+	}
+	return syms == len(db.Children)
 }
 
 // DataVersion returns data version for this block, which is assumed
@@ -429,6 +448,14 @@ func NewFileBlockWithPtrs(isInd bool) BlockWithPtrs {
 // NewEmpty implements the Block interface for FileBlock
 func (fb *FileBlock) NewEmpty() Block {
 	return &FileBlock{}
+}
+
+// IsTail implements the Block interface for FileBlock.
+func (fb *FileBlock) IsTail() bool {
+	if fb.IsInd {
+		return len(fb.IPtrs) == 0
+	}
+	return true
 }
 
 // DataVersion returns data version for this block, which is assumed

--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -231,13 +231,12 @@ func (db *DirBlock) IsTail() bool {
 	if db.IsInd {
 		return len(db.IPtrs) == 0
 	}
-	syms := 0
 	for _, de := range db.Children {
-		if de.Type == Sym {
-			syms++
+		if de.Type != Sym {
+			return false
 		}
 	}
-	return syms == len(db.Children)
+	return true
 }
 
 // DataVersion returns data version for this block, which is assumed

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -107,6 +107,10 @@ func (tb *TestBlock) IsIndirect() bool {
 	return false
 }
 
+func (tb *TestBlock) IsTail() bool {
+	return true
+}
+
 func (tb TestBlock) OffsetExceedsData(_, _ Offset) bool {
 	return false
 }
@@ -403,6 +407,10 @@ func (tba *testBlockArray) Set(other Block) {
 
 func (tba testBlockArray) IsIndirect() bool {
 	return false
+}
+
+func (tba *testBlockArray) IsTail() bool {
+	return true
 }
 
 func (tba testBlockArray) OffsetExceedsData(_, _ Offset) bool {

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -751,10 +751,10 @@ func TestDiskBlockCacheMoveBlock(t *testing.T) {
 	require.Equal(t, 1, cache.syncCache.numBlocks)
 	require.Equal(t, 0, cache.workingSetCache.numBlocks)
 
-	t.Log("After the move, make sure the prefetch status is right.")
+	t.Log("After the move, make sure the prefetch status is reset.")
 	_, _, prefetchStatus, err := cache.Get(
 		ctx, tlf1, block1Ptr.ID, DiskBlockAnyCache)
 	require.NoError(t, err)
 	require.Equal(t, 1, cache.syncCache.numBlocks)
-	require.Equal(t, TriggeredPrefetch, prefetchStatus)
+	require.Equal(t, NoPrefetch, prefetchStatus)
 }

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -161,11 +161,14 @@ func (cache *diskBlockCacheWrapped) Get(
 				// The cache will log the non-fatal error, so just return nil.
 				return buf, serverHalf, prefetchStatus, nil
 			}
-			err = primaryCache.UpdateMetadata(ctx, blockID, prefetchStatus)
-			if err != nil {
-				// The cache will log the non-fatal error, so just return nil.
-				return buf, serverHalf, prefetchStatus, nil
-			}
+			// Note that we're not updating the metadata in the
+			// primary cache, because that metadata needs to reflect
+			// the status of the block with respect to this cache.
+			// That is, if it was FinishedPrefetch, that means all
+			// child blocks must be in THIS cache, which might not be
+			// the case.
+			prefetchStatus = NoPrefetch
+
 			// Remove the block from the non-preferred cache (which is
 			// set to be the secondary cache at this point).
 			cache.deleteGroup.Add(1)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -471,23 +471,6 @@ func (fbo *folderBlockOps) getFileBlockHelperLocked(ctx context.Context,
 	return fblock, nil
 }
 
-// GetBlockForReading retrieves the block pointed to by ptr, which
-// must be valid, either from the cache or from the server.  The
-// returned block may have a generic type (not DirBlock or FileBlock).
-//
-// This should be called for "internal" operations, like conflict
-// resolution and state checking, which don't know what kind of block
-// the pointer refers to.  The block will not be cached, if it wasn't
-// in the cache already.
-func (fbo *folderBlockOps) GetBlockForReading(ctx context.Context,
-	lState *lockState, kmd KeyMetadata, ptr BlockPointer, branch BranchName) (
-	Block, error) {
-	fbo.blockLock.RLock(lState)
-	defer fbo.blockLock.RUnlock(lState)
-	return fbo.getBlockHelperLocked(ctx, lState, kmd, ptr, branch,
-		NewCommonBlock, NoCacheEntry, path{}, blockRead)
-}
-
 // GetCleanEncodedBlocksSizeSum retrieves the sum of the encoded sizes
 // of the blocks pointed to by ptrs, all of which must be valid,
 // either from the cache or from the server.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1657,7 +1657,7 @@ type Prefetcher interface {
 	// the block isn't currently being prefetched, it will return an
 	// already-closed channel.  When the channel is closed, the caller
 	// should still verify that the prefetch status of the block is
-	// `FinishedPrefetch`, in case there was an error.
+	// what they expect it to be, in case there was an error.
 	WaitChannelForBlockPrefetch(ctx context.Context, ptr BlockPointer) (
 		<-chan struct{}, error)
 	// CancelPrefetch notifies the prefetcher that a prefetch should be

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -148,6 +148,9 @@ type Block interface {
 	ToCommonBlock() *CommonBlock
 	// IsIndirect indicates whether this block contains indirect pointers.
 	IsIndirect() bool
+	// IsTail returns true if this block doesn't point to any other
+	// blocks, either indirectly or in child directory entries.
+	IsTail() bool
 	// OffsetExceedsData returns true if `off` is greater than the
 	// data contained in a direct block, assuming it starts at
 	// `startOff`.  Note that the offset of the next block isn't

--- a/libkbfs/kbfs_ops_test.go
+++ b/libkbfs/kbfs_ops_test.go
@@ -179,7 +179,7 @@ func kbfsTestShutdown(mockCtrl *gomock.Controller, config *ConfigMock,
 	if err := CleanupCancellationDelayer(ctx); err != nil {
 		panic(err)
 	}
-	<-config.mockBops.Prefetcher().Shutdown()
+	config.mockBops.Prefetcher().Shutdown()
 	mockCtrl.Finish()
 }
 

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1132,6 +1132,20 @@ func (mr *MockBlockMockRecorder) IsIndirect() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIndirect", reflect.TypeOf((*MockBlock)(nil).IsIndirect))
 }
 
+// IsTail mocks base method
+func (m *MockBlock) IsTail() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsTail")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTail indicates an expected call of IsTail
+func (mr *MockBlockMockRecorder) IsTail() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTail", reflect.TypeOf((*MockBlock)(nil).IsTail))
+}
+
 // OffsetExceedsData mocks base method
 func (m *MockBlock) OffsetExceedsData(startOff, off Offset) bool {
 	m.ctrl.T.Helper()
@@ -1275,6 +1289,20 @@ func (m *MockBlockWithPtrs) IsIndirect() bool {
 func (mr *MockBlockWithPtrsMockRecorder) IsIndirect() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIndirect", reflect.TypeOf((*MockBlockWithPtrs)(nil).IsIndirect))
+}
+
+// IsTail mocks base method
+func (m *MockBlockWithPtrs) IsTail() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsTail")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTail indicates an expected call of IsTail
+func (mr *MockBlockWithPtrsMockRecorder) IsTail() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTail", reflect.TypeOf((*MockBlockWithPtrs)(nil).IsTail))
 }
 
 // OffsetExceedsData mocks base method

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -721,7 +721,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 			}
 
 			// If the request is finished (i.e., if it's marked as
-			// finished or if it has no children block to fetch), then
+			// finished or if it has no child blocks to fetch), then
 			// complete the prefetch.
 			if req.prefetchStatus == FinishedPrefetch || b.IsTail() {
 				// First we handle finished prefetches.

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -233,6 +233,8 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 
 	t.Log("Wait for the prefetch to finish.")
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[0].BlockPointer)
+	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[1].BlockPointer)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
@@ -291,6 +293,8 @@ func testPrefetcherIndirectDirBlockTail(
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	rootStatus := NoPrefetch
 	if withSync {
+		waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[0].BlockPointer)
+		waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[1].BlockPointer)
 		rootStatus = TriggeredPrefetch
 		testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
 			indBlock1, NoPrefetch, TransientEntry)
@@ -365,6 +369,8 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	continueChFileA <- context.Canceled
 	t.Log("Wait for the prefetch to finish.")
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
+	waitForPrefetchOrBust(
+		t, ctx, q.Prefetcher(), rootDir.Children["c"].BlockPointer)
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,


### PR DESCRIPTION
Consider this simple scenario:
* Blocks a -> b -> c
* User requests block a, which is fetched with a `BlockRequestWithPrefetch` action.
* Block a is fetched, triggering a prefetch of b with a `BlockRequestPrefetchTail` action.
* When the b request is handled by the main prefetcher loop, it skips further prefetching because the action says it should stop.

That's all correct, but then the prefetch requests for b and a both stay in `p.prefetches` forever!  If a is never requested again, it is never removed from that map, causing a memory leak (including a pointer to the assembled block).

Moreover, if someone has requested the prefetch wait channel for a and is waiting on it, they'll wait forever since it'll never be closed. The correct behavior is for the channel to be closed whenever all scheduled work is complete, even if the status is not supposed to be `FinishedPrefetch`.

So instead, we now make sure to cancel a request that we're skipping, as long as some other previous request is not already prefetching it.

Furthermore, if the block is a tail block, we can mark it as finished right away and complete the prefetch, instead of just skipping it.

This also fixes up some action-propagation issues to make sure that a new, upgraded action always overrides an existing lesser action.

These changes alter the timing of the partial sync test a bit, and so the test is now simplified to only check the statuses of the blocks that should definitely be finished prefetching.

It also simplifies the prefetcher tests by waiting on specific prefetches to finish, rather than waiting for the whole prefetcher to shutdown.

Other changes included here (reviewable in their own commits if desired):
* Remove dead code around `CommonBlock`.
* interfaces: add `Block.IsTail()` method
* disk_block_cache_wrapped: no move prefetch status with block, since the status should be with respect to the new cache.