### PR TITLE
prefetcher: avoid mem leaks by not storing block in request

### DIFF
--- a/libkbfs/block_types.go
+++ b/libkbfs/block_types.go
@@ -148,6 +148,11 @@ func (cb *CommonBlock) NewEmpty() Block {
 	return NewCommonBlock()
 }
 
+// NewEmptier implements the Block interface for CommonBlock.
+func (cb *CommonBlock) NewEmptier() func() Block {
+	return NewCommonBlock
+}
+
 // ToCommonBlock implements the Block interface for CommonBlock.
 func (cb *CommonBlock) ToCommonBlock() *CommonBlock {
 	return cb
@@ -224,6 +229,11 @@ func NewDirBlockWithPtrs(isInd bool) BlockWithPtrs {
 // NewEmpty implements the Block interface for DirBlock
 func (db *DirBlock) NewEmpty() Block {
 	return NewDirBlock()
+}
+
+// NewEmptier implements the Block interface for DirBlock.
+func (db *DirBlock) NewEmptier() func() Block {
+	return NewDirBlock
 }
 
 // IsTail implements the Block interface for DirBlock.
@@ -447,6 +457,11 @@ func NewFileBlockWithPtrs(isInd bool) BlockWithPtrs {
 // NewEmpty implements the Block interface for FileBlock
 func (fb *FileBlock) NewEmpty() Block {
 	return &FileBlock{}
+}
+
+// NewEmptier implements the Block interface for FileBlock.
+func (fb *FileBlock) NewEmptier() func() Block {
+	return NewFileBlock
 }
 
 // IsTail implements the Block interface for FileBlock.

--- a/libkbfs/crypto_common_test.go
+++ b/libkbfs/crypto_common_test.go
@@ -94,6 +94,10 @@ func (tb TestBlock) NewEmpty() Block {
 	return &TestBlock{}
 }
 
+func (tb TestBlock) NewEmptier() func() Block {
+	return tb.NewEmpty
+}
+
 func (tb *TestBlock) Set(other Block) {
 	otherTb := other.(*TestBlock)
 	tb.A = otherTb.A
@@ -394,6 +398,10 @@ func (testBlockArray) DataVersion() DataVer { return FirstValidDataVer }
 
 func (tba testBlockArray) NewEmpty() Block {
 	return &testBlockArray{}
+}
+
+func (tba testBlockArray) NewEmptier() func() Block {
+	return tba.NewEmpty
 }
 
 func (tba testBlockArray) ToCommonBlock() *CommonBlock {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -142,6 +142,9 @@ type Block interface {
 	SetEncodedSize(size uint32)
 	// NewEmpty returns a new block of the same type as this block
 	NewEmpty() Block
+	// NewEmptier returns a function that creates a new block of the
+	// same type as this block.
+	NewEmptier() func() Block
 	// Set sets this block to the same value as the passed-in block
 	Set(other Block)
 	// ToCommonBlock retrieves this block as a *CommonBlock.

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1092,6 +1092,20 @@ func (mr *MockBlockMockRecorder) NewEmpty() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEmpty", reflect.TypeOf((*MockBlock)(nil).NewEmpty))
 }
 
+// NewEmptier mocks base method
+func (m *MockBlock) NewEmptier() func() Block {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewEmptier")
+	ret0, _ := ret[0].(func() Block)
+	return ret0
+}
+
+// NewEmptier indicates an expected call of NewEmptier
+func (mr *MockBlockMockRecorder) NewEmptier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEmptier", reflect.TypeOf((*MockBlock)(nil).NewEmptier))
+}
+
 // Set mocks base method
 func (m *MockBlock) Set(other Block) {
 	m.ctrl.T.Helper()
@@ -1249,6 +1263,20 @@ func (m *MockBlockWithPtrs) NewEmpty() Block {
 func (mr *MockBlockWithPtrsMockRecorder) NewEmpty() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEmpty", reflect.TypeOf((*MockBlockWithPtrs)(nil).NewEmpty))
+}
+
+// NewEmptier mocks base method
+func (m *MockBlockWithPtrs) NewEmptier() func() Block {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewEmptier")
+	ret0, _ := ret[0].(func() Block)
+	return ret0
+}
+
+// NewEmptier indicates an expected call of NewEmptier
+func (mr *MockBlockWithPtrsMockRecorder) NewEmptier() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewEmptier", reflect.TypeOf((*MockBlockWithPtrs)(nil).NewEmptier))
 }
 
 // Set mocks base method

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -375,7 +375,7 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 		// handled.
 		pre.req.action = newAction
 		ch := p.retriever.Request(
-			pre.ctx, priority, kmd, ptr, block, lifetime, action)
+			pre.ctx, priority, kmd, ptr, block.NewEmpty(), lifetime, action)
 		p.inFlightFetches.In() <- ch
 	}
 	_, isParentWaiting := p.prefetches[parentPtr.ID]

--- a/libkbfs/prefetcher.go
+++ b/libkbfs/prefetcher.go
@@ -360,8 +360,8 @@ func (p *blockPrefetcher) request(ctx context.Context, priority int,
 	if !isPrefetchWaiting {
 		// If the block isn't in the tree, we add it with a block count of 1 (a
 		// later TriggerPrefetch will come in and decrement it).
-		req := &prefetchRequest{ptr, block.NewEmpty, kmd, priority, lifetime,
-			NoPrefetch, action, nil}
+		req := &prefetchRequest{ptr, block.NewEmptier(), kmd, priority,
+			lifetime, NoPrefetch, action, nil}
 		pre = p.newPrefetch(1, false, req)
 		p.prefetches[ptr.ID] = pre
 	}
@@ -971,7 +971,7 @@ func (p *blockPrefetcher) ProcessBlockForPrefetch(ctx context.Context,
 	ptr BlockPointer, block Block, kmd KeyMetadata, priority int,
 	lifetime BlockCacheLifetime, prefetchStatus PrefetchStatus,
 	action BlockRequestAction) {
-	req := &prefetchRequest{ptr, block.NewEmpty, kmd, priority, lifetime,
+	req := &prefetchRequest{ptr, block.NewEmptier(), kmd, priority, lifetime,
 		prefetchStatus, action, nil}
 	if prefetchStatus == FinishedPrefetch {
 		// Finished prefetches can always be short circuited.


### PR DESCRIPTION
We don't actually use the contents of the block in the request; we only use it to generate a new block.  So just store the function for generating the new block instead, to be more explicit.

Also, don't pass the same block used to make that function to the `Request()` function, which fills in the block.  I suspect that was a memory leak.

Issue: #1958 