### PR TITLE
favorites: remove unfavorited TLFs from edit history

### DIFF
--- a/kbfsedits/user_history.go
+++ b/kbfsedits/user_history.go
@@ -203,3 +203,11 @@ func (uh *UserHistory) Clear() {
 	defer uh.lock.Unlock()
 	uh.histories = make(map[tlfKey]writersByRevision)
 }
+
+// ClearTLF removes a TLF from this UserHistory.
+func (uh *UserHistory) ClearTLF(tlfName tlf.CanonicalName, tlfType tlf.Type) {
+	key := tlfKey{tlfName, tlfType}
+	uh.lock.Lock()
+	defer uh.lock.Unlock()
+	delete(uh.histories, key)
+}


### PR DESCRIPTION
When KBFS becomes aware that a TLF is no longer a favorite, tell the
kbfsedits.UserHistory to delete it.

This is important because it prevents a recently edited file from appearing in the
history in the widget, which causes that TLF to be readded to favorites.

Issue: KBFS-3689