### PR TITLE
vendor: Update github.com/xanzy/ssh-agent for Go 1.11 on Windows

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -805,9 +805,10 @@
 			"revisionTime": "2017-08-04T03:51:56Z"
 		},
 		{
+			"checksumSHA1": "VNhImVFfxO7x8Kp1BrM2zgp4vi0=",
 			"path": "github.com/xanzy/ssh-agent",
-			"revision": "ba9c9e33906f58169366275e3450db66139a31a9",
-			"revisionTime": "2015-12-15T16:34:51+01:00"
+			"revision": "640f0ab560aeb89d523bb6ac322b1244d5c3796c",
+			"revisionTime": "2018-07-03T18:17:07Z"
 		},
 		{
 			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",


### PR DESCRIPTION
Update vendor because of Windows.

Compilation fails on Windows with Go 1.11.4 without this because the vendored package used to use "import . unsafe; import . syscall" in Windows specific code. This was broken by the addition of syscall.Pointer. 
