### PR TITLE
bcache: stop tracking prefetch status in memory

### DIFF
--- a/libkbfs/bcache.go
+++ b/libkbfs/bcache.go
@@ -16,11 +16,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-type blockContainer struct {
-	block          Block
-	prefetchStatus PrefetchStatus
-}
-
 type idCacheKey struct {
 	tlf           tlf.ID
 	plaintextHash kbfshash.RawDefaultHash
@@ -42,9 +37,6 @@ type BlockCacheStandard struct {
 
 	bytesLock       sync.Mutex
 	cleanTotalBytes uint64
-
-	// Covers the `prefetchStatus` field for all `blockContainer`s.
-	prefetchLock sync.RWMutex
 }
 
 // NewBlockCacheStandard constructs a new BlockCacheStandard instance
@@ -76,18 +68,16 @@ func NewBlockCacheStandard(transientCapacity int,
 	return b
 }
 
-// GetWithPrefetch implements the BlockCache interface for BlockCacheStandard.
-func (b *BlockCacheStandard) GetWithPrefetch(ptr BlockPointer) (
-	Block, PrefetchStatus, BlockCacheLifetime, error) {
+// GetWithLifetime implements the BlockCache interface for BlockCacheStandard.
+func (b *BlockCacheStandard) GetWithLifetime(ptr BlockPointer) (
+	Block, BlockCacheLifetime, error) {
 	if b.cleanTransient != nil {
 		if tmp, ok := b.cleanTransient.Get(ptr.ID); ok {
-			bc, ok := tmp.(*blockContainer)
+			block, ok := tmp.(Block)
 			if !ok {
-				return nil, NoPrefetch, NoCacheEntry, BadDataError{ptr.ID}
+				return nil, NoCacheEntry, BadDataError{ptr.ID}
 			}
-			b.prefetchLock.RLock()
-			defer b.prefetchLock.RUnlock()
-			return bc.block, bc.prefetchStatus, TransientEntry, nil
+			return block, TransientEntry, nil
 		}
 	}
 
@@ -97,19 +87,15 @@ func (b *BlockCacheStandard) GetWithPrefetch(ptr BlockPointer) (
 		return b.cleanPermanent[ptr.ID]
 	}()
 	if block != nil {
-		// A permanent entry can only be created if this client is performing a
-		// write. Since the client is writing, it knows what goes into it,
-		// including any potential directory entries or indirect blocks.
-		// Thus, it is treated as having triggered a prefetch.
-		return block, TriggeredPrefetch, PermanentEntry, nil
+		return block, PermanentEntry, nil
 	}
 
-	return nil, NoPrefetch, NoCacheEntry, NoSuchBlockError{ptr.ID}
+	return nil, NoCacheEntry, NoSuchBlockError{ptr.ID}
 }
 
 // Get implements the BlockCache interface for BlockCacheStandard.
 func (b *BlockCacheStandard) Get(ptr BlockPointer) (Block, error) {
-	block, _, _, err := b.GetWithPrefetch(ptr)
+	block, _, err := b.GetWithLifetime(ptr)
 	return block, err
 }
 
@@ -142,11 +128,11 @@ func (b *BlockCacheStandard) subtractBlockBytes(block Block) {
 }
 
 func (b *BlockCacheStandard) onEvict(key interface{}, value interface{}) {
-	bc, ok := value.(*blockContainer)
+	block, ok := value.(Block)
 	if !ok {
 		return
 	}
-	b.subtractBlockBytes(bc.block)
+	b.subtractBlockBytes(block)
 }
 
 // CheckForKnownPtr implements the BlockCache interface for BlockCacheStandard.
@@ -239,15 +225,15 @@ func (b *BlockCacheStandard) makeRoomForSize(size uint64, lifetime BlockCacheLif
 	return true
 }
 
-// PutWithPrefetch implements the BlockCache interface for BlockCacheStandard.
-// This method is idempotent for a given ptr, but that invariant is not
-// currently goroutine-safe, and it does not hold if a block size changes
-// between Puts. That is, we assume that a cached block associated with a given
-// pointer will never change its size, even when it gets Put into the cache
-// again.
-func (b *BlockCacheStandard) PutWithPrefetch(
-	ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime,
-	prefetchStatus PrefetchStatus) (err error) {
+// Put implements the BlockCache interface for BlockCacheStandard.
+// This method is idempotent for a given ptr, but that invariant is
+// not currently goroutine-safe, and it does not hold if a block size
+// changes between Puts. That is, we assume that a cached block
+// associated with a given pointer will never change its size, even
+// when it gets Put into the cache again.
+func (b *BlockCacheStandard) Put(
+	ptr BlockPointer, tlf tlf.ID, block Block,
+	lifetime BlockCacheLifetime) error {
 	// We first check if the block shouldn't be cached, since CommonBlocks can
 	// take this path.
 	if lifetime == NoCacheEntry {
@@ -285,19 +271,7 @@ func (b *BlockCacheStandard) PutWithPrefetch(
 		// We could use `cleanTransient.Contains()`, but that wouldn't update
 		// the LRU time. By using `Get`, we make it less likely that another
 		// goroutine will evict this block before we can `Put` it again.
-		var bc interface{}
-		bc, wasInCache = b.cleanTransient.Get(ptr.ID)
-		if wasInCache {
-			b.prefetchLock.RLock()
-			defer b.prefetchLock.RUnlock()
-
-			oldPrefetchStatus := bc.(*blockContainer).prefetchStatus
-			// If the cache believes our prefetch status is greater than the
-			// passed-in status, then that is the authoritative status.
-			if oldPrefetchStatus > prefetchStatus {
-				prefetchStatus = oldPrefetchStatus
-			}
-		}
+		_, wasInCache = b.cleanTransient.Get(ptr.ID)
 		// Cache it later, once we know there's room
 
 	case PermanentEntry:
@@ -327,38 +301,10 @@ func (b *BlockCacheStandard) PutWithPrefetch(
 		if !transientCacheHasRoom {
 			return cachePutCacheFullError{ptr.ID}
 		}
-		b.cleanTransient.Add(ptr.ID, &blockContainer{block, prefetchStatus})
+		b.cleanTransient.Add(ptr.ID, block)
 	}
 
 	return nil
-}
-
-// ClearTransientPrefetch implements the BlockCache interface for
-// BlockCacheStandard.
-func (b *BlockCacheStandard) ClearTransientPrefetch(id kbfsblock.ID) {
-	if b.cleanTransient == nil {
-		return
-	}
-
-	tmp, ok := b.cleanTransient.Peek(id)
-	if !ok {
-		return
-	}
-	bc, ok := tmp.(*blockContainer)
-	if !ok {
-		panic(fmt.Sprintf("Unexpected block cache type: %T", tmp))
-	}
-	b.prefetchLock.Lock()
-	defer b.prefetchLock.Unlock()
-	bc.prefetchStatus = NoPrefetch
-}
-
-// Put implements the BlockCache interface for BlockCacheStandard.
-func (b *BlockCacheStandard) Put(
-	ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime) error {
-	// Default should be to assume that a prefetch has happened, and thus it
-	// won't trigger prefetches in the future.
-	return b.PutWithPrefetch(ptr, tlf, block, lifetime, TriggeredPrefetch)
 }
 
 // DeletePermanent implements the BlockCache interface for
@@ -384,11 +330,10 @@ func (b *BlockCacheStandard) DeleteTransient(
 	// If the block is cached and a file block, delete the known
 	// pointer as well.
 	if tmp, ok := b.cleanTransient.Get(id); ok {
-		bc, ok := tmp.(*blockContainer)
+		block, ok := tmp.(Block)
 		if !ok {
 			return BadDataError{id}
 		}
-		block := bc.block
 
 		// Remove the key if it exists
 		if fBlock, ok := block.(*FileBlock); b.ids != nil && ok &&

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1680,17 +1680,15 @@ func (c *ConfigLocal) GetAllSyncedTlfs() []tlf.ID {
 // PrefetchStatus implements the Config interface for ConfigLocal.
 func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 	ptr BlockPointer) PrefetchStatus {
-	_, prefetchStatus, _, err := c.BlockCache().GetWithPrefetch(ptr)
+	dbc := c.DiskBlockCache()
+	if dbc == nil {
+		return NoPrefetch
+	}
+
+	_, _, prefetchStatus, err := dbc.Get(
+		ctx, tlfID, ptr.ID, DiskBlockAnyCache)
 	if err != nil {
-		prefetchStatus = NoPrefetch
-		dbc := c.DiskBlockCache()
-		if dbc != nil {
-			_, _, prefetchStatus, err = dbc.Get(
-				ctx, tlfID, ptr.ID, DiskBlockAnyCache)
-			if err != nil {
-				prefetchStatus = NoPrefetch
-			}
-		}
+		return NoPrefetch
 	}
 	return prefetchStatus
 }

--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1682,7 +1682,12 @@ func (c *ConfigLocal) PrefetchStatus(ctx context.Context, tlfID tlf.ID,
 	ptr BlockPointer) PrefetchStatus {
 	dbc := c.DiskBlockCache()
 	if dbc == nil {
-		return NoPrefetch
+		// We must be in testing mode, so check the block retrieval queue.
+		bops, ok := c.BlockOps().(*BlockOpsStandard)
+		if !ok {
+			return NoPrefetch
+		}
+		return bops.queue.getPrefetchStatus(ptr.ID)
 	}
 
 	_, _, prefetchStatus, err := dbc.Get(

--- a/libkbfs/disk_block_cache.go
+++ b/libkbfs/disk_block_cache.go
@@ -750,7 +750,6 @@ func (cache *DiskBlockCacheLocal) deleteLocked(ctx context.Context,
 		removalSizes[metadata.TlfID] += uint64(metadata.BlockSize)
 		sizeRemoved += int64(metadata.BlockSize)
 		numRemoved++
-		cache.config.BlockCache().ClearTransientPrefetch(entry)
 	}
 	// TODO: more gracefully handle non-atomic failures here.
 	if err := cache.metaDb.Write(metadataBatch, nil); err != nil {

--- a/libkbfs/folder_block_ops.go
+++ b/libkbfs/folder_block_ops.go
@@ -381,8 +381,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		return block, nil
 	}
 
-	if block, prefetchStatus, lifetime, err :=
-		fbo.config.BlockCache().GetWithPrefetch(ptr); err == nil {
+	if block, lifetime, err := fbo.config.BlockCache().GetWithLifetime(ptr); err == nil {
 		// If the block was cached in the past, we need to handle it as if it's
 		// an on-demand request so that its downstream prefetches are triggered
 		// correctly according to the new on-demand fetch priority.
@@ -390,6 +389,7 @@ func (fbo *folderBlockOps) getBlockHelperLocked(ctx context.Context,
 		if fbo.config.IsSyncedTlf(fbo.id()) {
 			action = action.AddSync()
 		}
+		prefetchStatus := fbo.config.PrefetchStatus(ctx, fbo.id(), ptr)
 		fbo.config.BlockOps().Prefetcher().ProcessBlockForPrefetch(ctx, ptr,
 			block, kmd, defaultOnDemandRequestPriority-1, lifetime,
 			prefetchStatus, action)
@@ -3341,8 +3341,7 @@ func (fbo *folderBlockOps) updatePointer(kmd KeyMetadata, oldPtr BlockPointer, n
 		// Prefetch the new ref, but only if the old ref already exists in
 		// the block cache. Ideally we'd always prefetch it, but we need
 		// the type of the block so that we can call `NewEmpty`.
-		block, _, lifetime, err :=
-			fbo.config.BlockCache().GetWithPrefetch(oldPtr)
+		block, lifetime, err := fbo.config.BlockCache().GetWithLifetime(oldPtr)
 		if err != nil {
 			return updatedNode
 		}

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -1170,8 +1170,7 @@ func (fbo *folderBranchOps) commitFlushedMD(
 			return
 		}
 
-		_, prefetchStatus, _, err := fbo.config.BlockCache().GetWithPrefetch(
-			rootPtr)
+		prefetchStatus := fbo.config.PrefetchStatus(ctx, fbo.id(), rootPtr)
 		if err != nil {
 			fbo.log.CDebugf(ctx, "Error getting prefetched block: %+v", err)
 			return

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -140,8 +140,6 @@ func TestFBStatusAllFields(t *testing.T) {
 	fbsk.addDirtyNode(n2)
 
 	config.mockRekeyQueue.EXPECT().IsRekeyPending(id)
-	config.mockBcache.EXPECT().GetWithPrefetch(gomock.Any()).
-		Return(nil, NoPrefetch, NoCacheEntry, nil)
 
 	config.mockClock.EXPECT().Now().AnyTimes().Return(time.Now())
 	config.mockBserv.EXPECT().GetUserQuotaInfo(gomock.Any()).AnyTimes().Return(

--- a/libkbfs/interface_test.go
+++ b/libkbfs/interface_test.go
@@ -97,7 +97,7 @@ type testInitModeGetter struct {
 var _ initModeGetter = (*testInitModeGetter)(nil)
 
 func (t testInitModeGetter) Mode() InitMode {
-	return NewInitModeFromType(t.mode)
+	return modeTest{NewInitModeFromType(t.mode)}
 }
 
 func (t testInitModeGetter) IsTestMode() bool {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -1169,17 +1169,10 @@ type BlockCache interface {
 	// DeleteKnownPtr removes the cached ID for the given file
 	// block. It does not remove the block itself.
 	DeleteKnownPtr(tlf tlf.ID, block *FileBlock) error
-	// GetWithPrefetch retrieves a block from the cache, along with the block's
-	// prefetch status.
-	GetWithPrefetch(ptr BlockPointer) (block Block,
-		prefetchStatus PrefetchStatus, lifetime BlockCacheLifetime, err error)
-	// PutWithPrefetch puts a block into the cache, along with whether or not
-	// it has triggered or finished a prefetch.
-	PutWithPrefetch(ptr BlockPointer, tlf tlf.ID, block Block,
-		lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error
-	// ClearTransientPrefetch clears the cached prefetch status of the
-	// block, if it's transiently cached.
-	ClearTransientPrefetch(id kbfsblock.ID)
+	// GetWithLifetime retrieves a block from the cache, along with
+	// the block's lifetime.
+	GetWithLifetime(ptr BlockPointer) (
+		block Block, lifetime BlockCacheLifetime, err error)
 
 	// SetCleanBytesCapacity atomically sets clean bytes capacity for block
 	// cache.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -4745,47 +4745,20 @@ func (mr *MockBlockCacheMockRecorder) DeleteKnownPtr(tlf, block interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKnownPtr", reflect.TypeOf((*MockBlockCache)(nil).DeleteKnownPtr), tlf, block)
 }
 
-// GetWithPrefetch mocks base method
-func (m *MockBlockCache) GetWithPrefetch(ptr BlockPointer) (Block, PrefetchStatus, BlockCacheLifetime, error) {
+// GetWithLifetime mocks base method
+func (m *MockBlockCache) GetWithLifetime(ptr BlockPointer) (Block, BlockCacheLifetime, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWithPrefetch", ptr)
+	ret := m.ctrl.Call(m, "GetWithLifetime", ptr)
 	ret0, _ := ret[0].(Block)
-	ret1, _ := ret[1].(PrefetchStatus)
-	ret2, _ := ret[2].(BlockCacheLifetime)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
+	ret1, _ := ret[1].(BlockCacheLifetime)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// GetWithPrefetch indicates an expected call of GetWithPrefetch
-func (mr *MockBlockCacheMockRecorder) GetWithPrefetch(ptr interface{}) *gomock.Call {
+// GetWithLifetime indicates an expected call of GetWithLifetime
+func (mr *MockBlockCacheMockRecorder) GetWithLifetime(ptr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithPrefetch", reflect.TypeOf((*MockBlockCache)(nil).GetWithPrefetch), ptr)
-}
-
-// PutWithPrefetch mocks base method
-func (m *MockBlockCache) PutWithPrefetch(ptr BlockPointer, tlf tlf.ID, block Block, lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutWithPrefetch", ptr, tlf, block, lifetime, prefetchStatus)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PutWithPrefetch indicates an expected call of PutWithPrefetch
-func (mr *MockBlockCacheMockRecorder) PutWithPrefetch(ptr, tlf, block, lifetime, prefetchStatus interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutWithPrefetch", reflect.TypeOf((*MockBlockCache)(nil).PutWithPrefetch), ptr, tlf, block, lifetime, prefetchStatus)
-}
-
-// ClearTransientPrefetch mocks base method
-func (m *MockBlockCache) ClearTransientPrefetch(id kbfsblock.ID) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClearTransientPrefetch", id)
-}
-
-// ClearTransientPrefetch indicates an expected call of ClearTransientPrefetch
-func (mr *MockBlockCacheMockRecorder) ClearTransientPrefetch(id interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearTransientPrefetch", reflect.TypeOf((*MockBlockCache)(nil).ClearTransientPrefetch), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithLifetime", reflect.TypeOf((*MockBlockCache)(nil).GetWithLifetime), ptr)
 }
 
 // SetCleanBytesCapacity mocks base method

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -284,7 +284,7 @@ func (p *blockPrefetcher) completePrefetch(
 	}
 }
 
-func (p *blockPrefetcher) decrementPrefetch(_ kbfsblock.ID, pp *prefetch) {
+func (p *blockPrefetcher) decrementPrefetch(blockID kbfsblock.ID, pp *prefetch) {
 	pp.subtreeBlockCount--
 	if pp.subtreeBlockCount < 0 {
 		// Both log and panic so that we get the PFID in the log.
@@ -929,7 +929,7 @@ func (p *blockPrefetcher) run(testSyncCh <-chan struct{}) {
 				numBlocks, req.ptr.ID)
 			// Walk up the block tree and add numBlocks to every parent,
 			// starting with this block.
-			p.applyToParentsRecursive(func(_ kbfsblock.ID, pp *prefetch) {
+			p.applyToParentsRecursive(func(blockID kbfsblock.ID, pp *prefetch) {
 				pp.subtreeBlockCount += numBlocks
 			}, req.ptr.ID, pre)
 		case <-p.almostDoneCh:

--- a/libkbfs/prefetcher_test.go
+++ b/libkbfs/prefetcher_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"math"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/keybase/client/go/protocol/keybase1"
 	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
+	"github.com/keybase/kbfs/kbfscrypto"
+	"github.com/keybase/kbfs/tlf"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,23 +81,74 @@ func initPrefetcherTestWithDiskCache(t *testing.T, dbc DiskBlockCache) (
 	return q, bg, config
 }
 
+// fakeDiskBlockCacheWithPrefetchStatus is a simple shim of a disk
+// block cache that only stores and retrieves the prefetch status of
+// blocks.  It must be used in conjunction with a `blockGetter` that
+// doesn't require real bytes and server halves to assemble blocks
+// (such as `fakeBlockGetter`).
+type fakeDiskBlockCacheWithPrefetchStatus struct {
+	DiskBlockCache
+
+	lock   sync.Mutex
+	status map[kbfsblock.ID]PrefetchStatus
+}
+
+func (f *fakeDiskBlockCacheWithPrefetchStatus) Get(
+	_ context.Context, _ tlf.ID, blockID kbfsblock.ID,
+	_ DiskBlockCacheType) (
+	[]byte, kbfscrypto.BlockCryptKeyServerHalf, PrefetchStatus, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	if s, ok := f.status[blockID]; ok {
+		// Return a fake, but non-nil, byte buffer, so that the block
+		// retrieval thinks it found a real block and will pass it to
+		// the assemble function.
+		return []byte{1}, kbfscrypto.BlockCryptKeyServerHalf{}, s, nil
+	}
+	return nil, kbfscrypto.BlockCryptKeyServerHalf{}, NoPrefetch,
+		NoSuchBlockError{blockID}
+}
+
+func (f *fakeDiskBlockCacheWithPrefetchStatus) UpdateMetadata(
+	_ context.Context, blockID kbfsblock.ID,
+	prefetchStatus PrefetchStatus) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.status[blockID] = prefetchStatus
+	return nil
+}
+
+func (f *fakeDiskBlockCacheWithPrefetchStatus) DoesCacheHaveSpace(
+	_ context.Context, _ DiskBlockCacheType) (bool, error) {
+	return true, nil
+}
+
 func initPrefetcherTest(t *testing.T) (*blockRetrievalQueue,
 	*fakeBlockGetter, *testBlockRetrievalConfig) {
-	return initPrefetcherTestWithDiskCache(t, nil)
+	cache := &fakeDiskBlockCacheWithPrefetchStatus{
+		status: make(map[kbfsblock.ID]PrefetchStatus),
+	}
+	return initPrefetcherTestWithDiskCache(t, cache)
 }
 
 func shutdownPrefetcherTest(q *blockRetrievalQueue) {
 	q.Shutdown()
 }
 
-func testPrefetcherCheckGet(t *testing.T, bcache BlockCache, ptr BlockPointer,
-	expectedBlock Block, expectedPrefetchStatus PrefetchStatus,
-	expectedLifetime BlockCacheLifetime) {
-	block, prefetchStatus, lifetime, err := bcache.GetWithPrefetch(ptr)
+func testPrefetcherCheckGet(
+	t *testing.T, bcache BlockCache, ptr BlockPointer, expectedBlock Block,
+	expectedPrefetchStatus PrefetchStatus, tlfID tlf.ID,
+	dcache DiskBlockCache) {
+	block, err := bcache.Get(ptr)
 	require.NoError(t, err)
+	if dcache == nil {
+		return
+	}
 	require.Equal(t, expectedBlock, block)
-	require.Equal(t, expectedPrefetchStatus.String(), prefetchStatus.String())
-	require.Equal(t, expectedLifetime.String(), lifetime.String())
+	_, _, prefetchStatus, err := dcache.Get(
+		context.Background(), tlfID, ptr.ID, DiskBlockAnyCache)
+	require.NoError(t, err)
+	require.Equal(t, expectedPrefetchStatus.String(), prefetchStatus.String(), ptr.String())
 }
 
 func getStack() string {
@@ -167,8 +221,9 @@ func TestPrefetcherIndirectFileBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()
+	kmd := makeKMD()
 	ch := q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
+		ctx, defaultOnDemandRequestPriority, kmd, rootPtr, block,
 		TransientEntry, BlockRequestWithPrefetch)
 	continueChRootBlock <- nil
 	err := <-ch
@@ -186,11 +241,11 @@ func TestPrefetcherIndirectFileBlock(t *testing.T) {
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
-		indBlock1, FinishedPrefetch, TransientEntry)
+		indBlock1, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[1].BlockPointer,
-		indBlock2, FinishedPrefetch, TransientEntry)
+		indBlock2, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func TestPrefetcherIndirectDirBlock(t *testing.T) {
@@ -219,8 +274,9 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()
+	kmd := makeKMD()
 	ch := q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
+		ctx, defaultOnDemandRequestPriority, kmd, rootPtr, block,
 		TransientEntry, BlockRequestWithPrefetch)
 	continueChRootBlock <- nil
 	err := <-ch
@@ -238,11 +294,11 @@ func TestPrefetcherIndirectDirBlock(t *testing.T) {
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
-		indBlock1, NoPrefetch, TransientEntry)
+		indBlock1, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[1].BlockPointer,
-		indBlock2, NoPrefetch, TransientEntry)
+		indBlock2, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func testPrefetcherIndirectDirBlockTail(
@@ -273,8 +329,9 @@ func testPrefetcherIndirectDirBlockTail(
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()
+	kmd := makeKMD()
 	ch := q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
+		ctx, defaultOnDemandRequestPriority, kmd, rootPtr, block,
 		TransientEntry, action)
 	continueChRootBlock <- nil
 	err := <-ch
@@ -297,12 +354,12 @@ func testPrefetcherIndirectDirBlockTail(
 		waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrs[1].BlockPointer)
 		rootStatus = TriggeredPrefetch
 		testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
-			indBlock1, NoPrefetch, TransientEntry)
+			indBlock1, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 		testPrefetcherCheckGet(t, config.BlockCache(), ptrs[1].BlockPointer,
-			indBlock2, NoPrefetch, TransientEntry)
+			indBlock2, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	}
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
-		rootStatus, TransientEntry)
+		rootStatus, kmd.TlfID(), config.DiskBlockCache())
 
 }
 
@@ -354,8 +411,9 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()
+	kmd := makeKMD()
 	ch := q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
+		ctx, defaultOnDemandRequestPriority, kmd, rootPtr, block,
 		TransientEntry, BlockRequestWithPrefetch)
 	continueChRootDir <- nil
 	err := <-ch
@@ -374,13 +432,13 @@ func TestPrefetcherDirectDirBlock(t *testing.T) {
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		rootDir.Children["c"].BlockPointer, fileC, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		rootDir.Children["b"].BlockPointer, dirB, NoPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Ensure that the largest block isn't in the cache.")
 	block, err = config.BlockCache().Get(rootDir.Children["a"].BlockPointer)
@@ -463,10 +521,10 @@ func TestPrefetcherAlreadyCached(t *testing.T) {
 		t, ctx, q.Prefetcher(), rootDir.Children["b"].BlockPointer)
 
 	testPrefetcherCheckGet(t, cache, dirA.Children["b"].BlockPointer, fileB,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	// Check that the dir block is marked as having been prefetched.
 	testPrefetcherCheckGet(t, cache, rootDir.Children["a"].BlockPointer, dirA,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Remove the prefetched file block from the cache.")
 	cache.DeleteTransient(dirA.Children["b"].BlockPointer.ID, kmd.TlfID())
@@ -528,7 +586,7 @@ func TestPrefetcherNoRepeatedPrefetch(t *testing.T) {
 		"block is in the cache.")
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), ptrA)
 	testPrefetcherCheckGet(
-		t, config.BlockCache(), ptrA, fileA, FinishedPrefetch, TransientEntry)
+		t, config.BlockCache(), ptrA, fileA, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Remove the prefetched block from the cache.")
 	cache.DeleteTransient(ptrA.ID, kmd.TlfID())
@@ -570,8 +628,9 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 	ctx, cancel := context.WithTimeout(
 		context.Background(), individualTestTimeout)
 	defer cancel()
+	kmd := makeKMD()
 	ch := q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(),
+		ctx, defaultOnDemandRequestPriority, kmd,
 		rootPtr, block, TransientEntry, BlockRequestWithPrefetch)
 	continueChRootDir <- nil
 	err := <-ch
@@ -584,7 +643,7 @@ func TestPrefetcherEmptyDirectDirBlock(t *testing.T) {
 
 	t.Log("Ensure that the directory block is in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func testPrefetcherForSyncedTLF(
@@ -700,25 +759,25 @@ func testPrefetcherForSyncedTLF(
 
 	t.Log("Ensure that the prefetched blocks are all in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		rootDir.Children["c"].BlockPointer, fileC, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		rootDir.Children["b"].BlockPointer, dirB, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		rootDir.Children["a"].BlockPointer, fileA, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		dirB.Children["d"].BlockPointer, dirBfileD, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		dirBfileDptrs[0].BlockPointer, dirBfileDblock1, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
 		dirBfileDptrs[1].BlockPointer, dirBfileDblock2, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	block = &DirBlock{}
 	ch = q.Request(
@@ -735,7 +794,7 @@ func testPrefetcherForSyncedTLF(
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootDir,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func TestPrefetcherForSyncedTLF(t *testing.T) {
@@ -814,8 +873,9 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 		bg.setBlockToReturn(indBlock2.IPtrs[1].BlockPointer, indBlock22)
 
 	var block Block = &FileBlock{}
+	kmd := makeKMD()
 	ch := q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(), rootPtr, block,
+		ctx, defaultOnDemandRequestPriority, kmd, rootPtr, block,
 		TransientEntry, BlockRequestWithPrefetch)
 	continueChRootBlock <- nil
 	notifySyncCh(t, prefetchSyncCh)
@@ -836,16 +896,16 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 
 	t.Log("Ensure that the prefetched blocks are in the cache.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, rootBlock,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
-		indBlock1, NoPrefetch, TransientEntry)
+		indBlock1, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[1].BlockPointer,
-		indBlock2, NoPrefetch, TransientEntry)
+		indBlock2, NoPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Fetch indirect block1 on-demand.")
 	block = &FileBlock{}
 	ch = q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(),
+		ctx, defaultOnDemandRequestPriority, kmd,
 		rootBlock.IPtrs[0].BlockPointer, block, TransientEntry,
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
@@ -861,7 +921,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	t.Log("Fetch indirect block2 on-demand.")
 	block = &FileBlock{}
 	ch = q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(),
+		ctx, defaultOnDemandRequestPriority, kmd,
 		rootBlock.IPtrs[1].BlockPointer, block, TransientEntry,
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
@@ -877,7 +937,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	t.Log("Fetch indirect block11 on-demand.")
 	block = &FileBlock{}
 	ch = q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(),
+		ctx, defaultOnDemandRequestPriority, kmd,
 		indBlock1.IPtrs[0].BlockPointer, block, TransientEntry,
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
@@ -886,7 +946,7 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	t.Log("Fetch indirect block12 on-demand.")
 	block = &FileBlock{}
 	ch = q.Request(
-		ctx, defaultOnDemandRequestPriority, makeKMD(),
+		ctx, defaultOnDemandRequestPriority, kmd,
 		indBlock1.IPtrs[1].BlockPointer, block, TransientEntry,
 		BlockRequestWithPrefetch)
 	notifySyncCh(t, prefetchSyncCh)
@@ -899,19 +959,19 @@ func TestPrefetcherMultiLevelIndirectFile(t *testing.T) {
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[1].BlockPointer,
-		indBlock2, FinishedPrefetch, TransientEntry)
+		indBlock2, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(
 		t, config.BlockCache(), indBlock2.IPtrs[0].BlockPointer, indBlock21,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(
 		t, config.BlockCache(), indBlock2.IPtrs[1].BlockPointer, indBlock22,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), ptrs[0].BlockPointer,
-		indBlock1, FinishedPrefetch, TransientEntry)
+		indBlock1, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		indBlock1.IPtrs[0].BlockPointer, indBlock11, FinishedPrefetch, TransientEntry)
+		indBlock1.IPtrs[0].BlockPointer, indBlock11, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		indBlock1.IPtrs[1].BlockPointer, indBlock12, FinishedPrefetch, TransientEntry)
+		indBlock1.IPtrs[1].BlockPointer, indBlock12, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func TestPrefetcherBackwardPrefetch(t *testing.T) {
@@ -1049,19 +1109,19 @@ func TestPrefetcherBackwardPrefetch(t *testing.T) {
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		root.Children["a"].BlockPointer, a, FinishedPrefetch, TransientEntry)
+		root.Children["a"].BlockPointer, a, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		root.Children["b"].BlockPointer, b, FinishedPrefetch, TransientEntry)
+		root.Children["b"].BlockPointer, b, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		a.Children["aa"].BlockPointer, aa, FinishedPrefetch, TransientEntry)
+		a.Children["aa"].BlockPointer, aa, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		a.Children["ab"].BlockPointer, ab, FinishedPrefetch, TransientEntry)
+		a.Children["ab"].BlockPointer, ab, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		aa.Children["aaa"].BlockPointer, aaa, FinishedPrefetch, TransientEntry)
+		aa.Children["aaa"].BlockPointer, aaa, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(),
-		aa.Children["aab"].BlockPointer, aab, FinishedPrefetch, TransientEntry)
+		aa.Children["aab"].BlockPointer, aab, FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
@@ -1134,11 +1194,11 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, NoPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), bPtr, b, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Fetch dir root again.")
 	block = &DirBlock{}
@@ -1180,19 +1240,19 @@ func TestPrefetcherUnsyncedThenSyncedPrefetch(t *testing.T) {
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), bPtr, b,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aaPtr, aa,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), abPtr, ab,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aaaPtr, aaa,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aabPtr, aab,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func setLimiterLimits(
@@ -1274,11 +1334,11 @@ func TestSyncBlockCacheWithPrefetcher(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, NoPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), bPtr, b, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Set the cache maximum bytes to the current total.")
 	syncBytes := int64(syncCache.currBytes)
@@ -1345,9 +1405,9 @@ func TestPrefetcherBasicUnsyncedPrefetch(t *testing.T) {
 	require.NoError(t, err)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
@@ -1389,7 +1449,7 @@ func TestPrefetcherBasicUnsyncedBackwardPrefetch(t *testing.T) {
 	err := <-ch
 	require.NoError(t, err)
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Fetch dir root.")
 	block = &DirBlock{}
@@ -1403,9 +1463,9 @@ func TestPrefetcherBasicUnsyncedBackwardPrefetch(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
@@ -1489,9 +1549,9 @@ func TestPrefetcherUnsyncedPrefetchEvicted(t *testing.T) {
 	require.NoError(t, err)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
 	close(prefetchSyncCh)
@@ -1609,11 +1669,11 @@ func TestPrefetcherUnsyncedPrefetchChildCanceled(t *testing.T) {
 	require.NoError(t, err)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), bPtr, b, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
 	close(prefetchSyncCh)
@@ -1725,11 +1785,11 @@ func TestPrefetcherUnsyncedPrefetchParentCanceled(t *testing.T) {
 	require.NoError(t, err)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), bPtr, b, FinishedPrefetch,
-		TransientEntry)
+		kmd.TlfID(), config.DiskBlockCache())
 
 	// Then we wait for the pending prefetches to complete.
 	close(prefetchSyncCh)
@@ -1829,7 +1889,7 @@ func TestPrefetcherReschedules(t *testing.T) {
 	notifySyncCh(t, prefetchSyncCh)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Make room in the cache.")
 	setLimiterLimits(limiter, math.MaxInt64, math.MaxInt64)
@@ -1856,11 +1916,11 @@ func TestPrefetcherReschedules(t *testing.T) {
 	require.NoError(t, err)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a,
-		TriggeredPrefetch, TransientEntry)
+		TriggeredPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), bPtr, b,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	t.Log("Set the cache maximum bytes to the current total again.")
 	syncBytes = int64(syncCache.currBytes)
@@ -1880,13 +1940,13 @@ func TestPrefetcherReschedules(t *testing.T) {
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), rootPtr)
 
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aPtr, a,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), aaPtr, aa,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 	testPrefetcherCheckGet(t, config.BlockCache(), abPtr, ab,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func TestPrefetcherWithDedupBlocks(t *testing.T) {
@@ -1954,7 +2014,7 @@ func TestPrefetcherWithDedupBlocks(t *testing.T) {
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
 	testPrefetcherCheckGet(t, config.BlockCache(), rootPtr, root,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 }
 
 func TestPrefetcherWithCanceledDedupBlocks(t *testing.T) {
@@ -2076,7 +2136,7 @@ func TestPrefetcherWithCanceledDedupBlocks(t *testing.T) {
 	t.Log("Ensure that the prefetched blocks are in the cache, " +
 		"and the prefetch statuses are correct.")
 	testPrefetcherCheckGet(t, config.BlockCache(), a2Ptr, a2Block,
-		FinishedPrefetch, TransientEntry)
+		FinishedPrefetch, kmd.TlfID(), config.DiskBlockCache())
 
 	waitForPrefetchOrBust(t, ctx, q.Prefetcher(), a2Ptr)
 }


### PR DESCRIPTION
Now that blocks can move from the working set cache to the sync cache (which changes the block's prefetch status), it's hard to keep a synchronized view of the prefetch status in memory.  So, just rely on the disk cache entirely for the prefetch status.

Note this contains a bit of a hack for storing the prefetch status in the block retrieval queue when there's no disk block cache.  I couldn't find a more elegant way of doing it that didn't require splitting up the disk cache lookup into two calls, so I thought this was better.

Issue: KBFS-3644