### PR TITLE
libkbfs: Do propagate errors correctly

### DIFF
--- a/libkbfs/config_local.go
+++ b/libkbfs/config_local.go
@@ -1620,7 +1620,8 @@ func (c *ConfigLocal) setTlfSyncState(tlfID tlf.ID, config FolderSyncConfig) (
 			if cancel, ok := c.tlfClearCancels[tlfID]; ok {
 				cancel()
 			}
-			buf, err := c.codec.Encode(&config)
+			var buf []byte
+			buf, err = c.codec.Encode(&config)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/libkbfs/favorites.go
+++ b/libkbfs/favorites.go
@@ -226,6 +226,9 @@ func (f *Favorites) writeCacheToDisk(ctx context.Context) error {
 		version:        favoritesDiskCacheStorageVersion,
 	}
 	encodedData, err := f.config.Codec().Encode(cacheEncryptedForDisk)
+	if err != nil {
+		return err
+	}
 
 	// Write the encrypted cache to disk
 	session, err := f.config.KBPKI().GetCurrentSession(ctx)


### PR DESCRIPTION
Ran staticcheck while doing an unrelated stuff and these came up.