### PR TITLE
interfaces: make interface for `blockPutState`

### DIFF
--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -864,8 +864,12 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.Equal(t, 0, entries.adds.numBlocks())
 	require.Len(t, entries.other, 5)
 	ptrs := entries.puts.ptrs()
-	require.Equal(t, bID1, ptrs[0].ID)
-	require.Equal(t, bID4, ptrs[1].ID)
+	ids := make([]kbfsblock.ID, len(ptrs))
+	for i, ptr := range ptrs {
+		ids[i] = ptr.ID
+	}
+	require.Contains(t, ids, bID1)
+	require.Contains(t, ids, bID4)
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 		bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
 		entries, DiskBlockAnyCache)

--- a/libkbfs/block_journal_test.go
+++ b/libkbfs/block_journal_test.go
@@ -786,8 +786,8 @@ func TestBlockJournalFlushMDRevMarkerForPendingLocalSquash(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rev-1, gotRev)
 	require.Equal(t, 6, entries.length())
-	require.Len(t, entries.puts.blockStates, 2)
-	require.Len(t, entries.adds.blockStates, 0)
+	require.Equal(t, 2, entries.puts.numBlocks())
+	require.Equal(t, 0, entries.adds.numBlocks())
 	require.Len(t, entries.other, 4)
 
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
@@ -860,11 +860,12 @@ func TestBlockJournalIgnoreBlocks(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, kbfsmd.RevisionUninitialized, gotRev)
 	require.Equal(t, 7, entries.length())
-	require.Len(t, entries.puts.blockStates, 2)
-	require.Len(t, entries.adds.blockStates, 0)
+	require.Equal(t, 2, entries.puts.numBlocks())
+	require.Equal(t, 0, entries.adds.numBlocks())
 	require.Len(t, entries.other, 5)
-	require.Equal(t, bID1, entries.puts.blockStates[0].blockPtr.ID)
-	require.Equal(t, bID4, entries.puts.blockStates[1].blockPtr.ID)
+	ptrs := entries.puts.ptrs()
+	require.Equal(t, bID1, ptrs[0].ID)
+	require.Equal(t, bID4, ptrs[1].ID)
 	err = flushBlockEntries(ctx, j.log, j.deferLog, blockServer,
 		bcache, reporter, tlfID, tlf.CanonicalName("fake TLF"),
 		entries, DiskBlockAnyCache)

--- a/libkbfs/block_put_state_memory.go
+++ b/libkbfs/block_put_state_memory.go
@@ -1,0 +1,178 @@
+// Copyright 2018 Keybase Inc. All rights reserved.
+// Use of this source code is governed by a BSD
+// license that can be found in the LICENSE file.
+
+package libkbfs
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+type blockState struct {
+	blockPtr       BlockPointer
+	block          Block
+	readyBlockData ReadyBlockData
+	syncedCb       func() error
+	oldPtr         BlockPointer
+}
+
+// blockPutStateMemory is an internal structure to track data in
+// memory when putting blocks.
+type blockPutStateMemory struct {
+	blockStates []blockState
+}
+
+var _ blockPutState = (*blockPutStateMemory)(nil)
+
+func newBlockPutStateMemory(length int) *blockPutStateMemory {
+	bps := &blockPutStateMemory{}
+	bps.blockStates = make([]blockState, 0, length)
+	return bps
+}
+
+// addNewBlock tracks a new block that will be put.  If syncedCb is
+// non-nil, it will be called whenever the put for that block is
+// complete (whether or not the put resulted in an error).  Currently
+// it will not be called if the block is never put (due to an earlier
+// error).
+func (bps *blockPutStateMemory) addNewBlock(
+	_ context.Context, blockPtr BlockPointer, block Block,
+	readyBlockData ReadyBlockData, syncedCb func() error) error {
+	bps.blockStates = append(bps.blockStates,
+		blockState{blockPtr, block, readyBlockData, syncedCb, zeroPtr})
+	return nil
+}
+
+// saveOldPtr stores the given BlockPointer as the old (pre-readied)
+// pointer for the most recent blockState.
+func (bps *blockPutStateMemory) saveOldPtr(
+	_ context.Context, oldPtr BlockPointer) error {
+	bps.blockStates[len(bps.blockStates)-1].oldPtr = oldPtr
+	return nil
+}
+
+func (bps *blockPutStateMemory) oldPtr(
+	_ context.Context, blockPtr BlockPointer) (BlockPointer, error) {
+	for _, bs := range bps.blockStates {
+		if bs.blockPtr == blockPtr {
+			return bs.oldPtr, nil
+		}
+	}
+	return BlockPointer{}, errors.WithStack(NoSuchBlockError{blockPtr.ID})
+}
+
+func (bps *blockPutStateMemory) mergeOtherBps(
+	_ context.Context, other blockPutState) error {
+	otherMem, ok := other.(*blockPutStateMemory)
+	if !ok {
+		return errors.Errorf("Cannot remove other bps of type %T", other)
+	}
+
+	bps.blockStates = append(bps.blockStates, otherMem.blockStates...)
+	return nil
+}
+
+func (bps *blockPutStateMemory) removeOtherBps(
+	_ context.Context, other blockPutState) error {
+	otherMem, ok := other.(*blockPutStateMemory)
+	if !ok {
+		return errors.Errorf("Cannot remove other bps of type %T", other)
+	}
+	if len(otherMem.blockStates) == 0 {
+		return nil
+	}
+
+	otherMemPtrs := make(map[BlockPointer]bool, len(otherMem.blockStates))
+	for _, bs := range otherMem.blockStates {
+		otherMemPtrs[bs.blockPtr] = true
+	}
+
+	// Assume that `otherMem` is a subset of `bps` when initializing the
+	// slice length.
+	newLen := len(bps.blockStates) - len(otherMem.blockStates)
+	if newLen < 0 {
+		newLen = 0
+	}
+
+	// Remove any blocks that appear in `otherMem`.
+	newBlockStates := make([]blockState, 0, newLen)
+	for _, bs := range bps.blockStates {
+		if otherMemPtrs[bs.blockPtr] {
+			continue
+		}
+		newBlockStates = append(newBlockStates, bs)
+	}
+	bps.blockStates = newBlockStates
+	return nil
+}
+
+func (bps *blockPutStateMemory) ptrs() []BlockPointer {
+	ret := make([]BlockPointer, len(bps.blockStates))
+	for i, bs := range bps.blockStates {
+		ret[i] = bs.blockPtr
+	}
+	return ret
+}
+
+func (bps *blockPutStateMemory) getBlock(
+	_ context.Context, blockPtr BlockPointer) (Block, error) {
+	for _, bs := range bps.blockStates {
+		if bs.blockPtr == blockPtr {
+			return bs.block, nil
+		}
+	}
+	return nil, errors.WithStack(NoSuchBlockError{blockPtr.ID})
+}
+
+func (bps *blockPutStateMemory) getReadyBlockData(
+	_ context.Context, blockPtr BlockPointer) (ReadyBlockData, error) {
+	for _, bs := range bps.blockStates {
+		if bs.blockPtr == blockPtr {
+			return bs.readyBlockData, nil
+		}
+	}
+	return ReadyBlockData{}, errors.WithStack(NoSuchBlockError{blockPtr.ID})
+}
+
+func (bps *blockPutStateMemory) synced(blockPtr BlockPointer) error {
+	for _, bs := range bps.blockStates {
+		if bs.blockPtr == blockPtr {
+			if bs.syncedCb != nil {
+				return bs.syncedCb()
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+func (bps *blockPutStateMemory) numBlocks() int {
+	return len(bps.blockStates)
+}
+
+func (bps *blockPutStateMemory) deepCopy(
+	_ context.Context) (blockPutState, error) {
+	newBps := &blockPutStateMemory{}
+	newBps.blockStates = make([]blockState, len(bps.blockStates))
+	copy(newBps.blockStates, bps.blockStates)
+	return newBps, nil
+}
+
+func (bps *blockPutStateMemory) deepCopyWithBlacklist(
+	_ context.Context, blacklist map[BlockPointer]bool) (blockPutState, error) {
+	newBps := &blockPutStateMemory{}
+	newCap := len(bps.blockStates) - len(blacklist)
+	if newCap < 0 {
+		newCap = 0
+	}
+	newBps.blockStates = make([]blockState, 0, newCap)
+	for _, bs := range bps.blockStates {
+		// Only save the good pointers
+		if !blacklist[bs.blockPtr] {
+			newBps.blockStates = append(newBps.blockStates, bs)
+		}
+	}
+	return newBps, nil
+}

--- a/libkbfs/block_util.go
+++ b/libkbfs/block_util.go
@@ -74,18 +74,25 @@ func PutBlockCheckLimitErrs(ctx context.Context, bserv BlockServer,
 }
 
 func doOneBlockPut(ctx context.Context, bserv BlockServer, reporter Reporter,
-	tlfID tlf.ID, tlfName tlf.CanonicalName, blockState blockState,
-	blocksToRemoveChan chan *FileBlock, cacheType DiskBlockCacheType) error {
-	err := PutBlockCheckLimitErrs(
-		ctx, bserv, reporter, tlfID, blockState.blockPtr,
-		blockState.readyBlockData, tlfName, cacheType)
-	if err == nil && blockState.syncedCb != nil {
-		err = blockState.syncedCb()
+	tlfID tlf.ID, tlfName tlf.CanonicalName, ptr BlockPointer,
+	bps blockPutState, blocksToRemoveChan chan BlockPointer,
+	cacheType DiskBlockCacheType) error {
+	readyBlockData, err := bps.getReadyBlockData(ctx, ptr)
+	if err != nil {
+		return err
+	}
+	err = PutBlockCheckLimitErrs(
+		ctx, bserv, reporter, tlfID, ptr, readyBlockData, tlfName, cacheType)
+	if err == nil {
+		err = bps.synced(ptr)
 	}
 	if err != nil && isRecoverableBlockError(err) {
-		fblock, ok := blockState.block.(*FileBlock)
-		if ok && !fblock.IsInd {
-			blocksToRemoveChan <- fblock
+		block, blockErr := bps.getBlock(ctx, ptr)
+		if blockErr == nil {
+			fblock, ok := block.(*FileBlock)
+			if ok && !fblock.IsInd {
+				blocksToRemoveChan <- ptr
+			}
 		}
 	}
 
@@ -103,7 +110,7 @@ func doBlockPuts(ctx context.Context, bserv BlockServer, bcache BlockCache,
 	reporter Reporter, log, deferLog traceLogger, tlfID tlf.ID,
 	tlfName tlf.CanonicalName, bps blockPutState,
 	cacheType DiskBlockCacheType) (blocksToRemove []BlockPointer, err error) {
-	blockCount := len(bps.blockStates)
+	blockCount := bps.numBlocks()
 	log.LazyTrace(ctx, "doBlockPuts with %d blocks", blockCount)
 	defer func() {
 		deferLog.LazyTrace(ctx, "doBlockPuts with %d blocks (err=%v)", blockCount, err)
@@ -111,21 +118,21 @@ func doBlockPuts(ctx context.Context, bserv BlockServer, bcache BlockCache,
 
 	eg, groupCtx := errgroup.WithContext(ctx)
 
-	blocks := make(chan blockState, len(bps.blockStates))
+	blocks := make(chan BlockPointer, blockCount)
 
-	numWorkers := len(bps.blockStates)
+	numWorkers := blockCount
 	if numWorkers > maxParallelBlockPuts {
 		numWorkers = maxParallelBlockPuts
 	}
 	// A channel to list any blocks that have been archived or
 	// deleted.  Any of these will result in an error, so the maximum
 	// we'll get is the same as the number of workers.
-	blocksToRemoveChan := make(chan *FileBlock, numWorkers)
+	blocksToRemoveChan := make(chan BlockPointer, numWorkers)
 
 	worker := func() error {
-		for blockState := range blocks {
+		for ptr := range blocks {
 			err := doOneBlockPut(groupCtx, bserv, reporter, tlfID,
-				tlfName, blockState, blocksToRemoveChan, cacheType)
+				tlfName, ptr, bps, blocksToRemoveChan, cacheType)
 			if err != nil {
 				return err
 			}
@@ -136,8 +143,8 @@ func doBlockPuts(ctx context.Context, bserv BlockServer, bcache BlockCache,
 		eg.Go(worker)
 	}
 
-	for _, blockState := range bps.blockStates {
-		blocks <- blockState
+	for _, ptr := range bps.ptrs() {
+		blocks <- ptr
 	}
 	close(blocks)
 
@@ -146,23 +153,21 @@ func doBlockPuts(ctx context.Context, bserv BlockServer, bcache BlockCache,
 	if isRecoverableBlockError(err) {
 		// Wait for all the outstanding puts to finish, to amortize
 		// the work of re-doing the put.
-		for fblock := range blocksToRemoveChan {
-			for i, bs := range bps.blockStates {
-				if bs.block == fblock {
-					// Let the caller know which blocks shouldn't be
-					// retried.
-					blocksToRemove = append(blocksToRemove,
-						bps.blockStates[i].blockPtr)
+		for ptr := range blocksToRemoveChan {
+			// Let the caller know which blocks shouldn't be
+			// retried.
+			blocksToRemove = append(blocksToRemove, ptr)
+			if block, err := bps.getBlock(ctx, ptr); err == nil {
+				if fblock, ok := block.(*FileBlock); ok {
+					// Remove each problematic block from the cache so
+					// the redo can just make a new block instead.
+					if err := bcache.DeleteKnownPtr(tlfID, fblock); err != nil {
+						log.CWarningf(
+							ctx, "Couldn't delete ptr for a block: %v", err)
+					}
 				}
 			}
-
-			// Remove each problematic block from the cache so the
-			// redo can just make a new block instead.
-			if err := bcache.DeleteKnownPtr(tlfID, fblock); err != nil {
-				log.CWarningf(ctx, "Couldn't delete ptr for a block: %v", err)
-			}
-			if err := bcache.DeleteTransient(
-				blocksToRemove[len(blocksToRemove)-1], tlfID); err != nil {
+			if err := bcache.DeleteTransient(ptr, tlfID); err != nil {
 				log.CWarningf(ctx, "Couldn't delete block: %v", err)
 			}
 		}

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3008,7 +3008,7 @@ func (cr *ConflictResolver) finalizeResolution(ctx context.Context,
 	lState *lockState, md *RootMetadata,
 	unmergedChains, mergedChains *crChains,
 	updates map[BlockPointer]BlockPointer,
-	bps *blockPutState, blocksToDelete []kbfsblock.ID, writerLocked bool) error {
+	bps blockPutState, blocksToDelete []kbfsblock.ID, writerLocked bool) error {
 	err := cr.checkDone(ctx)
 	if err != nil {
 		return err
@@ -3125,7 +3125,7 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	_, err = doBlockPuts(
 		ctx, cr.config.BlockServer(), cr.config.BlockCache(),
 		cr.config.Reporter(), cr.log, cr.deferLog, md.TlfID(),
-		md.GetTlfHandle().GetCanonicalName(), *bps, cacheType)
+		md.GetTlfHandle().GetCanonicalName(), bps, cacheType)
 	if err != nil {
 		return err
 	}

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -333,7 +333,7 @@ func (dd *dirData) removeEntry(ctx context.Context, name string) (
 // indirect pointers.  It returns a map pointing from the new block
 // info from any readied block to its corresponding old block pointer.
 func (dd *dirData) ready(ctx context.Context, id tlf.ID, bcache BlockCache,
-	dirtyBcache isDirtyProvider, bops BlockOps, bps *blockPutState,
+	dirtyBcache isDirtyProvider, bops BlockOps, bps blockPutState,
 	topBlock *DirBlock) (map[BlockInfo]BlockPointer, error) {
 	return dd.tree.ready(
 		ctx, id, bcache, dirtyBcache, bops, bps, topBlock, nil)

--- a/libkbfs/file_data.go
+++ b/libkbfs/file_data.go
@@ -985,7 +985,7 @@ func (fd *fileData) split(ctx context.Context, id tlf.ID,
 // indirect pointers.  It returns a map pointing from the new block
 // info from any readied block to its corresponding old block pointer.
 func (fd *fileData) ready(ctx context.Context, id tlf.ID, bcache BlockCache,
-	dirtyBcache isDirtyProvider, bops BlockOps, bps *blockPutState,
+	dirtyBcache isDirtyProvider, bops BlockOps, bps blockPutState,
 	topBlock *FileBlock, df *dirtyFile) (map[BlockInfo]BlockPointer, error) {
 	return fd.tree.ready(
 		ctx, id, bcache, dirtyBcache, bops, bps, topBlock,
@@ -1231,7 +1231,7 @@ func (fd *fileData) deepCopy(ctx context.Context, dataVer DataVer) (
 // ones that were deduplicated and the ones that weren't.  It returns
 // the BlockInfos for all children.
 func (fd *fileData) undupChildrenInCopy(ctx context.Context,
-	bcache BlockCache, bops BlockOps, bps *blockPutState,
+	bcache BlockCache, bops BlockOps, bps blockPutState,
 	topBlock *FileBlock) ([]BlockInfo, error) {
 	if !topBlock.IsInd {
 		return nil, nil
@@ -1295,7 +1295,7 @@ func (fd *fileData) undupChildrenInCopy(ctx context.Context,
 // It adds all readied blocks to the provided `bps`.  It returns the
 // BlockInfos for all non-leaf children.
 func (fd *fileData) readyNonLeafBlocksInCopy(ctx context.Context,
-	bcache BlockCache, bops BlockOps, bps *blockPutState,
+	bcache BlockCache, bops BlockOps, bps blockPutState,
 	topBlock *FileBlock) ([]BlockInfo, error) {
 	if !topBlock.IsInd {
 		return nil, nil

--- a/libkbfs/folder_block_manager.go
+++ b/libkbfs/folder_block_manager.go
@@ -275,7 +275,7 @@ func (fbm *folderBlockManager) shutdown() {
 // failed blocks should be built up in a separate data structure, and
 // this should be called when the operation finally succeeds.
 func (fbm *folderBlockManager) cleanUpBlockState(
-	md ReadOnlyRootMetadata, bps *blockPutState, bdType blockDeleteType) {
+	md ReadOnlyRootMetadata, bps blockPutState, bdType blockDeleteType) {
 	fbm.log.CDebugf(nil, "Clean up md %d %s, bdType=%d", md.Revision(),
 		md.MergedStatus(), bdType)
 	expBackoff := backoff.NewExponentialBackOff()
@@ -288,9 +288,7 @@ func (fbm *folderBlockManager) cleanUpBlockState(
 		bdType:  bdType,
 		backoff: expBackoff,
 	}
-	for _, bs := range bps.blockStates {
-		toDelete.blocks = append(toDelete.blocks, bs.blockPtr)
-	}
+	toDelete.blocks = append(toDelete.blocks, bps.ptrs()...)
 	fbm.enqueueBlocksToDelete(toDelete)
 }
 

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -2919,8 +2919,7 @@ func (fbo *folderBlockOps) cleanUpUnusedBlocks(ctx context.Context,
 			if refs[ptr] && bdType == blockDeleteAlways {
 				continue
 			}
-			failedBps.blockStates = append(failedBps.blockStates,
-				blockState{blockPtr: ptr})
+			failedBps.blockStates[ptr] = blockState{}
 			fbo.log.CDebugf(ctx, "Cleaning up block %v from a previous "+
 				"failed revision %d (oldMD is %s, bdType=%d)", ptr,
 				oldMD.md.Revision(), oldMD.md.MergedStatus(), bdType)

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -5077,10 +5077,9 @@ func (fbo *folderBranchOps) syncAllLocked(
 		// Any new files or directories need their pointers explicitly
 		// updated, because the sync will be treating them as a new
 		// ref, and not an update.
-		for _, bs := range bps.blockStates {
+		for ptr, bs := range bps.blockStates {
 			if newBlocks[bs.oldPtr] {
-				fbo.blocks.updatePointer(
-					md.ReadOnly(), bs.oldPtr, bs.blockPtr, false)
+				fbo.blocks.updatePointer(md.ReadOnly(), bs.oldPtr, ptr, false)
 			}
 		}
 		return nil

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -44,21 +44,25 @@ func (fup *folderUpdatePrepper) nowUnixNano() int64 {
 
 func (fup *folderUpdatePrepper) readyBlockMultiple(ctx context.Context,
 	kmd KeyMetadata, currBlock Block, chargedTo keybase1.UserOrTeamID,
-	bps *blockPutState, bType keybase1.BlockType) (
+	bps blockPutState, bType keybase1.BlockType) (
 	info BlockInfo, plainSize int, err error) {
 	info, plainSize, readyBlockData, err :=
 		ReadyBlock(ctx, fup.config.BlockCache(), fup.config.BlockOps(),
 			fup.config.cryptoPure(), kmd, currBlock, chargedTo, bType)
 	if err != nil {
-		return
+		return BlockInfo{}, 0, err
 	}
 
-	bps.addNewBlock(info.BlockPointer, currBlock, readyBlockData, nil)
-	return
+	err = bps.addNewBlock(
+		ctx, info.BlockPointer, currBlock, readyBlockData, nil)
+	if err != nil {
+		return BlockInfo{}, 0, err
+	}
+	return info, plainSize, nil
 }
 
 func (fup *folderUpdatePrepper) unembedBlockChanges(
-	ctx context.Context, bps *blockPutState, md *RootMetadata,
+	ctx context.Context, bps blockPutState, md *RootMetadata,
 	changes *BlockChanges, chargedTo keybase1.UserOrTeamID) error {
 	buf, err := fup.config.Codec().Encode(changes)
 	if err != nil {
@@ -193,7 +197,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 	md *RootMetadata, newBlock Block, newBlockPtr BlockPointer, dir path,
 	name string, entryType EntryType, mtime bool, ctime bool,
 	stopAt BlockPointer, lbc localBcache) (
-	path, DirEntry, *blockPutState, error) {
+	path, DirEntry, blockPutState, error) {
 	// now ready each dblock and write the DirEntry for the next one
 	// in the path
 	currBlock := newBlock
@@ -214,7 +218,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 		FolderBranch: dir.FolderBranch,
 		path:         make([]pathNode, 0, len(dir.path)),
 	}
-	bps := newBlockPutState(len(dir.path))
+	bps := newBlockPutStateMemory(len(dir.path))
 	var newDe DirEntry
 	doSetTime := true
 	now := fup.nowUnixNano()
@@ -315,10 +319,16 @@ func (fup *folderUpdatePrepper) prepUpdateForPath(
 
 		if prevIdx < 0 {
 			md.AddUpdate(md.data.Dir.BlockInfo, info)
-			bps.saveOldPtr(md.data.Dir.BlockPointer)
+			err = bps.saveOldPtr(ctx, md.data.Dir.BlockPointer)
+			if err != nil {
+				return path{}, DirEntry{}, nil, err
+			}
 		} else if prevDe, err := currDD.lookup(ctx, currName); err == nil {
 			md.AddUpdate(prevDe.BlockInfo, info)
-			bps.saveOldPtr(prevDe.BlockPointer)
+			err = bps.saveOldPtr(ctx, prevDe.BlockPointer)
+			if err != nil {
+				return path{}, DirEntry{}, nil, err
+			}
 		} else {
 			// this is a new block
 			md.AddRefBlock(info)
@@ -407,7 +417,7 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 	chargedTo keybase1.UserOrTeamID, node *pathTreeNode, stopAt BlockPointer,
 	lbc localBcache, newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCache,
 	copyBehavior prepFolderCopyBehavior) (
-	*blockPutState, error) {
+	blockPutState, error) {
 	// If this has no children, then sync it, as far back as stopAt.
 	if len(node.children) == 0 {
 		// Look for the directory block or the new file block.
@@ -438,12 +448,12 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 			entryType = File // TODO: FIXME for Ex and Sym
 		}
 
-		var childBps *blockPutState
+		var childBps blockPutState
 		// For an indirect file block, make sure a new
 		// reference is made for every child block.
 		if copyBehavior == prepFolderCopyIndirectFileBlocks &&
 			entryType != Dir && fblock.IsInd {
-			childBps = newBlockPutState(1)
+			childBps = newBlockPutStateMemory(1)
 			var infos []BlockInfo
 			var err error
 
@@ -477,8 +487,11 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 					// The indirect blocks were already added to
 					// childBps, so only add the dedup'd leaf blocks.
 					if info.RefNonce != kbfsblock.ZeroRefNonce {
-						childBps.addNewBlock(info.BlockPointer,
-							nil, ReadyBlockData{}, nil)
+						err = childBps.addNewBlock(
+							ctx, info.BlockPointer, nil, ReadyBlockData{}, nil)
+						if err != nil {
+							return nil, err
+						}
 					}
 				}
 			}
@@ -498,7 +511,10 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 		}
 
 		if childBps != nil {
-			bps.mergeOtherBps(childBps)
+			err = bps.mergeOtherBps(ctx, childBps)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		return bps, nil
@@ -506,7 +522,7 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 
 	// If there is more than one child, use this node as the stopAt
 	// since it is the branch point, except for the last child.
-	bps := newBlockPutState(len(lbc))
+	bps := newBlockPutStateMemory(len(lbc))
 	count := 0
 	for _, child := range node.children {
 		localStopAt := node.ptr
@@ -520,7 +536,10 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 		if err != nil {
 			return nil, err
 		}
-		bps.mergeOtherBps(childBps)
+		err = bps.mergeOtherBps(ctx, childBps)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return bps, nil
 }
@@ -531,7 +550,7 @@ func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 // `fup.cacheLock` must be taken before calling.
 func (fup *folderUpdatePrepper) updateResolutionUsageLockedCache(
 	ctx context.Context, lState *lockState, md *RootMetadata,
-	bps *blockPutState, unmergedChains, mergedChains *crChains,
+	bps blockPutState, unmergedChains, mergedChains *crChains,
 	mostRecentMergedMD ImmutableRootMetadata,
 	refs, unrefs map[BlockPointer]bool) error {
 	md.SetRefBytes(0)
@@ -541,9 +560,9 @@ func (fup *folderUpdatePrepper) updateResolutionUsageLockedCache(
 	md.SetMDDiskUsage(mostRecentMergedMD.MDDiskUsage())
 
 	localBlocks := make(map[BlockPointer]Block)
-	for _, bs := range bps.blockStates {
-		if bs.block != nil {
-			localBlocks[bs.blockPtr] = bs.block
+	for _, ptr := range bps.ptrs() {
+		if block, err := bps.getBlock(ctx, ptr); err == nil && block != nil {
+			localBlocks[ptr] = block
 		}
 	}
 
@@ -668,7 +687,7 @@ func addUnrefToFinalResOp(ops opsList, ptr BlockPointer,
 // any.  `fup.cacheLock` must be taken before calling.
 func (fup *folderUpdatePrepper) updateResolutionUsageAndPointersLockedCache(
 	ctx context.Context, lState *lockState, md *RootMetadata,
-	bps *blockPutState, unmergedChains, mergedChains *crChains,
+	bps blockPutState, unmergedChains, mergedChains *crChains,
 	mostRecentUnmergedMD, mostRecentMergedMD ImmutableRootMetadata,
 	isLocalSquash bool) (
 	blocksToDelete []kbfsblock.ID, err error) {
@@ -1128,7 +1147,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 	resolvedPaths map[BlockPointer]path, lbc localBcache,
 	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCache,
 	copyBehavior prepFolderCopyBehavior) (
-	updates map[BlockPointer]BlockPointer, bps *blockPutState,
+	updates map[BlockPointer]BlockPointer, bps blockPutState,
 	blocksToDelete []kbfsblock.ID, err error) {
 	updates = make(map[BlockPointer]BlockPointer)
 
@@ -1159,7 +1178,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 		// root pointer to the most recent root pointer, and fill up
 		// the resolution op with all the known chain updates for this
 		// branch.
-		bps = newBlockPutState(0)
+		bps = newBlockPutStateMemory(0)
 		md.data.Dir.BlockInfo =
 			unmergedChains.mostRecentChainMDInfo.GetRootDirEntry().BlockInfo
 		for original, chain := range unmergedChains.byOriginal {
@@ -1183,7 +1202,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 				return nil, nil, nil, err
 			}
 		} else {
-			bps = newBlockPutState(0)
+			bps = newBlockPutStateMemory(0)
 		}
 	}
 
@@ -1349,8 +1368,8 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 
 	if len(unmergedChains.resOps) > 0 {
 		newBlocks := make(map[BlockPointer]bool)
-		for _, bs := range bps.blockStates {
-			newBlocks[bs.blockPtr] = true
+		for _, ptr := range bps.ptrs() {
+			newBlocks[ptr] = true
 		}
 
 		// Look into the previous unmerged resolution ops and decide

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -2665,3 +2665,23 @@ type Chat interface {
 	// everything it might have cached, e.g. when a user logs out.
 	ClearCache()
 }
+
+type blockPutState interface {
+	addNewBlock(
+		ctx context.Context, blockPtr BlockPointer, block Block,
+		readyBlockData ReadyBlockData, syncedCb func() error) error
+	saveOldPtr(ctx context.Context, oldPtr BlockPointer) error
+	oldPtr(ctx context.Context, blockPtr BlockPointer) (BlockPointer, error)
+	mergeOtherBps(ctx context.Context, other blockPutState) error
+	removeOtherBps(ctx context.Context, other blockPutState) error
+	ptrs() []BlockPointer
+	getBlock(ctx context.Context, blockPtr BlockPointer) (Block, error)
+	getReadyBlockData(
+		ctx context.Context, blockPtr BlockPointer) (ReadyBlockData, error)
+	synced(blockPtr BlockPointer) error
+	numBlocks() int
+	deepCopy(ctx context.Context) (blockPutState, error)
+	deepCopyWithBlacklist(
+		ctx context.Context, blacklist map[BlockPointer]bool) (
+		blockPutState, error)
+}

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -10731,3 +10731,199 @@ func (mr *MockChatMockRecorder) ClearCache() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearCache", reflect.TypeOf((*MockChat)(nil).ClearCache))
 }
+
+// MockblockPutState is a mock of blockPutState interface
+type MockblockPutState struct {
+	ctrl     *gomock.Controller
+	recorder *MockblockPutStateMockRecorder
+}
+
+// MockblockPutStateMockRecorder is the mock recorder for MockblockPutState
+type MockblockPutStateMockRecorder struct {
+	mock *MockblockPutState
+}
+
+// NewMockblockPutState creates a new mock instance
+func NewMockblockPutState(ctrl *gomock.Controller) *MockblockPutState {
+	mock := &MockblockPutState{ctrl: ctrl}
+	mock.recorder = &MockblockPutStateMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockblockPutState) EXPECT() *MockblockPutStateMockRecorder {
+	return m.recorder
+}
+
+// addNewBlock mocks base method
+func (m *MockblockPutState) addNewBlock(ctx context.Context, blockPtr BlockPointer, block Block, readyBlockData ReadyBlockData, syncedCb func() error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "addNewBlock", ctx, blockPtr, block, readyBlockData, syncedCb)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// addNewBlock indicates an expected call of addNewBlock
+func (mr *MockblockPutStateMockRecorder) addNewBlock(ctx, blockPtr, block, readyBlockData, syncedCb interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addNewBlock", reflect.TypeOf((*MockblockPutState)(nil).addNewBlock), ctx, blockPtr, block, readyBlockData, syncedCb)
+}
+
+// saveOldPtr mocks base method
+func (m *MockblockPutState) saveOldPtr(ctx context.Context, oldPtr BlockPointer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "saveOldPtr", ctx, oldPtr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// saveOldPtr indicates an expected call of saveOldPtr
+func (mr *MockblockPutStateMockRecorder) saveOldPtr(ctx, oldPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "saveOldPtr", reflect.TypeOf((*MockblockPutState)(nil).saveOldPtr), ctx, oldPtr)
+}
+
+// oldPtr mocks base method
+func (m *MockblockPutState) oldPtr(ctx context.Context, blockPtr BlockPointer) (BlockPointer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "oldPtr", ctx, blockPtr)
+	ret0, _ := ret[0].(BlockPointer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// oldPtr indicates an expected call of oldPtr
+func (mr *MockblockPutStateMockRecorder) oldPtr(ctx, blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "oldPtr", reflect.TypeOf((*MockblockPutState)(nil).oldPtr), ctx, blockPtr)
+}
+
+// mergeOtherBps mocks base method
+func (m *MockblockPutState) mergeOtherBps(ctx context.Context, other blockPutState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "mergeOtherBps", ctx, other)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// mergeOtherBps indicates an expected call of mergeOtherBps
+func (mr *MockblockPutStateMockRecorder) mergeOtherBps(ctx, other interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mergeOtherBps", reflect.TypeOf((*MockblockPutState)(nil).mergeOtherBps), ctx, other)
+}
+
+// removeOtherBps mocks base method
+func (m *MockblockPutState) removeOtherBps(ctx context.Context, other blockPutState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "removeOtherBps", ctx, other)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// removeOtherBps indicates an expected call of removeOtherBps
+func (mr *MockblockPutStateMockRecorder) removeOtherBps(ctx, other interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeOtherBps", reflect.TypeOf((*MockblockPutState)(nil).removeOtherBps), ctx, other)
+}
+
+// ptrs mocks base method
+func (m *MockblockPutState) ptrs() []BlockPointer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ptrs")
+	ret0, _ := ret[0].([]BlockPointer)
+	return ret0
+}
+
+// ptrs indicates an expected call of ptrs
+func (mr *MockblockPutStateMockRecorder) ptrs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ptrs", reflect.TypeOf((*MockblockPutState)(nil).ptrs))
+}
+
+// getBlock mocks base method
+func (m *MockblockPutState) getBlock(ctx context.Context, blockPtr BlockPointer) (Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getBlock", ctx, blockPtr)
+	ret0, _ := ret[0].(Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getBlock indicates an expected call of getBlock
+func (mr *MockblockPutStateMockRecorder) getBlock(ctx, blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getBlock", reflect.TypeOf((*MockblockPutState)(nil).getBlock), ctx, blockPtr)
+}
+
+// getReadyBlockData mocks base method
+func (m *MockblockPutState) getReadyBlockData(ctx context.Context, blockPtr BlockPointer) (ReadyBlockData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getReadyBlockData", ctx, blockPtr)
+	ret0, _ := ret[0].(ReadyBlockData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getReadyBlockData indicates an expected call of getReadyBlockData
+func (mr *MockblockPutStateMockRecorder) getReadyBlockData(ctx, blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getReadyBlockData", reflect.TypeOf((*MockblockPutState)(nil).getReadyBlockData), ctx, blockPtr)
+}
+
+// synced mocks base method
+func (m *MockblockPutState) synced(blockPtr BlockPointer) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "synced", blockPtr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// synced indicates an expected call of synced
+func (mr *MockblockPutStateMockRecorder) synced(blockPtr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "synced", reflect.TypeOf((*MockblockPutState)(nil).synced), blockPtr)
+}
+
+// numBlocks mocks base method
+func (m *MockblockPutState) numBlocks() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "numBlocks")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// numBlocks indicates an expected call of numBlocks
+func (mr *MockblockPutStateMockRecorder) numBlocks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "numBlocks", reflect.TypeOf((*MockblockPutState)(nil).numBlocks))
+}
+
+// deepCopy mocks base method
+func (m *MockblockPutState) deepCopy(ctx context.Context) (blockPutState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "deepCopy", ctx)
+	ret0, _ := ret[0].(blockPutState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// deepCopy indicates an expected call of deepCopy
+func (mr *MockblockPutStateMockRecorder) deepCopy(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopy", reflect.TypeOf((*MockblockPutState)(nil).deepCopy), ctx)
+}
+
+// deepCopyWithBlacklist mocks base method
+func (m *MockblockPutState) deepCopyWithBlacklist(ctx context.Context, blacklist map[BlockPointer]bool) (blockPutState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "deepCopyWithBlacklist", ctx, blacklist)
+	ret0, _ := ret[0].(blockPutState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// deepCopyWithBlacklist indicates an expected call of deepCopyWithBlacklist
+func (mr *MockblockPutStateMockRecorder) deepCopyWithBlacklist(ctx, blacklist interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deepCopyWithBlacklist", reflect.TypeOf((*MockblockPutState)(nil).deepCopyWithBlacklist), ctx, blacklist)
+}

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -466,7 +466,7 @@ func (md *RootMetadata) updateFromTlfHandle(newHandle *TlfHandle) error {
 // future local accesses to this MD (from the cache) can directly
 // access the ops without needing to re-embed the block changes.
 func (md *RootMetadata) loadCachedBlockChanges(
-	ctx context.Context, bps *blockPutState, log logger.Logger) {
+	ctx context.Context, bps blockPutState, log logger.Logger) {
 	if md.data.Changes.Ops != nil {
 		return
 	}
@@ -493,9 +493,11 @@ func (md *RootMetadata) loadCachedBlockChanges(
 	// Prepare a map of all FileBlocks for easy access by fileData
 	// below.
 	fileBlocks := make(map[BlockPointer]*FileBlock)
-	for _, bs := range bps.blockStates {
-		if fblock, ok := bs.block.(*FileBlock); ok {
-			fileBlocks[bs.blockPtr] = fblock
+	for _, ptr := range bps.ptrs() {
+		if block, err := bps.getBlock(ctx, ptr); err == nil {
+			if fblock, ok := block.(*FileBlock); ok {
+				fileBlocks[ptr] = fblock
+			}
 		}
 	}
 

--- a/libkbfs/tlf_journal.go
+++ b/libkbfs/tlf_journal.go
@@ -1097,7 +1097,7 @@ func (j *tlfJournal) flushBlockEntries(
 	}
 
 	j.log.CDebugf(ctx, "Flushing %d blocks, up to rev %d",
-		len(entries.puts.blockStates), maxMDRevToFlush)
+		entries.puts.numBlocks(), maxMDRevToFlush)
 
 	// Mark these blocks as flushing, and clear when done.
 	err = j.markFlushingBlockIDs(entries)

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1693,8 +1693,12 @@ func testTLFJournalResolveBranch(t *testing.T, ver kbfsmd.MetadataVer) {
 	// 1 ignored block, 3 ignored MD markers, 1 real MD marker
 	require.Len(t, blocks.other, 5)
 	ptrs := blocks.puts.ptrs()
-	require.Equal(t, bids[0], ptrs[0].ID)
-	require.Equal(t, bids[2], ptrs[1].ID)
+	ids := make([]kbfsblock.ID, len(ptrs))
+	for i, ptr := range ptrs {
+		ids[i] = ptr.ID
+	}
+	require.Contains(t, ids, bids[0])
+	require.Contains(t, ids, bids[2])
 	// 2 bytes of data in 2 unignored blocks.
 	require.Equal(t, int64(2), b)
 

--- a/libkbfs/tlf_journal_test.go
+++ b/libkbfs/tlf_journal_test.go
@@ -1688,12 +1688,13 @@ func testTLFJournalResolveBranch(t *testing.T, ver kbfsmd.MetadataVer) {
 	require.Equal(t, firstRevision, maxMD)
 	// 3 blocks, 3 old MD markers, 1 new MD marker
 	require.Equal(t, 7, blocks.length())
-	require.Len(t, blocks.puts.blockStates, 2)
-	require.Len(t, blocks.adds.blockStates, 0)
+	require.Equal(t, 2, blocks.puts.numBlocks())
+	require.Equal(t, 0, blocks.adds.numBlocks())
 	// 1 ignored block, 3 ignored MD markers, 1 real MD marker
 	require.Len(t, blocks.other, 5)
-	require.Equal(t, bids[0], blocks.puts.blockStates[0].blockPtr.ID)
-	require.Equal(t, bids[2], blocks.puts.blockStates[1].blockPtr.ID)
+	ptrs := blocks.puts.ptrs()
+	require.Equal(t, bids[0], ptrs[0].ID)
+	require.Equal(t, bids[2], ptrs[1].ID)
 	// 2 bytes of data in 2 unignored blocks.
 	require.Equal(t, int64(2), b)
 


### PR DESCRIPTION
And move the current implementation to `blockPutStateMemory`.  Future work will make a disk-based `blockPutState`, so the new interface takes contexts and returns errors whenever it would make sense for the disk.

This also changes the memory-based implementation to use a map instead of a slice for block states, so blocks can be looked up more easily through the interface.

Issue: KBFS-3679
