### PR TITLE
folder_branch_ops: don't rekey team folders

### DIFF
--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6247,6 +6247,12 @@ func (fbo *folderBranchOps) rekeyLocked(ctx context.Context,
 				return RekeyResult{}, err
 			}
 		}
+
+		head, _ = fbo.getHead(ctx, lState, mdNoCommit)
+		if head.TypeForKeying() == tlf.TeamKeying {
+			fbo.log.CDebugf(ctx, "A team TLF doesn't need a rekey")
+			return RekeyResult{}, nil
+		}
 	}
 
 	md, lastWriterVerifyingKey, rekeyWasSet, err :=

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1795,7 +1795,7 @@ func (fbo *folderBranchOps) getMDForRekeyWriteLocked(
 	}
 
 	if md.TypeForKeying() == tlf.TeamKeying {
-		return nil, kbfscrypto.VerifyingKey{}, false, err
+		return nil, kbfscrypto.VerifyingKey{}, false, nil
 	}
 
 	session, err := fbo.config.KBPKI().GetCurrentSession(ctx)


### PR DESCRIPTION
A user could have an old rekey request hanging around for a TLF that was migrated to a team, and would crash if it tries to rekey it.

Issue: KBFS-3694