### PR TITLE
libkbfs: prefetch recently-edited files for non-synced TLFs

### DIFF
--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -1069,13 +1069,20 @@ func (bra BlockRequestAction) DeepSync() bool {
 	return bra == BlockRequestWithDeepSync
 }
 
+// DeepPrefetch returns true if the prefetcher should continue
+// prefetching the children of this block all the way to the leafs of
+// the tree.
+func (bra BlockRequestAction) DeepPrefetch() bool {
+	return bra.DeepSync() || bra == BlockRequestPrefetchUntilFull
+}
+
 // ChildAction returns the action that should propagate down to any
 // children of this block.
 func (bra BlockRequestAction) ChildAction(block Block) BlockRequestAction {
 	// When syncing, always prefetch child blocks of an indirect
 	// block, since it makes no sense to sync just part of a
 	// multi-block object.
-	if bra.DeepSync() || (block.IsIndirect() && bra.Sync()) {
+	if bra.DeepPrefetch() || (block.IsIndirect() && bra.Sync()) {
 		return bra
 	}
 	return bra &^ (blockRequestPrefetch | blockRequestSync)

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -449,14 +449,6 @@ func (cache *DiskBlockCacheLocal) getMetadataLocked(
 		return DiskBlockCacheMetadata{}, err
 	}
 	err = cache.config.Codec().Decode(metadataBytes, &metadata)
-	if cache.cacheType == workingSetCacheLimitTrackerType {
-		// KBFS-2402: a bug in a previous master caused the wrong prefetch
-		// status to be saved in the working set cache.
-		if metadata.FinishedPrefetch == true {
-			metadata.TriggeredPrefetch = true
-		}
-		metadata.FinishedPrefetch = false
-	}
 	return metadata, err
 }
 

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -871,7 +871,7 @@ func (fbo *folderBranchOps) doPartialSync(
 	ctx context.Context, syncConfig keybase1.FolderSyncConfig,
 	latestMerged ImmutableRootMetadata) (err error) {
 	fbo.log.CDebugf(
-		ctx, "Starting partial sync at revision %d", latestMerged.Revision())
+		ctx, "Starting partial sync at revision %d", latestMerged.Revision)
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "Partial sync done: %+v", err)
 	}()
@@ -2207,6 +2207,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 	var latestRootBlockFetch <-chan error
 	partialSyncMD := md
 	lState := makeFBOLockState()
+	var setHead bool
 	if md.IsReadable() && fbo.config.Mode().PrefetchWorkers() > 0 {
 		// We `Get` the root block to ensure downstream prefetches
 		// occur.  Use a fresh context, in case `ctx` is canceled by
@@ -2220,7 +2221,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 		// Kick off partial prefetching once the latest merged
 		// revision is set.
 		defer func() {
-			if err == nil {
+			if setHead && err == nil {
 				fbo.kickOffPartialSyncIfNeeded(ctx, lState, partialSyncMD)
 			}
 		}()
@@ -2293,6 +2294,7 @@ func (fbo *folderBranchOps) SetInitialHeadFromServer(
 		// updated either directly via writes or through the
 		// background update processor.
 		if fbo.head == (ImmutableRootMetadata{}) {
+			setHead = true
 			err = fbo.setInitialHeadTrustedLocked(ctx, lState, md)
 			if err != nil {
 				return err

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -871,7 +871,7 @@ func (fbo *folderBranchOps) doPartialSync(
 	ctx context.Context, syncConfig keybase1.FolderSyncConfig,
 	latestMerged ImmutableRootMetadata) (err error) {
 	fbo.log.CDebugf(
-		ctx, "Starting partial sync at revision %d", latestMerged.Revision)
+		ctx, "Starting partial sync at revision %d", latestMerged.Revision())
 	defer func() {
 		fbo.deferLog.CDebugf(ctx, "Partial sync done: %+v", err)
 	}()

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -979,6 +979,10 @@ pathLoop:
 func (fbo *folderBranchOps) kickOffPartialSync(
 	ctx context.Context, lState *lockState,
 	syncConfig keybase1.FolderSyncConfig, rmd ImmutableRootMetadata) {
+	if fbo.config.DiskBlockCache() == nil {
+		return
+	}
+
 	// Kick off a background partial sync.
 	partialSyncCtx, cancel := context.WithCancel(
 		fbo.ctxWithFBOID(context.Background()))

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -781,7 +781,8 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 			if req.prefetchStatus == TriggeredPrefetch &&
 				!req.action.DeepSync() &&
 				(isPrefetchWaiting &&
-					req.action.Sync() == pre.req.action.Sync()) {
+					req.action.Sync() == pre.req.action.Sync() &&
+					req.action.StopIfFull() == pre.req.action.StopIfFull()) {
 				p.log.CDebugf(ctx, "prefetch already triggered for block ID "+
 					"%s", req.ptr.ID)
 				continue

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -798,16 +798,10 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				continue
 			}
 
-			// Bail out early if we know the sync cache is already
-			// full, to avoid enqueuing the child blocks when they
-			// aren't able to be cached.
+			// Bail out early if we know the cache is already full, to
+			// avoid enqueuing the child blocks when they aren't able
+			// to be cached.
 			if doStop, doCancel := p.stopIfNeeded(ctx, req); doStop {
-				// This is inefficient since it'd be better to know if
-				// the `subtreeBlockCount` below is 0, or if `isTail`
-				// below is true before needlessly rescheduling this.
-				// But currently that requires some complexity to
-				// figure out, so for now just do this early and
-				// revisit if it becomes a problem.
 				if doCancel && isPrefetchWaiting {
 					p.applyToPtrParentsRecursive(p.cancelPrefetch, req.ptr, pre)
 				}

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -580,10 +580,16 @@ func (p *blockPrefetcher) stopIfNeeded(
 		return false
 	}
 
+	defer func() {
+		if doStop {
+			p.log.CDebugf(ctx,
+				"stopping prefetch for block %s due to full cache (sync=%t)",
+				req.ptr.ID, req.action.Sync())
+		}
+	}()
+
 	if req.action.Sync() {
 		// If the sync cache is close to full, reschedule the prefetch.
-		p.log.CDebugf(ctx, "rescheduling prefetch for block %s due to "+
-			"full sync cache.", req.ptr.ID)
 		p.reschedulePrefetch(req)
 		return true
 	}

--- a/libkbfs/state_checker.go
+++ b/libkbfs/state_checker.go
@@ -378,8 +378,7 @@ func (sc *StateChecker) CheckMergedState(ctx context.Context, tlfID tlf.ID) erro
 		}
 	}
 	if !ok {
-		return errors.New("StateChecker only works against " +
-			"BlockServerLocal")
+		return errors.New("StateChecker only works against BlockServerLocal")
 	}
 	bserverKnownBlocks, err := bserverLocal.getAllRefsForTest(ctx, tlfID)
 	if err != nil {


### PR DESCRIPTION
This PR enables the deep-prefetching of recently-edited files on TLFs into the working-set cache, as per design's request.  To make this work:

* Introduce a new block request action flag that stops a prefetch completely as soon as the cache is full.  This is different from how deep-sync caches work, which need to be rescheduled.
* These new "stop-if-full" requests trigger deep-prefetches, just like a "deep-sync" request does. (At least until the cache fills up.)
* Whenever loading a TLF for prefetching (including for synced folders), suppress identify popups and errors so that the user doesn't get random popups.  If the user tries to access data in these TLFs, they should get the popup and errors.
* Change the partial sync code so that if it receives a config with a DISABLED mode, but with partial paths, it syncs them into the working-set cache with a "stop-if-full" action.

I'm a bit scared of some of the implications here, since it means someone you don't know can create a folder with you and start making you download stuff.  In a future PR I'll make sure the edit history only includes favorited folders, but that will have to wait for Jakob's work on the favorites cache.  Also, I've observed this using quite a bit of CPU for the first few minutes after startup.

Issue: KBFS-3525