### PR TITLE
interfaces: make simple DirtyBlockCache interface

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -2225,7 +2225,7 @@ type fileBlockMap map[BlockPointer]map[string]*FileBlock
 func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 	lState *lockState, chains *crChains, mergedMostRecent BlockPointer,
 	parentPath path, name string, ptr BlockPointer, blocks fileBlockMap,
-	dirtyBcache DirtyBlockCache) (BlockPointer, error) {
+	dirtyBcache DirtyBlockCacheSimple) (BlockPointer, error) {
 	kmd := chains.mostRecentChainMDInfo
 
 	file := parentPath.ChildPath(name, ptr)
@@ -2241,7 +2241,7 @@ func (cr *ConflictResolver) makeFileBlockDeepCopy(ctx context.Context,
 		return BlockPointer{}, err
 	}
 
-	block, err := dirtyBcache.Get(cr.fbo.id(), newPtr, cr.fbo.branch())
+	block, err := dirtyBcache.Get(ctx, cr.fbo.id(), newPtr, cr.fbo.branch())
 	if err != nil {
 		return BlockPointer{}, err
 	}
@@ -2286,7 +2286,7 @@ func (cr *ConflictResolver) doOneAction(
 	mergedPaths map[BlockPointer]path, chargedTo keybase1.UserOrTeamID,
 	actionMap map[BlockPointer]crActionList, lbc localBcache,
 	doneActions map[BlockPointer]bool, newFileBlocks fileBlockMap,
-	dirtyBcache DirtyBlockCache) error {
+	dirtyBcache DirtyBlockCacheSimple) error {
 	unmergedMostRecent := unmergedPath.tailPointer()
 	unmergedChain, ok :=
 		unmergedChains.byMostRecent[unmergedMostRecent]
@@ -2445,7 +2445,7 @@ func (cr *ConflictResolver) doActions(ctx context.Context,
 	lState *lockState, unmergedChains, mergedChains *crChains,
 	unmergedPaths []path, mergedPaths map[BlockPointer]path,
 	actionMap map[BlockPointer]crActionList, lbc localBcache,
-	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCache) error {
+	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCacheSimple) error {
 	mergedMD := mergedChains.mostRecentChainMDInfo
 	chargedTo, err := chargedToForTLF(
 		ctx, cr.config.KBPKI(), cr.config.KBPKI(), mergedMD.GetTlfHandle())
@@ -3042,8 +3042,8 @@ func (cr *ConflictResolver) completeResolution(ctx context.Context,
 	lState *lockState, unmergedChains, mergedChains *crChains,
 	unmergedPaths []path, mergedPaths map[BlockPointer]path,
 	mostRecentUnmergedMD, mostRecentMergedMD ImmutableRootMetadata,
-	lbc localBcache, newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCache,
-	writerLocked bool) (err error) {
+	lbc localBcache, newFileBlocks fileBlockMap,
+	dirtyBcache DirtyBlockCacheSimple, writerLocked bool) (err error) {
 	md, err := cr.createResolvedMD(
 		ctx, lState, unmergedPaths, unmergedChains,
 		mergedChains, mostRecentMergedMD)

--- a/libkbfs/dir_data.go
+++ b/libkbfs/dir_data.go
@@ -185,7 +185,7 @@ func (dd *dirData) createIndirectBlock(ctx context.Context, dver DataVer) (
 	dd.tree.log.CDebugf(ctx, "Creating new level of indirection for dir %v, "+
 		"new block id for old top level is %v", dd.rootBlockPointer(), newID)
 
-	err = dd.tree.cacher(dd.rootBlockPointer(), dblock)
+	err = dd.tree.cacher(ctx, dd.rootBlockPointer(), dblock)
 	if err != nil {
 		return nil, err
 	}
@@ -199,12 +199,12 @@ func (dd *dirData) processModifiedBlock(
 	unrefs []BlockInfo, err error) {
 	newBlocks, newOffset := dd.tree.bsplit.SplitDirIfNeeded(block)
 
-	err = dd.tree.cacher(ptr, block)
+	err = dd.tree.cacher(ctx, ptr, block)
 	if err != nil {
 		return nil, err
 	}
 
-	_, newUnrefs, err := dd.tree.markParentsDirty(parentBlocks)
+	_, newUnrefs, err := dd.tree.markParentsDirty(ctx, parentBlocks)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (dd *dirData) processModifiedBlock(
 			// case `newRightBlock` doesn't cache the old top block,
 			// so we should do it here.
 			err = dd.tree.cacher(
-				rightParents[0].pblock.(*DirBlock).IPtrs[0].BlockPointer,
+				ctx, rightParents[0].pblock.(*DirBlock).IPtrs[0].BlockPointer,
 				newBlocks[0])
 			if err != nil {
 				return nil, err
@@ -236,7 +236,7 @@ func (dd *dirData) processModifiedBlock(
 		// Cache the split block in place of the blank one made by
 		// `newRightBlock`.
 		pb := rightParents[len(rightParents)-1]
-		err = dd.tree.cacher(pb.childBlockPtr(), newBlocks[1])
+		err = dd.tree.cacher(ctx, pb.childBlockPtr(), newBlocks[1])
 		if err != nil {
 			return nil, err
 		}

--- a/libkbfs/dir_data_test.go
+++ b/libkbfs/dir_data_test.go
@@ -35,10 +35,10 @@ func setupDirDataTest(t *testing.T, maxPtrsPerBlock, numDirEntries int) (
 
 	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)
 	dirtyBcache := simpleDirtyBlockCacheStandard()
-	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
+	getter := func(ctx context.Context, _ KeyMetadata, ptr BlockPointer,
 		_ path, _ blockReqType) (*DirBlock, bool, error) {
 		isDirty := true
-		block, err := dirtyBcache.Get(id, ptr, MasterBranch)
+		block, err := dirtyBcache.Get(ctx, id, ptr, MasterBranch)
 		if err != nil {
 			// Check the clean cache.
 			block, err = cleanCache.Get(ptr)
@@ -54,9 +54,8 @@ func setupDirDataTest(t *testing.T, maxPtrsPerBlock, numDirEntries int) (
 		}
 		return dblock, isDirty, nil
 	}
-	cacher := func(ptr BlockPointer, block Block) error {
-		t.Logf("Caching %v", ptr)
-		return dirtyBcache.Put(id, ptr, MasterBranch, block)
+	cacher := func(ctx context.Context, ptr BlockPointer, block Block) error {
+		return dirtyBcache.Put(ctx, id, ptr, MasterBranch, block)
 	}
 
 	dd := newDirData(
@@ -217,8 +216,9 @@ func testDirDataCheckLeafs(
 	dirtyBcache DirtyBlockCache, expectedLeafs []testDirDataLeaf,
 	maxPtrsPerBlock, numDirEntries int) {
 	// Top block should always be dirty.
+	ctx := context.Background()
 	cacheBlock, err := dirtyBcache.Get(
-		dd.tree.file.Tlf, dd.tree.rootBlockPointer(), MasterBranch)
+		ctx, dd.tree.file.Tlf, dd.tree.rootBlockPointer(), MasterBranch)
 	require.NoError(t, err)
 	topBlock := cacheBlock.(*DirBlock)
 	require.True(t, topBlock.IsIndirect())
@@ -238,7 +238,7 @@ func testDirDataCheckLeafs(
 			}
 
 			cacheBlock, err = dirtyBcache.Get(
-				dd.tree.file.Tlf, iptr.BlockPointer, MasterBranch)
+				ctx, dd.tree.file.Tlf, iptr.BlockPointer, MasterBranch)
 			wasDirty := err == nil
 			if wasDirty {
 				dirtyBlocks[cacheBlock.(*DirBlock)] = true

--- a/libkbfs/dirty_bcache.go
+++ b/libkbfs/dirty_bcache.go
@@ -187,8 +187,9 @@ func simpleDirtyBlockCacheStandard() *DirtyBlockCacheStandard {
 
 // Get implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) Get(_ tlf.ID, ptr BlockPointer,
-	branch BranchName) (Block, error) {
+func (d *DirtyBlockCacheStandard) Get(
+	_ context.Context, _ tlf.ID, ptr BlockPointer, branch BranchName) (
+	Block, error) {
 	block := func() Block {
 		dirtyID := dirtyBlockID{
 			id:       ptr.ID,
@@ -208,8 +209,9 @@ func (d *DirtyBlockCacheStandard) Get(_ tlf.ID, ptr BlockPointer,
 
 // Put implements the DirtyBlockCache interface for
 // DirtyBlockCacheStandard.
-func (d *DirtyBlockCacheStandard) Put(_ tlf.ID, ptr BlockPointer,
-	branch BranchName, block Block) error {
+func (d *DirtyBlockCacheStandard) Put(
+	_ context.Context, _ tlf.ID, ptr BlockPointer, branch BranchName,
+	block Block) error {
 	dirtyID := dirtyBlockID{
 		id:       ptr.ID,
 		refNonce: ptr.RefNonce,

--- a/libkbfs/dirty_file.go
+++ b/libkbfs/dirty_file.go
@@ -5,6 +5,7 @@
 package libkbfs
 
 import (
+	"context"
 	"fmt"
 	"sync"
 )
@@ -155,7 +156,8 @@ func (df *dirtyFile) isBlockOrphaned(ptr BlockPointer) bool {
 	return df.fileBlockStates[ptr].orphaned
 }
 
-func (df *dirtyFile) setBlockSyncing(ptr BlockPointer) error {
+func (df *dirtyFile) setBlockSyncing(
+	ctx context.Context, ptr BlockPointer) error {
 	df.lock.Lock()
 	defer df.lock.Unlock()
 	state := df.fileBlockStates[ptr]
@@ -164,7 +166,7 @@ func (df *dirtyFile) setBlockSyncing(ptr BlockPointer) error {
 	}
 	state.copy = blockNeedsCopy
 	state.sync = blockSyncing
-	block, err := df.dirtyBcache.Get(df.path.Tlf, ptr, df.path.Branch)
+	block, err := df.dirtyBcache.Get(ctx, df.path.Tlf, ptr, df.path.Branch)
 	if err != nil {
 		// The dirty block cache must always contain the dirty block
 		// until the full sync is completely done.  If the block is

--- a/libkbfs/file_data_test.go
+++ b/libkbfs/file_data_test.go
@@ -36,10 +36,10 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 
 	cleanCache := NewBlockCacheStandard(1<<10, 1<<20)
 	dirtyBcache := simpleDirtyBlockCacheStandard()
-	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
+	getter := func(ctx context.Context, _ KeyMetadata, ptr BlockPointer,
 		_ path, _ blockReqType) (*FileBlock, bool, error) {
 		isDirty := true
-		block, err := dirtyBcache.Get(id, ptr, MasterBranch)
+		block, err := dirtyBcache.Get(ctx, id, ptr, MasterBranch)
 		if err != nil {
 			// Check the clean cache.
 			block, err = cleanCache.Get(ptr)
@@ -55,8 +55,8 @@ func setupFileDataTest(t *testing.T, maxBlockSize int64,
 		}
 		return fblock, isDirty, nil
 	}
-	cacher := func(ptr BlockPointer, block Block) error {
-		return dirtyBcache.Put(id, ptr, MasterBranch, block)
+	cacher := func(ctx context.Context, ptr BlockPointer, block Block) error {
+		return dirtyBcache.Put(ctx, id, ptr, MasterBranch, block)
 	}
 
 	fd := newFileData(

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -3653,7 +3653,7 @@ func (fbo *folderBranchOps) createEntryLocked(
 	}
 
 	err = fbo.config.DirtyBlockCache().Put(
-		fbo.id(), newPtr, fbo.branch(), newBlock)
+		ctx, fbo.id(), newPtr, fbo.branch(), newBlock)
 	if err != nil {
 		return nil, DirEntry{}, err
 	}

--- a/libkbfs/folder_update_prepper.go
+++ b/libkbfs/folder_update_prepper.go
@@ -90,9 +90,9 @@ func (fup *folderUpdatePrepper) unembedBlockChanges(
 	dirtyBcache := simpleDirtyBlockCacheStandard()
 	// Simple dirty bcaches don't need to be shut down.
 
-	getter := func(_ context.Context, _ KeyMetadata, ptr BlockPointer,
+	getter := func(ctx context.Context, _ KeyMetadata, ptr BlockPointer,
 		_ path, _ blockReqType) (*FileBlock, bool, error) {
-		block, err := dirtyBcache.Get(fup.id(), ptr, fup.branch())
+		block, err := dirtyBcache.Get(ctx, fup.id(), ptr, fup.branch())
 		if err != nil {
 			return nil, false, err
 		}
@@ -103,11 +103,11 @@ func (fup *folderUpdatePrepper) unembedBlockChanges(
 		}
 		return fblock, true, nil
 	}
-	cacher := func(ptr BlockPointer, block Block) error {
-		return dirtyBcache.Put(fup.id(), ptr, fup.branch(), block)
+	cacher := func(ctx context.Context, ptr BlockPointer, block Block) error {
+		return dirtyBcache.Put(ctx, fup.id(), ptr, fup.branch(), block)
 	}
 	// Start off the cache with the new block
-	err = cacher(ptr, block)
+	err = cacher(ctx, ptr, block)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (fup *folderUpdatePrepper) unembedBlockChanges(
 	}
 
 	// There might be a new top block.
-	topBlock, err := dirtyBcache.Get(fup.id(), ptr, fup.branch())
+	topBlock, err := dirtyBcache.Get(ctx, fup.id(), ptr, fup.branch())
 	if err != nil {
 		return err
 	}
@@ -415,8 +415,8 @@ const (
 func (fup *folderUpdatePrepper) prepTree(ctx context.Context, lState *lockState,
 	unmergedChains *crChains, newMD *RootMetadata,
 	chargedTo keybase1.UserOrTeamID, node *pathTreeNode, stopAt BlockPointer,
-	lbc localBcache, newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCache,
-	copyBehavior prepFolderCopyBehavior) (
+	lbc localBcache, newFileBlocks fileBlockMap,
+	dirtyBcache DirtyBlockCacheSimple, copyBehavior prepFolderCopyBehavior) (
 	blockPutState, error) {
 	// If this has no children, then sync it, as far back as stopAt.
 	if len(node.children) == 0 {
@@ -1145,7 +1145,7 @@ func (fup *folderUpdatePrepper) prepUpdateForPaths(ctx context.Context,
 	lState *lockState, md *RootMetadata, unmergedChains, mergedChains *crChains,
 	mostRecentUnmergedMD, mostRecentMergedMD ImmutableRootMetadata,
 	resolvedPaths map[BlockPointer]path, lbc localBcache,
-	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCache,
+	newFileBlocks fileBlockMap, dirtyBcache DirtyBlockCacheSimple,
 	copyBehavior prepFolderCopyBehavior) (
 	updates map[BlockPointer]BlockPointer, bps blockPutState,
 	blocksToDelete []kbfsblock.ID, err error) {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1196,6 +1196,21 @@ type BlockCache interface {
 // struct{}.
 type DirtyPermChan <-chan struct{}
 
+// DirtyBlockCacheSimple is a bare-bones interface for a dirty block
+// cache.
+type DirtyBlockCacheSimple interface {
+	// Get gets the block associated with the given block ID.  Returns
+	// the dirty block for the given ID, if one exists.
+	Get(
+		ctx context.Context, tlfID tlf.ID, ptr BlockPointer,
+		branch BranchName) (Block, error)
+	// Put stores a dirty block currently identified by the
+	// given block pointer and branch name.
+	Put(
+		ctx context.Context, tlfID tlf.ID, ptr BlockPointer, branch BranchName,
+		block Block) error
+}
+
 type isDirtyProvider interface {
 	// IsDirty states whether or not the block associated with the
 	// given block pointer and branch name is dirty in this cache.
@@ -1211,13 +1226,8 @@ type isDirtyProvider interface {
 // they must be deleted explicitly.
 type DirtyBlockCache interface {
 	isDirtyProvider
+	DirtyBlockCacheSimple
 
-	// Get gets the block associated with the given block ID.  Returns
-	// the dirty block for the given ID, if one exists.
-	Get(tlfID tlf.ID, ptr BlockPointer, branch BranchName) (Block, error)
-	// Put stores a dirty block currently identified by the
-	// given block pointer and branch name.
-	Put(tlfID tlf.ID, ptr BlockPointer, branch BranchName, block Block) error
 	// Delete removes the dirty block associated with the given block
 	// pointer and branch from the cache.  No error is returned if no
 	// block exists for the given ID.

--- a/libkbfs/journal_dirty_bcache.go
+++ b/libkbfs/journal_dirty_bcache.go
@@ -20,22 +20,24 @@ type journalDirtyBlockCache struct {
 
 var _ DirtyBlockCache = journalDirtyBlockCache{}
 
-func (j journalDirtyBlockCache) Get(tlfID tlf.ID, ptr BlockPointer,
+func (j journalDirtyBlockCache) Get(
+	ctx context.Context, tlfID tlf.ID, ptr BlockPointer,
 	branch BranchName) (Block, error) {
 	if j.jServer.hasTLFJournal(tlfID) {
-		return j.journalCache.Get(tlfID, ptr, branch)
+		return j.journalCache.Get(ctx, tlfID, ptr, branch)
 	}
 
-	return j.syncCache.Get(tlfID, ptr, branch)
+	return j.syncCache.Get(ctx, tlfID, ptr, branch)
 }
 
-func (j journalDirtyBlockCache) Put(tlfID tlf.ID, ptr BlockPointer,
+func (j journalDirtyBlockCache) Put(
+	ctx context.Context, tlfID tlf.ID, ptr BlockPointer,
 	branch BranchName, block Block) error {
 	if j.jServer.hasTLFJournal(tlfID) {
-		return j.journalCache.Put(tlfID, ptr, branch, block)
+		return j.journalCache.Put(ctx, tlfID, ptr, branch, block)
 	}
 
-	return j.syncCache.Put(tlfID, ptr, branch, block)
+	return j.syncCache.Put(ctx, tlfID, ptr, branch, block)
 }
 
 func (j journalDirtyBlockCache) Delete(tlfID tlf.ID, ptr BlockPointer,

--- a/libkbfs/md_util.go
+++ b/libkbfs/md_util.go
@@ -516,7 +516,7 @@ func reembedBlockChanges(ctx context.Context, codec kbfscodec.Codec,
 		}
 		return block, false, nil
 	}
-	cacher := func(ptr BlockPointer, block Block) error {
+	cacher := func(_ context.Context, ptr BlockPointer, block Block) error {
 		return nil
 	}
 	// Reading doesn't use crypto or the block splitter, so for now

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4830,6 +4830,58 @@ func (mr *MockBlockCacheMockRecorder) GetCleanBytesCapacity() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCleanBytesCapacity", reflect.TypeOf((*MockBlockCache)(nil).GetCleanBytesCapacity))
 }
 
+// MockDirtyBlockCacheSimple is a mock of DirtyBlockCacheSimple interface
+type MockDirtyBlockCacheSimple struct {
+	ctrl     *gomock.Controller
+	recorder *MockDirtyBlockCacheSimpleMockRecorder
+}
+
+// MockDirtyBlockCacheSimpleMockRecorder is the mock recorder for MockDirtyBlockCacheSimple
+type MockDirtyBlockCacheSimpleMockRecorder struct {
+	mock *MockDirtyBlockCacheSimple
+}
+
+// NewMockDirtyBlockCacheSimple creates a new mock instance
+func NewMockDirtyBlockCacheSimple(ctrl *gomock.Controller) *MockDirtyBlockCacheSimple {
+	mock := &MockDirtyBlockCacheSimple{ctrl: ctrl}
+	mock.recorder = &MockDirtyBlockCacheSimpleMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockDirtyBlockCacheSimple) EXPECT() *MockDirtyBlockCacheSimpleMockRecorder {
+	return m.recorder
+}
+
+// Get mocks base method
+func (m *MockDirtyBlockCacheSimple) Get(ctx context.Context, tlfID tlf.ID, ptr BlockPointer, branch BranchName) (Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, tlfID, ptr, branch)
+	ret0, _ := ret[0].(Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (mr *MockDirtyBlockCacheSimpleMockRecorder) Get(ctx, tlfID, ptr, branch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDirtyBlockCacheSimple)(nil).Get), ctx, tlfID, ptr, branch)
+}
+
+// Put mocks base method
+func (m *MockDirtyBlockCacheSimple) Put(ctx context.Context, tlfID tlf.ID, ptr BlockPointer, branch BranchName, block Block) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Put", ctx, tlfID, ptr, branch, block)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Put indicates an expected call of Put
+func (mr *MockDirtyBlockCacheSimpleMockRecorder) Put(ctx, tlfID, ptr, branch, block interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDirtyBlockCacheSimple)(nil).Put), ctx, tlfID, ptr, branch, block)
+}
+
 // MockisDirtyProvider is a mock of isDirtyProvider interface
 type MockisDirtyProvider struct {
 	ctrl     *gomock.Controller
@@ -4905,32 +4957,32 @@ func (mr *MockDirtyBlockCacheMockRecorder) IsDirty(tlfID, ptr, branch interface{
 }
 
 // Get mocks base method
-func (m *MockDirtyBlockCache) Get(tlfID tlf.ID, ptr BlockPointer, branch BranchName) (Block, error) {
+func (m *MockDirtyBlockCache) Get(ctx context.Context, tlfID tlf.ID, ptr BlockPointer, branch BranchName) (Block, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", tlfID, ptr, branch)
+	ret := m.ctrl.Call(m, "Get", ctx, tlfID, ptr, branch)
 	ret0, _ := ret[0].(Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get
-func (mr *MockDirtyBlockCacheMockRecorder) Get(tlfID, ptr, branch interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) Get(ctx, tlfID, ptr, branch interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDirtyBlockCache)(nil).Get), tlfID, ptr, branch)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDirtyBlockCache)(nil).Get), ctx, tlfID, ptr, branch)
 }
 
 // Put mocks base method
-func (m *MockDirtyBlockCache) Put(tlfID tlf.ID, ptr BlockPointer, branch BranchName, block Block) error {
+func (m *MockDirtyBlockCache) Put(ctx context.Context, tlfID tlf.ID, ptr BlockPointer, branch BranchName, block Block) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", tlfID, ptr, branch, block)
+	ret := m.ctrl.Call(m, "Put", ctx, tlfID, ptr, branch, block)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put
-func (mr *MockDirtyBlockCacheMockRecorder) Put(tlfID, ptr, branch, block interface{}) *gomock.Call {
+func (mr *MockDirtyBlockCacheMockRecorder) Put(ctx, tlfID, ptr, branch, block interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDirtyBlockCache)(nil).Put), tlfID, ptr, branch, block)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDirtyBlockCache)(nil).Put), ctx, tlfID, ptr, branch, block)
 }
 
 // Delete mocks base method

--- a/libkbfs/root_metadata.go
+++ b/libkbfs/root_metadata.go
@@ -521,7 +521,7 @@ func (md *RootMetadata) loadCachedBlockChanges(
 			}
 			return fblock, false, nil
 		},
-		func(ptr BlockPointer, block Block) error {
+		func(_ context.Context, ptr BlockPointer, block Block) error {
 			return nil
 		}, log)
 


### PR DESCRIPTION
And add ctx to the `Get` and `Put` methods. This is in preparation for building a disk-based dirty block cache.

This is a very mechanical PR with no logic changes.

Issue: KBFS-3679