### PR TITLE
favorites/kbfs_ops: refresh edit histories on added favorites

### DIFF
--- a/libkbfs/favorites.go
+++ b/libkbfs/favorites.go
@@ -275,6 +275,11 @@ func (f *Favorites) sendChangesToEditHistory(oldCache map[Favorite]bool) {
 				oldFav.Type)
 		}
 	}
+	for newFav := range f.cache {
+		if !oldCache[newFav] {
+			f.config.KBFSOps().RefreshEditHistory(newFav)
+		}
+	}
 }
 
 func (f *Favorites) handleReq(req *favReq) (err error) {

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -337,6 +337,9 @@ type KBFSOps interface {
 	// the local cache.  Idempotent, so it succeeds even if the folder
 	// isn't favorited.
 	DeleteFavorite(ctx context.Context, fav Favorite) error
+	// RefreshEditHistory asks the FBO for the given favorite to reload its
+	// edit history.
+	RefreshEditHistory(fav Favorite)
 
 	// GetTLFCryptKeys gets crypt key of all generations as well as
 	// TLF ID for tlfHandle. The returned keys (the keys slice) are ordered by

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -303,6 +303,14 @@ func (fs *KBFSOpsStandard) getOpsByFav(fav Favorite) *folderBranchOps {
 	return fs.opsByFav[fav]
 }
 
+// RefreshEditHistory implements the KBFSOps interface for KBFSOpsStandard
+func (fs *KBFSOpsStandard) RefreshEditHistory(fav Favorite) {
+	fbo := fs.getOpsByFav(fav)
+	if fbo != nil {
+		fbo.refreshEditHistory()
+	}
+}
+
 // DeleteFavorite implements the KBFSOps interface for
 // KBFSOpsStandard.
 func (fs *KBFSOpsStandard) DeleteFavorite(ctx context.Context,

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -1812,6 +1812,18 @@ func (mr *MockKBFSOpsMockRecorder) DeleteFavorite(ctx, fav interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFavorite", reflect.TypeOf((*MockKBFSOps)(nil).DeleteFavorite), ctx, fav)
 }
 
+// RefreshEditHistory mocks base method
+func (m *MockKBFSOps) RefreshEditHistory(fav Favorite) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RefreshEditHistory", fav)
+}
+
+// RefreshEditHistory indicates an expected call of RefreshEditHistory
+func (mr *MockKBFSOpsMockRecorder) RefreshEditHistory(fav interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshEditHistory", reflect.TypeOf((*MockKBFSOps)(nil).RefreshEditHistory), fav)
+}
+
 // GetTLFCryptKeys mocks base method
 func (m *MockKBFSOps) GetTLFCryptKeys(ctx context.Context, tlfHandle *TlfHandle) ([]kbfscrypto.TLFCryptKey, tlf.ID, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This will hopefully fix the `EditHistory` fails seen here: https://ci.keyba.se/job/kbfs-server/job/PR-609/40/