### PR TITLE
journal_server_test: fix bad dirty ops check

### DIFF
--- a/libkbfs/journal_server_test.go
+++ b/libkbfs/journal_server_test.go
@@ -545,8 +545,8 @@ func TestJournalServerLogOutDirtyOp(t *testing.T) {
 		jServer.lock.RLock()
 		defer jServer.lock.RUnlock()
 		return jServer.dirtyOps[tlfID]
-	}
-	require.NotEqual(t, 0, dirtyOps)
+	}()
+	require.Equal(t, uint(0), dirtyOps)
 }
 
 func TestJournalServerMultiUser(t *testing.T) {


### PR DESCRIPTION
1) Execute the function.
2) The number of dirty ops should be 0, actually, since the shutdown that was waiting on it to become 0 finished.