### PR TITLE
folder_block_manager: check blocks for liveness before deleting from sync cache

### DIFF
--- a/kbfsblock/protocol_utils.go
+++ b/kbfsblock/protocol_utils.go
@@ -227,3 +227,39 @@ func ParseGetQuotaInfoRes(codec kbfscodec.Codec, res []byte, resErr error) (
 	}
 	return QuotaInfoDecode(res, codec)
 }
+
+// GetReferenceCount returns the number of live references (at least
+// as "live" as `refStatus`) for each block ID.
+func GetReferenceCount(
+	ctx context.Context, tlfID tlf.ID, contexts ContextMap,
+	refStatus keybase1.BlockStatus, server keybase1.BlockInterface) (
+	liveCounts map[ID]int, err error) {
+	arg := keybase1.GetReferenceCountArg{
+		Ids:    make([]keybase1.BlockIdCombo, 0, len(contexts)),
+		Folder: tlfID.String(),
+		Status: refStatus,
+	}
+	for id, idContexts := range contexts {
+		if len(idContexts) < 1 {
+			return nil, errors.New("Each ID must have at least one context")
+		}
+		context := idContexts[0]
+		arg.Ids = append(arg.Ids, makeIDCombo(id, context))
+	}
+
+	res, err := server.GetReferenceCount(ctx, arg)
+	if err != nil {
+		return nil, err
+	}
+
+	liveCounts = make(map[ID]int, len(res.Counts))
+	for _, count := range res.Counts {
+		id, err := IDFromString(count.Id.BlockHash)
+		if err != nil {
+			return nil, err
+		}
+
+		liveCounts[id] = count.LiveCount
+	}
+	return liveCounts, nil
+}

--- a/libkbfs/block_disk_store.go
+++ b/libkbfs/block_disk_store.go
@@ -252,6 +252,15 @@ func (s *blockDiskStore) hasNonArchivedRef(id kbfsblock.ID) (bool, error) {
 	return info.Refs.hasNonArchivedRef(), nil
 }
 
+func (s *blockDiskStore) getLiveCount(id kbfsblock.ID) (int, error) {
+	info, err := s.getInfo(id)
+	if err != nil {
+		return 0, err
+	}
+
+	return info.Refs.getLiveCount(), nil
+}
+
 func (s *blockDiskStore) hasContext(id kbfsblock.ID, context kbfsblock.Context) (
 	bool, blockRefStatus, error) {
 	info, err := s.getInfo(id)

--- a/libkbfs/block_ops.go
+++ b/libkbfs/block_ops.go
@@ -186,6 +186,18 @@ func (b *BlockOpsStandard) Archive(ctx context.Context, tlfID tlf.ID,
 	return b.config.BlockServer().ArchiveBlockReferences(ctx, tlfID, contexts)
 }
 
+// GetLiveCount implements the BlockOps interface for BlockOpsStandard.
+func (b *BlockOpsStandard) GetLiveCount(
+	ctx context.Context, tlfID tlf.ID, ptrs []BlockPointer) (
+	liveCounts map[kbfsblock.ID]int, err error) {
+	contexts := make(kbfsblock.ContextMap)
+	for _, ptr := range ptrs {
+		contexts[ptr.ID] = append(contexts[ptr.ID], ptr.Context)
+	}
+
+	return b.config.BlockServer().GetLiveBlockReferences(ctx, tlfID, contexts)
+}
+
 // TogglePrefetcher implements the BlockOps interface for BlockOpsStandard.
 func (b *BlockOpsStandard) TogglePrefetcher(enable bool) <-chan struct{} {
 	return b.queue.TogglePrefetcher(enable, nil)

--- a/libkbfs/block_ref_map.go
+++ b/libkbfs/block_ref_map.go
@@ -73,6 +73,15 @@ func (refs blockRefMap) hasNonArchivedRef() bool {
 	return false
 }
 
+func (refs blockRefMap) getLiveCount() (count int) {
+	for _, refEntry := range refs {
+		if refEntry.Status == liveBlockRef {
+			count++
+		}
+	}
+	return count
+}
+
 func (refs blockRefMap) checkExists(context kbfsblock.Context) (
 	bool, blockRefStatus, error) {
 	refEntry, ok := refs[context.GetRefNonce()]

--- a/libkbfs/bserver_disk.go
+++ b/libkbfs/bserver_disk.go
@@ -399,6 +399,43 @@ func (b *BlockServerDisk) ArchiveBlockReferences(ctx context.Context,
 	return tlfStorage.store.archiveReferences(contexts, "")
 }
 
+// GetLiveBlockReferences implements the BlockServer interface for
+// BlockServerDisk.
+func (b *BlockServerDisk) GetLiveBlockReferences(
+	ctx context.Context, tlfID tlf.ID, contexts kbfsblock.ContextMap) (
+	liveCounts map[kbfsblock.ID]int, err error) {
+	if err := checkContext(ctx); err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err = translateToBlockServerError(err)
+	}()
+	b.log.CDebugf(ctx, "BlockServerDisk.GetLiveBlockReferences "+
+		"tlfID=%s contexts=%v", tlfID, contexts)
+	tlfStorage, err := b.getStorage(tlfID)
+	if err != nil {
+		return nil, err
+	}
+
+	tlfStorage.lock.Lock()
+	defer tlfStorage.lock.Unlock()
+	if tlfStorage.store == nil {
+		return nil, errBlockServerDiskShutdown
+	}
+
+	liveCounts = make(map[kbfsblock.ID]int)
+	for id := range contexts {
+		liveCount, err := tlfStorage.store.getLiveCount(id)
+		if err != nil {
+			return nil, err
+		}
+		liveCounts[id] = liveCount
+	}
+
+	return liveCounts, nil
+}
+
 // getAllRefsForTest implements the blockServerLocal interface for
 // BlockServerDisk.
 func (b *BlockServerDisk) getAllRefsForTest(ctx context.Context, tlfID tlf.ID) (

--- a/libkbfs/bserver_remote.go
+++ b/libkbfs/bserver_remote.go
@@ -563,6 +563,15 @@ func (b *BlockServerRemote) ArchiveBlockReferences(ctx context.Context,
 	return err
 }
 
+// GetLiveBlockReferences implements the BlockServer interface for
+// BlockServerRemote.
+func (b *BlockServerRemote) GetLiveBlockReferences(
+	ctx context.Context, tlfID tlf.ID, contexts kbfsblock.ContextMap) (
+	liveCounts map[kbfsblock.ID]int, err error) {
+	return kbfsblock.GetReferenceCount(
+		ctx, tlfID, contexts, keybase1.BlockStatus_LIVE, b.getConn.getClient())
+}
+
 // IsUnflushed implements the BlockServer interface for BlockServerRemote.
 func (b *BlockServerRemote) IsUnflushed(
 	_ context.Context, _ tlf.ID, _ kbfsblock.ID) (

--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -95,8 +95,10 @@ func (dbcr *DiskBlockCacheRemote) Put(ctx context.Context, tlfID tlf.ID,
 }
 
 // Delete implements the DiskBlockCache interface for DiskBlockCacheRemote.
-func (dbcr *DiskBlockCacheRemote) Delete(ctx context.Context,
-	blockIDs []kbfsblock.ID) (numRemoved int, sizeRemoved int64, err error) {
+func (dbcr *DiskBlockCacheRemote) Delete(
+	ctx context.Context, blockIDs []kbfsblock.ID,
+	cacheType DiskBlockCacheType) (
+	numRemoved int, sizeRemoved int64, err error) {
 	numBlocks := len(blockIDs)
 	dbcr.log.LazyTrace(ctx, "DiskBlockCacheRemote: Delete %s block(s)",
 		numBlocks)

--- a/libkbfs/disk_block_cache_service.go
+++ b/libkbfs/disk_block_cache_service.go
@@ -119,7 +119,7 @@ func (cache *DiskBlockCacheService) DeleteBlocks(ctx context.Context,
 		}
 		blocks = append(blocks, blockID)
 	}
-	numRemoved, sizeRemoved, err := dbc.Delete(ctx, blocks)
+	numRemoved, sizeRemoved, err := dbc.Delete(ctx, blocks, DiskBlockAnyCache)
 	if err != nil {
 		return kbgitkbfs.DeleteBlocksRes{}, newDiskBlockCacheError(err)
 	}

--- a/libkbfs/disk_block_cache_test.go
+++ b/libkbfs/disk_block_cache_test.go
@@ -256,7 +256,8 @@ func TestDiskBlockCacheDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Delete two of the blocks from the cache.")
-	_, _, err = cache.Delete(ctx, []kbfsblock.ID{block1Ptr.ID, block2Ptr.ID})
+	_, _, err = cache.Delete(
+		ctx, []kbfsblock.ID{block1Ptr.ID, block2Ptr.ID}, DiskBlockAnyCache)
 	require.NoError(t, err)
 
 	t.Log("Verify that only the non-deleted block is still in the cache.")

--- a/libkbfs/disk_block_cache_wrapped.go
+++ b/libkbfs/disk_block_cache_wrapped.go
@@ -242,18 +242,28 @@ func (cache *diskBlockCacheWrapped) Put(ctx context.Context, tlfID tlf.ID,
 
 // Delete implements the DiskBlockCache interface for diskBlockCacheWrapped.
 func (cache *diskBlockCacheWrapped) Delete(ctx context.Context,
-	blockIDs []kbfsblock.ID) (numRemoved int, sizeRemoved int64, err error) {
+	blockIDs []kbfsblock.ID, cacheType DiskBlockCacheType) (
+	numRemoved int, sizeRemoved int64, err error) {
 	// This is a write operation but we are only reading the pointers to the
 	// caches. So we use a read lock.
 	cache.mtx.RLock()
 	defer cache.mtx.RUnlock()
-	numRemoved, sizeRemoved, err = cache.workingSetCache.Delete(ctx, blockIDs)
-	if cache.syncCache == nil || err != nil {
-		return numRemoved, sizeRemoved, err
+	if cacheType == DiskBlockAnyCache || cacheType == DiskBlockSyncCache {
+		numRemoved, sizeRemoved, err = cache.syncCache.Delete(ctx, blockIDs)
+		if err != nil {
+			return 0, 0, err
+		}
+		if cacheType == DiskBlockSyncCache {
+			return numRemoved, sizeRemoved, err
+		}
 	}
-	syncNumRemoved, syncSizeRemoved, err :=
-		cache.syncCache.Delete(ctx, blockIDs)
-	return numRemoved + syncNumRemoved, sizeRemoved + syncSizeRemoved, err
+
+	wsNumRemoved, wsSizeRemoved, err := cache.workingSetCache.Delete(
+		ctx, blockIDs)
+	if err != nil {
+		return 0, 0, err
+	}
+	return wsNumRemoved + numRemoved, wsSizeRemoved + sizeRemoved, nil
 }
 
 // UpdateMetadata implements the DiskBlockCache interface for

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -1364,9 +1364,30 @@ func (fbm *folderBlockManager) doCleanDiskCache(cacheType DiskBlockCacheType) (
 		}
 
 		ptrs := getUnrefPointersFromMD(rmd)
-		ids := make([]kbfsblock.ID, len(ptrs))
-		for i, ptr := range ptrs {
-			ids[i] = ptr.ID
+
+		ids := make([]kbfsblock.ID, 0, len(ptrs))
+		if cacheType == DiskBlockSyncCache {
+			// For sync caches, we need to make sure that all of the
+			// references to this block are really gone.
+			liveCounts, err := fbm.config.BlockOps().GetLiveCount(
+				ctx, fbm.id, ptrs)
+			if err != nil {
+				return err
+			}
+
+			for id, count := range liveCounts {
+				if count == 0 {
+					ids = append(ids, id)
+				} else {
+					fbm.log.CDebugf(ctx,
+						"Skipping deletion of %s; still has %d live references",
+						id, count)
+				}
+			}
+		} else {
+			for _, ptr := range ptrs {
+				ids = append(ids, ptr.ID)
+			}
 		}
 		_, _, err = dbc.Delete(ctx, ids)
 		if err != nil {

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5655,12 +5655,6 @@ func (fbo *folderBranchOps) notifyOneOpLocked(ctx context.Context,
 					"Couldn't delete transient entry for %v: %v", ptr, err)
 			}
 		}
-		diskCache := fbo.config.DiskBlockCache()
-		if diskCache != nil {
-			// Delete from the working set cache.  (The sync cache is
-			// managed by `folderBlockManager`.)
-			go diskCache.Delete(ctx, idsToDelete)
-		}
 	case *resolutionOp:
 		// If there are any unrefs of blocks that have a node, this is an
 		// implied rmOp (see KBFS-1424).

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1738,6 +1738,12 @@ type BlockOps interface {
 	// than folder writers.
 	Archive(ctx context.Context, tlfID tlf.ID, ptrs []BlockPointer) error
 
+	// GetLiveCount returns the number of "live"
+	// (non-archived, non-deleted) references for each given block.
+	GetLiveCount(
+		ctx context.Context, tlfID tlf.ID, ptrs []BlockPointer) (
+		liveCounts map[kbfsblock.ID]int, err error)
+
 	// TogglePrefetcher activates or deactivates the prefetcher.
 	TogglePrefetcher(enable bool) <-chan struct{}
 
@@ -2038,6 +2044,12 @@ type BlockServer interface {
 	// calls with the same ID/refnonce pair.
 	ArchiveBlockReferences(ctx context.Context, tlfID tlf.ID,
 		contexts kbfsblock.ContextMap) error
+
+	// GetLiveBlockReferences returns the number of "live"
+	// (non-archived, non-deleted) references for each given block.
+	GetLiveBlockReferences(ctx context.Context, tlfID tlf.ID,
+		contexts kbfsblock.ContextMap) (
+		liveCounts map[kbfsblock.ID]int, err error)
 
 	// IsUnflushed returns whether a given block is being queued
 	// locally for later flushing to another block server.  If the

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1325,8 +1325,10 @@ type DiskBlockCache interface {
 		serverHalf kbfscrypto.BlockCryptKeyServerHalf,
 		cacheType DiskBlockCacheType) error
 	// Delete deletes some blocks from the disk cache.
-	Delete(ctx context.Context, blockIDs []kbfsblock.ID) (numRemoved int,
-		sizeRemoved int64, err error)
+	Delete(
+		ctx context.Context, blockIDs []kbfsblock.ID,
+		cacheType DiskBlockCacheType) (
+		numRemoved int, sizeRemoved int64, err error)
 	// UpdateMetadata updates metadata for a given block in the disk cache.
 	UpdateMetadata(ctx context.Context, blockID kbfsblock.ID,
 		prefetchStatus PrefetchStatus) error

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -6582,6 +6582,21 @@ func (mr *MockBlockOpsMockRecorder) Archive(ctx, tlfID, ptrs interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Archive", reflect.TypeOf((*MockBlockOps)(nil).Archive), ctx, tlfID, ptrs)
 }
 
+// GetLiveCount mocks base method
+func (m *MockBlockOps) GetLiveCount(ctx context.Context, tlfID tlf.ID, ptrs []BlockPointer) (map[kbfsblock.ID]int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLiveCount", ctx, tlfID, ptrs)
+	ret0, _ := ret[0].(map[kbfsblock.ID]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLiveCount indicates an expected call of GetLiveCount
+func (mr *MockBlockOpsMockRecorder) GetLiveCount(ctx, tlfID, ptrs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLiveCount", reflect.TypeOf((*MockBlockOps)(nil).GetLiveCount), ctx, tlfID, ptrs)
+}
+
 // TogglePrefetcher mocks base method
 func (m *MockBlockOps) TogglePrefetcher(enable bool) <-chan struct{} {
 	m.ctrl.T.Helper()
@@ -7630,6 +7645,21 @@ func (mr *MockBlockServerMockRecorder) ArchiveBlockReferences(ctx, tlfID, contex
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveBlockReferences", reflect.TypeOf((*MockBlockServer)(nil).ArchiveBlockReferences), ctx, tlfID, contexts)
 }
 
+// GetLiveBlockReferences mocks base method
+func (m *MockBlockServer) GetLiveBlockReferences(ctx context.Context, tlfID tlf.ID, contexts kbfsblock.ContextMap) (map[kbfsblock.ID]int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLiveBlockReferences", ctx, tlfID, contexts)
+	ret0, _ := ret[0].(map[kbfsblock.ID]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLiveBlockReferences indicates an expected call of GetLiveBlockReferences
+func (mr *MockBlockServerMockRecorder) GetLiveBlockReferences(ctx, tlfID, contexts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLiveBlockReferences", reflect.TypeOf((*MockBlockServer)(nil).GetLiveBlockReferences), ctx, tlfID, contexts)
+}
+
 // IsUnflushed mocks base method
 func (m *MockBlockServer) IsUnflushed(ctx context.Context, tlfID tlf.ID, id kbfsblock.ID) (bool, error) {
 	m.ctrl.T.Helper()
@@ -7823,6 +7853,21 @@ func (m *MockblockServerLocal) ArchiveBlockReferences(ctx context.Context, tlfID
 func (mr *MockblockServerLocalMockRecorder) ArchiveBlockReferences(ctx, tlfID, contexts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveBlockReferences", reflect.TypeOf((*MockblockServerLocal)(nil).ArchiveBlockReferences), ctx, tlfID, contexts)
+}
+
+// GetLiveBlockReferences mocks base method
+func (m *MockblockServerLocal) GetLiveBlockReferences(ctx context.Context, tlfID tlf.ID, contexts kbfsblock.ContextMap) (map[kbfsblock.ID]int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLiveBlockReferences", ctx, tlfID, contexts)
+	ret0, _ := ret[0].(map[kbfsblock.ID]int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLiveBlockReferences indicates an expected call of GetLiveBlockReferences
+func (mr *MockblockServerLocalMockRecorder) GetLiveBlockReferences(ctx, tlfID, contexts interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLiveBlockReferences", reflect.TypeOf((*MockblockServerLocal)(nil).GetLiveBlockReferences), ctx, tlfID, contexts)
 }
 
 // IsUnflushed mocks base method

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -5144,9 +5144,9 @@ func (mr *MockDiskBlockCacheMockRecorder) Put(ctx, tlfID, blockID, buf, serverHa
 }
 
 // Delete mocks base method
-func (m *MockDiskBlockCache) Delete(ctx context.Context, blockIDs []kbfsblock.ID) (int, int64, error) {
+func (m *MockDiskBlockCache) Delete(ctx context.Context, blockIDs []kbfsblock.ID, cacheType DiskBlockCacheType) (int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, blockIDs)
+	ret := m.ctrl.Call(m, "Delete", ctx, blockIDs, cacheType)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
@@ -5154,9 +5154,9 @@ func (m *MockDiskBlockCache) Delete(ctx context.Context, blockIDs []kbfsblock.ID
 }
 
 // Delete indicates an expected call of Delete
-func (mr *MockDiskBlockCacheMockRecorder) Delete(ctx, blockIDs interface{}) *gomock.Call {
+func (mr *MockDiskBlockCacheMockRecorder) Delete(ctx, blockIDs, cacheType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDiskBlockCache)(nil).Delete), ctx, blockIDs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockDiskBlockCache)(nil).Delete), ctx, blockIDs, cacheType)
 }
 
 // UpdateMetadata mocks base method


### PR DESCRIPTION
If a block is deduped and has multiple references to it (as can happen when the writer of a TLF isn't using the journal), we need to check with the server before deleting it from the sync cache.  Otherwise, we could be missing a block from the sync cache if the user goes offline.

Also, this changes the disk block cache to only delete from a specific cache if a specific type is passed in, since the sync cache and working set cache now have different delete policies.  (It's fine and more performant to evict dedup'd blocks from the working set cache even if they still have references left.)

Issue: KBFS-3661