### PR TITLE
modes: use one prefetch worker on mobile

### DIFF
--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -74,7 +74,7 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 
 	errCh := b.queue.Request(
 		ctx, defaultOnDemandRequestPriority, kmd,
-		blockPtr, block, lifetime, BlockRequestWithPrefetch)
+		blockPtr, block, lifetime, defaultBlockRequestAction(b.config.Mode()))
 	err := <-errCh
 
 	b.log.LazyTrace(ctx, "BOps: Request fulfilled for %s (err=%v)", blockPtr.ID, err)

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -74,7 +74,7 @@ func (b *BlockOpsStandard) Get(ctx context.Context, kmd KeyMetadata,
 
 	errCh := b.queue.Request(
 		ctx, defaultOnDemandRequestPriority, kmd,
-		blockPtr, block, lifetime, defaultBlockRequestAction(b.config.Mode()))
+		blockPtr, block, lifetime, b.config.Mode().DefaultBlockRequestAction())
 	err := <-errCh
 
 	b.log.LazyTrace(ctx, "BOps: Request fulfilled for %s (err=%v)", blockPtr.ID, err)

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -1099,10 +1099,3 @@ func (bra BlockRequestAction) CacheType() DiskBlockCacheType {
 	}
 	return DiskBlockAnyCache
 }
-
-func defaultBlockRequestAction(mode InitMode) BlockRequestAction {
-	if mode.DoPrefetches() {
-		return BlockRequestWithPrefetch
-	}
-	return BlockRequestSolo
-}

--- a/libkbfs/data_types.go
+++ b/libkbfs/data_types.go
@@ -1099,3 +1099,10 @@ func (bra BlockRequestAction) CacheType() DiskBlockCacheType {
 	}
 	return DiskBlockAnyCache
 }
+
+func defaultBlockRequestAction(mode InitMode) BlockRequestAction {
+	if mode.DoPrefetches() {
+		return BlockRequestWithPrefetch
+	}
+	return BlockRequestSolo
+}

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -386,7 +386,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		action := defaultBlockRequestAction(fbo.config.Mode())
+		action := fbo.config.Mode().DefaultBlockRequestAction()
 		if fbo.config.IsSyncedTlf(fbo.id()) {
 			action = action.AddSync()
 		}
@@ -3366,7 +3366,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 		// No need to cache because it's already cached.
 		_ = fbo.config.BlockOps().BlockRetriever().Request(
 			ctx, updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
-			lifetime, defaultBlockRequestAction(fbo.config.Mode()))
+			lifetime, fbo.config.Mode().DefaultBlockRequestAction())
 	}
 	// Cancel any prefetches for the old pointer from the prefetcher.
 	fbo.config.BlockOps().Prefetcher().CancelPrefetch(oldPtr)

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -386,7 +386,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
-		action := BlockRequestWithPrefetch
+		action := defaultBlockRequestAction(fbo.config.Mode())
 		if fbo.config.IsSyncedTlf(fbo.id()) {
 			action = action.AddSync()
 		}
@@ -3366,7 +3366,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 		// No need to cache because it's already cached.
 		_ = fbo.config.BlockOps().BlockRetriever().Request(
 			ctx, updatePointerPrefetchPriority, kmd, newPtr, block.NewEmpty(),
-			lifetime, BlockRequestWithPrefetch)
+			lifetime, defaultBlockRequestAction(fbo.config.Mode()))
 	}
 	// Cancel any prefetches for the old pointer from the prefetcher.
 	fbo.config.BlockOps().Prefetcher().CancelPrefetch(oldPtr)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1029,7 +1029,7 @@ func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ptr := rmd.Data().Dir.BlockPointer
 	return fbo.config.BlockOps().BlockRetriever().Request(
 		ctx, defaultOnDemandRequestPriority-1, rmd, ptr, NewDirBlock(),
-		TransientEntry, defaultBlockRequestAction(fbo.config.Mode()))
+		TransientEntry, fbo.config.Mode().DefaultBlockRequestAction())
 }
 
 func (fbo *folderBranchOps) waitForRootBlockFetch(

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1029,7 +1029,7 @@ func (fbo *folderBranchOps) kickOffRootBlockFetch(
 	ptr := rmd.Data().Dir.BlockPointer
 	return fbo.config.BlockOps().BlockRetriever().Request(
 		ctx, defaultOnDemandRequestPriority-1, rmd, ptr, NewDirBlock(),
-		TransientEntry, BlockRequestWithPrefetch)
+		TransientEntry, defaultBlockRequestAction(fbo.config.Mode()))
 }
 
 func (fbo *folderBranchOps) waitForRootBlockFetch(

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2178,6 +2178,9 @@ type InitMode interface {
 	BlockWorkers() int
 	// PrefetchWorkers returns the number of prefetch workers to run.
 	PrefetchWorkers() int
+	// DoPrefetches returns true if block fetches should trigger
+	// automatic prefetching.
+	DoPrefetches() bool
 	// RekeyWorkers returns the number of rekey workers to run.
 	RekeyWorkers() int
 	// RekeyQueueSize returns the size of the rekey queue.

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2178,9 +2178,9 @@ type InitMode interface {
 	BlockWorkers() int
 	// PrefetchWorkers returns the number of prefetch workers to run.
 	PrefetchWorkers() int
-	// DoPrefetches returns true if block fetches should trigger
-	// automatic prefetching.
-	DoPrefetches() bool
+	// DefaultBlockRequestAction returns the action to be used by
+	// default whenever fetching a block.
+	DefaultBlockRequestAction() BlockRequestAction
 	// RekeyWorkers returns the number of rekey workers to run.
 	RekeyWorkers() int
 	// RekeyQueueSize returns the size of the rekey queue.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8219,18 +8219,18 @@ func (mr *MockInitModeMockRecorder) PrefetchWorkers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchWorkers", reflect.TypeOf((*MockInitMode)(nil).PrefetchWorkers))
 }
 
-// DoPrefetches mocks base method
-func (m *MockInitMode) DoPrefetches() bool {
+// DefaultBlockRequestAction mocks base method
+func (m *MockInitMode) DefaultBlockRequestAction() BlockRequestAction {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DoPrefetches")
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "DefaultBlockRequestAction")
+	ret0, _ := ret[0].(BlockRequestAction)
 	return ret0
 }
 
-// DoPrefetches indicates an expected call of DoPrefetches
-func (mr *MockInitModeMockRecorder) DoPrefetches() *gomock.Call {
+// DefaultBlockRequestAction indicates an expected call of DefaultBlockRequestAction
+func (mr *MockInitModeMockRecorder) DefaultBlockRequestAction() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoPrefetches", reflect.TypeOf((*MockInitMode)(nil).DoPrefetches))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DefaultBlockRequestAction", reflect.TypeOf((*MockInitMode)(nil).DefaultBlockRequestAction))
 }
 
 // RekeyWorkers mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -8219,6 +8219,20 @@ func (mr *MockInitModeMockRecorder) PrefetchWorkers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrefetchWorkers", reflect.TypeOf((*MockInitMode)(nil).PrefetchWorkers))
 }
 
+// DoPrefetches mocks base method
+func (m *MockInitMode) DoPrefetches() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoPrefetches")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DoPrefetches indicates an expected call of DoPrefetches
+func (mr *MockInitModeMockRecorder) DoPrefetches() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoPrefetches", reflect.TypeOf((*MockInitMode)(nil).DoPrefetches))
+}
+
 // RekeyWorkers mocks base method
 func (m *MockInitMode) RekeyWorkers() int {
 	m.ctrl.T.Helper()

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -171,7 +171,7 @@ func (mm modeMinimal) PrefetchWorkers() int {
 	return 0
 }
 
-func (md modeMinimal) DefaultBlockRequestAction() BlockRequestAction {
+func (mm modeMinimal) DefaultBlockRequestAction() BlockRequestAction {
 	return BlockRequestSolo
 }
 
@@ -369,7 +369,7 @@ func (mc modeConstrained) PrefetchWorkers() int {
 	return 1
 }
 
-func (md modeConstrained) DefaultBlockRequestAction() BlockRequestAction {
+func (mc modeConstrained) DefaultBlockRequestAction() BlockRequestAction {
 	return BlockRequestSolo
 }
 

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -53,6 +53,10 @@ func (md modeDefault) PrefetchWorkers() int {
 	return defaultPrefetchWorkerQueueSize
 }
 
+func (md modeDefault) DoPrefetches() bool {
+	return true
+}
+
 func (md modeDefault) RekeyWorkers() int {
 	return 16
 }
@@ -165,6 +169,10 @@ func (mm modeMinimal) BlockWorkers() int {
 
 func (mm modeMinimal) PrefetchWorkers() int {
 	return 0
+}
+
+func (md modeMinimal) DoPrefetches() bool {
+	return false
 }
 
 func (mm modeMinimal) RekeyWorkers() int {
@@ -358,7 +366,11 @@ func (mc modeConstrained) BlockWorkers() int {
 }
 
 func (mc modeConstrained) PrefetchWorkers() int {
-	return 0
+	return 1
+}
+
+func (md modeConstrained) DoPrefetches() bool {
+	return false
 }
 
 func (mc modeConstrained) RekeyWorkers() int {

--- a/libkbfs/modes.go
+++ b/libkbfs/modes.go
@@ -53,8 +53,8 @@ func (md modeDefault) PrefetchWorkers() int {
 	return defaultPrefetchWorkerQueueSize
 }
 
-func (md modeDefault) DoPrefetches() bool {
-	return true
+func (md modeDefault) DefaultBlockRequestAction() BlockRequestAction {
+	return BlockRequestWithPrefetch
 }
 
 func (md modeDefault) RekeyWorkers() int {
@@ -171,8 +171,8 @@ func (mm modeMinimal) PrefetchWorkers() int {
 	return 0
 }
 
-func (md modeMinimal) DoPrefetches() bool {
-	return false
+func (md modeMinimal) DefaultBlockRequestAction() BlockRequestAction {
+	return BlockRequestSolo
 }
 
 func (mm modeMinimal) RekeyWorkers() int {
@@ -369,8 +369,8 @@ func (mc modeConstrained) PrefetchWorkers() int {
 	return 1
 }
 
-func (md modeConstrained) DoPrefetches() bool {
-	return false
+func (md modeConstrained) DefaultBlockRequestAction() BlockRequestAction {
+	return BlockRequestSolo
 }
 
 func (mc modeConstrained) RekeyWorkers() int {


### PR DESCRIPTION
But add a new mode setting that will trigger prefetches on normal block fetches, and turn that off on mobile.

Issue: keybase/client#15087