### PR TITLE
Unused return value etc bugs

### DIFF
--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -867,6 +867,10 @@ func (cache *DiskBlockCacheLocal) evictFromTLFLocked(ctx context.Context,
 			continue
 		}
 		blockID, err := kbfsblock.IDFromBytes(blockIDBytes)
+		if err != nil {
+			cache.log.CWarningf(ctx, "Error getting id from bytes %x", blockIDBytes)
+			continue
+		}
 		lru, err := cache.getLRULocked(blockID)
 		if err != nil {
 			cache.log.CWarningf(ctx, "Error decoding LRU time for block %s",
@@ -915,6 +919,10 @@ func (cache *DiskBlockCacheLocal) evictLocked(ctx context.Context,
 			continue
 		}
 		blockID, err := kbfsblock.IDFromBytes(key)
+		if err != nil {
+			cache.log.CWarningf(ctx, "Error getting id from bytes %x", key)
+			continue
+		}
 		metadata := DiskBlockCacheMetadata{}
 		err = cache.config.Codec().Decode(iter.Value(), &metadata)
 		if err != nil {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -1866,6 +1866,7 @@ func (fbo *folderBlockOps) maybeWaitOnDeferredWrites(
 	doLogUnblocked := false
 	for {
 		var err error
+		outerSelect:
 		select {
 		case <-c:
 			if doLogUnblocked {
@@ -1875,7 +1876,7 @@ func (fbo *folderBlockOps) maybeWaitOnDeferredWrites(
 			select {
 			case err = <-errListener:
 				// Break the select to check the cause of the error below.
-				break
+				break outerSelect
 			default:
 			}
 			return nil

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5827,7 +5827,6 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 		return errors.WithStack(NoUpdatesWhileDirtyError{})
 	}
 
-	appliedRevs := make([]ImmutableRootMetadata, 0, len(rmds))
 	for i, rmd := range rmds {
 		// check that we're applying the expected MD revision
 		if rmd.Revision() <= fbo.getCurrMDRevisionLocked(lState) {
@@ -5873,7 +5872,6 @@ func (fbo *folderBranchOps) applyMDUpdatesLocked(ctx context.Context,
 		} else {
 			fbo.rekeyFSM.Event(NewRekeyNotNeededEvent())
 		}
-		appliedRevs = append(appliedRevs, rmd)
 	}
 	return nil
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1717,6 +1717,9 @@ func (fbo *folderBranchOps) getMDForReadNeedIdentifyOnMaybeFirstAccess(
 			return ImmutableRootMetadata{}, err
 		}
 		isReader, err := md.IsReader(ctx, fbo.config.KBPKI(), session.UID)
+		if err != nil {
+			return ImmutableRootMetadata{}, err
+		}
 		if !isReader {
 			return ImmutableRootMetadata{}, NewReadAccessError(
 				md.GetTlfHandle(), session.Name, md.GetTlfHandle().GetCanonicalPath())
@@ -2733,6 +2736,11 @@ func (fbo *folderBranchOps) statEntry(ctx context.Context, node Node) (
 
 		// Otherwise, proceed with the usual way.
 		md, err = fbo.getMDForReadNeedIdentify(ctx, lState)
+		// And handle the error, err is local to this block
+		// shadowing the err in the surrounding block.
+		if err != nil {
+			return DirEntry{}, err
+		}
 	} else {
 		// If nodePath has no valid parent, it's just the TLF root, so
 		// we don't need an identify in this case.  Note: we don't

--- a/libkbfs/key_manager.go
+++ b/libkbfs/key_manager.go
@@ -544,6 +544,9 @@ func (km *KeyManagerStandard) Rekey(ctx context.Context, md *RootMetadata, promp
 
 		// Check with the server to see if the handle became a conflict.
 		latestHandle, err := km.config.MDOps().GetLatestHandleForTLF(ctx, md.TlfID())
+		if err != nil {
+			return false, nil, err
+		}
 		if latestHandle.ConflictInfo != nil {
 			km.log.CDebugf(ctx, "handle for %s is conflicted",
 				handle.GetCanonicalPath())


### PR DESCRIPTION
Some nits found in libkbfs while doing an unrelated things.

This contains:
+ Handle some unhandled error returns
+ Remove a unused variable in folder_branch_ops
+ Fix bug in select in folder_block_ops, this original code broke only from the inner select.