### PR TITLE
Expose status of problematic conflict resolutions in .kbfs_status

### DIFF
--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -7,7 +7,6 @@ package libkbfs
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/syndtr/goleveldb/leveldb"
 	"os"
 	sysPath "path"
 	"sort"
@@ -16,11 +15,14 @@ import (
 	"time"
 
 	"github.com/keybase/client/go/protocol/keybase1"
+	"github.com/keybase/go-codec/codec"
 	"github.com/keybase/kbfs/kbfsblock"
 	"github.com/keybase/kbfs/kbfscrypto"
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/kbfssync"
 	"github.com/pkg/errors"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/storage"
 	"golang.org/x/net/context"
 )
 
@@ -3192,91 +3194,119 @@ outer:
 	return nil
 }
 
-func (cr *ConflictResolver) logFileName() string {
-	return sysPath.Join(cr.config.StorageRoot(), conflictResolverRecordsDir,
-		conflictResolverRecordsVersionString, conflictResolverRecordsDB)
-}
-
 const conflictRecordVersion = 1
 
 type conflictRecord struct {
-	version int
+	Version int
 	time.Time
-	merged   string
-	unmerged string
+	Merged      string
+	Unmerged    string
+	ErrorTime   time.Time
+	ErrorString string
+	PanicString string
+	codec.UnknownFieldSetHandler
 }
 
 func (cr *ConflictResolver) recordStartResolve(ci conflictInput) error {
-	// Make sure the directory for CR records exists.
-	err := os.MkdirAll(sysPath.Join(cr.config.StorageRoot(),
-		conflictResolverRecordsDir, conflictResolverRecordsVersionString),
-		os.ModePerm)
-	if err != nil {
-		return err
-	}
-
-	// TODO: consider keeping the DB open all the time instead of opening it
-	//  for each read, unless crashing while it is open will corrupt the DB
-	db, err := leveldb.OpenFile(cr.logFileName(), leveldbOptions)
-	if err != nil {
-		return err
-	}
-	defer db.Close()
-
+	db := cr.config.KBFSOps().GetConflictResolutionDB()
 	conflictsSoFarSerialized, err := db.Get([]byte(cr.fbo.id().String()), nil)
 	var conflictsSoFar []conflictRecord
 	switch err {
 	case leveldb.ErrNotFound:
 		conflictsSoFar = nil
 	case nil:
-		err = cr.config.Codec().Decode(conflictsSoFarSerialized, conflictsSoFar)
+		err = cr.config.Codec().Decode(conflictsSoFarSerialized,
+			&conflictsSoFar)
 		if err != nil {
 			return err
 		}
 	default:
 		return err
 	}
+	if len(conflictsSoFar) > 10 {
+		conflictsSoFar = conflictsSoFar[len(conflictsSoFar)-10:]
+	}
 	conflictsSoFar = append(conflictsSoFar, conflictRecord{
-		version:  conflictRecordVersion,
-		Time:     time.Now(),
-		merged:   ci.merged.String(),
-		unmerged: ci.unmerged.String(),
+		Version:  conflictRecordVersion,
+		Time:     cr.config.Clock().Now(),
+		Merged:   ci.merged.String(),
+		Unmerged: ci.unmerged.String(),
 	})
 	conflictsSerialized, err := cr.config.Codec().Encode(conflictsSoFar)
+	if err != nil {
+		return err
+	}
 	return db.Put([]byte(cr.fbo.id().String()), conflictsSerialized, nil)
 }
 
-// recordFinishResolve deletes the file that recorded conflict resolution
-// attempts for this resolver
+// recordFinishResolve does one of two things:
+//  - in the event of success, it deletes the DB entry that recorded conflict
+//    resolution attempts for this resolver
+//  - in the event of failure, it logs that CR failed and tries to record the
+//    failure to the DB.
 func (cr *ConflictResolver) recordFinishResolve(
-	ctx context.Context, ci conflictInput, err error) {
-	if err != nil {
-		// TODO: consider putting this in the CR records db
-		cr.log.CWarningf(ctx,
-			"Conflict resolution unsuccessful: err=%v", err)
+	ctx context.Context, ci conflictInput, receivedErr error) {
+	db := cr.config.KBFSOps().GetConflictResolutionDB()
+	panicVar := recover()
+
+	// If we neither errored nor panicked, this CR succeeded and we can wipe
+	// the DB entry.
+	if receivedErr == nil && panicVar == nil {
+		err := db.Delete([]byte(cr.fbo.id().String()), nil)
+		if err != nil {
+			cr.log.CWarningf(ctx,
+				"Could not record conflict resolution success: %v", err)
+		}
 		return
 	}
 
-	if r := recover(); r != nil {
-		// TODO: consider attempting to put this in the CR records DB
-		cr.log.CWarningf(ctx,
-			"Conflict resolution unsuccessful: panic(%v)", r)
-		panic(r)
+	var err error
+	defer func() {
+		// If we can't record the failure to the CR DB, at least log it.
+		if err != nil {
+			cr.log.CWarningf(ctx,
+				"Could not record conflict resolution failure [%v/%v]: %v",
+				receivedErr, panicVar, err)
+		}
+		// If we recovered from a panic, keep panicking.
+		if panicVar != nil {
+			panic(panicVar)
+		}
+	}()
+
+	// Otherwise we need to decode the most recent entry, modify it, and put it
+	// back in the DB.
+	var conflictsSerialized []byte
+	conflictsSerialized, err = db.Get([]byte(cr.fbo.id().String()), nil)
+	var conflictsSoFar []conflictRecord
+	switch err {
+	case leveldb.ErrNotFound:
+		err = errors.New("No CR records")
+		return
+	case nil:
+		err = cr.config.Codec().Decode(conflictsSerialized,
+			&conflictsSoFar)
+		if err != nil {
+			return
+		}
+	default:
+		return
 	}
 
-	db, err := leveldb.OpenFile(cr.logFileName(), leveldbOptions)
+	thisCR := &conflictsSoFar[len(conflictsSoFar)-1]
+	thisCR.ErrorTime = cr.config.Clock().Now()
+	if receivedErr != nil {
+		thisCR.ErrorString = receivedErr.Error()
+	}
+	if panicVar != nil {
+		thisCR.PanicString = fmt.Sprintf("%s", panicVar)
+	}
+
+	conflictsSerialized, err = cr.config.Codec().Encode(conflictsSoFar)
 	if err != nil {
-		cr.log.CWarningf(ctx,
-			"Could not record conflict resolution success: %v", err)
+		return
 	}
-	defer db.Close()
-
-	err = db.Delete([]byte(cr.fbo.id().String()), nil)
-	if err != nil {
-		cr.log.CWarningf(ctx,
-			"Could not record conflict resolution success: %v", err)
-	}
-
+	err = db.Put([]byte(cr.fbo.id().String()), conflictsSerialized, nil)
 }
 
 // CRWrapError wraps an error that happens during conflict resolution.
@@ -3299,8 +3329,9 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	if err != nil {
 		cr.log.CWarningf(ctx,
 			"Could not record conflict resolution attempt: %v", err)
+	} else {
+		defer cr.recordFinishResolve(ctx, ci, err)
 	}
-	defer cr.recordFinishResolve(ctx, ci, err)
 
 	cr.log.CDebugf(ctx, "Starting conflict resolution with input %+v", ci)
 	lState := makeFBOLockState()
@@ -3542,4 +3573,32 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 	// don't count against the quota forever.  (Though of course if we
 	// completely fail, we'll need to rely on a future complete scan
 	// to clean up the quota anyway . . .)
+}
+
+func openCRDBInternal(config Config) (*leveldb.DB, error) {
+	if config.IsTestMode() {
+		return leveldb.Open(storage.NewMemStorage(), leveldbOptions)
+	} else {
+		err := os.MkdirAll(sysPath.Join(config.StorageRoot(),
+			conflictResolverRecordsDir, conflictResolverRecordsVersionString),
+			os.ModePerm)
+		if err != nil {
+			return nil, err
+		}
+
+		return leveldb.OpenFile(sysPath.Join(config.StorageRoot(),
+			conflictResolverRecordsDir, conflictResolverRecordsVersionString,
+			conflictResolverRecordsDB), leveldbOptions)
+	}
+}
+
+func openCRDB(ctx context.Context, config Config) (db *leveldb.DB) {
+	db, err := openCRDBInternal(config)
+	if err != nil {
+		config.MakeLogger("CR").CWarningf(ctx,
+			"Could not open conflict resolver DB: %v", err)
+		// TODO: elsewhere we expect this db to be non-nil.
+		//  Should we just panic here?
+	}
+	return db
 }

--- a/libkbfs/conflict_resolver.go
+++ b/libkbfs/conflict_resolver.go
@@ -3578,18 +3578,17 @@ func (cr *ConflictResolver) doResolve(ctx context.Context, ci conflictInput) {
 func openCRDBInternal(config Config) (*leveldb.DB, error) {
 	if config.IsTestMode() {
 		return leveldb.Open(storage.NewMemStorage(), leveldbOptions)
-	} else {
-		err := os.MkdirAll(sysPath.Join(config.StorageRoot(),
-			conflictResolverRecordsDir, conflictResolverRecordsVersionString),
-			os.ModePerm)
-		if err != nil {
-			return nil, err
-		}
-
-		return leveldb.OpenFile(sysPath.Join(config.StorageRoot(),
-			conflictResolverRecordsDir, conflictResolverRecordsVersionString,
-			conflictResolverRecordsDB), leveldbOptions)
 	}
+	err := os.MkdirAll(sysPath.Join(config.StorageRoot(),
+		conflictResolverRecordsDir, conflictResolverRecordsVersionString),
+		os.ModePerm)
+	if err != nil {
+		return nil, err
+	}
+
+	return leveldb.OpenFile(sysPath.Join(config.StorageRoot(),
+		conflictResolverRecordsDir, conflictResolverRecordsVersionString,
+		conflictResolverRecordsDB), leveldbOptions)
 }
 
 func openCRDB(ctx context.Context, config Config) (db *leveldb.DB) {

--- a/libkbfs/conflict_resolver_test.go
+++ b/libkbfs/conflict_resolver_test.go
@@ -58,6 +58,9 @@ func crTestInit(t *testing.T) (ctx context.Context, cancel context.CancelFunc,
 	if err != nil {
 		t.Fatal(err)
 	}
+	crdb := openCRDB(ctx, config)
+	config.mockKbfs.EXPECT().GetConflictResolutionDB().Return(crdb).AnyTimes()
+
 	initSuccess = true
 	return ctx, cancel, mockCtrl, config, fbo.cr
 }

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -435,7 +435,7 @@ func newFolderBranchOps(
 		observers:     observers,
 		serviceStatus: serviceStatus,
 		status: newFolderBranchStatusKeeper(
-			config, nodeCache, quotaUsage),
+			config, nodeCache, quotaUsage, fb.Tlf.Bytes()),
 		mdWriterLock: mdWriterLock,
 		headLock:     headLock,
 		syncLock:     syncLock,

--- a/libkbfs/folder_branch_ops.go
+++ b/libkbfs/folder_branch_ops.go
@@ -6,6 +6,7 @@ package libkbfs
 
 import (
 	"fmt"
+	"github.com/syndtr/goleveldb/leveldb"
 	"os"
 	stdpath "path"
 	"path/filepath"
@@ -8015,6 +8016,12 @@ func (fbo *folderBranchOps) InvalidateNodeAndChildren(
 		fbo.observers.batchChanges(ctx, changes, affectedNodeIDs)
 	}
 	return nil
+}
+
+// GetConflictResolutionDB (does not) implement the KBFSOps interface for
+// folderBranchOps.
+func (fbo *folderBranchOps) GetConflictResolutionDB() (db *leveldb.DB) {
+	panic("FolderBranchOps does not implement GetConflictResolutionDB")
 }
 
 // KickoffAllOutstandingRekeys (does not) implement the KBFSOps interface for

--- a/libkbfs/folder_branch_status_test.go
+++ b/libkbfs/folder_branch_status_test.go
@@ -31,7 +31,7 @@ func fbStatusTestInit(t *testing.T) (*gomock.Controller, *ConfigMock,
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(ImplicitTeamInfo{}, errors.New("No such team"))
 	nodeCache := NewMockNodeCache(mockCtrl)
-	fbsk := newFolderBranchStatusKeeper(config, nodeCache, nil)
+	fbsk := newFolderBranchStatusKeeper(config, nodeCache, nil, nil)
 	interposeDaemonKBPKI(config, "alice", "bob")
 	return mockCtrl, config, fbsk, nodeCache
 }

--- a/libkbfs/interfaces.go
+++ b/libkbfs/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"github.com/keybase/kbfs/kbfsmd"
 	"github.com/keybase/kbfs/tlf"
 	metrics "github.com/rcrowley/go-metrics"
+	"github.com/syndtr/goleveldb/leveldb"
 	"golang.org/x/net/context"
 	billy "gopkg.in/src-d/go-billy.v4"
 )
@@ -508,7 +509,9 @@ type KBFSOps interface {
 
 	// GetNodeMetadata gets metadata associated with a Node.
 	GetNodeMetadata(ctx context.Context, node Node) (NodeMetadata, error)
-
+	// GetConflictResolutionDB gets the levelDB in which conflict resolution
+	// status is stored.
+	GetConflictResolutionDB() (db *leveldb.DB)
 	// Shutdown is called to clean up any resources associated with
 	// this KBFSOps instance.
 	Shutdown(ctx context.Context) error

--- a/libkbfs/kbfs_ops.go
+++ b/libkbfs/kbfs_ops.go
@@ -439,6 +439,7 @@ func (fs *KBFSOpsStandard) getOpsByHandle(ctx context.Context,
 	return ops
 }
 
+// GetConflictResolutionDB implements the KBFSOps interface for KBFSOpsStandard.
 func (fs *KBFSOpsStandard) GetConflictResolutionDB() (db *leveldb.DB) {
 	return fs.conflictResolutionDB
 }

--- a/libkbfs/mocks_test.go
+++ b/libkbfs/mocks_test.go
@@ -17,6 +17,7 @@ import (
 	kbfsmd "github.com/keybase/kbfs/kbfsmd"
 	tlf "github.com/keybase/kbfs/tlf"
 	go_metrics "github.com/rcrowley/go-metrics"
+	leveldb "github.com/syndtr/goleveldb/leveldb"
 	context "golang.org/x/net/context"
 	go_billy_v4 "gopkg.in/src-d/go-billy.v4"
 	reflect "reflect"
@@ -2197,6 +2198,20 @@ func (m *MockKBFSOps) GetNodeMetadata(ctx context.Context, node Node) (NodeMetad
 func (mr *MockKBFSOpsMockRecorder) GetNodeMetadata(ctx, node interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeMetadata", reflect.TypeOf((*MockKBFSOps)(nil).GetNodeMetadata), ctx, node)
+}
+
+// GetConflictResolutionDB mocks base method
+func (m *MockKBFSOps) GetConflictResolutionDB() *leveldb.DB {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConflictResolutionDB")
+	ret0, _ := ret[0].(*leveldb.DB)
+	return ret0
+}
+
+// GetConflictResolutionDB indicates an expected call of GetConflictResolutionDB
+func (mr *MockKBFSOpsMockRecorder) GetConflictResolutionDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConflictResolutionDB", reflect.TypeOf((*MockKBFSOps)(nil).GetConflictResolutionDB))
 }
 
 // Shutdown mocks base method


### PR DESCRIPTION
`$ cat /keybase/private/jakob223,jakob224/.kbfs_status`
```
{
  "Staged": true,
  "BranchID": "e69c4a435b3539df36144b9b9a25f1b7",
  "HeadWriter": "jakob223",
  "DiskUsage": 15761,
  "RekeyPending": false,
  "LatestKeyGeneration": 1,
  "FolderID": "593de796537d68ba511bbb37c4420016",
  "Revision": 67,
  "LastGCRevision": 26,
  "MDVersion": 4,
  "RootBlockID": "01a785527538db3da1863b52ec78b61a46bdec669a0d9dc95a88f9c2c3f16aaa0b",
  "SyncEnabled": false,
  "PrefetchStatus": "TriggeredPrefetch",
  "UsageBytes": 317141470,
  "ArchiveBytes": 10215578826,
  "LimitBytes": 268435456000,
  "GitUsageBytes": 0,
  "GitArchiveBytes": 0,
  "GitLimitBytes": 107374182400,
  "DirtyPaths": null,
  "Unmerged": null,
  "Merged": null,
  "ConflictResolutionAttempts": [
    {
      "Time": "2019-01-03T22:57:30.326635069Z",
      "Merged": "0",
      "Unmerged": "67",
      "ErrorTime": "2019-01-03T22:57:46.311921665Z",
      "ErrorString": "CR disabled",
      "PanicString": ""
    },
    {
      "Time": "2019-01-03T22:57:46.422647519Z",
      "Merged": "65",
      "Unmerged": "67",
      "ErrorTime": "2019-01-03T22:57:46.422772798Z",
      "ErrorString": "CR disabled",
      "PanicString": ""
    }
  ],
  "Journal": {
    "Dir": "/Users/jakob/Library/Application Support/Keybase/kbfs_journal/v1/0120cdf0293d087ba5e5f2c4d331ea6a2646-593de796537d68ba",
    "RevisionStart": 65,
    "RevisionEnd": 67,
    "BranchID": "e69c4a435b3539df36144b9b9a25f1b7",
    "BlockOpCount": 6,
    "StoredBytes": 25686,
    "StoredFiles": 42,
    "UnflushedBytes": 17124,
    "UnflushedPaths": [
      "/keybase/private/jakob223,jakob224/test2",
      "/keybase/private/jakob223,jakob224",
      "/keybase/private/jakob223,jakob224/test"
    ],
    "EndEstimate": "2019-01-03T17:57:52.312123508-05:00",
    "QuotaUsedBytes": 317150032,
    "QuotaLimitBytes": 268435456000
  }
}
```

Issue: KBFS-3682