### PR TITLE
disk_cache_block_remote: always pretend the cache has space

### DIFF
--- a/libkbfs/disk_block_cache_remote.go
+++ b/libkbfs/disk_block_cache_remote.go
@@ -160,7 +160,9 @@ func (dbcr *DiskBlockCacheRemote) Status(ctx context.Context) map[string]DiskBlo
 // DiskBlockCacheRemote.
 func (dbcr *DiskBlockCacheRemote) DoesCacheHaveSpace(
 	_ context.Context, _ DiskBlockCacheType) (bool, error) {
-	panic("DoesSyncCacheHaveSpace() not implemented in DiskBlockCacheRemote")
+	// We won't be kicking off long syncing prefetching via the remote
+	// cache, so just pretend the cache has space.
+	return true, nil
 }
 
 // Shutdown implements the DiskBlockCache interface for DiskBlockCacheRemote.


### PR DESCRIPTION
If kbfsgit tried to do a prefetch, it would crash here due to the recent changes to control prefetches to the working set cache.  For now, just make it always look like there's space, since those kinds of fetches won't be coming over the remote protocol.

Issue: keybase/client#15162