### PR TITLE
dokan: Use uintptr_t instead of pointers on the C side for cgo pointer rules

### DIFF
--- a/dokan/bridge.c
+++ b/dokan/bridge.c
@@ -6,9 +6,9 @@
 
 #include "bridge.h"
 
-void *kbfsLibdokanPtr_RemoveMountPoint;
-void *kbfsLibdokanPtr_OpenRequestorToken;
-void *kbfsLibdokanPtr_Main;
+uintptr_t kbfsLibdokanPtr_RemoveMountPoint;
+uintptr_t kbfsLibdokanPtr_OpenRequestorToken;
+uintptr_t kbfsLibdokanPtr_Main;
 
 extern NTSTATUS kbfsLibdokanCreateFile(LPCWSTR FileName,
 					 PDOKAN_IO_SECURITY_CONTEXT psec,
@@ -329,7 +329,7 @@ error_t kbfsLibdokanFree(struct kbfsLibdokanCtx* ctx) {
 }
 
 error_t kbfsLibdokanRun(struct kbfsLibdokanCtx* ctx) {
-	int __stdcall (*dokanMain)(PDOKAN_OPTIONS DokanOptions, PDOKAN_OPERATIONS DokanOperations) = kbfsLibdokanPtr_Main;
+	int __stdcall (*dokanMain)(PDOKAN_OPTIONS DokanOptions, PDOKAN_OPERATIONS DokanOperations) = (void*)kbfsLibdokanPtr_Main;
 	if(!dokanMain)
 		return kbfsLibDokan_DLL_LOAD_ERROR;
 	if((ctx->dokan_options.Options & kbfsLibdokanUseFindFilesWithPattern) != 0) {
@@ -345,7 +345,7 @@ int kbfsLibdokanFill_find(PFillFindData fptr, PWIN32_FIND_DATAW a1, PDOKAN_FILE_
 }
 
 BOOL kbfsLibdokan_RemoveMountPoint(LPCWSTR MountPoint) {
-	BOOL __stdcall (*removeMountPoint)(LPCWSTR MountPoint) = kbfsLibdokanPtr_RemoveMountPoint;
+	BOOL __stdcall (*removeMountPoint)(LPCWSTR MountPoint) = (void*)kbfsLibdokanPtr_RemoveMountPoint;
 	if(!removeMountPoint)
 		return 0;
 	return (*removeMountPoint)(MountPoint);
@@ -353,16 +353,16 @@ BOOL kbfsLibdokan_RemoveMountPoint(LPCWSTR MountPoint) {
 
 
 HANDLE kbfsLibdokan_OpenRequestorToken(PDOKAN_FILE_INFO DokanFileInfo) {
-	HANDLE __stdcall (*openRequestorToken)(PDOKAN_FILE_INFO DokanFileInfo) = kbfsLibdokanPtr_OpenRequestorToken;
+	HANDLE __stdcall (*openRequestorToken)(PDOKAN_FILE_INFO DokanFileInfo) = (void*)kbfsLibdokanPtr_OpenRequestorToken;
 	if(!openRequestorToken)
 		return INVALID_HANDLE_VALUE;
 	return (*openRequestorToken)(DokanFileInfo);
 }
 
-ULONG kbfsLibDokan_GetVersion(void *proc) {
+ULONG kbfsLibDokan_GetVersion(uintptr_t proc) {
 	if(!proc)
 		return 0;
-	ULONG __stdcall (*fun)() = proc;
+	ULONG __stdcall (*fun)() = (void*)proc;
 	return fun();
 }
 

--- a/dokan/bridge.h
+++ b/dokan/bridge.h
@@ -62,11 +62,11 @@ enum {
   kbfsLibDokan_DLL_LOAD_ERROR = -99,
 };
 
-extern void *kbfsLibdokanPtr_RemoveMountPoint;
-extern void *kbfsLibdokanPtr_OpenRequestorToken;
-extern void *kbfsLibdokanPtr_Main;
+extern uintptr_t kbfsLibdokanPtr_RemoveMountPoint;
+extern uintptr_t kbfsLibdokanPtr_OpenRequestorToken;
+extern uintptr_t kbfsLibdokanPtr_Main;
 
-ULONG kbfsLibDokan_GetVersion(void *proc);
+ULONG kbfsLibDokan_GetVersion(uintptr_t proc);
 
 #endif /* windows check */
 

--- a/dokan/loaddll.go
+++ b/dokan/loaddll.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"runtime"
-	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -86,10 +85,10 @@ func doLoadDokanAndGetSymbols(epc *errorPrinter, path string) error {
 	if err != nil {
 		return err
 	}
-	var dokanVersionProc, dokanDriverVersionProc unsafe.Pointer
+	var dokanVersionProc, dokanDriverVersionProc C.uintptr_t
 	for _, v := range []struct {
 		name string
-		ptr  *unsafe.Pointer
+		ptr  *C.uintptr_t
 	}{{`DokanRemoveMountPoint`, &C.kbfsLibdokanPtr_RemoveMountPoint},
 		{`DokanOpenRequestorToken`, &C.kbfsLibdokanPtr_OpenRequestorToken},
 		{`DokanMain`, &C.kbfsLibdokanPtr_Main},
@@ -99,7 +98,7 @@ func doLoadDokanAndGetSymbols(epc *errorPrinter, path string) error {
 		if err != nil {
 			return fmt.Errorf(`GetProcAddress(%q) -> %v,%v`, v.name, uptr, err)
 		}
-		*v.ptr = unsafe.Pointer(uptr)
+		*v.ptr = C.uintptr_t(uptr)
 	}
 	epc.Printf("Dokan version: %d driver %d\n",
 		C.kbfsLibDokan_GetVersion(dokanVersionProc),


### PR DESCRIPTION
Ended up being quite nice.